### PR TITLE
Fixes Discord error code 50006 when sending message

### DIFF
--- a/apprise/plugins/NotifyDiscord.py
+++ b/apprise/plugins/NotifyDiscord.py
@@ -42,6 +42,7 @@
 #
 import re
 import requests
+from json import dumps
 
 from .NotifyBase import NotifyBase
 from ..common import NotifyImageSize
@@ -319,9 +320,12 @@ class NotifyDiscord(NotifyBase):
             if attach:
                 files = {'file': (attach.name, open(attach.path, 'rb'))}
 
+            else:
+                headers['Content-Type'] = 'application/json; charset=utf-8'
+
             r = requests.post(
                 notify_url,
-                data=payload,
+                data=payload if files else dumps(payload),
                 headers=headers,
                 files=files,
                 verify=self.verify_certificate,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** fixes #179 
After finding [this StackOverflow post](https://stackoverflow.com/questions/59022027/discord-webhook-message-cannnot-send), it seems that Nov 24th 2019 (today) was a day Discord did make some kind of change upstream.

Today they enforces the `Content-Type` header `application/json` where in the past it was not a requirement at all.

The strange thing is that this appears to be very random.  I live in Canada and whatever server they're providing me, it's still accepting the old format.  However the reports of this breaking on people has been showing up on Reddit, StackOverFlow and other GitHub projects.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
