### PR TITLE
Fixes exception thrown when no localization is detected

### DIFF
--- a/apprise/AppriseLocale.py
+++ b/apprise/AppriseLocale.py
@@ -192,16 +192,24 @@ class AppriseLocale(object):
 
             if hasattr(ctypes, 'windll'):
                 windll = ctypes.windll.kernel32
-                lang = locale.windows_locale[
-                    windll.GetUserDefaultUILanguage()]
-            else:
                 try:
-                    # Detect language
-                    lang = locale.getdefaultlocale()[0]
+                    lang = locale.windows_locale[
+                        windll.GetUserDefaultUILanguage()]
 
-                except TypeError:
-                    # None is returned if the default can't be determined
-                    # we're done in this case
-                    return None
+                    # Our detected windows language
+                    return lang[0:2].lower()
 
-        return lang[0:2].lower()
+                except (TypeError, KeyError):
+                    # Fallback to posix detection
+                    pass
+
+            try:
+                # Detect language
+                lang = locale.getdefaultlocale()[0]
+
+            except TypeError:
+                # None is returned if the default can't be determined
+                # we're done in this case
+                return None
+
+        return None if not lang else lang[0:2].lower()


### PR DESCRIPTION
When a system language can't be detected from the OS, an exception was previously thrown. This pull request gracefully handles the exception.

This fixes #118 