### PR TITLE
PyPi markdown support fixed locally; refs #71

### DIFF
--- a/apprise/__init__.py
+++ b/apprise/__init__.py
@@ -24,7 +24,7 @@
 # THE SOFTWARE.
 
 __title__ = 'apprise'
-__version__ = '0.7.0'
+__version__ = '0.7.2'
 __author__ = 'Chris Caron'
 __license__ = 'MIT'
 __copywrite__ = 'Copyright 2019 Chris Caron <lead2gold@gmail.com>'

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ else:
 
 setup(
     name='apprise',
-    version='0.7.0',
+    version='0.7.2',
     description='A universal notification service',
     license='MIT',
     long_description=open('README.md').read(),


### PR DESCRIPTION
As it turns out just doing a `twine check dist/*` reveals that i'm missing the dependency **cmarkgfm**.

After adding that, PyPI looks great again.  Due to the nature of how PyPI works, I had to upload a different build in order for the server to acknowledge it.  Version got incremented to 0.7.2 and pushed upstream again.