### PR TITLE
Added default configuration paths for Microsoft users

### DIFF
--- a/apprise/cli.py
+++ b/apprise/cli.py
@@ -25,9 +25,11 @@
 
 import click
 import logging
+import platform
 import sys
 from os.path import isfile
 from os.path import expanduser
+from os.path import expandvars
 
 from . import NotifyType
 from . import Apprise
@@ -53,6 +55,16 @@ DEFAULT_SEARCH_PATHS = (
     '~/.config/apprise',
     '~/.config/apprise.yml',
 )
+
+# Detect Windows
+if platform.system() == 'Windows':
+    # Default Search Path for Windows Users
+    DEFAULT_SEARCH_PATHS = (
+        expandvars('%APPDATA%/Apprise/apprise'),
+        expandvars('%APPDATA%/Apprise/apprise.yml'),
+        expandvars('%LOCALAPPDATA%/Apprise/apprise'),
+        expandvars('%LOCALAPPDATA%/Apprise/apprise.yml'),
+    )
 
 
 def print_help_msg(command):

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -24,10 +24,22 @@
 # THE SOFTWARE.
 
 from __future__ import print_function
+import mock
 from apprise import cli
 from apprise import NotifyBase
 from click.testing import CliRunner
 from apprise.plugins import SCHEMA_MAP
+
+try:
+    # Python v3.4+
+    from importlib import reload
+except ImportError:
+    try:
+        # Python v3.0-v3.3
+        from imp import reload
+    except ImportError:
+        # Python v2.7
+        pass
 
 # Disable logging for a cleaner testing output
 import logging
@@ -157,3 +169,16 @@ def test_apprise_cli(tmpdir):
         '--tag', 'tagd',
     ])
     assert result.exit_code == 0
+
+
+@mock.patch('platform.system')
+def test_apprise_cli_windows_env(mock_system):
+    """
+    API: Apprise() CLI Windows Environment
+
+    """
+    # Force a windows environment
+    mock_system.return_value = 'Windows'
+
+    # Reload our module
+    reload(cli)


### PR DESCRIPTION
Added the following default search paths to the CLI too when the Operating System detected is Microsoft Windows:
* **%APPDATA%/Apprise/apprise**
* **%APPDATA%/Apprise/apprise.yml**
* **%LOCALAPPDATA%/Apprise/apprise**
* **%LOCALAPPDATA%/Apprise/apprise.yml**
