### PR TITLE
use Apprise.asset as asset when using Asset.add

### DIFF
--- a/apprise/Apprise.py
+++ b/apprise/Apprise.py
@@ -212,7 +212,7 @@ class Apprise(object):
         # Initialize our return status
         return_status = True
 
-        if isinstance(asset, AppriseAsset):
+        if asset is None:
             # prepare default asset
             asset = self.asset
 


### PR DESCRIPTION
hello
I updated apprise recently. I was using it like

```
appr_asset = apprise.AppriseAsset()
appr_asset.app_id = 'my app'
appr_asset.app_desc = 'my app desc'
appr = apprise.Apprise(asset=appr_asset)
appr.add('mailtos://...')
appr.notify(whatever)
```
then in the email I get, the "sender" would be shown as "my app". but after I updated apprise it was back to "Apprise Notifications" - as if I never set the custom asset. 

I did I git-bisect and found that it was 0ab86c21 where the functionality changed. So I look at the commit and saw [this](https://github.com/caronc/apprise/commit/0ab86c2115ef5482ab5b15f1000aa736793cfe2e#diff-1bccb1f6b8c68fdcdf33dc68684156eaL205).

I don't really understand it but I tried reverting that hunk and the email sender is the asset app_desc now (how it was before the commit). But of course maybe this is wrong and the change was correct, else/or I'm using apprise wrong

cheers