### PR TITLE
Use 'plain' instead of 'text' for mime subtype.

### DIFF
--- a/apprise/plugins/NotifyEmail.py
+++ b/apprise/plugins/NotifyEmail.py
@@ -352,11 +352,9 @@ class NotifyEmail(NotifyBase):
         # Prepare Email Message
         if self.notify_format == NotifyFormat.HTML:
             email = MIMEText(body, 'html')
-            email['Content-Type'] = 'text/html'
 
         else:
-            email = MIMEText(body, 'text')
-            email['Content-Type'] = 'text/plain'
+            email = MIMEText(body, 'plain')
 
         email['Subject'] = title
         email['From'] = '%s <%s>' % (from_name, self.from_addr)


### PR DESCRIPTION
Also remove manually set headers as they're not required.

Fixes #41.