### PR TITLE
Added BuildRequire setuptools to RPM package

### DIFF
--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -138,6 +138,7 @@ Summary: A simple wrapper to many popular notification services used today
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{pypi_name}}
 
 BuildRequires: python%{python3_pkgversion}-devel
+BuildRequires: python%{python3_pkgversion}-setuptools
 BuildRequires: python%{python3_pkgversion}-requests
 BuildRequires: python%{python3_pkgversion}-requests-oauthlib
 BuildRequires: python%{python3_pkgversion}-six


### PR DESCRIPTION
## Description:
**Related issue (if applicable): n/a

This issue was patched upstream by RedHat.  The user who made the change sourced [this](https://fedoraproject.org/wiki/Changes/Reduce_dependencies_on_python3-setuptools).  This is just to merge the same change to the upstream source code.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
