### PR TITLE
Cleaned up Mattermost Integration

### DIFF
--- a/apprise/plugins/NotifyMatterMost.py
+++ b/apprise/plugins/NotifyMatterMost.py
@@ -23,6 +23,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+# Create an incoming webhook; the website will provide you with something like:
+#  http://localhost:8065/hooks/yobjmukpaw3r3urc5h6i369yima
+#                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#                              |-- this is the webhook --|
+#
+# You can effectively turn the url above to read this:
+# mmost://localhost:8065/yobjmukpaw3r3urc5h6i369yima
+#  - swap http with mmost
+#  - drop /hooks/ reference
+
 import six
 import requests
 from json import dumps
@@ -94,7 +104,6 @@ class NotifyMatterMost(NotifyBase):
         'authtoken': {
             'name': _('Access Key'),
             'type': 'string',
-            'regex': (r'^[a-z0-9]{24,32}$', 'i'),
             'private': True,
             'required': True,
         },
@@ -150,8 +159,7 @@ class NotifyMatterMost(NotifyBase):
             fullpath, six.string_types) else fullpath.strip()
 
         # Authorization Token (associated with project)
-        self.authtoken = validate_regex(
-            authtoken, *self.template_tokens['authtoken']['regex'])
+        self.authtoken = validate_regex(authtoken)
         if not self.authtoken:
             msg = 'An invalid MatterMost Authorization Token ' \
                   '({}) was specified.'.format(authtoken)

--- a/apprise/plugins/NotifyMatterMost.py
+++ b/apprise/plugins/NotifyMatterMost.py
@@ -84,14 +84,14 @@ class NotifyMatterMost(NotifyBase):
 
     # Define object templates
     templates = (
-        '{schema}://{host}/{authtoken}',
-        '{schema}://{host}/{authtoken}:{port}',
-        '{schema}://{botname}@{host}/{authtoken}',
-        '{schema}://{botname}@{host}:{port}/{authtoken}',
-        '{schema}://{host}/{fullpath}/{authtoken}',
-        '{schema}://{host}/{fullpath}{authtoken}:{port}',
-        '{schema}://{botname}@{host}/{fullpath}/{authtoken}',
-        '{schema}://{botname}@{host}:{port}/{fullpath}/{authtoken}',
+        '{schema}://{host}/{token}',
+        '{schema}://{host}/{token}:{port}',
+        '{schema}://{botname}@{host}/{token}',
+        '{schema}://{botname}@{host}:{port}/{token}',
+        '{schema}://{host}/{fullpath}/{token}',
+        '{schema}://{host}/{fullpath}{token}:{port}',
+        '{schema}://{botname}@{host}/{fullpath}/{token}',
+        '{schema}://{botname}@{host}:{port}/{fullpath}/{token}',
     )
 
     # Define our template tokens
@@ -101,8 +101,8 @@ class NotifyMatterMost(NotifyBase):
             'type': 'string',
             'required': True,
         },
-        'authtoken': {
-            'name': _('Access Key'),
+        'token': {
+            'name': _('Webhook Token'),
             'type': 'string',
             'private': True,
             'required': True,
@@ -141,7 +141,7 @@ class NotifyMatterMost(NotifyBase):
         },
     })
 
-    def __init__(self, authtoken, fullpath=None, channels=None,
+    def __init__(self, token, fullpath=None, channels=None,
                  include_image=False, **kwargs):
         """
         Initialize MatterMost Object
@@ -159,10 +159,10 @@ class NotifyMatterMost(NotifyBase):
             fullpath, six.string_types) else fullpath.strip()
 
         # Authorization Token (associated with project)
-        self.authtoken = validate_regex(authtoken)
-        if not self.authtoken:
+        self.token = validate_regex(token)
+        if not self.token:
             msg = 'An invalid MatterMost Authorization Token ' \
-                  '({}) was specified.'.format(authtoken)
+                  '({}) was specified.'.format(token)
             self.logger.warning(msg)
             raise TypeError(msg)
 
@@ -219,7 +219,7 @@ class NotifyMatterMost(NotifyBase):
 
             url = '{}://{}:{}{}/hooks/{}'.format(
                 self.schema, self.host, self.port, self.fullpath,
-                self.authtoken)
+                self.token)
 
             self.logger.debug('MatterMost POST URL: %s (cert_verify=%r)' % (
                 url, self.verify_certificate,
@@ -311,7 +311,7 @@ class NotifyMatterMost(NotifyBase):
             )
 
         return \
-            '{schema}://{botname}{hostname}{port}{fullpath}{authtoken}' \
+            '{schema}://{botname}{hostname}{port}{fullpath}{token}' \
             '/?{params}'.format(
                 schema=default_schema,
                 botname=botname,
@@ -322,7 +322,7 @@ class NotifyMatterMost(NotifyBase):
                      else ':{}'.format(self.port),
                 fullpath='/' if not self.fullpath else '{}/'.format(
                     NotifyMatterMost.quote(self.fullpath, safe='/')),
-                authtoken=self.pprint(self.authtoken, privacy, safe=''),
+                token=self.pprint(self.token, privacy, safe=''),
                 params=NotifyMatterMost.urlencode(params),
             )
 
@@ -338,11 +338,11 @@ class NotifyMatterMost(NotifyBase):
             # We're done early as we couldn't load the results
             return results
 
-        # Acquire our tokens; the last one will always be our authtoken
+        # Acquire our tokens; the last one will always be our token
         # all entries before it will be our path
         tokens = NotifyMatterMost.split_path(results['fullpath'])
 
-        results['authtoken'] = None if not tokens else tokens.pop()
+        results['token'] = None if not tokens else tokens.pop()
 
         # Store our path
         results['fullpath'] = '' if not tokens \

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -49,7 +49,7 @@ it easy to access:
 
 Boxcar, ClickSend, Discord, E-Mail, Emby, Faast, FCM, Flock, Gitter, Google
 Chat, Gotify, Growl, IFTTT, Join, Kavenegar, KODI, Kumulos, LaMetric, MacOSX,
-Mailgun, MatterMost, Matrix, Microsoft Windows, Microsoft Teams, MessageBird,
+Mailgun, Mattermost, Matrix, Microsoft Windows, Microsoft Teams, MessageBird,
 MSG91, MyAndroid, Nexmo, Nextcloud, Notica, Notifico, Office365, OneSignal,
 Opsgenie, ParsePlatform, PopcornNotify, Prowl, Pushalot, PushBullet, Pushjet,
 Pushover, PushSafer, Rocket.Chat, SendGrid, SimplePush, Sinch, Slack, Spontit,

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -1780,7 +1780,7 @@ TEST_URLS = (
     }),
 
     ##################################
-    # NotifyMatterMost
+    # NotifyMattermost
     ##################################
     ('mmost://', {
         'instance': None,
@@ -1796,64 +1796,64 @@ TEST_URLS = (
         'instance': TypeError,
     }),
     ('mmost://localhost/3ccdd113474722377935511fc85d3dd4', {
-        'instance': plugins.NotifyMatterMost,
+        'instance': plugins.NotifyMattermost,
     }),
     ('mmost://user@localhost/3ccdd113474722377935511fc85d3dd4?channel=test', {
-        'instance': plugins.NotifyMatterMost,
+        'instance': plugins.NotifyMattermost,
     }),
     ('mmost://user@localhost/3ccdd113474722377935511fc85d3dd4?to=test', {
-        'instance': plugins.NotifyMatterMost,
+        'instance': plugins.NotifyMattermost,
 
         # Our expected url(privacy=True) startswith() response:
         'privacy_url': 'mmost://user@localhost/3...4/',
     }),
     ('mmost://localhost/3ccdd113474722377935511fc85d3dd4'
      '?to=test&image=True', {
-         'instance': plugins.NotifyMatterMost}),
+         'instance': plugins.NotifyMattermost}),
     ('mmost://localhost/3ccdd113474722377935511fc85d3dd4' \
      '?to=test&image=False', {
-         'instance': plugins.NotifyMatterMost}),
+         'instance': plugins.NotifyMattermost}),
     ('mmost://localhost/3ccdd113474722377935511fc85d3dd4' \
      '?to=test&image=True', {
-         'instance': plugins.NotifyMatterMost,
+         'instance': plugins.NotifyMattermost,
          # don't include an image by default
          'include_image': False}),
     ('mmost://localhost:8080/3ccdd113474722377935511fc85d3dd4', {
-        'instance': plugins.NotifyMatterMost,
+        'instance': plugins.NotifyMattermost,
 
         # Our expected url(privacy=True) startswith() response:
         'privacy_url': 'mmost://localhost:8080/3...4/',
     }),
     ('mmost://localhost:8080/3ccdd113474722377935511fc85d3dd4', {
-        'instance': plugins.NotifyMatterMost,
+        'instance': plugins.NotifyMattermost,
     }),
     ('mmost://localhost:invalid-port/3ccdd113474722377935511fc85d3dd4', {
         'instance': None,
     }),
     ('mmosts://localhost/3ccdd113474722377935511fc85d3dd4', {
-        'instance': plugins.NotifyMatterMost,
+        'instance': plugins.NotifyMattermost,
     }),
     # Test our paths
     ('mmosts://localhost/a/path/3ccdd113474722377935511fc85d3dd4', {
-        'instance': plugins.NotifyMatterMost,
+        'instance': plugins.NotifyMattermost,
     }),
     ('mmosts://localhost/////3ccdd113474722377935511fc85d3dd4///', {
-        'instance': plugins.NotifyMatterMost,
+        'instance': plugins.NotifyMattermost,
     }),
     ('mmost://localhost/3ccdd113474722377935511fc85d3dd4', {
-        'instance': plugins.NotifyMatterMost,
+        'instance': plugins.NotifyMattermost,
         # force a failure
         'response': False,
         'requests_response_code': requests.codes.internal_server_error,
     }),
     ('mmost://localhost/3ccdd113474722377935511fc85d3dd4', {
-        'instance': plugins.NotifyMatterMost,
+        'instance': plugins.NotifyMattermost,
         # throw a bizzare code forcing us to fail to look it up
         'response': False,
         'requests_response_code': 999,
     }),
     ('mmost://localhost/3ccdd113474722377935511fc85d3dd4', {
-        'instance': plugins.NotifyMatterMost,
+        'instance': plugins.NotifyMattermost,
         # Throws a series of connection and transfer exceptions when this flag
         # is set and tests that we gracfully handle them
         'test_requests_exceptions': True,
@@ -6362,7 +6362,7 @@ def test_notify_kumulos_plugin():
 
 def test_notify_mattermost_plugin():
     """
-    API: NotifyMatterMost() Extra Checks
+    API: NotifyMattermost() Extra Checks
 
     """
     # Disable Throttling to speed testing
@@ -6370,9 +6370,9 @@ def test_notify_mattermost_plugin():
 
     # Invalid Authorization Token
     with pytest.raises(TypeError):
-        plugins.NotifyMatterMost(None)
+        plugins.NotifyMattermost(None)
     with pytest.raises(TypeError):
-        plugins.NotifyMatterMost("     ")
+        plugins.NotifyMattermost("     ")
 
 
 @mock.patch('requests.post')


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #352

This just eliminates the webhook validation check; let the upstream service maintain how it's formatted, not Apprise.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
