### PR TITLE
MSTeams/Apprise custom template support

### DIFF
--- a/apprise/plugins/NotifyMSTeams.py
+++ b/apprise/plugins/NotifyMSTeams.py
@@ -215,9 +215,9 @@ class NotifyMSTeams(NotifyBase):
         self.template = AppriseAttachment(asset=self.asset)
         if template:
             # Add our definition to our template
-            if self.template.add(template):
-                # Enforce maximum file size
-                self.template[0].max_file_size = self.max_msteams_template_size
+            self.template.add(template)
+            # Enforce maximum file size
+            self.template[0].max_file_size = self.max_msteams_template_size
 
         # Template functionality
         self.tokens = {}

--- a/apprise/plugins/NotifyMSTeams.py
+++ b/apprise/plugins/NotifyMSTeams.py
@@ -228,8 +228,14 @@ class NotifyMSTeams(NotifyBase):
 
         # Template functionality
         self.tokens = {}
-        if tokens:
+        if isinstance(tokens, dict):
             self.tokens.update(tokens)
+
+        elif tokens:
+            msg = 'The specified MSTeams Template Tokens ' \
+                  '({}) are not identified as a dictionary.'.format(tokens)
+            self.logger.warning(msg)
+            raise TypeError(msg)
 
         return
 
@@ -286,7 +292,8 @@ class NotifyMSTeams(NotifyBase):
         tokens['app_id'] = self.app_id
         tokens['app_desc'] = self.app_desc
         tokens['app_color'] = self.color(notify_type)
-        tokens['app_url'] = image_url
+        tokens['app_image_url'] = image_url
+        tokens['app_url'] = self.app_url
 
         # Enforce Application mode
         tokens['app_mode'] = TemplateType.JSON

--- a/apprise/plugins/NotifyMSTeams.py
+++ b/apprise/plugins/NotifyMSTeams.py
@@ -75,6 +75,13 @@ from ..utils import TemplateType
 from ..AppriseAttachment import AppriseAttachment
 from ..AppriseLocale import gettext_lazy as _
 
+try:
+    from json.decoder import JSONDecodeError
+
+except ImportError:
+    # Python v2.7 Backwards Compatibility support
+    JSONDecodeError = ValueError
+
 # Used to prepare our UUID regex matching
 UUID4_RE = \
     r'[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}'
@@ -294,7 +301,7 @@ class NotifyMSTeams(NotifyBase):
                     template.url(privacy=True)))
             return None
 
-        except json.decoder.JSONDecodeError as e:
+        except JSONDecodeError as e:
             self.logger.error(
                 'MSTeam template {} contains invalid JSON.'.format(
                     template.url(privacy=True)))

--- a/apprise/plugins/NotifyMSTeams.py
+++ b/apprise/plugins/NotifyMSTeams.py
@@ -237,6 +237,7 @@ class NotifyMSTeams(NotifyBase):
             self.logger.warning(msg)
             raise TypeError(msg)
 
+        # else:  NoneType - this is okay
         return
 
     def gen_payload(self, body, title='', notify_type=NotifyType.INFO,

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -776,18 +776,17 @@ def test_apprise_asset(tmpdir):
     )
 
     a.default_html_color = '#abcabc'
-    a.html_notify_map[NotifyType.INFO] = '#aaaaaa'
 
     assert a.color('invalid', tuple) == (171, 202, 188)
-    assert a.color(NotifyType.INFO, tuple) == (170, 170, 170)
+    assert a.color(NotifyType.INFO, tuple) == (58, 163, 227)
 
     assert a.color('invalid', int) == 11258556
-    assert a.color(NotifyType.INFO, int) == 11184810
+    assert a.color(NotifyType.INFO, int) == 3843043
 
     assert a.color('invalid', None) == '#abcabc'
-    assert a.color(NotifyType.INFO, None) == '#aaaaaa'
+    assert a.color(NotifyType.INFO, None) == '#3AA3E3'
     # None is the default
-    assert a.color(NotifyType.INFO) == '#aaaaaa'
+    assert a.color(NotifyType.INFO) == '#3AA3E3'
 
     # Invalid Type
     with pytest.raises(ValueError):
@@ -1203,7 +1202,7 @@ def test_apprise_details_plugin_verification():
                         assert isinstance(arg['prefix'], six.string_types)
                         if section == 'kwargs':
                             # The only acceptable prefix types for kwargs
-                            assert arg['prefix'] in ('+', '-')
+                            assert arg['prefix'] in (':', '+', '-')
 
                     else:
                         # kwargs requires that the 'prefix' is defined

--- a/test/test_config_base.py
+++ b/test/test_config_base.py
@@ -605,7 +605,7 @@ urls:
 
 """, asset=asset)
 
-    # We expect to parse 4 entries from the above because the tgram:// entry
+    # We expect to parse 6 entries from the above because the tgram:// entry
     # would have failed to be loaded
     assert isinstance(result, list)
     assert len(result) == 6

--- a/test/test_config_base.py
+++ b/test/test_config_base.py
@@ -880,6 +880,20 @@ include:
     assert 'http://localhost/apprise/cfg02' in config
     assert 'http://localhost/apprise/cfg03' in config
 
+    # Test a configuration with an invalid schema with options
+    result, config = ConfigBase.config_parse_yaml("""
+    urls:
+      - invalid://:
+          tag: 'invalid'
+          :name: 'Testing2'
+          :body: 'test body2'
+          :title: 'test title2'
+""", asset=asset)
+
+    # We will have loaded no results
+    assert isinstance(result, list)
+    assert len(result) == 0
+
     # Valid Configuration (we allow comma separated entries for
     # each defined bullet)
     result, config = ConfigBase.config_parse_yaml("""

--- a/test/test_msteam_plugin.py
+++ b/test/test_msteam_plugin.py
@@ -1,0 +1,244 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import mock
+import json
+import requests
+from apprise import Apprise
+from apprise import plugins
+from apprise import NotifyType
+
+# Disable logging for a cleaner testing output
+import logging
+logging.disable(logging.CRITICAL)
+
+
+@mock.patch('requests.post')
+def test_msteams_templating(mock_post, tmpdir):
+    """
+    API: NotifyMSTeams() Templating
+
+    """
+    # Disable Throttling to speed testing
+    plugins.NotifyBase.request_rate_per_sec = 0
+
+    # Prepare Mock
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    uuid4 = '8b799edf-6f98-4d3a-9be7-2862fb4e5752'
+    url = 'msteams://{}@{}/{}/{}'.format(uuid4, uuid4, 'a' * 32, uuid4)
+
+    # Test cases where our URL is invalid
+    template = tmpdir.join("simple.json")
+    template.write("""
+    {
+      "@type": "MessageCard",
+      "@context": "https://schema.org/extensions",
+      "summary": "{{app_id}}",
+      "themeColor": "{{app_color}}",
+      "sections": [
+        {
+          "activityImage": null,
+          "activityTitle": "{{app_title}}",
+          "text": "{{app_body}}"
+        }
+      ]
+    }
+    """)
+
+    # Instantiate our URL
+    obj = Apprise.instantiate('{url}/?template={template}&{kwargs}'.format(
+        url=url,
+        template=str(template),
+        kwargs=':key1=token&:key2=token',
+    ))
+
+    assert isinstance(obj, plugins.NotifyMSTeams)
+    assert obj.notify(
+        body="body", title='title',
+        notify_type=NotifyType.INFO) is True
+
+    assert mock_post.called is True
+    assert mock_post.call_args_list[0][0][0].startswith(
+        'https://outlook.office.com/webhook/')
+
+    # Our Posted JSON Object
+    posted_json = json.loads(mock_post.call_args_list[0][1]['data'])
+    assert 'summary' in posted_json
+    assert posted_json['summary'] == 'Apprise'
+    assert posted_json['themeColor'] == '#3AA3E3'
+    assert posted_json['sections'][0]['activityTitle'] == 'title'
+    assert posted_json['sections'][0]['text'] == 'body'
+
+    # Test invalid JSON
+
+    # Test cases where our URL is invalid
+    template = tmpdir.join("invalid.json")
+    template.write("}")
+
+    # Instantiate our URL
+    obj = Apprise.instantiate('{url}/?template={template}&{kwargs}'.format(
+        url=url,
+        template=str(template),
+        kwargs=':key1=token&:key2=token',
+    ))
+
+    assert isinstance(obj, plugins.NotifyMSTeams)
+    # We will fail to preform our notifcation because the JSON is bad
+    assert obj.notify(
+        body="body", title='title',
+        notify_type=NotifyType.INFO) is False
+
+    # Test cases where we're missing the @type part of the URL
+    template = tmpdir.join("missing_type.json")
+    template.write("""
+    {
+      "@context": "https://schema.org/extensions",
+      "summary": "{{app_id}}",
+      "themeColor": "{{app_color}}",
+      "sections": [
+        {
+          "activityImage": null,
+          "activityTitle": "{{app_title}}",
+          "text": "{{app_body}}"
+        }
+      ]
+    }
+    """)
+
+    # Instantiate our URL
+    obj = Apprise.instantiate('{url}/?template={template}&{kwargs}'.format(
+        url=url,
+        template=str(template),
+        kwargs=':key1=token&:key2=token',
+    ))
+
+    assert isinstance(obj, plugins.NotifyMSTeams)
+
+    # We can not load the file because we're missing the @type entry
+    assert obj.notify(
+        body="body", title='title',
+        notify_type=NotifyType.INFO) is False
+
+    # Test cases where we're missing the @context part of the URL
+    template = tmpdir.join("missing_context.json")
+    template.write("""
+    {
+      "@type": "MessageCard",
+      "summary": "{{app_id}}",
+      "themeColor": "{{app_color}}",
+      "sections": [
+        {
+          "activityImage": null,
+          "activityTitle": "{{app_title}}",
+          "text": "{{app_body}}"
+        }
+      ]
+    }
+    """)
+
+    # Instantiate our URL
+    obj = Apprise.instantiate('{url}/?template={template}&{kwargs}'.format(
+        url=url,
+        template=str(template),
+        kwargs=':key1=token&:key2=token',
+    ))
+
+    assert isinstance(obj, plugins.NotifyMSTeams)
+    # We can not load the file because we're missing the @context entry
+    assert obj.notify(
+        body="body", title='title',
+        notify_type=NotifyType.INFO) is False
+
+    # Test a case where we can not access the file:
+    with mock.patch('json.loads', side_effect=OSError):
+        # we fail, but this time it's because we couldn't
+        # access the cached file contents for reading
+        assert obj.notify(
+            body="body", title='title',
+            notify_type=NotifyType.INFO) is False
+
+    # A more complicated example; uses a target
+    mock_post.reset_mock()
+    template = tmpdir.join("more_complicated_example.json")
+    template.write("""
+    {
+      "@type": "MessageCard",
+      "@context": "https://schema.org/extensions",
+      "summary": "{{app_desc}}",
+      "themeColor": "{{app_color}}",
+      "sections": [
+        {
+          "activityImage": null,
+          "activityTitle": "{{app_title}}",
+          "text": "{{app_body}}"
+        }
+      ],
+     "potentialAction": [{
+        "@type": "ActionCard",
+        "name": "Add a comment",
+        "inputs": [{
+            "@type": "TextInput",
+            "id": "comment",
+            "isMultiline": false,
+            "title": "Add a comment here for this task."
+        }],
+        "actions": [{
+            "@type": "HttpPOST",
+            "name": "Add Comment",
+            "target": "{{ target }}"
+        }]
+     }]
+    }
+    """)
+
+    # Instantiate our URL
+    obj = Apprise.instantiate('{url}/?template={template}&{kwargs}'.format(
+        url=url,
+        template=str(template),
+        kwargs=':key1=token&:key2=token&:target=http://localhost',
+    ))
+
+    assert isinstance(obj, plugins.NotifyMSTeams)
+    assert obj.notify(
+        body="body", title='title',
+        notify_type=NotifyType.INFO) is True
+
+    assert mock_post.called is True
+    assert mock_post.call_args_list[0][0][0].startswith(
+        'https://outlook.office.com/webhook/')
+
+    # Our Posted JSON Object
+    posted_json = json.loads(mock_post.call_args_list[0][1]['data'])
+    assert 'summary' in posted_json
+    assert posted_json['summary'] == 'Apprise Notifications'
+    assert posted_json['themeColor'] == '#3AA3E3'
+    assert posted_json['sections'][0]['activityTitle'] == 'title'
+    assert posted_json['sections'][0]['text'] == 'body'
+
+    # We even parsed our entry out of the URL
+    assert posted_json['potentialAction'][0]['actions'][0]['target'] \
+        == 'http://localhost'

--- a/test/test_msteam_plugin.py
+++ b/test/test_msteam_plugin.py
@@ -385,10 +385,10 @@ def test_msteams_yaml_config(mock_post, tmpdir):
       - {url}:
         - tag: 'msteams'
           template:  {template}
-          token:
-            - name: 'Testing'
-              body: 'test body'
-              title: 'test title'
+          tokens:
+            name: 'Testing'
+            body: 'test body'
+            title: 'test title'
     """.format(url=url, template=str(template)))
 
     cfg = AppriseConfig()
@@ -424,10 +424,10 @@ def test_msteams_yaml_config(mock_post, tmpdir):
       - {url}:
         tag: 'msteams'
         template:  {template}
-        token:
-          - name: 'Testing'
-            body: 'test body'
-            title: 'test title'
+        tokens:
+          name: 'Testing'
+          body: 'test body'
+          title: 'test title'
     """.format(url=url, template=str(template)))
 
     cfg = AppriseConfig()
@@ -460,10 +460,10 @@ def test_msteams_yaml_config(mock_post, tmpdir):
       - {url}:
         - tag: 'msteams'
           template:  {template}
-          :name: 'Testing'
-          token:
+          tokens:
               body: 'test body'
               title: 'test title'
+          :name: 'Testing'
     """.format(url=url, template=str(template)))
 
     cfg = AppriseConfig()
@@ -488,3 +488,22 @@ def test_msteams_yaml_config(mock_post, tmpdir):
     assert posted_json['themeColor'] == '#3AA3E3'
     assert posted_json['sections'][0]['activityTitle'] == 'test title'
     assert posted_json['sections'][0]['text'] == 'test body'
+
+    # Now let's do a combination of the two
+    config = tmpdir.join("msteams05.yml")
+    config.write("""
+    urls:
+      - {url}:
+        - tag: 'msteams'
+          template:  {template}
+          # Not a dictionary
+          tokens:
+            body
+    """.format(url=url, template=str(template)))
+
+    cfg = AppriseConfig()
+    cfg.add(str(config))
+    assert len(cfg) == 1
+
+    # It could not load because of invalid tokens
+    assert len(cfg[0]) == 0

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -5256,31 +5256,6 @@ def test_notify_msg91_plugin(mock_post):
         plugins.NotifyMSG91(authkey="    ", targets=target)
 
 
-def test_notify_msteams_plugin():
-    """
-    API: NotifyMSTeams() Extra Checks
-
-    """
-    # Initializes the plugin with an invalid token
-    with pytest.raises(TypeError):
-        plugins.NotifyMSTeams(token_a=None, token_b='abcd', token_c='abcd')
-    # Whitespace also acts as an invalid token value
-    with pytest.raises(TypeError):
-        plugins.NotifyMSTeams(token_a='  ', token_b='abcd', token_c='abcd')
-
-    with pytest.raises(TypeError):
-        plugins.NotifyMSTeams(token_a='abcd', token_b=None, token_c='abcd')
-    # Whitespace also acts as an invalid token value
-    with pytest.raises(TypeError):
-        plugins.NotifyMSTeams(token_a='abcd', token_b='  ', token_c='abcd')
-
-    with pytest.raises(TypeError):
-        plugins.NotifyMSTeams(token_a='abcd', token_b='abcd', token_c=None)
-    # Whitespace also acts as an invalid token value
-    with pytest.raises(TypeError):
-        plugins.NotifyMSTeams(token_a='abcd', token_b='abcd', token_c='  ')
-
-
 def test_notify_prowl_plugin():
     """
     API: NotifyProwl() Extra Checks


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #292 
This introduces the ability to create your own MSTeam JSON templates in the even you want to stray away from the default. You can read about all of the custom configuration you can place in your own JSON object [**here**](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using).

### The `template` URL Argument
This pull request introduces a few new features, first off... the `template=` argument you can specify on the Apprise URL (or configuration file). The `template` parameter can either point to a local file or a web based URL.  It's contents must be JSON (or you'll get an error trying to process it), and it at the very minimum must have the basic pattern: 
```json
{
  "@type": "MessageCard",
  "@context": "https://schema.org/extensions"
}
```

### The Template Tokens
The `template=` you point to, can either be fully populate and ready to go as is (up to the MSTeams chat server), or you can dynamically populate it on the fly each time you call Apprise. You do this by using the double curly brace `{{` and `}}` to surround a keyword that you invent; here is an example:
```json
{
  "@type": "MessageCard",
  "@context": "https://schema.org/extensions",
  "summary": "{{app_id}}",
  "sections": [
    {
        "activityImage": "{{app_image_url}}",
        "activityTitle": "{{app_title}}",
        "text": "Hello {{ target }}, how are you {{ whence }}?"
    }
  ]
}
```

In the above example, we introduce several tokens... `app_id`, `app_title`, `target` and `whence`.  There are a few entries that will ALWAYS be set and you can not over-ride them. They are:
* **app_id**: The Application identifier; usually set to `Apprise`, but developers of custom applications may choose to over-ride this and place their name here.  this is how you acquire this value.
* **app_desc**:  Similar the the Application Identifier, this is the Application Description. It's usually just a slightly more descriptive alternative to the *app_id*.  This is usually set to `Apprise Notification` unless it has been over-ridden by a developer.
* **app_color**: A hex code that identifies a colour associate with a message.  For instance, `info` type messages are generally blue where as `warning` ones are orange, etc.
* **app_type**: The message type itself; it may be `info`, `warning`, `success`, etc
* **app_title**: The actual title (`--title` or `-t` if from the command line) that was passed into the apprise notification when called.
* **app_body**: The actual body (`--body` or `-b` if from the command line)  that was passed into the apprise notification when called.
* **app_image_url**: The image URL associated with the message type (`info`, `warning`, etc) if one exists and/or was not specified to be turned off from the URL (`image=no`)
* **app_url**: The URL associated with the Apprise instance (found in the **AppriseAsset()** object).  Unless this has been over-ridden by a developer, it's value will be `https://github.com/caronc/apprise`.

Anything you invent outside of that is yours.  So lets get back to the `target` and `whence` that was define. Template tokens can be dynamically set by using the colon `:` operator before any URL argument you identify.  For example we can set these values on our Apprise URL like so:
* `msteams://credentials/?template=/path/to/template.json&:target=Chris&whence=this%20afternoon`
* `msteams://credentials/?template=http://host/to/template.json&:target=Chris&whence=this%20afternoon`

A notification like so:
```bash
# using colons, we can set our target and whence dynamically from the
# command line:
apprise -t "My Title" -b "This is Ignored" \
   "msteams://credentials/?template=http://host/to/template.json&:target=Chris&whence=this%20afternoon"
```
Would post to MSTeams (with respect to our template above):
```json
{
  "@type": "MessageCard",
  "@context": "https://schema.org/extensions",
  "summary": "Apprise",
  "sections": [
    {
        "activityImage": null,
        "activityTitle": "My Title",
        "text": "Hello Chris, how are you this afternoon?"
    }
  ]
}
```

The default Apprise template today (and still has no change even after this commit looks like this):
```json
# Prepare our payload
payload = {
  "@type": "MessageCard",
  "@context": "https://schema.org/extensions",
  "summary": "{{app_desc}}",
  "themeColor": "{{app_color}}",
  "sections": [
    {
        "activityImage": null,
        "activityTitle": "{{app_title}}",
        "text": "{{app_body}}"
    }
  ]
}
```

## Other Template Examples:
```json
{
  "@type": "MessageCard",
  "@context": "https://schema.org/extensions",
  "summary": "{{app_desc}}",
  "themeColor": "{{app_color}}",
  "sections": [
    {
      "activityImage": null,
      "activityTitle": "{{app_title}}",
      "text": "{{app_body}}",
    },
  ],
 "potentialAction": [{

        "@type": "ActionCard",
        "name": "Add a comment",
        "inputs": [{
            "@type": "TextInput",
            "id": "comment",
            "isMultiline": false,
            "title": "Add a comment here for this task"
        }],
        "actions": [{
            "@type": "HttpPOST",
            "name": "Add comment",
            "target": "{{ target }}"
        }]
 }]
}
```
## Additional Notes
* Tokens can have white space around them for readability if you like.  Hence `{{ token }}` is no different then `{{token}}`. 
* All tokens are escaped properly, so don't worry if your defined token has a double quote in it (`"`); it would be correctly escaped before it is sent upstream.
* Tokens ARE case sensitive, so `{{Token}}` NEEDS to be populated with a `:Token=` value on your URL.
* Tokens that are not matched correctly simply are not swapped and the {{keyword}} will remain as is in the message.
* Apprise always requires you to specify a `--body` (`-b`) at a very minimum which can be optionally referenced as `{{app_body}}` in your template.  Even if you choose not to use this token, you must still pass in something (anything) just to satisfy this requirement and make use of the template calls. 

## YAML Configuration Can Make Using Templates Easier
Placing all of your arguments and template tokens on a single URL can get rather cumbersome to read, but you can leverage [Apprise YAML configuration files](https://github.com/caronc/apprise/wiki/config_yaml) to make this a bit easier to work with. For example:
```YAML
# A Apprise YAML Configuration
urls:
  - msteams://auth_details:
   # 'tag' is a special keyword that allows you to associate tags with your
   # services:
    - tag: msteams-t01
      template: /path/to/template/file/or/web/url
      :token1: "my value"
      :token2: "my second value"
```
In the above example we associated a tag with our URL (so now life got really easy, we don't even need to type the URL out in the open again).  If you saved this file as `.config/apprise.yml` or `.apprise.yml` then you don't even need to specify `--config=/path/to/yaml/file/above` either:
```bash
# Send our notification using our template
apprise --tag=msteams-t01 -t "Hello" -b "World"
```

You can also format your template tokens like so:
```YAML
# A Apprise YAML Configuration
urls:
  - msteams://auth_details:
   # 'tag' is a special keyword that allows you to associate tags with your
   # services:
    - tag: msteams-t01
      template: /path/to/template/file/or/web/url
      tokens:
        token1: "my value"
        token2: "my second value"
```

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
