### PR TITLE
Preparation for Fedora and EPEL packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ sdist/
 *.manifest
 *.spec
 
+# Allow RPM SPEC files despite pyInstaller ignore
+!packaging/redhat/*.spec
+
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,6 @@ include requirements.txt
 include win-requirements.txt
 include dev-requirements.txt
 recursive-include test *
+recursive-include packaging *
 global-exclude *.pyc
 global-exclude __pycache__

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,31 @@
+## Packaging
+This directory contains any supporting files to grant usage of apprise in various distributions.
+
+### RPM Based Packages
+* [EPEL](https://fedoraproject.org/wiki/EPEL) based distributions are only supported if they are of v7 or higher. This includes:
+   * Red Hat 7.x (or higher)
+   * CentOS 7.x (or higher)
+   * Scientific OS 7.x (or higher)
+   * Oracle Linux 7.x (or higher)
+
+Provided you are connected to the [EPEL repositories](https://fedoraproject.org/wiki/EPEL), the following will just work for you:
+```bash
+# python2-apprise: contains all you need to develop with apprise
+# apprise: provides the 'apprise' administrative tool
+yum install python2-apprise apprise
+```
+
+**Fedora** packaging is available right out of the box; the following will get you going on any distribution (v29 or higher):
+```bash
+# python3-apprise: contains all you need to develop with apprise
+# apprise: provides the 'apprise' administrative tool
+dnf install python3-apprise apprise
+```
+
+Let me know if you'd like to help me host on more platforms or can offer to do it yourself!
+
+## Man Pages Information
+The man page were generated using [Ronn](http://github.com/rtomayko/ronn/tree/0.7.3).
+ - Content is directly written to entries in the **man/\*.md** files _following the
+   [the format structure available on the Ronn site](https://github.com/rtomayko/ronn/blob/master/man/ronn.1.ronn)_.
+ - Then the following is executed `ronn --roff man/apprise.md` to produce the man/apprise.1 which is used by distributions.

--- a/packaging/man/apprise.1
+++ b/packaging/man/apprise.1
@@ -1,0 +1,132 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "APPRISE" "1" "March 2019" "" ""
+.
+.SH "NAME"
+\fBapprise\fR \- Push Notifications that work with just about every platform!
+.
+.SH "SYNOPSIS"
+\fBapprise\fR [\fIoptions\fR\.\.\.] \fIservice\-url\fR\.\.\.
+.
+.br
+.
+.SH "DESCRIPTION"
+\fBApprise\fR allows you to send a notification to \fIalmost all\fR of the most popular notification services available to us today such as: Discord, Telegram, Pushbullet, Slack, Twitter, etc\.
+.
+.IP "\(bu" 4
+One notification library to rule them all\.
+.
+.IP "\(bu" 4
+A common and intuitive notification syntax\.
+.
+.IP "\(bu" 4
+Supports the handling of images (to the notification services that will accept them)\.
+.
+.IP "" 0
+.
+.SH "OPTIONS"
+The Apprise options are as follows:
+.
+.TP
+\fB\-b\fR, \fB\-\-body=\fR\fITEXT\fR
+Specify the message body\. If no body is specified then content is read from \fIstdin\fR\.
+.
+.TP
+\fB\-t\fR, \fB\-\-title=\fR\fITEXT\fR
+Specify the message title\. This field is complete optional\.
+.
+.TP
+\fB\-c\fR, \fB\-\-config=\fR\fICONFIG\-URL\fR
+Specify one or more configuration locations\.
+.
+.TP
+\fB\-n\fR, \fB\-\-notification\-type=\fR\fITYPE\fR
+Specify the message type (default=info)\. Possible values are "info", "success", "failure", and "warning"\.
+.
+.TP
+\fB\-T\fR, \fB\-\-theme=\fRTHEME
+Specify the default theme\.
+.
+.TP
+\fB\-g\fR, \fB\-\-tag=\fRTAG
+Specify one or more tags to filter which services to notify\. Use multiple \fB\-\-tag\fR (\fB\-g\fR) entries to \fBOR\fR the tags together and comma separated to \fBAND\fR them\. If no tags are specified then all services are notified\.
+.
+.TP
+\fB\-v\fR, \fB\-\-verbose\fR
+The more of these you specify, the more verbose the output is\.
+.
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Display the apprise version and exit\.
+.
+.TP
+\fB\-\-help\fR
+Show this message and exit\.
+.
+.SH "SERVICE URLS"
+There are to many service URL and combinations to list here\. It\'s best to visit the Apprise GitHub page \fIhttps://github\.com/caronc/apprise\fR and see what\'s available\.
+.
+.SH "EXAMPLES"
+Send a notification to as many servers as you want to specify as you can easily chain them together:
+.
+.IP "" 4
+.
+.nf
+
+$ apprise \-t \'my title\' \-b \'my notification body\' \e
+   \'mailto://myemail:mypass@gmail\.com\' \e
+   \'pbul://o\.gn5kj6nfhv736I7jC3cj3QLRiyhgl98b\'
+.
+.fi
+.
+.IP "" 0
+.
+.P
+If you don\'t specify a \fB\-\-body\fR (\fB\-b\fR) then stdin is used allowing you to use the tool as part of your every day administration:
+.
+.IP "" 4
+.
+.nf
+
+$ cat /proc/cpuinfo | apprise \-t \'cpu info\' \e
+    \'mailto://myemail:mypass@gmail\.com\'
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Load in a configuration file which identifies all of your notification service URLs and notify them all:
+.
+.IP "" 4
+.
+.nf
+
+$ apprise \-t \'my title\' \-b \'my notification body\' \e
+   \-\-config=~/apprise\.yml
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Load in a configuration file from a remote server that identifies all of your notification service URLs and only notify the ones tagged as \fIdevops\fR\.
+.
+.IP "" 4
+.
+.nf
+
+$ apprise \-t \'my title\' \-b \'my notification body\' \e
+   \-\-config=https://localhost/my/apprise/config \e
+   \-t devops
+.
+.fi
+.
+.IP "" 0
+.
+.SH "BUGS"
+\fBApprise\fR is written in Python with 100% test coverage; but it still makes it far from perfect since the notification services it talks to change all the time\. If you find any bugs, please make them known at: \fIhttps://github\.com/caronc/apprise/issues\fR
+.
+.SH "COPYRIGHT"
+Apprise is Copyright (C) 2019 Chris Caron \fIlead2gold@gmail\.com\fR

--- a/packaging/man/apprise.md
+++ b/packaging/man/apprise.md
@@ -1,0 +1,98 @@
+apprise(1) -- Push Notifications that work with just about every platform!
+==========================================================================
+
+## SYNOPSIS
+
+`apprise` [<options>...] <service-url>...<br>
+
+## DESCRIPTION
+
+**Apprise** allows you to send a notification to _almost all_ of the most
+popular notification services available to us today such as: Discord,
+Telegram, Pushbullet, Slack, Twitter, etc.
+
+  * One notification library to rule them all.
+  * A common and intuitive notification syntax.
+  * Supports the handling of images (to the notification services that will
+    accept them).
+
+## OPTIONS
+
+The Apprise options are as follows:
+
+  * `-b`, `--body=`<TEXT>:
+    Specify the message body. If no body is specified then content is read from
+    <stdin>.
+
+  * `-t`, `--title=`<TEXT>:
+    Specify the message title. This field is complete optional.
+
+  * `-c`, `--config=`<CONFIG-URL>:
+    Specify one or more configuration locations.
+
+  * `-n`, `--notification-type=`<TYPE>:
+    Specify the message type (default=info). Possible values are "info",
+    "success", "failure", and "warning".
+
+  * `-T`, `--theme=`THEME:
+    Specify the default theme.
+
+  * `-g`, `--tag=`TAG:
+    Specify one or more tags to filter which services to notify. Use multiple
+    **--tag** (**-g**) entries to `OR` the tags together and comma separated
+    to `AND` them. If no tags are specified then all services are notified.
+
+  * `-v`, `--verbose`:
+    The more of these you specify, the more verbose the output is.
+
+  * `-V`, `--version`:
+    Display the apprise version and exit.
+
+  * `--help`:
+    Show this message and exit.
+
+## SERVICE URLS
+
+There are to many service URL and combinations to list here. It's best to
+visit the [Apprise GitHub page][serviceurls] and see what's available.
+
+[serviceurls]: https://github.com/caronc/apprise
+
+## EXAMPLES
+
+Send a notification to as many servers as you want to specify as you can
+easily chain them together:
+
+    $ apprise -t 'my title' -b 'my notification body' \
+       'mailto://myemail:mypass@gmail.com' \
+       'pbul://o.gn5kj6nfhv736I7jC3cj3QLRiyhgl98b'
+
+If you don't specify a **--body** (**-b**) then stdin is used allowing you to
+use the tool as part of your every day administration:
+
+    $ cat /proc/cpuinfo | apprise -t 'cpu info' \
+        'mailto://myemail:mypass@gmail.com'
+
+Load in a configuration file which identifies all of your notification service
+URLs and notify them all:
+
+    $ apprise -t 'my title' -b 'my notification body' \
+       --config=~/apprise.yml
+
+Load in a configuration file from a remote server that identifies all of your
+notification service URLs and only notify the ones tagged as _devops_.
+
+    $ apprise -t 'my title' -b 'my notification body' \
+       --config=https://localhost/my/apprise/config \
+       -t devops
+
+## BUGS
+
+**Apprise** is written in Python with 100% test coverage; but it still makes
+it far from perfect since the notification services it talks to change
+all the time. If you find any bugs, please make them known at:
+<https://github.com/caronc/apprise/issues>
+
+## COPYRIGHT
+
+Apprise is Copyright (C) 2019 Chris Caron <lead2gold@gmail.com>

--- a/packaging/redhat/apprise-remove-shebang-on-cli.patch
+++ b/packaging/redhat/apprise-remove-shebang-on-cli.patch
@@ -1,0 +1,8 @@
+diff -Naur apprise-0.7.4/apprise/cli.py apprise-0.7.4-patched/apprise/cli.py
+--- apprise-0.7.4/apprise/cli.py	2019-03-10 10:52:36.000000000 -0400
++++ apprise-0.7.4-patched/apprise/cli.py	2019-03-13 19:20:31.284335462 -0400
+@@ -1,4 +1,3 @@
+-#!/usr/bin/env python
+ # -*- coding: utf-8 -*-
+ 
+ # Copyright (C) 2019 Chris Caron <lead2gold@gmail.com>

--- a/packaging/redhat/apprise-rhel7-support.patch
+++ b/packaging/redhat/apprise-rhel7-support.patch
@@ -1,0 +1,36 @@
+diff -Naur apprise-0.7.4/test/test_config_http.py apprise-0.7.4-patched/test/test_config_http.py
+--- apprise-0.7.4/test/test_config_http.py	2019-03-05 19:39:56.000000000 -0500
++++ apprise-0.7.4-patched/test/test_config_http.py	2019-03-12 18:58:01.796635838 -0400
+@@ -44,8 +44,6 @@
+         0, 'requests.RequestException() not handled'),
+     requests.HTTPError(
+         0, 'requests.HTTPError() not handled'),
+-    requests.ReadTimeout(
+-        0, 'requests.ReadTimeout() not handled'),
+     requests.TooManyRedirects(
+         0, 'requests.TooManyRedirects() not handled'),
+ )
+diff -Naur apprise-0.7.4/test/test_glib_plugin.py apprise-0.7.4-patched/test/test_glib_plugin.py
+--- apprise-0.7.4/test/test_glib_plugin.py	2019-03-05 19:39:56.000000000 -0500
++++ apprise-0.7.4-patched/test/test_glib_plugin.py	2019-03-12 18:59:32.764545807 -0400
+@@ -47,7 +47,7 @@
+ 
+ if 'dbus' not in sys.modules:
+     # Environment doesn't allow for dbus
+-    pytest.skip("Skipping dbus-python based tests", allow_module_level=True)
++    pytest.skip("Skipping dbus-python based tests")
+ 
+ 
+ @mock.patch('dbus.SessionBus')
+diff -Naur apprise-0.7.4/test/test_rest_plugins.py apprise-0.7.4-patched/test/test_rest_plugins.py
+--- apprise-0.7.4/test/test_rest_plugins.py	2019-03-10 14:28:40.000000000 -0400
++++ apprise-0.7.4-patched/test/test_rest_plugins.py	2019-03-12 18:58:08.538542247 -0400
+@@ -51,8 +51,6 @@
+         0, 'requests.RequestException() not handled'),
+     requests.HTTPError(
+         0, 'requests.HTTPError() not handled'),
+-    requests.ReadTimeout(
+-        0, 'requests.ReadTimeout() not handled'),
+     requests.TooManyRedirects(
+         0, 'requests.TooManyRedirects() not handled'),
+ )

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -1,0 +1,268 @@
+# Copyright (C) 2019 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+###############################################################################
+%global with_python2 1
+%global with_python3 1
+
+%if 0%{?fedora} || 0%{?rhel} >= 8
+# Python v2 Support dropped
+%global with_python2 0
+%endif # fedora and/or rhel7
+
+%if 0%{?_module_build}
+%bcond_with tests
+%else
+# When bootstrapping Python, we cannot test this yet
+%bcond_without tests
+%endif # module_build
+
+%if 0%{?rhel} && 0%{?rhel} <= 7
+%global with_python3 0
+%endif # using rhel7
+
+Name:           python-apprise
+Version:        0.7.4
+Release:        1%{?dist}
+Summary:        A simple wrapper to many popular notification services used today
+License:        MIT
+URL:            https://github.com/caronc/apprise
+Source0:        %{url}/archive/v%{version}/apprise-%{version}.tar.gz
+# A simple man page to help with rpmlint. Future versions of apprise would not
+# require this entry as it will be part of the distribution going forward.
+# this man page was added as part of the Fedora review process
+Source1:        apprise.1
+# this patch allows version of requests that ships with RHEL v7 to
+# correctly handle test coverage.  It also removes reference to a
+# extra check not supported in py.test in EPEL7 builds
+Patch0:         apprise-rhel7-support.patch
+# This patch was discovered during a public review made on this package
+# with the fedora packaging team.  Rather then spin a new release, this
+# patch will allow the cli she-bang details to be set correctly; they should
+# hae never been hardcoded in the first place.  This will be removed in
+# the next release
+Patch1:         apprise-remove-shebang-on-cli.patch
+BuildArch:      noarch
+
+%description
+Apprise is a Python package for simplifying access to all of the different
+notification services that are out there. Apprise opens the door and makes
+it easy to access:
+
+Boxcar, Discord, E-Mail, Emby, Faast, Growl, IFTTT, Join, KODI, MatterMost,
+Matrix, Notify My Android, Prowl, Pushalot, PushBullet, Pushjet, Pushover,
+Rocket.Chat, Slack, Super Toasty, Stride, Telegram, Twitter, XBMC
+
+%if 0%{?with_python2}
+%package -n python2-apprise
+Summary: A simple wrapper to many popular notification services used today
+%{?python_provide:%python_provide python2-apprise}
+
+BuildRequires: python2-devel
+BuildRequires: python-decorator
+BuildRequires: python-requests
+BuildRequires: python2-requests-oauthlib
+BuildRequires: python2-oauthlib
+BuildRequires: python-six
+BuildRequires: python2-click >= 5.0
+BuildRequires: python-markdown
+%if 0%{?rhel} && 0%{?rhel} <= 7
+BuildRequires: python-yaml
+%else
+BuildRequires: python2-yaml
+%endif # using rhel7
+
+Requires: python-decorator
+Requires: python-requests
+Requires: python2-requests-oauthlib
+Requires: python2-oauthlib
+Requires: python-six
+Requires: python-markdown
+%if 0%{?rhel} && 0%{?rhel} <= 7
+BuildRequires: python-yaml
+%else
+Requires: python2-yaml
+%endif # using rhel7
+
+%if %{with tests}
+BuildRequires: python-mock
+BuildRequires: python2-pytest-runner
+BuildRequires: python2-pytest
+
+%endif # with_tests
+
+%description -n python2-apprise
+Apprise is a Python package for simplifying access to all of the different
+notification services that are out there. Apprise opens the door and makes
+it easy to access:
+
+Boxcar, Discord, E-Mail, Emby, Faast, Growl, IFTTT, Join, KODI, MatterMost,
+Matrix, Notify My Android, Prowl, Pushalot, PushBullet, Pushjet, Pushover,
+Rocket.Chat, Slack, Super Toasty, Stride, Telegram, Twitter, XBMC
+%endif # with_python2
+
+%package -n apprise
+Summary: Apprise CLI Tool
+
+%if 0%{?with_python3}
+Requires: python%{python3_pkgversion}-click >= 5.0
+Requires: python%{python3_pkgversion}-apprise = %{version}-%{release}
+%endif # with_python3
+
+%if 0%{?with_python2}
+Requires: python2-click >= 5.0
+Requires: python2-apprise = %{version}-%{release}
+%endif # with_python2
+
+%description -n apprise
+An accompanied CLI tool that can be used as part of Apprise
+to issue notifications from the command line to you favorite
+services.
+
+%if 0%{?with_python3}
+%package -n python%{python3_pkgversion}-apprise
+Summary: A simple wrapper to many popular notification services used today
+%{?python_provide:%python_provide python%{python3_pkgversion}-apprise}
+
+BuildRequires: python%{python3_pkgversion}-devel
+BuildRequires: python%{python3_pkgversion}-decorator
+BuildRequires: python%{python3_pkgversion}-requests
+BuildRequires: python%{python3_pkgversion}-requests-oauthlib
+BuildRequires: python%{python3_pkgversion}-oauthlib
+BuildRequires: python%{python3_pkgversion}-six
+BuildRequires: python%{python3_pkgversion}-click >= 5.0
+BuildRequires: python%{python3_pkgversion}-markdown
+BuildRequires: python%{python3_pkgversion}-yaml
+Requires: python%{python3_pkgversion}-decorator
+Requires: python%{python3_pkgversion}-requests
+Requires: python%{python3_pkgversion}-requests-oauthlib
+Requires: python%{python3_pkgversion}-oauthlib
+Requires: python%{python3_pkgversion}-six
+Requires: python%{python3_pkgversion}-markdown
+Requires: python%{python3_pkgversion}-yaml
+
+%if %{with tests}
+BuildRequires: python%{python3_pkgversion}-mock
+BuildRequires: python%{python3_pkgversion}-pytest
+BuildRequires: python%{python3_pkgversion}-pytest-runner
+%endif # with_tests
+
+%description -n python%{python3_pkgversion}-apprise
+Apprise is a Python package for simplifying access to all of the different
+notification services that are out there. Apprise opens the door and makes
+it easy to access:
+
+Boxcar, Discord, E-Mail, Emby, Faast, Growl, IFTTT, Join, KODI, MatterMost,
+Matrix, Notify My Android, Prowl, Pushalot, PushBullet, Pushjet, Pushover,
+Rocket.Chat, Slack, Super Toasty, Stride, Telegram, Twitter, XBMC
+%endif # with_python3
+
+%prep
+%setup -q -n apprise-%{version}
+%if 0%{?rhel} && 0%{?rhel} <= 7
+# rhel7 older package work-arounds
+%patch0 -p1
+%endif # using rhel7
+# Remove shebang
+%patch1 -p1
+
+%build
+%if 0%{?with_python2}
+%py2_build
+%endif # with_python2
+%if 0%{?with_python3}
+%py3_build
+%endif # with_python3
+
+%install
+%if 0%{?with_python2}
+%py2_install
+%endif # with_python2
+%if 0%{?with_python3}
+%py3_install
+%endif # with_python3
+
+# Install man page
+# Future versions will look like this:
+# install -p -D -T -m 0644 packages/man/apprise.1 \
+#   %{buildroot}%{_mandir}/man1/apprise.1
+#
+# For now:
+install -p -D -T -m 0644 %{SOURCE1} \
+   %{buildroot}%{_mandir}/man1/apprise.1
+
+%if %{with tests}
+%check
+%if 0%{?with_python2}
+LANG=C.UTF-8 PYTHONPATH=%{buildroot}%{python2_sitelib} py.test
+%endif # with_python2
+%if 0%{?with_python3}
+LANG=C.UTF-8 PYTHONPATH=%{buildroot}%{python3_sitelib} py.test-%{python3_version}
+%endif # with_python3
+%endif # with_tests
+
+%if 0%{?with_python2}
+%files -n python2-apprise
+%license LICENSE
+%doc README.md
+%{python2_sitelib}/apprise
+%exclude %{python2_sitelib}/apprise/cli.*
+%{python2_sitelib}/*.egg-info
+%endif # with_python2
+
+%if 0%{?with_python3}
+%files -n python%{python3_pkgversion}-apprise
+%license LICENSE
+%doc README.md
+%{python3_sitelib}/apprise
+%exclude %{python3_sitelib}/apprise/cli.*
+%{python3_sitelib}/*.egg-info
+%endif # with_python3
+
+%files -n apprise
+%{_bindir}/apprise
+%{_mandir}/man1/apprise.1*
+
+%if 0%{?with_python3}
+%{python3_sitelib}/apprise/cli.*
+%endif # with_python3
+
+%if 0%{?with_python2}
+%{python2_sitelib}/apprise/cli.*
+%endif # with_python2
+
+%changelog
+* Sun Mar 10 2019 Chris Caron <lead2gold@gmail.com> - 0.7.4-1
+- Updated to v0.7.4
+- Fedora review process added a man page, spec restructuring and 2 patch files
+  to accomodate some valid points brought forth. These have already been pused
+  upstream and will be removed on the next version.
+
+* Fri Feb 22 2019 Chris Caron <lead2gold@gmail.com> - 0.7.3-1
+- Updated to v0.7.3
+- Added Python 3 build support
+
+* Sun Sep  9 2018 Chris Caron <lead2gold@gmail.com> - 0.5.0-1
+- Updated to v0.5.0
+
+* Sun Mar 11 2018 Chris Caron <lead2gold@gmail.com> - 0.0.8-1
+- Initial Release


### PR DESCRIPTION
- Joined Fedora Package Team ([BZ1687178](https://bugzilla.redhat.com/show_bug.cgi?id=1687178))
- Got sponsored after doing some package reviews and making many changes to the RPM SPEC file to pass approval. :tada:
- Adds a man page as part of the build process and a few patch files to accommodate some issues (already fixed now)
- Pushed Apprise RPM packages upstream to Fedora rawhide, f30, f29 and EL7 (EPEL7). These are all still in the approval process and could go either way at this point.

This pull request just places the SPEC file in with the repository for easier management.
