### PR TITLE
Handle ValueError Exception via Dbus import; refs #75

### DIFF
--- a/apprise/plugins/NotifyDBus.py
+++ b/apprise/plugins/NotifyDBus.py
@@ -86,9 +86,12 @@ try:
         from gi.repository import GdkPixbuf
         NOTIFY_DBUS_IMAGE_SUPPORT = True
 
-    except ImportError:
+    except (ImportError, ValueError):
         # No problem; this will get caught in outer try/catch
-        raise
+
+        # A ValueError will get thrown upon calling gi.require_version() if
+        # GDK/GTK isn't installed on the system but gi is.
+        pass
 
 except ImportError:
     # No problem; we just simply can't support this plugin; we could

--- a/test/test_gnome_plugin.py
+++ b/test/test_gnome_plugin.py
@@ -77,7 +77,7 @@ def test_gnome_plugin():
     gi.repository.Notify.init.return_value = True
     gi.repository.Notify.Notification = mock_notify
 
-    # Emulate require_version function1k:
+    # Emulate require_version function:
     gi.require_version = mock.Mock(
         name=gi_name + '.require_version')
 


### PR DESCRIPTION
This resolves an issue where the **gi** library is available however the GDK/GTK libraries are not.  A ValueError() exception is thrown and was not caught and silently handled as it should have been.