### PR TITLE
don't validate the format of the Mailgun API key

### DIFF
--- a/apprise/plugins/NotifyMailgun.py
+++ b/apprise/plugins/NotifyMailgun.py
@@ -61,7 +61,7 @@ from ..utils import is_email
 from ..AppriseLocale import gettext_lazy as _
 
 # Used to validate your personal access apikey
-VALIDATE_API_KEY = re.compile(r'^[a-z0-9]{32}-[a-z0-9]{8}-[a-z0-9]{8}$', re.I)
+# VALIDATE_API_KEY = re.compile(r'^[a-z0-9]{32}-[a-z0-9]{8}-[a-z0-9]{8}$', re.I)
 
 # Provide some known codes Mailgun uses and what they translate to:
 # Based on https://documentation.mailgun.com/en/latest/api-intro.html#errors
@@ -184,11 +184,11 @@ class NotifyMailgun(NotifyBase):
             self.logger.warning(msg)
             raise TypeError(msg)
 
-        if not VALIDATE_API_KEY.match(self.apikey):
-            msg = 'The API Key specified ({}) is invalid.' \
-                  .format(apikey)
-            self.logger.warning(msg)
-            raise TypeError(msg)
+#        if not VALIDATE_API_KEY.match(self.apikey):
+#            msg = 'The API Key specified ({}) is invalid.' \
+#                  .format(apikey)
+#            self.logger.warning(msg)
+#            raise TypeError(msg)
 
         # Validate our username
         if not self.user:

--- a/apprise/plugins/NotifyMailgun.py
+++ b/apprise/plugins/NotifyMailgun.py
@@ -134,7 +134,6 @@ class NotifyMailgun(NotifyBase):
         'apikey': {
             'name': _('API Key'),
             'type': 'string',
-            'regex': (r'[a-z0-9]{32}-[a-z0-9]{8}-[a-z0-9]{8}', 'i'),
             'private': True,
             'required': True,
         },

--- a/apprise/plugins/NotifyMailgun.py
+++ b/apprise/plugins/NotifyMailgun.py
@@ -51,7 +51,6 @@
 #  the email will be transmitted from.  If no email address is specified
 #  then it will also become the 'to' address as well.
 #
-import re
 import requests
 
 from .NotifyBase import NotifyBase
@@ -59,9 +58,6 @@ from ..common import NotifyType
 from ..utils import parse_list
 from ..utils import is_email
 from ..AppriseLocale import gettext_lazy as _
-
-# Used to validate your personal access apikey
-# VALIDATE_API_KEY = re.compile(r'^[a-z0-9]{32}-[a-z0-9]{8}-[a-z0-9]{8}$', re.I)
 
 # Provide some known codes Mailgun uses and what they translate to:
 # Based on https://documentation.mailgun.com/en/latest/api-intro.html#errors
@@ -183,12 +179,6 @@ class NotifyMailgun(NotifyBase):
             msg = 'No API Key was specified.'
             self.logger.warning(msg)
             raise TypeError(msg)
-
-#        if not VALIDATE_API_KEY.match(self.apikey):
-#            msg = 'The API Key specified ({}) is invalid.' \
-#                  .format(apikey)
-#            self.logger.warning(msg)
-#            raise TypeError(msg)
 
         # Validate our username
         if not self.user:

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -787,10 +787,6 @@ TEST_URLS = (
     ('mailgun://user@host', {
         'instance': TypeError,
     }),
-    # Token specified but it's invalid
-    ('mailgun://user@host/{}'.format('a' * 12), {
-        'instance': TypeError,
-    }),
     # Token is valid, but no user name specified
     ('mailgun://host/{}-{}-{}'.format('a' * 32, 'b' * 8, 'c' * 8), {
         'instance': TypeError,


### PR DESCRIPTION
This just prevents regex validation of the Mailgun API key because keys don't necessarily follow that format.