### PR TITLE
Mailgun cc, bcc, batch processing, and attachment support

### DIFF
--- a/apprise/plugins/NotifyMailgun.py
+++ b/apprise/plugins/NotifyMailgun.py
@@ -475,18 +475,16 @@ class NotifyMailgun(NotifyBase):
             # Prepare our To
             payload['to'] = ','.join(to)
 
-            try:
-                # Format our cc addresses to support the Name field
-                if cc:
+            if cc:
+                try:
+                    # Format our cc addresses to support the Name field
                     payload['cc'] = ','.join([formataddr(
                         (self.names.get(addr, False), addr), charset='utf-8')
                         for addr in cc])
 
-            except TypeError:
-                # Python v2.x Support (no charset keyword)
-                # Format our cc addresses to support the Name field
-
-                if cc:
+                except TypeError:
+                    # Python v2.x Support (no charset keyword)
+                    # Format our cc addresses to support the Name field
                     payload['cc'] = ','.join([formataddr(
                         (self.names.get(addr, False), addr))
                         for addr in cc])

--- a/apprise/plugins/NotifyMailgun.py
+++ b/apprise/plugins/NotifyMailgun.py
@@ -374,6 +374,10 @@ class NotifyMailgun(NotifyBase):
 
         # Prepare our payload
         payload = {
+            # pass skip-verification switch upstream too
+            'o:skip-verification': not self.verify_certificate,
+
+            # Base payload options
             'from': reply_to,
             'subject': title,
         }
@@ -540,12 +544,11 @@ class NotifyMailgun(NotifyBase):
                 has_error = True
                 continue
 
-            finally:
-                # Close any potential attachments that are still open
-                for entry in files.values():
-                    self.logger.trace(
-                        'Closing attachment {}'.format(entry[0]))
-                    entry[1].close()
+        # Close any potential attachments that are still open
+        for entry in files.values():
+            self.logger.trace(
+                'Closing attachment {}'.format(entry[0]))
+            entry[1].close()
 
         return not has_error
 

--- a/test/test_mailgun.py
+++ b/test/test_mailgun.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import os
+import mock
+import requests
+from apprise import plugins
+from apprise import Apprise
+from apprise import AppriseAttachment
+from apprise import NotifyType
+
+# Disable logging for a cleaner testing output
+import logging
+logging.disable(logging.CRITICAL)
+
+# Attachment Directory
+TEST_VAR_DIR = os.path.join(os.path.dirname(__file__), 'var')
+
+
+@mock.patch('requests.post')
+def test_notify_mailgun_plugin_attachments(mock_post):
+    """
+    API: NotifyMailgun() Attachments
+
+    """
+    # Disable Throttling to speed testing
+    plugins.NotifyBase.request_rate_per_sec = 0
+
+    okay_response = requests.Request()
+    okay_response.status_code = requests.codes.ok
+    okay_response.content = ""
+
+    # Assign our mock object our return value
+    mock_post.return_value = okay_response
+
+    # API Key
+    apikey = 'abc123'
+
+    obj = Apprise.instantiate(
+        'mailgun://user@localhost.localdomain/{}'.format(apikey))
+    assert isinstance(obj, plugins.NotifyMailgun)
+
+    # Test Valid Attachment
+    path = os.path.join(TEST_VAR_DIR, 'apprise-test.gif')
+    attach = AppriseAttachment(path)
+    assert obj.notify(
+        body='body', title='title', notify_type=NotifyType.INFO,
+        attach=attach) is True
+
+    # Test invalid attachment
+    path = os.path.join(TEST_VAR_DIR, '/invalid/path/to/an/invalid/file.jpg')
+    assert obj.notify(
+        body='body', title='title', notify_type=NotifyType.INFO,
+        attach=path) is False
+
+    mock_post.return_value = None
+    mock_post.side_effect = OSError()
+    # We can't send the message if we can't read the attachment
+    assert obj.notify(
+        body='body', title='title', notify_type=NotifyType.INFO,
+        attach=attach) is False
+
+    # Return our good configuration
+    mock_post.side_effect = None
+    mock_post.return_value = okay_response
+    with mock.patch('builtins.open', side_effect=OSError()):
+        # We can't send the message we can't open the attachment for reading
+        assert obj.notify(
+            body='body', title='title', notify_type=NotifyType.INFO,
+            attach=attach) is False
+
+    with mock.patch('builtins.open') as mock_open:
+        mock_fp = mock.Mock()
+        mock_fp.seek.side_effect = OSError()
+        mock_open.return_value = mock_fp
+
+        # We can't send the message we can't seek through it
+        assert obj.notify(
+            body='body', title='title', notify_type=NotifyType.INFO,
+            attach=attach) is False
+
+    obj = Apprise.instantiate(
+        'mailgun://no-reply@example.com/{}/'
+        'user1@example.com/user2@example.com?batch=yes'.format(apikey))
+    assert isinstance(obj, plugins.NotifyMailgun)
+
+    # Force our batch to break into separate messages
+    obj.default_batch_size = 1
+    # We'll send 2 messages
+    mock_post.reset_mock()
+
+    assert obj.notify(
+        body='body', title='title', notify_type=NotifyType.INFO,
+        attach=attach) is True
+    assert mock_post.call_count == 2
+
+    # single batch
+    mock_post.reset_mock()
+    # We'll send 1 message
+    obj.default_batch_size = 2
+
+    assert obj.notify(
+        body='body', title='title', notify_type=NotifyType.INFO,
+        attach=attach) is True
+    assert mock_post.call_count == 1

--- a/test/test_mailgun.py
+++ b/test/test_mailgun.py
@@ -24,6 +24,7 @@
 # THE SOFTWARE.
 
 import os
+import sys
 import mock
 import requests
 from apprise import plugins
@@ -82,16 +83,23 @@ def test_notify_mailgun_plugin_attachments(mock_post):
         body='body', title='title', notify_type=NotifyType.INFO,
         attach=attach) is False
 
+    # Get a appropriate "builtin" module name for pythons 2/3.
+    if sys.version_info.major >= 3:
+        builtin_open_function = 'builtins.open'
+
+    else:
+        builtin_open_function = '__builtin__.open'
+
     # Return our good configuration
     mock_post.side_effect = None
     mock_post.return_value = okay_response
-    with mock.patch('builtins.open', side_effect=OSError()):
+    with mock.patch(builtin_open_function, side_effect=OSError()):
         # We can't send the message we can't open the attachment for reading
         assert obj.notify(
             body='body', title='title', notify_type=NotifyType.INFO,
             attach=attach) is False
 
-    with mock.patch('builtins.open') as mock_open:
+    with mock.patch(builtin_open_function) as mock_open:
         mock_fp = mock.Mock()
         mock_fp.seek.side_effect = OSError()
         mock_open.return_value = mock_fp

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -1485,6 +1485,18 @@ TEST_URLS = (
         'a' * 32, 'b' * 8, 'c' * 8), {
             'instance': TypeError,
     }),
+    # headers
+    ('mailgun://user@localhost.localdomain/{}-{}-{}'
+        '?+X-Customer-Campaign-ID=Apprise'.format(
+            'a' * 32, 'b' * 8, 'c' * 8), {
+                'instance': plugins.NotifyMailgun,
+        }),
+    # template tokens
+    ('mailgun://user@localhost.localdomain/{}-{}-{}'
+        '?:name=Chris&:status=admin'.format(
+            'a' * 32, 'b' * 8, 'c' * 8), {
+                'instance': plugins.NotifyMailgun,
+        }),
     # bcc and cc
     ('mailgun://user@localhost.localdomain/{}-{}-{}'
         '?bcc=user@example.com&cc=user2@example.com'.format(

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -1458,6 +1458,18 @@ TEST_URLS = (
         'a' * 32, 'b' * 8, 'c' * 8), {
         'instance': plugins.NotifyMailgun,
     }),
+    ('mailgun://user@localhost.localdomain/{}-{}-{}?format=markdown'.format(
+        'a' * 32, 'b' * 8, 'c' * 8), {
+        'instance': plugins.NotifyMailgun,
+    }),
+    ('mailgun://user@localhost.localdomain/{}-{}-{}?format=html'.format(
+        'a' * 32, 'b' * 8, 'c' * 8), {
+        'instance': plugins.NotifyMailgun,
+    }),
+    ('mailgun://user@localhost.localdomain/{}-{}-{}?format=text'.format(
+        'a' * 32, 'b' * 8, 'c' * 8), {
+        'instance': plugins.NotifyMailgun,
+    }),
     # valid url with region specified (case insensitve)
     ('mailgun://user@localhost.localdomain/{}-{}-{}?region=uS'.format(
         'a' * 32, 'b' * 8, 'c' * 8), {
@@ -1473,6 +1485,12 @@ TEST_URLS = (
         'a' * 32, 'b' * 8, 'c' * 8), {
             'instance': TypeError,
     }),
+    # bcc and cc
+    ('mailgun://user@localhost.localdomain/{}-{}-{}'
+        '?bcc=user@example.com&cc=user2@example.com'.format(
+            'a' * 32, 'b' * 8, 'c' * 8), {
+                'instance': plugins.NotifyMailgun,
+        }),
     # One To Email address
     ('mailgun://user@localhost.localdomain/{}-{}-{}/test@example.com'.format(
         'a' * 32, 'b' * 8, 'c' * 8), {
@@ -1482,12 +1500,26 @@ TEST_URLS = (
         '{}-{}-{}?to=test@example.com'.format(
             'a' * 32, 'b' * 8, 'c' * 8), {
                 'instance': plugins.NotifyMailgun}),
-
     # One To Email address, a from name specified too
     ('mailgun://user@localhost.localdomain/{}-{}-{}/'
         'test@example.com?name="Frodo"'.format(
             'a' * 32, 'b' * 8, 'c' * 8), {
                 'instance': plugins.NotifyMailgun}),
+    # Invalid 'To' Email address
+    ('mailgun://user@localhost.localdomain/{}-{}-{}/invalid'.format(
+        'a' * 32, 'b' * 8, 'c' * 8), {
+            'instance': plugins.NotifyMailgun,
+            # Expected notify() response
+            'notify_response': False,
+    }),
+    # Multiple 'To', 'Cc', and 'Bcc' addresses (with invalid ones)
+    ('mailgun://user@example.com/{}-{}-{}/{}?bcc={}&cc={}'.format(
+        'a' * 32, 'b' * 8, 'c' * 8,
+        '/'.join(('user1@example.com', 'invalid', 'User2:user2@example.com')),
+        ','.join(('user3@example.com', 'i@v', 'User1:user1@example.com')),
+        ','.join(('user4@example.com', 'g@r@b', 'Da:user5@example.com'))), {
+            'instance': plugins.NotifyMailgun,
+    }),
     ('mailgun://user@localhost.localdomain/{}-{}-{}'.format(
         'a' * 32, 'b' * 8, 'c' * 8), {
         'instance': plugins.NotifyMailgun,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** n/a

Upon reviewing [Mailgun API](https://documentation.mailgun.com/en/latest/api-sending.html#sending) and reviewing the Apprise plugin code, there is room for significant improvements. This merge request adds:
* **bcc** support
* **cc** support
* **File Attachment** support
* **Batch Email** support
* **Email Header** support
* **Token Support** (allowing users to define `%token%` place holders in their email messages)

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
