### PR TITLE
Advanced email parsing added; eg: Full Name email@domain.com

### DIFF
--- a/apprise/Apprise.py
+++ b/apprise/Apprise.py
@@ -33,7 +33,7 @@ from .common import NotifyFormat
 from .common import MATCH_ALL_TAG
 from .utils import is_exclusive_match
 from .utils import parse_list
-from .utils import split_urls
+from .utils import parse_urls
 from .logger import logger
 
 from .AppriseAsset import AppriseAsset
@@ -197,7 +197,7 @@ class Apprise(object):
 
         if isinstance(servers, six.string_types):
             # build our server list
-            servers = split_urls(servers)
+            servers = parse_urls(servers)
             if len(servers) == 0:
                 return False
 

--- a/apprise/plugins/NotifyEmail.py
+++ b/apprise/plugins/NotifyEmail.py
@@ -409,7 +409,7 @@ class NotifyEmail(NotifyBase):
         # Acquire Blind Carbon Copies
         self.bcc = set()
 
-        # For tracking our name lookups
+        # For tracking our email -> name lookups
         self.names = {}
 
         # Now we want to construct the To and From email
@@ -629,9 +629,9 @@ class NotifyEmail(NotifyBase):
             self.logger.debug(
                 'Email From: {} <{}>'.format(from_name, self.from_addr))
             self.logger.debug('Email To: {}'.format(to_addr))
-            if len(cc):
+            if cc:
                 self.logger.debug('Email Cc: {}'.format(', '.join(cc)))
-            if len(bcc):
+            if bcc:
                 self.logger.debug('Email Bcc: {}'.format(', '.join(bcc)))
             self.logger.debug('Login ID: {}'.format(self.user))
             self.logger.debug(

--- a/apprise/plugins/NotifyEmail.py
+++ b/apprise/plugins/NotifyEmail.py
@@ -41,8 +41,7 @@ from ..URLBase import PrivacyMode
 from ..common import NotifyFormat
 from ..common import NotifyType
 from ..utils import is_email
-from ..utils import parse_list
-from ..utils import GET_EMAIL_RE
+from ..utils import parse_emails
 from ..AppriseLocale import gettext_lazy as _
 
 # Globally Default encoding mode set to Quoted Printable.
@@ -401,8 +400,8 @@ class NotifyEmail(NotifyBase):
         except (ValueError, TypeError):
             self.timeout = self.connect_timeout
 
-        # Acquire targets
-        self.targets = parse_list(targets)
+        # Acquire Email 'To'
+        self.targets = list()
 
         # Acquire Carbon Copies
         self.cc = set()
@@ -410,9 +409,11 @@ class NotifyEmail(NotifyBase):
         # Acquire Blind Carbon Copies
         self.bcc = set()
 
+        # For tracking our name lookups
+        self.names = {}
+
         # Now we want to construct the To and From email
         # addresses from the URL provided
-        self.from_name = from_name
         self.from_addr = from_addr
 
         if self.user and not self.from_addr:
@@ -422,15 +423,18 @@ class NotifyEmail(NotifyBase):
                 self.host,
             )
 
-        if not is_email(self.from_addr):
+        result = is_email(self.from_addr)
+        if not result:
             # Parse Source domain based on from_addr
             msg = 'Invalid ~From~ email specified: {}'.format(self.from_addr)
             self.logger.warning(msg)
             raise TypeError(msg)
 
-        # If our target email list is empty we want to add ourselves to it
-        if len(self.targets) == 0:
-            self.targets.append(self.from_addr)
+        # Store our email address
+        self.from_addr = result['full_email']
+
+        # Set our from name
+        self.from_name = from_name if from_name else result['name']
 
         # Now detect the SMTP Server
         self.smtp_host = \
@@ -446,11 +450,40 @@ class NotifyEmail(NotifyBase):
             self.logger.warning(msg)
             raise TypeError(msg)
 
-        # Validate recipients (cc:) and drop bad ones:
-        for recipient in parse_list(cc):
+        if targets:
+            # Validate recipients (to:) and drop bad ones:
+            for recipient in parse_emails(targets):
+                result = is_email(recipient)
+                if result:
+                    self.targets.append(
+                        (result['name'] if result['name'] else False,
+                            result['full_email']))
+                    continue
 
-            if GET_EMAIL_RE.match(recipient):
-                self.cc.add(recipient)
+                self.logger.warning(
+                    'Dropped invalid To email '
+                    '({}) specified.'.format(recipient),
+                )
+
+            if not self.targets:
+                msg = 'There were no valid target emails to send to.'
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
+        else:
+            # If our target email list is empty we want to add ourselves to it
+            self.targets.append(
+                (self.from_name if self.from_name else False, self.from_addr))
+
+        # Validate recipients (cc:) and drop bad ones:
+        for recipient in parse_emails(cc):
+            email = is_email(recipient)
+            if email:
+                self.cc.add(email['full_email'])
+
+                # Index our name (if one exists)
+                self.names[email['full_email']] = \
+                    email['name'] if email['name'] else False
                 continue
 
             self.logger.warning(
@@ -459,10 +492,14 @@ class NotifyEmail(NotifyBase):
             )
 
         # Validate recipients (bcc:) and drop bad ones:
-        for recipient in parse_list(bcc):
+        for recipient in parse_emails(bcc):
+            email = is_email(recipient)
+            if email:
+                self.bcc.add(email['full_email'])
 
-            if GET_EMAIL_RE.match(recipient):
-                self.bcc.add(recipient)
+                # Index our name (if one exists)
+                self.names[email['full_email']] = \
+                    email['name'] if email['name'] else False
                 continue
 
             self.logger.warning(
@@ -560,18 +597,34 @@ class NotifyEmail(NotifyBase):
         emails = list(self.targets)
         while len(emails):
             # Get our email to notify
-            to_addr = emails.pop(0)
-
-            if not is_email(to_addr):
-                self.logger.warning(
-                    'Invalid ~To~ email specified: {}'.format(to_addr))
-                has_error = True
-                continue
+            to_name, to_addr = emails.pop(0)
 
             # Strip target out of cc list if in To or Bcc
             cc = (self.cc - self.bcc - set([to_addr]))
+
             # Strip target out of bcc list if in To
             bcc = (self.bcc - set([to_addr]))
+
+            try:
+                # Format our cc addresses to support the Name field
+                cc = [formataddr(
+                    (self.names.get(addr, False), addr), charset='utf-8')
+                    for addr in cc]
+
+                # Format our bcc addresses to support the Name field
+                bcc = [formataddr(
+                    (self.names.get(addr, False), addr), charset='utf-8')
+                    for addr in bcc]
+
+            except TypeError:
+                # Python v2.x Support (no charset keyword)
+                # Format our cc addresses to support the Name field
+                cc = [formataddr(
+                    (self.names.get(addr, False), addr)) for addr in cc]
+
+                # Format our bcc addresses to support the Name field
+                bcc = [formataddr(
+                    (self.names.get(addr, False), addr)) for addr in bcc]
 
             self.logger.debug(
                 'Email From: {} <{}>'.format(from_name, self.from_addr))
@@ -597,13 +650,13 @@ class NotifyEmail(NotifyBase):
                 base['From'] = formataddr(
                     (from_name if from_name else False, self.from_addr),
                     charset='utf-8')
-                base['To'] = formataddr((False, to_addr), charset='utf-8')
+                base['To'] = formataddr((to_name, to_addr), charset='utf-8')
 
             except TypeError:
                 # Python v2.x Support (no charset keyword)
                 base['From'] = formataddr(
                     (from_name if from_name else False, self.from_addr))
-                base['To'] = formataddr((False, to_addr))
+                base['To'] = formataddr((to_name, to_addr))
 
             base['Cc'] = ','.join(cc)
             base['Date'] = \
@@ -706,7 +759,6 @@ class NotifyEmail(NotifyBase):
         # Define an URL parameters
         params = {
             'from': self.from_addr,
-            'name': self.from_name,
             'mode': self.secure_mode,
             'smtp': self.smtp_host,
             'timeout': self.timeout,
@@ -716,13 +768,22 @@ class NotifyEmail(NotifyBase):
         # Extend our parameters
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
 
+        if self.from_name:
+            params['name'] = self.from_name
+
         if len(self.cc) > 0:
             # Handle our Carbon Copy Addresses
-            params['cc'] = ','.join(self.cc)
+            params['cc'] = ','.join(
+                ['{}{}'.format(
+                    '' if not e not in self.names
+                    else '{}:'.format(self.names[e]), e) for e in self.cc])
 
         if len(self.bcc) > 0:
             # Handle our Blind Carbon Copy Addresses
-            params['bcc'] = ','.join(self.bcc)
+            params['bcc'] = ','.join(
+                ['{}{}'.format(
+                    '' if not e not in self.names
+                    else '{}:'.format(self.names[e]), e) for e in self.bcc])
 
         # pull email suffix from username (if present)
         user = None if not self.user else self.user.split('@')[0]
@@ -748,7 +809,8 @@ class NotifyEmail(NotifyBase):
         # a simple boolean check as to whether we display our target emails
         # or not
         has_targets = \
-            not (len(self.targets) == 1 and self.targets[0] == self.from_addr)
+            not (len(self.targets) == 1
+                 and self.targets[0][1] == self.from_addr)
 
         return '{schema}://{auth}{hostname}{port}/{targets}?{params}'.format(
             schema=self.secure_protocol if self.secure else self.protocol,
@@ -758,7 +820,9 @@ class NotifyEmail(NotifyBase):
             port='' if self.port is None or self.port == default_port
                  else ':{}'.format(self.port),
             targets='' if not has_targets else '/'.join(
-                [NotifyEmail.quote(x, safe='') for x in self.targets]),
+                [NotifyEmail.quote('{}{}'.format(
+                    '' if not e[0] else '{}:'.format(e[0]), e[1]),
+                    safe='') for e in self.targets]),
             params=NotifyEmail.urlencode(params),
         )
 
@@ -792,8 +856,7 @@ class NotifyEmail(NotifyBase):
 
         # Attempt to detect 'to' email address
         if 'to' in results['qsd'] and len(results['qsd']['to']):
-            results['targets'] += \
-                NotifyEmail.parse_list(results['qsd']['to'])
+            results['targets'].append(results['qsd']['to'])
 
         if 'name' in results['qsd'] and len(results['qsd']['name']):
             # Extract from name to associate with from address
@@ -814,13 +877,11 @@ class NotifyEmail(NotifyBase):
 
         # Handle Carbon Copy Addresses
         if 'cc' in results['qsd'] and len(results['qsd']['cc']):
-            results['cc'] = \
-                NotifyEmail.parse_list(results['qsd']['cc'])
+            results['cc'] = results['qsd']['cc']
 
         # Handle Blind Carbon Copy Addresses
         if 'bcc' in results['qsd'] and len(results['qsd']['bcc']):
-            results['bcc'] = \
-                NotifyEmail.parse_list(results['qsd']['bcc'])
+            results['bcc'] = results['qsd']['bcc']
 
         results['from_addr'] = from_addr
         results['smtp_host'] = smtp_host

--- a/apprise/plugins/NotifyEmail.py
+++ b/apprise/plugins/NotifyEmail.py
@@ -465,11 +465,6 @@ class NotifyEmail(NotifyBase):
                     '({}) specified.'.format(recipient),
                 )
 
-            if not self.targets:
-                msg = 'There were no valid target emails to send to.'
-                self.logger.warning(msg)
-                raise TypeError(msg)
-
         else:
             # If our target email list is empty we want to add ourselves to it
             self.targets.append(
@@ -592,6 +587,12 @@ class NotifyEmail(NotifyBase):
 
         # error tracking (used for function return)
         has_error = False
+
+        if not self.targets:
+            # There is no one to email; we're done
+            self.logger.warning(
+                'There are no Email recipients to notify')
+            return False
 
         # Create a copy of the targets list
         emails = list(self.targets)

--- a/apprise/plugins/NotifyOffice365.py
+++ b/apprise/plugins/NotifyOffice365.py
@@ -176,12 +176,13 @@ class NotifyOffice365(NotifyBase):
             self.logger.warning(msg)
             raise TypeError(msg)
 
-        if not is_email(email):
+        match = is_email(email)
+        if not match:
             msg = 'An invalid Office 365 Email Account ID' \
                   '({}) was specified.'.format(email)
             self.logger.warning(msg)
             raise TypeError(msg)
-        self.email = email
+        self.email = match['email']
 
         # Client Key (associated with generated OAuth2 Login)
         self.client_id = validate_regex(
@@ -207,13 +208,14 @@ class NotifyOffice365(NotifyBase):
         if targets:
             for target in targets:
                 # Validate targets and drop bad ones:
-                if not is_email(target):
+                match = is_email(target)
+                if not match:
                     self.logger.warning(
                         'Dropped invalid email specified: {}'.format(target))
                     continue
 
                 # Add our email to our target list
-                self.targets.append(target)
+                self.targets.append(match['email'])
         else:
             # Default to adding ourselves
             self.targets.append(self.email)

--- a/apprise/plugins/NotifyOffice365.py
+++ b/apprise/plugins/NotifyOffice365.py
@@ -238,11 +238,6 @@ class NotifyOffice365(NotifyBase):
                     'Dropped invalid To email ({}) specified.'
                     .format(recipient))
 
-            if not self.targets:
-                msg = 'There were no valid target emails to send to.'
-                self.logger.warning(msg)
-                raise TypeError(msg)
-
         else:
             # If our target email list is empty we want to add ourselves to it
             self.targets.append((False, self.email))
@@ -298,7 +293,7 @@ class NotifyOffice365(NotifyBase):
         if not self.targets:
             # There is no one to email; we're done
             self.logger.warning(
-                'There are no Office 365 recipients to notify')
+                'There are no Email recipients to notify')
             return False
 
         # Setup our Content Type

--- a/apprise/plugins/NotifyOffice365.py
+++ b/apprise/plugins/NotifyOffice365.py
@@ -66,7 +66,7 @@ from ..URLBase import PrivacyMode
 from ..common import NotifyFormat
 from ..common import NotifyType
 from ..utils import is_email
-from ..utils import parse_list
+from ..utils import parse_emails
 from ..utils import validate_regex
 from ..AppriseLocale import gettext_lazy as _
 
@@ -152,6 +152,14 @@ class NotifyOffice365(NotifyBase):
         'to': {
             'alias_of': 'targets',
         },
+        'cc': {
+            'name': _('Carbon Copy'),
+            'type': 'list:string',
+        },
+        'bcc': {
+            'name': _('Blind Carbon Copy'),
+            'type': 'list:string',
+        },
         'oauth_id': {
             'alias_of': 'client_id',
         },
@@ -161,7 +169,7 @@ class NotifyOffice365(NotifyBase):
     })
 
     def __init__(self, tenant, email, client_id, secret,
-                 targets=None, **kwargs):
+                 targets=None, cc=None, bcc=None, **kwargs):
         """
         Initialize Office 365 Object
         """
@@ -176,13 +184,15 @@ class NotifyOffice365(NotifyBase):
             self.logger.warning(msg)
             raise TypeError(msg)
 
-        match = is_email(email)
-        if not match:
+        result = is_email(email)
+        if not result:
             msg = 'An invalid Office 365 Email Account ID' \
                   '({}) was specified.'.format(email)
             self.logger.warning(msg)
             raise TypeError(msg)
-        self.email = match['email']
+
+        # Otherwise store our the email address
+        self.email = result['full_email']
 
         # Client Key (associated with generated OAuth2 Login)
         self.client_id = validate_regex(
@@ -201,24 +211,73 @@ class NotifyOffice365(NotifyBase):
             self.logger.warning(msg)
             raise TypeError(msg)
 
+        # For tracking our email -> name lookups
+        self.names = {}
+
+        # Acquire Carbon Copies
+        self.cc = set()
+
+        # Acquire Blind Carbon Copies
+        self.bcc = set()
+
         # Parse our targets
         self.targets = list()
 
-        targets = parse_list(targets)
         if targets:
-            for target in targets:
-                # Validate targets and drop bad ones:
-                match = is_email(target)
-                if not match:
-                    self.logger.warning(
-                        'Dropped invalid email specified: {}'.format(target))
+            for recipient in parse_emails(targets):
+                # Validate recipients (to:) and drop bad ones:
+                result = is_email(recipient)
+                if result:
+                    # Add our email to our target list
+                    self.targets.append(
+                        (result['name'] if result['name'] else False,
+                            result['full_email']))
                     continue
 
-                # Add our email to our target list
-                self.targets.append(match['email'])
+                self.logger.warning(
+                    'Dropped invalid To email ({}) specified.'
+                    .format(recipient))
+
+            if not self.targets:
+                msg = 'There were no valid target emails to send to.'
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
         else:
-            # Default to adding ourselves
-            self.targets.append(self.email)
+            # If our target email list is empty we want to add ourselves to it
+            self.targets.append((False, self.email))
+
+        # Validate recipients (cc:) and drop bad ones:
+        for recipient in parse_emails(cc):
+            email = is_email(recipient)
+            if email:
+                self.cc.add(email['full_email'])
+
+                # Index our name (if one exists)
+                self.names[email['full_email']] = \
+                    email['name'] if email['name'] else False
+                continue
+
+            self.logger.warning(
+                'Dropped invalid Carbon Copy email '
+                '({}) specified.'.format(recipient),
+            )
+
+        # Validate recipients (bcc:) and drop bad ones:
+        for recipient in parse_emails(bcc):
+            email = is_email(recipient)
+            if email:
+                self.bcc.add(email['full_email'])
+
+                # Index our name (if one exists)
+                self.names[email['full_email']] = \
+                    email['name'] if email['name'] else False
+                continue
+
+            self.logger.warning(
+                'Dropped invalid Blind Carbon Copy email '
+                '({}) specified.'.format(recipient),
+            )
 
         # Our token is acquired upon a successful login
         self.token = None
@@ -258,8 +317,8 @@ class NotifyOffice365(NotifyBase):
             'SaveToSentItems': 'false'
         }
 
-        # Create a copy of the targets list
-        targets = list(self.targets)
+        # Create a copy of the email list
+        emails = list(self.targets)
 
         # Define our URL to post to
         url = '{graph_url}/v1.0/users/{email}/sendmail'.format(
@@ -267,17 +326,7 @@ class NotifyOffice365(NotifyBase):
             graph_url=self.graph_url,
         )
 
-        while len(targets):
-            # Get our target to notify
-            target = targets.pop(0)
-
-            # Prepare our email
-            payload['Message']['ToRecipients'] = [{
-                'EmailAddress': {
-                    'Address': target
-                }
-            }]
-
+        while len(emails):
             # authenticate ourselves if we aren't already; but this function
             # also tracks if our token we have is still valid and will
             # re-authenticate ourselves if nessisary.
@@ -285,9 +334,68 @@ class NotifyOffice365(NotifyBase):
                 # We could not authenticate ourselves; we're done
                 return False
 
+            # Get our email to notify
+            to_name, to_addr = emails.pop(0)
+
+            # Strip target out of cc list if in To or Bcc
+            cc = (self.cc - self.bcc - set([to_addr]))
+
+            # Strip target out of bcc list if in To
+            bcc = (self.bcc - set([to_addr]))
+
+            # Prepare our email
+            payload['Message']['ToRecipients'] = [{
+                'EmailAddress': {
+                    'Address': to_addr
+                }
+            }]
+            if to_name:
+                # Apply our To Name
+                payload['Message']['ToRecipients'][0]['EmailAddress']['Name'] \
+                    = to_name
+
+            self.logger.debug('Email To: {}'.format(to_addr))
+
+            if cc:
+                # Prepare our CC list
+                payload['Message']['CcRecipients'] = []
+                for addr in cc:
+                    _payload = {'Address': addr}
+                    if self.names.get(addr):
+                        _payload['Name'] = self.names[addr]
+
+                    # Store our address in our payload
+                    payload['Message']['CcRecipients']\
+                        .append({'EmailAddress': _payload})
+
+                self.logger.debug('Email Cc: {}'.format(', '.join(
+                    ['{}{}'.format(
+                        '' if self.names.get(e)
+                        else '{}: '.format(self.names[e]), e) for e in cc])))
+
+            if bcc:
+                # Prepare our CC list
+                payload['Message']['BccRecipients'] = []
+                for addr in bcc:
+                    _payload = {'Address': addr}
+                    if self.names.get(addr):
+                        _payload['Name'] = self.names[addr]
+
+                    # Store our address in our payload
+                    payload['Message']['BccRecipients']\
+                        .append({'EmailAddress': _payload})
+
+                self.logger.debug('Email Bcc: {}'.format(', '.join(
+                    ['{}{}'.format(
+                        '' if self.names.get(e)
+                        else '{}: '.format(self.names[e]), e) for e in bcc])))
+
+            # Perform upstream fetch
             postokay, response = self._fetch(
                 url=url, payload=dumps(payload),
                 content_type='application/json')
+
+            # Test if we were okay
             if not postokay:
                 has_error = True
 
@@ -455,6 +563,20 @@ class NotifyOffice365(NotifyBase):
         # Our URL parameters
         params = self.url_parameters(privacy=privacy, *args, **kwargs)
 
+        if self.cc:
+            # Handle our Carbon Copy Addresses
+            params['cc'] = ','.join(
+                ['{}{}'.format(
+                    '' if not self.names.get(e)
+                    else '{}:'.format(self.names[e]), e) for e in self.cc])
+
+        if self.bcc:
+            # Handle our Blind Carbon Copy Addresses
+            params['bcc'] = ','.join(
+                ['{}{}'.format(
+                    '' if not self.names.get(e)
+                    else '{}:'.format(self.names[e]), e) for e in self.bcc])
+
         return '{schema}://{tenant}:{email}/{client_id}/{secret}' \
             '/{targets}/?{params}'.format(
                 schema=self.secure_protocol,
@@ -467,7 +589,9 @@ class NotifyOffice365(NotifyBase):
                     self.secret, privacy, mode=PrivacyMode.Secret,
                     safe=''),
                 targets='/'.join(
-                    [NotifyOffice365.quote(x, safe='') for x in self.targets]),
+                    [NotifyOffice365.quote('{}{}'.format(
+                        '' if not e[0] else '{}:'.format(e[0]), e[1]),
+                        safe='') for e in self.targets]),
                 params=NotifyOffice365.urlencode(params))
 
     @staticmethod
@@ -573,5 +697,13 @@ class NotifyOffice365(NotifyBase):
         if 'to' in results['qsd'] and len(results['qsd']['to']):
             results['targets'] += \
                 NotifyOffice365.parse_list(results['qsd']['to'])
+
+        # Handle Carbon Copy Addresses
+        if 'cc' in results['qsd'] and len(results['qsd']['cc']):
+            results['cc'] = results['qsd']['cc']
+
+        # Handle Blind Carbon Copy Addresses
+        if 'bcc' in results['qsd'] and len(results['qsd']['bcc']):
+            results['bcc'] = results['qsd']['bcc']
 
         return results

--- a/apprise/plugins/NotifyPopcornNotify.py
+++ b/apprise/plugins/NotifyPopcornNotify.py
@@ -28,7 +28,7 @@ import requests
 
 from .NotifyBase import NotifyBase
 from ..common import NotifyType
-from ..utils import GET_EMAIL_RE
+from ..utils import is_email
 from ..utils import parse_list
 from ..utils import parse_bool
 from ..utils import validate_regex
@@ -142,10 +142,10 @@ class NotifyPopcornNotify(NotifyBase):
                 self.targets.append(result)
                 continue
 
-            result = GET_EMAIL_RE.match(target)
+            result = is_email(target)
             if result:
                 # store valid email
-                self.targets.append(target)
+                self.targets.append(result['full_email'])
                 continue
 
             self.logger.warning(

--- a/apprise/plugins/NotifySendGrid.py
+++ b/apprise/plugins/NotifySendGrid.py
@@ -50,7 +50,7 @@ from .NotifyBase import NotifyBase
 from ..common import NotifyFormat
 from ..common import NotifyType
 from ..utils import parse_list
-from ..utils import GET_EMAIL_RE
+from ..utils import is_email
 from ..utils import validate_regex
 from ..AppriseLocale import gettext_lazy as _
 
@@ -170,17 +170,14 @@ class NotifySendGrid(NotifyBase):
             self.logger.warning(msg)
             raise TypeError(msg)
 
-        self.from_email = from_email
-        try:
-            result = GET_EMAIL_RE.match(self.from_email)
-            if not result:
-                # let outer exception handle this
-                raise TypeError
-
-        except (TypeError, AttributeError):
-            msg = 'Invalid ~From~ email specified: {}'.format(self.from_email)
+        result = is_email(from_email)
+        if not result:
+            msg = 'Invalid ~From~ email specified: {}'.format(from_email)
             self.logger.warning(msg)
             raise TypeError(msg)
+
+        # Store email address
+        self.from_email = result['full_email']
 
         # Acquire Targets (To Emails)
         self.targets = list()
@@ -201,8 +198,9 @@ class NotifySendGrid(NotifyBase):
         # Validate recipients (to:) and drop bad ones:
         for recipient in parse_list(targets):
 
-            if GET_EMAIL_RE.match(recipient):
-                self.targets.append(recipient)
+            result = is_email(recipient)
+            if result:
+                self.targets.append(result['full_email'])
                 continue
 
             self.logger.warning(
@@ -213,8 +211,9 @@ class NotifySendGrid(NotifyBase):
         # Validate recipients (cc:) and drop bad ones:
         for recipient in parse_list(cc):
 
-            if GET_EMAIL_RE.match(recipient):
-                self.cc.add(recipient)
+            result = is_email(recipient)
+            if result:
+                self.cc.add(result['full_email'])
                 continue
 
             self.logger.warning(
@@ -225,8 +224,9 @@ class NotifySendGrid(NotifyBase):
         # Validate recipients (bcc:) and drop bad ones:
         for recipient in parse_list(bcc):
 
-            if GET_EMAIL_RE.match(recipient):
-                self.bcc.add(recipient)
+            result = is_email(recipient)
+            if result:
+                self.bcc.add(result['full_email'])
                 continue
 
             self.logger.warning(

--- a/apprise/plugins/NotifyZulip.py
+++ b/apprise/plugins/NotifyZulip.py
@@ -62,7 +62,7 @@ from .NotifyBase import NotifyBase
 from ..common import NotifyType
 from ..utils import parse_list
 from ..utils import validate_regex
-from ..utils import GET_EMAIL_RE
+from ..utils import is_email
 from ..AppriseLocale import gettext_lazy as _
 
 # A Valid Bot Name
@@ -260,7 +260,8 @@ class NotifyZulip(NotifyBase):
         targets = list(self.targets)
         while len(targets):
             target = targets.pop(0)
-            if GET_EMAIL_RE.match(target):
+            result = is_email(target)
+            if result:
                 # Send a private message
                 payload['type'] = 'private'
             else:
@@ -268,7 +269,7 @@ class NotifyZulip(NotifyBase):
                 payload['type'] = 'stream'
 
             # Set our target
-            payload['to'] = target
+            payload['to'] = target if not result else result['full_email']
 
             self.logger.debug('Zulip POST URL: %s (cert_verify=%r)' % (
                 url, self.verify_certificate,

--- a/apprise/plugins/__init__.py
+++ b/apprise/plugins/__init__.py
@@ -449,7 +449,7 @@ def url_to_dict(url):
     schema = GET_SCHEMA_RE.match(_url)
     if schema is None:
         # Not a valid URL; take an early exit
-        logger.error('Unsupported URL {}'.format(url))
+        logger.error('Unsupported URL: {}'.format(url))
         return None
 
     # Ensure our schema is always in lower case

--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -581,11 +581,7 @@ def parse_emails(*args):
     result = []
     for arg in args:
         if isinstance(arg, six.string_types):
-            try:
-                result += EMAIL_DETECTION_RE.findall(arg)
-            except TypeError:
-                # Unparseable
-                pass
+            result += EMAIL_DETECTION_RE.findall(arg)
 
         elif isinstance(arg, (set, list, tuple)):
             result += parse_emails(*arg)
@@ -602,11 +598,7 @@ def parse_urls(*args):
     result = []
     for arg in args:
         if isinstance(arg, six.string_types):
-            try:
-                result += URL_DETECTION_RE.findall(arg)
-            except TypeError:
-                # Unparseable
-                pass
+            result += URL_DETECTION_RE.findall(arg)
 
         elif isinstance(arg, (set, list, tuple)):
             result += parse_urls(*arg)

--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -572,11 +572,16 @@ def parse_bool(arg, default=False):
     return bool(arg)
 
 
-def parse_emails(*args, store_unparseable=True):
+def parse_emails(*args, **kwargs):
     """
     Takes a string containing URLs separated by comma's and/or spaces and
     returns a list.
     """
+
+    # for Python 2.7 support, store_unparsable is not in the url above
+    # as just parse_emails(*args, store_unparseable=True) since it is
+    # an invalid syntax.  This is the workaround to be backards compatible:
+    store_unparseable = kwargs.get('store_unparseable', True)
 
     result = []
     for arg in args:
@@ -603,11 +608,16 @@ def parse_emails(*args, store_unparseable=True):
     return result
 
 
-def parse_urls(*args, store_unparseable=True):
+def parse_urls(*args, **kwargs):
     """
     Takes a string containing URLs separated by comma's and/or spaces and
     returns a list.
     """
+
+    # for Python 2.7 support, store_unparsable is not in the url above
+    # as just parse_urls(*args, store_unparseable=True) since it is
+    # an invalid syntax.  This is the workaround to be backards compatible:
+    store_unparseable = kwargs.get('store_unparseable', True)
 
     result = []
     for arg in args:

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -108,6 +108,12 @@ def test_apprise():
                  '3ccdd113474722377935511fc85d3dd4') is True
     assert len(a) == 3
 
+    # Try adding nothing but delimiters
+    assert a.add(',, ,, , , , ,') is False
+
+    # The number of servers added doesn't change
+    assert len(a) == 3
+
     # We can pop an object off of our stack by it's indexed value:
     obj = a.pop(0)
     assert isinstance(obj, NotifyBase) is True

--- a/test/test_email_plugin.py
+++ b/test/test_email_plugin.py
@@ -166,9 +166,11 @@ TEST_URLS = (
     ('mailtos://nuxref.com?user=&pass=.', {
         'instance': TypeError,
     }),
-    # Invalid To Address
+    # Invalid To Address is accepted, but we won't be able to properly email
+    # using the notify() call
     ('mailtos://user:pass@nuxref.com?to=@', {
-        'instance': TypeError,
+        'instance': plugins.NotifyEmail,
+        'response': False,
     }),
     # Valid URL, but can't structure a proper email
     ('mailtos://nuxref.com?user=%20!&pass=.', {

--- a/test/test_office365.py
+++ b/test/test_office365.py
@@ -77,6 +77,9 @@ def test_office365_general(mock_post):
 
     assert isinstance(obj, plugins.NotifyOffice365)
 
+    # Test our URL generation
+    assert isinstance(obj.url(), six.string_types)
+
     # Test our notification
     assert obj.notify(title='title', body='test') is True
 
@@ -89,8 +92,8 @@ def test_office365_general(mock_post):
             secret=secret,
             targets=targets,
             # Test the cc and bcc list (use good and bad email)
-            cc='Chuck Norris cnorris@yahoo.ca, invalid@!',
-            bcc='Bruce Willis bwillis@hotmail.com, invalid@!',
+            cc='Chuck Norris cnorris@yahoo.ca, Sauron@lotr.me, invalid@!',
+            bcc='Bruce Willis bwillis@hotmail.com, Frodo@lotr.me invalid@!',
         ))
 
     assert isinstance(obj, plugins.NotifyOffice365)
@@ -132,23 +135,27 @@ def test_office365_general(mock_post):
         )
 
     # One of the targets are invalid
-    plugins.NotifyOffice365(
+    obj = plugins.NotifyOffice365(
         email=email,
         client_id=client_id,
         tenant=tenant,
         secret=secret,
-        targets=('abc@gmail.com', 'garbage'),
+        targets=('Management abc@gmail.com', 'garbage'),
     )
+    # Test our notification (this will work and only notify abc@gmail.com)
+    assert obj.notify(title='title', body='test') is True
 
     # all of the targets are invalid
-    with pytest.raises(TypeError):
-        plugins.NotifyOffice365(
-            email=email,
-            client_id=client_id,
-            tenant=tenant,
-            secret=secret,
-            targets=('invalid', 'garbage'),
-        )
+    obj = plugins.NotifyOffice365(
+        email=email,
+        client_id=client_id,
+        tenant=tenant,
+        secret=secret,
+        targets=('invalid', 'garbage'),
+    )
+
+    # Test our notification (which will fail because of no entries)
+    assert obj.notify(title='title', body='test') is False
 
 
 @mock.patch('requests.post')

--- a/test/test_office365.py
+++ b/test/test_office365.py
@@ -23,6 +23,7 @@
 # THE SOFTWARE.
 
 import os
+import six
 import mock
 import pytest
 import requests
@@ -79,6 +80,27 @@ def test_office365_general(mock_post):
     # Test our notification
     assert obj.notify(title='title', body='test') is True
 
+    # Instantiate our object
+    obj = Apprise.instantiate(
+        'o365://{tenant}:{email}/{tenant}/{secret}/{targets}'
+        '?bcc={bcc}&cc={cc}'.format(
+            tenant=tenant,
+            email=email,
+            secret=secret,
+            targets=targets,
+            # Test the cc and bcc list (use good and bad email)
+            cc='Chuck Norris cnorris@yahoo.ca, invalid@!',
+            bcc='Bruce Willis bwillis@hotmail.com, invalid@!',
+        ))
+
+    assert isinstance(obj, plugins.NotifyOffice365)
+
+    # Test our URL generation
+    assert isinstance(obj.url(), six.string_types)
+
+    # Test our notification
+    assert obj.notify(title='title', body='test') is True
+
     with pytest.raises(TypeError):
         # No secret
         plugins.NotifyOffice365(
@@ -119,13 +141,14 @@ def test_office365_general(mock_post):
     )
 
     # all of the targets are invalid
-    assert plugins.NotifyOffice365(
-        email=email,
-        client_id=client_id,
-        tenant=tenant,
-        secret=secret,
-        targets=('invalid', 'garbage'),
-    ).notify(body="test") is False
+    with pytest.raises(TypeError):
+        plugins.NotifyOffice365(
+            email=email,
+            client_id=client_id,
+            tenant=tenant,
+            secret=secret,
+            targets=('invalid', 'garbage'),
+        )
 
 
 @mock.patch('requests.post')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -682,6 +682,11 @@ def test_parse_emails():
 
     results = utils.parse_emails('this is not a parseable email at all')
     assert isinstance(results, list)
+    assert len(results) == 8
+    # Now we do it again with the store_unparsable flag set to False
+    results = utils.parse_emails(
+        'this is not a parseable email at all', store_unparseable=False)
+    assert isinstance(results, list)
     assert len(results) == 0
 
     # Now test valid URLs
@@ -742,6 +747,15 @@ def test_parse_emails():
     for email in emails:
         assert email in results
 
+    # Pass in some unparseables
+    results = utils.parse_emails('garbage')
+    assert isinstance(results, list)
+    assert len(results) == 1
+
+    results = utils.parse_emails('garbage', store_unparseable=False)
+    assert isinstance(results, list)
+    assert len(results) == 0
+
     # Pass in garbage
     results = utils.parse_emails(object)
     assert isinstance(results, list)
@@ -781,6 +795,12 @@ def test_parse_urls():
     assert len(results) == 0
 
     results = utils.parse_urls('this is not a parseable url at all')
+    assert isinstance(results, list)
+    # we still end up returning this
+    assert len(results) == 8
+
+    results = utils.parse_urls(
+        'this is not a parseable url at all', store_unparseable=False)
     assert isinstance(results, list)
     assert len(results) == 0
 


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #271 

Email addresses can now be parsed as:
- `Full Name user@domain.com`
- `Full Name: user@domain.com`
- `Full Name <user@domain.com>`
- `Full Name : <user@domain.com>`
- `<user@domain.com>`

As well as the legacy format:
- `user@domain.com`
- `label+user@domain.com`

Some providers (such as SMTP/EMail will use the `Full Name` and incorporate it in the email.  For example:
- ` mailto://user:pass@gmail.com/Joe%20Rogan:jr@joerogan.net` would log into your `gmail` account and associate _Joe Rogan_ with the **To** email `jr@joerogan.net`
- ` mailto://user:pass@gmail.com/?cc=Uncle%Ben:ben@unclebens.com` would log into your `gmail` account and send an email to you while CCing  `ben@unclebens.com` and associating _Uncle Ben_ with it. 
- Office 365 Plugin now supports `bcc` and `cc` which in itself also supports the new email messaging format

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
