### PR TITLE
Remove Gotify Throttling

### DIFF
--- a/apprise/plugins/NotifyGotify.py
+++ b/apprise/plugins/NotifyGotify.py
@@ -77,6 +77,9 @@ class NotifyGotify(NotifyBase):
     # A URL that takes you to the setup/help of the specific protocol
     setup_url = 'https://github.com/caronc/apprise/wiki/Notify_gotify'
 
+    # Disable throttle rate
+    request_rate_per_sec = 0
+
     # Define object templates
     templates = (
         '{schema}://{host}/{token}',


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #244 
Gotify is usually on a self hosted server, so throttling isn't necessary for this. This also addresses the issue raised by an end user.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
