### PR TITLE
Handle ValueError Exception via Gnome import; refs #75

### DIFF
--- a/apprise/plugins/NotifyGnome.py
+++ b/apprise/plugins/NotifyGnome.py
@@ -47,10 +47,13 @@ try:
     # We're good to go!
     NOTIFY_GNOME_SUPPORT_ENABLED = True
 
-except ImportError:
+except (ImportError, ValueError):
     # No problem; we just simply can't support this plugin; we could
     # be in microsoft windows, or we just don't have the python-gobject
     # library available to us (or maybe one we don't support)?
+
+    # Alternativey A ValueError will get thrown upon calling
+    # gi.require_version() if the requested Notify namespace isn't available
     pass
 
 


### PR DESCRIPTION
This could be considered part no 2 of pull request #76 which just includes bulletproofing around systems that don't support all of the expected libraries/versioning associated with the DBus and Gnome Notifications.

Without this pull request and the other it is possible that users will experience an unexpected ValueError() exception.  This pull request (along with the previous) suppresses this from happening.