### PR TITLE
Better Email Internationalization Support

### DIFF
--- a/test/test_email_plugin.py
+++ b/test/test_email_plugin.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2019 Chris Caron <lead2gold@gmail.com>
+# Copyright (C) 2020 Chris Caron <lead2gold@gmail.com>
 # All rights reserved.
 #
 # This code is licensed under the MIT License.
@@ -28,6 +28,7 @@ import re
 import six
 import mock
 import smtplib
+from email.header import decode_header
 
 from apprise import plugins
 from apprise import NotifyType
@@ -509,6 +510,62 @@ def test_smtplib_send_okay(mock_smtplib):
     AttachBase.max_file_size = max_file_size
 
 
+@mock.patch('smtplib.SMTP')
+def test_smtplib_internationalization(mock_smtp):
+    """
+    API: Test email handling using internationalization
+
+    """
+    # Disable Throttling to speed testing
+    plugins.NotifyBase.request_rate_per_sec = 0
+
+    # Defaults to HTML
+    obj = Apprise.instantiate(
+        'mailto://user:pass@gmail.com?name=Например%20так',
+        suppress_exceptions=False)
+    assert isinstance(obj, plugins.NotifyEmail)
+
+    class SMTPMock(object):
+        def sendmail(self, *args, **kwargs):
+            match = re.search(
+                r'^(?P<line>From: (?P<name>[^ ]+) <(?P<email>[^>]+)>)',
+                args[2], re.I | re.M)
+            assert match is not None
+
+            # Verify our output was correctly stored
+            assert match.group('email') == 'user@gmail.com'
+            assert decode_header(
+                match.group('name'))[0][0].decode('utf-8') == 'Например так'
+
+            match = re.search(
+                r'^(?P<line>Subject: (?P<subject>.*))', args[2], re.I | re.M)
+            assert decode_header(match.group('subject'))[0][0]\
+                .decode('utf-8') == 'دعونا نجعل العالم مكانا أفضل.'
+
+        # Dummy Function
+        def quit(self, *args, **kwargs):
+            return True
+
+        # Dummy Function
+        def starttls(self, *args, **kwargs):
+            return True
+
+        # Dummy Function
+        def login(self, *args, **kwargs):
+            return True
+
+    # Prepare our object we will test our generated email against
+    mock_smtp.return_value = SMTPMock()
+
+    # Further test encoding through the message content as well
+    assert obj.notify(
+        # Google Translated to Arabic: "Let's make the world a better place."
+        title='دعونا نجعل العالم مكانا أفضل.',
+        # Google Translated to Hungarian: "One line of code at a time.'
+        body='Egy sor kódot egyszerre.',
+        notify_type=NotifyType.INFO) is True
+
+
 def test_email_url_escaping():
     """
     API: Test that user/passwords are properly escaped from URL
@@ -536,7 +593,7 @@ def test_email_url_escaping():
         suppress_exceptions=False)
     assert isinstance(obj, plugins.NotifyEmail) is True
 
-    # The password is escapped 'once' at this point
+    # The password is escaped only 'once'
     assert obj.password == ' %20'
 
 


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #268 

Email Internationalization improvements:
-  `From:` should use built in `formataddr()` to handle encoding
-  `Subject:` now enforcing character encoding
-  `utf-8` enforced throughout email message initialization

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] 100% test coverage
