### PR TITLE
Honor deprecated content by removing it and accompanied warnings

### DIFF
--- a/apprise/plugins/NotifyDiscord.py
+++ b/apprise/plugins/NotifyDiscord.py
@@ -469,20 +469,9 @@ class NotifyDiscord(NotifyBase):
         # Update Avatar Icon
         results['avatar'] = parse_bool(results['qsd'].get('avatar', True))
 
-        # Use Thumbnail
-        if 'thumbnail' in results['qsd']:
-            # Deprication Notice issued for v0.7.5
-            NotifyDiscord.logger.deprecate(
-                'The Discord URL contains the parameter '
-                '"thumbnail=" which will be deprecated in an upcoming '
-                'release. Please use "image=" instead.'
-            )
-
-        # use image= for consistency with the other plugins but we also
-        # support thumbnail= for backwards compatibility.
-        results['include_image'] = \
-            parse_bool(results['qsd'].get(
-                'image', results['qsd'].get('thumbnail', False)))
+        # Boolean to include an image or not
+        results['include_image'] = parse_bool(results['qsd'].get(
+            'image', NotifyDiscord.template_args['image']['default']))
 
         # Extract avatar url if it was specified
         if 'avatar_url' in results['qsd']:

--- a/apprise/plugins/NotifyMatrix.py
+++ b/apprise/plugins/NotifyMatrix.py
@@ -1069,34 +1069,12 @@ class NotifyMatrix(NotifyBase):
         if 'to' in results['qsd'] and len(results['qsd']['to']):
             results['targets'] += NotifyMatrix.parse_list(results['qsd']['to'])
 
-        # Thumbnail (old way)
-        if 'thumbnail' in results['qsd']:
-            # Deprication Notice issued for v0.7.5
-            NotifyMatrix.logger.deprecate(
-                'The Matrix URL contains the parameter '
-                '"thumbnail=" which will be deprecated in an upcoming '
-                'release. Please use "image=" instead.'
-            )
+        # Boolean to include an image or not
+        results['include_image'] = parse_bool(results['qsd'].get(
+            'image', NotifyMatrix.template_args['image']['default']))
 
-        # use image= for consistency with the other plugins but we also
-        # support thumbnail= for backwards compatibility.
-        results['include_image'] = \
-            parse_bool(results['qsd'].get(
-                'image', results['qsd'].get('thumbnail', False)))
-
-        # Webhook (old way)
-        if 'webhook' in results['qsd']:
-            # Deprication Notice issued for v0.7.5
-            NotifyMatrix.logger.deprecate(
-                'The Matrix URL contains the parameter '
-                '"webhook=" which will be deprecated in an upcoming '
-                'release. Please use "mode=" instead.'
-            )
-
-        # use mode= for consistency with the other plugins but we also
-        # support webhook= for backwards compatibility.
-        results['mode'] = results['qsd'].get(
-            'mode', results['qsd'].get('webhook'))
+        # Get our mode
+        results['mode'] = results['qsd'].get('mode')
 
         # t2bot detection... look for just a hostname, and/or just a user/host
         # if we match this; we can go ahead and set the mode (but only if

--- a/apprise/plugins/NotifyPushjet.py
+++ b/apprise/plugins/NotifyPushjet.py
@@ -60,10 +60,6 @@ class NotifyPushjet(NotifyBase):
         '{schema}://{host}/{secret_key}',
         '{schema}://{user}:{password}@{host}:{port}/{secret_key}',
         '{schema}://{user}:{password}@{host}/{secret_key}',
-
-        # Kept for backwards compatibility; will be depricated eventually
-        '{schema}://{secret_key}@{host}',
-        '{schema}://{secret_key}@{host}:{port}',
     )
 
     # Define our tokens
@@ -244,13 +240,6 @@ class NotifyPushjet(NotifyBase):
            pjets://hostname:port/secret_key
            pjets://user:pass@hostname/secret_key
            pjets://user:pass@hostname:port/secret_key
-
-        Legacy (Depricated) Syntax:
-           pjet://secret_key@hostname
-           pjet://secret_key@hostname:port
-           pjets://secret_key@hostname
-           pjets://secret_key@hostname:port
-
         """
         results = NotifyBase.parse_url(url)
         if not results:
@@ -272,23 +261,5 @@ class NotifyPushjet(NotifyBase):
         if 'secret' in results['qsd'] and len(results['qsd']['secret']):
             results['secret_key'] = \
                 NotifyPushjet.unquote(results['qsd']['secret'])
-
-        if results.get('secret_key') is None:
-            # Deprication Notice issued for v0.7.9
-            NotifyPushjet.logger.deprecate(
-                'The Pushjet URL contains secret_key in the user field'
-                ' which will be deprecated in an upcoming '
-                'release. Please place this in the path of the URL instead.'
-            )
-
-            # Store it as it's value based on the user field
-            results['secret_key'] = \
-                NotifyPushjet.unquote(results.get('user'))
-
-            # there is no way http-auth is enabled, be sure to unset the
-            # current defined user (if present). This is done due to some
-            # logic that takes place in the send() since we support http-auth.
-            results['user'] = None
-            results['password'] = None
 
         return results

--- a/apprise/plugins/NotifyRyver.py
+++ b/apprise/plugins/NotifyRyver.py
@@ -323,19 +323,8 @@ class NotifyRyver(NotifyBase):
             # no token
             results['token'] = None
 
-        if 'webhook' in results['qsd']:
-            # Deprication Notice issued for v0.7.5
-            NotifyRyver.logger.deprecate(
-                'The Ryver URL contains the parameter '
-                '"webhook=" which will be deprecated in an upcoming '
-                'release. Please use "mode=" instead.'
-            )
-
-        # use mode= for consistency with the other plugins but we also
-        # support webhook= for backwards compatibility.
-        results['mode'] = results['qsd'].get(
-            'mode', results['qsd'].get(
-                'webhook', RyverWebhookMode.RYVER))
+        # Retrieve the mode
+        results['mode'] = results['qsd'].get('mode', RyverWebhookMode.RYVER)
 
         # use image= for consistency with the other plugins
         results['include_image'] = \

--- a/apprise/plugins/NotifyTwitter.py
+++ b/apprise/plugins/NotifyTwitter.py
@@ -73,9 +73,8 @@ class NotifyTwitter(NotifyBase):
     # The services URL
     service_url = 'https://twitter.com/'
 
-    # The default secure protocol is twitter.  'tweet' is left behind
-    # for backwards compatibility of older apprise usage
-    secure_protocol = ('twitter', 'tweet')
+    # The default secure protocol is twitter.
+    secure_protocol = 'twitter'
 
     # A URL that takes you to the setup/help of the specific protocol
     setup_url = 'https://github.com/caronc/apprise/wiki/Notify_twitter'
@@ -593,7 +592,7 @@ class NotifyTwitter(NotifyBase):
 
         return '{schema}://{ckey}/{csecret}/{akey}/{asecret}' \
             '/{targets}/?{params}'.format(
-                schema=self.secure_protocol[0],
+                schema=self.secure_protocol,
                 ckey=self.pprint(self.ckey, privacy, safe=''),
                 csecret=self.pprint(
                     self.csecret, privacy, mode=PrivacyMode.Secret, safe=''),
@@ -662,10 +661,5 @@ class NotifyTwitter(NotifyBase):
         if 'to' in results['qsd'] and len(results['qsd']['to']):
             results['targets'] += \
                 NotifyTwitter.parse_list(results['qsd']['to'])
-
-        if results.get('schema', 'twitter').lower() == 'tweet':
-            # Deprication Notice issued for v0.7.9
-            NotifyTwitter.logger.deprecate(
-                'tweet:// has been replaced by twitter://')
 
         return results

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -281,25 +281,7 @@ TEST_URLS = (
         'instance': plugins.NotifyDiscord,
         'requests_response_code': requests.codes.no_content,
     }),
-
-    # Enable other options
-
-    # DEPRICATED reference to Thumbnail
-    ('discord://%s/%s?format=markdown&footer=Yes&thumbnail=Yes' % (
-        'i' * 24, 't' * 64), {
-            'instance': plugins.NotifyDiscord,
-            'requests_response_code': requests.codes.no_content,
-
-            # Our expected url(privacy=True) startswith() response:
-            'privacy_url': 'discord://i...i/t...t/',
-    }),
-    ('discord://%s/%s?format=markdown&footer=Yes&thumbnail=No' % (
-        'i' * 24, 't' * 64), {
-            'instance': plugins.NotifyDiscord,
-            'requests_response_code': requests.codes.no_content,
-    }),
-
-    # thumbnail= is depricated and image= is the proper entry
+    # test image= field
     ('discord://%s/%s?format=markdown&footer=Yes&image=Yes' % (
         'i' * 24, 't' * 64), {
             'instance': plugins.NotifyDiscord,
@@ -1549,20 +1531,6 @@ TEST_URLS = (
         # user and token correctly specified with webhook
         'instance': plugins.NotifyMatrix,
     }),
-    # Legacy (depricated) webhook reference
-    ('matrix://user:token@localhost?webhook=matrix&format=text', {
-        # user and token correctly specified with webhook
-        'instance': plugins.NotifyMatrix,
-        'response': False,
-    }),
-    ('matrix://user:token@localhost?webhook=matrix&format=html', {
-        # user and token correctly specified with webhook
-        'instance': plugins.NotifyMatrix,
-    }),
-    ('matrix://user:token@localhost?webhook=slack&format=text', {
-        # user and token correctly specified with webhook
-        'instance': plugins.NotifyMatrix,
-    }),
     ('matrixs://user:token@localhost?mode=SLACK&format=markdown', {
         # user and token specified; slack webhook still detected
         # despite uppercase characters
@@ -1595,15 +1563,6 @@ TEST_URLS = (
     }),
     # Test Native URL
     ('https://webhooks.t2bot.io/api/v1/matrix/hook/{}/'.format('d' * 64), {
-        # user and token specified; image set to True
-        'instance': plugins.NotifyMatrix,
-    }),
-    # Legacy (Depricated) image reference
-    ('matrixs://user:token@localhost?mode=slack&thumbnail=False', {
-        # user and token specified; image set to True
-        'instance': plugins.NotifyMatrix,
-    }),
-    ('matrixs://user:token@localhost?mode=slack&thumbnail=True', {
         # user and token specified; image set to True
         'instance': plugins.NotifyMatrix,
     }),
@@ -2767,10 +2726,6 @@ TEST_URLS = (
     ('pjet://%s' % ('a' * 32), {
         'instance': TypeError,
     }),
-    # Legacy method of logging in (soon to be depricated)
-    ('pjet://%s@localhost' % ('a' * 32), {
-        'instance': plugins.NotifyPushjet,
-    }),
     # The proper way to log in
     ('pjet://user:pass@localhost/%s' % ('a' * 32), {
         'instance': plugins.NotifyPushjet,
@@ -2785,12 +2740,6 @@ TEST_URLS = (
 
         # Our expected url(privacy=True) startswith() response:
         'privacy_url': 'pjet://user:****@localhost',
-    }),
-    # Specify your own server with login (no secret = fail normally)
-    # however this will work since we're providing depricated support
-    # at this time so the 'user' get's picked up as being the secret_key
-    ('pjet://user:pass@localhost', {
-        'instance': plugins.NotifyPushjet,
     }),
     # Specify your own server with port
     ('pjets://localhost:8080/%s' % ('a' * 32), {
@@ -3133,8 +3082,8 @@ TEST_URLS = (
         # Just org provided (no token)
         'instance': TypeError,
     }),
-    ('ryver://apprise/ckhrjW8w672m6HG?webhook=invalid', {
-        # Invalid webhook provided
+    ('ryver://apprise/ckhrjW8w672m6HG?mode=invalid', {
+        # invalid mode provided
         'instance': TypeError,
     }),
     ('ryver://x/ckhrjW8w672m6HG?mode=slack', {
@@ -4090,12 +4039,6 @@ TEST_URLS = (
     }),
     ('twitter://ckey/csecret/access_token/access_secret?mode=tweet', {
         # A Public Tweet
-        'instance': plugins.NotifyTwitter,
-    }),
-    ('tweet://consumer_key/consumer_secret/access_token/access_secret', {
-        # tweet:// is to be depricated; but we will support for purposes of
-        # generating a warning to the user; the above matches an above
-        # twitter:// reference so that it can use what was cached
         'instance': plugins.NotifyTwitter,
     }),
     ('twitter://user@ckey/csecret/access_token/access_secret?mode=invalid', {

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -293,8 +293,11 @@ TEST_URLS = (
         'i' * 24, 't' * 64), {
             'instance': plugins.NotifyDiscord,
             'requests_response_code': requests.codes.no_content,
-            # don't include an image by default
-            'include_image': True,
+    }),
+    ('discord://%s/%s?format=markdown&footer=Yes&image=Yes' % (
+        'i' * 24, 't' * 64), {
+            'instance': plugins.NotifyDiscord,
+            'requests_response_code': requests.codes.no_content,
     }),
     ('https://discord.com/api/webhooks/{}/{}'.format(
         '0' * 10, 'B' * 40), {

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -28,6 +28,7 @@ import pytest
 import mock
 import requests
 from json import dumps
+from apprise import Apprise
 from apprise import AppriseAttachment
 from apprise import AppriseAsset
 from apprise import NotifyType
@@ -279,3 +280,10 @@ def test_notify_telegram_plugin(mock_post, mock_get):
     assert len(obj.targets) == 0
     assert obj.notify(title='hello', body='world') is False
     assert len(obj.targets) == 0
+
+    # Test Telegram Group
+    obj = Apprise.instantiate(
+        'tgram://123456789:ABCdefghijkl123456789opqyz/-123456789525')
+    assert isinstance(obj, plugins.NotifyTelegram)
+    assert len(obj.targets) == 1
+    assert '-123456789525' in obj.targets


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** n/a

Just some code clean up; there have been deprecation warnings that date back more than a year now:
- **Twitter**: `tweet://` is not an accepted schema to initialize it with.
  - _Deprecation warning since Jun 29th, 2019 (14 months)_
- **Discord**: `thumbnail=` was switched to `image=` for consistency with other plugins
  - _Deprecation warning since April 5th, 2019 (17 months)_
- **Matrix**: There were 2 deprecations cleaned up here:
    1. Determining the type of webhook mode used is identified by `mode=` not `webhook=`; this was done for consistency with other plugins.
      - _Deprecation warning since April 5th, 2019 (17 months)_
    1.  `thumbnail=` was switched to `image=` for consistency with other plugins
      - _Deprecation warning since April 5th, 2019 (17 months)_
- **Pushjet**: `secret_key@hostame` is no longer accepted. The syntax is hostname/secret_key.  This was to remove conflicting cases where `user:pass@hostname/secret_key` was used.
  - _Deprecation warning since Sept 7th, 2019 (12 months)_
- **Ryver**: Determining the type of webhook mode used is identified by `mode=` not `webhook=`; this was done for consistency with other plugins.
      - _Deprecation warning since April 5th, 2019 (17 months)_

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
