### PR TITLE
Matrix t2bot token validation removed

### DIFF
--- a/apprise/plugins/NotifyMatrix.py
+++ b/apprise/plugins/NotifyMatrix.py
@@ -244,8 +244,7 @@ class NotifyMatrix(NotifyBase):
 
         if self.mode == MatrixWebhookMode.T2BOT:
             # t2bot configuration requires that a webhook id is specified
-            self.access_token = validate_regex(
-                self.host, r'^[a-z0-9]{64}$', 'i')
+            self.access_token = validate_regex(self.host)
             if not self.access_token:
                 msg = 'An invalid T2Bot/Matrix Webhook ID ' \
                       '({}) was specified.'.format(self.host)

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -1814,9 +1814,9 @@ TEST_URLS = (
         'response': False,
     }),
     ('matrix://localhost', {
-        # response is TypeError because we'll try to initialize as
-        # a t2bot and fail (localhost is too short of a api key)
-        'instance': TypeError
+        # not a valid t2bot api key but we don't prevent the object
+        # from initializing anyhow using it
+        'instance': plugins.NotifyMatrix,
     }),
     ('matrix://user:pass@localhost/#room1/#room2/#room3', {
         'instance': plugins.NotifyMatrix,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #393

Removed all validation for the t2bot key.

Would be great if someone could test this out:
```bash
# Create a virtual environment to work in
# This way you can just destroy it after when it's all over.
# The below will create a directory called apprise
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch with new validation update
pip install git+https://github.com/caronc/apprise.git@393-invalid-t2bot-webhook-id

# Give it a go:
# The syntax is like so:
# swap {values} accordingly:
apprise -t "Title" -b "Body" "matrix://{token}"
```

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] 100% test coverage
