### PR TITLE
Eliminated line restriction on Join calls

### DIFF
--- a/apprise/plugins/NotifyJoin.py
+++ b/apprise/plugins/NotifyJoin.py
@@ -88,10 +88,6 @@ class NotifyJoin(NotifyBase):
     # Allows the user to specify the NotifyImageSize object
     image_size = NotifyImageSize.XY_72
 
-    # Limit results to just the first 2 line otherwise there is just to much
-    # content to display
-    body_max_line_count = 2
-
     # The maximum allowable characters allowed in the body per message
     body_maxlen = 1000
 


### PR DESCRIPTION
Based on this [post](https://forum.joaoapps.com/index.php?threads/ouroboros-apprise-notifications-clipped.46295/) created on the Forum belonging to the **Join Notification** service, restrictions were imposed limiting message content to just 2 lines.

As it turns out, this was hard-coded right in the source code (dating back to the birth of Apprise).  I'm uncertain as to why this may have been the case therefore it's safe to assume it's a bug.

This pull request eliminates this restriction.