### PR TITLE
Implement asynchronous notify() method

### DIFF
--- a/apprise/Apprise.py
+++ b/apprise/Apprise.py
@@ -326,7 +326,8 @@ class Apprise(object):
                     notify_type=notify_type, body_format=body_format,
                     tag=tag, attach=attach,
                     interpret_escapes=interpret_escapes,
-                )
+                ),
+                debug=self.debug
             )
 
         else:
@@ -377,8 +378,7 @@ class Apprise(object):
         else:
             if len(coroutines) > 0:
                 # All notifications sent, return False if any failed.
-                return py3compat.asyncio.notify(
-                    coroutines, debug=self.debug)
+                return py3compat.asyncio.notify(coroutines)
 
             else:
                 # No notifications sent.

--- a/apprise/Apprise.py
+++ b/apprise/Apprise.py
@@ -322,7 +322,7 @@ class Apprise(object):
 
         try:
             if ASYNCIO_SUPPORT:
-                coroutines = peekable(
+                coroutines = list(
                     self._notifyall(
                         Apprise._async_notifyhandler,
                         body, title, notify_type, body_format,
@@ -330,14 +330,14 @@ class Apprise(object):
                     )
                 )
 
-                assigned = coroutines.peek(None) is not None
+                assigned = len(coroutines) > 0
                 if not assigned:
                     return None
 
                 else:
                     # perform our async notification(s)
                     return py3compat.asyncio.notify(
-                        list(coroutines), debug=self.debug)
+                        coroutines, debug=self.debug)
 
             else:
                 results = peekable(

--- a/apprise/Apprise.py
+++ b/apprise/Apprise.py
@@ -28,7 +28,7 @@ import os
 import six
 from markdown import markdown
 from itertools import chain
-from more_itertools import peekable
+from more_itertools import consume, peekable
 from .common import NotifyType
 from .common import NotifyFormat
 from .common import MATCH_ALL_TAG
@@ -348,7 +348,13 @@ class Apprise(object):
 
                 else:
                     # Return False if any notification fails.
-                    return all(results)
+                    status = all(results)
+
+                    # Make sure the rest of the notifications send even if
+                    # there has been a failure.
+                    consume(results)
+
+                    return status
 
             except TypeError:
                 # These our our internally thrown notifications

--- a/apprise/Apprise.py
+++ b/apprise/Apprise.py
@@ -28,6 +28,7 @@ import os
 import six
 from markdown import markdown
 from itertools import chain
+from functools import partial
 from more_itertools import peekable
 from .common import NotifyType
 from .common import NotifyFormat
@@ -392,11 +393,8 @@ class Apprise(object):
             return server.async_notify(**kwargs)
 
         else:
-            # Wrap the synchronous handler in a coroutine.
-            async def cor_handler():  # noqa: E999
-                return Apprise._notifyhandler(server, **kwargs)
-
-            return cor_handler()
+            return py3compat.asyncio.runsync(
+                partial(Apprise._notifyhandler, server, **kwargs))
 
     def _notifyall(self, handler, body, title, notify_type, body_format, tag,
                    attach, interpret_escapes):

--- a/apprise/Apprise.py
+++ b/apprise/Apprise.py
@@ -379,7 +379,7 @@ class Apprise(object):
 
             assigned = coroutines.peek(None) is not None
             if not assigned:
-                return py3compat.asyncio.runsync(lambda: None)
+                return py3compat.asyncio.toasyncwrap(None)
 
             else:
                 return py3compat.asyncio.async_notify(
@@ -387,7 +387,7 @@ class Apprise(object):
 
         except TypeError:
             # These our our internally thrown notifications
-            return py3compat.asyncio.runsync(lambda: False)
+            return py3compat.asyncio.toasyncwrap(False)
 
     @staticmethod
     def _notifyhandler(server, **kwargs):
@@ -421,7 +421,7 @@ class Apprise(object):
             return server.async_notify(**kwargs)
 
         else:
-            return py3compat.asyncio.runsync(
+            return py3compat.asyncio.toasyncblock(
                 partial(Apprise._notifyhandler, server, **kwargs))
 
     def _notifyall(self, handler, body, title='', notify_type=NotifyType.INFO,

--- a/apprise/py3compat/asyncio.py
+++ b/apprise/py3compat/asyncio.py
@@ -101,6 +101,17 @@ def notify(coroutines, debug=False):
     return status
 
 
+def runsync(fn):
+    """
+    Run a synchronous function in a coroutine without using an executor. This
+    blocks the event loop.
+    """
+
+    async def run():  # noqa: E999
+        return fn()
+    return run()
+
+
 class AsyncNotifyBase(URLBase):
     """
     asyncio wrapper for the NotifyBase object

--- a/apprise/py3compat/asyncio.py
+++ b/apprise/py3compat/asyncio.py
@@ -36,6 +36,8 @@ ASYNCIO_RUN_SUPPORT = \
     (sys.version_info.major == 3 and sys.version_info.minor >= 7)
 
 
+# async reference produces a SyntaxError (E999) in Python v2.7
+# For this reason we turn on the noqa flag
 async def notify(coroutines, debug=False):  # noqa: E999
     """
     An async wrapper to the AsyncNotifyBase.async_notify() calls allowing us

--- a/apprise/py3compat/asyncio.py
+++ b/apprise/py3compat/asyncio.py
@@ -111,13 +111,10 @@ class AsyncNotifyBase(URLBase):
         """
         Async Notification Wrapper
         """
+        loop = asyncio.get_event_loop()
         try:
-            loop = asyncio.get_event_loop()
-            with ThreadPoolExecutor() as executor:
-                return await loop.run_in_executor(
-                    executor,
-                    partial(self.notify, *args, **kwargs),
-                )
+            return await loop.run_in_executor(
+                None, partial(self.notify, *args, **kwargs))
 
         except TypeError:
             # These our our internally thrown notifications

--- a/apprise/py3compat/asyncio.py
+++ b/apprise/py3compat/asyncio.py
@@ -93,18 +93,6 @@ async def toasyncwrap(v):  # noqa: E999
     return v
 
 
-async def chain(*cors):  # noqa: E999
-    """
-    Chain multiple coroutines into a single sequential coroutine that returns
-    the value returned by the last coroutine.
-    """
-
-    v = None
-    for c in cors:
-        await c
-    return v
-
-
 class AsyncNotifyBase(URLBase):
     """
     asyncio wrapper for the NotifyBase object

--- a/apprise/py3compat/asyncio.py
+++ b/apprise/py3compat/asyncio.py
@@ -36,23 +36,15 @@ ASYNCIO_RUN_SUPPORT = \
     (sys.version_info.major == 3 and sys.version_info.minor >= 7)
 
 
-def notify(coroutines, debug=False):
+async def notify(coroutines, debug=False):  # noqa: E999
     """
-    A Wrapper to the AsyncNotifyBase.async_notify() calls allowing us
+    An async wrapper to the AsyncNotifyBase.async_notify() calls allowing us
     to call gather() and collect the responses
     """
 
     # Create log entry
     logger.info(
         'Notifying {} service(s) asynchronously.'.format(len(coroutines)))
-
-    return tosync(async_notify(coroutines, debug=debug))
-
-
-async def async_notify(coroutines, debug=False):  # noqa: E999
-    """
-    An asynchronous wrapper to AsyncNotifyBase.async_notify().
-    """
 
     results = await asyncio.gather(*coroutines, return_exceptions=True)
 

--- a/apprise/py3compat/asyncio.py
+++ b/apprise/py3compat/asyncio.py
@@ -85,28 +85,24 @@ def tosync(cor, debug=False):
         return loop.run_until_complete(cor)
 
 
-def toasyncwrap(v):
+async def toasyncwrap(v):  # noqa: E999
     """
     Create a coroutine that, when run, returns the provided value.
     """
 
-    async def cor():  # noqa: E999
-        return v
-    return cor()
+    return v
 
 
-def chain(*cors):
+async def chain(*cors):  # noqa: E999
     """
     Chain multiple coroutines into a single sequential coroutine that returns
     the value returned by the last coroutine.
     """
 
-    async def cor():
-        v = None
-        for c in cors:
-            await c
-        return v
-    return cor()
+    v = None
+    for c in cors:
+        await c
+    return v
 
 
 class AsyncNotifyBase(URLBase):

--- a/apprise/py3compat/asyncio.py
+++ b/apprise/py3compat/asyncio.py
@@ -95,6 +95,20 @@ def toasyncwrap(v):
     return cor()
 
 
+def chain(*cors):
+    """
+    Chain multiple coroutines into a single sequential coroutine that returns
+    the value returned by the last coroutine.
+    """
+
+    async def cor():
+        v = None
+        for c in cors:
+            await c
+        return v
+    return cor()
+
+
 class AsyncNotifyBase(URLBase):
     """
     asyncio wrapper for the NotifyBase object

--- a/apprise/py3compat/asyncio.py
+++ b/apprise/py3compat/asyncio.py
@@ -46,59 +46,7 @@ def notify(coroutines, debug=False):
     logger.info(
         'Notifying {} service(s) asynchronously.'.format(len(coroutines)))
 
-    if ASYNCIO_RUN_SUPPORT:
-        # async reference produces a SyntaxError (E999) in Python v2.7
-        # For this reason we turn on the noqa flag
-        async def main(results, coroutines):  # noqa: E999
-            """
-            Task: Notify all servers specified and return our result set
-                  through a mutable object.
-            """
-            # send our notifications and store our result set into
-            # our results dictionary
-            results['response'] = \
-                await asyncio.gather(*coroutines, return_exceptions=True)
-
-        # Initialize a mutable object we can populate with our notification
-        # responses
-        results = {}
-
-        # Send our notifications
-        asyncio.run(main(results, coroutines), debug=debug)
-
-        # Acquire our return status
-        status = next((s for s in results['response'] if s is False), True)
-
-    else:
-        #
-        # The Deprecated Way (<= Python v3.6)
-        #
-
-        try:
-            # acquire access to our event loop
-            loop = asyncio.get_event_loop()
-
-        except RuntimeError:
-            # This happens if we're inside a thread of another application
-            # where there is no running event_loop().  Pythong v3.7 and higher
-            # automatically take care of this case for us.  But for the lower
-            # versions we need to do the following:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-
-        if debug:
-            # Enable debug mode
-            loop.set_debug(1)
-
-        # Send our notifications and acquire our status
-        results = loop.run_until_complete(asyncio.gather(*coroutines))
-
-        # Acquire our return status
-        status = next((r for r in results if r is False), True)
-
-    # Returns True if all notifications succeeded, otherwise False is
-    # returned.
-    return status
+    return tosync(async_notify(coroutines, debug=debug))
 
 
 async def async_notify(coroutines, debug=False):  # noqa: E999
@@ -107,20 +55,61 @@ async def async_notify(coroutines, debug=False):  # noqa: E999
     """
 
     results = await asyncio.gather(*coroutines, return_exceptions=True)
+
+    # Returns True if all notifications succeeded, otherwise False is
+    # returned.
     failed = any(not status or isinstance(status, Exception)
                  for status in results)
     return not failed
 
 
-def runsync(fn):
+def tosync(cor, debug=False):
+    """
+    Await a coroutine from non-async code.
+    """
+
+    if ASYNCIO_RUN_SUPPORT:
+        return asyncio.run(cor, debug=debug)
+
+    else:
+        # The Deprecated Way (<= Python v3.6)
+        try:
+            # acquire access to our event loop
+            loop = asyncio.get_event_loop()
+
+        except RuntimeError:
+            # This happens if we're inside a thread of another application
+            # where there is no running event_loop().  Pythong v3.7 and
+            # higher automatically take care of this case for us.  But for
+            # the lower versions we need to do the following:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        # Enable debug mode
+        loop.set_debug(debug)
+
+        return loop.run_until_complete(cor)
+
+
+def toasyncblock(fn):
     """
     Run a synchronous function in a coroutine without using an executor. This
     blocks the event loop.
     """
 
-    async def run():  # noqa: E999
+    async def cor():  # noqa: E999
         return fn()
-    return run()
+    return cor()
+
+
+def toasyncwrap(v):
+    """
+    Create a coroutine that, when run, returns the provided value.
+    """
+
+    async def cor():  # noqa: E999
+        return v
+    return cor()
 
 
 class AsyncNotifyBase(URLBase):

--- a/apprise/py3compat/asyncio.py
+++ b/apprise/py3compat/asyncio.py
@@ -101,6 +101,17 @@ def notify(coroutines, debug=False):
     return status
 
 
+async def async_notify(coroutines, debug=False):  # noqa: E999
+    """
+    An asynchronous wrapper to AsyncNotifyBase.async_notify().
+    """
+
+    results = await asyncio.gather(*coroutines, return_Exceptions=True)
+    failed = any(not status or isinstance(status, Exception)
+                 for status in results)
+    return not failed
+
+
 def runsync(fn):
     """
     Run a synchronous function in a coroutine without using an executor. This

--- a/apprise/py3compat/asyncio.py
+++ b/apprise/py3compat/asyncio.py
@@ -121,7 +121,9 @@ class AsyncNotifyBase(URLBase):
         """
         Async Notification Wrapper
         """
+
         loop = asyncio.get_event_loop()
+
         try:
             return await loop.run_in_executor(
                 None, partial(self.notify, *args, **kwargs))

--- a/apprise/py3compat/asyncio.py
+++ b/apprise/py3compat/asyncio.py
@@ -106,7 +106,7 @@ async def async_notify(coroutines, debug=False):  # noqa: E999
     An asynchronous wrapper to AsyncNotifyBase.async_notify().
     """
 
-    results = await asyncio.gather(*coroutines, return_Exceptions=True)
+    results = await asyncio.gather(*coroutines, return_exceptions=True)
     failed = any(not status or isinstance(status, Exception)
                  for status in results)
     return not failed

--- a/apprise/py3compat/asyncio.py
+++ b/apprise/py3compat/asyncio.py
@@ -38,7 +38,7 @@ ASYNCIO_RUN_SUPPORT = \
 
 # async reference produces a SyntaxError (E999) in Python v2.7
 # For this reason we turn on the noqa flag
-async def notify(coroutines, debug=False):  # noqa: E999
+async def notify(coroutines):  # noqa: E999
     """
     An async wrapper to the AsyncNotifyBase.async_notify() calls allowing us
     to call gather() and collect the responses

--- a/apprise/py3compat/asyncio.py
+++ b/apprise/py3compat/asyncio.py
@@ -25,7 +25,6 @@
 
 import sys
 import asyncio
-from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from ..URLBase import URLBase
 from ..logger import logger

--- a/apprise/py3compat/asyncio.py
+++ b/apprise/py3compat/asyncio.py
@@ -91,17 +91,6 @@ def tosync(cor, debug=False):
         return loop.run_until_complete(cor)
 
 
-def toasyncblock(fn):
-    """
-    Run a synchronous function in a coroutine without using an executor. This
-    blocks the event loop.
-    """
-
-    async def cor():  # noqa: E999
-        return fn()
-    return cor()
-
-
 def toasyncwrap(v):
     """
     Create a coroutine that, when run, returns the provided value.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ six
 click >= 5.0
 markdown
 PyYAML
-more_itertools

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ six
 click >= 5.0
 markdown
 PyYAML
+more_itertools

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -53,10 +53,10 @@ import inspect
 # Sending notifications requires the coroutines to be awaited, so we need to
 # wrap the original function when mocking it. But don't import for Python 2.
 if six.PY2:
-    def notify():
+    def asyncio_notify():
         pass
 else:
-    from apprise.py3compat.asyncio import notify
+    from apprise.py3compat.asyncio import notify as asyncio_notify
 
 # Disable logging for a cleaner testing output
 import logging
@@ -1422,7 +1422,7 @@ def test_apprise_details_plugin_verification():
 
 @pytest.mark.skipif(sys.version_info.major <= 2, reason="Requires Python 3.x+")
 @mock.patch('requests.post')
-@mock.patch('apprise.py3compat.asyncio.notify', wraps=notify)
+@mock.patch('apprise.py3compat.asyncio.notify', wraps=asyncio_notify)
 def test_apprise_async_mode(mock_async_notify, mock_post, tmpdir):
     """
     API: Apprise() async_mode tests

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -47,6 +47,7 @@ from apprise import PrivacyMode
 from apprise.plugins import SCHEMA_MAP
 from apprise.plugins import __load_matrix
 from apprise.plugins import __reset_matrix
+from apprise.py3compat.asyncio import notify
 from apprise.utils import parse_list
 import inspect
 
@@ -1414,7 +1415,7 @@ def test_apprise_details_plugin_verification():
 
 @pytest.mark.skipif(sys.version_info.major <= 2, reason="Requires Python 3.x+")
 @mock.patch('requests.post')
-@mock.patch('apprise.py3compat.asyncio.notify')
+@mock.patch('apprise.py3compat.asyncio.notify', wraps=notify)
 def test_apprise_async_mode(mock_async_notify, mock_post, tmpdir):
     """
     API: Apprise() async_mode tests
@@ -1474,8 +1475,8 @@ def test_apprise_async_mode(mock_async_notify, mock_post, tmpdir):
 
     # Send Notifications Syncronously
     assert a.notify("sync") is True
-    # Verify our async code never got called
-    assert mock_async_notify.call_count == 0
+    # Verify our async code got called
+    assert mock_async_notify.call_count == 1
     mock_async_notify.reset_mock()
 
     # another way of looking a our false set asset configuration

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -47,9 +47,16 @@ from apprise import PrivacyMode
 from apprise.plugins import SCHEMA_MAP
 from apprise.plugins import __load_matrix
 from apprise.plugins import __reset_matrix
-from apprise.py3compat.asyncio import notify
 from apprise.utils import parse_list
 import inspect
+
+# Sending notifications requires the coroutines to be awaited, so we need to
+# wrap the original function when mocking it. But don't import for Python 2.
+if six.PY2:
+    def notify():
+        pass
+else:
+    from apprise.py3compat.asyncio import notify
 
 # Disable logging for a cleaner testing output
 import logging


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #396

Adds an asynchronous notify() method to the Apprise object. Python 3 callers can use it like so:

```python
async def main():
    apobj = Apprise()
    await apobj.async_notify(...)
```

...and, the current configuration permitting, notifications will be dispatched asynchronously using the same event loop as that of the caller.

To make this happen, I had to perform a major refactor of much of the existing async code. Some improvements include:

- Removal of each notification's ThreadPoolExecutor
- Use of generators over lists where possible

Don't hesitate to ask if you'd like something clarified! I've tested this PR successfully on Python 2.7 and 3.9.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
