### PR TITLE
ModuleNotFoundError exception on sys.exit() bugfix

### DIFF
--- a/apprise/plugins/NotifyEmby.py
+++ b/apprise/plugins/NotifyEmby.py
@@ -698,7 +698,7 @@ class NotifyEmby(NotifyBase):
             #   - https://github.com/kennethreitz/requests/issues/3578
             pass
 
-        except ModuleNotFoundError:  # pragma: no cover
+        except ImportError:  # pragma: no cover
             # Python code that makes early calls to sys.exit() can cause
             # the __del__() code to run. However in some newer versions of
             # Python, this causes the `sys` library to no longer be

--- a/apprise/plugins/NotifyEmby.py
+++ b/apprise/plugins/NotifyEmby.py
@@ -697,3 +697,24 @@ class NotifyEmby(NotifyBase):
             # ticket system as unresolved and has provided work-arounds
             #   - https://github.com/kennethreitz/requests/issues/3578
             pass
+
+        except ModuleNotFoundError:  # pragma: no cover
+            # Python code that makes early calls to sys.exit() can cause
+            # the __del__() code to run. However in some newer versions of
+            # Python, this causes the `sys` library to no longer be
+            # available. The stack overflow also goes on to suggest that
+            # it's not wise to use the __del__() as a deconstructor
+            # which is the case here.
+
+            # https://stackoverflow.com/questions/67218341/\
+            #       modulenotfounderror-import-of-time-halted-none-in-sys-\
+            #           modules-occured-when-obj?noredirect=1&lq=1
+            #
+            #
+            # Also see: https://stackoverflow.com/questions\
+            #       /1481488/what-is-the-del-method-and-how-do-i-call-it
+
+            # At this time it seems clean to try to log out (if we can)
+            # but not throw any unessisary exceptions (like this one) to
+            # the end user if we don't have to.
+            pass

--- a/apprise/plugins/NotifyEmby.py
+++ b/apprise/plugins/NotifyEmby.py
@@ -699,6 +699,10 @@ class NotifyEmby(NotifyBase):
             pass
 
         except ImportError:  # pragma: no cover
+            # The actual exception is `ModuleNotFoundError` however ImportError
+            # grants us backwards compatiblity with versions of Python older
+            # than v3.6
+
             # Python code that makes early calls to sys.exit() can cause
             # the __del__() code to run. However in some newer versions of
             # Python, this causes the `sys` library to no longer be

--- a/apprise/plugins/NotifyMatrix.py
+++ b/apprise/plugins/NotifyMatrix.py
@@ -1026,7 +1026,7 @@ class NotifyMatrix(NotifyBase):
             #   - https://github.com/kennethreitz/requests/issues/3578
             pass
 
-        except ModuleNotFoundError:  # pragma: no cover
+        except ImportError:  # pragma: no cover
             # Python code that makes early calls to sys.exit() can cause
             # the __del__() code to run. However in some newer versions of
             # Python, this causes the `sys` library to no longer be

--- a/apprise/plugins/NotifyTwist.py
+++ b/apprise/plugins/NotifyTwist.py
@@ -807,6 +807,10 @@ class NotifyTwist(NotifyBase):
             pass
 
         except ImportError:  # pragma: no cover
+            # The actual exception is `ModuleNotFoundError` however ImportError
+            # grants us backwards compatiblity with versions of Python older
+            # than v3.6
+
             # Python code that makes early calls to sys.exit() can cause
             # the __del__() code to run. However in some newer versions of
             # Python, this causes the `sys` library to no longer be

--- a/apprise/plugins/NotifyTwist.py
+++ b/apprise/plugins/NotifyTwist.py
@@ -790,7 +790,7 @@ class NotifyTwist(NotifyBase):
         try:
             self.logout()
 
-        except LookupError:
+        except LookupError:  # pragma: no cover
             # Python v3.5 call to requests can sometimes throw the exception
             #   "/usr/lib64/python3.7/socket.py", line 748, in getaddrinfo
             #   LookupError: unknown encoding: idna
@@ -804,4 +804,25 @@ class NotifyTwist(NotifyBase):
             # A ~similar~ issue can be identified here in the requests
             # ticket system as unresolved and has provided work-arounds
             #   - https://github.com/kennethreitz/requests/issues/3578
+            pass
+
+        except ModuleNotFoundError:  # pragma: no cover
+            # Python code that makes early calls to sys.exit() can cause
+            # the __del__() code to run. However in some newer versions of
+            # Python, this causes the `sys` library to no longer be
+            # available. The stack overflow also goes on to suggest that
+            # it's not wise to use the __del__() as a deconstructor
+            # which is the case here.
+
+            # https://stackoverflow.com/questions/67218341/\
+            #       modulenotfounderror-import-of-time-halted-none-in-sys-\
+            #           modules-occured-when-obj?noredirect=1&lq=1
+            #
+            #
+            # Also see: https://stackoverflow.com/questions\
+            #       /1481488/what-is-the-del-method-and-how-do-i-call-it
+
+            # At this time it seems clean to try to log out (if we can)
+            # but not throw any unessisary exceptions (like this one) to
+            # the end user if we don't have to.
             pass

--- a/apprise/plugins/NotifyTwist.py
+++ b/apprise/plugins/NotifyTwist.py
@@ -806,7 +806,7 @@ class NotifyTwist(NotifyBase):
             #   - https://github.com/kennethreitz/requests/issues/3578
             pass
 
-        except ModuleNotFoundError:  # pragma: no cover
+        except ImportError:  # pragma: no cover
             # Python code that makes early calls to sys.exit() can cause
             # the __del__() code to run. However in some newer versions of
             # Python, this causes the `sys` library to no longer be

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -1858,6 +1858,18 @@ TEST_URLS = (
         # despite uppercase characters
         'instance': plugins.NotifyMatrix,
     }),
+    ('matrix://user@localhost?mode=SLACK&format=markdown&token=mytoken', {
+        # user and token specified; slack webhook still detected
+        # despite uppercase characters; token also set on URL as arg
+        'instance': plugins.NotifyMatrix,
+    }),
+    ('matrix://_?mode=t2bot&token={}'.format('b' * 64), {
+        # Testing t2bot initialization and setting the password using the
+        # token directive
+        'instance': plugins.NotifyMatrix,
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'matrix://b...b/',
+    }),
     # Image Reference
     ('matrixs://user:token@localhost?mode=slack&format=markdown&image=True', {
         # user and token specified; image set to True


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #392

The `NotifyClass().__del__()` don't take well if a `sys.exit()` call is made.  While everything still works, it spits out a rather noisy alarm to users of Apprise.  Added the graceful handling for these circumstances.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
