### PR TITLE
Devel apprise tool library reference path updated

### DIFF
--- a/bin/apprise
+++ b/bin/apprise
@@ -39,18 +39,18 @@ from os.path import dirname
 # Update path
 #
 
-# First assume we might be in the ./devel directory
+# First assume we might be in the ./bin directory
 sys.path.insert(
-    0, join(dirname(dirname(abspath(__file__))), 'apprise'))  # noqa
+    0, join(dirname(dirname(abspath(__file__)))))  # noqa
 
 # The user might have copied the apprise script back one directory
 # so support this too..
 sys.path.insert(
-    0, join(dirname(abspath(__file__)), 'apprise'))  # noqa
+    0, join(dirname(abspath(__file__))))  # noqa
 
 # We can also use the current directory we're standing in as a last
 # resort
-sys.path.insert(0, join(getcwd(), 'apprise'))  # noqa
+sys.path.insert(0, join(getcwd()))  # noqa
 
 # Apprise tool now importable
 from apprise.cli import main


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** n/a

Just fixing a bug a discovered on my own where my `bin/apprise` tool wasn't actually correctly using the development package as intended.  This has now been fixed and the tool behaves as it should.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
