### PR TITLE
Fixed warning issued on pyYAML v5.1+

### DIFF
--- a/apprise/config/ConfigBase.py
+++ b/apprise/config/ConfigBase.py
@@ -309,8 +309,8 @@ class ConfigBase(URLBase):
         response = list()
 
         try:
-            # Load our data
-            result = yaml.load(content)
+            # Load our data (safely)
+            result = yaml.load(content, Loader=yaml.SafeLoader)
 
         except (AttributeError, yaml.error.MarkedYAMLError) as e:
             # Invalid content


### PR DESCRIPTION
YAML has introduced some safeguards in place for parsing it's format.  In v5.1 of pyYAML a warning has been issued to those not specifying which YAML parse you should use and to not just rely on a 'default'.

This was brought forth in #85 and fixed in this pull request.