### PR TITLE
Updated Discord API Endpoint for Nov 7th, 2020 Deadline

### DIFF
--- a/apprise/plugins/NotifyDiscord.py
+++ b/apprise/plugins/NotifyDiscord.py
@@ -28,17 +28,17 @@
 # here you'll be able to access the Webhooks menu and create a new one.
 #
 #  When you've completed, you'll get a URL that looks a little like this:
-#  https://discordapp.com/api/webhooks/417429632418316298/\
+#  https://discord.com/api/webhooks/417429632418316298/\
 #         JHZ7lQml277CDHmQKMHI8qBe7bk2ZwO5UKjCiOAF7711o33MyqU344Qpgv7YTpadV_js
 #
 #  Simplified, it looks like this:
-#     https://discordapp.com/api/webhooks/WEBHOOK_ID/WEBHOOK_TOKEN
+#     https://discord.com/api/webhooks/WEBHOOK_ID/WEBHOOK_TOKEN
 #
 #  This plugin will simply work using the url of:
 #     discord://WEBHOOK_ID/WEBHOOK_TOKEN
 #
 # API Documentation on Webhooks:
-#    - https://discordapp.com/developers/docs/resources/webhook
+#    - https://discord.com/developers/docs/resources/webhook
 #
 import re
 import requests
@@ -63,7 +63,7 @@ class NotifyDiscord(NotifyBase):
     service_name = 'Discord'
 
     # The services URL
-    service_url = 'https://discordapp.com/'
+    service_url = 'https://discord.com/'
 
     # The default secure protocol
     secure_protocol = 'discord'
@@ -72,7 +72,7 @@ class NotifyDiscord(NotifyBase):
     setup_url = 'https://github.com/caronc/apprise/wiki/Notify_discord'
 
     # Discord Webhook
-    notify_url = 'https://discordapp.com/api/webhooks'
+    notify_url = 'https://discord.com/api/webhooks'
 
     # Allows the user to specify the NotifyImageSize object
     image_size = NotifyImageSize.XY_256
@@ -494,11 +494,13 @@ class NotifyDiscord(NotifyBase):
     @staticmethod
     def parse_native_url(url):
         """
-        Support https://discordapp.com/api/webhooks/WEBHOOK_ID/WEBHOOK_TOKEN
+        Support https://discord.com/api/webhooks/WEBHOOK_ID/WEBHOOK_TOKEN
+        Support Legacy URL as well:
+            https://discordapp.com/api/webhooks/WEBHOOK_ID/WEBHOOK_TOKEN
         """
 
         result = re.match(
-            r'^https?://discordapp\.com/api/webhooks/'
+            r'^https?://discord(app)?\.com/api/webhooks/'
             r'(?P<webhook_id>[0-9]+)/'
             r'(?P<webhook_token>[A-Z0-9_-]+)/?'
             r'(?P<args>\?.+)?$', url, re.I)

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -309,9 +309,17 @@ TEST_URLS = (
             # don't include an image by default
             'include_image': True,
     }),
+    ('https://discord.com/api/webhooks/{}/{}'.format(
+        '0' * 10, 'B' * 40), {
+            # Native URL Support, support the provided discord URL from their
+            # webpage.
+            'instance': plugins.NotifyDiscord,
+            'requests_response_code': requests.codes.no_content,
+    }),
     ('https://discordapp.com/api/webhooks/{}/{}'.format(
         '0' * 10, 'B' * 40), {
-            # Native URL Support, take the discord URL and still build from it
+            # Legacy Native URL Support, support the older URL (to be
+            # decomissioned on Nov 7th 2020)
             'instance': plugins.NotifyDiscord,
             'requests_response_code': requests.codes.no_content,
     }),


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #248 
A quote from an email issued on July 18th, 2020:

> Discord API Domain Migration
> 
> Last month, we excitedly announced our official move to discord.com. It was a long time in the making, and the work isn't done yet! For now, our API will continue to handle requests made to discordapp.com. On November 7, 2020 we will be dropping support for the discordapp.com domain in favor of discord.com. Please ensure that your libraries, bots, and applications are updated accordingly.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
