### PR TITLE
Token details + internationalization (i18n) support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,6 @@ coverage.xml
 
 # Translations
 *.mo
-*.pot
 
 # Django stuff:
 *.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
       env: TOXENV=pypy3
 
 install:
+  - pip install babel
   - pip install .
   - pip install codecov
   - pip install -r dev-requirements.txt

--- a/apprise/AppriseLocale.py
+++ b/apprise/AppriseLocale.py
@@ -1,0 +1,207 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import six
+import ctypes
+import locale
+import contextlib
+from os.path import join
+from os.path import dirname
+from os.path import abspath
+
+# Define our translation domain
+DOMAIN = 'apprise'
+LOCALE_DIR = abspath(join(dirname(__file__), 'i18n'))
+
+# This gets toggled to True if we succeed
+GETTEXT_LOADED = False
+
+try:
+    # Initialize gettext
+    import gettext
+
+    # install() creates a _() in our builtins
+    gettext.install(DOMAIN, localedir=LOCALE_DIR)
+
+    # Toggle our flag
+    GETTEXT_LOADED = True
+
+except ImportError:
+    # gettext isn't available; no problem, just fall back to using
+    # the library features without multi-language support.
+    try:
+        # Python v2.7
+        import __builtin__
+        __builtin__.__dict__['_'] = lambda x: x  # pragma: no branch
+
+    except ImportError:
+        # Python v3.4+
+        import builtins
+        builtins.__dict__['_'] = lambda x: x  # pragma: no branch
+
+
+class LazyTranslation(object):
+    """
+    Doesn't translate anything until str() or unicode() references
+    are made.
+
+    """
+    def __init__(self, text, *args, **kwargs):
+        """
+        Store our text
+        """
+        self.text = text
+
+        super(LazyTranslation, self).__init__(*args, **kwargs)
+
+    def __str__(self):
+        return gettext.gettext(self.text)
+
+
+# Lazy translation handling
+def gettext_lazy(text):
+    """
+    A dummy function that can be referenced
+    """
+    return LazyTranslation(text=text)
+
+
+class AppriseLocale(object):
+    """
+    A wrapper class to gettext so that we can manipulate multiple lanaguages
+    on the fly if required.
+
+    """
+
+    def __init__(self, language=None):
+        """
+        Initializes our object, if a language is specified, then we
+        initialize ourselves to that, otherwise we use whatever we detect
+        from the local operating system. If all else fails, we resort to the
+        defined default_language.
+
+        """
+
+        # Cache previously loaded translations
+        self._gtobjs = {}
+
+        # Get our language
+        self.lang = AppriseLocale.detect_language(language)
+
+        if GETTEXT_LOADED is False:
+            # We're done
+            return
+
+        if self.lang:
+            # Load our gettext object and install our language
+            try:
+                self._gtobjs[self.lang] = gettext.translation(
+                    DOMAIN, localedir=LOCALE_DIR, languages=[self.lang])
+
+                # Install our language
+                self._gtobjs[self.lang].install()
+
+            except IOError:
+                # This occurs if we can't access/load our translations
+                pass
+
+    @contextlib.contextmanager
+    def lang_at(self, lang):
+        """
+        The syntax works as:
+            with at.lang_at('fr'):
+                # apprise works as though the french language has been
+                # defined. afterwards, the language falls back to whatever
+                # it was.
+        """
+
+        if GETTEXT_LOADED is False:
+            # yield
+            yield
+
+            # we're done
+            return
+
+        # Tidy the language
+        lang = AppriseLocale.detect_language(lang, detect_fallback=False)
+
+        # Now attempt to load it
+        try:
+            if lang in self._gtobjs:
+                if lang != self.lang:
+                    # Install our language only if we aren't using it
+                    # already
+                    self._gtobjs[lang].install()
+
+            else:
+                self._gtobjs[lang] = gettext.translation(
+                    DOMAIN, localedir=LOCALE_DIR, languages=[self.lang])
+
+                # Install our language
+                self._gtobjs[lang].install()
+
+            # Yield
+            yield
+
+        except (IOError, KeyError):
+            # This occurs if we can't access/load our translations
+            # Yield reguardless
+            yield
+
+        finally:
+            # Fall back to our previous language
+            if lang != self.lang and lang in self._gtobjs:
+                # Install our language
+                self._gtobjs[self.lang].install()
+
+        return
+
+    @staticmethod
+    def detect_language(lang=None, detect_fallback=True):
+        """
+        returns the language (if it's retrievable)
+        """
+        # We want to only use the 2 character version of this language
+        # hence en_CA becomes en, en_US becomes en.
+        if not isinstance(lang, six.string_types):
+            if detect_fallback is False:
+                # no detection enabled; we're done
+                return None
+
+            if hasattr(ctypes, 'windll'):
+                windll = ctypes.windll.kernel32
+                lang = locale.windows_locale[
+                    windll.GetUserDefaultUILanguage()]
+            else:
+                try:
+                    # Detect language
+                    lang = locale.getdefaultlocale()[0]
+
+                except TypeError:
+                    # None is returned if the default can't be determined
+                    # we're done in this case
+                    return None
+
+        return lang[0:2].lower()

--- a/apprise/URLBase.py
+++ b/apprise/URLBase.py
@@ -86,6 +86,9 @@ class URLBase(object):
     # Maintain a set of tags to associate with this specific notification
     tags = set()
 
+    # Secure sites should be verified against a Certificate Authority
+    verify_certificate = True
+
     # Logging
     logger = logging.getLogger(__name__)
 

--- a/apprise/i18n/apprise.pot
+++ b/apprise/i18n/apprise.pot
@@ -1,0 +1,289 @@
+# Translations template for apprise.
+# Copyright (C) 2019 Chris Caron
+# This file is distributed under the same license as the apprise project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: apprise 0.7.6\n"
+"Report-Msgid-Bugs-To: lead2gold@gmail.com\n"
+"POT-Creation-Date: 2019-05-28 16:56-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+msgid "API Key"
+msgstr ""
+
+msgid "Access Key"
+msgstr ""
+
+msgid "Access Key ID"
+msgstr ""
+
+msgid "Access Secret"
+msgstr ""
+
+msgid "Access Token"
+msgstr ""
+
+msgid "Account SID"
+msgstr ""
+
+msgid "Add Tokens"
+msgstr ""
+
+msgid "Application Key"
+msgstr ""
+
+msgid "Application Secret"
+msgstr ""
+
+msgid "Auth Token"
+msgstr ""
+
+msgid "Authorization Token"
+msgstr ""
+
+msgid "Avatar Image"
+msgstr ""
+
+msgid "Bot Name"
+msgstr ""
+
+msgid "Bot Token"
+msgstr ""
+
+msgid "Channels"
+msgstr ""
+
+msgid "Consumer Key"
+msgstr ""
+
+msgid "Consumer Secret"
+msgstr ""
+
+msgid "Detect Bot Owner"
+msgstr ""
+
+msgid "Device ID"
+msgstr ""
+
+msgid "Display Footer"
+msgstr ""
+
+msgid "Domain"
+msgstr ""
+
+msgid "Duration"
+msgstr ""
+
+msgid "Events"
+msgstr ""
+
+msgid "Footer Logo"
+msgstr ""
+
+msgid "From Email"
+msgstr ""
+
+msgid "From Name"
+msgstr ""
+
+msgid "From Phone No"
+msgstr ""
+
+msgid "Group"
+msgstr ""
+
+msgid "HTTP Header"
+msgstr ""
+
+msgid "Hostname"
+msgstr ""
+
+msgid "Include Image"
+msgstr ""
+
+msgid "Modal"
+msgstr ""
+
+msgid "Notify Format"
+msgstr ""
+
+msgid "Organization"
+msgstr ""
+
+msgid "Overflow Mode"
+msgstr ""
+
+msgid "Password"
+msgstr ""
+
+msgid "Port"
+msgstr ""
+
+msgid "Priority"
+msgstr ""
+
+msgid "Provider Key"
+msgstr ""
+
+msgid "Region"
+msgstr ""
+
+msgid "Region Name"
+msgstr ""
+
+msgid "Remove Tokens"
+msgstr ""
+
+msgid "Rooms"
+msgstr ""
+
+msgid "SMTP Server"
+msgstr ""
+
+msgid "Schema"
+msgstr ""
+
+msgid "Secret Access Key"
+msgstr ""
+
+msgid "Secret Key"
+msgstr ""
+
+msgid "Secure Mode"
+msgstr ""
+
+msgid "Server Timeout"
+msgstr ""
+
+msgid "Sound"
+msgstr ""
+
+msgid "Source JID"
+msgstr ""
+
+msgid "Target Channel"
+msgstr ""
+
+msgid "Target Chat ID"
+msgstr ""
+
+msgid "Target Device"
+msgstr ""
+
+msgid "Target Device ID"
+msgstr ""
+
+msgid "Target Email"
+msgstr ""
+
+msgid "Target Emails"
+msgstr ""
+
+msgid "Target Encoded ID"
+msgstr ""
+
+msgid "Target JID"
+msgstr ""
+
+msgid "Target Phone No"
+msgstr ""
+
+msgid "Target Room Alias"
+msgstr ""
+
+msgid "Target Room ID"
+msgstr ""
+
+msgid "Target Short Code"
+msgstr ""
+
+msgid "Target Tag ID"
+msgstr ""
+
+msgid "Target Topic"
+msgstr ""
+
+msgid "Target User"
+msgstr ""
+
+msgid "Targets"
+msgstr ""
+
+msgid "Text To Speech"
+msgstr ""
+
+msgid "To Channel ID"
+msgstr ""
+
+msgid "To Email"
+msgstr ""
+
+msgid "To User ID"
+msgstr ""
+
+msgid "Token"
+msgstr ""
+
+msgid "Token A"
+msgstr ""
+
+msgid "Token B"
+msgstr ""
+
+msgid "Token C"
+msgstr ""
+
+msgid "Urgency"
+msgstr ""
+
+msgid "Use Avatar"
+msgstr ""
+
+msgid "User"
+msgstr ""
+
+msgid "User Key"
+msgstr ""
+
+msgid "User Name"
+msgstr ""
+
+msgid "Username"
+msgstr ""
+
+msgid "Verify SSL"
+msgstr ""
+
+msgid "Version"
+msgstr ""
+
+msgid "Webhook"
+msgstr ""
+
+msgid "Webhook ID"
+msgstr ""
+
+msgid "Webhook Mode"
+msgstr ""
+
+msgid "Webhook Token"
+msgstr ""
+
+msgid "X-Axis"
+msgstr ""
+
+msgid "XEP"
+msgstr ""
+
+msgid "Y-Axis"
+msgstr ""
+

--- a/apprise/i18n/en/LC_MESSAGES/apprise.po
+++ b/apprise/i18n/en/LC_MESSAGES/apprise.po
@@ -1,0 +1,293 @@
+# English translations for apprise.
+# Copyright (C) 2019 Chris Caron
+# This file is distributed under the same license as the apprise project.
+# Chris Caron <lead2gold@gmail.com>, 2019.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: apprise 0.7.6\n"
+"Report-Msgid-Bugs-To: lead2gold@gmail.com\n"
+"POT-Creation-Date: 2019-05-28 16:56-0400\n"
+"PO-Revision-Date: 2019-05-24 20:00-0400\n"
+"Last-Translator: Chris Caron <lead2gold@gmail.com>\n"
+"Language: en\n"
+"Language-Team: en <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+msgid "API Key"
+msgstr ""
+
+msgid "Access Key"
+msgstr ""
+
+msgid "Access Key ID"
+msgstr ""
+
+msgid "Access Secret"
+msgstr ""
+
+msgid "Access Token"
+msgstr ""
+
+msgid "Account SID"
+msgstr ""
+
+msgid "Add Tokens"
+msgstr ""
+
+msgid "Application Key"
+msgstr ""
+
+msgid "Application Secret"
+msgstr ""
+
+msgid "Auth Token"
+msgstr ""
+
+msgid "Authorization Token"
+msgstr ""
+
+msgid "Avatar Image"
+msgstr ""
+
+msgid "Bot Name"
+msgstr ""
+
+msgid "Bot Token"
+msgstr ""
+
+msgid "Channels"
+msgstr ""
+
+msgid "Consumer Key"
+msgstr ""
+
+msgid "Consumer Secret"
+msgstr ""
+
+msgid "Detect Bot Owner"
+msgstr ""
+
+msgid "Device ID"
+msgstr ""
+
+msgid "Display Footer"
+msgstr ""
+
+msgid "Domain"
+msgstr ""
+
+msgid "Duration"
+msgstr ""
+
+msgid "Events"
+msgstr ""
+
+msgid "Footer Logo"
+msgstr ""
+
+msgid "From Email"
+msgstr ""
+
+msgid "From Name"
+msgstr ""
+
+msgid "From Phone No"
+msgstr ""
+
+msgid "Group"
+msgstr ""
+
+msgid "HTTP Header"
+msgstr ""
+
+msgid "Hostname"
+msgstr ""
+
+msgid "Include Image"
+msgstr ""
+
+msgid "Modal"
+msgstr ""
+
+msgid "Notify Format"
+msgstr ""
+
+msgid "Organization"
+msgstr ""
+
+msgid "Overflow Mode"
+msgstr ""
+
+msgid "Password"
+msgstr ""
+
+msgid "Port"
+msgstr ""
+
+msgid "Priority"
+msgstr ""
+
+msgid "Provider Key"
+msgstr ""
+
+msgid "Region"
+msgstr ""
+
+msgid "Region Name"
+msgstr ""
+
+msgid "Remove Tokens"
+msgstr ""
+
+msgid "Rooms"
+msgstr ""
+
+msgid "SMTP Server"
+msgstr ""
+
+msgid "Schema"
+msgstr ""
+
+msgid "Secret Access Key"
+msgstr ""
+
+msgid "Secret Key"
+msgstr ""
+
+msgid "Secure Mode"
+msgstr ""
+
+msgid "Server Timeout"
+msgstr ""
+
+msgid "Sound"
+msgstr ""
+
+msgid "Source JID"
+msgstr ""
+
+msgid "Target Channel"
+msgstr ""
+
+msgid "Target Chat ID"
+msgstr ""
+
+msgid "Target Device"
+msgstr ""
+
+msgid "Target Device ID"
+msgstr ""
+
+msgid "Target Email"
+msgstr ""
+
+msgid "Target Emails"
+msgstr ""
+
+msgid "Target Encoded ID"
+msgstr ""
+
+msgid "Target JID"
+msgstr ""
+
+msgid "Target Phone No"
+msgstr ""
+
+msgid "Target Room Alias"
+msgstr ""
+
+msgid "Target Room ID"
+msgstr ""
+
+msgid "Target Short Code"
+msgstr ""
+
+msgid "Target Tag ID"
+msgstr ""
+
+msgid "Target Topic"
+msgstr ""
+
+msgid "Target User"
+msgstr ""
+
+msgid "Targets"
+msgstr ""
+
+msgid "Text To Speech"
+msgstr ""
+
+msgid "To Channel ID"
+msgstr ""
+
+msgid "To Email"
+msgstr ""
+
+msgid "To User ID"
+msgstr ""
+
+msgid "Token"
+msgstr ""
+
+msgid "Token A"
+msgstr ""
+
+msgid "Token B"
+msgstr ""
+
+msgid "Token C"
+msgstr ""
+
+msgid "Urgency"
+msgstr ""
+
+msgid "Use Avatar"
+msgstr ""
+
+msgid "User"
+msgstr ""
+
+msgid "User Key"
+msgstr ""
+
+msgid "User Name"
+msgstr ""
+
+msgid "Username"
+msgstr ""
+
+msgid "Verify SSL"
+msgstr ""
+
+msgid "Version"
+msgstr ""
+
+msgid "Webhook"
+msgstr ""
+
+msgid "Webhook ID"
+msgstr ""
+
+msgid "Webhook Mode"
+msgstr ""
+
+msgid "Webhook Token"
+msgstr ""
+
+msgid "X-Axis"
+msgstr ""
+
+msgid "XEP"
+msgstr ""
+
+msgid "Y-Axis"
+msgstr ""
+
+#~ msgid "Access Key Secret"
+#~ msgstr ""
+

--- a/apprise/plugins/NotifyBase.py
+++ b/apprise/plugins/NotifyBase.py
@@ -32,6 +32,7 @@ from ..common import NotifyFormat
 from ..common import NOTIFY_FORMATS
 from ..common import OverflowMode
 from ..common import OVERFLOW_MODES
+from ..AppriseLocale import gettext_lazy as _
 
 
 class NotifyBase(URLBase):
@@ -77,6 +78,74 @@ class NotifyBase(URLBase):
     # title so that it can be placed into the body. The default is to just
     # use a <b> tag.  The below causes the <b>title</b> to get generated:
     default_html_tag_id = 'b'
+
+    # Define a default set of template arguments used for dynamically building
+    # details about our individual plugins for developers.
+
+    # Define object templates
+    templates = ()
+
+    # Provides a mapping of tokens, certain entries are fixed and automatically
+    # configured if found (such as schema, host, user, pass, and port)
+    template_tokens = {}
+
+    # Here is where we define all of the arguments we accept on the url
+    # such as: schema://whatever/?overflow=upstream&format=text
+    # These act the same way as tokens except they are optional and/or
+    # have default values set if mandatory. This rule must be followed
+    template_args = {
+        'overflow': {
+            'name': _('Overflow Mode'),
+            'type': 'choice:string',
+            'values': OVERFLOW_MODES,
+            # Provide a default
+            'default': overflow_mode,
+            # look up default using the following parent class value at
+            # runtime. The variable name identified here (in this case
+            # overflow_mode) is checked and it's result is placed over-top of
+            # the 'default'. This is done because once a parent class inherits
+            # this one, the overflow_mode already set as a default 'could' be
+            # potentially over-ridden and changed to a different value.
+            '_lookup_default': 'overflow_mode',
+        },
+        'format': {
+            'name': _('Notify Format'),
+            'type': 'choice:string',
+            'values': NOTIFY_FORMATS,
+            # Provide a default
+            'default': notify_format,
+            # look up default using the following parent class value at
+            # runtime.
+            '_lookup_default': 'notify_format',
+        },
+        'verify': {
+            'name': _('Verify SSL'),
+            # SSL Certificate Authority Verification
+            'type': 'bool',
+            # Provide a default
+            'default': URLBase.verify_certificate,
+            # look up default using the following parent class value at
+            # runtime.
+            '_lookup_default': 'verify_certificate',
+        },
+    }
+
+    # kwargs are dynamically built because a prefix causes us to parse the
+    # content slightly differently. The prefix is required and can be either
+    # a (+ or -). Below would handle the +key=value:
+    #    {
+    #        'headers': {
+    #           'name': _('HTTP Header'),
+    #           'prefix': '+',
+    #           'type': 'string',
+    #        },
+    #    },
+    #
+    # In a kwarg situation, the 'key' is always presumed to be treated as
+    # a string.  When the 'type' is defined, it is being defined to respect
+    # the 'value'.
+
+    template_kwargs = {}
 
     def __init__(self, **kwargs):
         """

--- a/apprise/plugins/NotifyBoxcar.py
+++ b/apprise/plugins/NotifyBoxcar.py
@@ -41,6 +41,7 @@ from .NotifyBase import NotifyBase
 from ..utils import parse_bool
 from ..common import NotifyType
 from ..common import NotifyImageSize
+from ..AppriseLocale import gettext_lazy as _
 
 # Default to sending to all devices if nothing is specified
 DEFAULT_TAG = '@all'
@@ -91,6 +92,62 @@ class NotifyBoxcar(NotifyBase):
 
     # The maximum allowable characters allowed in the body per message
     body_maxlen = 10000
+
+    # Define object templates
+    templates = (
+        '{schema}://{access_key}/{secret_key}/',
+        '{schema}://{access_key}/{secret_key}/{targets}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'access_key': {
+            'name': _('Access Key'),
+            'type': 'string',
+            'regex': (r'[A-Z0-9_-]{64}', 'i'),
+            'private': True,
+            'required': True,
+            'map_to': 'access',
+        },
+        'secret_key': {
+            'name': _('Secret Key'),
+            'type': 'string',
+            'regex': (r'[A-Z0-9_-]{64}', 'i'),
+            'private': True,
+            'required': True,
+            'map_to': 'secret',
+        },
+        'target_tag': {
+            'name': _('Target Tag ID'),
+            'type': 'string',
+            'prefix': '@',
+            'regex': (r'[A-Z0-9]{1,63}', 'i'),
+            'map_to': 'targets',
+        },
+        'target_device': {
+            'name': _('Target Device ID'),
+            'type': 'string',
+            'regex': (r'[A-Z0-9]{64}', 'i'),
+            'map_to': 'targets',
+        },
+        'targets': {
+            'name': _('Targets'),
+            'type': 'list:string',
+        },
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'image': {
+            'name': _('Include Image'),
+            'type': 'bool',
+            'default': True,
+            'map_to': 'include_image',
+        },
+        'to': {
+            'alias_of': 'targets',
+        },
+    })
 
     def __init__(self, access, secret, targets=None, include_image=True,
                  **kwargs):

--- a/apprise/plugins/NotifyDBus.py
+++ b/apprise/plugins/NotifyDBus.py
@@ -31,6 +31,7 @@ from ..common import NotifyImageSize
 from ..common import NotifyType
 from ..utils import GET_SCHEMA_RE
 from ..utils import parse_bool
+from ..AppriseLocale import gettext_lazy as _
 
 # Default our global support flag
 NOTIFY_DBUS_SUPPORT_ENABLED = False
@@ -170,6 +171,39 @@ class NotifyDBus(NotifyBase):
     # outside of what is defined in test/test_glib_plugin.py, please
     # let me know! :)
     _enabled = NOTIFY_DBUS_SUPPORT_ENABLED
+
+    # Define object templates
+    templates = (
+        '{schema}://_/',
+    )
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'urgency': {
+            'name': _('Urgency'),
+            'type': 'choice:int',
+            'values': DBUS_URGENCIES,
+            'default': DBusUrgency.NORMAL,
+        },
+        'x': {
+            'name': _('X-Axis'),
+            'type': 'int',
+            'min': 0,
+            'map_to': 'x_axis',
+        },
+        'y': {
+            'name': _('Y-Axis'),
+            'type': 'int',
+            'min': 0,
+            'map_to': 'y_axis',
+        },
+        'image': {
+            'name': _('Include Image'),
+            'type': 'bool',
+            'default': True,
+            'map_to': 'include_image',
+        },
+    })
 
     def __init__(self, urgency=None, x_axis=None, y_axis=None,
                  include_image=True, **kwargs):

--- a/apprise/plugins/NotifyDiscord.py
+++ b/apprise/plugins/NotifyDiscord.py
@@ -49,6 +49,7 @@ from ..common import NotifyImageSize
 from ..common import NotifyFormat
 from ..common import NotifyType
 from ..utils import parse_bool
+from ..AppriseLocale import gettext_lazy as _
 
 
 class NotifyDiscord(NotifyBase):
@@ -77,8 +78,66 @@ class NotifyDiscord(NotifyBase):
     # The maximum allowable characters allowed in the body per message
     body_maxlen = 2000
 
+    # Define object templates
+    templates = (
+        '{schema}://{webhook_id}/{webhook_token}',
+        '{schema}://{botname}@{webhook_id}/{webhook_token}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'botname': {
+            'name': _('Bot Name'),
+            'type': 'string',
+            'map_to': 'user',
+        },
+        'webhook_id': {
+            'name': _('Webhook ID'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+        },
+        'webhook_token': {
+            'name': _('Webhook Token'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+        },
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'tts': {
+            'name': _('Text To Speech'),
+            'type': 'bool',
+            'default': False,
+        },
+        'avatar': {
+            'name': _('Avatar Image'),
+            'type': 'bool',
+            'default': True,
+        },
+        'footer': {
+            'name': _('Display Footer'),
+            'type': 'bool',
+            'default': False,
+        },
+        'footer_logo': {
+            'name': _('Footer Logo'),
+            'type': 'bool',
+            'default': True,
+        },
+        'image': {
+            'name': _('Include Image'),
+            'type': 'bool',
+            'default': False,
+            'map_to': 'include_image',
+        },
+    })
+
     def __init__(self, webhook_id, webhook_token, tts=False, avatar=True,
-                 footer=False, footer_logo=True, include_image=True, **kwargs):
+                 footer=False, footer_logo=True, include_image=False,
+                 **kwargs):
         """
         Initialize Discord Object
 

--- a/apprise/plugins/NotifyEmby.py
+++ b/apprise/plugins/NotifyEmby.py
@@ -38,6 +38,7 @@ from .NotifyBase import NotifyBase
 from ..utils import parse_bool
 from ..common import NotifyType
 from .. import __version__ as VERSION
+from ..AppriseLocale import gettext_lazy as _
 
 
 class NotifyEmby(NotifyBase):
@@ -71,6 +72,46 @@ class NotifyEmby(NotifyBase):
     # The Emby message timeout; basically it is how long should our message be
     # displayed for.  The value is in milli-seconds
     emby_message_timeout_ms = 60000
+
+    # Define object templates
+    templates = (
+        '{schema}://{host}',
+        '{schema}://{host}:{port}',
+        '{schema}://{user}:{password}@{host}',
+        '{schema}://{user}:{password}@{host}:{port}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'host': {
+            'name': _('Hostname'),
+            'type': 'string',
+            'required': True,
+        },
+        'port': {
+            'name': _('Port'),
+            'type': 'int',
+            'min': 1,
+            'max': 65535,
+        },
+        'user': {
+            'name': _('Username'),
+            'type': 'string',
+        },
+        'password': {
+            'name': _('Password'),
+            'type': 'string',
+            'private': True,
+        },
+    })
+
+    template_args = dict(NotifyBase.template_args, **{
+        'modal': {
+            'name': _('Modal'),
+            'type': 'bool',
+            'default': False,
+        },
+    })
 
     def __init__(self, modal=False, **kwargs):
         """

--- a/apprise/plugins/NotifyFaast.py
+++ b/apprise/plugins/NotifyFaast.py
@@ -28,6 +28,7 @@ from .NotifyBase import NotifyBase
 from ..common import NotifyImageSize
 from ..common import NotifyType
 from ..utils import parse_bool
+from ..AppriseLocale import gettext_lazy as _
 
 
 class NotifyFaast(NotifyBase):
@@ -52,6 +53,31 @@ class NotifyFaast(NotifyBase):
 
     # Allows the user to specify the NotifyImageSize object
     image_size = NotifyImageSize.XY_72
+
+    # Define object templates
+    templates = (
+        '{schema}://{authtoken}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'authtoken': {
+            'name': _('Authorization Token'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+        },
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'image': {
+            'name': _('Include Image'),
+            'type': 'bool',
+            'default': True,
+            'map_to': 'include_image',
+        },
+    })
 
     def __init__(self, authtoken, include_image=True, **kwargs):
         """

--- a/apprise/plugins/NotifyFlock.py
+++ b/apprise/plugins/NotifyFlock.py
@@ -47,6 +47,7 @@ from ..common import NotifyFormat
 from ..common import NotifyImageSize
 from ..utils import parse_list
 from ..utils import parse_bool
+from ..AppriseLocale import gettext_lazy as _
 
 
 # Extend HTTP Error Messages
@@ -91,6 +92,60 @@ class NotifyFlock(NotifyBase):
 
     # Allows the user to specify the NotifyImageSize object
     image_size = NotifyImageSize.XY_72
+
+    # Define object templates
+    templates = (
+        '{schema}://{token}',
+        '{schema}://{user}@{token}',
+        '{schema}://{user}@{token}/{targets}',
+        '{schema}://{token}/{targets}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'token': {
+            'name': _('Access Key'),
+            'type': 'string',
+            'regex': (r'[a-z0-9-]{24}', 'i'),
+            'private': True,
+            'required': True,
+        },
+        'user': {
+            'name': _('Bot Name'),
+            'type': 'string',
+        },
+        'to_user': {
+            'name': _('To User ID'),
+            'type': 'string',
+            'prefix': '@',
+            'regex': (r'[A-Z0-9_]{12}', 'i'),
+            'map_to': 'targets',
+        },
+        'to_channel': {
+            'name': _('To Channel ID'),
+            'type': 'string',
+            'prefix': '#',
+            'regex': (r'[A-Z0-9_]{12}', 'i'),
+            'map_to': 'targets',
+        },
+        'targets': {
+            'name': _('Targets'),
+            'type': 'list:string',
+        },
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'image': {
+            'name': _('Include Image'),
+            'type': 'bool',
+            'default': True,
+            'map_to': 'include_image',
+        },
+        'to': {
+            'alias_of': 'targets',
+        },
+    })
 
     def __init__(self, token, targets=None, include_image=True, **kwargs):
         """

--- a/apprise/plugins/NotifyGitter.py
+++ b/apprise/plugins/NotifyGitter.py
@@ -50,7 +50,7 @@ from ..common import NotifyFormat
 from ..common import NotifyType
 from ..utils import parse_list
 from ..utils import parse_bool
-
+from ..AppriseLocale import gettext_lazy as _
 
 # API Gitter URL
 GITTER_API_URL = 'https://api.gitter.im/v1'
@@ -102,7 +102,40 @@ class NotifyGitter(NotifyBase):
     # Default Notification Format
     notify_format = NotifyFormat.MARKDOWN
 
-    def __init__(self, token, targets, include_image=True, **kwargs):
+    # Define object templates
+    templates = (
+        '{schema}://{token}:{targets}/',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'token': {
+            'name': _('Token'),
+            'type': 'string',
+            'regex': (r'[a-z0-9]{40}', 'i'),
+            'private': True,
+            'required': True,
+        },
+        'targets': {
+            'name': _('Rooms'),
+            'type': 'list:string',
+        },
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'image': {
+            'name': _('Include Image'),
+            'type': 'bool',
+            'default': False,
+            'map_to': 'include_image',
+        },
+        'to': {
+            'alias_of': 'targets',
+        },
+    })
+
+    def __init__(self, token, targets, include_image=False, **kwargs):
         """
         Initialize Gitter Object
         """

--- a/apprise/plugins/NotifyGnome.py
+++ b/apprise/plugins/NotifyGnome.py
@@ -30,6 +30,7 @@ from .NotifyBase import NotifyBase
 from ..common import NotifyImageSize
 from ..common import NotifyType
 from ..utils import parse_bool
+from ..AppriseLocale import gettext_lazy as _
 
 # Default our global support flag
 NOTIFY_GNOME_SUPPORT_ENABLED = False
@@ -109,6 +110,27 @@ class NotifyGnome(NotifyBase):
     # outside of what is defined in test/test_gnome_plugin.py, please
     # let me know! :)
     _enabled = NOTIFY_GNOME_SUPPORT_ENABLED
+
+    # Define object templates
+    templates = (
+        '{schema}://_/',
+    )
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'urgency': {
+            'name': _('Urgency'),
+            'type': 'choice:int',
+            'values': GNOME_URGENCIES,
+            'default': GnomeUrgency.NORMAL,
+        },
+        'image': {
+            'name': _('Include Image'),
+            'type': 'bool',
+            'default': True,
+            'map_to': 'include_image',
+        },
+    })
 
     def __init__(self, urgency=None, include_image=True, **kwargs):
         """

--- a/apprise/plugins/NotifyGotify.py
+++ b/apprise/plugins/NotifyGotify.py
@@ -37,6 +37,7 @@ from json import dumps
 
 from .NotifyBase import NotifyBase
 from ..common import NotifyType
+from ..AppriseLocale import gettext_lazy as _
 
 
 # Priorities
@@ -75,6 +76,43 @@ class NotifyGotify(NotifyBase):
 
     # A URL that takes you to the setup/help of the specific protocol
     setup_url = 'https://github.com/caronc/apprise/wiki/Notify_gotify'
+
+    # Define object templates
+    templates = (
+        '{schema}://{host}/{token}',
+        '{schema}://{host}:{port}/{token}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'token': {
+            'name': _('Token'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+        },
+        'host': {
+            'name': _('Hostname'),
+            'type': 'string',
+            'required': True,
+        },
+        'port': {
+            'name': _('Port'),
+            'type': 'int',
+            'min': 1,
+            'max': 65535,
+        },
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'priority': {
+            'name': _('Priority'),
+            'type': 'choice:int',
+            'values': GOTIFY_PRIORITIES,
+            'default': GotifyPriority.NORMAL,
+        },
+    })
 
     def __init__(self, token, priority=None, **kwargs):
         """

--- a/apprise/plugins/NotifyGrowl/__init__.py
+++ b/apprise/plugins/NotifyGrowl/__init__.py
@@ -29,6 +29,7 @@ from ..NotifyBase import NotifyBase
 from ...common import NotifyImageSize
 from ...common import NotifyType
 from ...utils import parse_bool
+from ...AppriseLocale import gettext_lazy as _
 
 
 # Priorities
@@ -86,6 +87,51 @@ class NotifyGrowl(NotifyBase):
 
     # Default Growl Port
     default_port = 23053
+
+    # Define object templates
+    templates = (
+        '{schema}://{apikey}',
+        '{schema}://{apikey}/{providerkey}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'apikey': {
+            'name': _('API Key'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+            'map_to': 'host',
+        },
+        'providerkey': {
+            'name': _('Provider Key'),
+            'type': 'string',
+            'private': True,
+            'map_to': 'fullpath',
+        },
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'priority': {
+            'name': _('Priority'),
+            'type': 'choice:int',
+            'values': GROWL_PRIORITIES,
+            'default': GrowlPriority.NORMAL,
+        },
+        'version': {
+            'name': _('Version'),
+            'type': 'choice:int',
+            'values': (1, 2),
+            'default': 2,
+        },
+        'image': {
+            'name': _('Include Image'),
+            'type': 'bool',
+            'default': True,
+            'map_to': 'include_image',
+        },
+    })
 
     def __init__(self, priority=None, version=2, include_image=True, **kwargs):
         """

--- a/apprise/plugins/NotifyIFTTT.py
+++ b/apprise/plugins/NotifyIFTTT.py
@@ -45,6 +45,7 @@ from json import dumps
 from .NotifyBase import NotifyBase
 from ..common import NotifyType
 from ..utils import parse_list
+from ..AppriseLocale import gettext_lazy as _
 
 
 class NotifyIFTTT(NotifyBase):
@@ -91,6 +92,45 @@ class NotifyIFTTT(NotifyBase):
     notify_url = 'https://maker.ifttt.com/' \
                  'trigger/{event}/with/key/{webhook_id}'
 
+    # Define object templates
+    templates = (
+        '{schema}://{webhook_id}/{events}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'webhook_id': {
+            'name': _('Webhook ID'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+        },
+        'events': {
+            'name': _('Events'),
+            'type': 'list:string',
+            'required': True,
+        },
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'to': {
+            'alias_of': 'events',
+        },
+    })
+
+    # Define our token control
+    template_kwargs = {
+        'add_tokens': {
+            'name': _('Add Tokens'),
+            'prefix': '+',
+        },
+        'del_tokens': {
+            'name': _('Remove Tokens'),
+            'prefix': '-',
+        },
+    }
+
     def __init__(self, webhook_id, events, add_tokens=None, del_tokens=None,
                  **kwargs):
         """
@@ -133,6 +173,10 @@ class NotifyIFTTT(NotifyBase):
         if del_tokens is not None:
             if isinstance(del_tokens, (list, tuple, set)):
                 self.del_tokens = del_tokens
+
+            elif isinstance(del_tokens, dict):
+                # Convert the dictionary into a list
+                self.del_tokens = set(del_tokens.keys())
 
             else:
                 msg = 'del_token must be a list; {} was provided'.format(

--- a/apprise/plugins/NotifyJSON.py
+++ b/apprise/plugins/NotifyJSON.py
@@ -30,6 +30,7 @@ from json import dumps
 from .NotifyBase import NotifyBase
 from ..common import NotifyImageSize
 from ..common import NotifyType
+from ..AppriseLocale import gettext_lazy as _
 
 
 class NotifyJSON(NotifyBase):
@@ -55,6 +56,48 @@ class NotifyJSON(NotifyBase):
     # Disable throttle rate for JSON requests since they are normally
     # local anyway
     request_rate_per_sec = 0
+
+    # Define object templates
+    templates = (
+        '{schema}://{host}',
+        '{schema}://{host}:{port}',
+        '{schema}://{user}@{host}',
+        '{schema}://{user}@{host}:{port}',
+        '{schema}://{user}:{password}@{host}',
+        '{schema}://{user}:{password}@{host}:{port}',
+    )
+
+    # Define our tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'host': {
+            'name': _('Hostname'),
+            'type': 'string',
+            'required': True,
+        },
+        'port': {
+            'name': _('Port'),
+            'type': 'int',
+            'min': 1,
+            'max': 65535,
+        },
+        'user': {
+            'name': _('Username'),
+            'type': 'string',
+        },
+        'password': {
+            'name': _('Password'),
+            'type': 'string',
+            'private': True,
+        },
+    })
+
+    # Define any kwargs we're using
+    template_kwargs = {
+        'headers': {
+            'name': _('HTTP Header'),
+            'prefix': '+',
+        },
+    }
 
     def __init__(self, headers=None, **kwargs):
         """

--- a/apprise/plugins/NotifyJoin.py
+++ b/apprise/plugins/NotifyJoin.py
@@ -41,9 +41,10 @@ from ..common import NotifyImageSize
 from ..common import NotifyType
 from ..utils import parse_list
 from ..utils import parse_bool
+from ..AppriseLocale import gettext_lazy as _
 
 # Token required as part of the API request
-VALIDATE_APIKEY = re.compile(r'[A-Za-z0-9]{32}')
+VALIDATE_APIKEY = re.compile(r'[a-z0-9]{32}', re.I)
 
 # Extend HTTP Error Messages
 JOIN_HTTP_ERROR_MAP = {
@@ -51,7 +52,7 @@ JOIN_HTTP_ERROR_MAP = {
 }
 
 # Used to detect a device
-IS_DEVICE_RE = re.compile(r'([A-Za-z0-9]{32})')
+IS_DEVICE_RE = re.compile(r'([a-z0-9]{32})', re.I)
 
 # Used to detect a device
 IS_GROUP_RE = re.compile(
@@ -96,6 +97,53 @@ class NotifyJoin(NotifyBase):
 
     # The default group to use if none is specified
     default_join_group = 'group.all'
+
+    # Define object templates
+    templates = (
+        '{schema}://{apikey}/{targets}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'apikey': {
+            'name': _('API Key'),
+            'type': 'string',
+            'regex': (r'[a-z0-9]{32}', 'i'),
+            'private': True,
+            'required': True,
+        },
+        'device': {
+            'name': _('Device ID'),
+            'type': 'string',
+            'regex': (r'[a-z0-9]{32}', 'i'),
+            'map_to': 'targets',
+        },
+        'group': {
+            'name': _('Group'),
+            'type': 'choice:string',
+            'values': (
+                'all', 'android', 'chrome', 'windows10', 'phone', 'tablet',
+                'pc'),
+            'map_to': 'targets',
+        },
+        'targets': {
+            'name': _('Targets'),
+            'type': 'list:string',
+            'required': True,
+        },
+    })
+
+    template_args = dict(NotifyBase.template_args, **{
+        'image': {
+            'name': _('Include Image'),
+            'type': 'bool',
+            'default': False,
+            'map_to': 'include_image',
+        },
+        'to': {
+            'alias_of': 'targets',
+        },
+    })
 
     def __init__(self, apikey, targets, include_image=True, **kwargs):
         """

--- a/apprise/plugins/NotifyMSTeams.py
+++ b/apprise/plugins/NotifyMSTeams.py
@@ -69,6 +69,7 @@ from ..common import NotifyImageSize
 from ..common import NotifyType
 from ..common import NotifyFormat
 from ..utils import parse_bool
+from ..AppriseLocale import gettext_lazy as _
 
 # Used to prepare our UUID regex matching
 UUID4_RE = \
@@ -114,7 +115,48 @@ class NotifyMSTeams(NotifyBase):
     # The maximum allowable characters allowed in the body per message
     body_maxlen = 1000
 
+    # Default Notification Format
     notify_format = NotifyFormat.MARKDOWN
+
+    # Define object templates
+    templates = (
+        '{schema}://{token_a}/{token_b}{token_c}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'token_a': {
+            'name': _('Token A'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+            'regex': (r'{}@{}'.format(UUID4_RE, UUID4_RE), 'i'),
+        },
+        'token_b': {
+            'name': _('Token B'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+            'regex': (r'[a-z0-9]{32}', 'i'),
+        },
+        'token_c': {
+            'name': _('Token C'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+            'regex': (UUID4_RE, 'i'),
+        },
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'image': {
+            'name': _('Include Image'),
+            'type': 'bool',
+            'default': False,
+            'map_to': 'include_image',
+        },
+    })
 
     def __init__(self, token_a, token_b, token_c, include_image=True,
                  **kwargs):

--- a/apprise/plugins/NotifyMailgun.py
+++ b/apprise/plugins/NotifyMailgun.py
@@ -58,7 +58,7 @@ from .NotifyBase import NotifyBase
 from ..common import NotifyType
 from ..utils import parse_list
 from ..utils import is_email
-
+from ..AppriseLocale import gettext_lazy as _
 
 # Used to validate your personal access apikey
 VALIDATE_API_KEY = re.compile(r'^[a-z0-9]{32}-[a-z0-9]{8}-[a-z0-9]{8}$', re.I)
@@ -116,6 +116,56 @@ class NotifyMailgun(NotifyBase):
 
     # The default region to use if one isn't otherwise specified
     mailgun_default_region = MailgunRegion.US
+
+    # Define object templates
+    templates = (
+        '{schema}://{user}@{host}:{apikey}/',
+        '{schema}://{user}@{host}:{apikey}/{targets}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'user': {
+            'name': _('User Name'),
+            'type': 'string',
+            'required': True,
+        },
+        'host': {
+            'name': _('Domain'),
+            'type': 'string',
+            'required': True,
+        },
+        'apikey': {
+            'name': _('API Key'),
+            'type': 'string',
+            'regex': (r'[a-z0-9]{32}-[a-z0-9]{8}-[a-z0-9]{8}', 'i'),
+            'private': True,
+            'required': True,
+        },
+        'targets': {
+            'name': _('Target Emails'),
+            'type': 'list:string',
+        },
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'name': {
+            'name': _('From Name'),
+            'type': 'string',
+            'map_to': 'from_name',
+        },
+        'region': {
+            'name': _('Region Name'),
+            'type': 'choice:string',
+            'values': MAILGUN_REGIONS,
+            'default': MailgunRegion.US,
+            'map_to': 'region_name',
+        },
+        'to': {
+            'alias_of': 'targets',
+        },
+    })
 
     def __init__(self, apikey, targets, from_name=None, region_name=None,
                  **kwargs):

--- a/apprise/plugins/NotifyProwl.py
+++ b/apprise/plugins/NotifyProwl.py
@@ -28,6 +28,7 @@ import requests
 
 from .NotifyBase import NotifyBase
 from ..common import NotifyType
+from ..AppriseLocale import gettext_lazy as _
 
 # Used to validate API Key
 VALIDATE_APIKEY = re.compile(r'[A-Za-z0-9]{40}')
@@ -89,6 +90,37 @@ class NotifyProwl(NotifyBase):
 
     # Defines the maximum allowable characters in the title
     title_maxlen = 1024
+
+    # Define object templates
+    templates = (
+        '{schema}://{apikey}',
+        '{schema}://{apikey}/{providerkey}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'apikey': {
+            'name': _('API Key'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+        },
+        'providerkey': {
+            'name': _('Provider Key'),
+            'type': 'string',
+            'private': True,
+        },
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'priority': {
+            'name': _('Priority'),
+            'type': 'choice:int',
+            'values': PROWL_PRIORITIES,
+            'default': ProwlPriority.NORMAL,
+        },
+    })
 
     def __init__(self, apikey, providerkey=None, priority=None, **kwargs):
         """

--- a/apprise/plugins/NotifyPushBullet.py
+++ b/apprise/plugins/NotifyPushBullet.py
@@ -30,6 +30,7 @@ from .NotifyBase import NotifyBase
 from ..utils import GET_EMAIL_RE
 from ..common import NotifyType
 from ..utils import parse_list
+from ..AppriseLocale import gettext_lazy as _
 
 # Flag used as a placeholder to sending to all devices
 PUSHBULLET_SEND_TO_ALL = 'ALL_DEVICES'
@@ -59,6 +60,49 @@ class NotifyPushBullet(NotifyBase):
 
     # PushBullet uses the http protocol with JSON requests
     notify_url = 'https://api.pushbullet.com/v2/pushes'
+
+    # Define object templates
+    templates = (
+        '{schema}://{accesstoken}',
+        '{schema}://{accesstoken}/{targets}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'accesstoken': {
+            'name': _('Access Token'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+        },
+        'target_device': {
+            'name': _('Target Device'),
+            'type': 'string',
+            'map_to': 'targets',
+        },
+        'target_channel': {
+            'name': _('Target Channel'),
+            'type': 'string',
+            'prefix': '#',
+            'map_to': 'targets',
+        },
+        'target_email': {
+            'name': _('Target Email'),
+            'type': 'string',
+            'map_to': 'targets',
+        },
+        'targets': {
+            'name': _('Targets'),
+            'type': 'list:string',
+        },
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'to': {
+            'alias_of': 'targets',
+        },
+    })
 
     def __init__(self, accesstoken, targets=None, **kwargs):
         """

--- a/apprise/plugins/NotifyPushed.py
+++ b/apprise/plugins/NotifyPushed.py
@@ -31,6 +31,7 @@ from itertools import chain
 from .NotifyBase import NotifyBase
 from ..common import NotifyType
 from ..utils import parse_list
+from ..AppriseLocale import gettext_lazy as _
 
 # Used to detect and parse channels
 IS_CHANNEL = re.compile(r'^#(?P<name>[A-Za-z0-9]+)$')
@@ -66,6 +67,51 @@ class NotifyPushed(NotifyBase):
 
     # The maximum allowable characters allowed in the body per message
     body_maxlen = 140
+
+    # Define object templates
+    templates = (
+        '{schema}://{app_key}/{app_secret}',
+        '{schema}://{app_key}/{app_secret}@{targets}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'app_key': {
+            'name': _('Application Key'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+        },
+        'app_secret': {
+            'name': _('Application Secret'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+        },
+        'target_user': {
+            'name': _('Target User'),
+            'prefix': '@',
+            'type': 'string',
+            'map_to': 'targets',
+        },
+        'target_channel': {
+            'name': _('Target Channel'),
+            'type': 'string',
+            'prefix': '#',
+            'map_to': 'targets',
+        },
+        'targets': {
+            'name': _('Targets'),
+            'type': 'list:string',
+        },
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'to': {
+            'alias_of': 'targets',
+        },
+    })
 
     def __init__(self, app_key, app_secret, targets=None, **kwargs):
         """

--- a/apprise/plugins/NotifyPushjet/__init__.py
+++ b/apprise/plugins/NotifyPushjet/__init__.py
@@ -28,6 +28,7 @@ from . import pushjet
 
 from ..NotifyBase import NotifyBase
 from ...common import NotifyType
+from ...AppriseLocale import gettext_lazy as _
 
 PUBLIC_KEY_RE = re.compile(
     r'^[a-z0-9]{4}-[a-z0-9]{6}-[a-z0-9]{12}-[a-z0-9]{5}-[a-z0-9]{9}$', re.I)
@@ -55,6 +56,33 @@ class NotifyPushjet(NotifyBase):
     # Disable throttle rate for Pushjet requests since they are normally
     # local anyway (the remote/online service is no more)
     request_rate_per_sec = 0
+
+    # Define object templates
+    templates = (
+        '{schema}://{secret_key}@{host}',
+        '{schema}://{secret_key}@{host}:{port}',
+    )
+
+    # Define our tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'host': {
+            'name': _('Hostname'),
+            'type': 'string',
+            'required': True,
+        },
+        'port': {
+            'name': _('Port'),
+            'type': 'int',
+            'min': 1,
+            'max': 65535,
+        },
+        'secret_key': {
+            'name': _('Secret Key'),
+            'type': 'string',
+            'required': True,
+            'private': True,
+        },
+    })
 
     def __init__(self, secret_key, **kwargs):
         """

--- a/apprise/plugins/NotifyRyver.py
+++ b/apprise/plugins/NotifyRyver.py
@@ -40,6 +40,7 @@ from .NotifyBase import NotifyBase
 from ..common import NotifyImageSize
 from ..common import NotifyType
 from ..utils import parse_bool
+from ..AppriseLocale import gettext_lazy as _
 
 # Token required as part of the API request
 VALIDATE_TOKEN = re.compile(r'[A-Za-z0-9]{15}')
@@ -85,6 +86,47 @@ class NotifyRyver(NotifyBase):
 
     # The maximum allowable characters allowed in the body per message
     body_maxlen = 1000
+
+    # Define object templates
+    templates = (
+        '{schema}://{organization}/{token}',
+        '{schema}://{user}@{organization}/{token}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'organization': {
+            'name': _('Organization'),
+            'type': 'string',
+            'required': True,
+        },
+        'token': {
+            'name': _('Token'),
+            'type': 'string',
+            'required': True,
+            'private': True,
+        },
+        'user': {
+            'name': _('Bot Name'),
+            'type': 'string',
+        },
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'mode': {
+            'name': _('Webhook Mode'),
+            'type': 'choice:string',
+            'values': RYVER_WEBHOOK_MODES,
+            'default': RyverWebhookMode.RYVER,
+        },
+        'image': {
+            'name': _('Include Image'),
+            'type': 'bool',
+            'default': True,
+            'map_to': 'include_image',
+        },
+    })
 
     def __init__(self, organization, token, mode=RyverWebhookMode.RYVER,
                  include_image=True, **kwargs):

--- a/apprise/plugins/NotifySNS.py
+++ b/apprise/plugins/NotifySNS.py
@@ -35,6 +35,7 @@ from itertools import chain
 from .NotifyBase import NotifyBase
 from ..common import NotifyType
 from ..utils import parse_list
+from ..AppriseLocale import gettext_lazy as _
 
 # Some Phone Number Detection
 IS_PHONE_NO = re.compile(r'^\+?(?P<phone>[0-9\s)(+-]+)\s*$')
@@ -91,6 +92,58 @@ class NotifySNS(NotifyBase):
     # A title can not be used for SMS Messages.  Setting this to zero will
     # cause any title (if defined) to get placed into the message body.
     title_maxlen = 0
+
+    # Define object templates
+    templates = (
+        '{schema}://{access_key_id}/{secret_access_key}{region}/{targets}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'access_key_id': {
+            'name': _('Access Key ID'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+        },
+        'secret_access_key': {
+            'name': _('Secret Access Key'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+        },
+        'region': {
+            'name': _('Region'),
+            'type': 'string',
+            'required': True,
+            'regex': (r'[a-z]{2}-[a-z]+-[0-9]+', 'i'),
+            'map_to': 'region_name',
+        },
+        'target_phone_no': {
+            'name': _('Target Phone No'),
+            'type': 'string',
+            'map_to': 'targets',
+            'regex': (r'[0-9\s)(+-]+', 'i')
+        },
+        'target_topic': {
+            'name': _('Target Topic'),
+            'type': 'string',
+            'map_to': 'targets',
+            'prefix': '#',
+            'regex': (r'[A-Za-z0-9_-]+', 'i'),
+        },
+        'targets': {
+            'name': _('Targets'),
+            'type': 'list:string',
+        },
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'to': {
+            'alias_of': 'targets',
+        },
+    })
 
     def __init__(self, access_key_id, secret_access_key, region_name,
                  targets=None, **kwargs):

--- a/apprise/plugins/NotifyTwilio.py
+++ b/apprise/plugins/NotifyTwilio.py
@@ -47,6 +47,7 @@ from json import loads
 from .NotifyBase import NotifyBase
 from ..common import NotifyType
 from ..utils import parse_list
+from ..AppriseLocale import gettext_lazy as _
 
 
 # Used to validate your personal access apikey
@@ -92,6 +93,70 @@ class NotifyTwilio(NotifyBase):
     # A title can not be used for SMS Messages.  Setting this to zero will
     # cause any title (if defined) to get placed into the message body.
     title_maxlen = 0
+
+    # Define object templates
+    templates = (
+        '{schema}://{account_sid}:{auth_token}@{from_phone}',
+        '{schema}://{account_sid}:{auth_token}@{from_phone}/{targets}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'account_sid': {
+            'name': _('Account SID'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+            'regex': (r'AC[a-f0-9]{32}', 'i'),
+        },
+        'auth_token': {
+            'name': _('Auth Token'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+            'regex': (r'[a-f0-9]{32}', 'i'),
+        },
+        'from_phone': {
+            'name': _('From Phone No'),
+            'type': 'string',
+            'required': True,
+            'regex': (r'\+?[0-9\s)(+-]+', 'i'),
+            'map_to': 'source',
+        },
+        'target_phone': {
+            'name': _('Target Phone No'),
+            'type': 'string',
+            'prefix': '+',
+            'regex': (r'[0-9\s)(+-]+', 'i'),
+            'map_to': 'targets',
+        },
+        'short_code': {
+            'name': _('Target Short Code'),
+            'type': 'string',
+            'regex': (r'[0-9]{5,6}', 'i'),
+            'map_to': 'targets',
+        },
+        'targets': {
+            'name': _('Targets'),
+            'type': 'list:string',
+        },
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'to': {
+            'alias_of': 'targets',
+        },
+        'from': {
+            'alias_of': 'from_phone',
+        },
+        'sid': {
+            'alias_of': 'account_sid',
+        },
+        'token': {
+            'alias_of': 'auth_token',
+        },
+    })
 
     def __init__(self, account_sid, auth_token, source, targets=None,
                  **kwargs):

--- a/apprise/plugins/NotifyTwitter/__init__.py
+++ b/apprise/plugins/NotifyTwitter/__init__.py
@@ -27,6 +27,7 @@ from . import tweepy
 from ..NotifyBase import NotifyBase
 from ...common import NotifyType
 from ...utils import parse_list
+from ...AppriseLocale import gettext_lazy as _
 
 
 class NotifyTwitter(NotifyBase):
@@ -54,6 +55,54 @@ class NotifyTwitter(NotifyBase):
 
     # Twitter does have titles when creating a message
     title_maxlen = 0
+
+    templates = (
+        '{schema}://{user}@{ckey}{csecret}/{akey}/{asecret}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'ckey': {
+            'name': _('Consumer Key'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+        },
+        'csecret': {
+            'name': _('Consumer Secret'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+        },
+        'akey': {
+            'name': _('Access Key'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+        },
+        'asecret': {
+            'name': _('Access Secret'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+        },
+        'user': {
+            'name': _('User'),
+            'type': 'string',
+            'map_to': 'targets',
+        },
+        'targets': {
+            'name': _('Targets'),
+            'type': 'list:string',
+        },
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'to': {
+            'alias_of': 'targets',
+        },
+    })
 
     def __init__(self, ckey, csecret, akey, asecret, targets=None, **kwargs):
         """

--- a/apprise/plugins/NotifyWebexTeams.py
+++ b/apprise/plugins/NotifyWebexTeams.py
@@ -63,6 +63,7 @@ from json import dumps
 from .NotifyBase import NotifyBase
 from ..common import NotifyType
 from ..common import NotifyFormat
+from ..AppriseLocale import gettext_lazy as _
 
 # Token required as part of the API request
 VALIDATE_TOKEN = re.compile(r'[a-z0-9]{80}', re.I)
@@ -105,6 +106,22 @@ class NotifyWebexTeams(NotifyBase):
 
     # Default to markdown; fall back to text
     notify_format = NotifyFormat.MARKDOWN
+
+    # Define object templates
+    templates = (
+        '{schema}://{token}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'token': {
+            'name': _('Token'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+            'regex': (r'[a-z0-9]{80}', 'i'),
+        },
+    })
 
     def __init__(self, token, **kwargs):
         """

--- a/apprise/plugins/NotifyWindows.py
+++ b/apprise/plugins/NotifyWindows.py
@@ -32,6 +32,7 @@ from .NotifyBase import NotifyBase
 from ..common import NotifyImageSize
 from ..common import NotifyType
 from ..utils import parse_bool
+from ..AppriseLocale import gettext_lazy as _
 
 # Default our global support flag
 NOTIFY_WINDOWS_SUPPORT_ENABLED = False
@@ -87,6 +88,27 @@ class NotifyWindows(NotifyBase):
     # outside of what is defined in test/test_windows_plugin.py, please
     # let me know! :)
     _enabled = NOTIFY_WINDOWS_SUPPORT_ENABLED
+
+    # Define object templates
+    templates = (
+        '{schema}://_/',
+    )
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'duration': {
+            'name': _('Duration'),
+            'type': 'int',
+            'min': 1,
+            'default': 12,
+        },
+        'image': {
+            'name': _('Include Image'),
+            'type': 'bool',
+            'default': True,
+            'map_to': 'include_image',
+        },
+    })
 
     def __init__(self, include_image=True, duration=None, **kwargs):
         """

--- a/apprise/plugins/NotifyXBMC.py
+++ b/apprise/plugins/NotifyXBMC.py
@@ -30,6 +30,7 @@ from .NotifyBase import NotifyBase
 from ..common import NotifyType
 from ..common import NotifyImageSize
 from ..utils import parse_bool
+from ..AppriseLocale import gettext_lazy as _
 
 
 class NotifyXBMC(NotifyBase):
@@ -79,6 +80,54 @@ class NotifyXBMC(NotifyBase):
 
     # KODI default protocol version (v6)
     kodi_remote_protocol = 6
+
+    # Define object templates
+    templates = (
+        '{schema}://{host}',
+        '{schema}://{host}:{port}',
+        '{schema}://{user}:{password}@{host}',
+        '{schema}://{user}:{password}@{host}:{port}',
+    )
+
+    # Define our tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'host': {
+            'name': _('Hostname'),
+            'type': 'string',
+            'required': True,
+        },
+        'port': {
+            'name': _('Port'),
+            'type': 'int',
+            'min': 1,
+            'max': 65535,
+        },
+        'user': {
+            'name': _('Username'),
+            'type': 'string',
+        },
+        'password': {
+            'name': _('Password'),
+            'type': 'string',
+            'private': True,
+        },
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'duration': {
+            'name': _('Duration'),
+            'type': 'int',
+            'min': 1,
+            'default': 12,
+        },
+        'image': {
+            'name': _('Include Image'),
+            'type': 'bool',
+            'default': True,
+            'map_to': 'include_image',
+        },
+    })
 
     def __init__(self, include_image=True, duration=None, **kwargs):
         """

--- a/apprise/plugins/NotifyXML.py
+++ b/apprise/plugins/NotifyXML.py
@@ -30,6 +30,7 @@ import requests
 from .NotifyBase import NotifyBase
 from ..common import NotifyImageSize
 from ..common import NotifyType
+from ..AppriseLocale import gettext_lazy as _
 
 
 class NotifyXML(NotifyBase):
@@ -55,6 +56,51 @@ class NotifyXML(NotifyBase):
     # Disable throttle rate for JSON requests since they are normally
     # local anyway
     request_rate_per_sec = 0
+
+    # Define object templates
+    # Define object templates
+    templates = (
+        '{schema}://{host}',
+        '{schema}://{host}:{port}',
+        '{schema}://{user}@{host}',
+        '{schema}://{user}@{host}:{port}',
+        '{schema}://{user}:{password}@{host}',
+        '{schema}://{user}:{password}@{host}:{port}',
+    )
+
+    # Define our tokens; these are the minimum tokens required required to
+    # be passed into this function (as arguments). The syntax appends any
+    # previously defined in the base package and builds onto them
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'host': {
+            'name': _('Hostname'),
+            'type': 'string',
+            'required': True,
+        },
+        'port': {
+            'name': _('Port'),
+            'type': 'int',
+            'min': 1,
+            'max': 65535,
+        },
+        'user': {
+            'name': _('Username'),
+            'type': 'string',
+        },
+        'password': {
+            'name': _('Password'),
+            'type': 'string',
+            'private': True,
+        },
+    })
+
+    # Define any kwargs we're using
+    template_kwargs = {
+        'headers': {
+            'name': _('HTTP Header'),
+            'prefix': '+',
+        },
+    }
 
     def __init__(self, headers=None, **kwargs):
         """

--- a/apprise/plugins/NotifyXMPP.py
+++ b/apprise/plugins/NotifyXMPP.py
@@ -30,6 +30,7 @@ from os.path import isfile
 from .NotifyBase import NotifyBase
 from ..common import NotifyType
 from ..utils import parse_list
+from ..AppriseLocale import gettext_lazy as _
 
 # xep string parser
 XEP_PARSE_RE = re.compile('^[^1-9]*(?P<xep>[1-9][0-9]{0,3})$')
@@ -97,6 +98,71 @@ class NotifyXMPP(NotifyBase):
     # outside of what is defined in test/test_xmpp_plugin.py, please
     # let me know! :)
     _enabled = NOTIFY_XMPP_SUPPORT_ENABLED
+
+    # Define object templates
+    templates = (
+        '{schema}://{host}',
+        '{schema}://{password}@{host}',
+        '{schema}://{password}@{host}:{port}',
+        '{schema}://{user}:{password}@{host}',
+        '{schema}://{user}:{password}@{host}:{port}',
+        '{schema}://{host}/{targets}',
+        '{schema}://{password}@{host}/{targets}',
+        '{schema}://{password}@{host}:{port}/{targets}',
+        '{schema}://{user}:{password}@{host}/{targets}',
+        '{schema}://{user}:{password}@{host}:{port}/{targets}',
+    )
+
+    # Define our tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'host': {
+            'name': _('Hostname'),
+            'type': 'string',
+            'required': True,
+        },
+        'port': {
+            'name': _('Port'),
+            'type': 'int',
+            'min': 1,
+            'max': 65535,
+        },
+        'user': {
+            'name': _('Username'),
+            'type': 'string',
+        },
+        'password': {
+            'name': _('Password'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+        },
+        'target_jid': {
+            'name': _('Target JID'),
+            'type': 'string',
+            'map_to': 'targets',
+        },
+        'targets': {
+            'name': _('Targets'),
+            'type': 'list:string',
+        },
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'to': {
+            'alias_of': 'targets',
+        },
+        'xep': {
+            'name': _('XEP'),
+            'type': 'list:string',
+            'prefix': 'xep-',
+            'regex': (r'[1-9][0-9]{0,3}', 'i'),
+        },
+        'jid': {
+            'name': _('Source JID'),
+            'type': 'string',
+        },
+    })
 
     def __init__(self, targets=None, jid=None, xep=None, **kwargs):
         """

--- a/apprise/plugins/__init__.py
+++ b/apprise/plugins/__init__.py
@@ -25,6 +25,7 @@
 
 import six
 import re
+import copy
 
 from os import listdir
 from os.path import dirname
@@ -45,6 +46,9 @@ from ..common import NotifyImageSize
 from ..common import NOTIFY_IMAGE_SIZES
 from ..common import NotifyType
 from ..common import NOTIFY_TYPES
+from ..utils import parse_list
+from ..AppriseLocale import gettext_lazy as _
+from ..AppriseLocale import LazyTranslation
 
 # Maintains a mapping of all of the Notification services
 SCHEMA_MAP = {}
@@ -66,6 +70,10 @@ __all__ = [
     # tweepy (used for NotifyTwitter Testing)
     'tweepy',
 ]
+
+# we mirror our base purely for the ability to reset everything; this
+# is generally only used in testing and should not be used by developers
+__MODULE_MAP = {}
 
 
 # Load our Lookup Matrix
@@ -109,15 +117,20 @@ def __load_matrix(path=abspath(dirname(__file__)), name='apprise.plugins'):
             # Filter out non-notification modules
             continue
 
-        elif plugin_name in __all__:
+        elif plugin_name in __MODULE_MAP:
             # we're already handling this object
             continue
+
+        # Add our plugin name to our module map
+        __MODULE_MAP[plugin_name] = {
+            'plugin': plugin,
+            'module': module,
+        }
 
         # Add our module name to our __all__
         __all__.append(plugin_name)
 
-        # Ensure we provide the class as the reference to this directory and
-        # not the module:
+        # Load our module into memory so it's accessible to all
         globals()[plugin_name] = plugin
 
         # Load protocol(s) if defined
@@ -147,5 +160,257 @@ def __load_matrix(path=abspath(dirname(__file__)), name='apprise.plugins'):
     return SCHEMA_MAP
 
 
+# Reset our Lookup Matrix
+def __reset_matrix():
+    """
+    Restores the Lookup matrix to it's base setting. This is only used through
+    testing and should not be directly called.
+    """
+
+    # Reset our schema map
+    SCHEMA_MAP.clear()
+
+    # Iterate over our module map so we can clear out our __all__ and globals
+    for plugin_name in __MODULE_MAP.keys():
+        # Clear out globals
+        del globals()[plugin_name]
+
+        # Remove element from plugins
+        __all__.remove(plugin_name)
+
+    # Clear out our module map
+    __MODULE_MAP.clear()
+
+
 # Dynamically build our schema base
 __load_matrix()
+
+
+def _sanitize_token(tokens, default_delimiter):
+    """
+    This is called by the details() function and santizes the output by
+    populating expected and consistent arguments if they weren't otherwise
+    specified.
+
+    """
+
+    # Iterate over our tokens
+    for key in tokens.keys():
+
+        for element in tokens[key].keys():
+            # Perform translations (if detected to do so)
+            if isinstance(tokens[key][element], LazyTranslation):
+                tokens[key][element] = str(tokens[key][element])
+
+        if 'alias_of' in tokens[key]:
+            # Do not touch this field
+            continue
+
+        if 'map_to' not in tokens[key]:
+            # Default type to key
+            tokens[key]['map_to'] = key
+
+        if 'type' not in tokens[key]:
+            # Default type to string
+            tokens[key]['type'] = 'string'
+
+        elif tokens[key]['type'].startswith('list') \
+                and 'delim' not in tokens[key]:
+            # Default list delimiter (if not otherwise specified)
+            tokens[key]['delim'] = default_delimiter
+
+        elif tokens[key]['type'].startswith('choice') \
+                and 'default' not in tokens[key] \
+                and 'values' in tokens[key] \
+                and len(tokens[key]['values']) == 1:
+            # If there is only one choice; then make it the default
+            tokens[key]['default'] = \
+                tokens[key]['values'][0]
+
+        if 'regex' in tokens[key]:
+            # Verify that we are a tuple; convert strings to tuples
+            if isinstance(tokens[key]['regex'], six.string_types):
+                # Default tuple setup
+                tokens[key]['regex'] = \
+                    (tokens[key]['regex'], None)
+
+            elif not isinstance(tokens[key]['regex'], (list, tuple)):
+                # Invalid regex
+                del tokens[key]['regex']
+
+        if 'required' not in tokens[key]:
+            # Default required is False
+            tokens[key]['required'] = False
+
+        if 'private' not in tokens[key]:
+            # Private flag defaults to False if not set
+            tokens[key]['private'] = False
+    return
+
+
+def details(plugin):
+    """
+    Provides templates that can be used by developers to build URLs
+    dynamically.
+
+    If a list of templates is provided, then they will be used over
+    the default value.
+
+    If a list of tokens are provided, then they will over-ride any
+    additional settings built from this script and/or will be appended
+    to them afterwards.
+    """
+
+    # Our unique list of parsing will be based on the provided templates
+    # if none are provided we will use our own
+    templates = tuple(plugin.templates)
+
+    # The syntax is simple
+    #   {
+    #       # The token_name must tie back to an entry found in the
+    #       # templates list.
+    #       'token_name': {
+    #
+    #            # types can be 'string', 'int', 'choice', 'list, 'float'
+    #            # both choice and list may additionally have a : identify
+    #            # what the list/choice type is comprised of; the default
+    #            # is string.
+    #            'type': 'choice:string',
+    #
+    #            # values will only exist the type must be a fixed
+    #            # list of inputs (generated from type choice for example)
+    #
+    #            # If this is a choice:bool then you should ALWAYS define
+    #            # this list as a (True, False) such as ('Yes, 'No') or
+    #            # ('Enabled', 'Disabled'), etc
+    #            'values': [ 'http', 'https' ],
+    #
+    #            # Identifies if the entry specified is required or not
+    #            'required': True,
+    #
+    #            # Identify a default value
+    #            'default': 'http',
+    #
+    #            # Optional Verification Entries min and max are for floats
+    #            # and/or integers
+    #            'min': 4,
+    #            'max': 5,
+    #
+    #            # A list will always identify a delimiter.  If this is
+    #            # part of a path, this may be a '/', or it could be a
+    #            # comma and/or space. delimiters are always in a list
+    #            #  eg (if space and/or comma is a delimiter the entry
+    #            #      would look like: 'delim': [',' , ' ' ]
+    #            'delim': None,
+    #
+    #            # Use regex if you want to share the regular expression
+    #            # required to validate the field. The regex will never
+    #            # accomodate the prefix (if one is specified).  That is
+    #            # up to the user building the URLs to include the prefix
+    #            # on the URL when constructing it.
+    #            # The format is ('regex', 'reg options')
+    #            'regex': (r'[A-Z0-9]+', 'i'),
+    #
+    #            # A Prefix is always a string, to differentiate between
+    #            # multiple arguments, sometimes content is prefixed.
+    #            'prefix': '@',
+    #
+    #            # By default the key of this object is to be interpreted
+    #            # as the argument to the notification in question. However
+    #            # To accomodate cases where there are multiple types that
+    #            # all map to the same entry, one can find a map_to value.
+    #            'map_to': 'function_arg',
+    #
+    #            # Some arguments act as an alias_of an already defined object
+    #            # This plays a role more with configuration file generation
+    #            # since yaml files allow you to define different argumuments
+    #            # in line to simplify things.  If this directive is set, then
+    #            # it should be treated exactly the same as the object it is
+    #            # an alias of
+    #            'alias_of': 'function_arg',
+    #
+    #            # Advise developers to consider the potential sensitivity
+    #            # of this field owned by the user. This is for passwords,
+    #            # and api keys, etc...
+    #            'private': False,
+    #       },
+    #   }
+
+    # Template tokens identify the arguments required to initialize the
+    # plugin itself.  It identifies all of the tokens and provides some
+    # details on their use.  Each token defined should in some way map
+    # back to at least one URL {token} defined in the templates
+
+    # Since we nest a dictionary within a dictionary, a simple copy isn't
+    # enough. a deepcopy allows us to manipulate this object in this
+    # funtion without obstructing the original.
+    template_tokens = copy.deepcopy(plugin.template_tokens)
+
+    # Arguments and/or Options either have a default value and/or are
+    # optional to be set.
+    #
+    # Since we nest a dictionary within a dictionary, a simple copy isn't
+    # enough. a deepcopy allows us to manipulate this object in this
+    # funtion without obstructing the original.
+    template_args = copy.deepcopy(plugin.template_args)
+
+    # Our template keyword arguments ?+key=value&-key=value
+    # Basically the user provides both the key and the value. this is only
+    # possibly by identifying the key prefix required for them to be
+    # interpreted hence the +/- keys are built into apprise by default for easy
+    # reference. In these cases, entry might look like '+' being the prefix:
+    #   {
+    #      'arg_name': {
+    #          'name': 'label',
+    #          'prefix': '+',
+    #       }
+    #   }
+    #
+    # Since we nest a dictionary within a dictionary, a simple copy isn't
+    # enough. a deepcopy allows us to manipulate this object in this
+    # funtion without obstructing the original.
+    template_kwargs = copy.deepcopy(plugin.template_kwargs)
+
+    # We automatically create a schema entry
+    template_tokens['schema'] = {
+        'name': _('Schema'),
+        'type': 'choice:string',
+        'required': True,
+        'values': parse_list(plugin.secure_protocol, plugin.protocol)
+    }
+
+    # Sanitize our tokens
+    _sanitize_token(template_tokens, default_delimiter=('/', ))
+    # Delimiter(s) are space and/or comma
+    _sanitize_token(template_args, default_delimiter=(',', ' '))
+    _sanitize_token(template_kwargs, default_delimiter=(',', ' '))
+
+    # Argument/Option Handling
+    for key in list(template_args.keys()):
+
+        # _lookup_default looks up what the default value
+        if '_lookup_default' in template_args[key]:
+            template_args[key]['default'] = getattr(
+                plugin, template_args[key]['_lookup_default'])
+
+            # Tidy as we don't want to pass this along in response
+            del template_args[key]['_lookup_default']
+
+        # _exists_if causes the argument to only exist IF after checking
+        # the return of an internal variable requiring a check
+        if '_exists_if' in template_args[key]:
+            if not getattr(plugin,
+                           template_args[key]['_exists_if']):
+                # Remove entire object
+                del template_args[key]
+
+            else:
+                # We only nee to remove this key
+                del template_args[key]['_exists_if']
+
+    return {
+        'templates': templates,
+        'tokens': template_tokens,
+        'args': template_args,
+        'kwargs': template_kwargs,
+    }

--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -25,6 +25,8 @@
 
 import re
 import six
+import contextlib
+import os
 from os.path import expanduser
 
 try:
@@ -589,3 +591,29 @@ def is_exclusive_match(logic, data):
     # Return True if we matched against our logic (or simply none was
     # specified).
     return matched
+
+
+@contextlib.contextmanager
+def environ(*remove, **update):
+    """
+    Temporarily updates the ``os.environ`` dictionary in-place.
+
+    The ``os.environ`` dictionary is updated in-place so that the modification
+    is sure to work in all situations.
+
+    :param remove: Environment variable(s) to remove.
+    :param update: Dictionary of environment variables and values to
+                   add/update.
+    """
+
+    # Create a backup of our environment for restoration purposes
+    env_orig = os.environ.copy()
+
+    try:
+        os.environ.update(update)
+        [os.environ.pop(k, None) for k in remove]
+        yield
+
+    finally:
+        # Restore our snapshot
+        os.environ = env_orig.copy()

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,3 +4,4 @@ mock
 pytest
 pytest-cov
 tox
+babel

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -95,8 +95,10 @@ Requires: python-six
 Requires: python-markdown
 %if 0%{?rhel} && 0%{?rhel} <= 7
 BuildRequires: python-yaml
+BuildRequires: python-babel
 %else
 Requires: python2-yaml
+Requires: python2-babel
 %endif # using rhel7
 
 %if %{with tests}
@@ -141,6 +143,7 @@ BuildRequires: python%{python3_pkgversion}-six
 BuildRequires: python%{python3_pkgversion}-click >= 5.0
 BuildRequires: python%{python3_pkgversion}-markdown
 BuildRequires: python%{python3_pkgversion}-yaml
+BuildRequires: python%{python3_pkgversion}-babel
 Requires: python%{python3_pkgversion}-decorator
 Requires: python%{python3_pkgversion}-requests
 Requires: python%{python3_pkgversion}-requests-oauthlib
@@ -167,9 +170,11 @@ BuildRequires: python%{python3_pkgversion}-pytest-runner
 
 %build
 %if 0%{?with_python2}
+%{__python2} setup.py compile_catalog
 %py2_build
 %endif # with_python2
 %if 0%{?with_python3}
+%{__python3} setup.py compile_catalog
 %py3_build
 %endif # with_python3
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,17 +5,12 @@ universal = 1
 # ensure LICENSE is included in wheel metadata
 license_file = LICENSE
 
-[pycodestyle]
-# We exclude packages we don't maintain
-exclude = .eggs,.tox,gntp,tweepy,pushjet
-ignore = E722,W503,W504
-statistics = true
-
 [flake8]
 # We exclude packages we don't maintain
 exclude = .eggs,.tox,gntp,tweepy,pushjet
 ignore = E722,W503,W504
 statistics = true
+builtins = _
 
 [aliases]
 test=pytest
@@ -26,3 +21,28 @@ python_files = test/test_*.py
 filterwarnings =
 	once::Warning
 strict = true
+
+[extract_messages]
+output-file = apprise/i18n/apprise.pot
+sort-output = true
+copyright-holder = Chris Caron
+msgid-bugs-address = lead2gold@gmail.com
+charset = utf-8
+no-location = true
+add-comments = false
+
+[compile_catalog]
+domain = apprise
+directory = apprise/i18n
+statistics = true
+use-fuzzy = true
+
+[init_catalog]
+domain = apprise
+input-file = apprise/i18n/apprise.pot
+output-dir = apprise/i18n
+
+[update_catalog]
+domain = apprise
+input-file = apprise/i18n/apprise.pot
+output-dir = apprise/i18n

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ except ImportError:
     from distutils.core import setup
 
 from setuptools import find_packages
+from babel.messages import frontend as babel
 
 install_options = os.environ.get("APPRISE_INSTALL", "").split(",")
 install_requires = open('requirements.txt').readlines()
@@ -55,6 +56,12 @@ setup(
     license='MIT',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
+    cmdclass={
+        'compile_catalog': babel.compile_catalog,
+        'extract_messages': babel.extract_messages,
+        'init_catalog': babel.init_catalog,
+        'update_catalog': babel.update_catalog,
+    },
     url='https://github.com/caronc/apprise',
     keywords='Push Notifications Alerts Email AWS SNS Boxcar Discord Dbus '
         'Emby Faast Flock Gitter Gnome Gotify Growl IFTTT Join KODI Mailgun '
@@ -69,6 +76,8 @@ setup(
             'assets/NotifyXML-1.0.xsd',
             'assets/themes/default/*.png',
             'assets/themes/default/*.ico',
+            'i18n/*.py',
+            'i18n/*/LC_MESSAGES/*.mo',
         ],
     },
     install_requires=install_requires,
@@ -87,6 +96,6 @@ setup(
     ),
     entry_points={'console_scripts': console_scripts},
     python_requires='>=2.7',
-    setup_requires=['pytest-runner', ],
+    setup_requires=['pytest-runner', 'babel', ],
     tests_require=open('dev-requirements.txt').readlines(),
 )

--- a/test/test_config_base.py
+++ b/test/test_config_base.py
@@ -358,14 +358,9 @@ urls:
     - tag: my-custom-tag, my-other-tag
 
   # How to stack multiple entries:
-  - mailto://:
-    - user: jeff
-      pass: 123abc
-      from: jeff@yahoo.ca
-
-    - user: jack
-      pass: pass123
-      from: jack@hotmail.com
+  - mailto://user:123abc@yahoo.ca:
+    - to: test@examle.com
+    - to: test2@examle.com
 
       # This is an illegal entry; the schema can not be changed
       schema: json

--- a/test/test_gitter_plugin.py
+++ b/test/test_gitter_plugin.py
@@ -43,7 +43,7 @@ def test_notify_gitter_plugin_general(mock_post, mock_get):
 
     """
     # Disable Throttling to speed testing
-    plugins.NotifyBase.NotifyBase.request_rate_per_sec = 0
+    plugins.NotifyBase.request_rate_per_sec = 0
 
     # Generate a valid token (40 characters)
     token = 'a' * 40

--- a/test/test_growl_plugin.py
+++ b/test/test_growl_plugin.py
@@ -223,7 +223,7 @@ def test_growl_plugin(mock_gntp):
 
             assert(isinstance(obj, instance) is True)
 
-            if isinstance(obj, plugins.NotifyBase.NotifyBase):
+            if isinstance(obj, plugins.NotifyBase):
                 # We loaded okay; now lets make sure we can reverse this url
                 assert(isinstance(obj.url(), six.string_types) is True)
 
@@ -233,7 +233,7 @@ def test_growl_plugin(mock_gntp):
 
                 # Our object should be the same instance as what we had
                 # originally expected above.
-                if not isinstance(obj_cmp, plugins.NotifyBase.NotifyBase):
+                if not isinstance(obj_cmp, plugins.NotifyBase):
                     # Assert messages are hard to trace back with the way
                     # these tests work. Just printing before throwing our
                     # assertion failure makes things easier to debug later on

--- a/test/test_locale.py
+++ b/test/test_locale.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import mock
+import ctypes
+
+from apprise import AppriseLocale
+
+try:
+    # Python v3.4+
+    from importlib import reload
+except ImportError:
+    try:
+        # Python v3.0-v3.3
+        from imp import reload
+    except ImportError:
+        # Python v2.7
+        pass
+
+# Disable logging for a cleaner testing output
+import logging
+logging.disable(logging.CRITICAL)
+
+
+@mock.patch('gettext.install')
+def test_apprise_locale(mock_gettext_install):
+    """
+    API: Test apprise locale object
+    """
+    lazytrans = AppriseLocale.LazyTranslation('Token')
+    assert str(lazytrans) == 'Token'
+
+
+@mock.patch('gettext.install')
+def test_gettext_init(mock_gettext_install):
+    """
+    API: Mock Gettext init
+    """
+    mock_gettext_install.side_effect = ImportError()
+    # Test our fall back to not supporting translations
+    reload(AppriseLocale)
+
+    # Objects can still be created
+    al = AppriseLocale.AppriseLocale()
+
+    with al.lang_at('en'):
+        # functions still behave as normal
+        pass
+
+    # restore the object
+    mock_gettext_install.side_effect = None
+    reload(AppriseLocale)
+
+
+@mock.patch('gettext.translation')
+def test_gettext_translations(mock_gettext_trans):
+    """
+    API: Apprise() Gettext translations
+
+    """
+
+    mock_gettext_trans.side_effect = IOError()
+
+    # This throws internally but we handle it gracefully
+    al = AppriseLocale.AppriseLocale()
+
+    with al.lang_at('en'):
+        # functions still behave as normal
+        pass
+
+    # This throws internally but we handle it gracefully
+    AppriseLocale.AppriseLocale(language="fr")
+
+
+@mock.patch('gettext.translation')
+def test_gettext_installs(mock_gettext_trans):
+    """
+    API: Apprise() Gettext install
+
+    """
+
+    mock_lang = mock.Mock()
+    mock_lang.install.return_value = True
+    mock_gettext_trans.return_value = mock_lang
+
+    # This throws internally but we handle it gracefully
+    al = AppriseLocale.AppriseLocale()
+
+    with al.lang_at('en'):
+        # functions still behave as normal
+        pass
+
+    # This throws internally but we handle it gracefully
+    AppriseLocale.AppriseLocale(language="fr")
+
+    # Force a few different languages
+    al._gtobjs['en'] = mock_lang
+    al._gtobjs['es'] = mock_lang
+    al.lang = 'en'
+
+    with al.lang_at('en'):
+        # functions still behave as normal
+        pass
+
+    with al.lang_at('es'):
+        # functions still behave as normal
+        pass
+
+    with al.lang_at('fr'):
+        # functions still behave as normal
+        pass
+
+
+@mock.patch('locale.getdefaultlocale')
+def test_detect_language(mock_getlocale):
+    """
+    API: Apprise() Detect language
+
+    """
+
+    if not hasattr(ctypes, 'windll'):
+        windll = mock.Mock()
+        # 4105 = en_CA
+        windll.kernel32.GetUserDefaultUILanguage.return_value = 4105
+        setattr(ctypes, 'windll', windll)
+
+    # The below accesses the windows fallback code
+    assert AppriseLocale.AppriseLocale.detect_language() == 'en'
+
+    assert AppriseLocale.AppriseLocale\
+        .detect_language(detect_fallback=False) is None
+
+    # Handle case where getdefaultlocale() can't be detected
+    mock_getlocale.return_value = None
+    delattr(ctypes, 'windll')
+    assert AppriseLocale.AppriseLocale.detect_language() is None
+
+    # if detect_language and windows env fail us, then we don't
+    # set up a default language on first load
+    AppriseLocale.AppriseLocale()

--- a/test/test_pushjet_plugin.py
+++ b/test/test_pushjet_plugin.py
@@ -127,7 +127,7 @@ def test_plugin(mock_refresh, mock_send):
 
             assert(isinstance(obj, instance))
 
-            if isinstance(obj, plugins.NotifyBase.NotifyBase):
+            if isinstance(obj, plugins.NotifyBase):
                 # We loaded okay; now lets make sure we can reverse this url
                 assert(isinstance(obj.url(), six.string_types) is True)
 
@@ -137,7 +137,7 @@ def test_plugin(mock_refresh, mock_send):
 
                 # Our object should be the same instance as what we had
                 # originally expected above.
-                if not isinstance(obj_cmp, plugins.NotifyBase.NotifyBase):
+                if not isinstance(obj_cmp, plugins.NotifyBase):
                     # Assert messages are hard to trace back with the way
                     # these tests work. Just printing before throwing our
                     # assertion failure makes things easier to debug later on

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -2195,7 +2195,7 @@ def test_rest_plugins(mock_post, mock_get):
 
     """
     # Disable Throttling to speed testing
-    plugins.NotifyBase.NotifyBase.request_rate_per_sec = 0
+    plugins.NotifyBase.request_rate_per_sec = 0
 
     # Define how many characters exist per line
     row = 80
@@ -2298,7 +2298,7 @@ def test_rest_plugins(mock_post, mock_get):
 
             assert isinstance(obj, instance) is True
 
-            if isinstance(obj, plugins.NotifyBase.NotifyBase):
+            if isinstance(obj, plugins.NotifyBase):
                 # We loaded okay; now lets make sure we can reverse this url
                 assert isinstance(obj.url(), six.string_types) is True
 
@@ -2308,7 +2308,7 @@ def test_rest_plugins(mock_post, mock_get):
 
                 # Our object should be the same instance as what we had
                 # originally expected above.
-                if not isinstance(obj_cmp, plugins.NotifyBase.NotifyBase):
+                if not isinstance(obj_cmp, plugins.NotifyBase):
                     # Assert messages are hard to trace back with the way
                     # these tests work. Just printing before throwing our
                     # assertion failure makes things easier to debug later on
@@ -2446,7 +2446,7 @@ def test_notify_boxcar_plugin(mock_post, mock_get):
 
     """
     # Disable Throttling to speed testing
-    plugins.NotifyBase.NotifyBase.request_rate_per_sec = 0
+    plugins.NotifyBase.request_rate_per_sec = 0
 
     # Generate some generic message types
     device = 'A' * 64
@@ -2517,7 +2517,7 @@ def test_notify_discord_plugin(mock_post, mock_get):
 
     """
     # Disable Throttling to speed testing
-    plugins.NotifyBase.NotifyBase.request_rate_per_sec = 0
+    plugins.NotifyBase.request_rate_per_sec = 0
 
     # Initialize some generic (but valid) tokens
     webhook_id = 'A' * 24
@@ -2600,7 +2600,7 @@ def test_notify_emby_plugin_login(mock_post, mock_get):
 
     """
     # Disable Throttling to speed testing
-    plugins.NotifyBase.NotifyBase.request_rate_per_sec = 0
+    plugins.NotifyBase.request_rate_per_sec = 0
 
     # Prepare Mock
     mock_get.return_value = requests.Request()
@@ -2719,7 +2719,7 @@ def test_notify_emby_plugin_sessions(mock_post, mock_get, mock_logout,
 
     """
     # Disable Throttling to speed testing
-    plugins.NotifyBase.NotifyBase.request_rate_per_sec = 0
+    plugins.NotifyBase.request_rate_per_sec = 0
 
     # Prepare Mock
     mock_get.return_value = requests.Request()
@@ -2814,7 +2814,7 @@ def test_notify_twilio_plugin(mock_post):
 
     """
     # Disable Throttling to speed testing
-    plugins.NotifyBase.NotifyBase.request_rate_per_sec = 0
+    plugins.NotifyBase.request_rate_per_sec = 0
 
     # Prepare our response
     response = requests.Request()
@@ -2875,7 +2875,7 @@ def test_notify_emby_plugin_logout(mock_post, mock_get, mock_login):
 
     """
     # Disable Throttling to speed testing
-    plugins.NotifyBase.NotifyBase.request_rate_per_sec = 0
+    plugins.NotifyBase.request_rate_per_sec = 0
 
     # Prepare Mock
     mock_get.return_value = requests.Request()
@@ -2941,7 +2941,7 @@ def test_notify_emby_plugin_notify(mock_post, mock_get, mock_logout,
 
     """
     # Disable Throttling to speed testing
-    plugins.NotifyBase.NotifyBase.request_rate_per_sec = 0
+    plugins.NotifyBase.request_rate_per_sec = 0
 
     req = requests.Request()
     req.status_code = requests.codes.ok
@@ -3014,7 +3014,7 @@ def test_notify_ifttt_plugin(mock_post, mock_get):
 
     """
     # Disable Throttling to speed testing
-    plugins.NotifyBase.NotifyBase.request_rate_per_sec = 0
+    plugins.NotifyBase.request_rate_per_sec = 0
 
     # Initialize some generic (but valid) tokens
     webhook_id = 'webhook_id'
@@ -3097,6 +3097,19 @@ def test_notify_ifttt_plugin(mock_post, mock_get):
     assert obj.notify(
         body='body', title='title', notify_type=NotifyType.INFO) is True
 
+    # Test removal of tokens as dict
+    obj = plugins.NotifyIFTTT(
+        webhook_id=webhook_id, events=events,
+        add_tokens={
+            'MyKey': 'MyValue'
+        },
+        del_tokens={
+            plugins.NotifyIFTTT.ifttt_default_title_key: None,
+            plugins.NotifyIFTTT.ifttt_default_body_key: None,
+            plugins.NotifyIFTTT.ifttt_default_type_key: None})
+
+    assert isinstance(obj, plugins.NotifyIFTTT) is True
+
 
 @mock.patch('requests.get')
 @mock.patch('requests.post')
@@ -3106,7 +3119,7 @@ def test_notify_join_plugin(mock_post, mock_get):
 
     """
     # Disable Throttling to speed testing
-    plugins.NotifyBase.NotifyBase.request_rate_per_sec = 0
+    plugins.NotifyBase.request_rate_per_sec = 0
 
     # Generate some generic message types
     device = 'A' * 32
@@ -3140,7 +3153,7 @@ def test_notify_pover_plugin():
 
     """
     # Disable Throttling to speed testing
-    plugins.NotifyBase.NotifyBase.request_rate_per_sec = 0
+    plugins.NotifyBase.request_rate_per_sec = 0
 
     # No token
     try:
@@ -3158,7 +3171,7 @@ def test_notify_ryver_plugin():
 
     """
     # Disable Throttling to speed testing
-    plugins.NotifyBase.NotifyBase.request_rate_per_sec = 0
+    plugins.NotifyBase.request_rate_per_sec = 0
 
     # must be 15 characters long
     token = 'a' * 15
@@ -3181,7 +3194,7 @@ def test_notify_slack_plugin(mock_post, mock_get):
 
     """
     # Disable Throttling to speed testing
-    plugins.NotifyBase.NotifyBase.request_rate_per_sec = 0
+    plugins.NotifyBase.request_rate_per_sec = 0
 
     # Initialize some generic (but valid) tokens
     token_a = 'A' * 9
@@ -3230,7 +3243,7 @@ def test_notify_pushbullet_plugin(mock_post, mock_get):
 
     """
     # Disable Throttling to speed testing
-    plugins.NotifyBase.NotifyBase.request_rate_per_sec = 0
+    plugins.NotifyBase.request_rate_per_sec = 0
 
     # Initialize some generic (but valid) tokens
     accesstoken = 'a' * 32
@@ -3275,7 +3288,7 @@ def test_notify_pushed_plugin(mock_post, mock_get):
 
     """
     # Disable Throttling to speed testing
-    plugins.NotifyBase.NotifyBase.request_rate_per_sec = 0
+    plugins.NotifyBase.request_rate_per_sec = 0
 
     # Chat ID
     recipients = '@ABCDEFG, @DEFGHIJ, #channel, #channel2'
@@ -3344,7 +3357,7 @@ def test_notify_pushover_plugin(mock_post, mock_get):
 
     """
     # Disable Throttling to speed testing
-    plugins.NotifyBase.NotifyBase.request_rate_per_sec = 0
+    plugins.NotifyBase.request_rate_per_sec = 0
 
     # Initialize some generic (but valid) tokens
     token = 'a' * 30
@@ -3408,7 +3421,7 @@ def test_notify_rocketchat_plugin(mock_post, mock_get):
 
     """
     # Disable Throttling to speed testing
-    plugins.NotifyBase.NotifyBase.request_rate_per_sec = 0
+    plugins.NotifyBase.request_rate_per_sec = 0
 
     # Chat ID
     recipients = 'AbcD1245, @l2g, @lead2gold, #channel, #channel2'
@@ -3513,7 +3526,7 @@ def test_notify_telegram_plugin(mock_post, mock_get):
 
     """
     # Disable Throttling to speed testing
-    plugins.NotifyBase.NotifyBase.request_rate_per_sec = 0
+    plugins.NotifyBase.request_rate_per_sec = 0
 
     # Bot Token
     bot_token = '123456789:abcdefg_hijklmnop'
@@ -3587,7 +3600,7 @@ def test_notify_telegram_plugin(mock_post, mock_get):
 
     # We don't override the title maxlen so we should be set to the same
     # as our parent class in this case
-    assert obj.title_maxlen == plugins.NotifyBase.NotifyBase.title_maxlen
+    assert obj.title_maxlen == plugins.NotifyBase.title_maxlen
 
     # This tests erroneous messages involving multiple chat ids
     assert obj.notify(
@@ -3732,7 +3745,7 @@ def test_notify_overflow_truncate():
     #
 
     # Disable Throttling to speed testing
-    plugins.NotifyBase.NotifyBase.request_rate_per_sec = 0
+    plugins.NotifyBase.request_rate_per_sec = 0
 
     # Number of characters per line
     row = 24
@@ -3912,7 +3925,7 @@ def test_notify_overflow_split():
     #
 
     # Disable Throttling to speed testing
-    plugins.NotifyBase.NotifyBase.request_rate_per_sec = 0
+    plugins.NotifyBase.request_rate_per_sec = 0
 
     # Number of characters per line
     row = 24

--- a/test/test_twitter_plugin.py
+++ b/test/test_twitter_plugin.py
@@ -85,7 +85,7 @@ def test_plugin(mock_oauth, mock_api):
 
     """
     # Disable Throttling to speed testing
-    plugins.NotifyBase.NotifyBase.request_rate_per_sec = 0
+    plugins.NotifyBase.request_rate_per_sec = 0
 
     # Define how many characters exist per line
     row = 80
@@ -140,7 +140,7 @@ def test_plugin(mock_oauth, mock_api):
 
             assert isinstance(obj, instance) is True
 
-            if isinstance(obj, plugins.NotifyBase.NotifyBase):
+            if isinstance(obj, plugins.NotifyBase):
                 # We loaded okay; now lets make sure we can reverse this url
                 assert isinstance(obj.url(), six.string_types) is True
 
@@ -150,7 +150,7 @@ def test_plugin(mock_oauth, mock_api):
 
                 # Our object should be the same instance as what we had
                 # originally expected above.
-                if not isinstance(obj_cmp, plugins.NotifyBase.NotifyBase):
+                if not isinstance(obj_cmp, plugins.NotifyBase):
                     # Assert messages are hard to trace back with the way
                     # these tests work. Just printing before throwing our
                     # assertion failure makes things easier to debug later on

--- a/test/test_xmpp_plugin.py
+++ b/test/test_xmpp_plugin.py
@@ -108,7 +108,7 @@ def test_xmpp_plugin(tmpdir):
         .CA_CERTIFICATE_FILE_LOCATIONS = []
 
     # Disable Throttling to speed testing
-    apprise.plugins.NotifyBase.NotifyBase.request_rate_per_sec = 0
+    apprise.plugins.NotifyBase.request_rate_per_sec = 0
 
     # Create our instance
     obj = apprise.Apprise.instantiate('xmpp://', suppress_exceptions=False)

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps=
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev-requirements.txt
 commands =
+    python setup.py compile_catalog
     coverage run --parallel -m pytest {posargs}
     flake8 . --count --show-source --statistics
 
@@ -20,6 +21,7 @@ deps=
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev-requirements.txt
 commands =
+    python setup.py compile_catalog
     coverage run --parallel -m pytest {posargs}
     flake8 . --count --show-source --statistics
 
@@ -29,6 +31,7 @@ deps=
    -r{toxinidir}/requirements.txt
    -r{toxinidir}/dev-requirements.txt
 commands =
+    python setup.py compile_catalog
     coverage run --parallel -m pytest {posargs}
     flake8 . --count --show-source --statistics
 
@@ -38,6 +41,7 @@ deps=
    -r{toxinidir}/requirements.txt
    -r{toxinidir}/dev-requirements.txt
 commands =
+    python setup.py compile_catalog
     coverage run --parallel -m pytest {posargs}
     flake8 . --count --show-source --statistics
 
@@ -47,6 +51,7 @@ deps=
    -r{toxinidir}/requirements.txt
    -r{toxinidir}/dev-requirements.txt
 commands =
+    python setup.py compile_catalog
     coverage run --parallel -m pytest {posargs}
     flake8 . --count --show-source --statistics
 
@@ -56,6 +61,7 @@ deps=
    -r{toxinidir}/requirements.txt
    -r{toxinidir}/dev-requirements.txt
 commands =
+    python setup.py compile_catalog
     coverage run --parallel -m pytest {posargs}
     flake8 . --count --show-source --statistics
 
@@ -64,6 +70,7 @@ deps=
    -r{toxinidir}/requirements.txt
    -r{toxinidir}/dev-requirements.txt
 commands =
+    python setup.py compile_catalog
     coverage run --parallel -m pytest {posargs}
     flake8 . --count --show-source --statistics
 
@@ -72,6 +79,7 @@ deps=
    -r{toxinidir}/requirements.txt
    -r{toxinidir}/dev-requirements.txt
 commands =
+    python setup.py compile_catalog
     coverage run --parallel -m pytest {posargs}
     flake8 . --count --show-source --statistics
 


### PR DESCRIPTION
# Apprise details() Enhancement

**Apprise().details()** now returns a significant more amount of information about each notification allowing developers to dynamically build the URLs used by Apprise by knowing (in advance) all of the arguments needed to do so.
```python
import apprise
from json import dumps

# Our Apprise Object
a = apprise.Apprise()

# Our details we've always used in the past but now provide much more
# detail. The below shows how you can simply view them for yourself as
# this is all explained below
print(dumps(a.details(), indent=2)
```

It does this by introducing four (4) new sections in the _details_ section of the JSON output:

1. **templates**: Identifies the URL structure associated with the specific service, eg:
```json
    {
      "service_name": "Discord", 
      ...
      "details": {
        "templates": [
          "{schema}://{webhook_id}/{webhook_token}", 
          "{schema}://{botname}@{webhook_id}/{webhook_token}"
        ]
      ...
     }
...
```
2. **tokens**: This provides the full mappings of each entry identified in the **templates** (identified above).  It gives some data to easily build a web page and/or application from by allowing developers to dynamically generate the Apprise URLs.<br/> It also provides a **map_to** argument which maps the token directly to the Apprise Notification Class (should you want to manually initialize it this way instead of via a URL). Some tokens can be combined into one single token (as a list).  The **map_to** argument additionally provides this connection as well.  This is discussed more below.
```json
    {
      "service_name": "Discord", 
      ...
      "details": {
        ...
        "tokens": {
          "webhook_token": {
            "map_to": "webhook_token", 
            "required": true, 
            "type": "string", 
            "name": "Webhook Token", 
            "private": true
          }, 
          "schema": {
            "name": "Schema", 
            "default": "discord", 
            "required": true, 
            "private": false, 
            "map_to": "schema", 
            "values": [
              "discord"
            ], 
            "type": "choice:string"
          }, 
          "botname": {
            "type": "string", 
            "required": false, 
            "map_to": "user", 
            "name": "Bot Name", 
            "private": false
          }, 
          "webhook_id": {
            "map_to": "webhook_id", 
            "required": true, 
            "type": "string", 
            "name": "Webhook ID", 
            "private": true
          }
        }
      ...
     }
...
``` 
3. **args**: This identifies any URL arguments you want to define.  The arguments reside after the URL is defined, such as `http://path/?arg=val&arg2=val2`.  URL arguments are never mandatory for a URL's construction with Apprise and merely provide extended options.  A continued example (with respect to Discord) would look like this:
```json
...
    {
      "service_name": "Discord", 
      ...
      "details": {
        ...
        "args": {
          "footer": {
            "name": "Display Footer", 
            "default": false, 
            "required": false, 
            "private": false, 
            "map_to": "footer", 
            "type": "bool"
          }, 
          "tts": {
            "name": "Text To Speech", 
            "default": false, 
            "required": false, 
            "private": false, 
            "map_to": "tts", 
            "type": "bool"
          }, 
          "format": {
            "name": "Notify Format", 
            "default": "text", 
            "type": "choice:string", 
            "required": false, 
            "private": false, 
            "map_to": "format", 
            "values": [
              "text", 
              "html", 
              "markdown"
            ]
          }, 
          "footer_logo": {
            "name": "Footer Logo", 
            "default": true, 
            "required": false, 
            "private": false, 
            "map_to": "footer_logo", 
            "type": "bool"
          }, 
          "avatar": {
            "name": "Avatar Image", 
            "default": true, 
            "required": false, 
            "private": false, 
            "map_to": "avatar", 
            "type": "bool"
          }, 
          "overflow": {
            "name": "Overflow Mode", 
            "default": "upstream", 
            "type": "choice:string", 
            "required": false, 
            "private": false, 
            "map_to": "overflow", 
            "values": [
              "upstream", 
              "truncate", 
              "split"
            ]
          }
        }
      ...
     }
...
``` 
4. **kwargs**: Simiar to args, these are never required, the subtle difference between **args** and **kwargs* is with **args** the key names are already defined.  with **kwargs** the user defines both the key and it's value when building the `?+key=value&-key2=value`.  Custom **kwargs** in Apprise are _ALWAYS_ prefixed with a plus (**+**) or minus (**-**) symbol; for this reason there will ALWAYS be a **prefix** field that identities which symbol is applicable.  There are very few notification services at this time that use this, but to support them, you'll find them here. JSON and XML URLs for example allow one to set the _HTTP Headers_ passed to the server they _POST_ to.

```json
...
    {
      "service_name": "JSON", 
      ...
      "details": {
        ...
        "kwargs": {
          "headers": {
            "name": "HTTP Header", 
            "required": false, 
            "private": false, 
            "prefix": "+", 
            "map_to": "headers", 
            "type": "string"
          }
        }
      ...
     }
...
```
## Argument Breakdown
Here I'll break down the arguments a bit more and what they mean:

| Argument  | Values        | Description  |
| --------- |:-------------:| ------------ |
| **type**  | **int**, **float**, **bool**, **string**<br/>**list:int**, **list:float**, **list:string**<br/>**choice:int**, **choice:float**, **choice:string** | The **type** field will always be present except if an **alias_of** exists. It will allow you to determine what the expected object should be. Many of the additional arguments that can reside in this new section will be completely conditional on the type. |
| **name**  | **string** | This is a fully translatable string. That said, at this time this pull request only supports English; but opens the door for others who want to translate this into other languages. The **name** field will always be present except if an **alias_of** exists.
| **values**  | **list()**| The **values** field **ONLY** exists if the **type** was a **choice:** or **bool** (choice:bool is redudant). This provides the actual choices that are explicitly allowed.
| **required**  | **bool**| This is only set if you can be rest assured the plugin will fail to initialize if this value isn't set.
| **default**  | _some value_ | To simplify a users life; sometimes it's easier to pre-provide default values they can use.
| **private**  | **bool** | This is set to **True** if the argument contains something that would otherwise be private to the user making the notification.  This could be something such as a password, or a private token, an authentication key, etc.  If you're building a website, it might be kind of you to place the **password** input type on these.
| **min**  | **int** / **float** | When the **type** is of **int** or **float** this would identify the minimum value that would be accepted. The **min** will not always be present if there are no restrictions set.  This is just a field that the developer can use to help with some early verification.
| **max**  | **int** / **float** | When the **type** is of **int** or **float** this would identify the maximum value that would be accepted. The **max** will not always be present if there are no restrictions set.  This is just a field that the developer can use to help with some early verification.
| **delim**  | **list** | If we are dealing with a **list:** type, then we are accepting more then one element.  For that we need a way to separate one element from another.  This identifies one or more entries that are acceptable as delimiters. The **delim** argument will only be present if the type is of **list:**.
| **regex**  | **(regex, options)** | If we are dealing with a **string** type (this includes a **list:string**), then we provide a regular expression the developer can optionally use to validate the strings specified.  The result is always returned as a tuple where index zero (0) is the actual regex string and index one (1) is the regex options as a string ('i' = case insensitive, etc). It's important to note that not all **string** entries have this entry.  So you shouldn't depend on it's presence.
| **prefix**  | **string** | Some arguments are identified by apprise based on a prefix value placed in front of them.  For example with slack, the at (@) symbol identifies a user where as pound/hashtag (#) identifies a channel.  If a prefix is identified, it _usually_ means that the attribute has a **map_to** argument causing to map to a shared list. It's important to make sure the prefix exists when constructing the URL and/or passing the argument directly into the Apprise Plugin for it to be effective.
| **alias_of**  | **string** | If you see this, then you won't even see a **type** block.  In fact **alias_of** is a lone wolf and when it exists it merely points to a **token** entry (_never another **arg**_) where you can get the details of this item from.  Think of it as a _symbolic-link_; to make apprise easy to work with, some Notification services have more than one way to provide the same information.  **apprise_of** prevents ambiguity of defining the same thing twice.
| **map_to**  | **string** | This has one core meaning and one helping one.   First off, it's primary reason for existence is for those people who don't want to build URLs from the **templates** and want to directly _instantiate_ their own instance of the Notification service manually (using the class object).  **map_to** always points to the function argument name.<br/> The other use of this is in cases where the **prefix** is used.  You should always check the **token** table to see if the **map_to** can be mapped back to an element already identified here.

## Using The Tokens
So, let's presume you built your website and/or application and provided all of these options to the user.  They provided you with all of these options/tokens populated with their data and now you need to send a notification for them.

No problem, the **Apprise.add()** function now supports dictionaries of URL arguments (not just the URL strings themselves).
```python
import apprise

# First you'll get your details which will provide your app with all the information you need
# to get the data you need from the user with any supported notification service.
a = apprise.Apprise()
apprise_details = details()

# work your magic and get the user to populate the tokens associated with the
# notification services
results = your_code_that_gets_input_from_user(apprise_details)

# Presuming you have all of your tokens now from one of the notification services:
# for example, for email you might have:
# results = {
#   'schema': 'mailto',
#   'host': 'google.com',
#   'user': 'myuser',
#   'password': 'mypassword',
# }
#
# Simply add your results:
a.add(results)

# Done!
```
**Note:** The dictionary keys that you pass into Apprise.add() must be based on the **map_to** directive.

## Internationalization
Full I18n support is built into this pull request allowing the **name** directive to be translated into other languages (making the **details()** support people who've built their website around multi-language support).

The language is automatically translated on the fly to each call to **details()**.  At this time only English is supported, but I welcome anyone wishing to help with translations into other languages.

Here is how it works:
```python
import apprise

# Our Apprise Object
a = apprise.Apprise()

# Get our details in the local language detected from the OS
# apprise is installed on
details = a.details()

# Get our details in English
details = a.details('en')

# Get our details in French
# Note: While this is possible, i need the translations still
details = a.details('fr')
```

Here is how you can help if you want to.  Let's say you want to help translate apprise into another language:
```bash
# First checkout your own copy of apprise and change into the directory
# it downloaded to

# Next prepare your language (the below prepares the French - fr)
python setup.py init_catalog -l fr

# Now have a look at a new file that appeared; with respect to the
# above command it will be:  apprise/i18n/fr/LC_MESSAGES/apprise.po
# Use your favorite editor to edit this file:
code apprise/i18n/fr/LC_MESSAGES/apprise.po
# or #
gvim apprise/i18n/fr/LC_MESSAGES/apprise.po
# or #
notpad apprise/i18n/fr/LC_MESSAGES/apprise.po
# or #
emacs apprise/i18n/fr/LC_MESSAGES/apprise.po
# you get the idea...
# add your translations and pass them back; it's that easy
```
This pull request was based on the request made in #59 