### PR TITLE
--input-format (-i) switch added to CLI

### DIFF
--- a/apprise/cli.py
+++ b/apprise/cli.py
@@ -32,11 +32,13 @@ from os.path import expanduser
 from os.path import expandvars
 
 from . import NotifyType
+from . import NotifyFormat
 from . import Apprise
 from . import AppriseAsset
 from . import AppriseConfig
 from .utils import parse_list
 from .common import NOTIFY_TYPES
+from .common import NOTIFY_FORMATS
 from .logger import logger
 
 from . import __title__
@@ -104,9 +106,16 @@ def print_version_msg():
               help='Specify one or more configuration locations.')
 @click.option('--notification-type', '-n', default=NotifyType.INFO, type=str,
               metavar='TYPE',
-              help='Specify the message type (default=info). Possible values'
-              ' are "{}", and "{}".'.format(
-                  '", "'.join(NOTIFY_TYPES[:-1]), NOTIFY_TYPES[-1]))
+              help='Specify the message type (default={}). '
+              'Possible values are "{}", and "{}".'.format(
+                  NotifyType.INFO, '", "'.join(NOTIFY_TYPES[:-1]),
+                  NOTIFY_TYPES[-1]))
+@click.option('--input-format', '-i', default=NotifyFormat.TEXT, type=str,
+              metavar='FORMAT',
+              help='Specify the message input format (default={}). '
+              'Possible values are "{}", and "{}".'.format(
+                  NotifyFormat.TEXT, '", "'.join(NOTIFY_FORMATS[:-1]),
+                  NOTIFY_FORMATS[-1]))
 @click.option('--theme', '-T', default='default', type=str, metavar='THEME',
               help='Specify the default theme.')
 @click.option('--tag', '-g', default=None, type=str, multiple=True,
@@ -126,7 +135,7 @@ def print_version_msg():
 @click.argument('urls', nargs=-1,
                 metavar='SERVER_URL [SERVER_URL2 [SERVER_URL3]]',)
 def main(body, title, config, attach, urls, notification_type, theme, tag,
-         dry_run, verbose, version):
+         input_format, dry_run, verbose, version):
     """
     Send a notification to all of the specified servers identified by their
     URLs the content provided within the title, body and notification-type.
@@ -170,8 +179,23 @@ def main(body, title, config, attach, urls, notification_type, theme, tag,
         print_version_msg()
         sys.exit(0)
 
+    # Simple Error Checking
+    notification_type = notification_type.strip().lower()
+    if notification_type not in NOTIFY_TYPES:
+        logger.error(
+            'The --notification-type (-n) value of {} is not supported.'
+            .format(notification_type))
+        sys.exit(1)
+
+    input_format = input_format.strip().lower()
+    if input_format not in NOTIFY_FORMATS:
+        logger.error(
+            'The --input-format (-i) value of {} is not supported.'
+            .format(input_format))
+        sys.exit(1)
+
     # Prepare our asset
-    asset = AppriseAsset(theme=theme)
+    asset = AppriseAsset(body_format=input_format, theme=theme)
 
     # Create our object
     a = Apprise(asset=asset)

--- a/packaging/man/apprise.1
+++ b/packaging/man/apprise.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "APPRISE" "1" "January 2020" "" ""
+.TH "APPRISE" "1" "July 2020" "" ""
 .
 .SH "NAME"
 \fBapprise\fR \- Push Notifications that work with just about every platform!
@@ -47,6 +47,10 @@ Specify one or more file attachment locations\.
 .TP
 \fB\-n\fR, \fB\-\-notification\-type=\fR\fITYPE\fR
 Specify the message type (default=info)\. Possible values are "info", "success", "failure", and "warning"\.
+.
+.TP
+\fB\-i\fR, \fB\-\-input\-format=\fR\fIFORMAT\fR
+Specify the input message format (default=text)\. Possible values are "text", "html", and "markdown"\.
 .
 .TP
 \fB\-T\fR, \fB\-\-theme=\fRTHEME
@@ -154,7 +158,7 @@ $ apprise \-t \'School Assignment\' \-b \'See attached\' \e
 .IP "" 0
 .
 .SH "BUGS"
-\fBApprise\fR is written in Python with 100% test coverage; but it still makes it far from perfect since the notification services it talks to change all the time\. If you find any bugs, please make them known at: \fIhttps://github\.com/caronc/apprise/issues\fR
+If you find any bugs, please make them known at: \fIhttps://github\.com/caronc/apprise/issues\fR
 .
 .SH "COPYRIGHT"
 Apprise is Copyright (C) 2020 Chris Caron \fIlead2gold@gmail\.com\fR

--- a/packaging/man/apprise.md
+++ b/packaging/man/apprise.md
@@ -37,6 +37,10 @@ The Apprise options are as follows:
     Specify the message type (default=info). Possible values are "info",
     "success", "failure", and "warning".
 
+  * `-i`, `--input-format=`<FORMAT>:
+    Specify the input message format (default=text). Possible values are "text",
+    "html", and "markdown".
+
   * `-T`, `--theme=`THEME:
     Specify the default theme.
 
@@ -107,9 +111,7 @@ Include an attachment:
 
 ## BUGS
 
-**Apprise** is written in Python with 100% test coverage; but it still makes
-it far from perfect since the notification services it talks to change
-all the time. If you find any bugs, please make them known at:
+If you find any bugs, please make them known at:
 <https://github.com/caronc/apprise/issues>
 
 ## COPYRIGHT

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -193,6 +193,56 @@ def test_apprise_cli(tmpdir):
     ])
     assert result.exit_code == 0
 
+    # Test our notification type switch (it defaults to info) so we want to
+    # try it as a different value. Should return without a problem
+    result = runner.invoke(cli.main, [
+        '-b', '# test config',
+        '--config', str(t),
+        '-n', 'success',
+    ])
+    assert result.exit_code == 0
+
+    # Test our notification type switch when set to something unsupported
+    result = runner.invoke(cli.main, [
+        '-b', 'test config',
+        '--config', str(t),
+        '--notification-type', 'invalid',
+    ])
+    assert result.exit_code == 1
+
+    # The notification type switch is case-insensitive
+    result = runner.invoke(cli.main, [
+        '-b', 'test config',
+        '--config', str(t),
+        '--notification-type', 'WARNING',
+    ])
+    assert result.exit_code == 0
+
+    # Test our formatting switch (it defaults to text) so we want to try it as
+    # a different value. Should return without a problem
+    result = runner.invoke(cli.main, [
+        '-b', '# test config',
+        '--config', str(t),
+        '-i', 'markdown',
+    ])
+    assert result.exit_code == 0
+
+    # Test our formatting switch when set to something unsupported
+    result = runner.invoke(cli.main, [
+        '-b', 'test config',
+        '--config', str(t),
+        '--input-format', 'invalid',
+    ])
+    assert result.exit_code == 1
+
+    # The formatting switch is not case sensitive
+    result = runner.invoke(cli.main, [
+        '-b', '# test config',
+        '--config', str(t),
+        '--input-format', 'HTML',
+    ])
+    assert result.exit_code == 0
+
     # As a way of ensuring we match the first 5 entries, we can run a
     # --dry-run against the same result set above and verify the output
     result = runner.invoke(cli.main, [


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #256 

Added new **--input-format** (**-i**) switch to the `apprise` CLI tool which allows users to tell the tool what the expected input message type is.  It can be set to either **text** (_this is the default if nothing is specified_), **html**, or **markdown**.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
