### PR TITLE
default user references to reference AppriseAsset.app_id()

### DIFF
--- a/apprise/plugins/NotifyFlock.py
+++ b/apprise/plugins/NotifyFlock.py
@@ -55,9 +55,6 @@ FLOCK_HTTP_ERROR_MAP = {
     401: 'Unauthorized - Invalid Token.',
 }
 
-# Default User
-FLOCK_DEFAULT_USER = 'apprise'
-
 # Used to detect a channel/user
 IS_CHANNEL_RE = re.compile(r'^(#|g:)(?P<id>[A-Z0-9_]{12})$', re.I)
 IS_USER_RE = re.compile(r'^(@|u:)?(?P<id>[A-Z0-9_]{12})$', re.I)
@@ -223,7 +220,7 @@ class NotifyFlock(NotifyBase):
             'token': self.token,
             'flockml': body,
             'sendAs': {
-                'name': FLOCK_DEFAULT_USER if not self.user else self.user,
+                'name': self.app_id if not self.user else self.user,
                 # A Profile Image is only configured if we're configured to
                 # allow it
                 'profileImage': None if not self.include_image

--- a/apprise/plugins/NotifyMatrix.py
+++ b/apprise/plugins/NotifyMatrix.py
@@ -62,9 +62,6 @@ IS_ROOM_ID = re.compile(
     r'^\s*(!|&#33;|%21)(?P<room>[a-z0-9-]+)((:|%3A)'
     r'(?P<home_server>[a-z0-9.-]+))?\s*$', re.I)
 
-# Default User
-SLACK_DEFAULT_USER = 'apprise'
-
 
 class MatrixWebhookMode(object):
     # Webhook Mode is disabled
@@ -360,7 +357,7 @@ class NotifyMatrix(NotifyBase):
 
         # prepare JSON Object
         payload = {
-            'username': self.user if self.user else SLACK_DEFAULT_USER,
+            'username': self.user if self.user else self.app_id,
             # Use Markdown language
             'mrkdwn': (self.notify_format == NotifyFormat.MARKDOWN),
             'attachments': [{

--- a/apprise/plugins/NotifySlack.py
+++ b/apprise/plugins/NotifySlack.py
@@ -60,9 +60,6 @@ VALIDATE_TOKEN_B = re.compile(r'[A-Z0-9]{9}')
 #  /........./........./CCCCCCCCCCCCCCCCCCCCCCCC
 VALIDATE_TOKEN_C = re.compile(r'[A-Za-z0-9]{24}')
 
-# Default User
-SLACK_DEFAULT_USER = 'apprise'
-
 # Extend HTTP Error Messages
 SLACK_HTTP_ERROR_MAP = {
     401: 'Unauthorized - Invalid Token.',
@@ -228,7 +225,7 @@ class NotifySlack(NotifyBase):
 
         if not self.user:
             self.logger.warning(
-                'No user was specified; using %s.' % SLACK_DEFAULT_USER)
+                'No user was specified; using "%s".' % self.app_id)
 
         # Build list of channels
         self.channels = parse_list(targets)
@@ -287,7 +284,7 @@ class NotifySlack(NotifyBase):
 
         # prepare JSON Object
         payload = {
-            'username': self.user if self.user else SLACK_DEFAULT_USER,
+            'username': self.user if self.user else self.app_id,
             # Use Markdown language
             'mrkdwn': (self.notify_format == NotifyFormat.MARKDOWN),
             'attachments': [{


### PR DESCRIPTION
This addresses a very valid point identified in #130.

Basically instead of enforcing a new variable to identify default bot names (currently set to _apprise_); use the value identified in the **AppriseAsset()** object instead.