### PR TITLE
Apprise configuration support for 'include' keyword

### DIFF
--- a/apprise/AppriseConfig.py
+++ b/apprise/AppriseConfig.py
@@ -47,7 +47,7 @@ class AppriseConfig(object):
     """
 
     def __init__(self, paths=None, asset=None, cache=True, recursion=0,
-                 insecure_imports=False, **kwargs):
+                 insecure_includes=False, **kwargs):
         """
         Loads all of the paths specified (if any).
 
@@ -79,7 +79,7 @@ class AppriseConfig(object):
         it is off.  There is no limit to how high you set this value. It would
         be recommended to keep it low if you do intend to use it.
 
-        insecure imports by default are disabled. When set to True, all
+        insecure includes by default are disabled. When set to True, all
         Apprise Config files marked to be in STRICT mode are treated as being
         in ALWAYS mode.
 
@@ -87,12 +87,12 @@ class AppriseConfig(object):
         configuration can import another file:// based one. because it is set
         to STRICT mode. If an http:// based configuration file attempted to
         import a file:// one it woul fail. However this import would be
-        possible if insecure_imports is set to True.
+        possible if insecure_includes is set to True.
 
         There are cases where a self hosting apprise developer may wish to load
         configuration from memory (in a string format) that contains import
         entries (even file:// based ones).  In these circumstances if you want
-        these imports to be honored, this value must be set to True.
+        these includes to be honored, this value must be set to True.
         """
 
         # Initialize a server list of URLs
@@ -108,8 +108,8 @@ class AppriseConfig(object):
         # Initialize our recursion value
         self.recursion = recursion
 
-        # Initialize our insecure_imports flag
-        self.insecure_imports = insecure_imports
+        # Initialize our insecure_includes flag
+        self.insecure_includes = insecure_includes
 
         if paths is not None:
             # Store our path(s)
@@ -118,7 +118,7 @@ class AppriseConfig(object):
         return
 
     def add(self, configs, asset=None, tag=None, cache=True, recursion=None,
-            insecure_imports=None):
+            insecure_includes=None):
         """
         Adds one or more config URLs into our list.
 
@@ -141,8 +141,8 @@ class AppriseConfig(object):
 
         Optionally override the default recursion value.
 
-        Optionally override the insecure_imports flag.
-        if insecure_imports is set to True then all plugins that are
+        Optionally override the insecure_includes flag.
+        if insecure_includes is set to True then all plugins that are
         set to a STRICT mode will be a treated as ALWAYS.
         """
 
@@ -155,10 +155,10 @@ class AppriseConfig(object):
         # Initialize our default recursion value
         recursion = recursion if recursion is not None else self.recursion
 
-        # Initialize our default insecure_imports value
-        insecure_imports = \
-            insecure_imports if insecure_imports is not None \
-            else self.insecure_imports
+        # Initialize our default insecure_includes value
+        insecure_includes = \
+            insecure_includes if insecure_includes is not None \
+            else self.insecure_includes
 
         if asset is None:
             # prepare default asset
@@ -200,7 +200,7 @@ class AppriseConfig(object):
             # returns None if it fails
             instance = AppriseConfig.instantiate(
                 _config, asset=asset, tag=tag, cache=cache,
-                recursion=recursion, insecure_imports=insecure_imports)
+                recursion=recursion, insecure_includes=insecure_includes)
             if not isinstance(instance, ConfigBase):
                 return_status = False
                 continue
@@ -212,7 +212,7 @@ class AppriseConfig(object):
         return return_status
 
     def add_config(self, content, asset=None, tag=None, format=None,
-                   recursion=None, insecure_imports=None):
+                   recursion=None, insecure_includes=None):
         """
         Adds one configuration file in it's raw format. Content gets loaded as
         a memory based object and only exists for the life of this
@@ -224,18 +224,18 @@ class AppriseConfig(object):
 
         Optionally override the default recursion value.
 
-        Optionally override the insecure_imports flag.
-        if insecure_imports is set to True then all plugins that are
+        Optionally override the insecure_includes flag.
+        if insecure_includes is set to True then all plugins that are
         set to a STRICT mode will be a treated as ALWAYS.
         """
 
         # Initialize our default recursion value
         recursion = recursion if recursion is not None else self.recursion
 
-        # Initialize our default insecure_imports value
-        insecure_imports = \
-            insecure_imports if insecure_imports is not None \
-            else self.insecure_imports
+        # Initialize our default insecure_includes value
+        insecure_includes = \
+            insecure_includes if insecure_includes is not None \
+            else self.insecure_includes
 
         if asset is None:
             # prepare default asset
@@ -252,7 +252,7 @@ class AppriseConfig(object):
         # Create ourselves a ConfigMemory Object to store our configuration
         instance = config.ConfigMemory(
             content=content, format=format, asset=asset, tag=tag,
-            recursion=self.recursion, insecure_imports=insecure_imports)
+            recursion=self.recursion, insecure_includes=insecure_includes)
 
         # Add our initialized plugin to our server listings
         self.configs.append(instance)
@@ -297,7 +297,7 @@ class AppriseConfig(object):
 
     @staticmethod
     def instantiate(url, asset=None, tag=None, cache=None,
-                    recursion=0, insecure_imports=False,
+                    recursion=0, insecure_includes=False,
                     suppress_exceptions=True):
         """
         Returns the instance of a instantiated configuration plugin based on
@@ -345,8 +345,8 @@ class AppriseConfig(object):
         # Recursion can never be parsed from the URL
         results['recursion'] = recursion
 
-        # Insecure Imports flag can never be parsed from the URL
-        results['insecure_imports'] = insecure_imports
+        # Insecure includes flag can never be parsed from the URL
+        results['insecure_includes'] = insecure_includes
 
         if suppress_exceptions:
             try:

--- a/apprise/URLBase.py
+++ b/apprise/URLBase.py
@@ -674,3 +674,24 @@ class URLBase(object):
             response = ''
 
         return response
+
+    def schemas(self):
+        """A simple function that returns a set of all schemas associated
+        with this object based on the object.protocol and
+        object.secure_protocol
+        """
+
+        schemas = set([])
+
+        for key in ('protocol', 'secure_protocol'):
+            # Load protocol(s) if defined
+            proto = getattr(self, key, None)
+            if isinstance(proto, six.string_types):
+                schemas.add(proto)
+
+            elif isinstance(self, (set, list, tuple)):
+                # Support iterables list types
+                for p in proto:
+                    schemas.add(p)
+
+        return schemas

--- a/apprise/URLBase.py
+++ b/apprise/URLBase.py
@@ -684,14 +684,14 @@ class URLBase(object):
         schemas = set([])
 
         for key in ('protocol', 'secure_protocol'):
-            # Load protocol(s) if defined
-            proto = getattr(self, key, None)
-            if isinstance(proto, six.string_types):
-                schemas.add(proto)
+            schema = getattr(self, key, None)
+            if isinstance(schema, six.string_types):
+                schemas.add(schema)
 
-            elif isinstance(self, (set, list, tuple)):
+            elif isinstance(schema, (set, list, tuple)):
                 # Support iterables list types
-                for p in proto:
-                    schemas.add(p)
+                for s in schema:
+                    if isinstance(s, six.string_types):
+                        schemas.add(s)
 
         return schemas

--- a/apprise/__init__.py
+++ b/apprise/__init__.py
@@ -41,6 +41,8 @@ from .common import OverflowMode
 from .common import OVERFLOW_MODES
 from .common import ConfigFormat
 from .common import CONFIG_FORMATS
+from .common import ConfigImportMode
+from .common import CONFIG_IMPORT_MODES
 
 from .URLBase import URLBase
 from .URLBase import PrivacyMode
@@ -66,5 +68,7 @@ __all__ = [
     # Reference
     'NotifyType', 'NotifyImageSize', 'NotifyFormat', 'OverflowMode',
     'NOTIFY_TYPES', 'NOTIFY_IMAGE_SIZES', 'NOTIFY_FORMATS', 'OVERFLOW_MODES',
-    'ConfigFormat', 'CONFIG_FORMATS', 'PrivacyMode',
+    'ConfigFormat', 'CONFIG_FORMATS',
+    'ConfigImportMode', 'CONFIG_IMPORT_MODES',
+    'PrivacyMode',
 ]

--- a/apprise/__init__.py
+++ b/apprise/__init__.py
@@ -41,8 +41,8 @@ from .common import OverflowMode
 from .common import OVERFLOW_MODES
 from .common import ConfigFormat
 from .common import CONFIG_FORMATS
-from .common import ConfigImportMode
-from .common import CONFIG_IMPORT_MODES
+from .common import ConfigIncludeMode
+from .common import CONFIG_INCLUDE_MODES
 
 from .URLBase import URLBase
 from .URLBase import PrivacyMode
@@ -69,6 +69,6 @@ __all__ = [
     'NotifyType', 'NotifyImageSize', 'NotifyFormat', 'OverflowMode',
     'NOTIFY_TYPES', 'NOTIFY_IMAGE_SIZES', 'NOTIFY_FORMATS', 'OVERFLOW_MODES',
     'ConfigFormat', 'CONFIG_FORMATS',
-    'ConfigImportMode', 'CONFIG_IMPORT_MODES',
+    'ConfigIncludeMode', 'CONFIG_INCLUDE_MODES',
     'PrivacyMode',
 ]

--- a/apprise/cli.py
+++ b/apprise/cli.py
@@ -129,6 +129,10 @@ def print_version_msg():
               help='Perform a trial run but only prints the notification '
               'services to-be triggered to stdout. Notifications are never '
               'sent using this mode.')
+@click.option('--recursion-level', '-r', default=1, type=int,
+              help='Specify the number of recursive import entries that can '
+              'loaded from the loaded specified configuration. By default '
+              'this is set to 1.')
 @click.option('--verbose', '-v', count=True,
               help='Makes the operation more talkative. Use multiple v to '
               'increase the verbosity. I.e.: -vvvv')
@@ -138,7 +142,8 @@ def print_version_msg():
 @click.argument('urls', nargs=-1,
                 metavar='SERVER_URL [SERVER_URL2 [SERVER_URL3]]',)
 def main(body, title, config, attach, urls, notification_type, theme, tag,
-         input_format, dry_run, verbose, disable_async, debug, version):
+         input_format, dry_run, recursion_level, verbose, disable_async,
+         debug, version):
     """
     Send a notification to all of the specified servers identified by their
     URLs the content provided within the title, body and notification-type.
@@ -227,7 +232,7 @@ def main(body, title, config, attach, urls, notification_type, theme, tag,
     a.add(AppriseConfig(
         paths=[f for f in DEFAULT_SEARCH_PATHS if isfile(expanduser(f))]
         if not (config or urls) else config,
-        asset=asset))
+        asset=asset, recursion=recursion_level))
 
     # Load our inventory up
     for url in urls:

--- a/apprise/common.py
+++ b/apprise/common.py
@@ -129,6 +129,29 @@ CONFIG_FORMATS = (
     ConfigFormat.YAML,
 )
 
+
+class ConfigImportMode(object):
+    """
+    The different mode categories of configuration importing
+    """
+    # Importing of same type only; hence a file:// can import a file://
+    # Cross importing is not allowed unless insecure_imports (a flag)
+    # is set to True on the configuration file making the import itself.
+    STRICT = 'strict'
+
+    # This configuration type can never be imported
+    NEVER = 'never'
+
+    # Importing the specified configuration is always allowed
+    ALWAYS = 'always'
+
+
+CONFIG_IMPORT_MODES = (
+    ConfigImportMode.STRICT,
+    ConfigImportMode.NEVER,
+    ConfigImportMode.ALWAYS,
+)
+
 # This is a reserved tag that is automatically assigned to every
 # Notification Plugin
 MATCH_ALL_TAG = 'all'

--- a/apprise/common.py
+++ b/apprise/common.py
@@ -130,26 +130,28 @@ CONFIG_FORMATS = (
 )
 
 
-class ConfigImportMode(object):
+class ConfigIncludeMode(object):
     """
-    The different mode categories of configuration importing
+    The different Cofiguration inclusion modes.  All Configuration
+    plugins will have one of these associated with it.
     """
-    # Importing of same type only; hence a file:// can import a file://
-    # Cross importing is not allowed unless insecure_imports (a flag)
-    # is set to True on the configuration file making the import itself.
+    # - Configuration inclusion of same type only; hence a file:// can include
+    #   a file://
+    # - Cross file inclusion is not allowed unless insecure_includes (a flag)
+    #   is set to True. In these cases STRICT acts as type ALWAYS
     STRICT = 'strict'
 
-    # This configuration type can never be imported
+    # This configuration type can never be included
     NEVER = 'never'
 
-    # Importing the specified configuration is always allowed
+    # File configuration can always be included
     ALWAYS = 'always'
 
 
-CONFIG_IMPORT_MODES = (
-    ConfigImportMode.STRICT,
-    ConfigImportMode.NEVER,
-    ConfigImportMode.ALWAYS,
+CONFIG_INCLUDE_MODES = (
+    ConfigIncludeMode.STRICT,
+    ConfigIncludeMode.NEVER,
+    ConfigIncludeMode.ALWAYS,
 )
 
 # This is a reserved tag that is automatically assigned to every

--- a/apprise/config/ConfigBase.py
+++ b/apprise/config/ConfigBase.py
@@ -714,10 +714,6 @@ class ConfigBase(URLBase):
         # Iterate over each config URL
         for no, url in enumerate(imports):
 
-            # Our results object is what we use to instantiate our object if
-            # we can. Reset it to None on each iteration
-            results = list()
-
             if isinstance(url, six.string_types):
                 # We're just a simple URL string...
                 configs.append(url)
@@ -725,10 +721,6 @@ class ConfigBase(URLBase):
             elif isinstance(url, dict):
                 # Store the url and ignore arguments associated
                 configs.extend(u for u in url.keys())
-
-            elif isinstance(url, (list, tuple)):
-                # Lists are fine
-                configs.extend(u for u in url)
 
         #
         # urls root directive

--- a/apprise/config/ConfigBase.py
+++ b/apprise/config/ConfigBase.py
@@ -254,10 +254,10 @@ class ConfigBase(URLBase):
                 # Prepare our Asset Object
                 results['asset'] = asset
 
-                if self.cache is not None:
-                    # Force an over-ride of the cache value to what we have
-                    # specified
-                    results['cache'] = self.cache
+                # No cache is required because we're just lumping this in
+                # and associating it with the cache value we've already
+                # declared (prior to our recursion)
+                results['cache'] = False
 
                 # Recursion can never be parsed from the URL; we decrement
                 # it one level

--- a/apprise/config/ConfigBase.py
+++ b/apprise/config/ConfigBase.py
@@ -702,20 +702,41 @@ class ConfigBase(URLBase):
         #
         # import root directive
         #
-        configs = result.get('imports', None)
-        if not isinstance(configs, (list, tuple)):
+        imports = result.get('import', None)
+        if isinstance(imports, six.string_types):
+            # Support a single inline string
+            imports = list([imports])
+
+        elif not isinstance(imports, (list, tuple)):
             # Not a problem; we simply have no imports
-            configs = list()
+            imports = list()
+
+        # Iterate over each config URL
+        for no, url in enumerate(imports):
+
+            # Our results object is what we use to instantiate our object if
+            # we can. Reset it to None on each iteration
+            results = list()
+
+            if isinstance(url, six.string_types):
+                # We're just a simple URL string...
+                configs.append(url)
+
+            elif isinstance(url, dict):
+                # Store the url and ignore arguments associated
+                configs.extend(u for u in url.keys())
+
+            elif isinstance(url, (list, tuple)):
+                # Lists are fine
+                configs.extend(u for u in url)
 
         #
         # urls root directive
         #
         urls = result.get('urls', None)
         if not isinstance(urls, (list, tuple)):
-            # Unsupported
-            ConfigBase.logger.error(
-                'Missing "urls" directive in Apprise YAML configuration.')
-            return (list(), list())
+            # Not a problem; we simply have no urls
+            urls = list()
 
         # Iterate over each URL
         for no, url in enumerate(urls):

--- a/apprise/config/ConfigFile.py
+++ b/apprise/config/ConfigFile.py
@@ -28,7 +28,7 @@ import io
 import os
 from .ConfigBase import ConfigBase
 from ..common import ConfigFormat
-from ..common import ConfigImportMode
+from ..common import ConfigIncludeMode
 from ..AppriseLocale import gettext_lazy as _
 
 
@@ -43,8 +43,8 @@ class ConfigFile(ConfigBase):
     # The default protocol
     protocol = 'file'
 
-    # File imports can only import the same type
-    allow_cross_import = ConfigImportMode.STRICT
+    # Configuration file inclusion can only be of the same type
+    allow_cross_includes = ConfigIncludeMode.STRICT
 
     def __init__(self, path, **kwargs):
         """

--- a/apprise/config/ConfigFile.py
+++ b/apprise/config/ConfigFile.py
@@ -28,6 +28,7 @@ import io
 import os
 from .ConfigBase import ConfigBase
 from ..common import ConfigFormat
+from ..common import ConfigImportMode
 from ..AppriseLocale import gettext_lazy as _
 
 
@@ -41,6 +42,9 @@ class ConfigFile(ConfigBase):
 
     # The default protocol
     protocol = 'file'
+
+    # File imports can only import the same type
+    allow_cross_import = ConfigImportMode.STRICT
 
     def __init__(self, path, **kwargs):
         """

--- a/apprise/config/ConfigHTTP.py
+++ b/apprise/config/ConfigHTTP.py
@@ -28,7 +28,7 @@ import six
 import requests
 from .ConfigBase import ConfigBase
 from ..common import ConfigFormat
-from ..common import ConfigImportMode
+from ..common import ConfigIncludeMode
 from ..URLBase import PrivacyMode
 from ..AppriseLocale import gettext_lazy as _
 
@@ -65,9 +65,8 @@ class ConfigHTTP(ConfigBase):
     # from queries to services that may be untrusted.
     max_error_buffer_size = 2048
 
-    # We allow configuration entries to import us from their configuration
-    # files
-    allow_cross_import = ConfigImportMode.ALWAYS
+    # Configuration file inclusion can always include this type
+    allow_cross_includes = ConfigIncludeMode.ALWAYS
 
     def __init__(self, headers=None, **kwargs):
         """

--- a/apprise/config/ConfigHTTP.py
+++ b/apprise/config/ConfigHTTP.py
@@ -28,6 +28,7 @@ import six
 import requests
 from .ConfigBase import ConfigBase
 from ..common import ConfigFormat
+from ..common import ConfigImportMode
 from ..URLBase import PrivacyMode
 from ..AppriseLocale import gettext_lazy as _
 
@@ -63,6 +64,10 @@ class ConfigHTTP(ConfigBase):
     # The idea behind enforcing this kind of restriction is to prevent abuse
     # from queries to services that may be untrusted.
     max_error_buffer_size = 2048
+
+    # We allow configuration entries to import us from their configuration
+    # files
+    allow_cross_import = ConfigImportMode.ALWAYS
 
     def __init__(self, headers=None, **kwargs):
         """

--- a/apprise/config/__init__.py
+++ b/apprise/config/__init__.py
@@ -114,10 +114,9 @@ def __load_matrix(path=abspath(dirname(__file__)), name='apprise.config'):
         # map our schema to our plugin
         for schema in schemas:
             if schema in SCHEMA_MAP:
-                if SCHEMA_MAP[schema] != plugin:
-                    logger.error(
-                        "Config schema duplicate ({}) detected; {} != {}"
-                        .format(schema, SCHEMA_MAP[schema], plugin))
+                logger.error(
+                    "Config schema ({}) mismatch detected - {} to {}"
+                    .format(schema, SCHEMA_MAP[schema], plugin))
                 continue
 
             # Assign plugin

--- a/apprise/plugins/__init__.py
+++ b/apprise/plugins/__init__.py
@@ -129,7 +129,27 @@ def __load_matrix(path=abspath(dirname(__file__)), name='apprise.plugins'):
         globals()[plugin_name] = plugin
 
         fn = getattr(plugin, 'schemas', None)
-        schemas = set([]) if not callable(fn) else fn(plugin)
+        try:
+            schemas = set([]) if not callable(fn) else fn(plugin)
+
+        except TypeError:
+            # Python v2.x support where functions associated with classes
+            # were considered bound to them and could not be called prior
+            # to the classes initialization.  This code can be dropped
+            # once Python v2.x support is dropped. The below code introduces
+            # replication as it already exists and is tested in
+            # URLBase.schemas()
+            schemas = set([])
+            for key in ('protocol', 'secure_protocol'):
+                schema = getattr(plugin, key, None)
+                if isinstance(schema, six.string_types):
+                    schemas.add(schema)
+
+                elif isinstance(schema, (set, list, tuple)):
+                    # Support iterables list types
+                    for s in schema:
+                        if isinstance(s, six.string_types):
+                            schemas.add(s)
 
         # map our schema to our plugin
         for schema in schemas:

--- a/apprise/plugins/__init__.py
+++ b/apprise/plugins/__init__.py
@@ -154,10 +154,9 @@ def __load_matrix(path=abspath(dirname(__file__)), name='apprise.plugins'):
         # map our schema to our plugin
         for schema in schemas:
             if schema in SCHEMA_MAP:
-                if SCHEMA_MAP[schema] != plugin:
-                    logger.error(
-                        "Config schema duplicate ({}) detected; {} != {}"
-                        .format(schema, SCHEMA_MAP[schema], plugin))
+                logger.error(
+                    "Notification schema ({}) mismatch detected - {} to {}"
+                    .format(schema, SCHEMA_MAP[schema], plugin))
                 continue
 
             # Assign plugin

--- a/apprise/plugins/__init__.py
+++ b/apprise/plugins/__init__.py
@@ -128,29 +128,20 @@ def __load_matrix(path=abspath(dirname(__file__)), name='apprise.plugins'):
         # Load our module into memory so it's accessible to all
         globals()[plugin_name] = plugin
 
-        # Load protocol(s) if defined
-        proto = getattr(plugin, 'protocol', None)
-        if isinstance(proto, six.string_types):
-            if proto not in SCHEMA_MAP:
-                SCHEMA_MAP[proto] = plugin
+        fn = getattr(plugin, 'schemas', None)
+        schemas = set([]) if not callable(fn) else fn(plugin)
 
-        elif isinstance(proto, (set, list, tuple)):
-            # Support iterables list types
-            for p in proto:
-                if p not in SCHEMA_MAP:
-                    SCHEMA_MAP[p] = plugin
+        # map our schema to our plugin
+        for schema in schemas:
+            if schema in SCHEMA_MAP:
+                if SCHEMA_MAP[schema] != plugin:
+                    logger.error(
+                        "Config schema duplicate ({}) detected; {} != {}"
+                        .format(schema, SCHEMA_MAP[schema], plugin))
+                continue
 
-        # Load secure protocol(s) if defined
-        protos = getattr(plugin, 'secure_protocol', None)
-        if isinstance(protos, six.string_types):
-            if protos not in SCHEMA_MAP:
-                SCHEMA_MAP[protos] = plugin
-
-        if isinstance(protos, (set, list, tuple)):
-            # Support iterables list types
-            for p in protos:
-                if p not in SCHEMA_MAP:
-                    SCHEMA_MAP[p] = plugin
+            # Assign plugin
+            SCHEMA_MAP[schema] = plugin
 
     return SCHEMA_MAP
 

--- a/packaging/man/apprise.1
+++ b/packaging/man/apprise.1
@@ -73,6 +73,10 @@ The more of these you specify, the more verbose the output is\.
 Send notifications synchronously (one after the other) instead of all at once\.
 .
 .TP
+\fB\-R\fR, \fB\-\-recursion\-depth\fR
+he number of recursive import entries that can be loaded from within Apprise configuration\. By default this is set to 1\. If this is set to zero, then import statements found in any configuration is ignored\.
+.
+.TP
 \fB\-D\fR, \fB\-\-debug\fR
 A debug mode; useful for troubleshooting\.
 .
@@ -85,10 +89,10 @@ Display the apprise version and exit\.
 Show this message and exit\.
 .
 .SH "EXIT STATUS"
-\fBapprise\fR exits with a status 0 if all notifications were sent successfully otherwise \fBapprise\fR returns a value of 1\.
+\fBapprise\fR exits with a status 0 if all notifications were sent successfully otherwise \fBapprise\fR returns a value of 1\. \fBapprise\fR returns a value of 2 if there was an error specified on the command line (such as not providing an valid argument)\.
 .
 .P
-\fBapprise\fR exits with a status of 2 if there were no notifcations sent due (as a result of end user actions)\. This occurs in the case where you have assigned one or more tags to all of the Apprise URLs being notified and did not match any when actually executing the \fBapprise\fR tool\. This can also occur if you specified a tag that has not been assigned to anything defined in your configuration\.
+\fBapprise\fR exits with a status of 3 if there were no notifcations sent due (as a result of end user actions)\. This occurs in the case where you have assigned one or more tags to all of the Apprise URLs being notified and did not match any when actually executing the \fBapprise\fR tool\. This can also occur if you specified a tag that has not been assigned to anything defined in your configuration\.
 .
 .SH "SERVICE URLS"
 There are to many service URL and combinations to list here\. It\'s best to visit the Apprise GitHub page \fIhttps://github\.com/caronc/apprise/wiki#notification\-services\fR and see what\'s available\.
@@ -100,7 +104,7 @@ Send a notification to as many servers as you want to specify as you can easily 
 .
 .nf
 
-$ apprise \-t \'my title\' \-b \'my notification body\' \e
+$ apprise \-vv \-t \'my title\' \-b \'my notification body\' \e
    \'mailto://myemail:mypass@gmail\.com\' \e
    \'pbul://o\.gn5kj6nfhv736I7jC3cj3QLRiyhgl98b\'
 .
@@ -115,7 +119,7 @@ If you don\'t specify a \fB\-\-body\fR (\fB\-b\fR) then stdin is used allowing y
 .
 .nf
 
-$ cat /proc/cpuinfo | apprise \-t \'cpu info\' \e
+$ cat /proc/cpuinfo | apprise \-vv \-t \'cpu info\' \e
     \'mailto://myemail:mypass@gmail\.com\'
 .
 .fi
@@ -129,7 +133,7 @@ Load in a configuration file which identifies all of your notification service U
 .
 .nf
 
-$ apprise \-t \'my title\' \-b \'my notification body\' \e
+$ apprise \-vv \-t \'my title\' \-b \'my notification body\' \e
    \-\-config=~/apprise\.yml
 .
 .fi
@@ -143,7 +147,7 @@ Load in a configuration file from a remote server that identifies all of your no
 .
 .nf
 
-$ apprise \-t \'my title\' \-b \'my notification body\' \e
+$ apprise \-vv \-t \'my title\' \-b \'my notification body\' \e
    \-\-config=https://localhost/my/apprise/config \e
    \-t devops
 .
@@ -158,7 +162,7 @@ Include an attachment:
 .
 .nf
 
-$ apprise \-t \'School Assignment\' \-b \'See attached\' \e
+$ apprise \-vv \-t \'School Assignment\' \-b \'See attached\' \e
    \-\-attach=Documents/FinalReport\.docx
 .
 .fi

--- a/packaging/man/apprise.md
+++ b/packaging/man/apprise.md
@@ -60,6 +60,11 @@ The Apprise options are as follows:
     Send notifications synchronously (one after the other) instead of
     all at once.
 
+  * `-R`, `--recursion-depth`:
+    he number of recursive import entries that can be loaded from within
+    Apprise configuration. By default this is set to 1. If this is set to
+    zero, then import statements found in any configuration is ignored.
+
   * `-D`, `--debug`:
     A debug mode; useful for troubleshooting.
 
@@ -71,9 +76,11 @@ The Apprise options are as follows:
 
 ## EXIT STATUS
 
-**apprise** exits with a status 0 if all notifications were sent successfully otherwise **apprise** returns a value of 1.
+**apprise** exits with a status 0 if all notifications were sent successfully otherwise **apprise** returns a value of 1. **apprise** returns a value of 2 if
+there was an error specified on the command line (such as not providing an valid
+argument).
 
-**apprise** exits with a status of 2 if there were no notifcations sent due (as a result of end user actions).  This occurs in the case where you have assigned one or more tags to all of the Apprise URLs being notified and did not match any when actually executing the **apprise** tool.  This can also occur if you specified a tag that has not been assigned to anything defined in your configuration.
+**apprise** exits with a status of 3 if there were no notifcations sent due (as a result of end user actions).  This occurs in the case where you have assigned one or more tags to all of the Apprise URLs being notified and did not match any when actually executing the **apprise** tool.  This can also occur if you specified a tag that has not been assigned to anything defined in your configuration.
 
 
 ## SERVICE URLS
@@ -88,32 +95,32 @@ visit the [Apprise GitHub page][serviceurls] and see what's available.
 Send a notification to as many servers as you want to specify as you can
 easily chain them together:
 
-    $ apprise -t 'my title' -b 'my notification body' \
+    $ apprise -vv -t 'my title' -b 'my notification body' \
        'mailto://myemail:mypass@gmail.com' \
        'pbul://o.gn5kj6nfhv736I7jC3cj3QLRiyhgl98b'
 
 If you don't specify a **--body** (**-b**) then stdin is used allowing you to
 use the tool as part of your every day administration:
 
-    $ cat /proc/cpuinfo | apprise -t 'cpu info' \
+    $ cat /proc/cpuinfo | apprise -vv -t 'cpu info' \
         'mailto://myemail:mypass@gmail.com'
 
 Load in a configuration file which identifies all of your notification service
 URLs and notify them all:
 
-    $ apprise -t 'my title' -b 'my notification body' \
+    $ apprise -vv -t 'my title' -b 'my notification body' \
        --config=~/apprise.yml
 
 Load in a configuration file from a remote server that identifies all of your
 notification service URLs and only notify the ones tagged as _devops_.
 
-    $ apprise -t 'my title' -b 'my notification body' \
+    $ apprise -vv -t 'my title' -b 'my notification body' \
        --config=https://localhost/my/apprise/config \
        -t devops
 
 Include an attachment:
 
-    $ apprise -t 'School Assignment' -b 'See attached' \
+    $ apprise -vv -t 'School Assignment' -b 'See attached' \
        --attach=Documents/FinalReport.docx
 
 ## BUGS

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -168,6 +168,11 @@ def test_apprise():
             # Support URL
             return ''
 
+        @staticmethod
+        def parse_url(url, *args, **kwargs):
+            # always parseable
+            return NotifyBase.parse_url(url, verify_host=False)
+
     class GoodNotification(NotifyBase):
         def __init__(self, **kwargs):
             super(GoodNotification, self).__init__(
@@ -180,6 +185,11 @@ def test_apprise():
         def send(self, **kwargs):
             # Pretend everything is okay
             return True
+
+        @staticmethod
+        def parse_url(url, *args, **kwargs):
+            # always parseable
+            return NotifyBase.parse_url(url, verify_host=False)
 
     # Store our bad notification in our schema map
     SCHEMA_MAP['bad'] = BadNotification
@@ -1433,10 +1443,15 @@ class NotifyGoober(NotifyBase):
     # trying to over-ride items previously used
 
     # The default simple (insecure) protocol (used by NotifyMail)
-    protocol = 'mailto'
+    protocol = ('mailto', 'goober')
 
     # The default secure protocol (used by NotifyMail)
-    secure_protocol = 'mailtos'""")
+    secure_protocol = 'mailtos'
+
+    @staticmethod
+    def parse_url(url, *args, **kwargs):
+        # always parseable
+        return ConfigBase.parse_url(url, verify_host=False)""")
 
     # Utilizes a schema:// already occupied (as tuple)
     base.join('NotifyBugger.py').write("""
@@ -1450,6 +1465,11 @@ class NotifyBugger(NotifyBase):
     protocol = ('mailto', 'bugger-test' )
 
     # The default secure protocol (used by NotifyMail), the other isn't
-    secure_protocol = ('mailtos', 'bugger-tests')""")
+    secure_protocol = ('mailtos', ['garbage'])
+
+    @staticmethod
+    def parse_url(url, *args, **kwargs):
+        # always parseable
+        return ConfigBase.parse_url(url, verify_host=False)""")
 
     __load_matrix(path=str(base), name=module_name)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -588,9 +588,70 @@ def test_apprise_tagging(mock_post, mock_get):
         tag=[(object, ), ]) is None
 
 
+def test_apprise_schemas(tmpdir):
+    """
+    API: Apprise().schema() tests
+
+    """
+    # Caling load matix a second time which is an internal function causes it
+    # to skip over content already loaded into our matrix and thefore accesses
+    # other if/else parts of the code that aren't otherwise called
+    __load_matrix()
+
+    a = Apprise()
+
+    # no items
+    assert len(a) == 0
+
+    class TextNotification(NotifyBase):
+        # set our default notification format
+        notify_format = NotifyFormat.TEXT
+
+        # Garbage Protocol Entries
+        protocol = None
+
+        secure_protocol = (None, object)
+
+    class HtmlNotification(NotifyBase):
+
+        protocol = ('html', 'htm')
+
+        secure_protocol = ('htmls', 'htms')
+
+    class MarkDownNotification(NotifyBase):
+
+        protocol = 'markdown'
+
+        secure_protocol = 'markdowns'
+
+    # Store our notifications into our schema map
+    SCHEMA_MAP['text'] = TextNotification
+    SCHEMA_MAP['html'] = HtmlNotification
+    SCHEMA_MAP['markdown'] = MarkDownNotification
+
+    schemas = URLBase.schemas(TextNotification)
+    assert isinstance(schemas, set) is True
+    # We didn't define a protocol or secure protocol
+    assert len(schemas) == 0
+
+    schemas = URLBase.schemas(HtmlNotification)
+    assert isinstance(schemas, set) is True
+    assert len(schemas) == 4
+    assert 'html' in schemas
+    assert 'htm' in schemas
+    assert 'htmls' in schemas
+    assert 'htms' in schemas
+
+    # Invalid entries do not disrupt schema calls
+    for garbage in (object(), None, 42):
+        schemas = URLBase.schemas(garbage)
+        assert isinstance(schemas, set) is True
+        assert len(schemas) == 0
+
+
 def test_apprise_notify_formats(tmpdir):
     """
-    API: Apprise() TextFormat tests
+    API: Apprise() Input Formats tests
 
     """
     # Caling load matix a second time which is an internal function causes it

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -588,6 +588,7 @@ def test_apprise_tagging(mock_post, mock_get):
         tag=[(object, ), ]) is None
 
 
+@pytest.mark.skipif(sys.version_info.major <= 2, reason="Requires Python 3.x+")
 def test_apprise_schemas(tmpdir):
     """
     API: Apprise().schema() tests

--- a/test/test_apprise_config.py
+++ b/test/test_apprise_config.py
@@ -23,11 +23,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+import sys
 import six
 import io
 import mock
 import pytest
 from apprise import NotifyFormat
+from apprise import ConfigImportMode
 from apprise.Apprise import Apprise
 from apprise.AppriseConfig import AppriseConfig
 from apprise.AppriseAsset import AppriseAsset
@@ -578,6 +580,197 @@ def test_apprise_config_with_apprise_obj(tmpdir):
         assert isinstance(a.pop(len(a) - 1), NotifyBase) is True
 
 
+def test_config_recursive_importing(tmpdir):
+    """
+    API: Apprise() Config Recursive Importing
+
+    """
+
+    # To test our config classes, we make three dummy configs
+    class ConfigCrossPostAlways(ConfigFile):
+        """
+        A dummy config that is set to always allow importing
+        """
+
+        service_name = 'always'
+
+        # protocol
+        protocol = 'always'
+
+        # Always type
+        allow_cross_import = ConfigImportMode.ALWAYS
+
+    class ConfigCrossPostStrict(ConfigFile):
+        """
+        A dummy config that is set to strict importing
+        """
+
+        service_name = 'strict'
+
+        # protocol
+        protocol = 'strict'
+
+        # Always type
+        allow_cross_import = ConfigImportMode.STRICT
+
+    class ConfigCrossPostNever(ConfigFile):
+        """
+        A dummy config that is set to never allow importing
+        """
+
+        service_name = 'never'
+
+        # protocol
+        protocol = 'never'
+
+        # Always type
+        allow_cross_import = ConfigImportMode.NEVER
+
+    # store our entries
+    CONFIG_SCHEMA_MAP['never'] = ConfigCrossPostNever
+    CONFIG_SCHEMA_MAP['strict'] = ConfigCrossPostStrict
+    CONFIG_SCHEMA_MAP['always'] = ConfigCrossPostAlways
+
+    # Make our new path valid
+    suite = tmpdir.mkdir("apprise_config_recursion")
+
+    cfg01 = suite.join("cfg01.cfg")
+    cfg02 = suite.mkdir("dir1").join("cfg02.cfg")
+    cfg03 = suite.mkdir("dir2").join("cfg03.cfg")
+    cfg04 = suite.mkdir("dir3").join("cfg04.cfg")
+
+    # Populate our files with valid configuration import lines
+    cfg01.write("""
+# json entry
+json://localhost:8080
+
+# absolute path inclusion to ourselves
+import {}""".format(str(cfg01)))
+
+    cfg02.write("""
+# syslog entry
+syslog://
+
+# recursively include ourselves
+import cfg02.cfg""")
+
+    cfg03.write("""
+# xml entry
+xml://localhost:8080
+
+# relative path inclusion
+import ../dir1/cfg02.cfg
+
+# test that we can't import invalid entries
+import invalid://entry
+
+# Include non includable type
+import memory://""")
+
+    cfg04.write("""
+# xml entry
+xml://localhost:8080
+
+# always import of our file
+import always://{}
+
+# never import of our file
+import never://{}
+
+# strict import of our file
+import strict://{}""".format(str(cfg04), str(cfg04), str(cfg04)))
+
+    # Create ourselves a config object
+    ac = AppriseConfig()
+
+    # There are no servers loaded
+    assert len(ac) == 0
+
+    # load our configuration
+    assert ac.add(configs=str(cfg01)) is True
+
+    # verify it loaded
+    assert len(ac) == 1
+
+    # 1 service will be loaded as there is no recursion at this point
+    assert len(ac.servers()) == 1
+
+    # Create ourselves a config object
+    ac = AppriseConfig(recursion=1)
+
+    # load our configuration
+    assert ac.add(configs=str(cfg01)) is True
+
+    # verify one configuration file loaded however since it recursively
+    # loaded itself 1 more time, it still doesn't impact the load count:
+    assert len(ac) == 1
+
+    # 2 services loaded now that we loaded the same file twice
+    assert len(ac.servers()) == 2
+
+    #
+    # Now we test relative importing
+    #
+
+    # Create ourselves a config object
+    ac = AppriseConfig(recursion=10)
+
+    # There are no servers loaded
+    assert len(ac) == 0
+
+    # load our configuration
+    assert ac.add(configs=str(cfg02)) is True
+
+    # verify it loaded
+    assert len(ac) == 1
+
+    # 11 services loaded because we reloaded ourselves 10 times
+    # after loading the first entry
+    assert len(ac.servers()) == 11
+
+    # Test our import modes (strict, always, and never)
+
+    # Create ourselves a config object
+    ac = AppriseConfig(recursion=1)
+
+    # There are no servers loaded
+    assert len(ac) == 0
+
+    # load our configuration
+    assert ac.add(configs=str(cfg04)) is True
+
+    # verify it loaded
+    assert len(ac) == 1
+
+    # 2 servers loaded
+    # 1 - from the file read (which is set at mode STRICT
+    # 1 - from the always://
+    #
+    # The never:// can ever be imported, and the strict:// is ot of type
+    #  file:// (the one doing the import) so it is also ignored.
+    #
+    # By turning on the insecure_imports, we can import the strict files too
+    assert len(ac.servers()) == 2
+
+    # Create ourselves a config object
+    ac = AppriseConfig(recursion=1, insecure_imports=True)
+
+    # There are no servers loaded
+    assert len(ac) == 0
+
+    # load our configuration
+    assert ac.add(configs=str(cfg04)) is True
+
+    # verify it loaded
+    assert len(ac) == 1
+
+    # 3 servers loaded
+    # 1 - from the file read (which is set at mode STRICT
+    # 1 - from the always://
+    # 1 - from the strict:// (due to insecure_imports set)
+    assert len(ac.servers()) == 3
+
+
 def test_apprise_config_matrix_load():
     """
     API: AppriseConfig() matrix initialization
@@ -647,6 +840,71 @@ def test_apprise_config_matrix_load():
 
     # Call it again so we detect our entries already loaded
     __load_matrix()
+
+
+def test_configmatrix_dynamic_importing(tmpdir):
+    """
+    API: Apprise() Config Matrix Importing
+
+    """
+
+    # Make our new path valid
+    suite = tmpdir.mkdir("apprise_config_test_suite")
+    suite.join("__init__.py").write('')
+
+    module_name = 'badconfig'
+
+    # Update our path to point to our new test suite
+    sys.path.insert(0, str(suite))
+
+    # Create a base area to work within
+    base = suite.mkdir(module_name)
+    base.join("__init__.py").write('')
+
+    # Test no app_id
+    base.join('ConfigBadFile1.py').write(
+        """
+class ConfigBadFile1(object):
+    pass""")
+
+    # No class of the same name
+    base.join('ConfigBadFile2.py').write(
+        """
+class BadClassName(object):
+    pass""")
+
+    # Exception thrown
+    base.join('ConfigBadFile3.py').write("""raise ImportError()""")
+
+    # Utilizes a schema:// already occupied (as string)
+    base.join('ConfigGoober.py').write(
+        """
+from apprise.config import ConfigBase
+class ConfigGoober(ConfigBase):
+    # This class tests the fact we have a new class name, but we're
+    # trying to over-ride items previously used
+
+    # The default simple (insecure) protocol (used by ConfigHTTP)
+    protocol = 'http'
+
+    # The default secure protocol (used by ConfigHTTP)
+    secure_protocol = 'https'""")
+
+    # Utilizes a schema:// already occupied (as tuple)
+    base.join('ConfigBugger.py').write("""
+from apprise.config import ConfigBase
+class ConfigBugger(ConfigBase):
+    # This class tests the fact we have a new class name, but we're
+    # trying to over-ride items previously used
+
+    # The default simple (insecure) protocol (used by ConfigHTTP), the other
+    # isn't
+    protocol = ('http', 'bugger-test' )
+
+    # The default secure protocol (used by ConfigHTTP), the other isn't
+    secure_protocol = ('https', 'bugger-tests')""")
+
+    __load_matrix(path=str(base), name=module_name)
 
 
 @mock.patch('os.path.getsize')

--- a/test/test_apprise_config.py
+++ b/test/test_apprise_config.py
@@ -497,7 +497,7 @@ def test_apprise_config_with_apprise_obj(tmpdir):
     NOTIFY_SCHEMA_MAP['good'] = GoodNotification
 
     # Create ourselves a config object
-    ac = AppriseConfig(cache=None)
+    ac = AppriseConfig(cache=False)
 
     # Nothing loaded yet
     assert len(ac) == 0

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -180,19 +180,27 @@ def test_apprise_cli_nux_env(tmpdir):
     # Write a simple text based configuration file
     t = tmpdir.mkdir("apprise-obj").join("apprise")
     buf = """
+    # Import ourselves
+    import {}
+
     taga,tagb=good://localhost
     tagc=good://nuxref.com
-    """
+    """.format(str(t))
     t.write(buf)
 
     # This will read our configuration and not send any notices at all
     # because we assigned tags to all of our urls and didn't identify
     # a specific match below.
+
+    # Import would have imported the file a second time (since recursion
+    # default is 1).
     result = runner.invoke(cli.main, [
         '-b', 'test config',
         '--config', str(t),
     ])
-    assert result.exit_code == 2
+    # Even when recursion take place, tags are all honored
+    # so 2 is returned because nothing was notified
+    assert result.exit_code == 3
 
     # This will send out 1 notification because our tag matches
     # one of the entries above
@@ -201,6 +209,48 @@ def test_apprise_cli_nux_env(tmpdir):
         '-b', 'has taga',
         '--config', str(t),
         '--tag', 'taga',
+    ])
+    assert result.exit_code == 0
+
+    # Test recursion
+    result = runner.invoke(cli.main, [
+        '-t', 'test title',
+        '-b', 'test body',
+        '--config', str(t),
+        '--tag', 'tagc',
+        # Invalid entry specified for recursion
+        '-R', 'invalid',
+    ])
+    assert result.exit_code == 2
+
+    result = runner.invoke(cli.main, [
+        '-t', 'test title',
+        '-b', 'test body',
+        '--config', str(t),
+        '--tag', 'tagc',
+        # missing entry specified for recursion
+        '--recursive-depth',
+    ])
+    assert result.exit_code == 2
+
+    result = runner.invoke(cli.main, [
+        '-t', 'test title',
+        '-b', 'test body',
+        '--config', str(t),
+        '--tag', 'tagc',
+        # Disable recursion (thus import will be ignored)
+        '-R', '0',
+    ])
+    assert result.exit_code == 0
+
+    # Test recursion
+    result = runner.invoke(cli.main, [
+        '-t', 'test title',
+        '-b', 'test body',
+        '--config', str(t),
+        '--tag', 'tagc',
+        # Recurse up to 5 times
+        '--recursion-depth', '5',
     ])
     assert result.exit_code == 0
 
@@ -252,7 +302,9 @@ def test_apprise_cli_nux_env(tmpdir):
         '--config', str(t),
         '--notification-type', 'invalid',
     ])
-    assert result.exit_code == 1
+    # An error code of 2 is returned if invalid input is specified on the
+    # command line
+    assert result.exit_code == 2
 
     # The notification type switch is case-insensitive
     result = runner.invoke(cli.main, [
@@ -277,7 +329,9 @@ def test_apprise_cli_nux_env(tmpdir):
         '--config', str(t),
         '--input-format', 'invalid',
     ])
-    assert result.exit_code == 1
+    # An error code of 2 is returned if invalid input is specified on the
+    # command line
+    assert result.exit_code == 2
 
     # The formatting switch is not case sensitive
     result = runner.invoke(cli.main, [
@@ -309,7 +363,7 @@ def test_apprise_cli_nux_env(tmpdir):
         '--config', str(t),
         '--tag', 'mytag',
     ])
-    assert result.exit_code == 2
+    assert result.exit_code == 3
 
     # Same command as the one identified above except we set the --dry-run
     # flag. This causes our list of matched results to be printed only.
@@ -321,7 +375,7 @@ def test_apprise_cli_nux_env(tmpdir):
         '--tag', 'mytag',
         '--dry-run'
     ])
-    assert result.exit_code == 2
+    assert result.exit_code == 3
 
     # Here is a case where we get what was expected; we also attach a file
     result = runner.invoke(cli.main, [

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -180,8 +180,8 @@ def test_apprise_cli_nux_env(tmpdir):
     # Write a simple text based configuration file
     t = tmpdir.mkdir("apprise-obj").join("apprise")
     buf = """
-    # Import ourselves
-    import {}
+    # Include ourselves
+    include {}
 
     taga,tagb=good://localhost
     tagc=good://nuxref.com
@@ -192,8 +192,8 @@ def test_apprise_cli_nux_env(tmpdir):
     # because we assigned tags to all of our urls and didn't identify
     # a specific match below.
 
-    # Import would have imported the file a second time (since recursion
-    # default is 1).
+    # 'include' reference in configuration file would have included the file a
+    # second time (since recursion default is 1).
     result = runner.invoke(cli.main, [
         '-b', 'test config',
         '--config', str(t),
@@ -238,7 +238,7 @@ def test_apprise_cli_nux_env(tmpdir):
         '-b', 'test body',
         '--config', str(t),
         '--tag', 'tagc',
-        # Disable recursion (thus import will be ignored)
+        # Disable recursion (thus inclusion will be ignored)
         '-R', '0',
     ])
     assert result.exit_code == 0

--- a/test/test_config_base.py
+++ b/test/test_config_base.py
@@ -165,7 +165,7 @@ def test_config_base_config_parse():
     # with it
     assert len(result[0][0].tags) == 0
 
-    # The second is the number of configuration import lines parsed
+    # The second is the number of configuration include lines parsed
     assert len(result[1]) == 0
 
     # Valid Configuration
@@ -245,11 +245,11 @@ def test_config_base_config_parse_text():
     # A line with mulitiple tag assignments to it
     taga,tagb=kde://
 
-    # An import statement to Apprise API with trailing spaces:
-    import http://localhost:8080/notify/apprise
+    # An include statement to Apprise API with trailing spaces:
+    include http://localhost:8080/notify/apprise
 
-    # A relative import statement (with trailing spaces)
-    import apprise.cfg     """, asset=AppriseAsset())
+    # A relative include statement (with trailing spaces)
+    include apprise.cfg     """, asset=AppriseAsset())
 
     # We expect to parse 3 entries from the above
     assert isinstance(result, list)
@@ -285,7 +285,7 @@ def test_config_base_config_parse_text():
     assert isinstance(result, list)
     assert len(result) == 0
 
-    # There were no import entries defined
+    # There were no include entries defined
     assert len(config) == 0
 
     # More invalid data
@@ -303,14 +303,14 @@ def test_config_base_config_parse_text():
     sns://T1JJ3T3L2/
 
     # Even with the above invalid entries, we can still
-    # have valid import lines
-    import file:///etc/apprise.cfg
+    # have valid include lines
+    include file:///etc/apprise.cfg
 
-    # An invalid import (nothing specified afterwards)
-    import
+    # An invalid include (nothing specified afterwards)
+    include
 
-    # An import of a config type we don't support
-    import invalid://
+    # An include of a config type we don't support
+    include invalid://
     """)
 
     # We expect to parse 0 entries from the above
@@ -326,7 +326,7 @@ def test_config_base_config_parse_text():
     assert isinstance(result, list)
     assert len(result) == 0
 
-    # There were no import entries defined
+    # There were no include entries defined
     assert len(config) == 0
 
 
@@ -357,7 +357,7 @@ def test_config_base_config_parse_yaml():
     assert isinstance(result, list)
     assert len(result) == 0
 
-    # There were no import entries defined
+    # There were no include entries defined
     assert len(config) == 0
 
     # Invalid Syntax (throws a ScannerError)
@@ -372,7 +372,7 @@ urls
     assert isinstance(result, list)
     assert len(result) == 0
 
-    # There were no import entries defined
+    # There were no include entries defined
     assert len(config) == 0
 
     # Missing url token
@@ -386,7 +386,7 @@ version: 1
     assert isinstance(result, list)
     assert len(result) == 0
 
-    # There were no import entries defined
+    # There were no include entries defined
     assert len(config) == 0
 
     # No urls defined
@@ -401,7 +401,7 @@ urls:
     assert isinstance(result, list)
     assert len(result) == 0
 
-    # There were no import entries defined
+    # There were no include entries defined
     assert len(config) == 0
 
     # Invalid url defined
@@ -417,7 +417,7 @@ urls: 43
     assert isinstance(result, list)
     assert len(result) == 0
 
-    # There were no import entries defined
+    # There were no include entries defined
     assert len(config) == 0
 
     # Invalid url/schema
@@ -434,7 +434,7 @@ urls:
     assert isinstance(result, list)
     assert len(result) == 0
 
-    # There were no import entries defined
+    # There were no include entries defined
     assert len(config) == 0
 
     # Invalid url/schema
@@ -452,13 +452,13 @@ urls:
     assert isinstance(result, list)
     assert len(result) == 0
 
-    # There were no import entries defined
+    # There were no include entries defined
     assert len(config) == 0
 
     # Invalid url/schema
     result, config = ConfigBase.config_parse_yaml("""
-# Import entry with nothing associated with it
-import:
+# Include entry with nothing associated with it
+include:
 
 urls:
   - just some free text that isn't valid:
@@ -470,7 +470,7 @@ urls:
     assert isinstance(result, list)
     assert len(result) == 0
 
-    # There were no import entries defined
+    # There were no include entries defined
     assert len(config) == 0
 
     # Invalid url/schema
@@ -487,7 +487,7 @@ urls:
     assert isinstance(result, list)
     assert len(result) == 0
 
-    # There were no import entries defined
+    # There were no include entries defined
     assert len(config) == 0
 
     # Invalid url/schema
@@ -495,8 +495,8 @@ urls:
 # no lists... just no
 urls: [milk, pumpkin pie, eggs, juice]
 
-# Importing by list is okay
-import: [file:///absolute/path/, relative/path, http://test.com]
+# Including by list is okay
+include: [file:///absolute/path/, relative/path, http://test.com]
 
 """, asset=asset)
 
@@ -504,7 +504,7 @@ import: [file:///absolute/path/, relative/path, http://test.com]
     assert isinstance(result, list)
     assert len(result) == 0
 
-    # There were 3 import entries
+    # There were 3 include entries
     assert len(config) == 3
     assert 'file:///absolute/path/' in config
     assert 'relative/path' in config
@@ -531,7 +531,7 @@ urls:
     assert isinstance(result, list)
     assert len(result) == 0
 
-    # There were no import entries defined
+    # There were no include entries defined
     assert len(config) == 0
 
     # Valid Configuration
@@ -539,12 +539,12 @@ urls:
 # if no version is specified then version 1 is presumed
 version: 1
 
-# Importing by dict
-import:
-  # File imports
+# Including by dict
+include:
+  # File includes
   - file:///absolute/path/
   - relative/path
-  # Trailing colon shouldn't disrupt import
+  # Trailing colon shouldn't disrupt include
   - http://test.com:
 
   # invalid (numeric)
@@ -571,7 +571,7 @@ urls:
     assert len(result) == 3
     assert len(result[0].tags) == 0
 
-    # There were 3 import entries
+    # There were 3 include entries
     assert len(config) == 3
     assert 'file:///absolute/path/' in config
     assert 'relative/path' in config
@@ -579,8 +579,8 @@ urls:
 
     # Valid Configuration
     result, config = ConfigBase.config_parse_yaml("""
-# A single line import is supported
-import: http://localhost:8080/notify/apprise
+# A single line include is supported
+include: http://localhost:8080/notify/apprise
 
 urls:
   - json://localhost:
@@ -615,7 +615,7 @@ urls:
     assert len(result) == 5
     assert len(result[0].tags) == 2
 
-    # Our single line import
+    # Our single line included
     assert len(config) == 1
     assert 'http://localhost:8080/notify/apprise' in config
 
@@ -635,7 +635,7 @@ urls:
     assert isinstance(result, list)
     assert len(result) == 2
 
-    # There were no import entries defined
+    # There were no include entries defined
     assert len(config) == 0
 
     # all entries will have our global tags defined in them
@@ -677,7 +677,7 @@ urls:
     assert len(result[1].tags) == 4
     assert 'list-tag' in result[1].tags
 
-    # There were no import entries defined
+    # There were no include entries defined
     assert len(config) == 0
 
     # An invalid set of entries
@@ -694,7 +694,7 @@ urls:
     assert isinstance(result, list)
     assert len(result) == 0
 
-    # There were no import entries defined
+    # There were no include entries defined
     assert len(config) == 0
 
     # An asset we'll manipulate
@@ -735,7 +735,7 @@ urls:
     assert isinstance(result, list)
     assert len(result) == 1
 
-    # There were no import entries defined
+    # There were no include entries defined
     assert len(config) == 0
 
     assert asset.app_id == "AppriseTest"
@@ -841,5 +841,5 @@ urls:
     assert 'customer' in result[5].tags
     assert 'chris' in result[5].tags
 
-    # There were no import entries defined
+    # There were no include entries defined
     assert len(config) == 0

--- a/test/test_config_base.py
+++ b/test/test_config_base.py
@@ -248,7 +248,7 @@ def test_config_base_config_parse_text():
     taga,tagb=kde://
 
     # An import statement to Apprise API with trailing spaces:
-    import http://localhost:8080/notify/apprise   
+    import http://localhost:8080/notify/apprise
 
     # A relative import statement (with trailing spaces)
     import apprise.cfg     """, asset=AppriseAsset())
@@ -264,7 +264,6 @@ def test_config_base_config_parse_text():
     assert 'taga' in result[-1].tags
     assert 'tagb' in result[-1].tags
 
-    # There are two import lines
     assert len(config) == 2
     assert 'http://localhost:8080/notify/apprise' in config
     assert 'apprise.cfg' in config
@@ -460,6 +459,9 @@ urls:
 
     # Invalid url/schema
     result, config = ConfigBase.config_parse_yaml("""
+# Import entry with nothing associated with it
+import:
+
 urls:
   - just some free text that isn't valid:
     - a garbage entry to go with it
@@ -495,14 +497,20 @@ urls:
 # no lists... just no
 urls: [milk, pumpkin pie, eggs, juice]
 
+# Importing by list is okay
+import: [file:///absolute/path/, relative/path, http://test.com]
+
 """, asset=asset)
 
     # Invalid data gets us an empty result set
     assert isinstance(result, list)
     assert len(result) == 0
 
-    # There were no import entries defined
-    assert len(config) == 0
+    # There were 3 import entries
+    assert len(config) == 3
+    assert 'file:///absolute/path/' in config
+    assert 'relative/path' in config
+    assert 'http://test.com' in config
 
     # Invalid url/schema
     result, config = ConfigBase.config_parse_yaml("""
@@ -533,6 +541,14 @@ urls:
 # if no version is specified then version 1 is presumed
 version: 1
 
+# Importing by dict
+import:
+  # File imports
+  - file:///absolute/path/
+  - relative/path
+  # Trailing colon shouldn't disrupt import
+  - http://test.com:
+
 #
 # Define your notification urls:
 #
@@ -549,11 +565,17 @@ urls:
     assert len(result) == 3
     assert len(result[0].tags) == 0
 
-    # There were no import entries defined
-    assert len(config) == 0
+    # There were 3 import entries
+    assert len(config) == 3
+    assert 'file:///absolute/path/' in config
+    assert 'relative/path' in config
+    assert 'http://test.com' in config
 
     # Valid Configuration
     result, config = ConfigBase.config_parse_yaml("""
+# A single line import is supported
+import: http://localhost:8080/notify/apprise
+
 urls:
   - json://localhost:
     - tag: my-custom-tag, my-other-tag
@@ -587,8 +609,9 @@ urls:
     assert len(result) == 5
     assert len(result[0].tags) == 2
 
-    # There were no import entries defined
-    assert len(config) == 0
+    # Our single line import
+    assert len(config) == 1
+    assert 'http://localhost:8080/notify/apprise' in config
 
     # Global Tags
     result, config = ConfigBase.config_parse_yaml("""

--- a/test/test_config_base.py
+++ b/test/test_config_base.py
@@ -143,10 +143,22 @@ def test_config_base_config_parse():
     """
 
     # Garbage Handling
-    assert isinstance(ConfigBase.config_parse(object()), list)
-    assert isinstance(ConfigBase.config_parse(None), list)
-    assert isinstance(ConfigBase.config_parse(''), list)
-    assert isinstance(ConfigBase.config_parse(12), list)
+    result = ConfigBase.config_parse(object())
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    assert result == (list(), list())
+    result = ConfigBase.config_parse(None)
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    assert result == (list(), list())
+    result = ConfigBase.config_parse('')
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    assert result == (list(), list())
+    result = ConfigBase.config_parse(12)
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    assert result == (list(), list())
 
     # Valid Text Configuration
     result = ConfigBase.config_parse("""
@@ -154,9 +166,16 @@ def test_config_base_config_parse():
     mailto://userb:pass@gmail.com
     """, asset=AppriseAsset())
     # We expect to parse 1 entry from the above
-    assert isinstance(result, list)
-    assert len(result) == 1
-    assert len(result[0].tags) == 0
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    # The first element is the number of notification services processed
+    assert len(result[0]) == 1
+    # If we index into the item, we can check to see the tags associate
+    # with it
+    assert len(result[0][0].tags) == 0
+
+    # The second is the number of configuration import lines parsed
+    assert len(result[1]) == 0
 
     # Valid Configuration
     result = ConfigBase.config_parse("""
@@ -174,11 +193,13 @@ urls:
     """, asset=AppriseAsset())
 
     # We expect to parse 3 entries from the above
-    assert isinstance(result, list)
-    assert len(result) == 3
-    assert len(result[0].tags) == 0
-    assert len(result[1].tags) == 0
-    assert len(result[2].tags) == 2
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    assert isinstance(result[0], list)
+    assert len(result[0]) == 3
+    assert len(result[0][0].tags) == 0
+    assert len(result[0][1].tags) == 0
+    assert len(result[0][2].tags) == 2
 
     # Test case where we pass in a bad format
     result = ConfigBase.config_parse("""
@@ -187,10 +208,11 @@ urls:
     """, config_format='invalid-format')
 
     # This is not parseable despite the valid text
-    assert isinstance(result, list)
-    assert len(result) == 0
+    assert isinstance(result, tuple)
+    assert isinstance(result[0], list)
+    assert len(result[0]) == 0
 
-    result = ConfigBase.config_parse("""
+    result, _ = ConfigBase.config_parse("""
     ; A comment line over top of a URL
     mailto://userb:pass@gmail.com
     """, config_format=ConfigFormat.TEXT)
@@ -210,6 +232,7 @@ def test_config_base_config_parse_text():
     assert isinstance(ConfigBase.config_parse_text(object()), list)
     assert isinstance(ConfigBase.config_parse_text(None), list)
     assert isinstance(ConfigBase.config_parse_text(''), list)
+    assert isinstance(ConfigBase.config_parse_text(12), list)
 
     # Valid Configuration
     result = ConfigBase.config_parse_text("""


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #226

The ability to include more Apprise configuration from within another configuration file.
## Feature Checklist
* [x] `include` keyword added to `TEXT` based configuration files.
   ```php
   include http://localhost/path/to/more/configuration/entries
   # No limit to the number of includes you specify
   include file:///path/to/another/configuration/file/on/your/system
   ```
* `include` keyword added to `YAML` based configuration files supporting the following syntaxes:
   * [x] Single entry:
      ```yaml
      include: http://localhost:8080/notify/apprise
      ```
   * [x] Bullet form:
      ```yaml
      include:
         - http://localhost/path/to/more/configuration/entries
         - file:///path/to/another/configuration/file/on/your/system
      ```
   * [x] List form:
      ```yaml
      include: [ http://localhost, file:///path ]
      ```
* [x] The `include` statements are only parsed if a flag entitled `recursion` is set when calling _AppriseConfig()_.  By default `recursion` is set to `None` (_making it disabled and thus ignoring `include` statements_).  Setting this to a positive integer dictates the depth of how deep you will support the `include` statement.  Having it just set to `1` willl enable it to work in all of the configuration files it reads.  However if these included configuration files also have a `include` statement, they won't be further read.  Setting the `recursion` to a higher value will keep processing the `include` statements recursively found in subsequent configuration files (already included).
* [x] The `apprise` CLI tool automatically has recursion enabled and set at `1` (one) which is configurable using the `--recursion-depth=<value>`  (`-R <value>`) switch.

:lock: **Security**
* [x] Relative paths specified in `file://` based configurations will include relative to the configuration file it was read from.
* [x]  It will not be possible to include `file://` based configuration if the request to do so came from a non-`file://` based one (such as `http://`).  Only a `file://` based configuration can include another `file://` based one. 
* [x] `memory://` based configurations can't include `file://` based either on it's own.  However developers can set `insecure_includes=True` when calling `Apprise.add_config()` to over-ride this.

## Mandatory Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
