### PR TITLE
Apprise and AppriseConfig truth value support added

### DIFF
--- a/apprise/Apprise.py
+++ b/apprise/Apprise.py
@@ -519,6 +519,20 @@ class Apprise(object):
         # If we reach here, then we indexed out of range
         raise IndexError('list index out of range')
 
+    def __bool__(self):
+        """
+        Allows the Apprise object to be wrapped in an Python 3.x based 'if
+        statement'.  True is returned if at least one service has been loaded.
+        """
+        return len(self) > 0
+
+    def __nonzero__(self):
+        """
+        Allows the Apprise object to be wrapped in an Python 2.x based 'if
+        statement'.  True is returned if at least one service has been loaded.
+        """
+        return len(self) > 0
+
     def __iter__(self):
         """
         Returns an iterator to each of our servers loaded. This includes those

--- a/apprise/AppriseConfig.py
+++ b/apprise/AppriseConfig.py
@@ -276,6 +276,20 @@ class AppriseConfig(object):
         """
         return self.configs[index]
 
+    def __bool__(self):
+        """
+        Allows the Apprise object to be wrapped in an Python 3.x based 'if
+        statement'.  True is returned if at least one service has been loaded.
+        """
+        return True if self.configs else False
+
+    def __nonzero__(self):
+        """
+        Allows the Apprise object to be wrapped in an Python 2.x based 'if
+        statement'.  True is returned if at least one service has been loaded.
+        """
+        return True if self.configs else False
+
     def __iter__(self):
         """
         Returns an iterator to our config list

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -68,6 +68,10 @@ def test_apprise():
     # no items
     assert(len(a) == 0)
 
+    # Apprise object can also be directly tested with 'if' keyword
+    # No entries results in a False response
+    assert(not a)
+
     # Create an Asset object
     asset = AppriseAsset(theme='default')
 
@@ -84,6 +88,10 @@ def test_apprise():
 
     # 2 servers loaded
     assert(len(a) == 2)
+
+    # Apprise object can also be directly tested with 'if' keyword
+    # At least one entry results in a True response
+    assert(a)
 
     # We can retrieve our URLs this way:
     assert(len(a.urls()) == 2)

--- a/test/test_apprise_config.py
+++ b/test/test_apprise_config.py
@@ -55,6 +55,10 @@ def test_apprise_config(tmpdir):
     # There are no servers loaded
     assert len(ac) == 0
 
+    # Object can be directly checked as a boolean; response is False
+    # when there are no entries loaded
+    assert not ac
+
     # lets try anyway
     assert len(ac.servers()) == 0
 
@@ -82,6 +86,10 @@ def test_apprise_config(tmpdir):
 
     # One configuration file should have been found
     assert len(ac) == 1
+
+    # Object can be directly checked as a boolean; response is True
+    # when there is at least one entry
+    assert ac
 
     # We should be able to read our 3 servers from that
     assert len(ac.servers()) == 3


### PR DESCRIPTION
Adds _truth_ support to both **Apprise** and **AppriseConfig**.
```python
import apprise

a = apprise.Apprise()

# This pull request allows logic like this:
if a:
  print("The Apprise Object has at least 1 element loaded into it")
else:
  print("The Apprise Object has no elements loaded into it")
```

In the above example, the text `The Apprise Object has no elements loaded into it` would fire.  This syntax is much cleaner than:
```python
if len(a) > 0:
   # content
```

The same logic has been applied to the **AppriseConfig** for testing if at least one URL was loaded.