### PR TITLE
tox: Add flake8 tests for syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,28 +18,24 @@ matrix:
     - python: "pypy2.7-5.8.0"
       env: TOXENV=pypy
     - python: "pypy3.5-5.8.0"
-env: TOXENV=pypy3
+      env: TOXENV=pypy3
 
 
 install:
   - pip install .
-  - pip install tox
+  - pip install codecov tox
   - pip install -r dev-requirements.txt
   - pip install -r requirements.txt
-
-
-before_install:
-  - pip install codecov
-
-
-after_success:
-  - tox -e coverage-report
-  - codecov
 
 
 # run tests
 script:
   - tox
+
+
+after_success:
+  - tox -e coverage-report
+  - codecov
 
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ matrix:
       env: TOXENV=py36
     - python: "3.7"
       dist: xenial
-      sudo: required
       env: TOXENV=py37
     - python: "pypy2.7-5.8.0"
       env: TOXENV=pypy

--- a/apprise/plugins/NotifyGrowl/gntp/shim.py
+++ b/apprise/plugins/NotifyGrowl/gntp/shim.py
@@ -27,16 +27,16 @@ if PY3:
 	from configparser import RawConfigParser
 else:
 	def b(s):
-		if isinstance(s, unicode):
+		if isinstance(s, unicode):  # noqa
 			return s.encode('utf8', 'replace')
 		return s
 
 	def u(s):
-		if isinstance(s, unicode):
+		if isinstance(s, unicode):  # noqa
 			return s
 		if isinstance(s, int):
 			s = str(s)
-		return unicode(s, "utf8", "replace")
+		return unicode(s, "utf8", "replace")  # noqa
 
 	from StringIO import StringIO
 	from ConfigParser import RawConfigParser

--- a/apprise/plugins/NotifyPushjet/pushjet/pushjet.py
+++ b/apprise/plugins/NotifyPushjet/pushjet/pushjet.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 
+import sys
 import requests
 from functools import partial
+
+from six import text_type
+from six.moves.urllib.parse import urljoin
 
 from .utilities import (
     NoNoneDict,
@@ -9,14 +13,6 @@ from .utilities import (
     is_valid_uuid, is_valid_public_key, is_valid_secret_key, repr_format
 )
 from .errors import NonexistentError, SubscriptionError, RequestError, ServerError
-
-import sys
-if sys.version_info[0] >= 3:
-    from urllib.parse import urljoin
-    unicode_type = str
-else:
-    from urlparse import urljoin
-    unicode_type = unicode
 
 DEFAULT_API_URL = 'https://api.pushjet.io/'
 
@@ -52,8 +48,8 @@ class Service(PushjetModel):
             raise ValueError("Invalid secret key provided.")
         elif public_key and not is_valid_public_key(public_key):
             raise ValueError("Invalid public key provided.")
-        self.secret_key = unicode_type(secret_key) if secret_key else None
-        self.public_key = unicode_type(public_key) if public_key else None
+        self.secret_key = text_type(secret_key) if secret_key else None
+        self.public_key = text_type(public_key) if public_key else None
         self.refresh()
     
     def _request(self, endpoint, method, is_secret, params=None, data=None):
@@ -97,8 +93,8 @@ class Service(PushjetModel):
         if not data:
             return
         self._request('service', 'PATCH', is_secret=True, data=data)
-        self.name = unicode_type(name)
-        self.icon_url = unicode_type(icon_url)
+        self.name = text_type(name)
+        self.icon_url = text_type(icon_url)
 
     @requires_secret_key
     def delete(self):
@@ -171,10 +167,10 @@ class Device(PushjetModel):
         return "<Pushjet Device: {}>".format(self.uuid)
 
     def __init__(self, uuid):
-        uuid = unicode_type(uuid)
+        uuid = text_type(uuid)
         if not is_valid_uuid(uuid):
             raise ValueError("Invalid UUID provided. Try uuid.uuid4().")
-        self.uuid = unicode_type(uuid)
+        self.uuid = text_type(uuid)
     
     def _request(self, endpoint, method, params=None, data=None):
         params = (params or {})
@@ -292,7 +288,7 @@ class Api(object):
         return "<Pushjet Api: {}>".format(self.url).encode(sys.stdout.encoding, errors='replace')
 
     def __init__(self, url):
-        self.url = unicode_type(url)
+        self.url = text_type(url)
         self.Service = with_api_bound(Service, self)
         self.Device = with_api_bound(Device, self)
     

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
-pytest
 coverage
-pytest-cov
-pycodestyle
+flake8
 mock
+pytest
+pytest-cov
 tox

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,9 @@ commands = coverage run --parallel -m pytest {posargs}
 deps=
    -r{toxinidir}/requirements.txt
    -r{toxinidir}/dev-requirements.txt
-commands = coverage run --parallel -m pytest {posargs}
+commands =
+    flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics 
+    coverage run --parallel -m pytest {posargs}
 
 [testenv:pypy]
 deps=


### PR DESCRIPTION
The Python 3.7 test will fail until #37 is resolved.

[flake8](http://flake8.pycqa.org) is a superset of pycodestyle that is used here to find syntax errors and undefined names.

E901,E999,F821,F822,F823 are the "showstopper" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.

    F821: undefined name name
    F822: undefined name name in __all__
    F823: local variable name referenced before assignment
    E901: SyntaxError or IndentationError
    E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
