### PR TITLE
YAML extended configuration support for 'include' keyword

### DIFF
--- a/apprise/config/ConfigBase.py
+++ b/apprise/config/ConfigBase.py
@@ -38,6 +38,7 @@ from ..common import ConfigIncludeMode
 from ..utils import GET_SCHEMA_RE
 from ..utils import parse_list
 from ..utils import parse_bool
+from ..utils import parse_urls
 from . import SCHEMA_MAP
 
 
@@ -704,8 +705,9 @@ class ConfigBase(URLBase):
         #
         includes = result.get('include', None)
         if isinstance(includes, six.string_types):
-            # Support a single inline string
-            includes = list([includes])
+            # Support a single inline string or multiple ones separated by a
+            # comma and/or space
+            includes = parse_urls(includes)
 
         elif not isinstance(includes, (list, tuple)):
             # Not a problem; we simply have no includes
@@ -715,8 +717,9 @@ class ConfigBase(URLBase):
         for no, url in enumerate(includes):
 
             if isinstance(url, six.string_types):
-                # We're just a simple URL string...
-                configs.append(url)
+                # Support a single inline string or multiple ones separated by
+                # a comma and/or space
+                configs.extend(parse_urls(url))
 
             elif isinstance(url, dict):
                 # Store the url and ignore arguments associated

--- a/test/test_config_base.py
+++ b/test/test_config_base.py
@@ -843,3 +843,66 @@ urls:
 
     # There were no include entries defined
     assert len(config) == 0
+
+    # Valid Configuration (multi inline configuration entries)
+    result, config = ConfigBase.config_parse_yaml("""
+# A configuration file that contains 2 includes separated by a comma and/or
+# space:
+include: http://localhost:8080/notify/apprise, http://localhost/apprise/cfg
+
+""", asset=asset)
+
+    # We will have loaded no results
+    assert isinstance(result, list)
+    assert len(result) == 0
+
+    # But our two configuration files will be present:
+    assert len(config) == 2
+    assert 'http://localhost:8080/notify/apprise' in config
+    assert 'http://localhost/apprise/cfg' in config
+
+    # Valid Configuration (another way of specifying more then one include)
+    result, config = ConfigBase.config_parse_yaml("""
+# A configuration file that contains 4 includes on their own
+# lines beneath the keyword `include`:
+include:
+   http://localhost:8080/notify/apprise
+   http://localhost/apprise/cfg01
+   http://localhost/apprise/cfg02
+   http://localhost/apprise/cfg03
+
+""", asset=asset)
+
+    # We will have loaded no results
+    assert isinstance(result, list)
+    assert len(result) == 0
+
+    # But our 4 configuration files will be present:
+    assert len(config) == 4
+    assert 'http://localhost:8080/notify/apprise' in config
+    assert 'http://localhost/apprise/cfg01' in config
+    assert 'http://localhost/apprise/cfg02' in config
+    assert 'http://localhost/apprise/cfg03' in config
+
+    # Valid Configuration (we allow comma separated entries for
+    # each defined bullet)
+    result, config = ConfigBase.config_parse_yaml("""
+# A configuration file that contains 4 includes on their own
+# lines beneath the keyword `include`:
+include:
+   - http://localhost:8080/notify/apprise, http://localhost/apprise/cfg01
+     http://localhost/apprise/cfg02
+   - http://localhost/apprise/cfg03
+
+""", asset=asset)
+
+    # We will have loaded no results
+    assert isinstance(result, list)
+    assert len(result) == 0
+
+    # But our 4 configuration files will be present:
+    assert len(config) == 4
+    assert 'http://localhost:8080/notify/apprise' in config
+    assert 'http://localhost/apprise/cfg01' in config
+    assert 'http://localhost/apprise/cfg02' in config
+    assert 'http://localhost/apprise/cfg03' in config


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #226 

Just adding extended support to allow for comma separated `include` entries for `YAML` files only.  To keep `TEXT` configuration files clean, they should still only have one `include` URL per statement. 

This new Pull Request extends the existing YAML `include` support to additionally allows this:
```yaml
# comma separated
include: http://localhost:8080/notify/apprise, http://localhost/apprise/cfg
```
... and this:
```yaml
# new entry, but not bulleted (which is already supported)
# entries are still honoured and parsed accordingly to avoid end user
# confusion.
include:
   http://localhost:8080/notify/apprise
   http://localhost/apprise/cfg01
   http://localhost/apprise/cfg02
   http://localhost/apprise/cfg03
```
... and finally this too:
```yaml
# a mix of supported bullets and comma separated URLs.  This
# looks unclean for what the intentions are, but there is no need to
# yell at a user to change it when it's still very parse-able.
include:
   - http://localhost:8080/notify/apprise, http://localhost/apprise/cfg01
     http://localhost/apprise/cfg02
   - http://localhost/apprise/cfg03
```

This merge request contains test cases to support the 3 examples above.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
