### PR TITLE
Added support for markdown in Gotify plugin

### DIFF
--- a/apprise/plugins/NotifyGotify.py
+++ b/apprise/plugins/NotifyGotify.py
@@ -35,7 +35,7 @@ import requests
 from json import dumps
 
 from .NotifyBase import NotifyBase
-from ..common import NotifyType
+from ..common import NotifyType, NotifyFormat
 from ..utils import validate_regex
 from ..AppriseLocale import gettext_lazy as _
 
@@ -181,6 +181,13 @@ class NotifyGotify(NotifyBase):
             'title': title,
             'message': body,
         }
+
+        if self.notify_format == NotifyFormat.MARKDOWN:
+            payload["extras"] = {
+                "client::display": {
+                    "contentType": "text/markdown"
+                }
+            }
 
         # Our headers
         headers = {


### PR DESCRIPTION
## Description:

Gotify supports markdown as a [message "extra"](https://gotify.net/docs/msgextras), thought it would be nice to be supported here.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
