### PR TITLE
AppriseAsset refactored; added body_format default

### DIFF
--- a/apprise/Apprise.py
+++ b/apprise/Apprise.py
@@ -323,6 +323,10 @@ class Apprise(object):
                 # bad attachments
                 return False
 
+        # Allow Asset default value
+        body_format = self.asset.body_format \
+            if body_format is None else body_format
+
         # Iterate over our loaded plugins
         for server in self.find(tag):
             if status is None:

--- a/apprise/AppriseAsset.py
+++ b/apprise/AppriseAsset.py
@@ -86,23 +86,32 @@ class AppriseAsset(object):
         'apprise-{TYPE}-{XY}{EXTENSION}',
     ))
 
-    def __init__(self, theme='default', image_path_mask=None,
-                 image_url_mask=None, default_extension=None):
+    # This value can also be set on calls to Apprise.notify(). This allows
+    # you to let Apprise upfront the type of data being passed in.  This
+    # must be of type NotifyFormat. Possible values could be:
+    # - NotifyFormat.TEXT
+    # - NotifyFormat.MARKDOWN
+    # - NotifyFormat.HTML
+    # - None
+    #
+    # If no format is specified (hence None), then no special pre-formating
+    # actions will take place during a notificaton. This has been and always
+    # will be the default.
+    body_format = None
+
+    def __init__(self, **kwargs):
         """
         Asset Initialization
 
         """
-        if theme:
-            self.theme = theme
+        # Assign default arguments if specified
+        for key, value in kwargs.items():
+            if not hasattr(AppriseAsset, key):
+                raise AttributeError(
+                    'AppriseAsset init(): '
+                    'An invalid key {} was specified.'.format(key))
 
-        if image_path_mask is not None:
-            self.image_path_mask = image_path_mask
-
-        if image_url_mask is not None:
-            self.image_url_mask = image_url_mask
-
-        if default_extension is not None:
-            self.default_extension = default_extension
+            setattr(self, key, value)
 
     def color(self, notify_type, color_type=None):
         """

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -666,9 +666,13 @@ def test_apprise_asset(tmpdir):
     API: AppriseAsset() object
 
     """
-    a = AppriseAsset(theme=None)
+    a = AppriseAsset(theme='light')
     # Default theme
-    assert a.theme == 'default'
+    assert a.theme == 'light'
+
+    # Invalid kw handling
+    with pytest.raises(AttributeError):
+        AppriseAsset(invalid_kw='value')
 
     a = AppriseAsset(
         theme='dark',


### PR DESCRIPTION
## Description:
Re-factored **AppriseAsset()** object.
* You can now set any arguments you want during it's initialization.  You can alternatively set them all after too.
* an **AttributeError()** exception is thrown if you try to initialize a kwarg that simply does not exist as part of the object.
* added default **body_format** that can be used to tell apprise what the type of content you will be notifying in advance.  This gives you a little bit of an edge on how it will look using different notification services.  By default this takes a value of `None` so that no pre-formatting takes place at all.  This is the same `body_format` value that can also be passed in with the **Apprise.notify()** call.
* Specifying a `body_format` on a call to **Apprise.Notify()** will always override the default set in the **AppriseAsset()** object.
* If a value is specified in the **AppriseAsset()** object and you want to call **Apprise.Notify()** without referencing it; simply set `body_format=False`. This will disable any potential message pre-formatting during call.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
