### PR TITLE
eliminate Slack webhook token restrictions

### DIFF
--- a/apprise/plugins/NotifySlack.py
+++ b/apprise/plugins/NotifySlack.py
@@ -176,7 +176,7 @@ class NotifySlack(NotifyBase):
             'type': 'string',
             'private': True,
             'required': True,
-            'regex': (r'^[A-Z0-9]{9}$', 'i'),
+            'regex': (r'^[A-Z0-9]+$', 'i'),
         },
         # Token required as part of the Webhook request
         #  /........./BBBBBBBBB/........................
@@ -185,7 +185,7 @@ class NotifySlack(NotifyBase):
             'type': 'string',
             'private': True,
             'required': True,
-            'regex': (r'^[A-Z0-9]{9}$', 'i'),
+            'regex': (r'^[A-Z0-9]+$', 'i'),
         },
         # Token required as part of the Webhook request
         #  /........./........./CCCCCCCCCCCCCCCCCCCCCCCC
@@ -194,7 +194,7 @@ class NotifySlack(NotifyBase):
             'type': 'string',
             'private': True,
             'required': True,
-            'regex': (r'^[A-Za-z0-9]{24}$', 'i'),
+            'regex': (r'^[A-Za-z0-9]+$', 'i'),
         },
         'target_encoded_id': {
             'name': _('Target Encoded ID'),

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -3213,15 +3213,15 @@ TEST_URLS = (
             'message': '',
         },
     }),
-    ('slack://username@INVALID/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/#cool', {
+    ('slack://username@-INVALID-/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/#cool', {
         # invalid 1st Token
         'instance': TypeError,
     }),
-    ('slack://username@T1JJ3T3L2/INVALID/TIiajkdnlazkcOXrIdevi7FQ/#great', {
+    ('slack://username@T1JJ3T3L2/-INVALID-/TIiajkdnlazkcOXrIdevi7FQ/#great', {
         # invalid 2rd Token
         'instance': TypeError,
     }),
-    ('slack://username@T1JJ3T3L2/A1BRTD4JD/INVALID/#channel', {
+    ('slack://username@T1JJ3T3L2/A1BRTD4JD/-INVALID-/#channel', {
         # invalid 3rd Token
         'instance': TypeError,
     }),


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #218
Just completely drop the webhook restrictions put in place by Apprise.  Let the upstream handle it.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage