### PR TITLE
Run synchronous code asynchronously

### DIFF
--- a/apprise/py3compat/asyncio.py
+++ b/apprise/py3compat/asyncio.py
@@ -25,6 +25,7 @@
 
 import sys
 import asyncio
+from functools import partial
 from ..URLBase import URLBase
 from ..logger import logger
 
@@ -101,7 +102,8 @@ class AsyncNotifyBase(URLBase):
         Async Notification Wrapper
         """
         try:
-            return self.notify(*args, **kwargs)
+            loop = asyncio.get_event_loop()
+            return await loop.run_in_executor(None, partial(self.notify, *args, **kwargs))
 
         except TypeError:
             # These our our internally thrown notifications

--- a/apprise/py3compat/asyncio.py
+++ b/apprise/py3compat/asyncio.py
@@ -105,7 +105,10 @@ class AsyncNotifyBase(URLBase):
         try:
             loop = asyncio.get_event_loop()
             executor = ThreadPoolExecutor(max_workers=3)
-            return await loop.run_in_executor(executor, partial(self.notify, *args, **kwargs))
+            return await loop.run_in_executor(
+                executor,
+                partial(self.notify, *args, **kwargs),
+            )
 
         except TypeError:
             # These our our internally thrown notifications

--- a/apprise/py3compat/asyncio.py
+++ b/apprise/py3compat/asyncio.py
@@ -104,7 +104,7 @@ class AsyncNotifyBase(URLBase):
         """
         try:
             loop = asyncio.get_event_loop()
-            executor = ThreadPoolExecutor(3)
+            executor = ThreadPoolExecutor(max_workers=3)
             return await loop.run_in_executor(executor, partial(self.notify, *args, **kwargs))
 
         except TypeError:

--- a/apprise/py3compat/asyncio.py
+++ b/apprise/py3compat/asyncio.py
@@ -104,7 +104,7 @@ class AsyncNotifyBase(URLBase):
         """
         try:
             loop = asyncio.get_event_loop()
-            executor = ThreadPoolExecutor(max_workers=3)
+            executor = ThreadPoolExecutor()
             return await loop.run_in_executor(
                 executor,
                 partial(self.notify, *args, **kwargs),

--- a/apprise/py3compat/asyncio.py
+++ b/apprise/py3compat/asyncio.py
@@ -25,6 +25,7 @@
 
 import sys
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from ..URLBase import URLBase
 from ..logger import logger
@@ -103,7 +104,8 @@ class AsyncNotifyBase(URLBase):
         """
         try:
             loop = asyncio.get_event_loop()
-            return await loop.run_in_executor(None, partial(self.notify, *args, **kwargs))
+            executor = ThreadPoolExecutor(3)
+            return await loop.run_in_executor(executor, partial(self.notify, *args, **kwargs))
 
         except TypeError:
             # These our our internally thrown notifications

--- a/apprise/py3compat/asyncio.py
+++ b/apprise/py3compat/asyncio.py
@@ -104,11 +104,11 @@ class AsyncNotifyBase(URLBase):
         """
         try:
             loop = asyncio.get_event_loop()
-            executor = ThreadPoolExecutor()
-            return await loop.run_in_executor(
-                executor,
-                partial(self.notify, *args, **kwargs),
-            )
+            with ThreadPoolExecutor() as executor:
+                return await loop.run_in_executor(
+                    executor,
+                    partial(self.notify, *args, **kwargs),
+                )
 
         except TypeError:
             # These our our internally thrown notifications


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** home-assistant/core#40184

As discussed in the thread, Home Assistant is detecting that synchronous I/O is being performed in the event loop (this is still occurring after this is still occurring after home-assistant/core#40213) which is not good for the reason highlighted here: https://github.com/home-assistant/core/issues/40184#issuecomment-694442159

This change prevents the error from my testing. I wasn't sure how to write a test for this so I didn't make any changes there but your existing tests should pass meaning worst case scenario, this is a no-op

## New Service Completion Status
<!-- This section is only applicable if you're adding a new service -->
* [ ] apprise/plugins/Notify<!--ServiceName goes here-->.py
* [ ] setup.py
    - add new service into the `keywords` section of the `setup()` declaration
* [ ] README.md
    - add entry for new service to table (as a quick reference)
* [ ] packaging/redhat/python-apprise.spec
    - add new service into the `%global common_description`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] 100% test coverage
