### PR TITLE
Exclusive tag matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,35 @@ apprise -t 'my title' -b 'my notification body' \
 apprise -t 'my title' -b 'my notification body' \
 	--config=/path/to/my/config.yml \
 	--config=https://localhost/my/apprise/config
+
+```
+
+If you just want to see the Apprise services loaded out of all of your configuration files but not actually perform the notification itself, you can use the **--dry-run** (**-d**) switch. This will just print the notifications that would have otherwise been notified with the same action and exits. The best part is that the output is carefully formatted to hide private elements such as your password, API Keys, and tokens from prying eyes.
+```bash
+# Use --dry-run (or -d) to just print out the match
+# notifications; but not actually perform the notification
+# itself.
+apprise --dry-run \
+	--config=/path/to/my/config.yml \
+	--config=https://localhost/my/apprise/config
+
+# If your notifications are hidden behind tags, then the above
+# command may not output anything.  In this case, just add the
+# --tag=all switch. 'all' matches against everything!
+apprise --dry-run \
+	--config=/path/to/my/config.yml \
+	--config=https://localhost/my/apprise/config \
+    --tag=all
+
+# Use the --dry-run with --tag (assuming you tagged your URLs)
+# to find the perfect trigger. If your configuration files have
+# all loaded from their default locations, then the command
+# can be as simple as this:
+apprise --dry-run --tag=friends
+
+# When you're happy, just drop the --dry-run to send off all of
+# your notifications:
+apprise --tag=friends
 ```
 
 ## Developers

--- a/apprise/AppriseConfig.py
+++ b/apprise/AppriseConfig.py
@@ -30,6 +30,7 @@ from . import ConfigBase
 from . import URLBase
 from .AppriseAsset import AppriseAsset
 
+from .common import MATCH_ALL_TAG
 from .utils import GET_SCHEMA_RE
 from .utils import parse_list
 from .utils import is_exclusive_match
@@ -133,7 +134,7 @@ class AppriseConfig(object):
         # Return our status
         return return_status
 
-    def servers(self, tag=None, cache=True):
+    def servers(self, tag=MATCH_ALL_TAG, cache=True):
         """
         Returns all of our servers dynamically build based on parsed
         configuration.
@@ -160,13 +161,11 @@ class AppriseConfig(object):
         for entry in self.configs:
 
             # Apply our tag matching based on our defined logic
-            if tag is not None and not is_exclusive_match(
-                    logic=tag, data=entry.tags):
-                continue
-
-            # Build ourselves a list of services dynamically and return the
-            # as a list
-            response.extend(entry.servers(cache=cache))
+            if is_exclusive_match(
+                    logic=tag, data=entry.tags, match_all=MATCH_ALL_TAG):
+                # Build ourselves a list of services dynamically and return the
+                # as a list
+                response.extend(entry.servers(cache=cache))
 
         return response
 

--- a/apprise/cli.py
+++ b/apprise/cli.py
@@ -188,23 +188,23 @@ def main(body, title, config, urls, notification_type, theme, tag, dry_run,
         print_help_msg(main)
         sys.exit(1)
 
-    if body is None:
-        logger.trace('Reading from stdin')
-        # if no body was specified, then read from STDIN
-        body = click.get_text_stream('stdin').read()
-
     # each --tag entry comprises of a comma separated 'and' list
     # we or each of of the --tag and sets specified.
     tags = None if not tag else [parse_list(t) for t in tag]
 
     if not dry_run:
+        if body is None:
+            logger.trace('No --body (-b) specified; reading from stdin')
+            # if no body was specified, then read from STDIN
+            body = click.get_text_stream('stdin').read()
+
         # now print it out
         result = a.notify(
             body=body, title=title, notify_type=notification_type, tag=tags)
     else:
-        click.secho("Apprise Matched Notifications", bold=True)
         # Number of rows to assume in the terminal.  In future, maybe this can
-        # be detected and made dynamic
+        # be detected and made dynamic. The actual row count is 80, but 5
+        # characters are already reserved for the counter on the left
         rows = 75
 
         # Initialize our URL response;  This is populated within the for/loop
@@ -213,7 +213,7 @@ def main(body, title, config, urls, notification_type, theme, tag, dry_run,
         url = None
 
         for idx, server in enumerate(a.find(tag=tags)):
-            url = server.url()
+            url = server.url(privacy=True)
             click.echo("{: 3d}. {}".format(
                 idx + 1,
                 url if len(url) <= rows else '{}...'.format(url[:rows - 3])))

--- a/apprise/cli.py
+++ b/apprise/cli.py
@@ -111,13 +111,17 @@ def print_version_msg():
               'which services to notify. Use multiple --tag (-g) entries to '
               '"OR" the tags together and comma separated to "AND" them. '
               'If no tags are specified then all services are notified.')
-@click.option('-v', '--verbose', count=True)
-@click.option('-V', '--version', is_flag=True,
+@click.option('--dry-run', '-d', is_flag=True,
+              help='Perform a trial run but only prints the notification '
+              'services to-be triggered to the screen instead of actually '
+              'performing the action.')
+@click.option('--verbose', '-v', count=True)
+@click.option('--version', '-V', is_flag=True,
               help='Display the apprise version and exit.')
 @click.argument('urls', nargs=-1,
                 metavar='SERVER_URL [SERVER_URL2 [SERVER_URL3]]',)
-def main(body, title, config, urls, notification_type, theme, tag, verbose,
-         version):
+def main(body, title, config, urls, notification_type, theme, tag, dry_run,
+         verbose, version):
     """
     Send a notification to all of the specified servers identified by their
     URLs the content provided within the title, body and notification-type.
@@ -185,6 +189,7 @@ def main(body, title, config, urls, notification_type, theme, tag, verbose,
         sys.exit(1)
 
     if body is None:
+        logger.trace('Reading from stdin')
         # if no body was specified, then read from STDIN
         body = click.get_text_stream('stdin').read()
 
@@ -192,8 +197,40 @@ def main(body, title, config, urls, notification_type, theme, tag, verbose,
     # we or each of of the --tag and sets specified.
     tags = None if not tag else [parse_list(t) for t in tag]
 
-    # now print it out
-    if a.notify(
-            body=body, title=title, notify_type=notification_type, tag=tags):
-        sys.exit(0)
-    sys.exit(1)
+    if not dry_run:
+        # now print it out
+        result = a.notify(
+            body=body, title=title, notify_type=notification_type, tag=tags)
+    else:
+        click.secho("Apprise Matched Notifications", bold=True)
+        # Number of rows to assume in the terminal.  In future, maybe this can
+        # be detected and made dynamic
+        rows = 75
+
+        # Initialize our URL response;  This is populated within the for/loop
+        # below; but plays a factor at the end when we need to determine if
+        # we iterated at least once in the loop.
+        url = None
+
+        for idx, server in enumerate(a.find(tag=tags)):
+            url = server.url()
+            click.echo("{: 3d}. {}".format(
+                idx + 1,
+                url if len(url) <= rows else '{}...'.format(url[:rows - 3])))
+
+        # Initialize a default response of nothing matched, otherwise
+        # if we matched at least one entry, we can return True
+        result = None if url is None else True
+
+    if result is None:
+        # There were no notifications set.  This is a result of just having
+        # empty configuration files and/or being to restrictive when filtering
+        # by specific tag(s)
+        sys.exit(2)
+
+    elif result is False:
+        # At least 1 notification service failed to send
+        sys.exit(1)
+
+    # else:  We're good!
+    sys.exit(0)

--- a/apprise/common.py
+++ b/apprise/common.py
@@ -128,3 +128,7 @@ CONFIG_FORMATS = (
     ConfigFormat.TEXT,
     ConfigFormat.YAML,
 )
+
+# This is a reserved tag that is automatically assigned to every
+# Notification Plugin
+MATCH_ALL_TAG = 'all'

--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -529,7 +529,7 @@ def parse_list(*args):
     return sorted([x for x in filter(bool, list(set(result)))])
 
 
-def is_exclusive_match(logic, data):
+def is_exclusive_match(logic, data, match_all='all'):
     """
 
     The data variable should always be a set of strings that the logic can be
@@ -547,21 +547,22 @@ def is_exclusive_match(logic, data):
         logic=[('tagB', 'tagC')]          = tagB and tagC
     """
 
-    if logic is None:
-        # If there is no logic to apply then we're done early
-        return True
-
-    elif isinstance(logic, six.string_types):
+    if isinstance(logic, six.string_types):
         # Update our logic to support our delimiters
         logic = set(parse_list(logic))
+
+    if not logic:
+        # If there is no logic to apply then we're done early; we only match
+        # if there is also no data to match against
+        return not data
 
     if not isinstance(logic, (list, tuple, set)):
         # garbage input
         return False
 
-    # using the data detected; determine if we'll allow the
-    # notification to be sent or not
-    matched = (len(logic) == 0)
+    # Track what we match against; but by default we do not match
+    # against anything
+    matched = False
 
     # Every entry here will be or'ed with the next
     for entry in logic:
@@ -573,7 +574,7 @@ def is_exclusive_match(logic, data):
         # must exist in the notification service
         entries = set(parse_list(entry))
 
-        if len(entries.intersection(data)) == len(entries):
+        if len(entries.intersection(data.union({match_all}))) == len(entries):
             # our set contains all of the entries found
             # in our notification data set
             matched = True

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -461,11 +461,12 @@ def test_apprise_tagging(mock_post, mock_get):
     assert(a.notify(
         title="my title", body="my body", tag=['awesome', 'mmost']) is True)
 
-    # there is nothing to notify using tags 'missing'. However we intentionally
-    # don't fail as there is value in identifying a tag that simply have
-    # nothing to notify from while the object itself contains items
+    # When we query against our loaded notifications for a tag that simply
+    # isn't assigned to anything, we return None.  None (different then False)
+    # tells us that we litterally had nothing to query.  We didn't fail...
+    # but we also didn't do anything...
     assert(a.notify(
-        title="my title", body="my body", tag='missing') is True)
+        title="my title", body="my body", tag='missing') is None)
 
     # Now to test the ability to and and/or notifications
     a = Apprise()
@@ -494,10 +495,10 @@ def test_apprise_tagging(mock_post, mock_get):
         title="my title", body="my body", tag=[('TagC', 'TagD')]) is True)
 
     # Expression: (TagY and TagZ) or TagX
-    # Matches nothing
+    # Matches nothing, None is returned in this case
     assert(a.notify(
         title="my title", body="my body",
-        tag=[('TagY', 'TagZ'), 'TagX']) is True)
+        tag=[('TagY', 'TagZ'), 'TagX']) is None)
 
     # Expression: (TagY and TagZ) or TagA
     # Matches the following only:
@@ -515,10 +516,11 @@ def test_apprise_tagging(mock_post, mock_get):
         title="my title", body="my body",
         tag=[('TagE', 'TagD'), 'TagB']) is True)
 
-    # Garbage Entries
+    # Garbage Entries; we can't do anything with the tag so we have nothing to
+    # notify as a result.  So we simply return None
     assert(a.notify(
         title="my title", body="my body",
-        tag=[(object, ), ]) is True)
+        tag=[(object, ), ]) is None)
 
 
 def test_apprise_notify_formats(tmpdir):

--- a/test/test_apprise_config.py
+++ b/test/test_apprise_config.py
@@ -307,6 +307,8 @@ def test_apprise_config_tagging(tmpdir):
     assert len(ac.servers(tag='a,b')) == 3
     # Now filter: a and b
     assert len(ac.servers(tag=[('a', 'b')])) == 1
+    # all matches everything
+    assert len(ac.servers(tag='all')) == 3
 
 
 def test_apprise_instantiate():

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -60,7 +60,7 @@ def test_apprise_cli(tmpdir):
             # Pretend everything is okay
             return True
 
-        def url(self):
+        def url(self, *args, **kwargs):
             # Support url()
             return 'good://'
 
@@ -72,7 +72,7 @@ def test_apprise_cli(tmpdir):
             # Force a notification failure
             return False
 
-        def url(self):
+        def url(self, *args, **kwargs):
             # Support url()
             return 'bad://'
 
@@ -200,10 +200,10 @@ def test_apprise_cli(tmpdir):
     ])
     assert result.exit_code == 0
     lines = re.split(r'[\r\n]', result.output.strip())
-    # 5 lines of all good:// entries matched + header
-    assert len(lines) == 6
+    # 5 lines of all good:// entries matched
+    assert len(lines) == 5
     # Verify we match against the remaining good:// entries
-    for i in range(1, 6):
+    for i in range(0, 5):
         assert lines[i].endswith('good://')
 
     # This will fail because nothing matches mytag. It's case sensitive

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -68,7 +68,7 @@ def test_apprise_cli(tmpdir):
             super(BadNotification, self).__init__(*args, **kwargs)
 
         def notify(self, **kwargs):
-            # Pretend everything is okay
+            # Force a notification failure
             return False
 
         def url(self):
@@ -120,6 +120,16 @@ def test_apprise_cli(tmpdir):
     ])
     assert result.exit_code == 1
 
+    # Testing with the --dry-run flag reveals a successful response since we
+    # don't actually execute the bad:// notification; we only display it
+    result = runner.invoke(cli.main, [
+        '-t', 'test title',
+        '-b', 'test body',
+        'bad://localhost',
+        '--dry-run',
+    ])
+    assert result.exit_code == 0
+
     # Write a simple text based configuration file
     t = tmpdir.mkdir("apprise-obj").join("apprise")
     buf = """
@@ -128,13 +138,14 @@ def test_apprise_cli(tmpdir):
     """
     t.write(buf)
 
-    # This will read our configuration and send 2 notices to
-    # each of the above defined good:// entries
+    # This will read our configuration and not send any notices at all
+    # because we assigned tags to all of our urls and didn't identify
+    # a specific match below.
     result = runner.invoke(cli.main, [
         '-b', 'test config',
         '--config', str(t),
     ])
-    assert result.exit_code == 0
+    assert result.exit_code == 2
 
     # This will send out 1 notification because our tag matches
     # one of the entries above
@@ -143,17 +154,6 @@ def test_apprise_cli(tmpdir):
         '-b', 'has taga',
         '--config', str(t),
         '--tag', 'taga',
-    ])
-    assert result.exit_code == 0
-
-    # This will send out 0 notification because our tag requests that we meet
-    # at least 2 tags associated with the same notification service (which
-    # isn't the case above)
-    # translation: has taga AND tagd
-    result = runner.invoke(cli.main, [
-        '-b', 'has taga AND tagd',
-        '--config', str(t),
-        '--tag', 'taga,tagd',
     ])
     assert result.exit_code == 0
 
@@ -166,6 +166,66 @@ def test_apprise_cli(tmpdir):
         '--tag', 'taga',
         '--tag', 'tagc',
         '--tag', 'tagd',
+    ])
+    assert result.exit_code == 0
+
+    # Write a simple text based configuration file
+    t = tmpdir.mkdir("apprise-obj2").join("apprise-test2")
+    buf = """
+    good://localhost/1
+    good://localhost/2
+    good://localhost/3
+    good://localhost/4
+    good://localhost/5
+    myTag=good://localhost/6
+    """
+    t.write(buf)
+
+    # This will read our configuration and send a notification to
+    # the first 5 entries in the list, but not the one that has
+    # the tag associated with it
+    result = runner.invoke(cli.main, [
+        '-b', 'test config',
+        '--config', str(t),
+    ])
+    assert result.exit_code == 0
+
+    # This will fail because nothing matches mytag. It's case sensitive
+    # and we would only actually match against myTag
+    result = runner.invoke(cli.main, [
+        '-b', 'has taga',
+        '--config', str(t),
+        '--tag', 'mytag',
+    ])
+    assert result.exit_code == 2
+
+    # Same command as the one identified above except we set the --dry-run
+    # flag. This causes our list of matched results to be printed only.
+    # However, since we don't match anything; we still fail with a return code
+    # of 2.
+    result = runner.invoke(cli.main, [
+        '-b', 'has taga',
+        '--config', str(t),
+        '--tag', 'mytag',
+        '--dry-run'
+    ])
+    assert result.exit_code == 2
+
+    # Here is a case where we get what was expected
+    result = runner.invoke(cli.main, [
+        '-b', 'has taga',
+        '--config', str(t),
+        '--tag', 'myTag',
+    ])
+    assert result.exit_code == 0
+
+    # Testing with the --dry-run flag reveals the same positive results
+    # because there was at least one match
+    result = runner.invoke(cli.main, [
+        '-b', 'has taga',
+        '--config', str(t),
+        '--tag', 'myTag',
+        '--dry-run',
     ])
     assert result.exit_code == 0
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -644,14 +644,17 @@ def test_exclusive_match():
     """utils: is_exclusive_match() testing
     """
 
-    # No Logic always returns True
+    # No Logic always returns True if there is also no data
     assert utils.is_exclusive_match(data=None, logic=None) is True
     assert utils.is_exclusive_match(data=None, logic=set()) is True
     assert utils.is_exclusive_match(data='', logic=set()) is True
     assert utils.is_exclusive_match(data=u'', logic=set()) is True
-    assert utils.is_exclusive_match(data=u'check', logic=set()) is True
+
+    # however, once data is introduced, True is no longer returned
+    # if no logic has been specified
+    assert utils.is_exclusive_match(data=u'check', logic=set()) is False
     assert utils.is_exclusive_match(
-        data=['check', 'checkb'], logic=set()) is True
+        data=['check', 'checkb'], logic=set()) is False
 
     # String delimters are stripped out so that a list can be formed
     # the below is just an empty token list
@@ -696,6 +699,10 @@ def test_exclusive_match():
     #
     data = set(['abc', 'def', 'efg', 'xyz'])
 
+    # match_all matches everything
+    assert utils.is_exclusive_match(logic='all', data=data) is True
+    assert utils.is_exclusive_match(logic=['all'], data=data) is True
+
     # def and abc in data
     assert utils.is_exclusive_match(
         logic=[('abc', 'def')], data=data) is True
@@ -714,6 +721,18 @@ def test_exclusive_match():
     # www or zzz or abc and jjj
     assert utils.is_exclusive_match(
         logic=['www', 'zzz', ('abc', 'jjj')], data=data) is False
+
+    #
+    # Empty data set
+    #
+    data = set()
+    assert utils.is_exclusive_match(logic=['www'], data=data) is False
+    assert utils.is_exclusive_match(logic='all', data=data) is True
+
+    # Change default value from 'all' to 'match_me'. Logic matches
+    # so we pass
+    assert utils.is_exclusive_match(
+        logic='match_me', data=data, match_all='match_me') is True
 
 
 def test_environ_temporary_change():


### PR DESCRIPTION
## Details
Tags matching is much more exclusive then before. Once an Apprise URL has been branded with one or more tags, it is officially bound to them, and them only.  Tagging can be further explained [here](https://github.com/caronc/apprise/wiki/Development_API#tagging).

**References** #153 

## Summary
* [x] Only tagged URLs will be notified when a _matched_ tag (or [tag logic](https://github.com/caronc/apprise/wiki/Development_API#leverage-tagging)) is specified. Apprise URLs bound to tags can no longer be triggered when performing a notification without a tag specified at all.
* [x] URLs that have no tags bound to them at all will still be notified under default circumstances (where no tag is also specified).
* [x] URLs that have no tags bound to them at all will NOT be notified if a tag is specified. _This is already the state the system operates in today.  This point is to just note that this part will remain as is._
* [x] CLI has an exit code of `2` now in the event filters prevent any notification from taking place. An exit code of `2` can also happen if you've loaded empty configuration files into Apprise (or they contain bad entries so there is nothing to notify).
* [x] A new system level tag called `all`  will cause Apprise to match against ALL loaded services regardless of any tags already associated with them or not.
   * When binding a tag to new URLs, the tag `all` should never be assigned since it already takes on this association anyway.   That said, there is no harm in doing so; it just creates unnecessary overhead.
* [x] A new function called **find(tag)** has been made available which contains the extracted logic used just before a notification is sent. It can be used to sift through loaded configuration files and only return the ones matching a specified tag logic. by default, if no tag is specified, then `all` is used causing everything to return.
   * it's worth pointing out that **find()** can reference tag logic.   [This is already documented here](https://github.com/caronc/apprise/wiki/Development_API#leverage-tagging) for advanced syntax examples.
   * **find()** returns an iterator
* [x] Update CLI to include a `--dry-run` or `-d` which prevents the notifications from actually taking place, but can allow you to debug or determine which ones will fire depending on the tag logic you specify. _At this time; the output is restricted to 80 columns_.
* [x] Merged with Pull Request #156 which allows a much cleaner output display when used with `--dry-run` switch.  Once merged, no private credentials will display on the CLI

An example of new `--dry-run` (`-d`) switch added to the Apprise command line interface (CLI) might looks like this (_via stdout_):
```
  1. msteams://a...d/3...e/a...3/?verify=yes&overflow=upstream&image=yes&form...
  2. slack://test@T...2/B...D/T...x/%23random/%40l2g/?verify=yes&overflow=ups...
  3. twitter://0...w/****/1...F/****//?verify=yes&overflow=upstream&mode=dm&f...
```
Private details such as passwords and API keys are masked to either `****` or `s....e` (where `s` is the starting character and `e` is the ending one).