### PR TITLE
Escape < and > characters for Telegram (TEXT mode)

### DIFF
--- a/apprise/plugins/NotifyTelegram.py
+++ b/apprise/plugins/NotifyTelegram.py
@@ -547,8 +547,17 @@ class NotifyTelegram(NotifyBase):
                 body,
             )
 
-        else:  # TEXT
+        else:  # pass directly as is...
             payload['parse_mode'] = 'HTML'
+
+            # Telegram strangely escapes all HTML characters for us already
+            # but to avoid causing issues with HTML, we escape the < and >
+            # characters
+            title = re.sub('>', '&gt;', title, re.I)
+            title = re.sub('<', '&lt;', title, re.I)
+            body = re.sub('>', '&gt;', body, re.I)
+            body = re.sub('<', '&lt;', body, re.I)
+
             payload['text'] = '{}{}'.format(
                 '<b>{}</b>\r\n'.format(title) if title else '',
                 body,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #373 and #383 

PR #383 broke telegram requests that include `<` and `>` symbols.  This restores the essential HTML character escaped characters only.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
