### PR TITLE
New Travis-CI (.org -> .com) Integration Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,10 @@ matrix:
       env: TOXENV=py37
     - python: "3.8"
       env: TOXENV=py38
-    - python: "3.9-dev"
+    - python: "3.9"
       env: TOXENV=py39
+    - python: "3.9-dev"
+      env: TOXENV=py39-dev
     - python: "pypy2.7-6.0"
       env: TOXENV=pypy
     - python: "pypy3.5-7.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,9 @@ matrix:
 
 install:
   - pip install babel
-  - pip install .
+  # upgrade tox, pip, and virtualenv so Python 3.6 will build crytography:
+  # https://travis-ci.community/t/pip-install-cryptography-fails-on-py36/11233
+  - pip install -U tox pip virtualenv
   - pip install codecov
   - pip install -r dev-requirements.txt
   - pip install -r requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,5 @@ setup(
     ),
     entry_points={'console_scripts': console_scripts},
     python_requires='>=2.7',
-    setup_requires=['pytest-runner', 'babel', ],
-    tests_require=open('dev-requirements.txt').readlines(),
+    setup_requires=['babel', ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,py38,py39,pypy,pypy3,coverage-report
+envlist = py27,py35,py36,py37,py38,py39,py39-dev,pypy,pypy3,coverage-report
 
 
 [testenv]
@@ -66,6 +66,16 @@ commands =
     flake8 . --count --show-source --statistics
 
 [testenv:py39]
+deps=
+   dbus-python
+   -r{toxinidir}/requirements.txt
+   -r{toxinidir}/dev-requirements.txt
+commands =
+    python setup.py compile_catalog
+    coverage run --parallel -m pytest {posargs}
+    flake8 . --count --show-source --statistics
+
+[testenv:py39-dev]
 deps=
    dbus-python
    -r{toxinidir}/requirements.txt


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** n/a

Travis CI has begun the process of migrating all of it's users from it's [.org URL](https://travis-ci.org) to it's [.com URL](https://travis-ci.com). The new service consumes credits; you get a few to start out with.  The new service makes a valiant effort to tell you that if your project is Open Source (which Apprise is), you'll be granted free credits.

Well.. Apprise ran out of it's starting credits, and when I asked for more, it took more then 5 months for them to get back to me.   I can only imagine how many emails they must have had to go through to get backlogged that much.

Either way... here we are... with enough credits to operate again now under the new domain. However we're not building properly anymore.

In 5 months the CI broke... :astonished: 

This PR is in attempts to restore the build process again to how it was.

## Community Help
I opened Travis CI Community Ticket [here](https://travis-ci.community/t/pypy-v2-7-backwards-compatible-travis-runner-failing-print-k-syntaxerror-invalid-syntax/11536).

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] 100% test coverage
