### PR TITLE
Refactored testing and code cleanup

### DIFF
--- a/apprise/plugins/NotifyClickSend.py
+++ b/apprise/plugins/NotifyClickSend.py
@@ -112,7 +112,7 @@ class NotifyClickSend(NotifyBase):
             'name': _('Target Phone No'),
             'type': 'string',
             'prefix': '+',
-            'regex': (r'[0-9\s)(+-]+', 'i'),
+            'regex': (r'^[0-9\s)(+-]+$', 'i'),
             'map_to': 'targets',
         },
         'targets': {

--- a/apprise/plugins/NotifyD7Networks.py
+++ b/apprise/plugins/NotifyD7Networks.py
@@ -131,7 +131,7 @@ class NotifyD7Networks(NotifyBase):
             'name': _('Target Phone No'),
             'type': 'string',
             'prefix': '+',
-            'regex': (r'[0-9\s)(+-]+', 'i'),
+            'regex': (r'^[0-9\s)(+-]+$', 'i'),
             'map_to': 'targets',
         },
         'targets': {
@@ -226,6 +226,8 @@ class NotifyD7Networks(NotifyBase):
             msg = 'There are no valid targets identified to notify.'
             self.logger.warning(msg)
             raise TypeError(msg)
+
+        return
 
     def send(self, body, title='', notify_type=NotifyType.INFO, **kwargs):
         """

--- a/apprise/plugins/NotifyDBus.py
+++ b/apprise/plugins/NotifyDBus.py
@@ -240,6 +240,8 @@ class NotifyDBus(NotifyBase):
         # or not.
         self.include_image = include_image
 
+        return
+
     def send(self, body, title='', notify_type=NotifyType.INFO, **kwargs):
         """
         Perform DBus Notification

--- a/apprise/plugins/NotifyDiscord.py
+++ b/apprise/plugins/NotifyDiscord.py
@@ -49,6 +49,7 @@ from ..common import NotifyImageSize
 from ..common import NotifyFormat
 from ..common import NotifyType
 from ..utils import parse_bool
+from ..utils import validate_regex
 from ..AppriseLocale import gettext_lazy as _
 
 
@@ -144,19 +145,21 @@ class NotifyDiscord(NotifyBase):
         """
         super(NotifyDiscord, self).__init__(**kwargs)
 
-        if not webhook_id:
-            msg = 'An invalid Client ID was specified.'
+        # Webhook ID (associated with project)
+        self.webhook_id = validate_regex(webhook_id)
+        if not self.webhook_id:
+            msg = 'An invalid Discord Webhook ID ' \
+                  '({}) was specified.'.format(webhook_id)
             self.logger.warning(msg)
             raise TypeError(msg)
 
-        if not webhook_token:
-            msg = 'An invalid Webhook Token was specified.'
+        # Webhook Token (associated with project)
+        self.webhook_token = validate_regex(webhook_token)
+        if not self.webhook_token:
+            msg = 'An invalid Discord Webhook Token ' \
+                  '({}) was specified.'.format(webhook_token)
             self.logger.warning(msg)
             raise TypeError(msg)
-
-        # Store our data
-        self.webhook_id = webhook_id
-        self.webhook_token = webhook_token
 
         # Text To Speech
         self.tts = tts

--- a/apprise/plugins/NotifyEmby.py
+++ b/apprise/plugins/NotifyEmby.py
@@ -139,7 +139,7 @@ class NotifyEmby(NotifyBase):
 
         if not self.user:
             # User was not specified
-            msg = 'No Username was specified.'
+            msg = 'No Emby username was specified.'
             self.logger.warning(msg)
             raise TypeError(msg)
 

--- a/apprise/plugins/NotifyFaast.py
+++ b/apprise/plugins/NotifyFaast.py
@@ -91,6 +91,8 @@ class NotifyFaast(NotifyBase):
         # Associate an image with our post
         self.include_image = include_image
 
+        return
+
     def send(self, body, title='', notify_type=NotifyType.INFO, **kwargs):
         """
         Perform Faast Notification

--- a/apprise/plugins/NotifyGitter.py
+++ b/apprise/plugins/NotifyGitter.py
@@ -50,13 +50,11 @@ from ..common import NotifyFormat
 from ..common import NotifyType
 from ..utils import parse_list
 from ..utils import parse_bool
+from ..utils import validate_regex
 from ..AppriseLocale import gettext_lazy as _
 
 # API Gitter URL
 GITTER_API_URL = 'https://api.gitter.im/v1'
-
-# Used to validate your personal access token
-VALIDATE_TOKEN = re.compile(r'^[a-z0-9]{40}$', re.I)
 
 # Used to break path apart into list of targets
 TARGET_LIST_DELIM = re.compile(r'[ \t\r\n,\\/]+')
@@ -112,9 +110,9 @@ class NotifyGitter(NotifyBase):
         'token': {
             'name': _('Token'),
             'type': 'string',
-            'regex': (r'[a-z0-9]{40}', 'i'),
             'private': True,
             'required': True,
+            'regex': (r'^[a-z0-9]{40}$', 'i'),
         },
         'targets': {
             'name': _('Rooms'),
@@ -141,24 +139,21 @@ class NotifyGitter(NotifyBase):
         """
         super(NotifyGitter, self).__init__(**kwargs)
 
-        try:
-            # The personal access token associated with the account
-            self.token = token.strip()
-
-        except AttributeError:
-            # Token was None
-            msg = 'No API Token was specified.'
-            self.logger.warning(msg)
-            raise TypeError(msg)
-
-        if not VALIDATE_TOKEN.match(self.token):
-            msg = 'The Personal Access Token specified ({}) is invalid.' \
-                  .format(token)
+        # Secret Key (associated with project)
+        self.token = validate_regex(
+            token, *self.template_tokens['token']['regex'])
+        if not self.token:
+            msg = 'An invalid Gitter API Token ' \
+                  '({}) was specified.'.format(token)
             self.logger.warning(msg)
             raise TypeError(msg)
 
         # Parse our targets
         self.targets = parse_list(targets)
+        if not self.targets:
+            msg = 'There are no valid Gitter targets to notify.'
+            self.logger.warning(msg)
+            raise TypeError(msg)
 
         # Used to track maping of rooms to their numeric id lookup for
         # messaging
@@ -167,6 +162,8 @@ class NotifyGitter(NotifyBase):
         # Track whether or not we want to send an image with our notification
         # or not.
         self.include_image = include_image
+
+        return
 
     def send(self, body, title='', notify_type=NotifyType.INFO, **kwargs):
         """
@@ -183,8 +180,6 @@ class NotifyGitter(NotifyBase):
         if image_url:
             body = '![alt]({})\n{}'.format(image_url, body)
 
-        # Create a copy of the targets list
-        targets = list(self.targets)
         if self._room_mapping is None:
             # Populate our room mapping
             self._room_mapping = {}
@@ -225,10 +220,8 @@ class NotifyGitter(NotifyBase):
                     'uri': entry['uri'],
                 }
 
-        if len(targets) == 0:
-            # No targets specified
-            return False
-
+        # Create a copy of the targets list
+        targets = list(self.targets)
         while len(targets):
             target = targets.pop(0).lower()
 

--- a/apprise/plugins/NotifyGnome.py
+++ b/apprise/plugins/NotifyGnome.py
@@ -150,6 +150,8 @@ class NotifyGnome(NotifyBase):
         # or not.
         self.include_image = include_image
 
+        return
+
     def send(self, body, title='', notify_type=NotifyType.INFO, **kwargs):
         """
         Perform Gnome Notification

--- a/apprise/plugins/NotifyGotify.py
+++ b/apprise/plugins/NotifyGotify.py
@@ -31,12 +31,12 @@
 #        f2c2688f0b5e6a816bbcec768ca1c0de5af76b88/ADD_MESSAGE_EXAMPLES.md#python
 # API: https://gotify.net/docs/swagger-docs
 
-import six
 import requests
 from json import dumps
 
 from .NotifyBase import NotifyBase
 from ..common import NotifyType
+from ..utils import validate_regex
 from ..AppriseLocale import gettext_lazy as _
 
 
@@ -121,9 +121,12 @@ class NotifyGotify(NotifyBase):
         """
         super(NotifyGotify, self).__init__(**kwargs)
 
-        if not isinstance(token, six.string_types):
-            msg = 'An invalid Gotify token was specified.'
-            self.logger.warning('msg')
+        # Token (associated with project)
+        self.token = validate_regex(token)
+        if not self.token:
+            msg = 'An invalid Gotify Token ' \
+                  '({}) was specified.'.format(token)
+            self.logger.warning(msg)
             raise TypeError(msg)
 
         if priority not in GOTIFY_PRIORITIES:
@@ -137,11 +140,6 @@ class NotifyGotify(NotifyBase):
 
         else:
             self.schema = 'http'
-
-        # Our access token does not get created until we first
-        # authenticate with our Gotify server. The same goes for the
-        # user id below.
-        self.token = token
 
         return
 

--- a/apprise/plugins/NotifyGrowl/__init__.py
+++ b/apprise/plugins/NotifyGrowl/__init__.py
@@ -324,7 +324,6 @@ class NotifyGrowl(NotifyBase):
             # We're done early as we couldn't load the results
             return results
 
-        # Apply our settings now
         version = None
         if 'version' in results['qsd'] and len(results['qsd']['version']):
             # Allow the user to specify the version of the protocol to use.

--- a/apprise/plugins/NotifyIFTTT.py
+++ b/apprise/plugins/NotifyIFTTT.py
@@ -46,6 +46,7 @@ from json import dumps
 from .NotifyBase import NotifyBase
 from ..common import NotifyType
 from ..utils import parse_list
+from ..utils import validate_regex
 from ..AppriseLocale import gettext_lazy as _
 
 
@@ -148,21 +149,20 @@ class NotifyIFTTT(NotifyBase):
         """
         super(NotifyIFTTT, self).__init__(**kwargs)
 
-        if not webhook_id:
-            msg = 'You must specify the Webhooks webhook_id.'
+        # Webhook ID (associated with project)
+        self.webhook_id = validate_regex(webhook_id)
+        if not self.webhook_id:
+            msg = 'An invalid IFTTT Webhook ID ' \
+                  '({}) was specified.'.format(webhook_id)
             self.logger.warning(msg)
             raise TypeError(msg)
 
         # Store our Events we wish to trigger
         self.events = parse_list(events)
-
         if not self.events:
             msg = 'You must specify at least one event you wish to trigger on.'
             self.logger.warning(msg)
             raise TypeError(msg)
-
-        # Store our APIKey
-        self.webhook_id = webhook_id
 
         # Tokens to include in post
         self.add_tokens = {}

--- a/apprise/plugins/NotifyMailgun.py
+++ b/apprise/plugins/NotifyMailgun.py
@@ -57,6 +57,7 @@ from .NotifyBase import NotifyBase
 from ..common import NotifyType
 from ..utils import parse_list
 from ..utils import is_email
+from ..utils import validate_regex
 from ..AppriseLocale import gettext_lazy as _
 
 # Provide some known codes Mailgun uses and what they translate to:
@@ -169,19 +170,17 @@ class NotifyMailgun(NotifyBase):
         """
         super(NotifyMailgun, self).__init__(**kwargs)
 
-        try:
-            # The personal access apikey associated with the account
-            self.apikey = apikey.strip()
-
-        except AttributeError:
-            # Token was None
-            msg = 'No API Key was specified.'
+        # API Key (associated with project)
+        self.apikey = validate_regex(apikey)
+        if not self.apikey:
+            msg = 'An invalid Mailgun API Key ' \
+                  '({}) was specified.'.format(apikey)
             self.logger.warning(msg)
             raise TypeError(msg)
 
         # Validate our username
         if not self.user:
-            msg = 'No username was specified.'
+            msg = 'No Mailgun username was specified.'
             self.logger.warning(msg)
             raise TypeError(msg)
 
@@ -198,7 +197,7 @@ class NotifyMailgun(NotifyBase):
                 raise
         except:
             # Invalid region specified
-            msg = 'The region specified ({}) is invalid.' \
+            msg = 'The Mailgun region specified ({}) is invalid.' \
                   .format(region_name)
             self.logger.warning(msg)
             raise TypeError(msg)

--- a/apprise/plugins/NotifyMatterMost.py
+++ b/apprise/plugins/NotifyMatterMost.py
@@ -23,7 +23,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import re
 import six
 import requests
 from json import dumps
@@ -33,14 +32,12 @@ from ..common import NotifyImageSize
 from ..common import NotifyType
 from ..utils import parse_bool
 from ..utils import parse_list
+from ..utils import validate_regex
 from ..AppriseLocale import gettext_lazy as _
 
 # Some Reference Locations:
 # - https://docs.mattermost.com/developer/webhooks-incoming.html
 # - https://docs.mattermost.com/administration/config-settings.html
-
-# Used to validate Authorization Token
-VALIDATE_AUTHTOKEN = re.compile(r'[a-z0-9]{24,32}', re.I)
 
 
 class NotifyMatterMost(NotifyBase):
@@ -97,7 +94,7 @@ class NotifyMatterMost(NotifyBase):
         'authtoken': {
             'name': _('Access Key'),
             'type': 'string',
-            'regex': (r'[a-z0-9]{24,32}', 'i'),
+            'regex': (r'^[a-z0-9]{24,32}$', 'i'),
             'private': True,
             'required': True,
         },
@@ -152,17 +149,12 @@ class NotifyMatterMost(NotifyBase):
         self.fullpath = '' if not isinstance(
             fullpath, six.string_types) else fullpath.strip()
 
-        # Our Authorization Token
-        self.authtoken = authtoken
-
-        # Validate authtoken
-        if not authtoken:
-            msg = 'Missing MatterMost Authorization Token.'
-            self.logger.warning(msg)
-            raise TypeError(msg)
-
-        if not VALIDATE_AUTHTOKEN.match(authtoken):
-            msg = 'Invalid MatterMost Authorization Token Specified.'
+        # Authorization Token (associated with project)
+        self.authtoken = validate_regex(
+            authtoken, *self.template_tokens['authtoken']['regex'])
+        if not self.authtoken:
+            msg = 'An invalid MatterMost Authorization Token ' \
+                  '({}) was specified.'.format(authtoken)
             self.logger.warning(msg)
             raise TypeError(msg)
 
@@ -340,7 +332,6 @@ class NotifyMatterMost(NotifyBase):
         # all entries before it will be our path
         tokens = NotifyMatterMost.split_path(results['fullpath'])
 
-        # Apply our settings now
         results['authtoken'] = None if not tokens else tokens.pop()
 
         # Store our path

--- a/apprise/plugins/NotifyPushBullet.py
+++ b/apprise/plugins/NotifyPushBullet.py
@@ -30,6 +30,7 @@ from .NotifyBase import NotifyBase
 from ..utils import GET_EMAIL_RE
 from ..common import NotifyType
 from ..utils import parse_list
+from ..utils import validate_regex
 from ..AppriseLocale import gettext_lazy as _
 
 # Flag used as a placeholder to sending to all devices
@@ -110,11 +111,19 @@ class NotifyPushBullet(NotifyBase):
         """
         super(NotifyPushBullet, self).__init__(**kwargs)
 
-        self.accesstoken = accesstoken
+        # Access Token (associated with project)
+        self.accesstoken = validate_regex(accesstoken)
+        if not self.accesstoken:
+            msg = 'An invalid PushBullet Access Token ' \
+                  '({}) was specified.'.format(accesstoken)
+            self.logger.warning(msg)
+            raise TypeError(msg)
 
         self.targets = parse_list(targets)
         if len(self.targets) == 0:
             self.targets = (PUSHBULLET_SEND_TO_ALL, )
+
+        return
 
     def send(self, body, title='', notify_type=NotifyType.INFO, **kwargs):
         """

--- a/apprise/plugins/NotifySimplePush.py
+++ b/apprise/plugins/NotifySimplePush.py
@@ -29,6 +29,7 @@ import requests
 from .NotifyBase import NotifyBase
 from ..URLBase import PrivacyMode
 from ..common import NotifyType
+from ..utils import validate_regex
 from ..AppriseLocale import gettext_lazy as _
 
 # Default our global support flag
@@ -120,11 +121,26 @@ class NotifySimplePush(NotifyBase):
         """
         super(NotifySimplePush, self).__init__(**kwargs)
 
-        # Store the API key
-        self.apikey = apikey
+        # API Key (associated with project)
+        self.apikey = validate_regex(apikey)
+        if not self.apikey:
+            msg = 'An invalid SimplePush API Key ' \
+                  '({}) was specified.'.format(apikey)
+            self.logger.warning(msg)
+            raise TypeError(msg)
 
-        # Event Name
-        self.event = event
+        if event:
+            # Event Name (associated with project)
+            self.event = validate_regex(event)
+            if not self.event:
+                msg = 'An invalid SimplePush Event Name ' \
+                      '({}) was specified.'.format(event)
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
+        else:
+            # Default Event Name
+            self.event = None
 
         # Encrypt Message (providing support is available)
         if self.password and self.user and not CRYPTOGRAPHY_AVAILABLE:
@@ -182,7 +198,6 @@ class NotifySimplePush(NotifyBase):
         payload = {
             'key': self.apikey,
         }
-        event = self.event
 
         if self.password and self.user and CRYPTOGRAPHY_AVAILABLE:
             body = self._encrypt(body)
@@ -198,8 +213,9 @@ class NotifySimplePush(NotifyBase):
             'title': title,
         })
 
-        if event:
-            payload['event'] = event
+        if self.event:
+            # Store Event
+            payload['event'] = self.event
 
         self.logger.debug('SimplePush POST URL: %s (cert_verify=%r)' % (
             self.notify_url, self.verify_certificate,

--- a/apprise/plugins/NotifyTwitter.py
+++ b/apprise/plugins/NotifyTwitter.py
@@ -37,6 +37,7 @@ from ..URLBase import PrivacyMode
 from ..common import NotifyType
 from ..utils import parse_list
 from ..utils import parse_bool
+from ..utils import validate_regex
 from ..AppriseLocale import gettext_lazy as _
 
 IS_USER = re.compile(r'^\s*@?(?P<user>[A-Z0-9_]+)$', re.I)
@@ -186,23 +187,27 @@ class NotifyTwitter(NotifyBase):
         """
         super(NotifyTwitter, self).__init__(**kwargs)
 
-        if not ckey:
-            msg = 'An invalid Consumer API Key was specified.'
+        self.ckey = validate_regex(ckey)
+        if not self.ckey:
+            msg = 'An invalid Twitter Consumer Key was specified.'
             self.logger.warning(msg)
             raise TypeError(msg)
 
-        if not csecret:
-            msg = 'An invalid Consumer Secret API Key was specified.'
+        self.csecret = validate_regex(csecret)
+        if not self.csecret:
+            msg = 'An invalid Twitter Consumer Secret was specified.'
             self.logger.warning(msg)
             raise TypeError(msg)
 
-        if not akey:
-            msg = 'An invalid Access Token API Key was specified.'
+        self.akey = validate_regex(akey)
+        if not self.akey:
+            msg = 'An invalid Twitter Access Key was specified.'
             self.logger.warning(msg)
             raise TypeError(msg)
 
-        if not asecret:
-            msg = 'An invalid Access Token Secret API Key was specified.'
+        self.asecret = validate_regex(asecret)
+        if not self.asecret:
+            msg = 'An invalid Access Secret was specified.'
             self.logger.warning(msg)
             raise TypeError(msg)
 
@@ -219,6 +224,9 @@ class NotifyTwitter(NotifyBase):
             self.logger.warning(msg)
             raise TypeError(msg)
 
+        # Track any errors
+        has_error = False
+
         # Identify our targets
         self.targets = []
         for target in parse_list(targets):
@@ -227,15 +235,19 @@ class NotifyTwitter(NotifyBase):
                 self.targets.append(match.group('user'))
                 continue
 
+            has_error = True
             self.logger.warning(
                 'Dropped invalid user ({}) specified.'.format(target),
             )
 
-        # Store our data
-        self.ckey = ckey
-        self.csecret = csecret
-        self.akey = akey
-        self.asecret = asecret
+        if has_error and not self.targets:
+            # We have specified that we want to notify one or more individual
+            # and we failed to load any of them.  Since it's also valid to
+            # notify no one at all (which means we notify ourselves), it's
+            # important we don't switch from the users original intentions
+            msg = 'No Twitter targets to notify.'
+            self.logger.warning(msg)
+            raise TypeError(msg)
 
         return
 
@@ -297,7 +309,7 @@ class NotifyTwitter(NotifyBase):
             }
         }
 
-        # Lookup our users
+        # Lookup our users (otherwise we look up ourselves)
         targets = self._whoami(lazy=self.cache) if not len(self.targets) \
             else self._user_lookup(self.targets, lazy=self.cache)
 

--- a/apprise/plugins/NotifyXMPP.py
+++ b/apprise/plugins/NotifyXMPP.py
@@ -157,7 +157,7 @@ class NotifyXMPP(NotifyBase):
             'name': _('XEP'),
             'type': 'list:string',
             'prefix': 'xep-',
-            'regex': (r'[1-9][0-9]{0,3}', 'i'),
+            'regex': (r'^[1-9][0-9]{0,3}$', 'i'),
         },
         'jid': {
             'name': _('Source JID'),

--- a/apprise/plugins/__init__.py
+++ b/apprise/plugins/__init__.py
@@ -378,6 +378,16 @@ def details(plugin):
     # Argument/Option Handling
     for key in list(template_args.keys()):
 
+        if 'alias_of' in template_args[key]:
+            # Check if the mapped reference is a list; if it is, then
+            # we need to store a different delimiter
+            alias_of = template_tokens.get(template_args[key]['alias_of'], {})
+            if alias_of.get('type', '').startswith('list') \
+                    and 'delim' not in template_args[key]:
+                # Set a default delimiter of a comma and/or space if one
+                # hasn't already been specified
+                template_args[key]['delim'] = (',', ' ')
+
         # _lookup_default looks up what the default value
         if '_lookup_default' in template_args[key]:
             template_args[key]['default'] = getattr(

--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -28,6 +28,7 @@ import six
 import contextlib
 import os
 from os.path import expanduser
+from functools import reduce
 
 try:
     # Python 2.7
@@ -113,9 +114,16 @@ GET_EMAIL_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Regular expression used to extract a phone number
+GET_PHONE_NO_RE = re.compile(r'^\+?(?P<phone>[0-9\s)(+-]+)\s*$')
+
 # Regular expression used to destinguish between multiple URLs
 URL_DETECTION_RE = re.compile(
     r'([a-z0-9]+?:\/\/.*?)[\s,]*(?=$|[a-z0-9]+?:\/\/)', re.I)
+
+# validate_regex() utilizes this mapping to track and re-use pre-complied
+# regular expressions
+REGEX_VALIDATE_LOOKUP = {}
 
 
 def is_hostname(hostname):
@@ -512,14 +520,6 @@ def parse_list(*args):
         elif isinstance(arg, (set, list, tuple)):
             result += parse_list(*arg)
 
-        elif arg is None:
-            # Ignore
-            continue
-
-        else:
-            # Convert whatever it is to a string and work with it
-            result += parse_list(str(arg))
-
     #
     # filter() eliminates any empty entries
     #
@@ -573,6 +573,11 @@ def is_exclusive_match(logic, data, match_all='all'):
         # treat these entries as though all elements found
         # must exist in the notification service
         entries = set(parse_list(entry))
+        if not entries:
+            # We got a bogus set of tags to parse
+            # If there is no logic to apply then we're done early; we only
+            # match if there is also no data to match against
+            return not data
 
         if len(entries.intersection(data.union({match_all}))) == len(entries):
             # our set contains all of the entries found
@@ -585,6 +590,82 @@ def is_exclusive_match(logic, data, match_all='all'):
     # Return True if we matched against our logic (or simply none was
     # specified).
     return matched
+
+
+def validate_regex(value, regex=r'[^\s]+', flags=re.I, strip=True, fmt=None):
+    """
+    A lot of the tokens, secrets, api keys, etc all have some regular
+    expression validation they support.  This hashes the regex after it's
+    compiled and returns it's content if matched, otherwise it returns None.
+
+    This function greatly increases performance as it prevents apprise modules
+    from having to pre-compile all of their regular expressions.
+
+        value is the element being tested
+        regex is the regular expression to be compiled and tested. By default
+         we extract the first chunk of code while eliminating surrounding
+         whitespace (if present)
+
+        flags is the regular expression flags that should be applied
+        format is used to alter the response format if the regular
+         expression matches. You identify your format using {tags}.
+         Effectively nesting your ID's between {}. Consider a regex of:
+          '(?P<year>[0-9]{2})[0-9]+(?P<value>[A-Z])'
+        to which you could set your format up as '{value}-{year}'. This
+        would substitute the matched groups and format a response.
+    """
+
+    if flags:
+        # Regex String -> Flag Lookup Map
+        _map = {
+            # Ignore Case
+            'i': re.I,
+            # Multi Line
+            'm': re.M,
+            # Dot Matches All
+            's': re.S,
+            # Locale Dependant
+            'L': re.L,
+            # Unicode Matching
+            'u': re.U,
+            # Verbose
+            'x': re.X,
+        }
+
+        if isinstance(flags, six.string_types):
+            # Convert a string of regular expression flags into their
+            # respected integer (expected) Python values and perform
+            # a bit-wise or on each match found:
+            flags = reduce(
+                lambda x, y: x | y,
+                [0] + [_map[f] for f in flags if f in _map])
+
+    else:
+        # Handles None/False/'' cases
+        flags = 0
+
+    # A key is used to store our compiled regular expression
+    key = '{}{}'.format(regex, flags)
+
+    if key not in REGEX_VALIDATE_LOOKUP:
+        REGEX_VALIDATE_LOOKUP[key] = re.compile(regex, flags)
+
+    # Perform our lookup usig our pre-compiled result
+    try:
+        result = REGEX_VALIDATE_LOOKUP[key].match(value)
+        if not result:
+            # let outer exception handle this
+            raise TypeError
+
+        if fmt:
+            # Map our format back to our response
+            value = fmt.format(**result.groupdict())
+
+    except (TypeError, AttributeError):
+        return None
+
+    # Return our response
+    return value.strip() if strip else value
 
 
 @contextlib.contextmanager

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -68,11 +68,11 @@ def test_apprise():
     a = Apprise()
 
     # no items
-    assert(len(a) == 0)
+    assert len(a) == 0
 
     # Apprise object can also be directly tested with 'if' keyword
     # No entries results in a False response
-    assert(not a)
+    assert not a
 
     # Create an Asset object
     asset = AppriseAsset(theme='default')
@@ -89,66 +89,62 @@ def test_apprise():
     a = Apprise(servers=servers)
 
     # 2 servers loaded
-    assert(len(a) == 2)
+    assert len(a) == 2
 
     # Apprise object can also be directly tested with 'if' keyword
     # At least one entry results in a True response
-    assert(a)
+    assert a
 
     # We can retrieve our URLs this way:
-    assert(len(a.urls()) == 2)
+    assert len(a.urls()) == 2
 
     # We can add another server
-    assert(
-        a.add('mmosts://mattermost.server.local/'
-              '3ccdd113474722377935511fc85d3dd4') is True)
-    assert(len(a) == 3)
+    assert a.add('mmosts://mattermost.server.local/'
+                 '3ccdd113474722377935511fc85d3dd4') is True
+    assert len(a) == 3
 
     # We can pop an object off of our stack by it's indexed value:
     obj = a.pop(0)
-    assert(isinstance(obj, NotifyBase) is True)
-    assert(len(a) == 2)
+    assert isinstance(obj, NotifyBase) is True
+    assert len(a) == 2
 
     # We can retrieve elements from our list too by reference:
-    assert(isinstance(a[0].url(), six.string_types) is True)
+    assert isinstance(a[0].url(), six.string_types) is True
 
     # We can iterate over our list too:
     count = 0
     for o in a:
-        assert(isinstance(o.url(), six.string_types) is True)
+        assert isinstance(o.url(), six.string_types) is True
         count += 1
     # verify that we did indeed iterate over each element
-    assert(len(a) == count)
+    assert len(a) == count
 
     # We can empty our set
     a.clear()
-    assert(len(a) == 0)
+    assert len(a) == 0
 
     # An invalid schema
-    assert(
-        a.add('this is not a parseable url at all') is False)
-    assert(len(a) == 0)
+    assert a.add('this is not a parseable url at all') is False
+    assert len(a) == 0
 
     # An unsupported schema
-    assert(
-        a.add('invalid://we.just.do.not.support.this.plugin.type') is False)
-    assert(len(a) == 0)
+    assert a.add(
+        'invalid://we.just.do.not.support.this.plugin.type') is False
+    assert len(a) == 0
 
     # A poorly formatted URL
-    assert(
-        a.add('json://user:@@@:bad?no.good') is False)
-    assert(len(a) == 0)
+    assert a.add('json://user:@@@:bad?no.good') is False
+    assert len(a) == 0
 
     # Add a server with our asset we created earlier
-    assert(
-        a.add('mmosts://mattermost.server.local/'
-              '3ccdd113474722377935511fc85d3dd4', asset=asset) is True)
+    assert a.add('mmosts://mattermost.server.local/'
+                 '3ccdd113474722377935511fc85d3dd4', asset=asset) is True
 
     # Clear our server listings again
     a.clear()
 
     # No servers to notify
-    assert(a.notify(title="my title", body="my body") is False)
+    assert a.notify(title="my title", body="my body") is False
 
     class BadNotification(NotifyBase):
         def __init__(self, **kwargs):
@@ -183,26 +179,26 @@ def test_apprise():
     # Just to explain what is happening here, we would have parsed the
     # url properly but failed when we went to go and create an instance
     # of it.
-    assert(a.add('bad://localhost') is False)
-    assert(len(a) == 0)
+    assert a.add('bad://localhost') is False
+    assert len(a) == 0
 
-    assert(a.add('good://localhost') is True)
-    assert(len(a) == 1)
+    assert a.add('good://localhost') is True
+    assert len(a) == 1
 
     # Bad Notification Type is still allowed as it is presumed the user
     # know's what their doing
-    assert(a.notify(
-        title="my title", body="my body", notify_type='bad') is True)
+    assert a.notify(
+        title="my title", body="my body", notify_type='bad') is True
 
     # No Title/Body combo's
-    assert(a.notify(title=None, body=None) is False)
-    assert(a.notify(title='', body=None) is False)
-    assert(a.notify(title=None, body='') is False)
+    assert a.notify(title=None, body=None) is False
+    assert a.notify(title='', body=None) is False
+    assert a.notify(title=None, body='') is False
 
     # As long as one is present, we're good
-    assert(a.notify(title=None, body='present') is True)
-    assert(a.notify(title='present', body=None) is True)
-    assert(a.notify(title="present", body="present") is True)
+    assert a.notify(title=None, body='present') is True
+    assert a.notify(title='present', body=None) is True
+    assert a.notify(title="present", body="present") is True
 
     # Clear our server listings again
     a.clear()
@@ -244,14 +240,14 @@ def test_apprise():
     # Store our good notification in our schema map
     SCHEMA_MAP['runtime'] = RuntimeNotification
 
-    assert(a.add('runtime://localhost') is True)
-    assert(a.add('throw://localhost') is True)
-    assert(a.add('fail://localhost') is True)
-    assert(len(a) == 3)
+    assert a.add('runtime://localhost') is True
+    assert a.add('throw://localhost') is True
+    assert a.add('fail://localhost') is True
+    assert len(a) == 3
 
     # Test when our notify both throws an exception and or just
     # simply returns False
-    assert(a.notify(title="present", body="present") is False)
+    assert a.notify(title="present", body="present") is False
 
     # Create a Notification that throws an unexected exception
     class ThrowInstantiateNotification(NotifyBase):
@@ -267,7 +263,7 @@ def test_apprise():
 
     # Reset our object
     a.clear()
-    assert(len(a) == 0)
+    assert len(a) == 0
 
     # Instantiate a bad object
     plugin = a.instantiate(object, tag="bad_object")
@@ -275,40 +271,37 @@ def test_apprise():
 
     # Instantiate a good object
     plugin = a.instantiate('good://localhost', tag="good")
-    assert(isinstance(plugin, NotifyBase))
+    assert isinstance(plugin, NotifyBase)
 
     # Test simple tagging inside of the object
-    assert("good" in plugin)
-    assert("bad" not in plugin)
+    assert "good" in plugin
+    assert "bad" not in plugin
 
     # the in (__contains__ override) is based on or'ed content; so although
     # 'bad' isn't tagged as being in the plugin, 'good' is, so the return
     # value of this is True
-    assert(["bad", "good"] in plugin)
-    assert(set(["bad", "good"]) in plugin)
-    assert(("bad", "good") in plugin)
+    assert ["bad", "good"] in plugin
+    assert set(["bad", "good"]) in plugin
+    assert ("bad", "good") in plugin
 
     # We an add already substatiated instances into our Apprise object
     a.add(plugin)
-    assert(len(a) == 1)
+    assert len(a) == 1
 
     # We can add entries as a list too (to add more then one)
     a.add([plugin, plugin, plugin])
-    assert(len(a) == 4)
+    assert len(a) == 4
 
     # Reset our object again
     a.clear()
-    try:
+    with pytest.raises(TypeError):
         a.instantiate('throw://localhost', suppress_exceptions=False)
-        assert(False)
 
-    except TypeError:
-        assert(True)
-    assert(len(a) == 0)
+    assert len(a) == 0
 
-    assert(a.instantiate(
-        'throw://localhost', suppress_exceptions=True) is None)
-    assert(len(a) == 0)
+    assert a.instantiate(
+        'throw://localhost', suppress_exceptions=True) is None
+    assert len(a) == 0
 
     #
     # We rince and repeat the same tests as above, however we do them
@@ -317,50 +310,53 @@ def test_apprise():
 
     # Reset our object
     a.clear()
-    assert(len(a) == 0)
+    assert len(a) == 0
 
     # Instantiate a good object
     plugin = a.instantiate({
         'schema': 'good',
         'host': 'localhost'}, tag="good")
-    assert(isinstance(plugin, NotifyBase))
+    assert isinstance(plugin, NotifyBase)
 
     # Test simple tagging inside of the object
-    assert("good" in plugin)
-    assert("bad" not in plugin)
+    assert "good" in plugin
+    assert "bad" not in plugin
 
     # the in (__contains__ override) is based on or'ed content; so although
     # 'bad' isn't tagged as being in the plugin, 'good' is, so the return
     # value of this is True
-    assert(["bad", "good"] in plugin)
-    assert(set(["bad", "good"]) in plugin)
-    assert(("bad", "good") in plugin)
+    assert ["bad", "good"] in plugin
+    assert set(["bad", "good"]) in plugin
+    assert ("bad", "good") in plugin
 
     # We an add already substatiated instances into our Apprise object
     a.add(plugin)
-    assert(len(a) == 1)
+    assert len(a) == 1
 
     # We can add entries as a list too (to add more then one)
     a.add([plugin, plugin, plugin])
-    assert(len(a) == 4)
+    assert len(a) == 4
 
     # Reset our object again
     a.clear()
-    try:
+    with pytest.raises(TypeError):
         a.instantiate({
             'schema': 'throw',
             'host': 'localhost'}, suppress_exceptions=False)
-        assert(False)
 
-    except TypeError:
-        assert(True)
-    assert(len(a) == 0)
+    assert len(a) == 0
 
-    assert(a.instantiate({
+    assert a.instantiate({
         'schema': 'throw',
-        'host': 'localhost'}, suppress_exceptions=True) is None)
-    assert(len(a) == 0)
+        'host': 'localhost'}, suppress_exceptions=True) is None
+    assert len(a) == 0
 
+
+def test_apprise_pretty_print(tmpdir):
+    """
+    API: Apprise() Pretty Print tests
+
+    """
     # Privacy Print
     # PrivacyMode.Secret always returns the same thing to avoid guessing
     assert URLBase.pprint(
@@ -410,6 +406,10 @@ def test_apprise():
     assert URLBase.pprint(
         "abcdefghijk", privacy=True, mode=PrivacyMode.Tail) == '...hijk'
 
+    # Quoting settings
+    assert URLBase.pprint(" ", privacy=False, safe='') == '%20'
+    assert URLBase.pprint(" ", privacy=False, quote=False, safe='') == ' '
+
 
 @mock.patch('requests.get')
 @mock.patch('requests.post')
@@ -437,90 +437,94 @@ def test_apprise_tagging(mock_post, mock_get):
     a = Apprise()
 
     # An invalid addition can't add the tag
-    assert(a.add('averyinvalidschema://localhost', tag='uhoh') is False)
-    assert(a.add({
+    assert a.add('averyinvalidschema://localhost', tag='uhoh') is False
+    assert a.add({
         'schema': 'averyinvalidschema',
-        'host': 'localhost'}, tag='uhoh') is False)
+        'host': 'localhost'}, tag='uhoh') is False
 
     # Add entry and assign it to a tag called 'awesome'
-    assert(a.add('json://localhost/path1/', tag='awesome') is True)
-    assert(a.add({
+    assert a.add('json://localhost/path1/', tag='awesome') is True
+    assert a.add({
         'schema': 'json',
         'host': 'localhost',
-        'fullpath': '/path1/'}, tag='awesome') is True)
+        'fullpath': '/path1/'}, tag='awesome') is True
 
     # Add another notification and assign it to a tag called 'awesome'
     # and another tag called 'local'
-    assert(a.add('json://localhost/path2/', tag=['mmost', 'awesome']) is True)
+    assert a.add('json://localhost/path2/', tag=['mmost', 'awesome']) is True
 
     # notify the awesome tag; this would notify both services behind the
     # scenes
-    assert(a.notify(title="my title", body="my body", tag='awesome') is True)
+    assert a.notify(title="my title", body="my body", tag='awesome') is True
 
     # notify all of the tags
-    assert(a.notify(
-        title="my title", body="my body", tag=['awesome', 'mmost']) is True)
+    assert a.notify(
+        title="my title", body="my body", tag=['awesome', 'mmost']) is True
 
     # When we query against our loaded notifications for a tag that simply
     # isn't assigned to anything, we return None.  None (different then False)
     # tells us that we litterally had nothing to query.  We didn't fail...
     # but we also didn't do anything...
-    assert(a.notify(
-        title="my title", body="my body", tag='missing') is None)
+    assert a.notify(
+        title="my title", body="my body", tag='missing') is None
 
     # Now to test the ability to and and/or notifications
     a = Apprise()
 
     # Add a tag by tuple
-    assert(a.add('json://localhost/tagA/', tag=("TagA", )) is True)
+    assert a.add('json://localhost/tagA/', tag=("TagA", )) is True
     # Add 2 tags by string
-    assert(a.add('json://localhost/tagAB/', tag="TagA, TagB") is True)
+    assert a.add('json://localhost/tagAB/', tag="TagA, TagB") is True
     # Add a tag using a set
-    assert(a.add('json://localhost/tagB/', tag=set(["TagB"])) is True)
+    assert a.add('json://localhost/tagB/', tag=set(["TagB"])) is True
     # Add a tag by string (again)
-    assert(a.add('json://localhost/tagC/', tag="TagC") is True)
+    assert a.add('json://localhost/tagC/', tag="TagC") is True
     # Add 2 tags using a list
-    assert(a.add('json://localhost/tagCD/', tag=["TagC", "TagD"]) is True)
+    assert a.add('json://localhost/tagCD/', tag=["TagC", "TagD"]) is True
     # Add a tag by string (again)
-    assert(a.add('json://localhost/tagD/', tag="TagD") is True)
+    assert a.add('json://localhost/tagD/', tag="TagD") is True
     # add a tag set by set (again)
-    assert(a.add('json://localhost/tagCDE/',
-           tag=set(["TagC", "TagD", "TagE"])) is True)
+    assert a.add('json://localhost/tagCDE/',
+                 tag=set(["TagC", "TagD", "TagE"])) is True
 
     # Expression: TagC and TagD
     # Matches the following only:
     #   - json://localhost/tagCD/
     #   - json://localhost/tagCDE/
-    assert(a.notify(
-        title="my title", body="my body", tag=[('TagC', 'TagD')]) is True)
+    assert a.notify(
+        title="my title", body="my body", tag=[('TagC', 'TagD')]) is True
 
     # Expression: (TagY and TagZ) or TagX
     # Matches nothing, None is returned in this case
-    assert(a.notify(
+    assert a.notify(
         title="my title", body="my body",
-        tag=[('TagY', 'TagZ'), 'TagX']) is None)
+        tag=[('TagY', 'TagZ'), 'TagX']) is None
 
     # Expression: (TagY and TagZ) or TagA
     # Matches the following only:
     #   - json://localhost/tagAB/
-    assert(a.notify(
+    assert a.notify(
         title="my title", body="my body",
-        tag=[('TagY', 'TagZ'), 'TagA']) is True)
+        tag=[('TagY', 'TagZ'), 'TagA']) is True
 
     # Expression: (TagE and TagD) or TagB
     # Matches the following only:
     #   - json://localhost/tagCDE/
     #   - json://localhost/tagAB/
     #   - json://localhost/tagB/
-    assert(a.notify(
+    assert a.notify(
         title="my title", body="my body",
-        tag=[('TagE', 'TagD'), 'TagB']) is True)
+        tag=[('TagE', 'TagD'), 'TagB']) is True
 
-    # Garbage Entries; we can't do anything with the tag so we have nothing to
-    # notify as a result.  So we simply return None
-    assert(a.notify(
+    # Garbage Entries in tag field just get stripped out. the below
+    # is the same as notifying no tags at all. Since we have not added
+    # any entries that do not have tags (that we can match against)
+    # we fail.  None is returned as a way of letting us know that we
+    # had Notifications to notify, but since none of them matched our tag
+    # none were notified.
+    assert a.notify(
         title="my title", body="my body",
-        tag=[(object, ), ]) is None)
+        tag=[(object, ), ]) is None
 
 
 def test_apprise_notify_formats(tmpdir):
@@ -536,7 +540,7 @@ def test_apprise_notify_formats(tmpdir):
     a = Apprise()
 
     # no items
-    assert(len(a) == 0)
+    assert len(a) == 0
 
     class TextNotification(NotifyBase):
         # set our default notification format
@@ -594,26 +598,29 @@ def test_apprise_notify_formats(tmpdir):
     # defined plugin above was defined to default to HTML which triggers
     # a markdown to take place if the body_format specified on the notify
     # call
-    assert(a.add('html://localhost') is True)
-    assert(a.add('html://another.server') is True)
-    assert(a.add('html://and.another') is True)
-    assert(a.add('text://localhost') is True)
-    assert(a.add('text://another.server') is True)
-    assert(a.add('text://and.another') is True)
-    assert(a.add('markdown://localhost') is True)
-    assert(a.add('markdown://another.server') is True)
-    assert(a.add('markdown://and.another') is True)
+    assert a.add('html://localhost') is True
+    assert a.add('html://another.server') is True
+    assert a.add('html://and.another') is True
+    assert a.add('text://localhost') is True
+    assert a.add('text://another.server') is True
+    assert a.add('text://and.another') is True
+    assert a.add('markdown://localhost') is True
+    assert a.add('markdown://another.server') is True
+    assert a.add('markdown://and.another') is True
 
-    assert(len(a) == 9)
+    assert len(a) == 9
 
-    assert(a.notify(title="markdown", body="## Testing Markdown",
-           body_format=NotifyFormat.MARKDOWN) is True)
+    assert a.notify(
+        title="markdown", body="## Testing Markdown",
+        body_format=NotifyFormat.MARKDOWN) is True
 
-    assert(a.notify(title="text", body="Testing Text",
-           body_format=NotifyFormat.TEXT) is True)
+    assert a.notify(
+        title="text", body="Testing Text",
+        body_format=NotifyFormat.TEXT) is True
 
-    assert(a.notify(title="html", body="<b>HTML</b>",
-           body_format=NotifyFormat.HTML) is True)
+    assert a.notify(
+        title="html", body="<b>HTML</b>",
+        body_format=NotifyFormat.HTML) is True
 
 
 def test_apprise_asset(tmpdir):
@@ -623,7 +630,7 @@ def test_apprise_asset(tmpdir):
     """
     a = AppriseAsset(theme=None)
     # Default theme
-    assert(a.theme == 'default')
+    assert a.theme == 'default'
 
     a = AppriseAsset(
         theme='dark',
@@ -634,58 +641,49 @@ def test_apprise_asset(tmpdir):
     a.default_html_color = '#abcabc'
     a.html_notify_map[NotifyType.INFO] = '#aaaaaa'
 
-    assert(a.color('invalid', tuple) == (171, 202, 188))
-    assert(a.color(NotifyType.INFO, tuple) == (170, 170, 170))
+    assert a.color('invalid', tuple) == (171, 202, 188)
+    assert a.color(NotifyType.INFO, tuple) == (170, 170, 170)
 
-    assert(a.color('invalid', int) == 11258556)
-    assert(a.color(NotifyType.INFO, int) == 11184810)
+    assert a.color('invalid', int) == 11258556
+    assert a.color(NotifyType.INFO, int) == 11184810
 
-    assert(a.color('invalid', None) == '#abcabc')
-    assert(a.color(NotifyType.INFO, None) == '#aaaaaa')
+    assert a.color('invalid', None) == '#abcabc'
+    assert a.color(NotifyType.INFO, None) == '#aaaaaa'
     # None is the default
-    assert(a.color(NotifyType.INFO) == '#aaaaaa')
+    assert a.color(NotifyType.INFO) == '#aaaaaa'
 
     # Invalid Type
-    try:
-        a.color(NotifyType.INFO, dict)
-        # We should not get here (exception should be thrown)
-        assert(False)
-
-    except ValueError:
+    with pytest.raises(ValueError):
         # The exception we expect since dict is not supported
-        assert(True)
+        a.color(NotifyType.INFO, dict)
 
-    except Exception:
-        # Any other exception is not good
-        assert(False)
+    assert a.image_url(NotifyType.INFO, NotifyImageSize.XY_256) == \
+        'http://localhost/dark/info-256x256.png'
 
-    assert(a.image_url(NotifyType.INFO, NotifyImageSize.XY_256) ==
-           'http://localhost/dark/info-256x256.png')
-
-    assert(a.image_path(
+    assert a.image_path(
         NotifyType.INFO,
         NotifyImageSize.XY_256,
-        must_exist=False) == '/dark/info-256x256.png')
+        must_exist=False) == '/dark/info-256x256.png'
 
     # This path doesn't exist so image_raw will fail (since we just
     # randompyl picked it for testing)
-    assert(a.image_raw(NotifyType.INFO, NotifyImageSize.XY_256) is None)
+    assert a.image_raw(NotifyType.INFO, NotifyImageSize.XY_256) is None
 
-    assert(a.image_path(
+    assert a.image_path(
         NotifyType.INFO,
         NotifyImageSize.XY_256,
-        must_exist=True) is None)
+        must_exist=True) is None
 
     # Create a new object (with our default settings)
     a = AppriseAsset()
 
     # Our default configuration can access our file
-    assert(a.image_path(
+    assert a.image_path(
         NotifyType.INFO,
         NotifyImageSize.XY_256,
-        must_exist=True) is not None)
+        must_exist=True) is not None
 
-    assert(a.image_raw(NotifyType.INFO, NotifyImageSize.XY_256) is not None)
+    assert a.image_raw(NotifyType.INFO, NotifyImageSize.XY_256) is not None
 
     # Create a temporary directory
     sub = tmpdir.mkdir("great.theme")
@@ -703,14 +701,14 @@ def test_apprise_asset(tmpdir):
     )
 
     # We'll be able to read file we just created
-    assert(a.image_raw(NotifyType.INFO, NotifyImageSize.XY_256) is not None)
+    assert a.image_raw(NotifyType.INFO, NotifyImageSize.XY_256) is not None
 
     # We can retrieve the filename at this point even with must_exist set
     # to True
-    assert(a.image_path(
+    assert a.image_path(
         NotifyType.INFO,
         NotifyImageSize.XY_256,
-        must_exist=True) is not None)
+        must_exist=True) is not None
 
     # If we make the file un-readable however, we won't be able to read it
     # This test is just showing that we won't throw an exception
@@ -720,37 +718,37 @@ def test_apprise_asset(tmpdir):
         pytest.skip('The Root user can not run file permission tests.')
 
     chmod(dirname(sub.strpath), 0o000)
-    assert(a.image_raw(NotifyType.INFO, NotifyImageSize.XY_256) is None)
+    assert a.image_raw(NotifyType.INFO, NotifyImageSize.XY_256) is None
 
     # Our path doesn't exist anymore using this logic
-    assert(a.image_path(
+    assert a.image_path(
         NotifyType.INFO,
         NotifyImageSize.XY_256,
-        must_exist=True) is None)
+        must_exist=True) is None
 
     # Return our permission so we don't have any problems with our cleanup
     chmod(dirname(sub.strpath), 0o700)
 
     # Our content is retrivable again
-    assert(a.image_raw(NotifyType.INFO, NotifyImageSize.XY_256) is not None)
+    assert a.image_raw(NotifyType.INFO, NotifyImageSize.XY_256) is not None
 
     # our file path is accessible again too
-    assert(a.image_path(
+    assert a.image_path(
         NotifyType.INFO,
         NotifyImageSize.XY_256,
-        must_exist=True) is not None)
+        must_exist=True) is not None
 
     # We do the same test, but set the permission on the file
     chmod(a.image_path(NotifyType.INFO, NotifyImageSize.XY_256), 0o000)
 
     # our path will still exist in this case
-    assert(a.image_path(
+    assert a.image_path(
         NotifyType.INFO,
         NotifyImageSize.XY_256,
-        must_exist=True) is not None)
+        must_exist=True) is not None
 
     # but we will not be able to open it
-    assert(a.image_raw(NotifyType.INFO, NotifyImageSize.XY_256) is None)
+    assert a.image_raw(NotifyType.INFO, NotifyImageSize.XY_256) is None
 
     # Restore our permissions
     chmod(a.image_path(NotifyType.INFO, NotifyImageSize.XY_256), 0o640)
@@ -759,12 +757,12 @@ def test_apprise_asset(tmpdir):
     a = AppriseAsset(image_path_mask=False, image_url_mask=False)
 
     # We always return none in these calls now
-    assert(a.image_raw(NotifyType.INFO, NotifyImageSize.XY_256) is None)
-    assert(a.image_url(NotifyType.INFO, NotifyImageSize.XY_256) is None)
-    assert(a.image_path(NotifyType.INFO, NotifyImageSize.XY_256,
-           must_exist=False) is None)
-    assert(a.image_path(NotifyType.INFO, NotifyImageSize.XY_256,
-           must_exist=True) is None)
+    assert a.image_raw(NotifyType.INFO, NotifyImageSize.XY_256) is None
+    assert a.image_url(NotifyType.INFO, NotifyImageSize.XY_256) is None
+    assert a.image_path(NotifyType.INFO, NotifyImageSize.XY_256,
+                        must_exist=False) is None
+    assert a.image_path(NotifyType.INFO, NotifyImageSize.XY_256,
+                        must_exist=True) is None
 
     # Test our default extension out
     a = AppriseAsset(
@@ -772,28 +770,28 @@ def test_apprise_asset(tmpdir):
         image_url_mask='http://localhost/{THEME}/{TYPE}-{XY}{EXTENSION}',
         default_extension='.jpeg',
     )
-    assert(a.image_path(
+    assert a.image_path(
         NotifyType.INFO,
         NotifyImageSize.XY_256,
-        must_exist=False) == '/default/info-256x256.jpeg')
+        must_exist=False) == '/default/info-256x256.jpeg'
 
-    assert(a.image_url(
+    assert a.image_url(
         NotifyType.INFO,
-        NotifyImageSize.XY_256) == 'http://localhost/'
-                                   'default/info-256x256.jpeg')
+        NotifyImageSize.XY_256) == \
+        'http://localhost/default/info-256x256.jpeg'
 
     # extension support
-    assert(a.image_path(
+    assert a.image_path(
         NotifyType.INFO,
         NotifyImageSize.XY_128,
         must_exist=False,
-        extension='.ico') == '/default/info-128x128.ico')
+        extension='.ico') == '/default/info-128x128.ico'
 
-    assert(a.image_url(
+    assert a.image_url(
         NotifyType.INFO,
         NotifyImageSize.XY_256,
-        extension='.test') == 'http://localhost/'
-                              'default/info-256x256.test')
+        extension='.test') == \
+        'http://localhost/default/info-256x256.test'
 
 
 def test_apprise_details():
@@ -894,6 +892,11 @@ def test_apprise_details():
                 #
                 '_exists_if': 'always_true',
             },
+            # alias_of testing
+            'test_alias_of': {
+                'alias_of': 'mylistB',
+                'delim': ('-', ' ')
+            }
         })
 
         def url(self):
@@ -1116,10 +1119,11 @@ def test_apprise_details_plugin_verification():
                             assert '{} is an invalid regex'\
                                 .format(arg['regex'][0])
 
-                        # Regex should never start and/or end with ^/$; leave
-                        # that up to the user making use of the regex instead
-                        assert re.match(r'^[()\s]*\^', arg['regex'][0]) is None
-                        assert re.match(r'[()\s$]*\$', arg['regex'][0]) is None
+                        # Regex should always start and/or end with ^/$
+                        assert re.match(
+                            r'^\^.+?$', arg['regex'][0]) is not None
+                        assert re.match(
+                            r'^.+?\$$', arg['regex'][0]) is not None
 
                     if arg['type'].startswith('list'):
                         # Delimiters MUST be defined
@@ -1132,8 +1136,55 @@ def test_apprise_details_plugin_verification():
                     assert isinstance(arg['alias_of'], six.string_types)
                     # Track our alias_of object
                     map_to_aliases.add(arg['alias_of'])
-                    # 2 entries (name, and alias_of only!)
-                    assert len(entry['details'][section][key]) == 1
+
+                    # Ensure we're not already in the tokens section
+                    # The alias_of object has no value here
+                    assert section != 'tokens'
+
+                    # We can't be an alias_of ourselves
+                    if key == arg['alias_of']:
+                        # This is acceptable as long as we exist in the tokens
+                        # table because that is truely what we map back to
+                        assert key in entry['details']['tokens']
+
+                    else:
+                        # Throw the problem into an assert tag for debugging
+                        # purposes... the mapping is not acceptable
+                        assert key != arg['alias_of']
+
+                    # alias_of always references back to tokens
+                    assert \
+                        arg['alias_of'] in entry['details']['tokens'] or \
+                        arg['alias_of'] in entry['details']['args']
+
+                    # Find a list directive in our tokens
+                    t_match = entry['details']['tokens']\
+                        .get(arg['alias_of'], {})\
+                        .get('type', '').startswith('list')
+
+                    a_match = entry['details']['args']\
+                        .get(arg['alias_of'], {})\
+                        .get('type', '').startswith('list')
+
+                    if not (t_match or a_match):
+                        # Ensure the only token we have is the alias_of
+                        assert len(entry['details'][section][key]) == 1
+
+                    else:
+                        # We're a list, we allow up to 2 variables
+                        # Obviously we have the alias_of entry; that's why
+                        # were at this part of the code.  But we can
+                        # additionally provide a 'delim' over-ride.
+                        assert len(entry['details'][section][key]) <= 2
+                        if len(entry['details'][section][key]) == 2:
+                            # Verify that it is in fact the 'delim' tag
+                            assert 'delim' in entry['details'][section][key]
+                            # If we do have a delim value set, it must be of
+                            # a list/set/tuple type
+                            assert isinstance(
+                                entry['details'][section][key]['delim'],
+                                (tuple, set, list),
+                            )
 
         if six.PY2:
             # inspect our object

--- a/test/test_config_base.py
+++ b/test/test_config_base.py
@@ -25,6 +25,7 @@
 
 import sys
 import six
+import pytest
 from apprise.AppriseAsset import AppriseAsset
 from apprise.config.ConfigBase import ConfigBase
 from apprise.config import __load_matrix
@@ -41,22 +42,12 @@ def test_config_base():
     """
 
     # invalid types throw exceptions
-    try:
+    with pytest.raises(TypeError):
         ConfigBase(**{'format': 'invalid'})
-        # We should never reach here as an exception should be thrown
-        assert(False)
-
-    except TypeError:
-        assert(True)
 
     # Config format types are not the same as ConfigBase ones
-    try:
+    with pytest.raises(TypeError):
         ConfigBase(**{'format': 'markdown'})
-        # We should never reach here as an exception should be thrown
-        assert(False)
-
-    except TypeError:
-        assert(True)
 
     cb = ConfigBase(**{'format': 'yaml'})
     assert isinstance(cb, ConfigBase)

--- a/test/test_email_plugin.py
+++ b/test/test_email_plugin.py
@@ -274,17 +274,17 @@ def test_email_plugin(mock_smtp, mock_smtpssl):
                 # Expected None but didn't get it
                 print('%s instantiated %s (but expected None)' % (
                     url, str(obj)))
-                assert(False)
+                assert False
 
-            assert(isinstance(obj, instance))
+            assert isinstance(obj, instance)
 
             if isinstance(obj, plugins.NotifyBase):
                 # We loaded okay; now lets make sure we can reverse this url
-                assert(isinstance(obj.url(), six.string_types) is True)
+                assert isinstance(obj.url(), six.string_types) is True
 
                 # Test url() with privacy=True
-                assert(isinstance(
-                    obj.url(privacy=True), six.string_types) is True)
+                assert isinstance(
+                    obj.url(privacy=True), six.string_types) is True
 
                 # Some Simple Invalid Instance Testing
                 assert instance.parse_url(None) is None
@@ -307,14 +307,14 @@ def test_email_plugin(mock_smtp, mock_smtpssl):
                     # assertion failure makes things easier to debug later on
                     print('TEST FAIL: {} regenerated as {}'.format(
                         url, obj.url()))
-                    assert(False)
+                    assert False
 
             if self:
                 # Iterate over our expected entries inside of our object
                 for key, val in self.items():
                     # Test that our object has the desired key
-                    assert(hasattr(key, obj))
-                    assert(getattr(key, obj) == val)
+                    assert hasattr(key, obj)
+                    assert getattr(key, obj) == val
 
             try:
                 if test_smtplib_exceptions is False:
@@ -389,7 +389,7 @@ def test_webbase_lookup(mock_smtp, mock_smtpssl):
     obj = Apprise.instantiate(
         'mailto://user:pass@l2g.com', suppress_exceptions=True)
 
-    assert(isinstance(obj, plugins.NotifyEmail))
+    assert isinstance(obj, plugins.NotifyEmail)
     assert len(obj.targets) == 1
     assert 'user@l2g.com' in obj.targets
     assert obj.from_addr == 'user@l2g.com'
@@ -417,7 +417,7 @@ def test_smtplib_init_fail(mock_smtplib):
 
     obj = Apprise.instantiate(
         'mailto://user:pass@gmail.com', suppress_exceptions=False)
-    assert(isinstance(obj, plugins.NotifyEmail))
+    assert isinstance(obj, plugins.NotifyEmail)
 
     # Support Exception handling of smtplib.SMTP
     mock_smtplib.side_effect = RuntimeError('Test')
@@ -443,7 +443,7 @@ def test_smtplib_send_okay(mock_smtplib):
     # Defaults to HTML
     obj = Apprise.instantiate(
         'mailto://user:pass@gmail.com', suppress_exceptions=False)
-    assert(isinstance(obj, plugins.NotifyEmail))
+    assert isinstance(obj, plugins.NotifyEmail)
 
     # Support an email simulation where we can correctly quit
     mock_smtplib.starttls.return_value = True
@@ -451,16 +451,16 @@ def test_smtplib_send_okay(mock_smtplib):
     mock_smtplib.sendmail.return_value = True
     mock_smtplib.quit.return_value = True
 
-    assert(obj.notify(
-        body='body', title='test', notify_type=NotifyType.INFO) is True)
+    assert obj.notify(
+        body='body', title='test', notify_type=NotifyType.INFO) is True
 
     # Set Text
     obj = Apprise.instantiate(
         'mailto://user:pass@gmail.com?format=text', suppress_exceptions=False)
-    assert(isinstance(obj, plugins.NotifyEmail))
+    assert isinstance(obj, plugins.NotifyEmail)
 
-    assert(obj.notify(
-        body='body', title='test', notify_type=NotifyType.INFO) is True)
+    assert obj.notify(
+        body='body', title='test', notify_type=NotifyType.INFO) is True
 
 
 def test_email_url_escaping():

--- a/test/test_glib_plugin.py
+++ b/test/test_glib_plugin.py
@@ -136,141 +136,149 @@ def test_dbus_plugin(mock_mainloop, mock_byte, mock_bytearray,
 
     # Create our instance (identify all supported types)
     obj = apprise.Apprise.instantiate('dbus://', suppress_exceptions=False)
-    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
+    assert isinstance(obj, apprise.plugins.NotifyDBus) is True
     obj = apprise.Apprise.instantiate('kde://', suppress_exceptions=False)
-    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
+    assert isinstance(obj, apprise.plugins.NotifyDBus) is True
     obj = apprise.Apprise.instantiate('qt://', suppress_exceptions=False)
-    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
+    assert isinstance(obj, apprise.plugins.NotifyDBus) is True
     obj = apprise.Apprise.instantiate('glib://', suppress_exceptions=False)
-    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
+    assert isinstance(obj, apprise.plugins.NotifyDBus) is True
     obj.duration = 0
 
     # Check that it found our mocked environments
-    assert(obj._enabled is True)
+    assert obj._enabled is True
 
     # Test our class loading using a series of arguments
-    try:
+    with pytest.raises(TypeError):
         apprise.plugins.NotifyDBus(**{'schema': 'invalid'})
-        # We should not reach here as the invalid schema
-        # should force an exception
-        assert(False)
-    except TypeError:
-        # Expected behaviour
-        assert(True)
 
     # Invalid URLs
     assert apprise.plugins.NotifyDBus.parse_url('') is None
 
     # Set our X and Y coordinate and try the notification
-    assert(
-        apprise.plugins.NotifyDBus(
-            x_axis=0, y_axis=0, **{'schema': 'dbus'})
+    assert apprise.plugins.NotifyDBus(
+        x_axis=0, y_axis=0, **{'schema': 'dbus'})\
         .notify(title='', body='body',
-                notify_type=apprise.NotifyType.INFO) is True)
+                notify_type=apprise.NotifyType.INFO) is True
 
     # test notifications
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is True
 
     # test notification without a title
-    assert(obj.notify(title='', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert obj.notify(
+        title='', body='body',
+        notify_type=apprise.NotifyType.INFO) is True
 
     # Test our arguments through the instantiate call
     obj = apprise.Apprise.instantiate(
         'dbus://_/?image=True', suppress_exceptions=False)
-    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
-    assert(isinstance(obj.url(), six.string_types) is True)
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert isinstance(obj, apprise.plugins.NotifyDBus) is True
+    assert isinstance(obj.url(), six.string_types) is True
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is True
 
     obj = apprise.Apprise.instantiate(
         'dbus://_/?image=False', suppress_exceptions=False)
-    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
-    assert(isinstance(obj.url(), six.string_types) is True)
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert isinstance(obj, apprise.plugins.NotifyDBus) is True
+    assert isinstance(obj.url(), six.string_types) is True
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is True
 
     # Test priority (alias to urgency) handling
     obj = apprise.Apprise.instantiate(
         'dbus://_/?priority=invalid', suppress_exceptions=False)
-    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
-    assert(isinstance(obj.url(), six.string_types) is True)
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert isinstance(obj, apprise.plugins.NotifyDBus) is True
+    assert isinstance(obj.url(), six.string_types) is True
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is True
 
     obj = apprise.Apprise.instantiate(
         'dbus://_/?priority=high', suppress_exceptions=False)
-    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
-    assert(isinstance(obj.url(), six.string_types) is True)
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert isinstance(obj, apprise.plugins.NotifyDBus) is True
+    assert isinstance(obj.url(), six.string_types) is True
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is True
 
     obj = apprise.Apprise.instantiate(
         'dbus://_/?priority=2', suppress_exceptions=False)
-    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
-    assert(isinstance(obj.url(), six.string_types) is True)
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert isinstance(obj, apprise.plugins.NotifyDBus) is True
+    assert isinstance(obj.url(), six.string_types) is True
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is True
 
     # Test urgency handling
     obj = apprise.Apprise.instantiate(
         'dbus://_/?urgency=invalid', suppress_exceptions=False)
-    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
-    assert(isinstance(obj.url(), six.string_types) is True)
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert isinstance(obj, apprise.plugins.NotifyDBus) is True
+    assert isinstance(obj.url(), six.string_types) is True
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is True
 
     obj = apprise.Apprise.instantiate(
         'dbus://_/?urgency=high', suppress_exceptions=False)
-    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
-    assert(isinstance(obj.url(), six.string_types) is True)
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert isinstance(obj, apprise.plugins.NotifyDBus) is True
+    assert isinstance(obj.url(), six.string_types) is True
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is True
 
     obj = apprise.Apprise.instantiate(
         'dbus://_/?urgency=2', suppress_exceptions=False)
-    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
-    assert(isinstance(obj.url(), six.string_types) is True)
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert isinstance(obj, apprise.plugins.NotifyDBus) is True
+    assert isinstance(obj.url(), six.string_types) is True
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is True
 
     obj = apprise.Apprise.instantiate(
         'dbus://_/?urgency=', suppress_exceptions=False)
-    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
-    assert(isinstance(obj.url(), six.string_types) is True)
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert isinstance(obj, apprise.plugins.NotifyDBus) is True
+    assert isinstance(obj.url(), six.string_types) is True
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is True
 
     # Test x/y
     obj = apprise.Apprise.instantiate(
         'dbus://_/?x=5&y=5', suppress_exceptions=False)
-    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
-    assert(isinstance(obj.url(), six.string_types) is True)
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert isinstance(obj, apprise.plugins.NotifyDBus) is True
+    assert isinstance(obj.url(), six.string_types) is True
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is True
 
     obj = apprise.Apprise.instantiate(
         'dbus://_/?x=invalid&y=invalid', suppress_exceptions=False)
-    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
-    assert(isinstance(obj.url(), six.string_types) is True)
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert isinstance(obj, apprise.plugins.NotifyDBus) is True
+    assert isinstance(obj.url(), six.string_types) is True
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is True
 
-    # If our underlining object throws for whatever reason, we will
+    # If our underlining object throws for whatever rea on, we will
     # gracefully fail
     mock_notify = mock.Mock()
     mock_interface.return_value = mock_notify
     mock_notify.Notify.side_effect = AttributeError()
-    assert(obj.notify(title='', body='body',
-           notify_type=apprise.NotifyType.INFO) is False)
+    assert obj.notify(
+        title='', body='body',
+        notify_type=apprise.NotifyType.INFO) is False
     mock_notify.Notify.side_effect = None
 
     # Test our loading of our icon exception; it will still allow the
     # notification to be sent
     mock_pixbuf.new_from_file.side_effect = AttributeError()
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is True
     # Undo our change
     mock_pixbuf.new_from_file.side_effect = None
 
@@ -278,8 +286,9 @@ def test_dbus_plugin(mock_mainloop, mock_byte, mock_bytearray,
     # Toggle our testing for when we can't send notifications because the
     # package has been made unavailable to us
     obj._enabled = False
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is False)
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is False
 
     # Test the setting of a the urgency
     apprise.plugins.NotifyDBus(urgency=0)
@@ -306,15 +315,16 @@ def test_dbus_plugin(mock_mainloop, mock_byte, mock_bytearray,
 
     # Create our instance
     obj = apprise.Apprise.instantiate('glib://', suppress_exceptions=False)
-    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
+    assert isinstance(obj, apprise.plugins.NotifyDBus) is True
     obj.duration = 0
 
     # Test url() call
-    assert(isinstance(obj.url(), six.string_types) is True)
+    assert isinstance(obj.url(), six.string_types) is True
 
     # Our notification succeeds even though the gi library was not loaded
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is True
 
     # Verify this all works in the event a ValueError is also thronw
     # out of the call to gi.require_version()
@@ -336,15 +346,16 @@ def test_dbus_plugin(mock_mainloop, mock_byte, mock_bytearray,
 
     # Create our instance
     obj = apprise.Apprise.instantiate('glib://', suppress_exceptions=False)
-    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
+    assert isinstance(obj, apprise.plugins.NotifyDBus) is True
     obj.duration = 0
 
     # Test url() call
-    assert(isinstance(obj.url(), six.string_types) is True)
+    assert isinstance(obj.url(), six.string_types) is True
 
     # Our notification succeeds even though the gi library was not loaded
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is True
 
     # Force a global import error
     _session_bus = sys.modules['dbus']
@@ -358,15 +369,16 @@ def test_dbus_plugin(mock_mainloop, mock_byte, mock_bytearray,
 
     # Create our instance
     obj = apprise.Apprise.instantiate('glib://', suppress_exceptions=False)
-    assert(isinstance(obj, apprise.plugins.NotifyDBus) is True)
+    assert isinstance(obj, apprise.plugins.NotifyDBus) is True
     obj.duration = 0
 
     # Test url() call
-    assert(isinstance(obj.url(), six.string_types) is True)
+    assert isinstance(obj.url(), six.string_types) is True
 
     # Our notification fail because the dbus library wasn't present
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is False)
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is False
 
     # Since playing with the sys.modules is not such a good idea,
     # let's just put it back now :)

--- a/test/test_growl_plugin.py
+++ b/test/test_growl_plugin.py
@@ -211,7 +211,7 @@ def test_growl_plugin(mock_gntp):
         try:
             obj = Apprise.instantiate(url, suppress_exceptions=False)
 
-            assert(exception is None)
+            assert exception is None
 
             if obj is None:
                 # We're done
@@ -219,17 +219,17 @@ def test_growl_plugin(mock_gntp):
 
             if instance is None:
                 # Expected None but didn't get it
-                assert(False)
+                assert False
 
-            assert(isinstance(obj, instance) is True)
+            assert isinstance(obj, instance) is True
 
             if isinstance(obj, plugins.NotifyBase):
                 # We loaded okay; now lets make sure we can reverse this url
-                assert(isinstance(obj.url(), six.string_types) is True)
+                assert isinstance(obj.url(), six.string_types) is True
 
                 # Test our privacy=True flag
-                assert(isinstance(
-                    obj.url(privacy=True), six.string_types) is True)
+                assert isinstance(
+                    obj.url(privacy=True), six.string_types) is True
 
                 # Instantiate the exact same object again using the URL from
                 # the one that was already created properly
@@ -243,14 +243,14 @@ def test_growl_plugin(mock_gntp):
                     # assertion failure makes things easier to debug later on
                     print('TEST FAIL: {} regenerated as {}'.format(
                         url, obj.url()))
-                    assert(False)
+                    assert False
 
             if self:
                 # Iterate over our expected entries inside of our object
                 for key, val in self.items():
                     # Test that our object has the desired key
-                    assert(hasattr(key, obj))
-                    assert(getattr(key, obj) == val)
+                    assert hasattr(key, obj)
+                    assert getattr(key, obj) == val
 
             try:
                 if test_growl_notify_exceptions is False:
@@ -292,5 +292,5 @@ def test_growl_plugin(mock_gntp):
         except Exception as e:
             # Handle our exception
             print('%s / %s' % (url, str(e)))
-            assert(exception is not None)
-            assert(isinstance(e, exception))
+            assert exception is not None
+            assert isinstance(e, exception)

--- a/test/test_notify_base.py
+++ b/test/test_notify_base.py
@@ -23,6 +23,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 import six
+import pytest
 from datetime import datetime
 from datetime import timedelta
 
@@ -43,22 +44,12 @@ def test_notify_base():
     """
 
     # invalid types throw exceptions
-    try:
+    with pytest.raises(TypeError):
         NotifyBase(**{'format': 'invalid'})
-        # We should never reach here as an exception should be thrown
-        assert(False)
-
-    except TypeError:
-        assert(True)
 
     # invalid types throw exceptions
-    try:
+    with pytest.raises(TypeError):
         NotifyBase(**{'overflow': 'invalid'})
-        # We should never reach here as an exception should be thrown
-        assert(False)
-
-    except TypeError:
-        assert(True)
 
     # Bad port information
     nb = NotifyBase(port='invalid')
@@ -216,7 +207,7 @@ def test_notify_base():
 
     # Test invalid data
     assert NotifyBase.parse_list(None) == []
-    assert NotifyBase.parse_list(42) == ['42', ]
+    assert NotifyBase.parse_list(42) == []
 
     result = NotifyBase.parse_list(
         ',path,?name=Dr%20Disrespect', unquote=False)

--- a/test/test_sns_plugin.py
+++ b/test/test_sns_plugin.py
@@ -24,6 +24,7 @@
 # THE SOFTWARE.
 
 import mock
+import pytest
 import requests
 from apprise import plugins
 from apprise import Apprise
@@ -45,7 +46,7 @@ def test_object_initialization():
     """
 
     # Initializes the plugin with a valid access, but invalid access key
-    try:
+    with pytest.raises(TypeError):
         # No access_key_id specified
         plugins.NotifySNS(
             access_key_id=None,
@@ -53,14 +54,8 @@ def test_object_initialization():
             region_name=TEST_REGION,
             targets='+1800555999',
         )
-        # The entries above are invalid, our code should never reach here
-        assert(False)
 
-    except TypeError:
-        # Exception correctly caught
-        assert(True)
-
-    try:
+    with pytest.raises(TypeError):
         # No secret_access_key specified
         plugins.NotifySNS(
             access_key_id=TEST_ACCESS_KEY_ID,
@@ -68,14 +63,8 @@ def test_object_initialization():
             region_name=TEST_REGION,
             targets='+1800555999',
         )
-        # The entries above are invalid, our code should never reach here
-        assert(False)
 
-    except TypeError:
-        # Exception correctly caught
-        assert(True)
-
-    try:
+    with pytest.raises(TypeError):
         # No region_name specified
         plugins.NotifySNS(
             access_key_id=TEST_ACCESS_KEY_ID,
@@ -83,14 +72,8 @@ def test_object_initialization():
             region_name=None,
             targets='+1800555999',
         )
-        # The entries above are invalid, our code should never reach here
-        assert(False)
 
-    except TypeError:
-        # Exception correctly caught
-        assert(True)
-
-    try:
+    with pytest.raises(TypeError):
         # No recipients
         plugins.NotifySNS(
             access_key_id=TEST_ACCESS_KEY_ID,
@@ -98,14 +81,8 @@ def test_object_initialization():
             region_name=TEST_REGION,
             targets=None,
         )
-        # Still valid even without recipients
-        assert(True)
 
-    except TypeError:
-        # Exception correctly caught
-        assert(False)
-
-    try:
+    with pytest.raises(TypeError):
         # No recipients - garbage recipients object
         plugins.NotifySNS(
             access_key_id=TEST_ACCESS_KEY_ID,
@@ -113,14 +90,8 @@ def test_object_initialization():
             region_name=TEST_REGION,
             targets=object(),
         )
-        # Still valid even without recipients
-        assert(True)
 
-    except TypeError:
-        # Exception correctly caught
-        assert(False)
-
-    try:
+    with pytest.raises(TypeError):
         # The phone number is invalid, and without it, there is nothing
         # to notify
         plugins.NotifySNS(
@@ -129,15 +100,8 @@ def test_object_initialization():
             region_name=TEST_REGION,
             targets='+1809',
         )
-        # The recipient is invalid, but it's still okay; this Notification
-        # still becomes pretty much useless at this point though
-        assert(True)
 
-    except TypeError:
-        # Exception correctly caught
-        assert(False)
-
-    try:
+    with pytest.raises(TypeError):
         # The phone number is invalid, and without it, there is nothing
         # to notify; we
         plugins.NotifySNS(
@@ -146,13 +110,6 @@ def test_object_initialization():
             region_name=TEST_REGION,
             targets='#(invalid-topic-because-of-the-brackets)',
         )
-        # The recipient is invalid, but it's still okay; this Notification
-        # still becomes pretty much useless at this point though
-        assert(True)
-
-    except TypeError:
-        # Exception correctly caught
-        assert(False)
 
 
 def test_url_parsing():
@@ -169,13 +126,13 @@ def test_url_parsing():
     )
 
     # Confirm that there were no recipients found
-    assert(len(results['targets']) == 0)
-    assert('region_name' in results)
-    assert(TEST_REGION == results['region_name'])
-    assert('access_key_id' in results)
-    assert(TEST_ACCESS_KEY_ID == results['access_key_id'])
-    assert('secret_access_key' in results)
-    assert(TEST_ACCESS_KEY_SECRET == results['secret_access_key'])
+    assert len(results['targets']) == 0
+    assert 'region_name' in results
+    assert TEST_REGION == results['region_name']
+    assert 'access_key_id' in results
+    assert TEST_ACCESS_KEY_ID == results['access_key_id']
+    assert 'secret_access_key' in results
+    assert TEST_ACCESS_KEY_SECRET == results['secret_access_key']
 
     # Detect recipients
     results = plugins.NotifySNS.parse_url('sns://%s/%s/%s/%s/%s/' % (
@@ -188,15 +145,15 @@ def test_url_parsing():
     )
 
     # Confirm that our recipients were found
-    assert(len(results['targets']) == 2)
-    assert('+18001234567' in results['targets'])
-    assert('MyTopic' in results['targets'])
-    assert('region_name' in results)
-    assert(TEST_REGION == results['region_name'])
-    assert('access_key_id' in results)
-    assert(TEST_ACCESS_KEY_ID == results['access_key_id'])
-    assert('secret_access_key' in results)
-    assert(TEST_ACCESS_KEY_SECRET == results['secret_access_key'])
+    assert len(results['targets']) == 2
+    assert '+18001234567' in results['targets']
+    assert 'MyTopic' in results['targets']
+    assert 'region_name' in results
+    assert TEST_REGION == results['region_name']
+    assert 'access_key_id' in results
+    assert TEST_ACCESS_KEY_ID == results['access_key_id']
+    assert 'secret_access_key' in results
+    assert TEST_ACCESS_KEY_SECRET == results['secret_access_key']
 
 
 def test_object_parsing():
@@ -209,20 +166,20 @@ def test_object_parsing():
     a = Apprise()
 
     # Now test failing variations of our URL
-    assert(a.add('sns://') is False)
-    assert(a.add('sns://nosecret') is False)
-    assert(a.add('sns://nosecret/noregion/') is False)
+    assert a.add('sns://') is False
+    assert a.add('sns://nosecret') is False
+    assert a.add('sns://nosecret/noregion/') is False
 
-    # This is valid, but a rather useless URL; there is nothing to notify
-    assert(a.add('sns://norecipient/norecipient/us-west-2') is True)
-    assert(len(a) == 1)
+    # This is valid but without valid recipients, the URL is actually useless
+    assert a.add('sns://norecipient/norecipient/us-west-2') is False
+    assert len(a) == 0
 
     # Parse a good one
-    assert(a.add('sns://oh/yeah/us-west-2/abcdtopic/+12223334444') is True)
-    assert(len(a) == 2)
+    assert a.add('sns://oh/yeah/us-west-2/abcdtopic/+12223334444') is True
+    assert len(a) == 1
 
-    assert(a.add('sns://oh/yeah/us-west-2/12223334444') is True)
-    assert(len(a) == 3)
+    assert a.add('sns://oh/yeah/us-west-2/12223334444') is True
+    assert len(a) == 2
 
 
 def test_aws_response_handling():
@@ -232,25 +189,25 @@ def test_aws_response_handling():
     """
     # Not a string
     response = plugins.NotifySNS.aws_response_to_dict(None)
-    assert(response['type'] is None)
-    assert(response['request_id'] is None)
+    assert response['type'] is None
+    assert response['request_id'] is None
 
     # Invalid XML
     response = plugins.NotifySNS.aws_response_to_dict(
         '<Bad Response xmlns="http://sns.amazonaws.com/doc/2010-03-31/">')
-    assert(response['type'] is None)
-    assert(response['request_id'] is None)
+    assert response['type'] is None
+    assert response['request_id'] is None
 
     # Single Element in XML
     response = plugins.NotifySNS.aws_response_to_dict(
         '<SingleElement></SingleElement>')
-    assert(response['type'] == 'SingleElement')
-    assert(response['request_id'] is None)
+    assert response['type'] == 'SingleElement'
+    assert response['request_id'] is None
 
     # Empty String
     response = plugins.NotifySNS.aws_response_to_dict('')
-    assert(response['type'] is None)
-    assert(response['request_id'] is None)
+    assert response['type'] is None
+    assert response['request_id'] is None
 
     response = plugins.NotifySNS.aws_response_to_dict(
         """
@@ -263,9 +220,9 @@ def test_aws_response_handling():
             </ResponseMetadata>
         </PublishResponse>
         """)
-    assert(response['type'] == 'PublishResponse')
-    assert(response['request_id'] == 'dc258024-d0e6-56bb-af1b-d4fe5f4181a4')
-    assert(response['message_id'] == '5e16935a-d1fb-5a31-a716-c7805e5c1d2e')
+    assert response['type'] == 'PublishResponse'
+    assert response['request_id'] == 'dc258024-d0e6-56bb-af1b-d4fe5f4181a4'
+    assert response['message_id'] == '5e16935a-d1fb-5a31-a716-c7805e5c1d2e'
 
     response = plugins.NotifySNS.aws_response_to_dict(
         """
@@ -278,9 +235,9 @@ def test_aws_response_handling():
             </ResponseMetadata>
         </CreateTopicResponse>
         """)
-    assert(response['type'] == 'CreateTopicResponse')
-    assert(response['request_id'] == '604bef0f-369c-50c5-a7a4-bbd474c83d6a')
-    assert(response['topic_arn'] == 'arn:aws:sns:us-east-1:000000000000:abcd')
+    assert response['type'] == 'CreateTopicResponse'
+    assert response['request_id'] == '604bef0f-369c-50c5-a7a4-bbd474c83d6a'
+    assert response['topic_arn'] == 'arn:aws:sns:us-east-1:000000000000:abcd'
 
     response = plugins.NotifySNS.aws_response_to_dict(
         """
@@ -294,12 +251,12 @@ def test_aws_response_handling():
             <RequestId>b5614883-babe-56ca-93b2-1c592ba6191e</RequestId>
         </ErrorResponse>
         """)
-    assert(response['type'] == 'ErrorResponse')
-    assert(response['request_id'] == 'b5614883-babe-56ca-93b2-1c592ba6191e')
-    assert(response['error_type'] == 'Sender')
-    assert(response['error_code'] == 'InvalidParameter')
-    assert(response['error_message'].startswith('Invalid parameter:'))
-    assert(response['error_message'].endswith('required parameter'))
+    assert response['type'] == 'ErrorResponse'
+    assert response['request_id'] == 'b5614883-babe-56ca-93b2-1c592ba6191e'
+    assert response['error_type'] == 'Sender'
+    assert response['error_code'] == 'InvalidParameter'
+    assert response['error_message'].startswith('Invalid parameter:')
+    assert response['error_message'].endswith('required parameter')
 
 
 @mock.patch('requests.post')
@@ -356,7 +313,7 @@ def test_aws_topic_handling(mock_post):
         '12223334444/TopicA'])
 
     # CreateTopic fails
-    assert(a.notify(title='', body='test') is False)
+    assert a.notify(title='', body='test') is False
 
     def post(url, data, **kwargs):
         """
@@ -383,7 +340,7 @@ def test_aws_topic_handling(mock_post):
     mock_post.side_effect = post
 
     # Publish fails
-    assert(a.notify(title='', body='test') is False)
+    assert a.notify(title='', body='test') is False
 
     # Disable our side effect
     mock_post.side_effect = None
@@ -395,14 +352,14 @@ def test_aws_topic_handling(mock_post):
 
     # Assign ourselves a new function
     mock_post.return_value = robj
-    assert(a.notify(title='', body='test') is False)
+    assert a.notify(title='', body='test') is False
 
     # Handle case where we fails get a bad response
     robj = mock.Mock()
     robj.content = ''
     robj.status_code = requests.codes.bad_request
     mock_post.return_value = robj
-    assert(a.notify(title='', body='test') is False)
+    assert a.notify(title='', body='test') is False
 
     # Handle case where we get a valid response and TopicARN
     robj = mock.Mock()
@@ -410,4 +367,4 @@ def test_aws_topic_handling(mock_post):
     robj.status_code = requests.codes.ok
     mock_post.return_value = robj
     # We would have failed to make Post
-    assert(a.notify(title='', body='test') is True)
+    assert a.notify(title='', body='test') is True

--- a/test/test_twitter_plugin.py
+++ b/test/test_twitter_plugin.py
@@ -25,6 +25,7 @@
 
 import six
 import mock
+import pytest
 import requests
 from json import dumps
 from datetime import datetime
@@ -41,57 +42,40 @@ def test_twitter_plugin_init():
 
     """
 
-    try:
+    with pytest.raises(TypeError):
         plugins.NotifyTwitter(
             ckey=None, csecret=None, akey=None, asecret=None)
-        assert False
-    except TypeError:
-        # All keys set to none
-        assert True
 
-    try:
+    with pytest.raises(TypeError):
         plugins.NotifyTwitter(
             ckey='value', csecret=None, akey=None, asecret=None)
-        assert False
-    except TypeError:
-        # csecret not set
-        assert True
 
-    try:
+    with pytest.raises(TypeError):
         plugins.NotifyTwitter(
             ckey='value', csecret='value', akey=None, asecret=None)
-        assert False
-    except TypeError:
-        # akey not set
-        assert True
 
-    try:
+    with pytest.raises(TypeError):
         plugins.NotifyTwitter(
             ckey='value', csecret='value', akey='value', asecret=None)
-        assert False
-    except TypeError:
-        # asecret not set
-        assert True
 
-    try:
+    assert isinstance(
         plugins.NotifyTwitter(
-            ckey='value', csecret='value', akey='value', asecret='value')
-        assert True
-    except TypeError:
-        # user not set; but this is okay
-        # We should not reach here
-        assert False
+            ckey='value', csecret='value', akey='value', asecret='value'),
+        plugins.NotifyTwitter,
+    )
 
-    try:
+    assert isinstance(
         plugins.NotifyTwitter(
             ckey='value', csecret='value', akey='value', asecret='value',
-            user='l2gnux')
-        # We should initialize properly
-        assert True
+            user='l2gnux'),
+        plugins.NotifyTwitter,
+    )
 
-    except TypeError:
-        # We should not reach here
-        assert False
+    # Invalid Target User
+    with pytest.raises(TypeError):
+        plugins.NotifyTwitter(
+            ckey='value', csecret='value', akey='value', asecret='value',
+            targets='%G@rB@g3')
 
 
 @mock.patch('requests.get')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -45,293 +45,290 @@ def test_parse_qsd():
     "utils: parse_qsd() testing """
 
     result = utils.parse_qsd('a=1&b=&c&d=abcd')
-    assert(isinstance(result, dict) is True)
-    assert(len(result) == 3)
+    assert isinstance(result, dict) is True
+    assert len(result) == 3
     assert 'qsd' in result
     assert 'qsd+' in result
     assert 'qsd-' in result
 
-    assert(len(result['qsd']) == 4)
+    assert len(result['qsd']) == 4
     assert 'a' in result['qsd']
     assert 'b' in result['qsd']
     assert 'c' in result['qsd']
     assert 'd' in result['qsd']
 
-    assert(len(result['qsd-']) == 0)
-    assert(len(result['qsd+']) == 0)
+    assert len(result['qsd-']) == 0
+    assert len(result['qsd+']) == 0
 
 
 def test_parse_url():
     "utils: parse_url() testing """
 
     result = utils.parse_url('http://hostname')
-    assert(result['schema'] == 'http')
-    assert(result['host'] == 'hostname')
-    assert(result['port'] is None)
-    assert(result['user'] is None)
-    assert(result['password'] is None)
-    assert(result['fullpath'] is None)
-    assert(result['path'] is None)
-    assert(result['query'] is None)
-    assert(result['url'] == 'http://hostname')
-    assert(result['qsd'] == {})
-    assert(result['qsd-'] == {})
-    assert(result['qsd+'] == {})
+    assert result['schema'] == 'http'
+    assert result['host'] == 'hostname'
+    assert result['port'] is None
+    assert result['user'] is None
+    assert result['password'] is None
+    assert result['fullpath'] is None
+    assert result['path'] is None
+    assert result['query'] is None
+    assert result['url'] == 'http://hostname'
+    assert result['qsd'] == {}
+    assert result['qsd-'] == {}
+    assert result['qsd+'] == {}
 
     result = utils.parse_url('http://hostname/')
-    assert(result['schema'] == 'http')
-    assert(result['host'] == 'hostname')
-    assert(result['port'] is None)
-    assert(result['user'] is None)
-    assert(result['password'] is None)
-    assert(result['fullpath'] == '/')
-    assert(result['path'] == '/')
-    assert(result['query'] is None)
-    assert(result['url'] == 'http://hostname/')
-    assert(result['qsd'] == {})
-    assert(result['qsd-'] == {})
-    assert(result['qsd+'] == {})
+    assert result['schema'] == 'http'
+    assert result['host'] == 'hostname'
+    assert result['port'] is None
+    assert result['user'] is None
+    assert result['password'] is None
+    assert result['fullpath'] == '/'
+    assert result['path'] == '/'
+    assert result['query'] is None
+    assert result['url'] == 'http://hostname/'
+    assert result['qsd'] == {}
+    assert result['qsd-'] == {}
+    assert result['qsd+'] == {}
 
     result = utils.parse_url('hostname')
-    assert(result['schema'] == 'http')
-    assert(result['host'] == 'hostname')
-    assert(result['port'] is None)
-    assert(result['user'] is None)
-    assert(result['password'] is None)
-    assert(result['fullpath'] is None)
-    assert(result['path'] is None)
-    assert(result['query'] is None)
-    assert(result['url'] == 'http://hostname')
-    assert(result['qsd'] == {})
-    assert(result['qsd-'] == {})
-    assert(result['qsd+'] == {})
+    assert result['schema'] == 'http'
+    assert result['host'] == 'hostname'
+    assert result['port'] is None
+    assert result['user'] is None
+    assert result['password'] is None
+    assert result['fullpath'] is None
+    assert result['path'] is None
+    assert result['query'] is None
+    assert result['url'] == 'http://hostname'
+    assert result['qsd'] == {}
+    assert result['qsd-'] == {}
+    assert result['qsd+'] == {}
 
     result = utils.parse_url('http://hostname/?-KeY=Value')
-    assert(result['schema'] == 'http')
-    assert(result['host'] == 'hostname')
-    assert(result['port'] is None)
-    assert(result['user'] is None)
-    assert(result['password'] is None)
-    assert(result['fullpath'] == '/')
-    assert(result['path'] == '/')
-    assert(result['query'] is None)
-    assert(result['url'] == 'http://hostname/')
-    assert('-key' in result['qsd'])
-    assert(unquote(result['qsd']['-key']) == 'Value')
-    assert('KeY' in result['qsd-'])
-    assert(unquote(result['qsd-']['KeY']) == 'Value')
-    assert(result['qsd+'] == {})
+    assert result['schema'] == 'http'
+    assert result['host'] == 'hostname'
+    assert result['port'] is None
+    assert result['user'] is None
+    assert result['password'] is None
+    assert result['fullpath'] == '/'
+    assert result['path'] == '/'
+    assert result['query'] is None
+    assert result['url'] == 'http://hostname/'
+    assert '-key' in result['qsd']
+    assert unquote(result['qsd']['-key']) == 'Value'
+    assert 'KeY' in result['qsd-']
+    assert unquote(result['qsd-']['KeY']) == 'Value'
+    assert result['qsd+'] == {}
 
     result = utils.parse_url('http://hostname/?+KeY=Value')
-    assert(result['schema'] == 'http')
-    assert(result['host'] == 'hostname')
-    assert(result['port'] is None)
-    assert(result['user'] is None)
-    assert(result['password'] is None)
-    assert(result['fullpath'] == '/')
-    assert(result['path'] == '/')
-    assert(result['query'] is None)
-    assert(result['url'] == 'http://hostname/')
-    assert('+key' in result['qsd'])
-    assert('KeY' in result['qsd+'])
-    assert(result['qsd+']['KeY'] == 'Value')
-    assert(result['qsd-'] == {})
+    assert result['schema'] == 'http'
+    assert result['host'] == 'hostname'
+    assert result['port'] is None
+    assert result['user'] is None
+    assert result['password'] is None
+    assert result['fullpath'] == '/'
+    assert result['path'] == '/'
+    assert result['query'] is None
+    assert result['url'] == 'http://hostname/'
+    assert '+key' in result['qsd']
+    assert 'KeY' in result['qsd+']
+    assert result['qsd+']['KeY'] == 'Value'
+    assert result['qsd-'] == {}
 
     result = utils.parse_url(
         'http://hostname/?+KeY=ValueA&-kEy=ValueB&KEY=Value%20+C')
-    assert(result['schema'] == 'http')
-    assert(result['host'] == 'hostname')
-    assert(result['port'] is None)
-    assert(result['user'] is None)
-    assert(result['password'] is None)
-    assert(result['fullpath'] == '/')
-    assert(result['path'] == '/')
-    assert(result['query'] is None)
-    assert(result['url'] == 'http://hostname/')
-    assert('+key' in result['qsd'])
-    assert('-key' in result['qsd'])
-    assert('key' in result['qsd'])
-    assert('KeY' in result['qsd+'])
-    assert(result['qsd+']['KeY'] == 'ValueA')
-    assert('kEy' in result['qsd-'])
-    assert(result['qsd-']['kEy'] == 'ValueB')
-    assert(result['qsd']['key'] == 'Value  C')
-    assert(result['qsd']['+key'] == result['qsd+']['KeY'])
-    assert(result['qsd']['-key'] == result['qsd-']['kEy'])
+    assert result['schema'] == 'http'
+    assert result['host'] == 'hostname'
+    assert result['port'] is None
+    assert result['user'] is None
+    assert result['password'] is None
+    assert result['fullpath'] == '/'
+    assert result['path'] == '/'
+    assert result['query'] is None
+    assert result['url'] == 'http://hostname/'
+    assert '+key' in result['qsd']
+    assert '-key' in result['qsd']
+    assert 'key' in result['qsd']
+    assert 'KeY' in result['qsd+']
+    assert result['qsd+']['KeY'] == 'ValueA'
+    assert 'kEy' in result['qsd-']
+    assert result['qsd-']['kEy'] == 'ValueB'
+    assert result['qsd']['key'] == 'Value  C'
+    assert result['qsd']['+key'] == result['qsd+']['KeY']
+    assert result['qsd']['-key'] == result['qsd-']['kEy']
 
     result = utils.parse_url('http://hostname////')
-    assert(result['schema'] == 'http')
-    assert(result['host'] == 'hostname')
-    assert(result['port'] is None)
-    assert(result['user'] is None)
-    assert(result['password'] is None)
-    assert(result['fullpath'] == '/')
-    assert(result['path'] == '/')
-    assert(result['query'] is None)
-    assert(result['url'] == 'http://hostname/')
-    assert(result['qsd'] == {})
-    assert(result['qsd-'] == {})
-    assert(result['qsd+'] == {})
+    assert result['schema'] == 'http'
+    assert result['host'] == 'hostname'
+    assert result['port'] is None
+    assert result['user'] is None
+    assert result['password'] is None
+    assert result['fullpath'] == '/'
+    assert result['path'] == '/'
+    assert result['query'] is None
+    assert result['url'] == 'http://hostname/'
+    assert result['qsd'] == {}
+    assert result['qsd-'] == {}
+    assert result['qsd+'] == {}
 
     result = utils.parse_url('http://hostname:40////')
-    assert(result['schema'] == 'http')
-    assert(result['host'] == 'hostname')
-    assert(result['port'] == 40)
-    assert(result['user'] is None)
-    assert(result['password'] is None)
-    assert(result['fullpath'] == '/')
-    assert(result['path'] == '/')
-    assert(result['query'] is None)
-    assert(result['url'] == 'http://hostname:40/')
-    assert(result['qsd'] == {})
-    assert(result['qsd-'] == {})
-    assert(result['qsd+'] == {})
+    assert result['schema'] == 'http'
+    assert result['host'] == 'hostname'
+    assert result['port'] == 40
+    assert result['user'] is None
+    assert result['password'] is None
+    assert result['fullpath'] == '/'
+    assert result['path'] == '/'
+    assert result['query'] is None
+    assert result['url'] == 'http://hostname:40/'
+    assert result['qsd'] == {}
+    assert result['qsd-'] == {}
+    assert result['qsd+'] == {}
 
     result = utils.parse_url('HTTP://HoStNaMe:40/test.php')
-    assert(result['schema'] == 'http')
-    assert(result['host'] == 'HoStNaMe')
-    assert(result['port'] == 40)
-    assert(result['user'] is None)
-    assert(result['password'] is None)
-    assert(result['fullpath'] == '/test.php')
-    assert(result['path'] == '/')
-    assert(result['query'] == 'test.php')
-    assert(result['url'] == 'http://HoStNaMe:40/test.php')
-    assert(result['qsd'] == {})
-    assert(result['qsd-'] == {})
-    assert(result['qsd+'] == {})
+    assert result['schema'] == 'http'
+    assert result['host'] == 'HoStNaMe'
+    assert result['port'] == 40
+    assert result['user'] is None
+    assert result['password'] is None
+    assert result['fullpath'] == '/test.php'
+    assert result['path'] == '/'
+    assert result['query'] == 'test.php'
+    assert result['url'] == 'http://HoStNaMe:40/test.php'
+    assert result['qsd'] == {}
+    assert result['qsd-'] == {}
+    assert result['qsd+'] == {}
 
     result = utils.parse_url('HTTPS://user@hostname/test.py')
-    assert(result['schema'] == 'https')
-    assert(result['host'] == 'hostname')
-    assert(result['port'] is None)
-    assert(result['user'] == 'user')
-    assert(result['password'] is None)
-    assert(result['fullpath'] == '/test.py')
-    assert(result['path'] == '/')
-    assert(result['query'] == 'test.py')
-    assert(result['url'] == 'https://user@hostname/test.py')
-    assert(result['qsd'] == {})
-    assert(result['qsd-'] == {})
-    assert(result['qsd+'] == {})
+    assert result['schema'] == 'https'
+    assert result['host'] == 'hostname'
+    assert result['port'] is None
+    assert result['user'] == 'user'
+    assert result['password'] is None
+    assert result['fullpath'] == '/test.py'
+    assert result['path'] == '/'
+    assert result['query'] == 'test.py'
+    assert result['url'] == 'https://user@hostname/test.py'
+    assert result['qsd'] == {}
+    assert result['qsd-'] == {}
+    assert result['qsd+'] == {}
 
     result = utils.parse_url('  HTTPS://///user@@@hostname///test.py  ')
-    assert(result['schema'] == 'https')
-    assert(result['host'] == 'hostname')
-    assert(result['port'] is None)
-    assert(result['user'] == 'user')
-    assert(result['password'] is None)
-    assert(result['fullpath'] == '/test.py')
-    assert(result['path'] == '/')
-    assert(result['query'] == 'test.py')
-    assert(result['url'] == 'https://user@hostname/test.py')
-    assert(result['qsd'] == {})
-    assert(result['qsd-'] == {})
-    assert(result['qsd+'] == {})
+    assert result['schema'] == 'https'
+    assert result['host'] == 'hostname'
+    assert result['port'] is None
+    assert result['user'] == 'user'
+    assert result['password'] is None
+    assert result['fullpath'] == '/test.py'
+    assert result['path'] == '/'
+    assert result['query'] == 'test.py'
+    assert result['url'] == 'https://user@hostname/test.py'
+    assert result['qsd'] == {}
+    assert result['qsd-'] == {}
+    assert result['qsd+'] == {}
 
     result = utils.parse_url(
         'HTTPS://user:password@otherHost/full///path/name/',
     )
-    assert(result['schema'] == 'https')
-    assert(result['host'] == 'otherHost')
-    assert(result['port'] is None)
-    assert(result['user'] == 'user')
-    assert(result['password'] == 'password')
-    assert(result['fullpath'] == '/full/path/name/')
-    assert(result['path'] == '/full/path/name/')
-    assert(result['query'] is None)
-    assert(result['url'] == 'https://user:password@otherHost/full/path/name/')
-    assert(result['qsd'] == {})
-    assert(result['qsd-'] == {})
-    assert(result['qsd+'] == {})
+    assert result['schema'] == 'https'
+    assert result['host'] == 'otherHost'
+    assert result['port'] is None
+    assert result['user'] == 'user'
+    assert result['password'] == 'password'
+    assert result['fullpath'] == '/full/path/name/'
+    assert result['path'] == '/full/path/name/'
+    assert result['query'] is None
+    assert result['url'] == 'https://user:password@otherHost/full/path/name/'
+    assert result['qsd'] == {}
+    assert result['qsd-'] == {}
+    assert result['qsd+'] == {}
 
     # Handle garbage
-    assert(utils.parse_url(None) is None)
+    assert utils.parse_url(None) is None
 
     result = utils.parse_url(
         'mailto://user:password@otherHost/lead2gold@gmail.com' +
         '?from=test@test.com&name=Chris%20Caron&format=text'
     )
-    assert(result['schema'] == 'mailto')
-    assert(result['host'] == 'otherHost')
-    assert(result['port'] is None)
-    assert(result['user'] == 'user')
-    assert(result['password'] == 'password')
-    assert(unquote(result['fullpath']) == '/lead2gold@gmail.com')
-    assert(result['path'] == '/')
-    assert(unquote(result['query']) == 'lead2gold@gmail.com')
-    assert(unquote(
-        result['url']) ==
-        'mailto://user:password@otherHost/lead2gold@gmail.com')
-    assert(len(result['qsd']) == 3)
-    assert('name' in result['qsd'])
-    assert(unquote(result['qsd']['name']) == 'Chris Caron')
-    assert('from' in result['qsd'])
-    assert(unquote(result['qsd']['from']) == 'test@test.com')
-    assert('format' in result['qsd'])
-    assert(unquote(result['qsd']['format']) == 'text')
-    assert(result['qsd-'] == {})
-    assert(result['qsd+'] == {})
+    assert result['schema'] == 'mailto'
+    assert result['host'] == 'otherHost'
+    assert result['port'] is None
+    assert result['user'] == 'user'
+    assert result['password'] == 'password'
+    assert unquote(result['fullpath']) == '/lead2gold@gmail.com'
+    assert result['path'] == '/'
+    assert unquote(result['query']) == 'lead2gold@gmail.com'
+    assert unquote(result['url']) == \
+        'mailto://user:password@otherHost/lead2gold@gmail.com'
+    assert len(result['qsd']) == 3
+    assert 'name' in result['qsd']
+    assert unquote(result['qsd']['name']) == 'Chris Caron'
+    assert 'from' in result['qsd']
+    assert unquote(result['qsd']['from']) == 'test@test.com'
+    assert 'format' in result['qsd']
+    assert unquote(result['qsd']['format']) == 'text'
+    assert result['qsd-'] == {}
+    assert result['qsd+'] == {}
 
     # Test Passwords with question marks ?; not supported
     result = utils.parse_url(
         'http://user:pass.with.?question@host'
     )
-    assert(result is None)
+    assert result is None
 
     # just hostnames
     result = utils.parse_url(
         'nuxref.com'
     )
-    assert(result['schema'] == 'http')
-    assert(result['host'] == 'nuxref.com')
-    assert(result['port'] is None)
-    assert(result['user'] is None)
-    assert(result['password'] is None)
-    assert(result['fullpath'] is None)
-    assert(result['path'] is None)
-    assert(result['query'] is None)
-    assert(result['url'] == 'http://nuxref.com')
-    assert(result['qsd'] == {})
-    assert(result['qsd-'] == {})
-    assert(result['qsd+'] == {})
+    assert result['schema'] == 'http'
+    assert result['host'] == 'nuxref.com'
+    assert result['port'] is None
+    assert result['user'] is None
+    assert result['password'] is None
+    assert result['fullpath'] is None
+    assert result['path'] is None
+    assert result['query'] is None
+    assert result['url'] == 'http://nuxref.com'
+    assert result['qsd'] == {}
+    assert result['qsd-'] == {}
+    assert result['qsd+'] == {}
 
     # just host and path
-    result = utils.parse_url(
-        'invalid/host'
-    )
-    assert(result['schema'] == 'http')
-    assert(result['host'] == 'invalid')
-    assert(result['port'] is None)
-    assert(result['user'] is None)
-    assert(result['password'] is None)
-    assert(result['fullpath'] == '/host')
-    assert(result['path'] == '/')
-    assert(result['query'] == 'host')
-    assert(result['url'] == 'http://invalid/host')
-    assert(result['qsd'] == {})
-    assert(result['qsd-'] == {})
-    assert(result['qsd+'] == {})
+    result = utils.parse_url('invalid/host')
+    assert result['schema'] == 'http'
+    assert result['host'] == 'invalid'
+    assert result['port'] is None
+    assert result['user'] is None
+    assert result['password'] is None
+    assert result['fullpath'] == '/host'
+    assert result['path'] == '/'
+    assert result['query'] == 'host'
+    assert result['url'] == 'http://invalid/host'
+    assert result['qsd'] == {}
+    assert result['qsd-'] == {}
+    assert result['qsd+'] == {}
 
     # just all out invalid
-    assert(utils.parse_url('?') is None)
-    assert(utils.parse_url('/') is None)
+    assert utils.parse_url('?') is None
+    assert utils.parse_url('/') is None
 
     # A default port of zero is still considered valid, but
     # is removed in the response.
     result = utils.parse_url('http://nuxref.com:0')
-    assert(result['schema'] == 'http')
-    assert(result['host'] == 'nuxref.com')
-    assert(result['port'] is None)
-    assert(result['user'] is None)
-    assert(result['password'] is None)
-    assert(result['fullpath'] is None)
-    assert(result['path'] is None)
-    assert(result['query'] is None)
-    assert(result['url'] == 'http://nuxref.com')
-    assert(result['qsd'] == {})
-    assert(result['qsd-'] == {})
-    assert(result['qsd+'] == {})
+    assert result['schema'] == 'http'
+    assert result['host'] == 'nuxref.com'
+    assert result['port'] is None
+    assert result['user'] is None
+    assert result['password'] is None
+    assert result['fullpath'] is None
+    assert result['path'] is None
+    assert result['query'] is None
+    assert result['url'] == 'http://nuxref.com'
+    assert result['qsd'] == {}
+    assert result['qsd-'] == {}
+    assert result['qsd+'] == {}
 
     # Test some illegal strings
     result = utils.parse_url(object, verify_host=False)
@@ -345,7 +342,7 @@ def test_parse_url():
 
     # Do it again without host validation
     result = utils.parse_url('test://', verify_host=False)
-    assert(result['schema'] == 'test')
+    assert result['schema'] == 'test'
     # It's worth noting that the hostname is an empty string and is NEVER set
     # to None if it wasn't specified.
     assert result['host'] == ''
@@ -423,10 +420,10 @@ def test_parse_url():
     assert result['port'] is None
     assert result['user'] == ''
     assert result['password'] == ''
-    assert(unquote(result['fullpath']) == '/_/@^&/jack.json')
-    assert(unquote(result['path']) == '/_/@^&/')
+    assert unquote(result['fullpath']) == '/_/@^&/jack.json'
+    assert unquote(result['path']) == '/_/@^&/'
     assert result['query'] == 'jack.json'
-    assert(unquote(result['url']) == 'crazy://:@/_/@^&/jack.json')
+    assert unquote(result['url']) == 'crazy://:@/_/@^&/jack.json'
     assert result['qsd'] == {}
     assert result['qsd-'] == {}
 
@@ -434,42 +431,42 @@ def test_parse_url():
 def test_parse_bool():
     "utils: parse_bool() testing """
 
-    assert(utils.parse_bool('Enabled', None) is True)
-    assert(utils.parse_bool('Disabled', None) is False)
-    assert(utils.parse_bool('Allow', None) is True)
-    assert(utils.parse_bool('Deny', None) is False)
-    assert(utils.parse_bool('Yes', None) is True)
-    assert(utils.parse_bool('YES', None) is True)
-    assert(utils.parse_bool('Always', None) is True)
-    assert(utils.parse_bool('No', None) is False)
-    assert(utils.parse_bool('NO', None) is False)
-    assert(utils.parse_bool('NEVER', None) is False)
-    assert(utils.parse_bool('TrUE', None) is True)
-    assert(utils.parse_bool('tRUe', None) is True)
-    assert(utils.parse_bool('FAlse', None) is False)
-    assert(utils.parse_bool('F', None) is False)
-    assert(utils.parse_bool('T', None) is True)
-    assert(utils.parse_bool('0', None) is False)
-    assert(utils.parse_bool('1', None) is True)
-    assert(utils.parse_bool('True', None) is True)
-    assert(utils.parse_bool('Yes', None) is True)
-    assert(utils.parse_bool(1, None) is True)
-    assert(utils.parse_bool(0, None) is False)
-    assert(utils.parse_bool(True, None) is True)
-    assert(utils.parse_bool(False, None) is False)
+    assert utils.parse_bool('Enabled', None) is True
+    assert utils.parse_bool('Disabled', None) is False
+    assert utils.parse_bool('Allow', None) is True
+    assert utils.parse_bool('Deny', None) is False
+    assert utils.parse_bool('Yes', None) is True
+    assert utils.parse_bool('YES', None) is True
+    assert utils.parse_bool('Always', None) is True
+    assert utils.parse_bool('No', None) is False
+    assert utils.parse_bool('NO', None) is False
+    assert utils.parse_bool('NEVER', None) is False
+    assert utils.parse_bool('TrUE', None) is True
+    assert utils.parse_bool('tRUe', None) is True
+    assert utils.parse_bool('FAlse', None) is False
+    assert utils.parse_bool('F', None) is False
+    assert utils.parse_bool('T', None) is True
+    assert utils.parse_bool('0', None) is False
+    assert utils.parse_bool('1', None) is True
+    assert utils.parse_bool('True', None) is True
+    assert utils.parse_bool('Yes', None) is True
+    assert utils.parse_bool(1, None) is True
+    assert utils.parse_bool(0, None) is False
+    assert utils.parse_bool(True, None) is True
+    assert utils.parse_bool(False, None) is False
 
     # only the int of 0 will return False since the function
     # casts this to a boolean
-    assert(utils.parse_bool(2, None) is True)
+    assert utils.parse_bool(2, None) is True
     # An empty list is still false
-    assert(utils.parse_bool([], None) is False)
+    assert utils.parse_bool([], None) is False
     # But a list that contains something is True
-    assert(utils.parse_bool(['value', ], None) is True)
+    assert utils.parse_bool(['value', ], None) is True
 
     # Use Default (which is False)
-    assert(utils.parse_bool('OhYeah') is False)
+    assert utils.parse_bool('OhYeah') is False
     # Adjust Default and get a different result
-    assert(utils.parse_bool('OhYeah', True) is True)
+    assert utils.parse_bool('OhYeah', True) is True
 
 
 def test_is_hostname():
@@ -608,14 +605,15 @@ def test_parse_list():
     results = utils.parse_list(
         '.mkv,.avi,.divx,.xvid,.mov,.wmv,.mp4,.mpg,.mpeg,.vob,.iso')
 
-    assert(results == sorted([
+    assert results == sorted([
         '.divx', '.iso', '.mkv', '.mov', '.mpg', '.avi', '.mpeg', '.vob',
         '.xvid', '.wmv', '.mp4',
-    ]))
+    ])
 
     class StrangeObject(object):
         def __str__(self):
             return '.avi'
+
     # Now 2 lists with lots of duplicates and other delimiters
     results = utils.parse_list(
         '.mkv,.avi,.divx,.xvid,.mov,.wmv,.mp4,.mpg .mpeg,.vob,,; ;',
@@ -623,10 +621,13 @@ def test_parse_list():
         '.vob,.iso', ['.vob', ['.vob', '.mkv', StrangeObject(), ], ],
         StrangeObject())
 
-    assert(results == sorted([
+    assert results == sorted([
         '.divx', '.iso', '.mkv', '.mov', '.mpg', '.avi', '.mpeg', '.vob',
         '.xvid', '.wmv', '.mp4',
-    ]))
+    ])
+
+    # Garbage in is removed
+    assert utils.parse_list(object(), 42, None) == []
 
     # Now a list with extras we want to add as strings
     # empty entries are removed
@@ -634,10 +635,10 @@ def test_parse_list():
         '.divx', '.iso', '.mkv', '.mov', '', '  ', '.avi', '.mpeg', '.vob',
         '.xvid', '.mp4'], '.mov,.wmv,.mp4,.mpg')
 
-    assert(results == sorted([
+    assert results == sorted([
         '.divx', '.wmv', '.iso', '.mkv', '.mov', '.mpg', '.avi', '.vob',
         '.xvid', '.mpeg', '.mp4',
-    ]))
+    ])
 
 
 def test_exclusive_match():
@@ -733,6 +734,46 @@ def test_exclusive_match():
     # so we pass
     assert utils.is_exclusive_match(
         logic='match_me', data=data, match_all='match_me') is True
+
+
+def test_apprise_validate_regex(tmpdir):
+    """
+    API: Apprise() Validate Regex tests
+
+    """
+    assert utils.validate_regex(None) is None
+    assert utils.validate_regex(object) is None
+    assert utils.validate_regex(42) is None
+    assert utils.validate_regex("") is None
+    assert utils.validate_regex("  ") is None
+    assert utils.validate_regex("abc") == "abc"
+
+    # value is a keyword that is extracted (if found)
+    assert utils.validate_regex(
+        "- abcd -", r'-(?P<value>[^-]+)-', fmt="{value}") == "abcd"
+    assert utils.validate_regex(
+        "- abcd -", r'-(?P<value>[^-]+)-', strip=False,
+        fmt="{value}") == " abcd "
+
+    # String flags supported in addition to numeric
+    assert utils.validate_regex(
+        "- abcd -", r'-(?P<value>[^-]+)-', 'i', fmt="{value}") == "abcd"
+    assert utils.validate_regex(
+        "- abcd -", r'-(?P<value>[^-]+)-', re.I, fmt="{value}") == "abcd"
+
+    # Test multiple flag settings
+    assert utils.validate_regex(
+        "- abcd -", r'-(?P<value>[^-]+)-', 'isax', fmt="{value}") == "abcd"
+
+    # Invalid flags are just ignored. The below fails to match
+    # because the default value of 'i' is over-ridden by what is
+    # identfied below, and no flag is set at the end of the day
+    assert utils.validate_regex(
+        "- abcd -", r'-(?P<value>[ABCD]+)-', '-%2gb', fmt="{value}") is None
+    assert utils.validate_regex(
+        "- abcd -", r'-(?P<value>[ABCD]+)-', '', fmt="{value}") is None
+    assert utils.validate_regex(
+        "- abcd -", r'-(?P<value>[ABCD]+)-', None, fmt="{value}") is None
 
 
 def test_environ_temporary_change():

--- a/test/test_windows_plugin.py
+++ b/test/test_windows_plugin.py
@@ -113,37 +113,41 @@ def test_windows_plugin():
     obj.duration = 0
 
     # Test URL functionality
-    assert(isinstance(obj.url(), six.string_types) is True)
+    assert isinstance(obj.url(), six.string_types) is True
 
     # Check that it found our mocked environments
-    assert(obj._enabled is True)
+    assert obj._enabled is True
 
     # _on_destroy check
     obj._on_destroy(0, '', 0, 0)
 
     # test notifications
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is True
 
     obj = apprise.Apprise.instantiate(
         'windows://_/?image=True', suppress_exceptions=False)
     obj.duration = 0
-    assert(isinstance(obj.url(), six.string_types) is True)
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert isinstance(obj.url(), six.string_types) is True
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is True
 
     obj = apprise.Apprise.instantiate(
         'windows://_/?image=False', suppress_exceptions=False)
     obj.duration = 0
-    assert(isinstance(obj.url(), six.string_types) is True)
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert isinstance(obj.url(), six.string_types) is True
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is True
 
     obj = apprise.Apprise.instantiate(
         'windows://_/?duration=1', suppress_exceptions=False)
-    assert(isinstance(obj.url(), six.string_types) is True)
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert isinstance(obj.url(), six.string_types) is True
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is True
     # loads okay
     assert obj.duration == 1
 
@@ -165,20 +169,23 @@ def test_windows_plugin():
     # Test our loading of our icon exception; it will still allow the
     # notification to be sent
     win32gui.LoadImage.side_effect = AttributeError
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is True)
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is True
     # Undo our change
     win32gui.LoadImage.side_effect = None
 
     # Test our global exception handling
     win32gui.UpdateWindow.side_effect = AttributeError
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is False)
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is False
     # Undo our change
     win32gui.UpdateWindow.side_effect = None
 
     # Toggle our testing for when we can't send notifications because the
     # package has been made unavailable to us
     obj._enabled = False
-    assert(obj.notify(title='title', body='body',
-           notify_type=apprise.NotifyType.INFO) is False)
+    assert obj.notify(
+        title='title', body='body',
+        notify_type=apprise.NotifyType.INFO) is False


### PR DESCRIPTION
 This PR was originally created to eliminate some of the Q/A that takes place (Refs #157), but some of the Q/A actually makes apprise easier to work with because it allows you to catch on your URL faults right out of the box in a clean elegant way instead of not finding out until you send off your notifications.

The Q/A was lifted for some services but not all of them.  The ones it was left on are old ones where the API has been in place for a very long time and is unlikely to change.

There was also massive re-factoring and code cleanup. Test cases were also updated and simplified.
Notifications were normalized so that they explain the faulted content (if any was found).