### PR TITLE
Matrix fix webhook integration

### DIFF
--- a/apprise/plugins/NotifyMatrix.py
+++ b/apprise/plugins/NotifyMatrix.py
@@ -1074,11 +1074,7 @@ class NotifyMatrix(NotifyBase):
             'image', NotifyMatrix.template_args['image']['default']))
 
         # Get our mode
-        if 'mode' in results['qsd']:
-            results['mode'] = results['qsd'].get('mode')
-
-        elif 'webhook' in results['qsd']:
-            results['mode'] = results['qsd'].get('webhook')
+        results['mode'] = results['qsd'].get('mode')
 
         # t2bot detection... look for just a hostname, and/or just a user/host
         # if we match this; we can go ahead and set the mode (but only if

--- a/apprise/plugins/NotifyMatrix.py
+++ b/apprise/plugins/NotifyMatrix.py
@@ -1074,7 +1074,11 @@ class NotifyMatrix(NotifyBase):
             'image', NotifyMatrix.template_args['image']['default']))
 
         # Get our mode
-        results['mode'] = results['qsd'].get('mode')
+        if 'mode' in results['qsd']:
+            results['mode'] = results['qsd'].get('mode')
+
+        elif 'webhook' in results['qsd']:
+            results['mode'] = results['qsd'].get('webhook')
 
         # t2bot detection... look for just a hostname, and/or just a user/host
         # if we match this; we can go ahead and set the mode (but only if

--- a/apprise/plugins/NotifyMatrix.py
+++ b/apprise/plugins/NotifyMatrix.py
@@ -283,7 +283,7 @@ class NotifyMatrix(NotifyBase):
             default_port = 443 if self.secure else 80
 
             # Prepare our URL
-            url = '{schema}://{hostname}:{port}/{webhook_path}/{token}'.format(
+            url = '{schema}://{hostname}:{port}{webhook_path}/{token}'.format(
                 schema='https' if self.secure else 'http',
                 hostname=self.host,
                 port='' if self.port is None


### PR DESCRIPTION
Fixes  #393. Thanks to this PR is wiki documentation https://github.com/caronc/apprise/wiki/Notify_matrix valid again.

<s>Kept legacy `?mode=` parameter, that is also used for other notifiers (e.g. Twitter) but added `?webhook=` as fallback.</s>

Removed double slashes in webhook url.