### PR TITLE
Bugfix - Global parameters placed in url() again

### DIFF
--- a/apprise/plugins/NotifyBase.py
+++ b/apprise/plugins/NotifyBase.py
@@ -356,8 +356,8 @@ class NotifyBase(BASE_OBJECT):
 
         params.update(super(NotifyBase, self).url_parameters(*args, **kwargs))
 
-        # return default arguments
-        return kwargs
+        # return default parameters
+        return params
 
     @staticmethod
     def parse_url(url, verify_host=True):


### PR DESCRIPTION
## Description:
There was a bug created/missed when merging #264 causing the extra URL arguments to not be replaced in the `url()` calls.  This is now fixed.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] 100% test coverage
