### PR TITLE
Resolves slack error on successful post

### DIFF
--- a/apprise/plugins/NotifySlack.py
+++ b/apprise/plugins/NotifySlack.py
@@ -525,25 +525,29 @@ class NotifySlack(NotifyBase):
                     'Response Details:\r\n{}'.format(r.content))
                 return False
 
-            try:
-                response = loads(r.content)
+            elif attach:
+                # Attachment posts return a JSON string
+                try:
+                    response = loads(r.content)
 
-            except (AttributeError, TypeError, ValueError):
-                # ValueError = r.content is Unparsable
-                # TypeError = r.content is None
-                # AttributeError = r is None
-                pass
+                except (AttributeError, TypeError, ValueError):
+                    # ValueError = r.content is Unparsable
+                    # TypeError = r.content is None
+                    # AttributeError = r is None
+                    pass
 
-            if not (response and response.get('ok', True)):
-                # Bare minimum requirements not met
-                self.logger.warning(
-                    'Failed to send {}to Slack: error={}.'.format(
-                        attach.name if attach else '',
-                        r.status_code))
+                if not (response and response.get('ok', True)):
+                    # Bare minimum requirements not met
+                    self.logger.warning(
+                        'Failed to send {}to Slack: error={}.'.format(
+                            attach.name if attach else '',
+                            r.status_code))
 
-                self.logger.debug(
-                    'Response Details:\r\n{}'.format(r.content))
-                return False
+                    self.logger.debug(
+                        'Response Details:\r\n{}'.format(r.content))
+                    return False
+            else:
+                response = r.content
 
             # Message Post Response looks like this:
             # {

--- a/test/test_slack_plugin.py
+++ b/test/test_slack_plugin.py
@@ -116,7 +116,7 @@ def test_slack_oauth_access_token(mock_post):
     request.content = '{'
 
     # As a result, we'll fail to send our notification
-    assert obj.send(body="test") is False
+    assert obj.send(body="test", attach=attach) is False
 
     request.content = dumps({
         'ok': False,
@@ -125,7 +125,7 @@ def test_slack_oauth_access_token(mock_post):
 
     # A response from Slack (even with a 200 response) still
     # results in a failure:
-    assert obj.send(body="test") is False
+    assert obj.send(body="test", attach=attach) is False
 
     # Handle exceptions reading our attachment from disk (should it happen)
     mock_post.side_effect = OSError("Attachment Error")


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** fixes #195 

Posting attachments to Slack return a JSON response that gives details on the status of the file (just uploaded).  An dictionary entry entitled `ok` reveals the status of the upload.

In introducing this, it was not considered that the actual content response was never looked at before.   A successful notification was based on having received a HTTP 200 Response code.

This push request still allows the logic to look at the JSON response of an attachment, but not if it's a single notification.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
