### PR TITLE
Refactored configuration + cache support added

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
 ## Description:
 **Related issue (if applicable):** fixes #<!--apprise issue number goes here-->
 
+<!-- Have anything else to describe? Define it here -->
+
 ## New Service Completion Status
 <!-- This section is only applicable if you're adding a new service -->
 * [ ] apprise/plugins/Notify<!--ServiceName goes here-->.py

--- a/apprise/attachment/AttachBase.py
+++ b/apprise/attachment/AttachBase.py
@@ -109,12 +109,14 @@ class AttachBase(URLBase):
         # Absolute path to attachment
         self.download_path = None
 
-        # Set our cache flag
-        # it can be True, or an integer
+        # Set our cache flag; it can be True or a (positive) integer
         try:
             self.cache = cache if isinstance(cache, bool) else int(cache)
             if self.cache < 0:
-                raise ValueError()
+                err = 'A negative cache value ({}) was specified.'.format(
+                    cache)
+                self.logger.warning(err)
+                raise TypeError(err)
 
         except (ValueError, TypeError):
             err = 'An invalid cache value ({}) was specified.'.format(cache)
@@ -212,7 +214,8 @@ class AttachBase(URLBase):
         if self.download_path and os.path.isfile(self.download_path) \
                 and self.cache:
 
-            # We have enough reason to look further into our cached value
+            # We have enough reason to look further into our cached content
+            # and verify it has not expired.
             if self.cache is True:
                 # return our fixed content as is; we will always cache it
                 return True

--- a/apprise/config/ConfigBase.py
+++ b/apprise/config/ConfigBase.py
@@ -27,6 +27,7 @@ import os
 import re
 import six
 import yaml
+import time
 
 from .. import plugins
 from ..AppriseAsset import AppriseAsset
@@ -35,6 +36,7 @@ from ..common import ConfigFormat
 from ..common import CONFIG_FORMATS
 from ..utils import GET_SCHEMA_RE
 from ..utils import parse_list
+from ..utils import parse_bool
 
 
 class ConfigBase(URLBase):
@@ -58,15 +60,30 @@ class ConfigBase(URLBase):
     # anything else. 128KB (131072B)
     max_buffer_size = 131072
 
-    def __init__(self, **kwargs):
+    def __init__(self, cache=True, **kwargs):
         """
         Initialize some general logging and common server arguments that will
         keep things consistent when working with the configurations that
         inherit this class.
 
+        By default we cache our responses so that subsiquent calls does not
+        cause the content to be retrieved again.  For local file references
+        this makes no difference at all.  But for remote content, this does
+        mean more then one call can be made to retrieve the (same) data.  This
+        method can be somewhat inefficient if disabled.  Only disable caching
+        if you understand the consequences.
+
+        You can alternatively set the cache value to an int identifying the
+        number of seconds the previously retrieved can exist for before it
+        should be considered expired.
         """
 
         super(ConfigBase, self).__init__(**kwargs)
+
+        # Tracks the time the content was last retrieved on.  This place a role
+        # for cases where we are not caching our response and are required to
+        # re-retrieve our settings.
+        self._cached_time = None
 
         # Tracks previously loaded content for speed
         self._cached_servers = None
@@ -86,20 +103,34 @@ class ConfigBase(URLBase):
                 self.logger.warning(err)
                 raise TypeError(err)
 
+        # Set our cache flag; it can be True or a (positive) integer
+        try:
+            self.cache = cache if isinstance(cache, bool) else int(cache)
+            if self.cache < 0:
+                err = 'A negative cache value ({}) was specified.'.format(
+                    cache)
+                self.logger.warning(err)
+                raise TypeError(err)
+
+        except (ValueError, TypeError):
+            err = 'An invalid cache value ({}) was specified.'.format(cache)
+            self.logger.warning(err)
+            raise TypeError(err)
+
         return
 
-    def servers(self, asset=None, cache=True, **kwargs):
+    def servers(self, asset=None, **kwargs):
         """
         Performs reads loaded configuration and returns all of the services
         that could be parsed and loaded.
 
         """
 
-        if cache is True and isinstance(self._cached_servers, list):
+        if not self.expired():
             # We already have cached results to return; use them
             return self._cached_servers
 
-        # Our response object
+        # Our cached response object
         self._cached_servers = list()
 
         # read() causes the child class to do whatever it takes for the
@@ -107,8 +138,11 @@ class ConfigBase(URLBase):
         # None is returned if there was an error or simply no data
         content = self.read(**kwargs)
         if not isinstance(content, six.string_types):
-            # Nothing more to do
-            return list()
+            # Set the time our content was cached at
+            self._cached_time = time.time()
+
+            # Nothing more to do; return our empty cache list
+            return self._cached_servers
 
         # Our Configuration format uses a default if one wasn't one detected
         # or enfored.
@@ -129,6 +163,9 @@ class ConfigBase(URLBase):
             self.logger.warning('Failed to load configuration from {}'.format(
                 self.url()))
 
+        # Set the time our content was cached at
+        self._cached_time = time.time()
+
         return self._cached_servers
 
     def read(self):
@@ -138,12 +175,34 @@ class ConfigBase(URLBase):
         """
         return None
 
+    def expired(self):
+        """
+        Simply returns True if the configuration should be considered
+        as expired or False if content should be retrieved.
+        """
+        if isinstance(self._cached_servers, list) and self.cache:
+            # We have enough reason to look further into our cached content
+            # and verify it has not expired.
+            if self.cache is True:
+                # we have not expired, return False
+                return False
+
+            # Verify our cache time to determine whether we will get our
+            # content again.
+            age_in_sec = time.time() - self._cached_time
+            if age_in_sec <= self.cache:
+                # We have not expired; return False
+                return False
+
+        # If we reach here our configuration should be considered
+        # missing and/or expired.
+        return True
+
     @staticmethod
     def parse_url(url, verify_host=True):
         """Parses the URL and returns it broken apart into a dictionary.
 
         This is very specific and customized for Apprise.
-
 
         Args:
             url (str): The URL you want to fully parse.
@@ -176,6 +235,17 @@ class ConfigBase(URLBase):
         # Defines the encoding of the payload
         if 'encoding' in results['qsd']:
             results['encoding'] = results['qsd'].get('encoding')
+
+        # Our cache value
+        if 'cache' in results['qsd']:
+            # First try to get it's integer value
+            try:
+                results['cache'] = int(results['qsd']['cache'])
+
+            except (ValueError, TypeError):
+                # No problem, it just isn't an integer; now treat it as a bool
+                # instead:
+                results['cache'] = parse_bool(results['qsd']['cache'])
 
         return results
 
@@ -542,15 +612,16 @@ class ConfigBase(URLBase):
 
         return response
 
-    def pop(self, index):
+    def pop(self, index=-1):
         """
-        Removes an indexed Notification Service from the stack and
-        returns it.
+        Removes an indexed Notification Service from the stack and returns it.
+
+        By default, the last element of the list is removed.
         """
 
         if not isinstance(self._cached_servers, list):
             # Generate ourselves a list of content we can pull from
-            self.servers(cache=True)
+            self.servers()
 
         # Pop the element off of the stack
         return self._cached_servers.pop(index)
@@ -562,7 +633,7 @@ class ConfigBase(URLBase):
         """
         if not isinstance(self._cached_servers, list):
             # Generate ourselves a list of content we can pull from
-            self.servers(cache=True)
+            self.servers()
 
         return self._cached_servers[index]
 
@@ -572,7 +643,7 @@ class ConfigBase(URLBase):
         """
         if not isinstance(self._cached_servers, list):
             # Generate ourselves a list of content we can pull from
-            self.servers(cache=True)
+            self.servers()
 
         return iter(self._cached_servers)
 
@@ -582,6 +653,28 @@ class ConfigBase(URLBase):
         """
         if not isinstance(self._cached_servers, list):
             # Generate ourselves a list of content we can pull from
-            self.servers(cache=True)
+            self.servers()
 
         return len(self._cached_servers)
+
+    def __bool__(self):
+        """
+        Allows the Apprise object to be wrapped in an Python 3.x based 'if
+        statement'.  True is returned if our content was downloaded correctly.
+        """
+        if not isinstance(self._cached_servers, list):
+            # Generate ourselves a list of content we can pull from
+            self.servers()
+
+        return True if self._cached_servers else False
+
+    def __nonzero__(self):
+        """
+        Allows the Apprise object to be wrapped in an Python 2.x based 'if
+        statement'.  True is returned if our content was downloaded correctly.
+        """
+        if not isinstance(self._cached_servers, list):
+            # Generate ourselves a list of content we can pull from
+            self.servers()
+
+        return True if self._cached_servers else False

--- a/apprise/config/__init__.py
+++ b/apprise/config/__init__.py
@@ -43,7 +43,7 @@ def __load_matrix(path=abspath(dirname(__file__)), name='apprise.config'):
     skip over modules we simply don't have the dependencies for.
 
     """
-    # Used for the detection of additional Notify Services objects
+    # Used for the detection of additional Configuration Services objects
     # The .py extension is optional as we support loading directories too
     module_re = re.compile(r'^(?P<name>Config[a-z0-9]+)(\.py)?$', re.I)
 

--- a/test/test_apprise_config.py
+++ b/test/test_apprise_config.py
@@ -26,6 +26,7 @@
 import six
 import io
 import mock
+import pytest
 from apprise import NotifyFormat
 from apprise.Apprise import Apprise
 from apprise.AppriseConfig import AppriseConfig
@@ -212,9 +213,6 @@ def test_apprise_config(tmpdir):
     # above, our results have been cached so we get a 1 response.
     assert len(ac.servers()) == 1
 
-    # Now do the same check but force a flushed cache
-    assert len(ac.servers(cache=False)) == 0
-
 
 def test_apprise_multi_config_entries(tmpdir):
     """
@@ -311,7 +309,7 @@ def test_apprise_config_tagging(tmpdir):
     assert len(ac.servers(tag='all')) == 3
 
 
-def test_apprise_instantiate():
+def test_apprise_config_instantiate():
     """
     API: AppriseConfig.instantiate()
 
@@ -332,15 +330,9 @@ def test_apprise_instantiate():
     # Store our bad configuration in our schema map
     CONFIG_SCHEMA_MAP['bad'] = BadConfig
 
-    try:
+    with pytest.raises(TypeError):
         AppriseConfig.instantiate(
             'bad://path', suppress_exceptions=False)
-        # We should never make it to this line
-        assert False
-
-    except TypeError:
-        # Exception caught as expected
-        assert True
 
     # Same call but exceptions suppressed
     assert AppriseConfig.instantiate(
@@ -378,7 +370,7 @@ def test_apprise_config_with_apprise_obj(tmpdir):
     # Store our good notification in our schema map
     NOTIFY_SCHEMA_MAP['good'] = GoodNotification
 
-    # Create ourselves a config object
+    # Create ourselves a config object with caching disbled
     ac = AppriseConfig(cache=False)
 
     # Nothing loaded yet
@@ -587,7 +579,7 @@ def test_apprise_config_matrix_load():
         # protocol as string
         protocol = 'true'
 
-    # Generate ourselfs a fake entry
+    # Generate ourselves a fake entry
     apprise.config.ConfigDummy = ConfigDummy
     apprise.config.ConfigDummy2 = ConfigDummy2
     apprise.config.ConfigDummy3 = ConfigDummy3

--- a/test/test_config_base.py
+++ b/test/test_config_base.py
@@ -651,10 +651,10 @@ class ConfigGoober(ConfigBase):
     # This class tests the fact we have a new class name, but we're
     # trying to over-ride items previously used
 
-    # The default simple (insecure) protocol (used by ConfigMail)
+    # The default simple (insecure) protocol
     protocol = 'http'
 
-    # The default secure protocol (used by ConfigMail)
+    # The default secure protocol
     secure_protocol = 'https'""")
 
     # Utilizes a schema:// already occupied (as tuple)
@@ -664,11 +664,10 @@ class ConfigBugger(ConfigBase):
     # This class tests the fact we have a new class name, but we're
     # trying to over-ride items previously used
 
-    # The default simple (insecure) protocol (used by ConfigMail), the other
-    # isn't
+    # The default simple (insecure) protocol
     protocol = ('http', 'bugger-test' )
 
-    # The default secure protocol (used by ConfigMail), the other isn't
+    # The default secure protocol
     secure_protocol = ('https', 'bugger-tests')""")
 
     __load_matrix(path=str(base), name=module_name)


### PR DESCRIPTION
## Description:
Re-factored some of the **AppriseConfig** class to additionally support the `cache=` directive similar to how it works with Attachments.  The idea is now you can tell Apprise not to cache the configuration files (which will cause them to retrieved each request made).  This provides a more dynamic solution allowing your configuration to change while Apprise has already been loaded in memory.

For web requests, you can set things like `cache=30` which will keep the last retrieved remote content for 30 seconds.  All requests made within this time period will use the same configuration retrieved from that one remote request.  After 30 seconds (in the case of this example) a new remote fetch for configuration is made (renewing it).

The default option is `cache=Yes` which causes Apprise to continue to behave as it had in the past; after a remote request for configuration has been made, it is re-used for the entire life of the program; no further requests are made.

You can also set `cache=No` to disable caching all together.  This has a bit of overhead involved; but this might be your intention.  Apprise URLs are queried from configuration files (regardless of where they are) each and every time.

## Checklist
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
