### PR TITLE
Zulip to reference the word 'stream' and not 'channel'

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The table below identifies the services this tool supports and some example serv
 | [XBMC](https://github.com/caronc/apprise/wiki/Notify_xbmc) | xbmc:// or xbmcs://    | (TCP) 8080 or 443   | xbmc://hostname<br />xbmc://user@hostname<br />xbmc://user:password@hostname:port
 | [XMPP](https://github.com/caronc/apprise/wiki/Notify_xmpp) | xmpp:// or xmpps://    | (TCP) 5222 or 5223   | xmpp://password@hostname<br />xmpp://user:password@hostname<br />xmpps://user:password@hostname:port?jid=user@hostname/resource<br/>xmpps://password@hostname/target@myhost, target2@myhost/resource
 | [Webex Teams (Cisco)](https://github.com/caronc/apprise/wiki/Notify_wxteams) | wxteams://  | (TCP) 443   | wxteams://Token
-| [Zulip Chat](https://github.com/caronc/apprise/wiki/Notify_zulip) | zulip://  | (TCP) 443   | zulip://botname@Organization/Token<br />zulip://botname@Organization/Token/Channel<br />zulip://botname@Organization/Token/Email
+| [Zulip Chat](https://github.com/caronc/apprise/wiki/Notify_zulip) | zulip://  | (TCP) 443   | zulip://botname@Organization/Token<br />zulip://botname@Organization/Token/Stream<br />zulip://botname@Organization/Token/Email
 
 
 ### SMS Notification Support

--- a/apprise/plugins/NotifyZulip.py
+++ b/apprise/plugins/NotifyZulip.py
@@ -77,12 +77,12 @@ ZULIP_HTTP_ERROR_MAP = {
     401: 'Unauthorized - Invalid Token.',
 }
 
-# Used to break path apart into list of channels
+# Used to break path apart into list of streams
 TARGET_LIST_DELIM = re.compile(r'[ \t\r\n,#\\/]+')
 
-# Used to detect a channel
+# Used to detect a streams
 IS_VALID_TARGET_RE = re.compile(
-    r'#?(?P<channel>[A-Z0-9_]{1,32})', re.I)
+    r'#?(?P<stream>[A-Z0-9_]{1,32})', re.I)
 
 
 class NotifyZulip(NotifyBase):
@@ -142,8 +142,8 @@ class NotifyZulip(NotifyBase):
             'type': 'string',
             'map_to': 'targets',
         },
-        'target_channel': {
-            'name': _('Target Channel'),
+        'target_stream': {
+            'name': _('Target Stream'),
             'type': 'string',
             'map_to': 'targets',
         },
@@ -164,8 +164,8 @@ class NotifyZulip(NotifyBase):
     # if one isn't defined in the apprise url
     default_hostname = 'zulipchat.com'
 
-    # The default channel to notify if no targets are specified
-    default_notification_channel = 'general'
+    # The default stream to notify if no targets are specified
+    default_notification_stream = 'general'
 
     def __init__(self, botname, organization, token, targets=None, **kwargs):
         """
@@ -218,8 +218,8 @@ class NotifyZulip(NotifyBase):
 
         self.targets = parse_list(targets)
         if len(self.targets) == 0:
-            # No channels identified, use default
-            self.targets.append(self.default_notification_channel)
+            # No streams identified, use default
+            self.targets.append(self.default_notification_stream)
 
     def send(self, body, title='', notify_type=NotifyType.INFO, **kwargs):
         """

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -4825,11 +4825,11 @@ TEST_URLS = (
     ('zulip://botname@apprise.zulipchat.com/{}'.format('a' * 32), {
         'instance': plugins.NotifyZulip,
     }),
-    # Valid everything - 2 channels specified
+    # Valid everything - 2 streams specified
     ('zulip://botname@apprise/{}/channel1/channel2'.format('a' * 32), {
         'instance': plugins.NotifyZulip,
     }),
-    # Valid everything - 2 channels specified (using to=)
+    # Valid everything - 2 streams specified (using to=)
     ('zulip://botname@apprise/{}/?to=channel1/channel2'.format('a' * 32), {
         'instance': plugins.NotifyZulip,
     }),


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #316 

Eliminate references to the word **channel** when referring to Zulip and instead use the word **stream**

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
