### PR TITLE
Nextcloud Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The table below identifies the services this tool supports and some example serv
 | [Matrix](https://github.com/caronc/apprise/wiki/Notify_matrix) | matrix:// or matrixs://  | (TCP) 80 or 443 | matrix://hostname<br />matrix://user@hostname<br />matrixs://user:pass@hostname:port/#room_alias<br />matrixs://user:pass@hostname:port/!room_id<br />matrixs://user:pass@hostname:port/#room_alias/!room_id/#room2<br />matrixs://token@hostname:port/?webhook=matrix<br />matrix://user:token@hostname/?webhook=slack&format=markdown
 | [Mattermost](https://github.com/caronc/apprise/wiki/Notify_mattermost) | mmost://  | (TCP) 8065 | mmost://hostname/authkey<br />mmost://hostname:80/authkey<br />mmost://user@hostname:80/authkey<br />mmost://hostname/authkey?channel=channel<br />mmosts://hostname/authkey<br />mmosts://user@hostname/authkey<br />
 | [Microsoft Teams](https://github.com/caronc/apprise/wiki/Notify_msteams) | msteams://  | (TCP) 443   | msteams://TokenA/TokenB/TokenC/
-| [NextCloud](https://github.com/caronc/apprise/wiki/Notify_nextcloud) | ncloud:// or nclouds:// | (TCP) 80 or 443 | ncloud://adminuser:pass@host/User<br/>nclouds://adminuser:pass@host/User1/User2/UserN
+| [Nextcloud](https://github.com/caronc/apprise/wiki/Notify_nextcloud) | ncloud:// or nclouds:// | (TCP) 80 or 443 | ncloud://adminuser:pass@host/User<br/>nclouds://adminuser:pass@host/User1/User2/UserN
 | [Notica](https://github.com/caronc/apprise/wiki/Notify_notica) | notica://  | (TCP) 443   | notica://Token/
 | [Notifico](https://github.com/caronc/apprise/wiki/Notify_notifico) | notifico://  | (TCP) 443   | notifico://ProjectID/MessageHook/
 | [Prowl](https://github.com/caronc/apprise/wiki/Notify_prowl) | prowl://   | (TCP) 443    | prowl://apikey<br />prowl://apikey/providerkey

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The table below identifies the services this tool supports and some example serv
 | [Matrix](https://github.com/caronc/apprise/wiki/Notify_matrix) | matrix:// or matrixs://  | (TCP) 80 or 443 | matrix://hostname<br />matrix://user@hostname<br />matrixs://user:pass@hostname:port/#room_alias<br />matrixs://user:pass@hostname:port/!room_id<br />matrixs://user:pass@hostname:port/#room_alias/!room_id/#room2<br />matrixs://token@hostname:port/?webhook=matrix<br />matrix://user:token@hostname/?webhook=slack&format=markdown
 | [Mattermost](https://github.com/caronc/apprise/wiki/Notify_mattermost) | mmost://  | (TCP) 8065 | mmost://hostname/authkey<br />mmost://hostname:80/authkey<br />mmost://user@hostname:80/authkey<br />mmost://hostname/authkey?channel=channel<br />mmosts://hostname/authkey<br />mmosts://user@hostname/authkey<br />
 | [Microsoft Teams](https://github.com/caronc/apprise/wiki/Notify_msteams) | msteams://  | (TCP) 443   | msteams://TokenA/TokenB/TokenC/
+| [NextCloud](https://github.com/caronc/apprise/wiki/Notify_nextcloud) | ncloud:// or nclouds:// | (TCP) 80 or 443 | ncloud://adminuser:pass@host/User<br/>nclouds://adminuser:pass@host/User1/User2/UserN
 | [Notica](https://github.com/caronc/apprise/wiki/Notify_notica) | notica://  | (TCP) 443   | notica://Token/
 | [Notifico](https://github.com/caronc/apprise/wiki/Notify_notifico) | notifico://  | (TCP) 443   | notifico://ProjectID/MessageHook/
 | [Prowl](https://github.com/caronc/apprise/wiki/Notify_prowl) | prowl://   | (TCP) 443    | prowl://apikey<br />prowl://apikey/providerkey

--- a/apprise/plugins/NotifyNextCloud.py
+++ b/apprise/plugins/NotifyNextCloud.py
@@ -1,0 +1,290 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CON
+
+import requests
+
+from .NotifyBase import NotifyBase
+from ..URLBase import PrivacyMode
+from ..common import NotifyType
+from ..utils import parse_list
+from ..AppriseLocale import gettext_lazy as _
+
+
+class NotifyNextCloud(NotifyBase):
+    """
+    A wrapper for NextCloud Notifications
+    """
+
+    # The default descriptive name associated with the Notification
+    service_name = 'NextCloud'
+
+    # The services URL
+    service_url = 'https://github.com/nextcloud/notifications'
+
+    # Insecure protocol (for those self hosted requests)
+    protocol = 'nextcloud'
+
+    # The default protocol (this is secure for notica)
+    secure_protocol = 'nextclouds'
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = 'https://github.com/caronc/apprise/wiki/Notify_nextcloud'
+
+    # NextCloud URL
+    notify_url = '{schema}://{host}/ocs/v2.php/apps/admin_notifications/' \
+                 'api/v1/notifications/{target}'
+
+    # NextCloud does not support a title
+    title_maxlen = 0
+
+    # Defines the maximum allowable characters per message.
+    body_maxlen = 4000
+
+    # If the message is less than this number of characters, there is another
+    # method of posting the message to Nextcloud. We use this if we can, but
+    # otherwise fall back to the larger size (which is our Apprise fixed limit)
+    # defined above.
+    short_message_length = 255
+
+    # Define object templates
+    templates = (
+        '{schema}://{user}:{password}@{host}/{targets}',
+        '{schema}://{user}:{password}@{host}:{port}/{targets}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'host': {
+            'name': _('Hostname'),
+            'type': 'string',
+            'required': True,
+        },
+        'port': {
+            'name': _('Port'),
+            'type': 'int',
+            'min': 1,
+            'max': 65535,
+        },
+        'user': {
+            'name': _('Username'),
+            'type': 'string',
+            'required': True,
+        },
+        'password': {
+            'name': _('Password'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+        },
+        'target_user': {
+            'name': _('Target User'),
+            'type': 'string',
+            'map_to': 'targets',
+        },
+        'targets': {
+            'name': _('Targets'),
+            'type': 'list:string',
+            'required': True,
+        },
+    })
+
+    # Define any kwargs we're using
+    template_kwargs = {
+        'headers': {
+            'name': _('HTTP Header'),
+            'prefix': '+',
+        },
+    }
+
+    def __init__(self, targets=None, headers=None, **kwargs):
+        """
+        Initialize NextCloud Object
+        """
+        super(NotifyNextCloud, self).__init__(**kwargs)
+
+        self.targets = parse_list(targets)
+        if len(self.targets) == 0:
+            msg = 'At least one NextCloud target user must be specified.'
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        self.headers = {}
+        if headers:
+            # Store our extra headers
+            self.headers.update(headers)
+
+        return
+
+    def send(self, body, title='', notify_type=NotifyType.INFO, **kwargs):
+        """
+        Perform NextCloud Notification
+        """
+
+        # Prepare our Header
+        headers = {
+            'User-Agent': self.app_id,
+        }
+
+        # error tracking (used for function return)
+        has_error = False
+
+        # Create a copy of the targets list
+        targets = list(self.targets)
+        while len(targets):
+            target = targets.pop(0)
+
+            # Prepare our Payload
+            payload = {}
+            if len(body) > 255:
+                payload['longMessage'] = body
+
+            else:
+                payload['shortMessage'] = body
+
+            # Auth is used for SELFHOSTED queries
+            auth = (self.user, self.password)
+
+            notify_url = self.notify_url.format(
+                schema='https' if self.secure else 'http',
+                host=self.host if not isinstance(self.port, int)
+                else '{}:{}'.format(self.host, self.port),
+                target=target,
+            )
+
+            self.logger.debug('NextCloud POST URL: %s (cert_verify=%r)' % (
+                notify_url, self.verify_certificate,
+            ))
+            self.logger.debug('NextCloud Payload: %s' % str(payload))
+
+            # Always call throttle before any remote server i/o is made
+            self.throttle()
+
+            try:
+                r = requests.post(
+                    notify_url.format(token=self.token),
+                    data=payload,
+                    headers=headers,
+                    auth=auth,
+                    verify=self.verify_certificate,
+                )
+                if r.status_code != requests.codes.ok:
+                    # We had a problem
+                    status_str = \
+                        NotifyNextCloud.http_response_code_lookup(
+                            r.status_code)
+
+                    self.logger.warning(
+                        'Failed to send NextCloud notification:'
+                        '{}{}error={}.'.format(
+                            status_str,
+                            ', ' if status_str else '',
+                            r.status_code))
+
+                    self.logger.debug(
+                        'Response Details:\r\n{}'.format(r.content))
+                    # track our failure
+                    has_error = True
+                    continue
+
+                else:
+                    self.logger.info('Sent NextCloud notification.')
+
+            except requests.RequestException as e:
+                self.logger.warning(
+                    'A Connection error occured sending NextCloud '
+                    'notification.',
+                )
+                self.logger.debug('Socket Exception: %s' % str(e))
+
+                # track our failure
+                has_error = True
+                continue
+
+        return not has_error
+
+    def url(self, privacy=False, *args, **kwargs):
+        """
+        Returns the URL built dynamically based on specified arguments.
+        """
+
+        # Define any arguments set
+        args = {
+            'format': self.notify_format,
+            'overflow': self.overflow_mode,
+            'verify': 'yes' if self.verify_certificate else 'no',
+        }
+
+        # Append our headers into our args
+        args.update({'+{}'.format(k): v for k, v in self.headers.items()})
+
+        auth = '{user}:{password}@'.format(
+            user=NotifyNextCloud.quote(self.user, safe=''),
+            password=self.pprint(
+                self.password, privacy, mode=PrivacyMode.Secret, safe=''),
+        )
+
+        default_port = 443 if self.secure else 80
+
+        return '{schema}://{auth}{hostname}{port}/{targets}?{args}' \
+               .format(
+                   schema=self.secure_protocol
+                   if self.secure else self.protocol,
+                   auth=auth,
+                   hostname=NotifyNextCloud.quote(self.host, safe=''),
+                   port='' if self.port is None or self.port == default_port
+                        else ':{}'.format(self.port),
+                   fullpath=NotifyNextCloud.quote(
+                       self.fullpath, safe='/'),
+                   targets='/'.join([NotifyNextCloud.quote(x)
+                                     for x in self.targets]),
+                   args=NotifyNextCloud.urlencode(args),
+               )
+
+    @staticmethod
+    def parse_url(url):
+        """
+        Parses the URL and returns enough arguments that can allow
+        us to substantiate this object.
+
+        """
+        results = NotifyBase.parse_url(url, verify_host=False)
+        if not results:
+            # We're done early as we couldn't load the results
+            return results
+
+        # Fetch our targets
+        results['targets'] = \
+            NotifyNextCloud.split_path(results['fullpath'])
+
+        # The 'to' makes it easier to use yaml configuration
+        if 'to' in results['qsd'] and len(results['qsd']['to']):
+            results['targets'] += \
+                NotifyNextCloud.parse_list(results['qsd']['to'])
+
+        # Add our headers that the user can potentially over-ride if they
+        # wish to to our returned result set
+        results['headers'] = results['qsd-']
+        results['headers'].update(results['qsd+'])
+
+        return results

--- a/apprise/plugins/NotifyNextcloud.py
+++ b/apprise/plugins/NotifyNextcloud.py
@@ -40,7 +40,7 @@ class NotifyNextcloud(NotifyBase):
     service_name = 'Nextcloud'
 
     # The services URL
-    service_url = 'https://github.com/nextcloud/notifications'
+    service_url = 'https://nextcloud.com/'
 
     # Insecure protocol (for those self hosted requests)
     protocol = 'ncloud'
@@ -152,9 +152,12 @@ class NotifyNextcloud(NotifyBase):
 
             # Prepare our Payload
             payload = {
-                'shortMessage': title,
-                'longMessage': body,
+                'shortMessage': title if title else self.app_desc,
             }
+            if body:
+                # Only store the longMessage if a body was defined; nextcloud
+                # doesn't take kindly to empty longMessage entries.
+                payload['longMessage'] = body
 
             auth = None
             if self.user:

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -49,7 +49,7 @@ it easy to access:
 
 Boxcar, ClickSend, Discord, E-Mail, Emby, Faast, Flock, Gitter, Gotify, Growl,
 IFTTT, Join, KODI, Kumulos, Mailgun, MatterMost, Matrix, Microsoft Windows
-Notifications, Microsoft Teams, MessageBird, MSG91, Nexmo, NextCloud, Notica,
+Notifications, Microsoft Teams, MessageBird, MSG91, Nexmo, Nextcloud, Notica,
 Notifico, Notify MyAndroid, Prowl, Pushalot, PushBullet, Pushjet, Pushover,
 PushSafer, Rocket.Chat, SendGrid, SimplePush, Slack, Super Toasty, Stride,
 Syslog, Techulus Push, Telegram, Twilio, Twitter, Twist, XBMC, XMPP,

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -49,10 +49,11 @@ it easy to access:
 
 Boxcar, ClickSend, Discord, E-Mail, Emby, Faast, Flock, Gitter, Gotify, Growl,
 IFTTT, Join, KODI, Kumulos, Mailgun, MatterMost, Matrix, Microsoft Windows
-Notifications, Microsoft Teams, MessageBird, MSG91, Nexmo, Notica, Notifico,
-Notify MyAndroid, Prowl, Pushalot, PushBullet, Pushjet, Pushover, PushSafer,
-Rocket.Chat, SendGrid, SimplePush, Slack, Super Toasty, Stride, Syslog,
-Techulus Push, Telegram, Twilio, Twitter, Twist, XBMC, XMPP, Webex Teams}
+Notifications, Microsoft Teams, MessageBird, MSG91, Nexmo, NextCloud, Notica,
+Notifico, Notify MyAndroid, Prowl, Pushalot, PushBullet, Pushjet, Pushover,
+PushSafer, Rocket.Chat, SendGrid, SimplePush, Slack, Super Toasty, Stride,
+Syslog, Techulus Push, Telegram, Twilio, Twitter, Twist, XBMC, XMPP,
+Webex Teams}
 
 Name:           python-%{pypi_name}
 Version:        0.8.2

--- a/setup.py
+++ b/setup.py
@@ -72,10 +72,10 @@ setup(
     keywords='Push Notifications Alerts Email AWS SNS Boxcar ClickSend '
         'Discord Dbus Emby Faast Flock Gitter Gnome Gotify Growl IFTTT Join '
         'KODI Kumulos Mailgun Matrix Mattermost MessageBird MSG91 Nexmo '
-        'Notica, Notifico Prowl PushBullet Pushjet Pushed Pushover PushSafer '
-        'Rocket.Chat Ryver SendGrid SimplePush Slack Stride Syslog Techulus '
-        'Push Telegram Twilio Twist Twitter XBMC Microsoft MSTeams Windows '
-        'Webex CLI API',
+        'NextCloud Notica, Notifico Prowl PushBullet Pushjet Pushed Pushover '
+        'PushSafer Rocket.Chat Ryver SendGrid SimplePush Slack Stride Syslog '
+        'Techulus Push Telegram Twilio Twist Twitter XBMC Microsoft MSTeams '
+        'Windows Webex CLI API',
     author='Chris Caron',
     author_email='lead2gold@gmail.com',
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     keywords='Push Notifications Alerts Email AWS SNS Boxcar ClickSend '
         'Discord Dbus Emby Faast Flock Gitter Gnome Gotify Growl IFTTT Join '
         'KODI Kumulos Mailgun Matrix Mattermost MessageBird MSG91 Nexmo '
-        'NextCloud Notica, Notifico Prowl PushBullet Pushjet Pushed Pushover '
+        'Nextcloud Notica, Notifico Prowl PushBullet Pushjet Pushed Pushover '
         'PushSafer Rocket.Chat Ryver SendGrid SimplePush Slack Stride Syslog '
         'Techulus Push Telegram Twilio Twist Twitter XBMC Microsoft MSTeams '
         'Windows Webex CLI API',

--- a/test/test_nextcloud_plugin.py
+++ b/test/test_nextcloud_plugin.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import six
+import mock
+import requests
+from apprise import plugins
+
+# Disable logging for a cleaner testing output
+import logging
+logging.disable(logging.CRITICAL)
+
+
+@mock.patch('requests.post')
+def test_nextcloud_empty_body(mock_post):
+    """
+    API: NotifyNextcloud() empty body
+
+    """
+    # Disable Throttling to speed testing
+    plugins.NotifyBase.request_rate_per_sec = 0
+
+    # A response
+    robj = mock.Mock()
+    robj.content = ''
+    robj.status_code = requests.codes.ok
+
+    # Prepare Mock
+    mock_post.return_value = robj
+
+    # Variation Initializations
+    obj = plugins.NotifyNextcloud(
+        host="localhost", user="admin", password="pass", targets="user")
+    assert isinstance(obj, plugins.NotifyNextcloud) is True
+    assert isinstance(obj.url(), six.string_types) is True
+
+    # An empty body
+    assert obj.send(body="") is True
+    assert 'data' in mock_post.call_args_list[0][1]
+    assert 'shortMessage' in mock_post.call_args_list[0][1]['data']
+    # The longMessage argument is not set
+    assert 'longMessage' not in mock_post.call_args_list[0][1]['data']

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -1738,6 +1738,72 @@ TEST_URLS = (
     }),
 
     ##################################
+    # NotifyNextCloud
+    ##################################
+    ('ncloud://:@/', {
+        'instance': None,
+    }),
+    ('ncloud://', {
+        'instance': None,
+    }),
+    ('nclouds://', {
+        # No hostname
+        'instance': None,
+    }),
+    ('ncloud://localhost', {
+        # No user specified
+        'instance': TypeError,
+    }),
+    ('ncloud://localhost/admin', {
+        'instance': plugins.NotifyNextCloud,
+    }),
+    ('ncloud://user@localhost/admin', {
+        'instance': plugins.NotifyNextCloud,
+    }),
+    ('ncloud://user@localhost?to=user1,user2', {
+        'instance': plugins.NotifyNextCloud,
+    }),
+    ('ncloud://user:pass@localhost/user1/user2', {
+        'instance': plugins.NotifyNextCloud,
+
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'ncloud://user:****@localhost/user1/user2',
+    }),
+    ('ncloud://user:pass@localhost:8080/admin', {
+        'instance': plugins.NotifyNextCloud,
+    }),
+    ('nclouds://user:pass@localhost/admin', {
+        'instance': plugins.NotifyNextCloud,
+
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'nclouds://user:****@localhost/admin',
+    }),
+    ('nclouds://user:pass@localhost:8080/admin/', {
+        'instance': plugins.NotifyNextCloud,
+    }),
+    ('ncloud://localhost:8080/admin?-HeaderKey=HeaderValue', {
+        'instance': plugins.NotifyNextCloud,
+    }),
+    ('ncloud://user:pass@localhost:8081/admin', {
+        'instance': plugins.NotifyNextCloud,
+        # force a failure
+        'response': False,
+        'requests_response_code': requests.codes.internal_server_error,
+    }),
+    ('ncloud://user:pass@localhost:8082/admin', {
+        'instance': plugins.NotifyNextCloud,
+        # throw a bizzare code forcing us to fail to look it up
+        'response': False,
+        'requests_response_code': 999,
+    }),
+    ('ncloud://user:pass@localhost:8083/user1/user2/user3', {
+        'instance': plugins.NotifyNextCloud,
+        # Throws a series of connection and transfer exceptions when this flag
+        # is set and tests that we gracfully handle them
+        'test_requests_exceptions': True,
+    }),
+
+    ##################################
     # NotifyProwl
     ##################################
     ('prowl://', {

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -1738,7 +1738,7 @@ TEST_URLS = (
     }),
 
     ##################################
-    # NotifyNextCloud
+    # NotifyNextcloud
     ##################################
     ('ncloud://:@/', {
         'instance': None,
@@ -1755,49 +1755,49 @@ TEST_URLS = (
         'instance': TypeError,
     }),
     ('ncloud://localhost/admin', {
-        'instance': plugins.NotifyNextCloud,
+        'instance': plugins.NotifyNextcloud,
     }),
     ('ncloud://user@localhost/admin', {
-        'instance': plugins.NotifyNextCloud,
+        'instance': plugins.NotifyNextcloud,
     }),
     ('ncloud://user@localhost?to=user1,user2', {
-        'instance': plugins.NotifyNextCloud,
+        'instance': plugins.NotifyNextcloud,
     }),
     ('ncloud://user:pass@localhost/user1/user2', {
-        'instance': plugins.NotifyNextCloud,
+        'instance': plugins.NotifyNextcloud,
 
         # Our expected url(privacy=True) startswith() response:
         'privacy_url': 'ncloud://user:****@localhost/user1/user2',
     }),
     ('ncloud://user:pass@localhost:8080/admin', {
-        'instance': plugins.NotifyNextCloud,
+        'instance': plugins.NotifyNextcloud,
     }),
     ('nclouds://user:pass@localhost/admin', {
-        'instance': plugins.NotifyNextCloud,
+        'instance': plugins.NotifyNextcloud,
 
         # Our expected url(privacy=True) startswith() response:
         'privacy_url': 'nclouds://user:****@localhost/admin',
     }),
     ('nclouds://user:pass@localhost:8080/admin/', {
-        'instance': plugins.NotifyNextCloud,
+        'instance': plugins.NotifyNextcloud,
     }),
     ('ncloud://localhost:8080/admin?-HeaderKey=HeaderValue', {
-        'instance': plugins.NotifyNextCloud,
+        'instance': plugins.NotifyNextcloud,
     }),
     ('ncloud://user:pass@localhost:8081/admin', {
-        'instance': plugins.NotifyNextCloud,
+        'instance': plugins.NotifyNextcloud,
         # force a failure
         'response': False,
         'requests_response_code': requests.codes.internal_server_error,
     }),
     ('ncloud://user:pass@localhost:8082/admin', {
-        'instance': plugins.NotifyNextCloud,
+        'instance': plugins.NotifyNextcloud,
         # throw a bizzare code forcing us to fail to look it up
         'response': False,
         'requests_response_code': 999,
     }),
     ('ncloud://user:pass@localhost:8083/user1/user2/user3', {
-        'instance': plugins.NotifyNextCloud,
+        'instance': plugins.NotifyNextcloud,
         # Throws a series of connection and transfer exceptions when this flag
         # is set and tests that we gracfully handle them
         'test_requests_exceptions': True,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** fixes #159 

### Syntax
Valid syntaxes are as follows:
* `ncloud://{hostname}/{notify_user}`
* `ncloud://{hostname}:{port}/{notify_user}`
* `ncloud://{admin_user}:{password}@{hostname}/{notify_user}`
* `ncloud://{admin_user}:{password}@{hostname}:{port}/{notify_user}`
* `nclouds://{hostname}/{notify_user}`
* `nclouds://{hostname}:{port}/{notify_user}`
* `nclouds://{admin_user}:{password}@{hostname}/{notify_user}`
* `nclouds://{admin_user}:{password}@{hostname}:{port}/{notify_user}`

You can notify more then one user by simply chaining them at the end of the URL.
* `ncloud://{admin_user}:{password}@{hostname}:{port}/{notify_user1}/{notify_user2}/{notify_userN}`
* `nclouds://{admin_user}:{password}@{hostname}:{port}/{notify_user1}/{notify_user2}/{notify_userN}`

## New Service Completion Status
<!-- This section is only applicable if you're adding a new service -->
* [x] apprise/plugins/NotifyNextCloud.py
* [x] setup.py
    - add new service into the `keywords` section of the `setup()` declaration
* [x] README.md
    - add entry for new service to table (as a quick reference)
* [x] packaging/redhat/python-apprise.spec
    - add new service into the `%global common_description`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
