### PR TITLE
Parse Amazon Web Service responses in unicode; not bytes

### DIFF
--- a/apprise/plugins/NotifySNS.py
+++ b/apprise/plugins/NotifySNS.py
@@ -361,7 +361,7 @@ class NotifySNS(NotifyBase):
 
                 self.logger.debug('Response Details:\r\n{}'.format(r.content))
 
-                return (False, NotifySNS.aws_response_to_dict(r.content))
+                return (False, NotifySNS.aws_response_to_dict(r.text))
 
             else:
                 self.logger.info(
@@ -375,7 +375,7 @@ class NotifySNS(NotifyBase):
             self.logger.debug('Socket Exception: %s' % str(e))
             return (False, NotifySNS.aws_response_to_dict(None))
 
-        return (True, NotifySNS.aws_response_to_dict(r.content))
+        return (True, NotifySNS.aws_response_to_dict(r.text))
 
     def aws_prepare_request(self, payload, reference=None):
         """

--- a/test/test_sns_plugin.py
+++ b/test/test_sns_plugin.py
@@ -288,7 +288,7 @@ def test_aws_topic_handling(mock_post):
 
         # A request
         robj = mock.Mock()
-        robj.content = ''
+        robj.text = ''
         robj.status_code = requests.codes.ok
 
         if data.find('=CreateTopic') >= 0:
@@ -323,11 +323,11 @@ def test_aws_topic_handling(mock_post):
 
         # A request
         robj = mock.Mock()
-        robj.content = ''
+        robj.text = ''
         robj.status_code = requests.codes.ok
 
         if data.find('=CreateTopic') >= 0:
-            robj.content = arn_response
+            robj.text = arn_response
 
         # Manipulate Topic Publishing only (not phone)
         elif data.find('=Publish') >= 0 and data.find('TopicArn=') >= 0:
@@ -347,7 +347,7 @@ def test_aws_topic_handling(mock_post):
 
     # Handle case where TopicArn is missing:
     robj = mock.Mock()
-    robj.content = "<CreateTopicResponse></CreateTopicResponse>"
+    robj.text = "<CreateTopicResponse></CreateTopicResponse>"
     robj.status_code = requests.codes.ok
 
     # Assign ourselves a new function
@@ -356,14 +356,14 @@ def test_aws_topic_handling(mock_post):
 
     # Handle case where we fails get a bad response
     robj = mock.Mock()
-    robj.content = ''
+    robj.text = ''
     robj.status_code = requests.codes.bad_request
     mock_post.return_value = robj
     assert a.notify(title='', body='test') is False
 
     # Handle case where we get a valid response and TopicARN
     robj = mock.Mock()
-    robj.content = arn_response
+    robj.text = arn_response
     robj.status_code = requests.codes.ok
     mock_post.return_value = robj
     # We would have failed to make Post


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #319 

Fix the encoding issue with Amazon Web Service responses

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
