### PR TITLE
Gotify connection timeout set to 2.5s

### DIFF
--- a/apprise/plugins/NotifyGotify.py
+++ b/apprise/plugins/NotifyGotify.py
@@ -80,6 +80,10 @@ class NotifyGotify(NotifyBase):
     # Disable throttle rate
     request_rate_per_sec = 0
 
+    # If no bytes have been received on the underlining socket for
+    # connection_timeout seconds, close the connection.
+    connection_timeout = 2.5
+
     # Define object templates
     templates = (
         '{schema}://{host}/{token}',
@@ -191,6 +195,7 @@ class NotifyGotify(NotifyBase):
                 data=dumps(payload),
                 headers=headers,
                 verify=self.verify_certificate,
+                timeout=self.connection_timeout,
             )
             if r.status_code != requests.codes.ok:
                 # We had a problem


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #244 
Thanks to @miggland for his observation on the `requests` `timeout` option.  Gotify time-out changed to **2.5s**.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
