### PR TITLE
Discord markdown support bulletproofing

### DIFF
--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -289,7 +289,7 @@ TEST_URLS = (
             # don't include an image by default
             'include_image': False,
     }),
-    ('discord://%s/%s?format=markdown&footer=Yes&image=No' % (
+    ('discord://%s/%s?format=markdown&footer=Yes&image=No&fields=no' % (
         'i' * 24, 't' * 64), {
             'instance': plugins.NotifyDiscord,
             'requests_response_code': requests.codes.no_content,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #294 

Enhanced Discord Markdown support significantly
* field mode (supporting # markdown keyword to trigger it) enhanced
* support multi-message if max documented fields (10 detected)
* if content is detected that has no header associated with, content is now correctly sent to Discord server.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
