### PR TITLE
Better handling of multiple URLs delimited by space/comma

### DIFF
--- a/apprise/Apprise.py
+++ b/apprise/Apprise.py
@@ -33,6 +33,7 @@ from .common import NotifyType
 from .common import NotifyFormat
 from .utils import is_exclusive_match
 from .utils import parse_list
+from .utils import split_urls
 from .utils import GET_SCHEMA_RE
 from .logger import logger
 
@@ -161,7 +162,9 @@ class Apprise(object):
 
         if isinstance(servers, six.string_types):
             # build our server list
-            servers = parse_list(servers)
+            servers = split_urls(servers)
+            if len(servers) == 0:
+                return False
 
         elif isinstance(servers, (ConfigBase, NotifyBase, AppriseConfig)):
             # Go ahead and just add our plugin into our list

--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -107,6 +107,10 @@ GET_EMAIL_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Regular expression used to destinguish between multiple URLs
+URL_DETECTION_RE = re.compile(
+    r'([a-z0-9]+?:\/\/.*?)[\s,]*(?=$|[a-z0-9]+?:\/\/)', re.I)
+
 
 def is_hostname(hostname):
     """
@@ -461,6 +465,28 @@ def parse_bool(arg, default=False):
 
     # Handle other types
     return bool(arg)
+
+
+def split_urls(urls):
+    """
+    Takes a string containing URLs separated by comma's and/or spaces and
+    returns a list.
+    """
+
+    try:
+        results = URL_DETECTION_RE.findall(urls)
+
+    except TypeError:
+        results = []
+
+    if len(results) > 0 and results[len(results) - 1][-1] != urls[-1]:
+        # we always want to save the end of url URL if we can; This handles
+        # cases where there is actually a comma (,) at the end of a single URL
+        # that would have otherwise got lost when our regex passed over it.
+        results[len(results) - 1] += \
+            re.match(r'.*?([\s,]+)?$', urls).group(1).rstrip()
+
+    return results
 
 
 def parse_list(*args):

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -318,6 +318,9 @@ def test_apprise_tagging(mock_post, mock_get):
     # Create our object
     a = Apprise()
 
+    # An invalid addition can't add the tag
+    assert(a.add('averyinvalidschema://localhost', tag='uhoh') is False)
+
     # Add entry and assign it to a tag called 'awesome'
     assert(a.add('json://localhost/path1/', tag='awesome') is True)
 


### PR DESCRIPTION
The current design (_before this pull request is applied_) allows a user to specify 1 or more URLs separated by comma's.   The problem is: the comma is also a delimiter from within a URL(s) as well.  For example:
```schema1://host?key=value1,value2,value3, schema2://host?password=test```
Would get split into the following (pre-this pull request):
1. `schema1://host?key=value1` :x: 
2. `value2` :x: 
3. `value3` :x:
4. `schema2://host?password=test` :white_check_mark: 

This only occurs if the actual URL has comma's in it (most URLs supported by apprise do not).  However #101 introduced a case where this was possible.

This patch attempts to decipher which comma's are inside a URL and which aren't and only split accordingly.  Hence with this Pull Request we'd have gotten the expected output (with respect to the example above):
1. `schema1://host?key=value1,value2,value3` :white_check_mark: 
2. `schema2://host?password=test` :white_check_mark:

This fix isn't 100% perfect as there is 1 side effect of this.  If your URL ends with a comma that is not a delimiter (thus it's expected to be here), it's not possible to know this is your intention.  While still PR is still a better state then before, unless the comma is in the last URL it will get removed.  As an example, here is how it works (and has it's caveat); a single URL ending with a comma is unaffected:
`http://hostname?password=abcd123,`

The comma at the end is okay (because it's the only URL and thus could be considered the last), it would get parsed exactly as expected (the password would be `abcd123,`). :white_check_mark: 

HOWEVER... if more then one URL is added (we'll use comma's as the last character to prove the point):
`http://hostname?password=abcd123, ,https://anotherhost?password=1234,`

The following would get parsed:
1. `http://hostname?password=abcd123` :x:  
2. `https://anotherhost?password=1234,` :white_check_mark: 

You'll notice the comma is lost on the first URL.  The odds of building a URL in a chain with several others where the one in the middle 'ends' with a comma you expect to keep is rare.  But it should just be worth noting this is still a side effect.

There are many ways to over-come these problems.
1. Pass in each URL seperately (and don't use comma separated)
   - You can do this via configuration files
   - If you're using the CLI, just pass in one string per URL, not one great big long string with a comma between each.
1. escape the comma in the URL (use **%2C**) in place of where the comma (,) should be.

Final thing to note is this pull request goes in to great length to explain that a comma as the last entry of the URL _could_ cause an issue.  Any other character would be fine. Overall this pull request does make the code much better.