### PR TITLE
--dry-run switch output includes associated url tags

### DIFF
--- a/apprise/cli.py
+++ b/apprise/cli.py
@@ -217,6 +217,8 @@ def main(body, title, config, urls, notification_type, theme, tag, dry_run,
             click.echo("{: 3d}. {}".format(
                 idx + 1,
                 url if len(url) <= rows else '{}...'.format(url[:rows - 3])))
+            if server.tags:
+                click.echo("{} - {}".format(' ' * 5, ', '.join(server.tags)))
 
         # Initialize a default response of nothing matched, otherwise
         # if we matched at least one entry, we can return True


### PR DESCRIPTION
Output now includes tag details below the URL (if at least one tag exists); e.g.:
```bash
./test_cli.py --dry-run
  1. msteams://a...d/3...e/a...3/?verify=yes&overflow=upstream&image=yes&form...
     - friends, colleagues, devops
  2. slack://test@T...2/B...D/T...x/%23random/%40l2g/?verify=yes&overflow=ups...
     - devops, testing
  3. twitter://0...w/****/1...F/****//?verify=yes&overflow=upstream&mode=dm&f...
     - public
```