### PR TITLE
Fix UnicodeDecodeError exception thrown on Python 2.7.6

### DIFF
--- a/apprise/Apprise.py
+++ b/apprise/Apprise.py
@@ -421,6 +421,9 @@ class Apprise(object):
                     # idenified here: https://bugs.python.org/issue21331
                     conversion_map[server.notify_format] = \
                         conversion_map[server.notify_format]\
+                        .decode('string_escape') \
+                        if six.PY2 else \
+                        conversion_map[server.notify_format]\
                         .encode('ascii', 'backslashreplace')\
                         .decode('unicode-escape')
 
@@ -432,7 +435,9 @@ class Apprise(object):
                 try:
                     # Added overhead requrired due to Python 3 Encoding Bug
                     # idenified here: https://bugs.python.org/issue21331
-                    title = title\
+                    title = title.decode('string_escape')\
+                        if six.PY2 else \
+                        title\
                         .encode('ascii', 'backslashreplace')\
                         .decode('unicode-escape')
 


### PR DESCRIPTION
## Description:
Fixes issue when running unit tests on Python v2.7.6 (for RPM building); producing:
```
# Backtrace of apprise/Apprise.py
          try:
              # Added overhead required due to Python 3 Encoding Bug
              # identified here: https://bugs.python.org/issue21331
              conversion_map[server.notify_format] = \
                  conversion_map[server.notify_format]\
>                 .encode('ascii', 'backslashreplace')\
                  .decode('unicode-escape')
E                 UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 9: ordinal not in range(128)
```

The error originates from **test/test_escapes.py** Line 241 in `test_apprise_escaping_py2()`

This error only occurs when using the `escape` functionality

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
