### PR TITLE
Added support for setting meta/headers on outbound emails

### DIFF
--- a/test/test_email_plugin.py
+++ b/test/test_email_plugin.py
@@ -165,6 +165,11 @@ TEST_URLS = (
             'instance': plugins.NotifyEmail,
         },
     ),
+    # headers
+    ('mailto://user:pass@localhost.localdomain'
+        '?+X-Customer-Campaign-ID=Apprise', {
+            'instance': plugins.NotifyEmail,
+        }),
     # No Password
     ('mailtos://user:@nuxref.com', {
         'instance': plugins.NotifyEmail,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** n/a

This adds the ability to define Email Header (Meta Tag) entries when you specify a plus (**+**) symbol infront of any arguments specified on your Apprise URL.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
