### PR TITLE
Added sound support to Pushover Notifications

### DIFF
--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -1349,6 +1349,10 @@ TEST_URLS = (
     ('pover://%s@%s' % ('u' * 30, 'a' * 24), {
         'instance': TypeError,
     }),
+    # APIKey + invalid sound setting
+    ('pover://%s@%s?sound=invalid' % ('u' * 30, 'a' * 30), {
+        'instance': TypeError,
+    }),
     # APIKey + Valid User
     ('pover://%s@%s' % ('u' * 30, 'a' * 30), {
         'instance': plugins.NotifyPushover,


### PR DESCRIPTION
Added **sound=** argument to **pover://** URLs. (refs #113)

**Example:**
`pover://user@token/?sound=magic`

The supported sounds are based on what they've identified on their website [here](https://pushover.net/api#sounds).  In the event this changes over time, i'll identify them here:

- **pushover** - Pushover (default)  
- **bike** - Bike  
- **bugle** - Bugle  
- **cashregister** - Cash Register  
- **classical** - Classical  
- **cosmic** - Cosmic  
- **falling** - Falling  
- **gamelan** - Gamelan  
- **incominpushover** - Pushover (default)  
- **bike** - Bike  
- **bugle** - Bugle  
- **cashregister** - Cash Register  
- **classical** - Classical  
- **cosmic** - Cosmic  
- **falling** - Falling  
- **gamelan** - Gamelan  
- **incoming** - Incoming  
- **intermission** - Intermission  
- **magic** - Magic  
- **mechanical** - Mechanical  
- **pianobar** - Piano Bar  
- **siren** - Siren  
- **spacealarm** - Space Alarm  
- **tugboat** - Tug Boat  
- **alien** - Alien Alarm (long)  
- **climb** - Climb (long)  
- **persistent** - Persistent (long)  
- **echo** - Pushover Echo (long)  
- **updown** - Up Down (long)  
- **none** - None (silent) g - Incoming  
- **intermission** - Intermission  
- **magic** - Magic  
- **mechanical** - Mechanical  
- **pianobar** - Piano Bar  
- **siren** - Siren  
- **spacealarm** - Space Alarm  
- **tugboat** - Tug Boat  
- **alien** - Alien Alarm (long)  
- **climb** - Climb (long)  
- **persistent** - Persistent (long)  
- **echo** - Pushover Echo (long)  
- **updown** - Up Down (long)  
- **none** - None (silent) 
