### PR TITLE
Added Spontit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The table below identifies the services this tool supports and some example serv
 | [SendGrid](https://github.com/caronc/apprise/wiki/Notify_sendgrid) | sendgrid://  | (TCP) 443   | sendgrid://APIToken:FromEmail/<br />sendgrid://APIToken:FromEmail/ToEmail<br />sendgrid://APIToken:FromEmail/ToEmail1/ToEmail2/ToEmailN/
 | [SimplePush](https://github.com/caronc/apprise/wiki/Notify_simplepush) | spush://   | (TCP) 443    | spush://apikey<br />spush://salt:password@apikey<br />spush://apikey?event=Apprise
 | [Slack](https://github.com/caronc/apprise/wiki/Notify_slack) | slack://  | (TCP) 443   | slack://TokenA/TokenB/TokenC/<br />slack://TokenA/TokenB/TokenC/Channel<br />slack://botname@TokenA/TokenB/TokenC/Channel<br />slack://user@TokenA/TokenB/TokenC/Channel1/Channel2/ChannelN
+| [Spontit](https://github.com/caronc/apprise/wiki/Notify_spontit) | spontit://  | (TCP) 443   | spontit://UserID@APIKey/<br />spontit://UserID@APIKey/Channel<br />spontit://UserID@APIKey/Channel1/Channel2/ChannelN
 | [Syslog](https://github.com/caronc/apprise/wiki/Notify_syslog) | syslog://  | n/a  | syslog://<br />syslog://Facility
 | [Telegram](https://github.com/caronc/apprise/wiki/Notify_telegram) | tgram://  | (TCP) 443   | tgram://bottoken/ChatID<br />tgram://bottoken/ChatID1/ChatID2/ChatIDN
 | [Twitter](https://github.com/caronc/apprise/wiki/Notify_twitter) | twitter://  | (TCP) 443   | twitter://CKey/CSecret/AKey/ASecret<br/>twitter://user@CKey/CSecret/AKey/ASecret<br/>twitter://CKey/CSecret/AKey/ASecret/User1/User2/User2<br/>twitter://CKey/CSecret/AKey/ASecret?mode=tweet

--- a/apprise/URLBase.py
+++ b/apprise/URLBase.py
@@ -562,15 +562,15 @@ class URLBase(object):
 
     @property
     def app_id(self):
-        return self.asset.app_id
+        return self.asset.app_id if self.asset.app_id else ''
 
     @property
     def app_desc(self):
-        return self.asset.app_desc
+        return self.asset.app_desc if self.asset.app_desc else ''
 
     @property
     def app_url(self):
-        return self.asset.app_url
+        return self.asset.app_url if self.asset.app_url else ''
 
     @property
     def request_timeout(self):

--- a/apprise/plugins/NotifySpontit.py
+++ b/apprise/plugins/NotifySpontit.py
@@ -329,23 +329,19 @@ class NotifySpontit(NotifyBase):
         Returns the URL built dynamically based on specified arguments.
         """
 
-        # Define any arguments set
-        args = {
-            'format': self.notify_format,
-            'overflow': self.overflow_mode,
-            'verify': 'yes' if self.verify_certificate else 'no',
-        }
+        # Our URL parameters
+        params = self.url_parameters(privacy=privacy, *args, **kwargs)
 
         if self.subtitle:
-            args['subtitle'] = self.subtitle
+            params['subtitle'] = self.subtitle
 
-        return '{schema}://{userid}@{apikey}/{targets}?{args}'.format(
+        return '{schema}://{userid}@{apikey}/{targets}?{params}'.format(
             schema=self.secure_protocol,
             userid=self.user,
             apikey=self.pprint(self.apikey, privacy, safe=''),
             targets='/'.join(
                 [NotifySpontit.quote(x, safe='') for x in self.targets]),
-            args=NotifySpontit.urlencode(args))
+            params=NotifySpontit.urlencode(params))
 
     @staticmethod
     def parse_url(url):

--- a/apprise/plugins/NotifySpontit.py
+++ b/apprise/plugins/NotifySpontit.py
@@ -52,7 +52,7 @@ from ..AppriseLocale import gettext_lazy as _
 # specified.  If not, we use the user of the person sending the notification
 # Finally the channel identifier is detected
 CHANNEL_REGEX = re.compile(
-    r'^\s*(#|%23)?((?P<user>[a-z0-9_]+)([/\\]|%2F))?'
+    r'^\s*(#|%23)?((@|%40)?(?P<user>[a-z0-9_]+)([/\\]|%2F))?'
     r'(?P<channel>[a-z0-9_-]+)\s*$', re.I)
 
 
@@ -180,12 +180,9 @@ class NotifySpontit(NotifyBase):
             # Validate targets and drop bad ones:
             result = CHANNEL_REGEX.match(target)
             if result:
-                # We're dealing with a channel; re-assemble it
-                user = result.group('user') \
-                    if result.group('user') else self.user
-
+                # Just extract the channel
                 self.targets.append(
-                    '{}/{}'.format(user, result.group('channel')))
+                    '{}'.format(result.group('channel')))
                 continue
 
             self.logger.warning(

--- a/apprise/plugins/NotifySpontit.py
+++ b/apprise/plugins/NotifySpontit.py
@@ -106,7 +106,7 @@ class NotifySpontit(NotifyBase):
             'name': _('User ID'),
             'type': 'string',
             'required': True,
-            'regex': (r'^[a-z0-9_]+$', 'i'),
+            'regex': (r'^[a-z0-9_-]+$', 'i'),
         },
         'apikey': {
             'name': _('API Key'),

--- a/apprise/plugins/NotifySpontit.py
+++ b/apprise/plugins/NotifySpontit.py
@@ -1,0 +1,336 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+# To use this service you will need a Spontit account from their website
+# at https://spontit.com/
+#
+# After you have an account created:
+#   - Visit your profile at https://spontit.com/profile and take note of your
+#     {username}.  It might look something like: user12345678901
+#   - Next generate an API key at https://spontit.com/secret_keys. This will
+#     generate a very long alpha-numeric string we'll refer to as the
+#     {apikey}
+
+# The Spontit Syntax is as follows:
+# spontit://{username}@{apikey}
+
+import re
+import requests
+from json import loads
+
+from .NotifyBase import NotifyBase
+from ..common import NotifyType
+from ..utils import parse_list
+from ..utils import validate_regex
+from ..AppriseLocale import gettext_lazy as _
+
+# Syntax suggests you use a hashtag '#' to help distinguish we're dealing
+# with a channel.
+# Secondly we extract the user information only if it's
+# specified.  If not, we use the user of the person sending the notification
+# Finally the channel identifier is detected
+CHANNEL_REGEX = re.compile(
+    r'#?((?P<user>[a-z0-9]+)[/\])?(?P<channel>[a-z0-9_-]+)\s*$', re.I)
+
+
+class NotifySpontit(NotifyBase):
+    """
+    A wrapper for Spontit Notifications
+    """
+
+    # The default descriptive name associated with the Notification
+    service_name = 'Spontit'
+
+    # The services URL
+    service_url = 'https://spontit.com/'
+
+    # All notification requests are secure
+    secure_protocol = 'spontit'
+
+    # Allow 300 requests per minute.
+    # 60/300 = 0.2
+    request_rate_per_sec = 0.20
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = 'https://github.com/caronc/apprise/wiki/Notify_spontit'
+
+    # Spontit single notification URL
+    notify_url = 'https://api.spontit.com/v3/push'
+
+    # The maximum length of the body
+    body_maxlen = 100
+
+    # The maximum length of the title
+    title_maxlen = 100
+
+    # Define object templates
+    templates = (
+        '{schema}://{user}@{apikey}',
+        '{schema}://{user}@{apikey}/{targets}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'user': {
+            'name': _('User ID'),
+            'type': 'string',
+            'required': True,
+            'regex': (r'^[a-z0-9]+$', 'i'),
+        },
+        'apikey': {
+            'name': _('API Key'),
+            'type': 'string',
+            'required': True,
+            'private': True,
+            'regex': (r'^[a-z0-9]+$', 'i'),
+        },
+        # Target Channel ID's
+        # If a slash is used; you must escape it
+        # If no slash is used; channel is presumed to be your own
+        'target_channel': {
+            'name': _('Target Channel ID'),
+            'type': 'string',
+            'prefix': '#',
+            'regex': (r'^[0-9\s)(+-]+$', 'i'),
+            'map_to': 'targets',
+        },
+        'targets': {
+            'name': _('Targets'),
+            'type': 'list:string',
+            'required': True,
+        },
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'to': {
+            'alias_of': 'targets',
+        },
+    })
+
+    def __init__(self, apikey, targets=None, **kwargs):
+        """
+        Initialize Spontit Object
+        """
+        super(NotifySpontit, self).__init__(**kwargs)
+
+        # User ID (associated with project)
+        user = validate_regex(
+            self.user, *self.template_tokens['user']['regex'])
+        if not user:
+            msg = 'An invalid Spontit User ID ' \
+                  '({}) was specified.'.format(self.user)
+            self.logger.warning(msg)
+            raise TypeError(msg)
+        # use cleaned up version
+        self.user = user
+
+        # API Key (associated with project)
+        self.apikey = validate_regex(
+            apikey, *self.template_tokens['apikey']['regex'])
+        if not self.apikey:
+            msg = 'An invalid Spontit API Key ' \
+                  '({}) was specified.'.format(apikey)
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # Parse our targets
+        self.targets = list()
+
+        for target in parse_list(targets):
+            # Validate targets and drop bad ones:
+            result = CHANNEL_REGEX.match(target)
+            if result:
+                # We're dealing with a channel; re-assemble it
+                user = result.group('user') \
+                    if result.group('user') else self.user
+
+                self.targets.append(
+                    '{}/{}'.format(user, result.group('channel')))
+                continue
+
+            self.logger.warning(
+                'Dropped invalid channel/user ({}) specified.'.format(target))
+
+        return
+
+    def send(self, body, title='', notify_type=NotifyType.INFO, **kwargs):
+        """
+        Sends Message
+        """
+
+        # error tracking (used for function return)
+        has_error = False
+
+        # Prepare our headers
+        headers = {
+            'User-Agent': self.app_id,
+            'Content-Type': 'application/json',
+            'X-Authorization': self.apikey,
+            'X-UserId': self.user,
+        }
+
+        # use the list directly
+        targets = list(self.targets)
+
+        if not len(targets):
+            # The user did not specify a channel and therefore wants to notify
+            # the main account only.  We just set a substitute marker of
+            # None so that our while loop below can still process one iteration
+            targets = [None, ]
+
+        while len(targets):
+            # Get our target(s) to notify
+            target = targets.pop(0)
+
+            # Prepare our payload
+            payload = {
+                'message': body,
+            }
+
+            if title:
+                # Set title if specified
+                payload['pushTitle'] = title
+
+            if target is not None:
+                payload['channelName'] = target
+
+            # Some Debug Logging
+            self.logger.debug(
+                'Spontit POST URL: {} (cert_verify={})'.format(
+                    self.notify_url, self.verify_certificate))
+            self.logger.debug('Spontit Payload: {}' .format(payload))
+
+            # Always call throttle before any remote server i/o is made
+            self.throttle()
+            try:
+                r = requests.post(
+                    self.notify_url,
+                    params=payload,
+                    headers=headers,
+                    verify=self.verify_certificate,
+                )
+
+                if r.status_code not in (
+                        requests.codes.created, requests.codes.ok):
+                    status_str = \
+                        NotifyBase.http_response_code_lookup(
+                            r.status_code)
+
+                    try:
+                        # Update our status response if we can
+                        json_response = loads(r.content)
+                        status_str = json_response.get('message', status_str)
+
+                    except (AttributeError, TypeError, ValueError):
+                        # ValueError = r.content is Unparsable
+                        # TypeError = r.content is None
+                        # AttributeError = r is None
+
+                        # We could not parse JSON response.
+                        # We will just use the status we already have.
+                        pass
+
+                    self.logger.warning(
+                        'Failed to send Spontit notification to {}: '
+                        '{}{}error={}.'.format(
+                            target,
+                            status_str,
+                            ', ' if status_str else '',
+                            r.status_code))
+
+                    self.logger.debug(
+                        'Response Details:\r\n{}'.format(r.content))
+
+                    # Mark our failure
+                    has_error = True
+                    continue
+
+                # If we reach here; the message was sent
+                self.logger.info(
+                    'Sent Spontit notification to {}.'.format(target))
+
+                self.logger.debug(
+                    'Response Details:\r\n{}'.format(r.content))
+
+            except requests.RequestException as e:
+                self.logger.warning(
+                    'A Connection error occurred sending Spontit:%s ' % (
+                        ', '.join(self.targets)) + 'notification.'
+                )
+                self.logger.debug('Socket Exception: %s' % str(e))
+                # Mark our failure
+                has_error = True
+                continue
+
+        return not has_error
+
+    def url(self, privacy=False, *args, **kwargs):
+        """
+        Returns the URL built dynamically based on specified arguments.
+        """
+
+        # Define any arguments set
+        args = {
+            'format': self.notify_format,
+            'overflow': self.overflow_mode,
+            'verify': 'yes' if self.verify_certificate else 'no',
+        }
+
+        return '{schema}://{userid}@{apikey}/{targets}?{args}'.format(
+            schema=self.secure_protocol,
+            userid=self.user,
+            apikey=self.pprint(self.apikey, privacy, safe=''),
+            targets='/'.join(
+                [NotifySpontit.quote(x, safe='') for x in self.targets]),
+            args=NotifySpontit.urlencode(args))
+
+    @staticmethod
+    def parse_url(url):
+        """
+        Parses the URL and returns enough arguments that can allow
+        us to substantiate this object.
+
+        """
+
+        results = NotifyBase.parse_url(url, verify_host=False)
+        if not results:
+            # We're done early as we couldn't load the results
+            return results
+
+        # Get our entries; split_path() looks after unquoting content for us
+        # by default
+        results['targets'] = NotifySpontit.split_path(results['fullpath'])
+
+        # The hostname is our authentication key
+        results['apikey'] = NotifySpontit.unquote(results['host'])
+
+        # Support the 'to' variable so that we can support targets this way too
+        # The 'to' makes it easier to use yaml configuration
+        if 'to' in results['qsd'] and len(results['qsd']['to']):
+            results['targets'] += \
+                NotifySpontit.parse_list(results['qsd']['to'])
+
+        return results

--- a/apprise/plugins/NotifySpontit.py
+++ b/apprise/plugins/NotifySpontit.py
@@ -52,7 +52,8 @@ from ..AppriseLocale import gettext_lazy as _
 # specified.  If not, we use the user of the person sending the notification
 # Finally the channel identifier is detected
 CHANNEL_REGEX = re.compile(
-    r'#?((?P<user>[a-z0-9]+)[/\])?(?P<channel>[a-z0-9_-]+)\s*$', re.I)
+    r'^\s*(#|%23)?((?P<user>[a-z0-9]+)([/\\]|%2F))?'
+    r'(?P<channel>[a-z0-9_-]+)\s*$', re.I)
 
 
 class NotifySpontit(NotifyBase):
@@ -231,6 +232,7 @@ class NotifySpontit(NotifyBase):
                     params=payload,
                     headers=headers,
                     verify=self.verify_certificate,
+                    timeout=self.request_timeout,
                 )
 
                 if r.status_code not in (

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -52,8 +52,8 @@ IFTTT, Join, Kavenegar, KODI, Kumulos, MacOSX, Mailgun, MatterMost, Matrix,
 Microsoft Windows, Microsoft Teams, MessageBird, MSG91, MyAndroid, Nexmo,
 Nextcloud, Notica, Notifico, Office365, PopcornNotify, Prowl, Pushalot,
 PushBullet, Pushjet, Pushover, PushSafer, Rocket.Chat, SendGrid, SimplePush,
-Sinch, Slack, Super Toasty, Stride, Syslog, Techulus Push, Telegram, Twilio,
-Twitter, Twist, XBMC, XMPP, Webex Teams}
+Sinch, Slack, Spontit, Super Toasty, Stride, Syslog, Techulus Push, Telegram,
+Twilio, Twitter, Twist, XBMC, XMPP, Webex Teams}
 
 Name:           python-%{pypi_name}
 Version:        0.8.6

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
         'Kavenegar KODI Kumulos MacOS Mailgun Matrix Mattermost MessageBird '
         'MSG91 Nexmo Nextcloud Notica Notifico Office365 PopcornNotify Prowl '
         'PushBullet Pushjet Pushed Pushover PushSafer Rocket.Chat Ryver '
-        'SendGrid SimplePush Sinch Slack Stride Syslog Techulus Push '
+        'SendGrid SimplePush Sinch Slack Spontit Stride Syslog Techulus Push '
         'Telegram Twilio Twist Twitter XBMC Microsoft MSTeams Windows Webex '
         'CLI API',
     author='Chris Caron',

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -3195,6 +3195,74 @@ TEST_URLS = (
     }),
 
     ##################################
+    # NotifySpontit
+    ##################################
+    ('spontit://', {
+        # invalid url
+        'instance': TypeError,
+    }),
+    # Another bad url
+    ('spontit://:@/', {
+        'instance': TypeError,
+    }),
+    # No user specified
+    ('spontit://%s' % ('a' * 100), {
+        'instance': TypeError,
+    }),
+    # Invalid API Key specified
+    ('spontit://user@%%20_', {
+        'instance': TypeError,
+    }),
+    # Provide a valid user and API Key
+    ('spontit://%s@%s' % ('u' * 11, 'b' * 100), {
+        'instance': plugins.NotifySpontit,
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'spontit://{}@b...b/'.format('u' * 11),
+    }),
+    # Provide a valid user and API Key, but provide an invalid channel
+    ('spontit://%s@%s/#!!' % ('u' * 11, 'b' * 100), {
+        'instance': plugins.NotifySpontit,
+    }),
+    # Provide a valid user and API Key, but provide a valid channel
+    ('spontit://%s@%s/#abcd' % ('u' * 11, 'b' * 100), {
+        'instance': plugins.NotifySpontit,
+    }),
+    # Provide a valid user and API Key, but provide a valid channel (that is
+    # not ours).
+    # Spontit uses a slash (/) to delimite the user from the channel id when
+    # specifying channel entries. For Apprise we need to encode this
+    # so we convert the slash (/) into %2F
+    ('spontit://{}@{}/#1245%2Fabcd'.format('u' * 11, 'b' * 100), {
+        'instance': plugins.NotifySpontit,
+    }),
+    # Provide multipe channels
+    ('spontit://{}@{}/#1245%2Fabcd/defg'.format('u' * 11, 'b' * 100), {
+        'instance': plugins.NotifySpontit,
+    }),
+    # Provide multipe channels through the use of the to= variable
+    ('spontit://{}@{}/?to=#1245/abcd'.format('u' * 11, 'b' * 100), {
+        'instance': plugins.NotifySpontit,
+    }),
+    ('spontit://%s@%s' % ('u' * 11, 'b' * 100), {
+        'instance': plugins.NotifySpontit,
+        # force a failure
+        'response': False,
+        'requests_response_code': requests.codes.internal_server_error,
+    }),
+    ('spontit://%s@%s' % ('u' * 11, 'b' * 100), {
+        'instance': plugins.NotifySpontit,
+        # throw a bizzare code forcing us to fail to look it up
+        'response': False,
+        'requests_response_code': 999,
+    }),
+    ('spontit://%s@%s' % ('u' * 11, 'b' * 100), {
+        'instance': plugins.NotifySpontit,
+        # Throws a series of connection and transfer exceptions when this flag
+        # is set and tests that we gracfully handle them
+        'test_requests_exceptions': True,
+    }),
+
+    ##################################
     # NotifySimplePush
     ##################################
     ('spush://', {

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -3221,10 +3221,19 @@ TEST_URLS = (
     }),
     # Provide a valid user and API Key, but provide an invalid channel
     ('spontit://%s@%s/#!!' % ('u' * 11, 'b' * 100), {
+        # An instance is still created, but the channel won't be notified
         'instance': plugins.NotifySpontit,
     }),
-    # Provide a valid user and API Key, but provide a valid channel
+    # Provide a valid user, API Key and a valid channel
     ('spontit://%s@%s/#abcd' % ('u' * 11, 'b' * 100), {
+        'instance': plugins.NotifySpontit,
+    }),
+    # Provide a valid user, API Key, and a subtitle
+    ('spontit://%s@%s/?subtitle=Test' % ('u' * 11, 'b' * 100), {
+        'instance': plugins.NotifySpontit,
+    }),
+    # Provide a valid user, API Key, and a lengthy subtitle
+    ('spontit://%s@%s/?subtitle=%s' % ('u' * 11, 'b' * 100, 'c' * 300), {
         'instance': plugins.NotifySpontit,
     }),
     # Provide a valid user and API Key, but provide a valid channel (that is
@@ -4586,6 +4595,45 @@ def test_rest_plugins(mock_post, mock_get):
                         body=body, title=title,
                         notify_type=notify_type,
                         overflow=OverflowMode.SPLIT) == notify_response
+
+                    #
+                    # Handle varations of the Asset Object missing fields
+                    #
+
+                    # First make a backup
+                    app_id = asset.app_id
+                    app_desc = asset.app_desc
+
+                    # now clear records
+                    asset.app_id = None
+                    asset.app_desc = None
+
+                    # Notify should still work
+                    assert obj.notify(
+                        body=body, title=title,
+                        notify_type=notify_type) == notify_response
+
+                    # App ID only
+                    asset.app_id = app_id
+                    asset.app_desc = None
+
+                    # Notify should still work
+                    assert obj.notify(
+                        body=body, title=title,
+                        notify_type=notify_type) == notify_response
+
+                    # App Desc only
+                    asset.app_id = None
+                    asset.app_desc = app_desc
+
+                    # Notify should still work
+                    assert obj.notify(
+                        body=body, title=title,
+                        notify_type=notify_type) == notify_response
+
+                    # Restore
+                    asset.app_id = app_id
+                    asset.app_desc = app_desc
 
                     if check_attachments:
                         # Test single attachment support; even if the service


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #249

Added [Spontit](https://spontit.com) Support.

### Setup
1. Visit https://spontit.com to create your account.
2. To acquire your `{user}`: Visit your profile at https://spontit.com/profile and take note of your User ID here.  It will look something like: `user12345678901`
3. To acquire your `{apikey}`: Generate an API key at https://spontit.com/secret_keys (if you haven't already done so).

### Syntax
Channels are optional; if no channel is specified then you are just personally notified.
* `spontit://{user}@{apikey}`
* `spontit://{user}@{apikey}/{channel_id}`
* `spontit://{user}@{apikey}/{channel_id1}/{channel_id2}/{channel_idN}/`

## New Service Completion Status
<!-- This section is only applicable if you're adding a new service -->
* [x] apprise/plugins/NotifySpontit.py
* [x] setup.py
    - add new service into the `keywords` section of the `setup()` declaration
* [x] README.md
    - add entry for new service to table (as a quick reference)
* [x] packaging/redhat/python-apprise.spec
    - add new service into the `%global common_description`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
