### PR TITLE
Removed HTML escaping for Telegram TEXT handling

### DIFF
--- a/apprise/plugins/NotifyTelegram.py
+++ b/apprise/plugins/NotifyTelegram.py
@@ -549,11 +549,6 @@ class NotifyTelegram(NotifyBase):
 
         else:  # TEXT
             payload['parse_mode'] = 'HTML'
-
-            # Escape content
-            title = NotifyTelegram.escape_html(title, whitespace=False)
-            body = NotifyTelegram.escape_html(body, whitespace=False)
-
             payload['text'] = '{}{}'.format(
                 '<b>{}</b>\r\n'.format(title) if title else '',
                 body,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #373 
Escaping the HTML characters before passing the content along to Telegram causes the upstream service to re-escape them again.

This small merge request just drops the escaping of these characters since it is no longer required.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
