### PR TITLE
Improved YAML argument parsing

### DIFF
--- a/apprise/config/ConfigBase.py
+++ b/apprise/config/ConfigBase.py
@@ -836,6 +836,17 @@ class ConfigBase(URLBase):
                             # add our results to our global set
                             results.append(r)
 
+                elif isinstance(tokens, dict):
+                    # Copy ourselves a template of our parsed URL as a base to
+                    # work with
+                    r = _results.copy()
+
+                    # add our result set
+                    r.update(tokens)
+
+                    # add our results to our global set
+                    results.append(r)
+
                 else:
                     # add our results to our global set
                     results.append(_results)


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** n/a

Until the this PR, the following code would not correctly register the `tags` being set:
```yaml
# This did not work until this pull request
urls:
  - mailtos://lead2gold:yesqbrulvaelyxve@gmail.com:
    tag: mytag
```

However the following would still work:
```yaml
# This works fine both before and after this PR
urls:
  - mailtos://lead2gold:yesqbrulvaelyxve@gmail.com:
    - tag: mytag
```

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
