### PR TITLE
asset passed into AppriseConfig() object now recognized

### DIFF
--- a/apprise/cli.py
+++ b/apprise/cli.py
@@ -204,7 +204,8 @@ def main(body, title, config, attach, urls, notification_type, theme, tag,
     # identified on the command line
     a.add(AppriseConfig(
         paths=[f for f in DEFAULT_SEARCH_PATHS if isfile(expanduser(f))]
-        if not (config or urls) else config), asset=asset)
+        if not (config or urls) else config,
+        asset=asset))
 
     # Load our inventory up
     for url in urls:

--- a/apprise/config/ConfigBase.py
+++ b/apprise/config/ConfigBase.py
@@ -154,6 +154,9 @@ class ConfigBase(URLBase):
         # Dynamically load our parse_ function based on our config format
         fn = getattr(ConfigBase, 'config_parse_{}'.format(config_format))
 
+        # Initialize our asset object
+        asset = asset if isinstance(asset, AppriseAsset) else self.asset
+
         # Execute our config parse function which always returns a list
         self._cached_servers.extend(fn(content=content, asset=asset))
 

--- a/test/test_config_file.py
+++ b/test/test_config_file.py
@@ -27,6 +27,7 @@ import six
 import mock
 from apprise.config.ConfigFile import ConfigFile
 from apprise.plugins.NotifyBase import NotifyBase
+from apprise.AppriseAsset import AppriseAsset
 
 # Disable logging for a cleaner testing output
 import logging
@@ -47,13 +48,19 @@ def test_config_file(tmpdir):
 
     assert ConfigFile.parse_url('file://?') is None
 
+    # Create an Apprise asset we can reference
+    asset = AppriseAsset()
+
     # Initialize our object
-    cf = ConfigFile(path=str(t), format='text')
+    cf = ConfigFile(path=str(t), format='text', asset=asset)
 
     # one entry added
     assert len(cf) == 1
 
     assert isinstance(cf.url(), six.string_types) is True
+
+    # Verify that we're using the same asset
+    assert cf[0].asset is asset
 
     # Testing of pop
     cf = ConfigFile(path=str(t), format='text')


### PR DESCRIPTION
## Description:
When initializing a `AppriseConfig()` object with an `asset` defined, it is discarded and not used.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
