### PR TITLE
normalize plugin classes mass code cleanup

### DIFF
--- a/apprise/plugins/NotifyBase.py
+++ b/apprise/plugins/NotifyBase.py
@@ -33,9 +33,6 @@ from ..common import NOTIFY_FORMATS
 from ..common import OverflowMode
 from ..common import OVERFLOW_MODES
 
-# HTML New Line Delimiter
-NOTIFY_NEWLINE = '\r\n'
-
 
 class NotifyBase(URLBase):
     """
@@ -94,12 +91,10 @@ class NotifyBase(URLBase):
             # Store the specified format if specified
             notify_format = kwargs.get('format', '')
             if notify_format.lower() not in NOTIFY_FORMATS:
-                self.logger.error(
-                    'Invalid notification format %s' % notify_format,
-                )
-                raise TypeError(
-                    'Invalid notification format %s' % notify_format,
-                )
+                msg = 'Invalid notification format %s'.format(notify_format)
+                self.logger.error(msg)
+                raise TypeError(msg)
+
             # Provide override
             self.notify_format = notify_format
 
@@ -107,12 +102,10 @@ class NotifyBase(URLBase):
             # Store the specified format if specified
             overflow = kwargs.get('overflow', '')
             if overflow.lower() not in OVERFLOW_MODES:
-                self.logger.error(
-                    'Invalid overflow method %s' % overflow,
-                )
-                raise TypeError(
-                    'Invalid overflow method %s' % overflow,
-                )
+                msg = 'Invalid overflow method {}'.format(overflow)
+                self.logger.error(msg)
+                raise TypeError(msg)
+
             # Provide override
             self.overflow_mode = overflow
 

--- a/apprise/plugins/NotifyEmby.py
+++ b/apprise/plugins/NotifyEmby.py
@@ -96,9 +96,10 @@ class NotifyEmby(NotifyBase):
         self.modal = modal
 
         if not self.user:
-            # Token was None
-            self.logger.warning('No Username was specified.')
-            raise TypeError('No Username was specified.')
+            # User was not specified
+            msg = 'No Username was specified.'
+            self.logger.warning(msg)
+            raise TypeError(msg)
 
         return
 
@@ -169,7 +170,7 @@ class NotifyEmby(NotifyBase):
             if r.status_code != requests.codes.ok:
                 # We had a problem
                 status_str = \
-                    NotifyBase.http_response_code_lookup(r.status_code)
+                    NotifyEmby.http_response_code_lookup(r.status_code)
 
                 self.logger.warning(
                     'Failed to authenticate Emby user {} details: '
@@ -329,7 +330,7 @@ class NotifyEmby(NotifyBase):
             if r.status_code != requests.codes.ok:
                 # We had a problem
                 status_str = \
-                    NotifyBase.http_response_code_lookup(r.status_code)
+                    NotifyEmby.http_response_code_lookup(r.status_code)
 
                 self.logger.warning(
                     'Failed to acquire Emby session for user {}: '
@@ -412,7 +413,7 @@ class NotifyEmby(NotifyBase):
 
                 # We had a problem
                 status_str = \
-                    NotifyBase.http_response_code_lookup(r.status_code)
+                    NotifyEmby.http_response_code_lookup(r.status_code)
 
                 self.logger.warning(
                     'Failed to logoff Emby user {}: '
@@ -508,7 +509,7 @@ class NotifyEmby(NotifyBase):
                         requests.codes.no_content):
                     # We had a problem
                     status_str = \
-                        NotifyBase.http_response_code_lookup(r.status_code)
+                        NotifyEmby.http_response_code_lookup(r.status_code)
 
                     self.logger.warning(
                         'Failed to send Emby notification: '
@@ -555,21 +556,21 @@ class NotifyEmby(NotifyBase):
         auth = ''
         if self.user and self.password:
             auth = '{user}:{password}@'.format(
-                user=self.quote(self.user, safe=''),
-                password=self.quote(self.password, safe=''),
+                user=NotifyEmby.quote(self.user, safe=''),
+                password=NotifyEmby.quote(self.password, safe=''),
             )
         else:  # self.user is set
             auth = '{user}@'.format(
-                user=self.quote(self.user, safe=''),
+                user=NotifyEmby.quote(self.user, safe=''),
             )
 
         return '{schema}://{auth}{hostname}{port}/?{args}'.format(
             schema=self.secure_protocol if self.secure else self.protocol,
             auth=auth,
-            hostname=self.host,
+            hostname=NotifyEmby.quote(self.host, safe=''),
             port='' if self.port is None or self.port == self.emby_default_port
                  else ':{}'.format(self.port),
-            args=self.urlencode(args),
+            args=NotifyEmby.urlencode(args),
         )
 
     @property

--- a/apprise/plugins/NotifyPushjet/__init__.py
+++ b/apprise/plugins/NotifyPushjet/__init__.py
@@ -62,6 +62,12 @@ class NotifyPushjet(NotifyBase):
         """
         super(NotifyPushjet, self).__init__(**kwargs)
 
+        if not secret_key:
+            # You must provide a Pushjet key to work with
+            msg = 'You must specify a Pushjet Secret Key.'
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
         # store our key
         self.secret_key = secret_key
 
@@ -107,11 +113,11 @@ class NotifyPushjet(NotifyBase):
 
         return '{schema}://{secret_key}@{hostname}{port}/?{args}'.format(
             schema=self.secure_protocol if self.secure else self.protocol,
-            secret_key=self.quote(self.secret_key, safe=''),
-            hostname=self.host,
+            secret_key=NotifyPushjet.quote(self.secret_key, safe=''),
+            hostname=NotifyPushjet.quote(self.host, safe=''),
             port='' if self.port is None or self.port == default_port
                  else ':{}'.format(self.port),
-            args=self.urlencode(args),
+            args=NotifyPushjet.urlencode(args),
         )
 
     @staticmethod
@@ -133,11 +139,8 @@ class NotifyPushjet(NotifyBase):
             # We're done early as we couldn't load the results
             return results
 
-        if not results.get('user'):
-            # a username is required
-            return None
-
         # Store it as it's value
-        results['secret_key'] = results.get('user')
+        results['secret_key'] = \
+            NotifyPushjet.unquote(results.get('user'))
 
         return results

--- a/test/test_gitter_plugin.py
+++ b/test/test_gitter_plugin.py
@@ -101,6 +101,7 @@ def test_notify_gitter_plugin_general(mock_post, mock_get):
     obj = plugins.NotifyGitter(token=token, targets='apprise')
     assert isinstance(obj, plugins.NotifyGitter) is True
     assert isinstance(obj.url(), six.string_types) is True
+
     # apprise room was found
     assert obj.send(body="test") is True
 

--- a/test/test_glib_plugin.py
+++ b/test/test_glib_plugin.py
@@ -176,6 +176,87 @@ def test_dbus_plugin(mock_mainloop, mock_byte, mock_bytearray,
     assert(obj.notify(title='', body='body',
            notify_type=apprise.NotifyType.INFO) is True)
 
+    # Test our arguments through the instantiate call
+    obj = apprise.Apprise.instantiate(
+        'dbus://_/?image=True', suppress_exceptions=False)
+    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
+    assert(isinstance(obj.url(), six.string_types) is True)
+    assert(obj.notify(title='title', body='body',
+           notify_type=apprise.NotifyType.INFO) is True)
+
+    obj = apprise.Apprise.instantiate(
+        'dbus://_/?image=False', suppress_exceptions=False)
+    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
+    assert(isinstance(obj.url(), six.string_types) is True)
+    assert(obj.notify(title='title', body='body',
+           notify_type=apprise.NotifyType.INFO) is True)
+
+    # Test priority (alias to urgency) handling
+    obj = apprise.Apprise.instantiate(
+        'dbus://_/?priority=invalid', suppress_exceptions=False)
+    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
+    assert(isinstance(obj.url(), six.string_types) is True)
+    assert(obj.notify(title='title', body='body',
+           notify_type=apprise.NotifyType.INFO) is True)
+
+    obj = apprise.Apprise.instantiate(
+        'dbus://_/?priority=high', suppress_exceptions=False)
+    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
+    assert(isinstance(obj.url(), six.string_types) is True)
+    assert(obj.notify(title='title', body='body',
+           notify_type=apprise.NotifyType.INFO) is True)
+
+    obj = apprise.Apprise.instantiate(
+        'dbus://_/?priority=2', suppress_exceptions=False)
+    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
+    assert(isinstance(obj.url(), six.string_types) is True)
+    assert(obj.notify(title='title', body='body',
+           notify_type=apprise.NotifyType.INFO) is True)
+
+    # Test urgency handling
+    obj = apprise.Apprise.instantiate(
+        'dbus://_/?urgency=invalid', suppress_exceptions=False)
+    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
+    assert(isinstance(obj.url(), six.string_types) is True)
+    assert(obj.notify(title='title', body='body',
+           notify_type=apprise.NotifyType.INFO) is True)
+
+    obj = apprise.Apprise.instantiate(
+        'dbus://_/?urgency=high', suppress_exceptions=False)
+    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
+    assert(isinstance(obj.url(), six.string_types) is True)
+    assert(obj.notify(title='title', body='body',
+           notify_type=apprise.NotifyType.INFO) is True)
+
+    obj = apprise.Apprise.instantiate(
+        'dbus://_/?urgency=2', suppress_exceptions=False)
+    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
+    assert(isinstance(obj.url(), six.string_types) is True)
+    assert(obj.notify(title='title', body='body',
+           notify_type=apprise.NotifyType.INFO) is True)
+
+    obj = apprise.Apprise.instantiate(
+        'dbus://_/?urgency=', suppress_exceptions=False)
+    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
+    assert(isinstance(obj.url(), six.string_types) is True)
+    assert(obj.notify(title='title', body='body',
+           notify_type=apprise.NotifyType.INFO) is True)
+
+    # Test x/y
+    obj = apprise.Apprise.instantiate(
+        'dbus://_/?x=5&y=5', suppress_exceptions=False)
+    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
+    assert(isinstance(obj.url(), six.string_types) is True)
+    assert(obj.notify(title='title', body='body',
+           notify_type=apprise.NotifyType.INFO) is True)
+
+    obj = apprise.Apprise.instantiate(
+        'dbus://_/?x=invalid&y=invalid', suppress_exceptions=False)
+    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
+    assert(isinstance(obj.url(), six.string_types) is True)
+    assert(obj.notify(title='title', body='body',
+           notify_type=apprise.NotifyType.INFO) is True)
+
     # If our underlining object throws for whatever reason, we will
     # gracefully fail
     mock_notify = mock.Mock()

--- a/test/test_gnome_plugin.py
+++ b/test/test_gnome_plugin.py
@@ -116,24 +116,80 @@ def test_gnome_plugin():
     obj.duration = 0
 
     # Check that it found our mocked environments
-    assert(obj._enabled is True)
+    assert obj._enabled is True
 
     # Test url() call
-    assert(isinstance(obj.url(), six.string_types) is True)
+    assert isinstance(obj.url(), six.string_types) is True
 
     # test notifications
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert obj.notify(title='title', body='body',
+                      notify_type=apprise.NotifyType.INFO) is True
 
     # test notification without a title
-    assert(obj.notify(title='', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert obj.notify(title='', body='body',
+                      notify_type=apprise.NotifyType.INFO) is True
+
+    obj = apprise.Apprise.instantiate(
+        'gnome://_/?image=True', suppress_exceptions=False)
+    assert isinstance(obj, apprise.plugins.NotifyGnome) is True
+    assert obj.notify(title='title', body='body',
+                      notify_type=apprise.NotifyType.INFO) is True
+
+    obj = apprise.Apprise.instantiate(
+        'gnome://_/?image=False', suppress_exceptions=False)
+    assert isinstance(obj, apprise.plugins.NotifyGnome) is True
+    assert obj.notify(title='title', body='body',
+                      notify_type=apprise.NotifyType.INFO) is True
+
+    # Test Priority (alias of urgency)
+    obj = apprise.Apprise.instantiate(
+        'gnome://_/?priority=invalid', suppress_exceptions=False)
+    assert isinstance(obj, apprise.plugins.NotifyGnome) is True
+    assert obj.urgency == 1
+    assert obj.notify(title='title', body='body',
+                      notify_type=apprise.NotifyType.INFO) is True
+
+    obj = apprise.Apprise.instantiate(
+        'gnome://_/?priority=high', suppress_exceptions=False)
+    assert isinstance(obj, apprise.plugins.NotifyGnome) is True
+    assert obj.urgency == 2
+    assert obj.notify(title='title', body='body',
+                      notify_type=apprise.NotifyType.INFO) is True
+
+    obj = apprise.Apprise.instantiate(
+        'gnome://_/?priority=2', suppress_exceptions=False)
+    assert isinstance(obj, apprise.plugins.NotifyGnome) is True
+    assert obj.urgency == 2
+    assert obj.notify(title='title', body='body',
+                      notify_type=apprise.NotifyType.INFO) is True
+
+    # Test Urgeny
+    obj = apprise.Apprise.instantiate(
+        'gnome://_/?urgency=invalid', suppress_exceptions=False)
+    assert obj.urgency == 1
+    assert isinstance(obj, apprise.plugins.NotifyGnome) is True
+    assert obj.notify(title='title', body='body',
+                      notify_type=apprise.NotifyType.INFO) is True
+
+    obj = apprise.Apprise.instantiate(
+        'gnome://_/?urgency=high', suppress_exceptions=False)
+    assert obj.urgency == 2
+    assert isinstance(obj, apprise.plugins.NotifyGnome) is True
+    assert obj.notify(title='title', body='body',
+                      notify_type=apprise.NotifyType.INFO) is True
+
+    obj = apprise.Apprise.instantiate(
+        'gnome://_/?urgency=2', suppress_exceptions=False)
+    assert isinstance(obj, apprise.plugins.NotifyGnome) is True
+    assert obj.urgency == 2
+    assert obj.notify(title='title', body='body',
+                      notify_type=apprise.NotifyType.INFO) is True
 
     # Test our loading of our icon exception; it will still allow the
     # notification to be sent
     mock_pixbuf.new_from_file.side_effect = AttributeError()
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert obj.notify(title='title', body='body',
+                      notify_type=apprise.NotifyType.INFO) is True
     # Undo our change
     mock_pixbuf.new_from_file.side_effect = None
 
@@ -142,8 +198,8 @@ def test_gnome_plugin():
         .Notification.new.return_value = None
     sys.modules['gi.repository.Notify']\
         .Notification.new.side_effect = AttributeError()
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is False)
+    assert obj.notify(title='title', body='body',
+                      notify_type=apprise.NotifyType.INFO) is False
 
     # Undo our change
     sys.modules['gi.repository.Notify']\
@@ -152,11 +208,11 @@ def test_gnome_plugin():
     # Toggle our testing for when we can't send notifications because the
     # package has been made unavailable to us
     obj._enabled = False
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is False)
+    assert obj.notify(title='title', body='body',
+                      notify_type=apprise.NotifyType.INFO) is False
 
-    # Test the setting of a the urgency
-    apprise.plugins.NotifyGnome(urgency=0)
+    # Test the setting of a the urgency (through priority keyword)
+    apprise.plugins.NotifyGnome(priority=0)
 
     # Verify this all works in the event a ValueError is also thronw
     # out of the call to gi.require_version()
@@ -178,10 +234,10 @@ def test_gnome_plugin():
 
     # Create our instance
     obj = apprise.Apprise.instantiate('gnome://', suppress_exceptions=False)
-    assert(isinstance(obj, apprise.plugins.NotifyGnome) is True)
+    assert isinstance(obj, apprise.plugins.NotifyGnome) is True
     obj.duration = 0
 
     # Our notifications can not work without our gi library having been
     # loaded.
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is False)
+    assert obj.notify(title='title', body='body',
+                      notify_type=apprise.NotifyType.INFO) is False

--- a/test/test_matrix_plugin.py
+++ b/test/test_matrix_plugin.py
@@ -61,25 +61,25 @@ def test_notify_matrix_plugin_general(mock_post, mock_get):
     mock_post.return_value = request
 
     # Variation Initializations
-    obj = plugins.NotifyMatrix(rooms='#abcd')
+    obj = plugins.NotifyMatrix(targets='#abcd')
     assert isinstance(obj, plugins.NotifyMatrix) is True
     assert isinstance(obj.url(), six.string_types) is True
     # Registration successful
     assert obj.send(body="test") is True
 
-    obj = plugins.NotifyMatrix(user='user', rooms='#abcd')
+    obj = plugins.NotifyMatrix(user='user', targets='#abcd')
     assert isinstance(obj, plugins.NotifyMatrix) is True
     assert isinstance(obj.url(), six.string_types) is True
     # Registration successful
     assert obj.send(body="test") is True
 
-    obj = plugins.NotifyMatrix(password='passwd', rooms='#abcd')
+    obj = plugins.NotifyMatrix(password='passwd', targets='#abcd')
     assert isinstance(obj, plugins.NotifyMatrix) is True
     assert isinstance(obj.url(), six.string_types) is True
     # A username gets automatically generated in these cases
     assert obj.send(body="test") is True
 
-    obj = plugins.NotifyMatrix(user='user', password='passwd', rooms='#abcd')
+    obj = plugins.NotifyMatrix(user='user', password='passwd', targets='#abcd')
     assert isinstance(obj.url(), six.string_types) is True
     assert isinstance(obj, plugins.NotifyMatrix) is True
     # Registration Successful
@@ -94,17 +94,17 @@ def test_notify_matrix_plugin_general(mock_post, mock_get):
     # Fails because we couldn't register because of 404 errors
     assert obj.send(body="test") is False
 
-    obj = plugins.NotifyMatrix(user='test', rooms='#abcd')
+    obj = plugins.NotifyMatrix(user='test', targets='#abcd')
     assert isinstance(obj, plugins.NotifyMatrix) is True
     # Fails because we still couldn't register
     assert obj.send(user='test', password='passwd', body="test") is False
 
-    obj = plugins.NotifyMatrix(user='test', password='passwd', rooms='#abcd')
+    obj = plugins.NotifyMatrix(user='test', password='passwd', targets='#abcd')
     assert isinstance(obj, plugins.NotifyMatrix) is True
     # Fails because we still couldn't register
     assert obj.send(body="test") is False
 
-    obj = plugins.NotifyMatrix(password='passwd', rooms='#abcd')
+    obj = plugins.NotifyMatrix(password='passwd', targets='#abcd')
     # Fails because we still couldn't register
     assert isinstance(obj, plugins.NotifyMatrix) is True
     assert obj.send(body="test") is False
@@ -132,7 +132,7 @@ def test_notify_matrix_plugin_general(mock_post, mock_get):
     request.content = dumps(response_obj)
     request.status_code = requests.codes.ok
 
-    obj = plugins.NotifyMatrix(rooms=None)
+    obj = plugins.NotifyMatrix(targets=None)
     assert isinstance(obj, plugins.NotifyMatrix) is True
 
     # Force a empty joined list response
@@ -191,7 +191,8 @@ def test_notify_matrix_plugin_fetch(mock_post, mock_get):
     mock_get.side_effect = fetch_failed
     mock_post.side_effect = fetch_failed
 
-    obj = plugins.NotifyMatrix(user='user', password='passwd', thumbnail=True)
+    obj = plugins.NotifyMatrix(
+        user='user', password='passwd', include_image=True)
     assert isinstance(obj, plugins.NotifyMatrix) is True
     # We would hve failed to send our image notification
     assert obj.send(user='test', password='passwd', body="test") is False
@@ -518,3 +519,23 @@ def test_notify_matrix_plugin_rooms(mock_post, mock_get):
     request.status_code = 403
     obj._room_cache = {}
     assert obj._room_id('#abc123:localhost') is None
+
+
+def test_notify_matrix_url_parsing():
+    """
+    API: NotifyMatrix() URL Testing
+
+    """
+    result = plugins.NotifyMatrix.parse_url(
+        'matrix://user:token@localhost?to=#room')
+    assert isinstance(result, dict) is True
+    assert len(result['targets']) == 1
+    assert '#room' in result['targets']
+
+    result = plugins.NotifyMatrix.parse_url(
+        'matrix://user:token@localhost?to=#room1,#room2,#room3')
+    assert isinstance(result, dict) is True
+    assert len(result['targets']) == 3
+    assert '#room1' in result['targets']
+    assert '#room2' in result['targets']
+    assert '#room3' in result['targets']

--- a/test/test_pushjet_plugin.py
+++ b/test/test_pushjet_plugin.py
@@ -45,9 +45,12 @@ TEST_URLS = (
     ('pjets://', {
         'instance': None,
     }),
+    ('pjet://:@/', {
+        'instance': None,
+    }),
     #  You must specify a username
     ('pjet://%s' % ('a' * 32), {
-        'instance': None,
+        'instance': TypeError,
     }),
     # Specify your own server
     ('pjet://%s@localhost' % ('a' * 32), {
@@ -56,9 +59,6 @@ TEST_URLS = (
     # Specify your own server with port
     ('pjets://%s@localhost:8080' % ('a' * 32), {
         'instance': plugins.NotifyPushjet,
-    }),
-    ('pjet://:@/', {
-        'instance': None,
     }),
     ('pjet://%s@localhost:8081' % ('a' * 32), {
         'instance': plugins.NotifyPushjet,

--- a/test/test_sns_plugin.py
+++ b/test/test_sns_plugin.py
@@ -51,7 +51,7 @@ def test_object_initialization():
             access_key_id=None,
             secret_access_key=TEST_ACCESS_KEY_SECRET,
             region_name=TEST_REGION,
-            recipients='+1800555999',
+            targets='+1800555999',
         )
         # The entries above are invalid, our code should never reach here
         assert(False)
@@ -66,7 +66,7 @@ def test_object_initialization():
             access_key_id=TEST_ACCESS_KEY_ID,
             secret_access_key=None,
             region_name=TEST_REGION,
-            recipients='+1800555999',
+            targets='+1800555999',
         )
         # The entries above are invalid, our code should never reach here
         assert(False)
@@ -81,7 +81,7 @@ def test_object_initialization():
             access_key_id=TEST_ACCESS_KEY_ID,
             secret_access_key=TEST_ACCESS_KEY_SECRET,
             region_name=None,
-            recipients='+1800555999',
+            targets='+1800555999',
         )
         # The entries above are invalid, our code should never reach here
         assert(False)
@@ -96,7 +96,7 @@ def test_object_initialization():
             access_key_id=TEST_ACCESS_KEY_ID,
             secret_access_key=TEST_ACCESS_KEY_SECRET,
             region_name=TEST_REGION,
-            recipients=None,
+            targets=None,
         )
         # Still valid even without recipients
         assert(True)
@@ -111,7 +111,7 @@ def test_object_initialization():
             access_key_id=TEST_ACCESS_KEY_ID,
             secret_access_key=TEST_ACCESS_KEY_SECRET,
             region_name=TEST_REGION,
-            recipients=object(),
+            targets=object(),
         )
         # Still valid even without recipients
         assert(True)
@@ -127,7 +127,7 @@ def test_object_initialization():
             access_key_id=TEST_ACCESS_KEY_ID,
             secret_access_key=TEST_ACCESS_KEY_SECRET,
             region_name=TEST_REGION,
-            recipients='+1809',
+            targets='+1809',
         )
         # The recipient is invalid, but it's still okay; this Notification
         # still becomes pretty much useless at this point though
@@ -144,7 +144,7 @@ def test_object_initialization():
             access_key_id=TEST_ACCESS_KEY_ID,
             secret_access_key=TEST_ACCESS_KEY_SECRET,
             region_name=TEST_REGION,
-            recipients='#(invalid-topic-because-of-the-brackets)',
+            targets='#(invalid-topic-because-of-the-brackets)',
         )
         # The recipient is invalid, but it's still okay; this Notification
         # still becomes pretty much useless at this point though
@@ -169,7 +169,7 @@ def test_url_parsing():
     )
 
     # Confirm that there were no recipients found
-    assert(len(results['recipients']) == 0)
+    assert(len(results['targets']) == 0)
     assert('region_name' in results)
     assert(TEST_REGION == results['region_name'])
     assert('access_key_id' in results)
@@ -188,9 +188,9 @@ def test_url_parsing():
     )
 
     # Confirm that our recipients were found
-    assert(len(results['recipients']) == 2)
-    assert('+18001234567' in results['recipients'])
-    assert('MyTopic' in results['recipients'])
+    assert(len(results['targets']) == 2)
+    assert('+18001234567' in results['targets'])
+    assert('MyTopic' in results['targets'])
     assert('region_name' in results)
     assert(TEST_REGION == results['region_name'])
     assert('access_key_id' in results)

--- a/test/test_windows_plugin.py
+++ b/test/test_windows_plugin.py
@@ -125,6 +125,43 @@ def test_windows_plugin():
     assert(obj.notify(title='title', body='body',
            notify_type=apprise.NotifyType.INFO) is True)
 
+    obj = apprise.Apprise.instantiate(
+        'windows://_/?image=True', suppress_exceptions=False)
+    obj.duration = 0
+    assert(isinstance(obj.url(), six.string_types) is True)
+    assert(obj.notify(title='title', body='body',
+           notify_type=apprise.NotifyType.INFO) is True)
+
+    obj = apprise.Apprise.instantiate(
+        'windows://_/?image=False', suppress_exceptions=False)
+    obj.duration = 0
+    assert(isinstance(obj.url(), six.string_types) is True)
+    assert(obj.notify(title='title', body='body',
+           notify_type=apprise.NotifyType.INFO) is True)
+
+    obj = apprise.Apprise.instantiate(
+        'windows://_/?duration=1', suppress_exceptions=False)
+    assert(isinstance(obj.url(), six.string_types) is True)
+    assert(obj.notify(title='title', body='body',
+           notify_type=apprise.NotifyType.INFO) is True)
+    # loads okay
+    assert obj.duration == 1
+
+    obj = apprise.Apprise.instantiate(
+        'windows://_/?duration=invalid', suppress_exceptions=False)
+    # Falls back to default
+    assert obj.duration == obj.default_popup_duration_sec
+
+    obj = apprise.Apprise.instantiate(
+        'windows://_/?duration=-1', suppress_exceptions=False)
+    # Falls back to default
+    assert obj.duration == obj.default_popup_duration_sec
+
+    obj = apprise.Apprise.instantiate(
+        'windows://_/?duration=0', suppress_exceptions=False)
+    # Falls back to default
+    assert obj.duration == obj.default_popup_duration_sec
+
     # Test our loading of our icon exception; it will still allow the
     # notification to be sent
     win32gui.LoadImage.side_effect = AttributeError

--- a/test/test_xmpp_plugin.py
+++ b/test/test_xmpp_plugin.py
@@ -26,7 +26,7 @@
 import six
 import mock
 import sys
-# import types
+import ssl
 
 import apprise
 
@@ -128,6 +128,39 @@ def test_xmpp_plugin(tmpdir):
 
     # Not possible because no password was specified
     assert obj is None
+
+    # SSL Flags
+    if hasattr(ssl, "PROTOCOL_TLS"):
+        # Test cases where PROTOCOL_TLS simply isn't available
+        ssl_temp_swap = ssl.PROTOCOL_TLS
+        del ssl.PROTOCOL_TLS
+
+        # Test our URL
+        url = 'xmpps://user:pass@example.com'
+        obj = apprise.Apprise.instantiate(url, suppress_exceptions=False)
+        # Test we loaded
+        assert isinstance(obj, apprise.plugins.NotifyXMPP) is True
+        assert obj.notify(
+            title='title', body='body',
+            notify_type=apprise.NotifyType.INFO) is True
+
+        # Restore the variable for remaining tests
+        setattr(ssl, 'PROTOCOL_TLS', ssl_temp_swap)
+
+    else:
+        # Handle case where it is not missing
+        setattr(ssl, 'PROTOCOL_TLS', ssl.PROTOCOL_TLSv1)
+        # Test our URL
+        url = 'xmpps://user:pass@example.com'
+        obj = apprise.Apprise.instantiate(url, suppress_exceptions=False)
+        # Test we loaded
+        assert isinstance(obj, apprise.plugins.NotifyXMPP) is True
+        assert obj.notify(
+            title='title', body='body',
+            notify_type=apprise.NotifyType.INFO) is True
+
+        # Restore settings as they were
+        del ssl.PROTOCOL_TLS
 
     # Try Different Variations of our URL
     for url in (


### PR DESCRIPTION
- slight re-factoring of how exceptions are handled in each plugin during their initialization
- tried to make use of the **to=** arg variable everywhere possible to make entries in the YAML configuration easier to chain with
- normalized class variables as much as possible (re-using the same name where it fit). The idea here was to just tie references to *recipients*, *channels*, *rooms*, to a single reference of *targets*.  Not a lot is accomplished here except that the code looks much cleaner when jumping from class to class.
- proper quote()/unquote() calls on all plugins
- added **image=** directive in many missing plugins that supported it (and enabled it by default);  This is now an option wherever referenced.