### PR TITLE
Apprise configuration bulletproofing

### DIFF
--- a/apprise/AppriseConfig.py
+++ b/apprise/AppriseConfig.py
@@ -27,6 +27,7 @@ import six
 
 from . import config
 from . import ConfigBase
+from . import CONFIG_FORMATS
 from . import URLBase
 from .AppriseAsset import AppriseAsset
 
@@ -252,7 +253,12 @@ class AppriseConfig(object):
         # Create ourselves a ConfigMemory Object to store our configuration
         instance = config.ConfigMemory(
             content=content, format=format, asset=asset, tag=tag,
-            recursion=self.recursion, insecure_includes=insecure_includes)
+            recursion=recursion, insecure_includes=insecure_includes)
+
+        if instance.config_format not in CONFIG_FORMATS:
+            logger.warning(
+                "The format of the configuration could not be deteced.")
+            return False
 
         # Add our initialized plugin to our server listings
         self.configs.append(instance)

--- a/test/test_apprise_config.py
+++ b/test/test_apprise_config.py
@@ -29,6 +29,7 @@ import io
 import mock
 import pytest
 from apprise import NotifyFormat
+from apprise import ConfigFormat
 from apprise import ConfigIncludeMode
 from apprise.Apprise import Apprise
 from apprise.AppriseConfig import AppriseConfig
@@ -304,10 +305,11 @@ def test_apprise_add_config():
     """
     # Create ourselves a config object
     ac = AppriseConfig()
-    assert ac.add_config(content=content)
+    assert ac.add_config(content=content) is True
 
     # One configuration file should have been found
     assert len(ac) == 1
+    assert ac[0].config_format is ConfigFormat.TEXT
 
     # Object can be directly checked as a boolean; response is True
     # when there is at least one entry
@@ -336,6 +338,39 @@ def test_apprise_add_config():
 
     # and 6 urls.. (as we've doubled up)
     assert len(ac.servers()) == 6
+
+    content = """
+    # A YAML File
+    urls:
+       - mailto://usera:pass@gmail.com
+       - gnome://:
+          tag: taga,tagb
+    """
+
+    # Create ourselves a config object
+    ac = AppriseConfig()
+    assert ac.add_config(content=content) is True
+
+    # One configuration file should have been found
+    assert len(ac) == 1
+    assert ac[0].config_format is ConfigFormat.YAML
+
+    # Object can be directly checked as a boolean; response is True
+    # when there is at least one entry
+    assert ac
+
+    # We should be able to read our 2 servers from that
+    assert len(ac.servers()) == 2
+
+    # Now an invalid configuration file
+    content = "invalid"
+
+    # Create ourselves a config object
+    ac = AppriseConfig()
+    assert ac.add_config(content=content) is False
+
+    # Nothing is loaded
+    assert len(ac.servers()) == 0
 
 
 def test_apprise_config_tagging(tmpdir):


### PR DESCRIPTION
## Description
Just some bulletproofing and small bugfixes applied that were detected while working on the [Apprise API auto-detect configuration feature](https://github.com/caronc/apprise-api/pull/18).
- if the configuration format can't be detected; don't return an _okay_ status.
- when calling `add_config()` and a `recursion` value is specified; use it.  This fixes a bug where the value was being ignored.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage