### PR TITLE
except AttributeError while importing `gi`

### DIFF
--- a/apprise/plugins/NotifyDBus.py
+++ b/apprise/plugins/NotifyDBus.py
@@ -89,7 +89,7 @@ try:
         from gi.repository import GdkPixbuf
         NOTIFY_DBUS_IMAGE_SUPPORT = True
 
-    except (ImportError, ValueError):
+    except (ImportError, ValueError, AttributeError):
         # No problem; this will get caught in outer try/catch
 
         # A ValueError will get thrown upon calling gi.require_version() if

--- a/apprise/plugins/NotifyGnome.py
+++ b/apprise/plugins/NotifyGnome.py
@@ -49,7 +49,7 @@ try:
     # We're good to go!
     NOTIFY_GNOME_SUPPORT_ENABLED = True
 
-except (ImportError, ValueError):
+except (ImportError, ValueError, AttributeError):
     # No problem; we just simply can't support this plugin; we could
     # be in microsoft windows, or we just don't have the python-gobject
     # library available to us (or maybe one we don't support)?


### PR DESCRIPTION
Hi. I don't have a python-gnome installed on my machine (as far as I know) and don't need it currently.
but when importing apprise I get this:

```
  File "/home/senan/.local/lib/python3.7/site-packages/apprise/plugins/NotifyGnome.py", line 43, in <module>
    gi.require_version("Notify", "0.7")
AttributeError: module 'gi' has no attribute 'require_version'
```

so I have some sort of `gi` installed somehow but not a relevant one

![](https://i.imgur.com/OIYQYZN.png)

## Checklist

* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
