### PR TITLE
APPRISE_URLS & APPRISE_CONFIG env variable support added

### DIFF
--- a/apprise/cli.py
+++ b/apprise/cli.py
@@ -251,8 +251,11 @@ def main(body, title, config, attach, urls, notification_type, theme, tag,
     #    5. Default Configuration File(s) (if found)
     #
     if urls:
-        # Ignore any tags specified
-        tag = None
+        if tag:
+            # Ignore any tags specified
+            logger.warning(
+                '--tag (-g) entries are ignored when using specified URLs')
+            tag = None
 
         # Load our URLs (if any defined)
         for url in urls:
@@ -272,8 +275,11 @@ def main(body, title, config, attach, urls, notification_type, theme, tag,
 
     elif os.environ.get('APPRISE_URLS', '').strip():
         logger.debug('Loading provided APPRISE_URLS environment variable')
-        # Ignore any tags specified
-        tag = None
+        if tag:
+            # Ignore any tags specified
+            logger.warning(
+                '--tag (-g) entries are ignored when using specified URLs')
+            tag = None
 
         # Attempt to use our APPRISE_URLS environment variable (if populated)
         a.add(os.environ['APPRISE_URLS'].strip())

--- a/apprise/cli.py
+++ b/apprise/cli.py
@@ -271,6 +271,7 @@ def main(body, title, config, attach, urls, notification_type, theme, tag,
             paths=config, asset=asset, recursion=recursion_depth))
 
     elif os.environ.get('APPRISE_URLS', '').strip():
+        logger.debug('Loading provided APPRISE_URLS environment variable')
         # Ignore any tags specified
         tag = None
 
@@ -278,6 +279,7 @@ def main(body, title, config, attach, urls, notification_type, theme, tag,
         a.add(os.environ['APPRISE_URLS'].strip())
 
     elif os.environ.get('APPRISE_CONFIG', '').strip():
+        logger.debug('Loading provided APPRISE_CONFIG environment variable')
         # Fall back to config environment variable (if populated)
         a.add(AppriseConfig(
             paths=os.environ['APPRISE_CONFIG'].strip(),

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -420,6 +420,14 @@ def test_apprise_cli_nux_env(tmpdir):
         # variable with a valid URL
         result = runner.invoke(cli.main, [
             '-b', 'test environment',
+            # Test that we ignore our tag
+            '--tag', 'mytag',
+        ])
+        assert result.exit_code == 0
+
+        # Same action but without --tag
+        result = runner.invoke(cli.main, [
+            '-b', 'test environment',
         ])
         assert result.exit_code == 0
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -31,6 +31,8 @@ from apprise import cli
 from apprise import NotifyBase
 from click.testing import CliRunner
 from apprise.plugins import SCHEMA_MAP
+from apprise.utils import environ
+
 
 try:
     # Python v3.4+
@@ -359,7 +361,7 @@ def test_apprise_cli_nux_env(tmpdir):
     # This will fail because nothing matches mytag. It's case sensitive
     # and we would only actually match against myTag
     result = runner.invoke(cli.main, [
-        '-b', 'has taga',
+        '-b', 'has mytag',
         '--config', str(t),
         '--tag', 'mytag',
     ])
@@ -370,7 +372,7 @@ def test_apprise_cli_nux_env(tmpdir):
     # However, since we don't match anything; we still fail with a return code
     # of 2.
     result = runner.invoke(cli.main, [
-        '-b', 'has taga',
+        '-b', 'has mytag',
         '--config', str(t),
         '--tag', 'mytag',
         '--dry-run'
@@ -379,7 +381,7 @@ def test_apprise_cli_nux_env(tmpdir):
 
     # Here is a case where we get what was expected; we also attach a file
     result = runner.invoke(cli.main, [
-        '-b', 'has taga',
+        '-b', 'has myTag',
         '--config', str(t),
         '--attach', join(dirname(__file__), 'var', 'apprise-test.gif'),
         '--tag', 'myTag',
@@ -389,12 +391,133 @@ def test_apprise_cli_nux_env(tmpdir):
     # Testing with the --dry-run flag reveals the same positive results
     # because there was at least one match
     result = runner.invoke(cli.main, [
-        '-b', 'has taga',
+        '-b', 'has myTag',
         '--config', str(t),
         '--tag', 'myTag',
         '--dry-run',
     ])
     assert result.exit_code == 0
+
+    #
+    # Test environment variables
+    #
+    # Write a simple text based configuration file
+    t2 = tmpdir.mkdir("apprise-obj-env").join("apprise")
+    buf = """
+    # A general one
+    good://localhost
+
+    # A failure (if we use the fail tag)
+    fail=bad://localhost
+
+    # A normal one tied to myTag
+    myTag=good://nuxref.com
+    """
+    t2.write(buf)
+
+    with environ(APPRISE_URLS="good://localhost"):
+        # This will load okay because we defined the environment
+        # variable with a valid URL
+        result = runner.invoke(cli.main, [
+            '-b', 'test environment',
+        ])
+        assert result.exit_code == 0
+
+    with environ(APPRISE_URLS="      "):
+        # An empty string is not valid and therefore not loaded
+        # so the below fails
+        result = runner.invoke(cli.main, [
+            '-b', 'test environment',
+        ])
+        assert result.exit_code == 3
+
+    with environ(APPRISE_URLS="bad://localhost"):
+        result = runner.invoke(cli.main, [
+            '-b', 'test environment',
+        ])
+        assert result.exit_code == 1
+
+        # If we specify an inline URL, it will over-ride the environment
+        # variable
+        result = runner.invoke(cli.main, [
+            '-t', 'test title',
+            '-b', 'test body',
+            'good://localhost',
+        ])
+        assert result.exit_code == 0
+
+        # A Config file also over-rides the environment variable if
+        # specified on the command line:
+        result = runner.invoke(cli.main, [
+            '-b', 'has myTag',
+            '--config', str(t2),
+            '--tag', 'myTag',
+        ])
+        assert result.exit_code == 0
+
+    with environ(APPRISE_CONFIG=str(t2)):
+        # Our configuration file will load from our environmment variable
+        result = runner.invoke(cli.main, [
+            '-b', 'has myTag',
+            '--tag', 'myTag',
+        ])
+        assert result.exit_code == 0
+
+    with environ(APPRISE_CONFIG="      "):
+        # We will fail to send the notification as no path was
+        # specified
+        result = runner.invoke(cli.main, [
+            '-b', 'my message',
+        ])
+        assert result.exit_code == 3
+
+    with environ(APPRISE_CONFIG="garbage/file/path.yaml"):
+        # We will fail to send the notification as the path
+        # specified is not loadable
+        result = runner.invoke(cli.main, [
+            '-b', 'my message',
+        ])
+        assert result.exit_code == 1
+
+        # We can force an over-ride by specifying a config file on the
+        # command line options:
+        result = runner.invoke(cli.main, [
+            '-b', 'has myTag',
+            '--config', str(t2),
+            '--tag', 'myTag',
+        ])
+        assert result.exit_code == 0
+
+    # Just a general test; if both the --config and urls are specified
+    # then the the urls trumps all
+    result = runner.invoke(cli.main, [
+        '-b', 'has myTag',
+        '--config', str(t2),
+        'good://localhost',
+        '--tag', 'fail',
+    ])
+    # Tags are ignored, URL specified, so it trump config
+    assert result.exit_code == 0
+
+    # we just repeat the test as a proof that it only executes
+    # the urls despite the fact the --config was specified
+    result = runner.invoke(cli.main, [
+        '-b', 'reads the url entry only',
+        '--config', str(t2),
+        'good://localhost',
+        '--tag', 'fail',
+    ])
+    # Tags are ignored, URL specified, so it trump config
+    assert result.exit_code == 0
+
+    # once agian, but we call bad://
+    result = runner.invoke(cli.main, [
+        '-b', 'reads the url entry only',
+        '--config', str(t2),
+        'bad://localhost',
+        '--tag', 'myTag',
+    ])
+    assert result.exit_code == 1
 
 
 @mock.patch('platform.system')


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #332

Two new environment variables added:

1. `APPRISE_URLS`: When defined, you can pre-provide **apprise** with a set of one or more URLs it can use to notify by default.
2. `APPRISE_CONFIG`: You can set this to the absolute path of an Apprise Configuration File (either TEXT or YAML based).

Some new rules/structuring come with this commit as well, content is always processed as follows.
- Tags (`--tag` or `-g`) are automatically dropped/ignored if specified with a URL
- The priorities of what is accepted are parsed in order below:
  1. URLs by command line
     - A warning is issued to the screen if a (`--config` or `-c`) is also specified as it will be ignored
     - A warning is issued to the screen if a (`--tag` or `-g`) is also specified as it will be ignored
  2. Configuration by command line
  3. URLs by environment variable: `APPRISE_URLS`
     - A warning is issued to the screen if a (`--tag` or `-g`) is also specified as it will be ignored
  4. Configuration by environment variable: `APPRISE_CONFIG`
  5. Default Configuration File(s) if found - no change here prior to this commit.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
