### PR TITLE
apprise-api python 3 compatibility bugfix

### DIFF
--- a/apprise/config/ConfigHTTP.py
+++ b/apprise/config/ConfigHTTP.py
@@ -211,7 +211,7 @@ class ConfigHTTP(ConfigBase):
                     return None
 
                 # Store our result (but no more than our buffer length)
-                response = r.content[:self.max_buffer_size + 1]
+                response = r.text[:self.max_buffer_size + 1]
 
                 # Verify that our content did not exceed the buffer size:
                 if len(response) > self.max_buffer_size:

--- a/test/test_config_http.py
+++ b/test/test_config_http.py
@@ -89,7 +89,7 @@ def test_config_http(mock_post):
             'Content-Type': 'text/plain',
         }
 
-        content = default_content
+        text = default_content
 
         # Pointer to file
         ptr = None
@@ -257,7 +257,7 @@ def test_config_http(mock_post):
     iter(ch)
 
     # Test a buffer size limit reach
-    ch.max_buffer_size = len(dummy_response.content)
+    ch.max_buffer_size = len(dummy_response.text)
     assert isinstance(ch.read(), six.string_types) is True
 
     # Test YAML detection
@@ -304,7 +304,7 @@ def test_config_http(mock_post):
     # Take a snapshot
     max_buffer_size = ch.max_buffer_size
 
-    ch.max_buffer_size = len(dummy_response.content) - 1
+    ch.max_buffer_size = len(dummy_response.text) - 1
     assert ch.read() is None
 
     # Restore buffer size count
@@ -321,12 +321,12 @@ def test_config_http(mock_post):
     assert isinstance(ch.read(), six.string_types) is True
 
     # Handle cases where the content length is exactly at our limit
-    dummy_response.content = 'a' * ch.max_buffer_size
+    dummy_response.text = 'a' * ch.max_buffer_size
     # This is acceptable
     assert isinstance(ch.read(), six.string_types) is True
 
     # If we are over our limit though..
-    dummy_response.content = 'b' * (ch.max_buffer_size + 1)
+    dummy_response.text = 'b' * (ch.max_buffer_size + 1)
     assert ch.read() is None
 
     # Test an invalid return code


### PR DESCRIPTION
## Description:
This resolves an issue brought up with the CLI not correctly working with the Apprise API brought up [here](https://github.com/caronc/apprise-api/issues/14).

The issue was a result of Apprise under the hood accessing the decoded byte code returned by the web request made for the configuration.  The later section of the code expects this to be a string (thus encoded).

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
