### PR TITLE
Improved CLI parsing; now support keywords containing URLs

### DIFF
--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -120,7 +120,7 @@ GET_PHONE_NO_RE = re.compile(r'^\+?(?P<phone>[0-9\s)(+-]+)\s*$')
 
 # Regular expression used to destinguish between multiple URLs
 URL_DETECTION_RE = re.compile(
-    r'([a-z0-9]+?:\/\/.*?)[\s,]*(?=$|[a-z0-9]+?:\/\/)', re.I)
+    r'([a-z0-9]+?:\/\/.*?)(?=$|[\s,]+[a-z0-9]{2,9}?:\/\/)', re.I)
 
 # validate_regex() utilizes this mapping to track and re-use pre-complied
 # regular expressions
@@ -481,13 +481,6 @@ def split_urls(urls):
 
     except TypeError:
         results = []
-
-    if len(results) > 0 and results[len(results) - 1][-1] != urls[-1]:
-        # we always want to save the end of url URL if we can; This handles
-        # cases where there is actually a comma (,) at the end of a single URL
-        # that would have otherwise got lost when our regex passed over it.
-        results[len(results) - 1] += \
-            re.match(r'.*?([\s,]+)?$', urls).group(1).rstrip()
 
     return results
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -542,6 +542,12 @@ def test_split_urls():
     assert 'windows://' in results
     assert 'gnome://' in results
 
+    # We don't want to parse out URLs that are part of another URL's arguments
+    results = utils.split_urls('discord://host?url=https://localhost')
+    assert isinstance(results, list)
+    assert len(results) == 1
+    assert 'discord://host?url=https://localhost' in results
+
     # Commas and spaces found inside URLs are ignored
     urls = [
         'mailgun://noreply@sandbox.mailgun.org/apikey/?to=test@example.com,'


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #234

A URL can now be assigned to a keyword in an Apprise URL; hence with this patch, this is now valid:
* `discord://abcd/123?avatar_url=https://path/to/image.png`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
