### PR TITLE
Drop Python v3.4 CI testing (accomodates PyYAML v5.3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ matrix:
   include:
     - python: "2.7"
       env: TOXENV=py27
-    - python: "3.4"
-      env: TOXENV=py34
     - python: "3.5"
       env: TOXENV=py35
     - python: "3.6"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,py38,pypy,pypy3,coverage-report
+envlist = py27,py35,py36,py37,py38,pypy,pypy3,coverage-report
 
 
 [testenv]
@@ -20,16 +20,6 @@ deps=
     dbus-python
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev-requirements.txt
-commands =
-    python setup.py compile_catalog
-    coverage run --parallel -m pytest {posargs}
-    flake8 . --count --show-source --statistics
-
-[testenv:py34]
-deps=
-   dbus-python
-   -r{toxinidir}/requirements.txt
-   -r{toxinidir}/dev-requirements.txt
 commands =
     python setup.py compile_catalog
     coverage run --parallel -m pytest {posargs}


### PR DESCRIPTION
## Description:
PyYAML removed support for Python v3.4.  To accommodate this we'll just drop the testing for it.  This can potentially affect CentOS/RedHat users who use my RPM packaging.  But these also perform testing (during their build), so any issues should get caught then.