### PR TITLE
Fixed argument parsing within YAML files

### DIFF
--- a/apprise/plugins/NotifyEmail.py
+++ b/apprise/plugins/NotifyEmail.py
@@ -363,10 +363,6 @@ class NotifyEmail(NotifyBase):
             'type': 'string',
             'map_to': 'from_name',
         },
-        'smtp_host': {
-            'name': _('SMTP Server'),
-            'type': 'string',
-        },
         'cc': {
             'name': _('Carbon Copy'),
             'type': 'list:string',
@@ -374,6 +370,11 @@ class NotifyEmail(NotifyBase):
         'bcc': {
             'name': _('Blind Carbon Copy'),
             'type': 'list:string',
+        },
+        'smtp': {
+            'name': _('SMTP Server'),
+            'type': 'string',
+            'map_to': 'smtp_host',
         },
         'mode': {
             'name': _('Secure Mode'),


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #403

YAML files are not correctly parsing the `kwargs` specified on a URL.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
