### PR TITLE
Change NotifySlack payload

### DIFF
--- a/apprise/plugins/NotifySlack.py
+++ b/apprise/plugins/NotifySlack.py
@@ -73,7 +73,6 @@ import re
 import requests
 from json import dumps
 from json import loads
-from time import time
 
 from .NotifyBase import NotifyBase
 from ..common import NotifyImageSize

--- a/apprise/plugins/NotifySlack.py
+++ b/apprise/plugins/NotifySlack.py
@@ -370,13 +370,15 @@ class NotifySlack(NotifyBase):
             )
 
         # Prepare JSON Object (applicable to both WEBHOOK and BOT mode)
+        _slack_format = 'mrkdwn' \
+            if self.notify_format == NotifyFormat.MARKDOWN else 'plain_text'
         payload = {
             'username': self.user if self.user else self.app_id,
             'attachments': [{
                 'blocks': [{
                     'type': 'section',
                     'text': {
-                        'type': 'mrkdwn' if self.notify_format == NotifyFormat.MARKDOWN else 'plain_text',
+                        'type': _slack_format,
                         'text': body
                     }
                 }],
@@ -412,7 +414,7 @@ class NotifySlack(NotifyBase):
             _footer = {
                 'type': 'context',
                 'elements': [{
-                    'type': 'mrkdwn' if self.notify_format == NotifyFormat.MARKDOWN else 'plain_text',
+                    'type': _slack_format,
                     'text': self.app_id
                 }]
             }


### PR DESCRIPTION
 to use new blocks feature to allow more markdown parsing and formatting.

## Description:
Changed the payload format of Slack from old attachment to new recommended `blocks` attachment.
Incl. sections for body ( title optional as header section ) and footer as context block.

See: https://api.slack.com/reference/messaging/payload under `attachments`.

I kept the outer attachment structure though for its support of the coloured bar. 

## Checklist
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage -

All Slack related tests passed.
