### PR TITLE
Fix version of cryptography to v3.1.1 for  Travis CI PyPy3.5 runner

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -88,7 +88,10 @@ commands =
 deps=
    -r{toxinidir}/requirements.txt
    -r{toxinidir}/dev-requirements.txt
+# Last supported cryptography version that can link against
+# OpenSSL v1.0.2 (which pypy35 uses) is 3.1.1
 commands =
+    pip install --upgrade cryptography==3.1.1
     python setup.py compile_catalog
     coverage run --parallel -m pytest {posargs}
     flake8 . --count --show-source --statistics


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #320 

Noticed that latest bugfix against Apprise that was fixed would no longer pass test runner.  Turns out that a new version of PyPi has flagged pypy35 as obsolete basically due to the version of OpenSSL loaded in that CI Container

This patch just forces an earlier version of `cryptography` to v3.1.1 in efforts to allow Apprise unit testing to continue to work.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
