### PR TITLE
Log Capturing for devs wishing to capture notification output

### DIFF
--- a/apprise/URLBase.py
+++ b/apprise/URLBase.py
@@ -25,7 +25,7 @@
 
 import re
 import six
-import logging
+from .logger import logger
 from time import sleep
 from datetime import datetime
 from xml.sax.saxutils import escape as sax_escape
@@ -115,8 +115,8 @@ class URLBase(object):
     # Secure sites should be verified against a Certificate Authority
     verify_certificate = True
 
-    # Logging
-    logger = logging.getLogger(__name__)
+    # Logging to our global logger
+    logger = logger
 
     # Define a default set of template arguments used for dynamically building
     # details about our individual plugins for developers.

--- a/apprise/__init__.py
+++ b/apprise/__init__.py
@@ -57,10 +57,13 @@ from .AppriseAsset import AppriseAsset
 from .AppriseConfig import AppriseConfig
 from .AppriseAttachment import AppriseAttachment
 
+# Inherit our logging with our additional entries added to it
+from .logger import logging
+from .logger import logger
+from .logger import LogCapture
+
 # Set default logging handler to avoid "No handler found" warnings.
-import logging
-from logging import NullHandler
-logging.getLogger(__name__).addHandler(NullHandler())
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
     # Core
@@ -74,4 +77,7 @@ __all__ = [
     'ContentIncludeMode', 'CONTENT_INCLUDE_MODES',
     'ContentLocation', 'CONTENT_LOCATIONS',
     'PrivacyMode',
+
+    # Logging
+    'logging', 'logger', 'LogCapture',
 ]

--- a/apprise/logger.py
+++ b/apprise/logger.py
@@ -83,7 +83,7 @@ class LogCapture(object):
 
     """
     def __init__(self, path=None, level=None, name=LOGGER_NAME, delete=True,
-                 fmt='%(asctime)s - %(thread)d - %(levelname)s - %(message)s'):
+                 fmt='%(asctime)s - %(levelname)s - %(message)s'):
         """
         Instantiate a temporary log capture object
 

--- a/apprise/logger.py
+++ b/apprise/logger.py
@@ -24,6 +24,10 @@
 # THE SOFTWARE.
 
 import logging
+from io import StringIO
+
+# The root identifier needed to monitor 'apprise' logging
+LOGGER_NAME = 'apprise'
 
 # Define a verbosity level that is a noisier then debug mode
 logging.TRACE = logging.DEBUG - 1
@@ -57,5 +61,104 @@ def deprecate(self, message, *args, **kwargs):
 logging.Logger.trace = trace
 logging.Logger.deprecate = deprecate
 
-# Create ourselve a generic logging reference
-logger = logging.getLogger('apprise')
+# Create ourselve a generic (singleton) logging reference
+logger = logging.getLogger(LOGGER_NAME)
+
+
+class LogCapture(object):
+    """
+    A class used to allow one to instantiate loggers that write to
+    memory for temporary purposes. e.g.:
+
+       1.  with LogCapture() as captured:
+       2.
+       3.      # Send our notification(s)
+       4.      aobj.notify("hello world")
+       5.
+       6.      # retrieve our logs produced by the above call via our
+       7.      # `captured` StringIO object we have access to within the `with`
+       8.      # block here:
+       9.      print(captured.getvalue())
+
+    """
+    def __init__(self, level=None, name=LOGGER_NAME,
+                 fmt='%(asctime)s - %(thread)d - %(levelname)s - %(message)s'):
+        """
+        Instantiate a temporary log capture object
+
+        You can optionally specify a logging level such as logging.INFO if you
+        wish, otherwise by default the script uses whatever logging has been
+        set globally.
+
+        Optionally over-ride the fmt as well if you wish.
+
+        """
+        # Our memory buffer placeholder
+        self.__mem_buffer = StringIO()
+
+        # Our logging level tracking
+        self.__level = level
+        self.__restore_level = None
+
+        # Acquire a pointer to our logger
+        self.__logger = logging.getLogger(name)
+
+        # Prepare our handler
+        self.__handler = logging.StreamHandler(self.__mem_buffer)
+
+        # Use the specified level, otherwise take on the already
+        # effective level of our logger
+        self.__handler.setLevel(
+            self.__level if self.__level is not None
+            else self.__logger.getEffectiveLevel())
+
+        # Prepare our formatter
+        self.__handler.setFormatter(logging.Formatter(fmt))
+
+    def __enter__(self):
+        """
+        Allows logger manipulation within a 'with' block
+        """
+
+        if self.__level is not None:
+            # Temporary adjust our log level if required
+            self.__restore_level = self.__logger.getEffectiveLevel()
+            if self.__restore_level > self.__level:
+                # Bump our log level up for the duration of our `with`
+                self.__logger.setLevel(self.__level)
+
+            else:
+                # No restoration required
+                self.__restore_level = None
+
+        else:
+            # Do nothing but enforce that we have nothing to restore to
+            self.__restore_level = None
+
+        # Add our handler
+        self.__logger.addHandler(self.__handler)
+
+        # return our memory pointer
+        return self.__mem_buffer
+
+    def __exit__(self, exc_type, exc_value, tb):
+        """
+        removes the handler gracefully when the with block has completed
+        """
+
+        # Flush our content
+        self.__handler.flush()
+        self.__mem_buffer.flush()
+
+        # Drop our handler
+        self.__logger.removeHandler(self.__handler)
+
+        if self.__restore_level is not None:
+            # Restore level
+            self.__logger.setLevel(self.__restore_level)
+
+        if exc_type is not None:
+            # pass exception on if one was generated
+            return False
+
+        return True

--- a/test/test_logger.py
+++ b/test/test_logger.py
@@ -24,6 +24,7 @@
 # THE SOFTWARE.
 
 import re
+import os
 import sys
 import mock
 import pytest
@@ -68,7 +69,7 @@ def test_apprise_logger():
 
 
 @pytest.mark.skipif(sys.version_info.major <= 2, reason="Requires Python 3.x+")
-def test_apprise_log_captures_py3():
+def test_apprise_log_memory_captures_py3():
     """
     API: Apprise() Python v3 Log Captures
 
@@ -211,7 +212,7 @@ def test_apprise_log_captures_py3():
 
 
 @pytest.mark.skipif(sys.version_info.major >= 3, reason="Requires Python 2.x+")
-def test_apprise_log_captures_py2():
+def test_apprise_log_memory_captures_py2():
     """
     API: Apprise() Python v2 Log Captures
 
@@ -348,6 +349,274 @@ def test_apprise_log_captures_py2():
             # is reverted as it was
             with LogCapture(level=logging.TRACE) as stream:
                 obj.send("hello world")
+
+    # Disable Logging
+    logging.disable(logging.CRITICAL)
+
+
+@pytest.mark.skipif(sys.version_info.major <= 2, reason="Requires Python 3.x+")
+def test_apprise_log_file_captures_py3(tmpdir):
+    """
+    API: Apprise() Python v3 Logfile Captures
+
+    """
+
+    # Ensure we're not running in a disabled state
+    logging.disable(logging.NOTSET)
+
+    log_file = tmpdir.join('capture.log')
+    assert not os.path.isfile(str(log_file))
+
+    logger.setLevel(logging.CRITICAL)
+    with LogCapture(path=str(log_file), level=logging.TRACE) as fp:
+        # The file will exit now
+        assert os.path.isfile(str(log_file))
+
+        logger.trace("trace")
+        logger.debug("debug")
+        logger.info("info")
+        logger.warning("warning")
+        logger.error("error")
+        logger.deprecate("deprecate")
+
+        content = fp.read().rstrip()
+        logs = re.split(r'\r*\n', content)
+
+        # We have a log entry for each of the 6 logs we generated above
+        assert 'trace' in content
+        assert 'debug' in content
+        assert 'info' in content
+        assert 'warning' in content
+        assert 'error' in content
+        assert 'deprecate' in content
+        assert len(logs) == 6
+
+    # The file is automatically cleaned up afterwards
+    assert not os.path.isfile(str(log_file))
+
+    # Verify that we did not lose our effective log level even though
+    # the above steps the level up for the duration of the capture
+    assert logger.getEffectiveLevel() == logging.CRITICAL
+
+    logger.setLevel(logging.TRACE)
+    with LogCapture(path=str(log_file), level=logging.DEBUG) as fp:
+        # The file will exit now
+        assert os.path.isfile(str(log_file))
+
+        logger.trace("trace")
+        logger.debug("debug")
+        logger.info("info")
+        logger.warning("warning")
+        logger.error("error")
+        logger.deprecate("deprecate")
+
+        content = fp.read().rstrip()
+        logs = re.split(r'\r*\n', content)
+
+        # We have a log entry for 5 of the log entries we generated above
+        # There will be no 'trace' entry
+        assert 'trace' not in content
+        assert 'debug' in content
+        assert 'info' in content
+        assert 'warning' in content
+        assert 'error' in content
+        assert 'deprecate' in content
+
+        assert len(logs) == 5
+
+        # Remove our file before we exit the with clause
+        # this causes our delete() call to throw gracefully inside
+        os.unlink(str(log_file))
+
+        # Verify file is gone
+        assert not os.path.isfile(str(log_file))
+
+    # Verify that we did not lose our effective log level even though
+    # the above steps the level up for the duration of the capture
+    assert logger.getEffectiveLevel() == logging.TRACE
+
+    logger.setLevel(logging.ERROR)
+    with LogCapture(path=str(log_file), delete=False,
+                    level=logging.WARNING) as fp:
+
+        # Verify exists
+        assert os.path.isfile(str(log_file))
+
+        logger.trace("trace")
+        logger.debug("debug")
+        logger.info("info")
+        logger.warning("warning")
+        logger.error("error")
+        logger.deprecate("deprecate")
+
+        content = fp.read().rstrip()
+        logs = re.split(r'\r*\n', content)
+
+        # We have a log entry for 3 of the log entries we generated above
+        # There will be no 'trace', 'debug', or 'info' entry
+        assert 'trace' not in content
+        assert 'debug' not in content
+        assert 'info' not in content
+        assert 'warning' in content
+        assert 'error' in content
+        assert 'deprecate' in content
+
+        assert len(logs) == 3
+
+    # Verify the file still exists (because delete was set to False)
+    assert os.path.isfile(str(log_file))
+
+    # remove it now
+    os.unlink(str(log_file))
+
+    # Enure it's been removed
+    assert not os.path.isfile(str(log_file))
+
+    # Set a global level of ERROR
+    logger.setLevel(logging.ERROR)
+
+    # Test case where we can't open the file
+    with mock.patch('builtins.open', side_effect=OSError()):
+        # Use the default level of None (by not specifying one); we then
+        # use whatever has been defined globally
+        with pytest.raises(OSError):
+            with LogCapture(path=str(log_file)) as fp:
+                # we'll never get here because we'll fail to open the file
+                pass
+
+    # Disable Logging
+    logging.disable(logging.CRITICAL)
+
+
+@pytest.mark.skipif(sys.version_info.major >= 3, reason="Requires Python 2.x+")
+def test_apprise_log_file_captures_py2(tmpdir):
+    """
+    API: Apprise() Python v2 Logfile Captures
+
+    """
+
+    # Ensure we're not running in a disabled state
+    logging.disable(logging.NOTSET)
+
+    log_file = tmpdir.join('capture.log')
+    assert not os.path.isfile(str(log_file))
+
+    logger.setLevel(logging.CRITICAL)
+    with LogCapture(path=str(log_file), level=logging.TRACE) as fp:
+        # The file will exit now
+        assert os.path.isfile(str(log_file))
+
+        logger.trace(u"trace")
+        logger.debug(u"debug")
+        logger.info(u"info")
+        logger.warning(u"warning")
+        logger.error(u"error")
+        logger.deprecate(u"deprecate")
+
+        content = fp.read().rstrip()
+        logs = re.split(r'\r*\n', content)
+
+        # We have a log entry for each of the 6 logs we generated above
+        assert 'trace' in content
+        assert 'debug' in content
+        assert 'info' in content
+        assert 'warning' in content
+        assert 'error' in content
+        assert 'deprecate' in content
+        assert len(logs) == 6
+
+    # The file is automatically cleaned up afterwards
+    assert not os.path.isfile(str(log_file))
+
+    # Verify that we did not lose our effective log level even though
+    # the above steps the level up for the duration of the capture
+    assert logger.getEffectiveLevel() == logging.CRITICAL
+
+    logger.setLevel(logging.TRACE)
+    with LogCapture(path=str(log_file), level=logging.DEBUG) as fp:
+        # The file will exit now
+        assert os.path.isfile(str(log_file))
+
+        logger.trace(u"trace")
+        logger.debug(u"debug")
+        logger.info(u"info")
+        logger.warning(u"warning")
+        logger.error(u"error")
+        logger.deprecate(u"deprecate")
+
+        content = fp.read().rstrip()
+        logs = re.split(r'\r*\n', content)
+
+        # We have a log entry for 5 of the log entries we generated above
+        # There will be no 'trace' entry
+        assert 'trace' not in content
+        assert 'debug' in content
+        assert 'info' in content
+        assert 'warning' in content
+        assert 'error' in content
+        assert 'deprecate' in content
+
+        assert len(logs) == 5
+
+        # Remove our file before we exit the with clause
+        # this causes our delete() call to throw gracefully inside
+        os.unlink(str(log_file))
+
+        # Verify file is gone
+        assert not os.path.isfile(str(log_file))
+
+    # Verify that we did not lose our effective log level even though
+    # the above steps the level up for the duration of the capture
+    assert logger.getEffectiveLevel() == logging.TRACE
+
+    logger.setLevel(logging.ERROR)
+    with LogCapture(path=str(log_file), delete=False,
+                    level=logging.WARNING) as fp:
+
+        # Verify exists
+        assert os.path.isfile(str(log_file))
+
+        logger.trace(u"trace")
+        logger.debug(u"debug")
+        logger.info(u"info")
+        logger.warning(u"warning")
+        logger.error(u"error")
+        logger.deprecate(u"deprecate")
+
+        content = fp.read().rstrip()
+        logs = re.split(r'\r*\n', content)
+
+        # We have a log entry for 3 of the log entries we generated above
+        # There will be no 'trace', 'debug', or 'info' entry
+        assert 'trace' not in content
+        assert 'debug' not in content
+        assert 'info' not in content
+        assert 'warning' in content
+        assert 'error' in content
+        assert 'deprecate' in content
+
+        assert len(logs) == 3
+
+    # Verify the file still exists (because delete was set to False)
+    assert os.path.isfile(str(log_file))
+
+    # remove it now
+    os.unlink(str(log_file))
+
+    # Enure it's been removed
+    assert not os.path.isfile(str(log_file))
+
+    # Set a global level of ERROR
+    logger.setLevel(logging.ERROR)
+
+    # Test case where we can't open the file
+    with mock.patch('__builtin__.open', side_effect=OSError()):
+        # Use the default level of None (by not specifying one); we then
+        # use whatever has been defined globally
+        with pytest.raises(OSError):
+            with LogCapture(path=str(log_file)) as fp:
+                # we'll never get here because we'll fail to open the file
+                pass
 
     # Disable Logging
     logging.disable(logging.CRITICAL)


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #306

- **LogCapture()** class created for storing log output in memory.

LogCapture works as follows:

```python
import apprise

# instantiate our notification services:
apobj = apprise.Apprise()

# Add all the notifications we want:
apobj.add('discord://credentials')
apobj.add('kodi://my.kodi.server')
apobj.add('json://localhost')

# but instead of calling apobj.notify() like one would normally do; capture the
# response from it:
with apprise.LogCapture(level=apprise.logging.INFO) as logs:
     # now call our notification
     apobj.notify("hello world")

     # At this point whether we were successful or not, we have all of the logs
     # generated from the above command stored in logs (which is of type StringIO)

     print(logs.getvalue())
     # Might print something like so:
     # 2020-10-09 16:14:10,284 - INFO - An 'info' message here
     # 2020-10-09 16:14:10,284 - WARNING - An 'warning' message here
     # 2020-10-09 16:14:10,284 - ERROR - An 'error' message here
```

You can perform all kinds of manipulation on the logs at this point such as converting it all to HTML for display:
```python
import re
with apprise.LogCapture(level=apprise.logging.INFO) as logs:
     # now call our notification
     apobj.notify("hello world")

     # convert them into a list if you like:
     entries_as_list = logs.rstrip().split('\n')

    # This regular expression might work great for parsing for you:
    log_entry_re = re.compile(
        r'(?P<datetime>[^,]+),0*?(?P<ms>[0-9]+) - '
        r'(?P<type>[a-z ]+) - (?P<message>.*)', re.I)

    # Iterate over each entry and access them
    for entry in entries_as_list:
        match = log_entry_re.match(entry)
        if match:
            print(match.group('datetime'))
            print(match.group('ms'))
            print(match.group('type'))
            print(match.group('message'))
        else:
            # the line is a carry over from the previous line (hence, it was
            # a multi-lined log entry).
            # Treat the entire thing as still part of the 'message'; it's
            # content should be associated with the previous line
            print(entry)
 ```

```python
    # This is the same as the above, except we prepare some HTML formatting:
    bullets = []
    for entry in entries_as_list:
        match = log_entry_re.match(entry)
        if match:
            if bullets:
                # append our tail
                bullets[-1] += '</span></li>'

            bullets.append(
                '<li><span class="log_date">{datetime},{ms}</span> - '
                '<span class="log_type">{type}</span> - '
                '<span class="log_msg">{message}'.format(
                    datetime=match.group('datetime'),
                    ms=match.group('ms'),
                    type=match.group('type'),
                    message=match.group('message'),
            ))

        else:   # append our content to the end of our last message
            if bullets:
                # append our tail
                bullets[-1] += '<br/>' + entry

    # after our for-loop add our tail
    if bullets:
        # append our tail
        bullets[-1] += '</span></li>'

    # Now wrap our content in an <ul> block:
    html = '<ul class="log_entries">{}</ul>.format(''.join(bullets))
```

If you want to have your capture get written to a file instead of a temporary memory object, just specify a `path` to the filename you wish to write the content to:
```python
with apprise.LogCapture(path="/tmp/capture", level=apprise.logging.INFO) as fp:
     # now call our notification
     apobj.notify("hello world")

     # Because `path` was used here, we have access to a file pointer to the log (not a StringIO object).
     # You can easily access the logs like so
     content = fp.read()
```

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
