### PR TITLE
Added sub-path support to MatterMost Notifications

### DIFF
--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -999,6 +999,13 @@ TEST_URLS = (
     ('mmosts://localhost/3ccdd113474722377935511fc85d3dd4', {
         'instance': plugins.NotifyMatterMost,
     }),
+    # Test our paths
+    ('mmosts://localhost/a/path/3ccdd113474722377935511fc85d3dd4', {
+        'instance': plugins.NotifyMatterMost,
+    }),
+    ('mmosts://localhost/////3ccdd113474722377935511fc85d3dd4///', {
+        'instance': plugins.NotifyMatterMost,
+    }),
     ('mmosts://localhost', {
         # Thrown because there was no webhook id specified
         'instance': TypeError,


### PR DESCRIPTION
Add **{path}** support to the MatterMost plugin. Hence the following URLs are now additionally supported:
* **mmosts**://**{hostname}**/**{path}**/**{authtoken}**
* **mmosts**://**{hostname}**:**{port}**/**{path}**/**{authtoken}**
* **mmosts**://**{botname}**@**{hostname}**/**{path}**/**{authtoken}**
* **mmosts**://**{botname}**@**{hostname}**:**{port}**/**{path}**/**{authtoken}**

refs #116 