### PR TITLE
Gotify supports extended URL paths beyond Hostname

### DIFF
--- a/apprise/plugins/NotifyNotica.py
+++ b/apprise/plugins/NotifyNotica.py
@@ -103,6 +103,14 @@ class NotifyNotica(NotifyBase):
         '{schema}://{user}@{host}:{port}/{token}',
         '{schema}://{user}:{password}@{host}/{token}',
         '{schema}://{user}:{password}@{host}:{port}/{token}',
+
+        # Self-hosted notica servers (with custom path)
+        '{schema}://{host}{path}{token}',
+        '{schema}://{host}:{port}{path}{token}',
+        '{schema}://{user}@{host}{path}{token}',
+        '{schema}://{user}@{host}:{port}{path}{token}',
+        '{schema}://{user}:{password}@{host}{path}{token}',
+        '{schema}://{user}:{password}@{host}:{port}{path}{token}',
     )
 
     # Define our template tokens
@@ -132,6 +140,12 @@ class NotifyNotica(NotifyBase):
             'name': _('Password'),
             'type': 'string',
             'private': True,
+        },
+        'path': {
+            'name': _('Path'),
+            'type': 'string',
+            'map_to': 'fullpath',
+            'default': '/',
         },
     })
 

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -803,6 +803,20 @@ TEST_URLS = (
         # Our expected url(privacy=True) startswith() response:
         'privacy_url': 'gotify://hostname/t...t',
     }),
+    # Provide a hostname, path, and token
+    ('gotify://hostname/a/path/ending/in/a/slash/%s' % ('u' * 16), {
+        'instance': plugins.NotifyGotify,
+
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'gotify://hostname/a/path/ending/in/a/slash/u...u/',
+    }),
+    # Provide a hostname, path, and token
+    ('gotify://hostname/a/path/not/ending/in/a/slash/%s' % ('v' * 16), {
+        'instance': plugins.NotifyGotify,
+
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'gotify://hostname/a/path/not/ending/in/a/slash/v...v/',
+    }),
     # Provide a priority
     ('gotify://hostname/%s?priority=high' % ('i' * 16), {
         'instance': plugins.NotifyGotify,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #258 

Support URL paths that extend beyond just the hostname
* `{schema}://{host}/{path}/{token}`
* `{schema}://{host}:{port}/{path}/{token}`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
