### PR TITLE
URL parameters preserved for attachment queries

### DIFF
--- a/test/test_apprise_attachments.py
+++ b/test/test_apprise_attachments.py
@@ -78,14 +78,14 @@ def test_apprise_attachment():
     assert aa
 
     # Add another entry already in it's AttachBase format
-    response = AppriseAttachment.instantiate(path)
+    response = AppriseAttachment.instantiate(path, cache=True)
     assert isinstance(response, AttachBase)
     assert aa.add(response, asset=AppriseAsset())
 
     # There is now 2 attachments
     assert len(aa) == 2
 
-    # No cache set, so our cache defaults to True
+    # Cache is initialized to True
     assert aa[1].cache is True
 
     # Reset our object
@@ -172,6 +172,10 @@ def test_apprise_attachment():
     # Negative cache are not allowed
     assert not aa.add(AppriseAttachment.instantiate(
         'file://{}?name=andanother.png&cache=-600'.format(path)))
+
+    # Invalid cache value
+    assert not aa.add(AppriseAttachment.instantiate(
+        'file://{}?name=andanother.png'.format(path), cache='invalid'))
 
     # No length change
     assert len(aa) == 3


### PR DESCRIPTION
## Description:
This extends the attachment URL's to retain arguments that aren't used by Apprise.  For example,  to download something from dropbox, you'd need a URL like: `https://www.dropbox.com/s/pu9ba7rhaierqqo/Avatar-sm.png?dl=1`.  Prior to this pull request, the `dl=1` would become lost.

Parameter arguments are now preserved as long as they don't conflict with the ones Apprise uses (`cache=`, '`verify=`, `name=`, and `mime=`).

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
