### PR TITLE
Path issue resolved with Home Assistant posts

### DIFF
--- a/apprise/plugins/NotifyHomeAssistant.py
+++ b/apprise/plugins/NotifyHomeAssistant.py
@@ -176,7 +176,7 @@ class NotifyHomeAssistant(NotifyBase):
         if isinstance(self.port, int):
             url += ':%d' % self.port
 
-        url += '/' + self.fullpath.strip('/')
+        url += '' if not self.fullpath else '/' + self.fullpath.strip('/')
         url += '/api/services/persistent_notification/create'
 
         self.logger.debug('Home Assistant POST URL: %s (cert_verify=%r)' % (

--- a/test/test_homeassistant_plugin.py
+++ b/test/test_homeassistant_plugin.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import six
+import mock
+import requests
+from apprise import plugins
+from apprise import Apprise
+
+# Disable logging for a cleaner testing output
+import logging
+logging.disable(logging.CRITICAL)
+
+
+@mock.patch('requests.post')
+def test_homeassistant_plugin(mock_post):
+    """
+    API: NotifyHomeAssistant() Tests
+
+    """
+    # Disable Throttling to speed testing
+    plugins.NotifyBase.request_rate_per_sec = 0
+
+    response = mock.Mock()
+    response.content = ''
+    response.status_code = requests.codes.ok
+
+    # Prepare Mock
+    mock_post.return_value = response
+
+    # Variation Initializations
+    obj = Apprise.instantiate('hassio://localhost/accesstoken')
+    assert isinstance(obj, plugins.NotifyHomeAssistant) is True
+    assert isinstance(obj.url(), six.string_types) is True
+
+    # Send Notification
+    assert obj.send(body="test") is True
+
+    assert mock_post.call_count == 1
+    assert mock_post.call_args_list[0][0][0] == \
+        'http://localhost:8123/api/services/persistent_notification/create'


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #369 and  [here](https://github.com/caronc/apprise/pull/354#discussion_r588897890)

Essentially an extra slash was appearing on the `POST` entries Apprise was making to the Home Assistant server causing it to reject the request.

This PR fixes this and also include a test to verify the path is being correctly assembled.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
