### PR TITLE
Notification Service Native URL Support

### DIFF
--- a/apprise/Apprise.py
+++ b/apprise/Apprise.py
@@ -124,12 +124,20 @@ class Apprise(object):
 
             # Some basic validation
             if schema not in plugins.SCHEMA_MAP:
-                logger.error('Unsupported schema {}.'.format(schema))
-                return None
+                # Give the user the benefit of the doubt that the user may be
+                # using one of the URLs provided to them by their notification
+                # service. Before we fail for good, just scan all the plugins
+                # that support he native_url() parse function
+                results = \
+                    next((r['plugin'].parse_native_url(_url)
+                          for r in plugins.MODULE_MAP.values()
+                          if r['plugin'].parse_native_url(_url) is not None),
+                         None)
 
-            # Parse our url details of the server object as dictionary
-            # containing all of the information parsed from our URL
-            results = plugins.SCHEMA_MAP[schema].parse_url(_url)
+            else:
+                # Parse our url details of the server object as dictionary
+                # containing all of the information parsed from our URL
+                results = plugins.SCHEMA_MAP[schema].parse_url(_url)
 
             if results is None:
                 # Failed to parse the server URL

--- a/apprise/plugins/NotifyBase.py
+++ b/apprise/plugins/NotifyBase.py
@@ -402,3 +402,21 @@ class NotifyBase(URLBase):
                 del results['overflow']
 
         return results
+
+    @staticmethod
+    def parse_native_url(url):
+        """
+        This is a base class that can be optionally over-ridden by child
+        classes who can build their Apprise URL based on the one provided
+        by the notification service they choose to use.
+
+        The intent of this is to make Apprise a little more userfriendly
+        to people who aren't familiar with constructing URLs and wish to
+        use the ones that were just provied by their notification serivice
+        that they're using.
+
+        This function will return None if the passed in URL can't be matched
+        as belonging to the notification service. Otherwise this function
+        should return the same set of results that parse_url() does.
+        """
+        return None

--- a/apprise/plugins/NotifyDiscord.py
+++ b/apprise/plugins/NotifyDiscord.py
@@ -396,6 +396,29 @@ class NotifyDiscord(NotifyBase):
         return results
 
     @staticmethod
+    def parse_native_url(url):
+        """
+        Support https://discordapp.com/api/webhooks/WEBHOOK_ID/WEBHOOK_TOKEN
+        """
+
+        result = re.match(
+            r'^https?://discordapp\.com/api/webhooks/'
+            r'(?P<webhook_id>[0-9]+)/'
+            r'(?P<webhook_token>[A-Z0-9_-]+)/?'
+            r'(?P<args>\?[.+])?$', url, re.I)
+
+        if result:
+            return NotifyDiscord.parse_url(
+                '{schema}://{webhook_id}/{webhook_token}/{args}'.format(
+                    schema=NotifyDiscord.secure_protocol,
+                    webhook_id=result.group('webhook_id'),
+                    webhook_token=result.group('webhook_token'),
+                    args='' if not result.group('args')
+                    else result.group('args')))
+
+        return None
+
+    @staticmethod
     def extract_markdown_sections(markdown):
         """
         Takes a string in a markdown type format and extracts

--- a/apprise/plugins/NotifyFlock.py
+++ b/apprise/plugins/NotifyFlock.py
@@ -358,3 +358,24 @@ class NotifyFlock(NotifyBase):
             parse_bool(results['qsd'].get('image', True))
 
         return results
+
+    @staticmethod
+    def parse_native_url(url):
+        """
+        Support https://api.flock.com/hooks/sendMessage/TOKEN
+        """
+
+        result = re.match(
+            r'^https?://api\.flock\.com/hooks/sendMessage/'
+            r'(?P<token>[a-z0-9-]{24})/?'
+            r'(?P<args>\?[.+])?$', url, re.I)
+
+        if result:
+            return NotifyFlock.parse_url(
+                '{schema}://{token}/{args}'.format(
+                    schema=NotifyFlock.secure_protocol,
+                    token=result.group('token'),
+                    args='' if not result.group('args')
+                    else result.group('args')))
+
+        return None

--- a/apprise/plugins/NotifySlack.py
+++ b/apprise/plugins/NotifySlack.py
@@ -472,3 +472,28 @@ class NotifySlack(NotifyBase):
             parse_bool(results['qsd'].get('image', True))
 
         return results
+
+    @staticmethod
+    def parse_native_url(url):
+        """
+        Support https://hooks.slack.com/services/TOKEN_A/TOKEN_B/TOKEN_C
+        """
+
+        result = re.match(
+            r'^https?://hooks\.slack\.com/services/'
+            r'(?P<token_a>[A-Z0-9]{9})/'
+            r'(?P<token_b>[A-Z0-9]{9})/'
+            r'(?P<token_c>[A-Z0-9]{24})/?'
+            r'(?P<args>\?[.+])?$', url, re.I)
+
+        if result:
+            return NotifySlack.parse_url(
+                '{schema}://{token_a}/{token_b}/{token_c}/{args}'.format(
+                    schema=NotifySlack.secure_protocol,
+                    token_a=result.group('token_a'),
+                    token_b=result.group('token_b'),
+                    token_c=result.group('token_c'),
+                    args='' if not result.group('args')
+                    else result.group('args')))
+
+        return None

--- a/apprise/plugins/NotifyWebexTeams.py
+++ b/apprise/plugins/NotifyWebexTeams.py
@@ -245,3 +245,24 @@ class NotifyWebexTeams(NotifyBase):
         results['token'] = NotifyWebexTeams.unquote(results['host'])
 
         return results
+
+    @staticmethod
+    def parse_native_url(url):
+        """
+        Support https://api.ciscospark.com/v1/webhooks/incoming/WEBHOOK_TOKEN
+        """
+
+        result = re.match(
+            r'^https?://api\.ciscospark\.com/v[1-9][0-9]*/webhooks/incoming/'
+            r'(?P<webhook_token>[A-Z0-9_-]+)/?'
+            r'(?P<args>\?[.+])?$', url, re.I)
+
+        if result:
+            return NotifyWebexTeams.parse_url(
+                '{schema}://{webhook_token}/{args}'.format(
+                    schema=NotifyWebexTeams.secure_protocol,
+                    webhook_token=result.group('webhook_token'),
+                    args='' if not result.group('args')
+                    else result.group('args')))
+
+        return None

--- a/apprise/plugins/__init__.py
+++ b/apprise/plugins/__init__.py
@@ -73,7 +73,7 @@ __all__ = [
 
 # we mirror our base purely for the ability to reset everything; this
 # is generally only used in testing and should not be used by developers
-__MODULE_MAP = {}
+MODULE_MAP = {}
 
 
 # Load our Lookup Matrix
@@ -117,12 +117,12 @@ def __load_matrix(path=abspath(dirname(__file__)), name='apprise.plugins'):
             # Filter out non-notification modules
             continue
 
-        elif plugin_name in __MODULE_MAP:
+        elif plugin_name in MODULE_MAP:
             # we're already handling this object
             continue
 
         # Add our plugin name to our module map
-        __MODULE_MAP[plugin_name] = {
+        MODULE_MAP[plugin_name] = {
             'plugin': plugin,
             'module': module,
         }
@@ -171,7 +171,7 @@ def __reset_matrix():
     SCHEMA_MAP.clear()
 
     # Iterate over our module map so we can clear out our __all__ and globals
-    for plugin_name in __MODULE_MAP.keys():
+    for plugin_name in MODULE_MAP.keys():
         # Clear out globals
         del globals()[plugin_name]
 
@@ -179,7 +179,7 @@ def __reset_matrix():
         __all__.remove(plugin_name)
 
     # Clear out our module map
-    __MODULE_MAP.clear()
+    MODULE_MAP.clear()
 
 
 # Dynamically build our schema base

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -177,7 +177,12 @@ TEST_URLS = (
             # don't include an image by default
             'include_image': True,
     }),
-
+    ('https://discordapp.com/api/webhooks/{}/{}'.format(
+        '0' * 10, 'B' * 40), {
+            # Native URL Support, take the discord URL and still build from it
+            'instance': plugins.NotifyDiscord,
+            'requests_response_code': requests.codes.no_content,
+    }),
     ('discord://%s/%s?format=markdown&avatar=No&footer=No' % (
         'i' * 24, 't' * 64), {
             'instance': plugins.NotifyDiscord,
@@ -329,6 +334,10 @@ TEST_URLS = (
     }),
     # Provide text format
     ('flock://%s?format=text' % ('i' * 24), {
+        'instance': plugins.NotifyFlock,
+    }),
+    # Native URL Support, take the slack URL and still build from it
+    ('https://api.flock.com/hooks/sendMessage/{}/'.format('i' * 24), {
         'instance': plugins.NotifyFlock,
     }),
     # Bot API presumed if one or more targets are specified
@@ -532,6 +541,14 @@ TEST_URLS = (
     }),
     # A nicely formed ifttt url with 2 events defined:
     ('ifttt://WebHookID@EventID/EventID2/', {
+        'instance': plugins.NotifyIFTTT,
+    }),
+    # Support native URL references
+    ('https://maker.ifttt.com/use/WebHookID/', {
+        # No EventID specified
+        'instance': TypeError,
+    }),
+    ('https://maker.ifttt.com/use/WebHookID/EventID/', {
         'instance': plugins.NotifyIFTTT,
     }),
     # Test website connection failures
@@ -1052,6 +1069,12 @@ TEST_URLS = (
         # All tokens provided - we're good
         'instance': plugins.NotifyMSTeams,
     }),
+    # Support native URLs
+    ('https://outlook.office.com/webhook/{}@{}/IncomingWebhook/{}/{}'
+     .format(UUID4, UUID4, 'a' * 32, UUID4), {
+         # All tokens provided - we're good
+         'instance': plugins.NotifyMSTeams}),
+
     ('msteams://{}@{}/{}/{}?t2'.format(UUID4, UUID4, 'a' * 32, UUID4), {
         # All tokens provided - we're good
         'instance': plugins.NotifyMSTeams,
@@ -1647,6 +1670,10 @@ TEST_URLS = (
         # the user told the webhook to use; set our ryver mode
         'instance': plugins.NotifyRyver,
     }),
+    # Support Native URLs
+    ('https://apprise.ryver.com/application/webhook/ckhrjW8w672m6HG', {
+        'instance': plugins.NotifyRyver,
+    }),
     ('ryver://caronc@apprise/ckhrjW8w672m6HG', {
         'instance': plugins.NotifyRyver,
         # don't include an image by default
@@ -1717,6 +1744,11 @@ TEST_URLS = (
     }),
     ('slack://username@T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ', {
         # Missing a channel, falls back to webhook channel bindings
+        'instance': plugins.NotifySlack,
+    }),
+    # Native URL Support, take the slack URL and still build from it
+    ('https://hooks.slack.com/services/{}/{}/{}'.format(
+        'A' * 9, 'B' * 9, 'c' * 24), {
         'instance': plugins.NotifySlack,
     }),
     ('slack://username@INVALID/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/#cool', {
@@ -2038,6 +2070,11 @@ TEST_URLS = (
         'instance': TypeError,
     }),
     ('wxteams://{}'.format('a' * 80), {
+        # token provided - we're good
+        'instance': plugins.NotifyWebexTeams,
+    }),
+    # Support Native URLs
+    ('https://api.ciscospark.com/v1/webhooks/incoming/{}'.format('a' * 80), {
         # token provided - we're good
         'instance': plugins.NotifyWebexTeams,
     }),


### PR DESCRIPTION
# Native URL Support
Basically this pull request saves the effort level involved in rebuilding a URL to fit the apprise syntax in certain scenarios.

Take Slack for example; it requires you to create an incoming webhook and provides you the URL to use right away. It looks something like this: `https://hooks.slack.com/services/T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7F`  which is effectively `https://hooks.slack.com/services/{tokenA}/{tokenB}/{tokenC}` when building your apprise URL.

Just the fact that I need to explain this means there is complications involved.   This pull request allows you to just paste the URL straight from the notification service as it was provided to you right into Apprise and still have it work.   With respect to the Slack example just provided, users would have to extract the tokens themselves from the url and create an Apprise URL that looks like this `slack://{tokenA}/{tokenB}/{tokenC}`.  With this pull request, apprise will also accept and accomplish the same feat by just specifying  `https://hooks.slack.com/services/{tokenA}/{tokenB}/{tokenC}` too.

The following notification services provide their own custom URL that users of apprise would need to manipulate in order to work with Apprise. Now this is no longer the case:

| Notification Service | Equal URLs |
| --------------------------- | ----------------- |
| discord:// | native: `https://discordapp.com/api/webhooks/{webhook_id}/{webhook_token}`<br/>apprise: `discord://{webhook_id}/{webhook_token}`
| flock:// | native: `https://api.flock.com/hooks/sendMessage/{webhook_token}`<br/>apprise: `flock://{webhook_token}`
| ifttt:// | native: `https://maker.ifttt.com/use/{webhook_id}/{event_id}`<br/>apprise: `ifttt://{webhook_id}/{event_id}`
| msteams:// | native: `https://outlook.office.com/webhook/{token_a}/IncomingWebhook/{token_b}/{token_c}`<br/>apprise: `msteams://{token_a}/IncomingWebhook/{token_b}/{token_c}`
| ryver:// | native: `https://{organization}.ryver.com/application/webhook/{webhook_token}`<br/>apprise: `ryver://{organization}/{webhook_token}`
| slack:// | native: `https://hooks.slack.com/services/{tokenA}/{tokenB}/{tokenC}`<br/>apprise: `slack://{token_a}/{token_b}/{token_c}`
| wxteams:// | native: `https://api.ciscospark.com/v1/webhooks/incoming/{webhook_token}`<br/>apprise: `wxteams://{webhook_token}`

Refs #109