### PR TITLE
Added additional security for file based attachment

### DIFF
--- a/apprise/Apprise.py
+++ b/apprise/Apprise.py
@@ -58,13 +58,15 @@ class Apprise(object):
 
     """
 
-    def __init__(self, servers=None, asset=None, debug=False):
+    def __init__(self, servers=None, asset=None, location=None, debug=False):
         """
         Loads a set of server urls while applying the Asset() module to each
         if specified.
 
         If no asset is provided, then the default asset is used.
 
+        Optionally specify a global ContentLocation for a more strict means
+        of handling Attachments.
         """
 
         # Initialize a server list of URLs
@@ -86,6 +88,11 @@ class Apprise(object):
 
         # Set our debug flag
         self.debug = debug
+
+        # Store our hosting location for optional strict rule handling
+        # of Attachments.  Setting this to None removes any attachment
+        # restrictions.
+        self.location = location
 
     @staticmethod
     def instantiate(url, asset=None, tag=None, suppress_exceptions=True):
@@ -325,7 +332,8 @@ class Apprise(object):
         # Prepare attachments if required
         if attach is not None and not isinstance(attach, AppriseAttachment):
             try:
-                attach = AppriseAttachment(attach, asset=self.asset)
+                attach = AppriseAttachment(
+                    attach, asset=self.asset, location=self.location)
 
             except TypeError:
                 # bad attachments

--- a/apprise/__init__.py
+++ b/apprise/__init__.py
@@ -41,8 +41,10 @@ from .common import OverflowMode
 from .common import OVERFLOW_MODES
 from .common import ConfigFormat
 from .common import CONFIG_FORMATS
-from .common import ConfigIncludeMode
-from .common import CONFIG_INCLUDE_MODES
+from .common import ContentIncludeMode
+from .common import CONTENT_INCLUDE_MODES
+from .common import ContentLocation
+from .common import CONTENT_LOCATIONS
 
 from .URLBase import URLBase
 from .URLBase import PrivacyMode
@@ -69,6 +71,7 @@ __all__ = [
     'NotifyType', 'NotifyImageSize', 'NotifyFormat', 'OverflowMode',
     'NOTIFY_TYPES', 'NOTIFY_IMAGE_SIZES', 'NOTIFY_FORMATS', 'OVERFLOW_MODES',
     'ConfigFormat', 'CONFIG_FORMATS',
-    'ConfigIncludeMode', 'CONFIG_INCLUDE_MODES',
+    'ContentIncludeMode', 'CONTENT_INCLUDE_MODES',
+    'ContentLocation', 'CONTENT_LOCATIONS',
     'PrivacyMode',
 ]

--- a/apprise/attachment/AttachBase.py
+++ b/apprise/attachment/AttachBase.py
@@ -28,6 +28,7 @@ import time
 import mimetypes
 from ..URLBase import URLBase
 from ..utils import parse_bool
+from ..common import ContentLocation
 from ..AppriseLocale import gettext_lazy as _
 
 
@@ -61,6 +62,11 @@ class AttachBase(URLBase):
     # 1 MB = 1048576 bytes
     # 5 MB = 5242880 bytes
     max_file_size = 5242880
+
+    # By default all attachments types are inaccessible.
+    # Developers of items identified in the attachment plugin directory
+    # are requried to set a location
+    location = ContentLocation.INACCESSIBLE
 
     # Here is where we define all of the arguments we accept on the url
     # such as: schema://whatever/?overflow=upstream&format=text

--- a/apprise/attachment/AttachFile.py
+++ b/apprise/attachment/AttachFile.py
@@ -26,6 +26,7 @@
 import re
 import os
 from .AttachBase import AttachBase
+from ..common import ContentLocation
 from ..AppriseLocale import gettext_lazy as _
 
 
@@ -39,6 +40,10 @@ class AttachFile(AttachBase):
 
     # The default protocol
     protocol = 'file'
+
+    # Content is local to the same location as the apprise instance
+    # being called (server-side)
+    location = ContentLocation.LOCAL
 
     def __init__(self, path, **kwargs):
         """
@@ -80,6 +85,10 @@ class AttachFile(AttachBase):
         For file base attachments, our data already exists, so we only need to
         validate it.
         """
+
+        if self.location == ContentLocation.INACCESSIBLE:
+            # our content is inaccessible
+            return False
 
         # Ensure any existing content set has been invalidated
         self.invalidate()

--- a/apprise/attachment/AttachHTTP.py
+++ b/apprise/attachment/AttachHTTP.py
@@ -29,6 +29,7 @@ import six
 import requests
 from tempfile import NamedTemporaryFile
 from .AttachBase import AttachBase
+from ..common import ContentLocation
 from ..URLBase import PrivacyMode
 from ..AppriseLocale import gettext_lazy as _
 
@@ -49,6 +50,9 @@ class AttachHTTP(AttachBase):
 
     # The number of bytes in memory to read from the remote source at a time
     chunk_size = 8192
+
+    # Web based requests are remote/external to our current location
+    location = ContentLocation.HOSTED
 
     def __init__(self, headers=None, **kwargs):
         """
@@ -85,6 +89,10 @@ class AttachHTTP(AttachBase):
         """
         Perform retrieval of the configuration based on the specified request
         """
+
+        if self.location == ContentLocation.INACCESSIBLE:
+            # our content is inaccessible
+            return False
 
         # Ensure any existing content set has been invalidated
         self.invalidate()

--- a/apprise/cli.py
+++ b/apprise/cli.py
@@ -39,6 +39,7 @@ from . import AppriseConfig
 from .utils import parse_list
 from .common import NOTIFY_TYPES
 from .common import NOTIFY_FORMATS
+from .common import ContentLocation
 from .logger import logger
 
 from . import __title__
@@ -224,8 +225,12 @@ def main(body, title, config, attach, urls, notification_type, theme, tag,
 
     # Prepare our asset
     asset = AppriseAsset(
+        # Our body format
         body_format=input_format,
+
+        # Set the theme
         theme=theme,
+
         # Async mode is only used for Python v3+ and allows a user to send
         # all of their notifications asyncronously.  This was made an option
         # incase there are problems in the future where it's better that
@@ -234,7 +239,7 @@ def main(body, title, config, attach, urls, notification_type, theme, tag,
     )
 
     # Create our Apprise object
-    a = Apprise(asset=asset, debug=debug)
+    a = Apprise(asset=asset, debug=debug, location=ContentLocation.LOCAL)
 
     # Load our configuration if no URLs or specified configuration was
     # identified on the command line

--- a/apprise/common.py
+++ b/apprise/common.py
@@ -130,28 +130,58 @@ CONFIG_FORMATS = (
 )
 
 
-class ConfigIncludeMode(object):
+class ContentIncludeMode(object):
     """
-    The different Cofiguration inclusion modes.  All Configuration
-    plugins will have one of these associated with it.
+    The different Content inclusion modes.  All content based plugins will
+    have one of these associated with it.
     """
-    # - Configuration inclusion of same type only; hence a file:// can include
+    # - Content inclusion of same type only; hence a file:// can include
     #   a file://
     # - Cross file inclusion is not allowed unless insecure_includes (a flag)
     #   is set to True. In these cases STRICT acts as type ALWAYS
     STRICT = 'strict'
 
-    # This configuration type can never be included
+    # This content type can never be included
     NEVER = 'never'
 
-    # File configuration can always be included
+    # This content can always be included
     ALWAYS = 'always'
 
 
-CONFIG_INCLUDE_MODES = (
-    ConfigIncludeMode.STRICT,
-    ConfigIncludeMode.NEVER,
-    ConfigIncludeMode.ALWAYS,
+CONTENT_INCLUDE_MODES = (
+    ContentIncludeMode.STRICT,
+    ContentIncludeMode.NEVER,
+    ContentIncludeMode.ALWAYS,
+)
+
+
+class ContentLocation(object):
+    """
+    This is primarily used for handling file attachments.  The idea is
+    to track the source of the attachment itself.  We don't want
+    remote calls to a server to access local attachments for example.
+
+    By knowing the attachment type and cross-associating it with how
+    we plan on accessing the content, we can make a judgement call
+    (for security reasons) if we will allow it.
+
+    Obviously local uses of apprise can access both local and remote
+    type files.
+    """
+    # Content is located locally (on the same server as apprise)
+    LOCAL = 'local'
+
+    # Content is located in a remote location
+    HOSTED = 'hosted'
+
+    # Content is inaccessible
+    INACCESSIBLE = 'n/a'
+
+
+CONTENT_LOCATIONS = (
+    ContentLocation.LOCAL,
+    ContentLocation.HOSTED,
+    ContentLocation.INACCESSIBLE,
 )
 
 # This is a reserved tag that is automatically assigned to every

--- a/apprise/config/ConfigBase.py
+++ b/apprise/config/ConfigBase.py
@@ -34,7 +34,7 @@ from ..AppriseAsset import AppriseAsset
 from ..URLBase import URLBase
 from ..common import ConfigFormat
 from ..common import CONFIG_FORMATS
-from ..common import ConfigIncludeMode
+from ..common import ContentIncludeMode
 from ..utils import GET_SCHEMA_RE
 from ..utils import parse_list
 from ..utils import parse_bool
@@ -65,7 +65,7 @@ class ConfigBase(URLBase):
 
     # By default all configuration is not includable using the 'include'
     # line found in configuration files.
-    allow_cross_includes = ConfigIncludeMode.NEVER
+    allow_cross_includes = ContentIncludeMode.NEVER
 
     # the config path manages the handling of relative include
     config_path = os.getcwd()
@@ -240,11 +240,11 @@ class ConfigBase(URLBase):
 
                 # Handle cross inclusion based on allow_cross_includes rules
                 if (SCHEMA_MAP[schema].allow_cross_includes ==
-                        ConfigIncludeMode.STRICT
+                        ContentIncludeMode.STRICT
                         and schema not in self.schemas()
                         and not self.insecure_includes) or \
                         SCHEMA_MAP[schema].allow_cross_includes == \
-                        ConfigIncludeMode.NEVER:
+                        ContentIncludeMode.NEVER:
 
                     # Prevent the loading if insecure base protocols
                     ConfigBase.logger.warning(

--- a/apprise/config/ConfigFile.py
+++ b/apprise/config/ConfigFile.py
@@ -28,7 +28,7 @@ import io
 import os
 from .ConfigBase import ConfigBase
 from ..common import ConfigFormat
-from ..common import ConfigIncludeMode
+from ..common import ContentIncludeMode
 from ..AppriseLocale import gettext_lazy as _
 
 
@@ -44,7 +44,7 @@ class ConfigFile(ConfigBase):
     protocol = 'file'
 
     # Configuration file inclusion can only be of the same type
-    allow_cross_includes = ConfigIncludeMode.STRICT
+    allow_cross_includes = ContentIncludeMode.STRICT
 
     def __init__(self, path, **kwargs):
         """

--- a/apprise/config/ConfigHTTP.py
+++ b/apprise/config/ConfigHTTP.py
@@ -28,7 +28,7 @@ import six
 import requests
 from .ConfigBase import ConfigBase
 from ..common import ConfigFormat
-from ..common import ConfigIncludeMode
+from ..common import ContentIncludeMode
 from ..URLBase import PrivacyMode
 from ..AppriseLocale import gettext_lazy as _
 
@@ -66,7 +66,7 @@ class ConfigHTTP(ConfigBase):
     max_error_buffer_size = 2048
 
     # Configuration file inclusion can always include this type
-    allow_cross_includes = ConfigIncludeMode.ALWAYS
+    allow_cross_includes = ContentIncludeMode.ALWAYS
 
     def __init__(self, headers=None, **kwargs):
         """

--- a/test/test_apprise_attachments.py
+++ b/test/test_apprise_attachments.py
@@ -33,6 +33,7 @@ from apprise.AppriseAsset import AppriseAsset
 from apprise.attachment.AttachBase import AttachBase
 from apprise.attachment import SCHEMA_MAP as ATTACH_SCHEMA_MAP
 from apprise.attachment import __load_matrix
+from apprise.common import ContentLocation
 
 # Disable logging for a cleaner testing output
 import logging
@@ -183,11 +184,6 @@ def test_apprise_attachment():
     # Reset our object
     aa.clear()
 
-    # if instantiating attachments from the class, it will throw a TypeError
-    # if attachments couldn't be loaded
-    with pytest.raises(TypeError):
-        AppriseAttachment('garbage://')
-
     # Garbage in produces garbage out
     assert aa.add(None) is False
     assert aa.add(object()) is False
@@ -209,6 +205,39 @@ def test_apprise_attachment():
 
     # length remains unchanged
     assert len(aa) == 0
+
+    # if instantiating attachments from the class, it will throw a TypeError
+    # if attachments couldn't be loaded
+    with pytest.raises(TypeError):
+        AppriseAttachment('garbage://')
+
+    # Load our other attachment types
+    aa = AppriseAttachment(location=ContentLocation.LOCAL)
+
+    # Hosted type won't allow us to import files
+    aa = AppriseAttachment(location=ContentLocation.HOSTED)
+    assert len(aa) == 0
+
+    # Add our attachments defined a the head of this function
+    aa.add(attachments)
+
+    # Our length is still zero because we can't import files in
+    # a hosted environment
+    assert len(aa) == 0
+
+    # Inaccessible type prevents the adding of new stuff
+    aa = AppriseAttachment(location=ContentLocation.INACCESSIBLE)
+    assert len(aa) == 0
+
+    # Add our attachments defined a the head of this function
+    aa.add(attachments)
+
+    # Our length is still zero
+    assert len(aa) == 0
+
+    with pytest.raises(TypeError):
+        # Invalid location specified
+        AppriseAttachment(location="invalid")
 
     # test cases when file simply doesn't exist
     aa = AppriseAttachment('file://non-existant-file.png')

--- a/test/test_apprise_config.py
+++ b/test/test_apprise_config.py
@@ -30,7 +30,7 @@ import mock
 import pytest
 from apprise import NotifyFormat
 from apprise import ConfigFormat
-from apprise import ConfigIncludeMode
+from apprise import ContentIncludeMode
 from apprise.Apprise import Apprise
 from apprise.AppriseConfig import AppriseConfig
 from apprise.AppriseAsset import AppriseAsset
@@ -417,7 +417,7 @@ def test_apprise_config_instantiate():
 
     class BadConfig(ConfigBase):
         # always allow incusion
-        allow_cross_includes = ConfigIncludeMode.ALWAYS
+        allow_cross_includes = ContentIncludeMode.ALWAYS
 
         def __init__(self, **kwargs):
             super(BadConfig, self).__init__(**kwargs)
@@ -450,7 +450,7 @@ def test_invalid_apprise_config(tmpdir):
 
     class BadConfig(ConfigBase):
         # always allow incusion
-        allow_cross_includes = ConfigIncludeMode.ALWAYS
+        allow_cross_includes = ContentIncludeMode.ALWAYS
 
         def __init__(self, **kwargs):
             super(BadConfig, self).__init__(**kwargs)
@@ -699,7 +699,7 @@ def test_recursive_config_inclusion(tmpdir):
         protocol = 'always'
 
         # Always type
-        allow_cross_includes = ConfigIncludeMode.ALWAYS
+        allow_cross_includes = ContentIncludeMode.ALWAYS
 
     class ConfigCrossPostStrict(ConfigFile):
         """
@@ -712,7 +712,7 @@ def test_recursive_config_inclusion(tmpdir):
         protocol = 'strict'
 
         # Always type
-        allow_cross_includes = ConfigIncludeMode.STRICT
+        allow_cross_includes = ContentIncludeMode.STRICT
 
     class ConfigCrossPostNever(ConfigFile):
         """
@@ -725,7 +725,7 @@ def test_recursive_config_inclusion(tmpdir):
         protocol = 'never'
 
         # Always type
-        allow_cross_includes = ConfigIncludeMode.NEVER
+        allow_cross_includes = ContentIncludeMode.NEVER
 
     # store our entries
     CONFIG_SCHEMA_MAP['never'] = ConfigCrossPostNever

--- a/test/test_attach_file.py
+++ b/test/test_attach_file.py
@@ -31,6 +31,7 @@ from os.path import join
 from apprise.attachment.AttachBase import AttachBase
 from apprise.attachment.AttachFile import AttachFile
 from apprise import AppriseAttachment
+from apprise.common import ContentLocation
 
 # Disable logging for a cleaner testing output
 import logging
@@ -101,6 +102,23 @@ def test_attach_file():
     # won't show up in the generated URL
     assert re.search(r'[?&]mime=', response.url()) is None
     assert re.search(r'[?&]name=', response.url()) is None
+
+    # Test case where location is simply set to INACCESSIBLE
+    # Below is a bad example, but it proves the section of code properly works.
+    # Ideally a server admin may wish to just disable all File based
+    # attachments entirely. In this case, they simply just need to change the
+    # global singleton at the start of their program like:
+    #
+    # import apprise
+    # apprise.attachment.AttachFile.location = \
+    #       apprise.ContentLocation.INACCESSIBLE
+    #
+    response = AppriseAttachment.instantiate(path)
+    assert isinstance(response, AttachFile)
+    response.location = ContentLocation.INACCESSIBLE
+    assert response.path is None
+    # Downloads just don't work period
+    assert response.download() is False
 
     # File handling (even if image is set to maxium allowable)
     response = AppriseAttachment.instantiate(path)

--- a/test/test_attach_file.py
+++ b/test/test_attach_file.py
@@ -197,3 +197,7 @@ def test_attach_file():
     # We will match on mime type now  (%2F = /)
     assert re.search(r'[?&]mime=image%2Fjpeg', response.url(), re.I)
     assert re.search(r'[?&]name=test\.jpeg', response.url(), re.I)
+
+    # Test hosted configuration and that we can't add a valid file
+    aa = AppriseAttachment(location=ContentLocation.HOSTED)
+    assert aa.add(path) is False

--- a/test/test_attach_http.py
+++ b/test/test_attach_http.py
@@ -35,6 +35,7 @@ from apprise.attachment.AttachHTTP import AttachHTTP
 from apprise import AppriseAttachment
 from apprise.plugins.NotifyBase import NotifyBase
 from apprise.plugins import SCHEMA_MAP
+from apprise.common import ContentLocation
 
 # Disable logging for a cleaner testing output
 import logging
@@ -227,6 +228,21 @@ def test_attach_http(mock_get):
     assert attachment.download()
     assert attachment
     assert len(attachment) == getsize(path)
+
+    # Test case where location is simply set to INACCESSIBLE
+    # Below is a bad example, but it proves the section of code properly works.
+    # Ideally a server admin may wish to just disable all HTTP based
+    # attachments entirely. In this case, they simply just need to change the
+    # global singleton at the start of their program like:
+    #
+    # import apprise
+    # apprise.attachment.AttachHTTP.location = \
+    #       apprise.ContentLocation.INACCESSIBLE
+    attachment = AttachHTTP(**results)
+    attachment.location = ContentLocation.INACCESSIBLE
+    assert attachment.path is None
+    # Downloads just don't work period
+    assert attachment.download() is False
 
     # No path specified
     # No Content-Disposition specified


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #292 

This PR will be required to be merged before #299.  It introduces some Attachment security (since templates wrap the attachment functionality) so that the system will not reference local files if they are being hosted remotely.  However local system access can access local and hosted content as per normal.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
