### PR TITLE
Pushover Notification: Added handling of emergency priority (requiring expire and retry values)

### DIFF
--- a/apprise/plugins/NotifyPushover.py
+++ b/apprise/plugins/NotifyPushover.py
@@ -209,7 +209,8 @@ class NotifyPushover(NotifyBase):
         },
     })
 
-    def __init__(self, token, targets=None, priority=None, sound=None, retry=None, expire=None,
+    def __init__(self, token, targets=None, priority=None, sound=None,
+                 retry=None, expire=None,
                  **kwargs):
         """
         Initialize Pushover Object
@@ -253,7 +254,7 @@ class NotifyPushover(NotifyBase):
         # The following are for emergency alerts
         if self.priority == PushoverPriority.EMERGENCY:
             if retry is None or expire is None:
-                msg = 'Emergency pushes require expire and retry to be specified.'
+                msg = 'Emergency requires expire and retry to be specified.'
                 self.logger.warning(msg)
                 raise TypeError(msg)
             if retry < 30:
@@ -261,7 +262,7 @@ class NotifyPushover(NotifyBase):
                 self.logger.warning(msg)
                 raise TypeError(msg)
             if expire < 0 or expire > 10800:
-                msg = 'Expire has a maximum value of at most 10800 seconds (3 hours).'
+                msg = 'Expire has a max value of at most 10800 seconds.'
                 self.logger.warning(msg)
                 raise TypeError(msg)
 
@@ -396,7 +397,8 @@ class NotifyPushover(NotifyBase):
                 else _map[self.priority],
             'verify': 'yes' if self.verify_certificate else 'no',
         }
-        # Only add expire and retry for emergency messages, pushover ignores for all other priorities
+        # Only add expire and retry for emergency messages,
+        # pushover ignores for all other priorities
         if self.priority == PushoverPriority.EMERGENCY:
             args.update({'expire': self.expire, 'retry': self.retry})
 

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -1379,6 +1379,10 @@ TEST_URLS = (
     ('pover://%s@%s?sound=invalid' % ('u' * 30, 'a' * 30), {
         'instance': TypeError,
     }),
+    # APIKey + valid alternate sound picked
+    ('pover://%s@%s?sound=spacealarm' % ('u' * 30, 'a' * 30), {
+        'instance': plugins.NotifyPushover,
+    }),
     # APIKey + Valid User
     ('pover://%s@%s' % ('u' * 30, 'a' * 30), {
         'instance': plugins.NotifyPushover,
@@ -1415,6 +1419,14 @@ TEST_URLS = (
     }),
     # APIKey + invalid priority setting
     ('pover://%s@%s?priority=invalid' % ('u' * 30, 'a' * 30), {
+        'instance': plugins.NotifyPushover,
+    }),
+    # APIKey + emergency(2) priority setting
+    ('pover://%s@%s?priority=emergency' % ('u' * 30, 'a' * 30), {
+        'instance': TypeError,
+    }),
+    # APIKey + emergency priority setting with retry and expire
+    ('pover://%s@%s?priority=emergency&retry=30&expire=300' % ('u' * 30, 'a' * 30), {
         'instance': plugins.NotifyPushover,
     }),
     # APIKey + priority setting (empty)

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -1423,7 +1423,7 @@ TEST_URLS = (
     }),
     # APIKey + emergency(2) priority setting
     ('pover://%s@%s?priority=emergency' % ('u' * 30, 'a' * 30), {
-        'instance': TypeError,
+        'instance': plugins.NotifyPushover,
     }),
     # APIKey + emergency priority setting with retry and expire
     ('pover://%s@%s?priority=emergency&%s&%s' % ('u' * 30,
@@ -1431,6 +1431,32 @@ TEST_URLS = (
                                                  'retry=30',
                                                  'expire=300'), {
         'instance': plugins.NotifyPushover,
+    }),
+    # APIKey + emergency priority setting with text retry
+    ('pover://%s@%s?priority=emergency&%s&%s' % ('u' * 30,
+                                                 'a' * 30,
+                                                 'retry=invalid',
+                                                 'expire=300'), {
+        'instance': plugins.NotifyPushover,
+    }),
+    # APIKey + emergency priority setting with text expire
+    ('pover://%s@%s?priority=emergency&%s&%s' % ('u' * 30,
+                                                 'a' * 30,
+                                                 'retry=30',
+                                                 'expire=invalid'), {
+        'instance': plugins.NotifyPushover,
+    }),
+    # APIKey + emergency priority setting with invalid expire
+    ('pover://%s@%s?priority=emergency&%s' % ('u' * 30,
+                                              'a' * 30,
+                                              'expire=100000'), {
+        'instance': TypeError,
+    }),
+    # APIKey + emergency priority setting with invalid retry
+    ('pover://%s@%s?priority=emergency&%s' % ('u' * 30,
+                                              'a' * 30,
+                                              'retry=15'), {
+        'instance': TypeError,
     }),
     # APIKey + priority setting (empty)
     ('pover://%s@%s?priority=' % ('u' * 30, 'a' * 30), {

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -1426,7 +1426,8 @@ TEST_URLS = (
         'instance': TypeError,
     }),
     # APIKey + emergency priority setting with retry and expire
-    ('pover://%s@%s?priority=emergency&retry=30&expire=300' % ('u' * 30, 'a' * 30), {
+    ('pover://%s@%s?priority=emergency&retry=30&expire=300'
+     % ('u' * 30, 'a' * 30), {
         'instance': plugins.NotifyPushover,
     }),
     # APIKey + priority setting (empty)

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -1426,8 +1426,10 @@ TEST_URLS = (
         'instance': TypeError,
     }),
     # APIKey + emergency priority setting with retry and expire
-    ('pover://%s@%s?priority=emergency&retry=30&expire=300'
-     % ('u' * 30, 'a' * 30), {
+    ('pover://%s@%s?priority=emergency&%s&%s' % ('u' * 30,
+                                                 'a' * 30,
+                                                 'retry=30',
+                                                 'expire=300'), {
         'instance': plugins.NotifyPushover,
     }),
     # APIKey + priority setting (empty)


### PR DESCRIPTION
Sending pushover notifications of emergency priority did not work since Pushover api requires that both retry and expire are set. This commit handles this by accepting these parameters and checks to make sure they are valid as well.