### PR TITLE
Python 3.9 Beta testing and Fedora 33 RPM support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
       env: TOXENV=py37
     - python: "3.8"
       env: TOXENV=py38
+    - python: "3.9-dev"
+      env: TOXENV=py39
     - python: "pypy2.7-6.0"
       env: TOXENV=pypy
     - python: "pypy3.5-6.0"

--- a/apprise/plugins/NotifySimplePush.py
+++ b/apprise/plugins/NotifySimplePush.py
@@ -142,14 +142,6 @@ class NotifySimplePush(NotifyBase):
             # Default Event Name
             self.event = None
 
-        # Encrypt Message (providing support is available)
-        if self.password and self.user and not CRYPTOGRAPHY_AVAILABLE:
-            # Provide the end user at least some notification that they're
-            # not getting what they asked for
-            self.logger.warning(
-                'SimplePush extended encryption is not supported by this '
-                'system.')
-
         # Used/cached in _encrypt() function
         self._iv = None
         self._iv_hex = None
@@ -188,6 +180,15 @@ class NotifySimplePush(NotifyBase):
         """
         Perform SimplePush Notification
         """
+
+        # Encrypt Message (providing support is available)
+        if self.password and self.user and not CRYPTOGRAPHY_AVAILABLE:
+            # Provide the end user at least some notification that they're
+            # not getting what they asked for
+            self.logger.warning(
+                "Authenticated SimplePush Notifications are not supported by "
+                "this system; `pip install cryptography`.")
+            return False
 
         headers = {
             'User-Agent': self.app_id,

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -182,7 +182,7 @@ BuildRequires: python%{python3_pkgversion}-pytest-runner
 %endif
 
 install -p -D -T -m 0644 packaging/man/%{pypi_name}.1 \
-	%{buildroot}%{_mandir}/man1/%{pypi_name}.1
+   %{buildroot}%{_mandir}/man1/%{pypi_name}.1
 
 %if %{with tests}
 %check

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -82,9 +82,11 @@ BuildRequires: python-six
 BuildRequires: python2-click >= 5.0
 BuildRequires: python-markdown
 %if 0%{?rhel} && 0%{?rhel} <= 7
+BuildRequires: python-cryptography
 BuildRequires: python-babel
 BuildRequires: python-yaml
 %else
+BuildRequires: python2-cryptography
 BuildRequires: python2-babel
 BuildRequires: python2-yaml
 %endif
@@ -140,6 +142,7 @@ BuildRequires: python%{python3_pkgversion}-click >= 5.0
 BuildRequires: python%{python3_pkgversion}-markdown
 BuildRequires: python%{python3_pkgversion}-yaml
 BuildRequires: python%{python3_pkgversion}-babel
+BuildRequires: python%{python3_pkgversion}-cryptography
 Requires: python%{python3_pkgversion}-requests
 Requires: python%{python3_pkgversion}-requests-oauthlib
 Requires: python%{python3_pkgversion}-six

--- a/test/test_simplepush_plugin.py
+++ b/test/test_simplepush_plugin.py
@@ -25,6 +25,7 @@
 
 import os
 import sys
+import pytest
 import apprise
 
 try:
@@ -43,6 +44,8 @@ import logging
 logging.disable(logging.CRITICAL)
 
 
+@pytest.mark.skipif(
+    'cryptography' not in sys.modules, reason="requires cryptography")
 def test_simplepush_plugin(tmpdir):
     """
     API: NotifySimplePush Plugin()
@@ -73,10 +76,14 @@ def test_simplepush_plugin(tmpdir):
     reload(sys.modules['apprise.Apprise'])
     reload(sys.modules['apprise'])
 
-    # imported and therefore the extra encryption offered by SimplePush is
-    # not available...
+    # Without the cryptography library objects can still be instantiated
+    # however notifications will fail
     obj = apprise.Apprise.instantiate('spush://salt:pass@valid_api_key')
     assert obj is not None
+
+    # We can't notify with a user/pass combo and no cryptography library
+    assert obj.notify(
+        title="test message title", body="message body") is False
 
     # Tidy-up / restore things to how they were
     os.unlink(str(suite.join("{}.py".format(module_name))))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,py38,pypy,pypy3,coverage-report
+envlist = py27,py35,py36,py37,py38,py39,pypy,pypy3,coverage-report
 
 
 [testenv]
@@ -56,6 +56,16 @@ commands =
     flake8 . --count --show-source --statistics
 
 [testenv:py38]
+deps=
+   dbus-python
+   -r{toxinidir}/requirements.txt
+   -r{toxinidir}/dev-requirements.txt
+commands =
+    python setup.py compile_catalog
+    coverage run --parallel -m pytest {posargs}
+    flake8 . --count --show-source --statistics
+
+[testenv:py39]
 deps=
    dbus-python
    -r{toxinidir}/requirements.txt


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #263 
* Fixes SimplePush tests so that it will skip if `cryptography` library isn't present
* Added `cryptography` to `BuildInstall` section of Apprise RPM Spec file
* Added Python v3.9 to Travis CI

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
