### PR TITLE
Fedora 35 can now correctly support Apprise RPM packaging

### DIFF
--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -59,7 +59,7 @@ Webex Teams}
 
 Name:           python-%{pypi_name}
 Version:        0.9.3
-Release:        1%{?dist}
+Release:        3%{?dist}
 Summary:        A simple wrapper to many popular notification services used today
 License:        MIT
 URL:            https://github.com/caronc/%{pypi_name}
@@ -84,9 +84,11 @@ BuildRequires: python-six
 BuildRequires: python2-click >= 5.0
 BuildRequires: python-markdown
 %if 0%{?rhel} && 0%{?rhel} <= 7
+BuildRequires: python-cryptography
 BuildRequires: python-babel
 BuildRequires: python-yaml
 %else
+BuildRequires: python2-cryptography
 BuildRequires: python2-babel
 BuildRequires: python2-yaml
 %endif
@@ -246,6 +248,12 @@ LANG=C.UTF-8 PYTHONPATH=%{buildroot}%{python3_sitelib} py.test-%{python3_version
 %endif
 
 %changelog
+* Fri Jul 23 2021 Fedora Release Engineering <releng@fedoraproject.org> - 0.9.3-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_35_Mass_Rebuild
+
+* Fri Jun 04 2021 Python Maint <python-maint@redhat.com> - 0.9.3-2
+- Rebuilt for Python 3.10
+
 * Sun May 16 2021 Chris Caron <lead2gold@gmail.com> - 0.9.3-1
 - Updated to v0.9.3
 

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -143,8 +143,8 @@ BuildRequires: python%{python3_pkgversion}-requests-oauthlib
 BuildRequires: python%{python3_pkgversion}-six
 BuildRequires: python%{python3_pkgversion}-click >= 5.0
 BuildRequires: python%{python3_pkgversion}-markdown
-%if 0%{?rhel} && 0%{?rhel} >= 8
-# gntp isn't available from EPEL for RHEL/CentOS 8
+%if (0%{?rhel} && 0%{?rhel} >= 8) || (0%{?fedora} && 0%{?fedora} <= 35)
+# gntp isn't available from EPEL for RHEL/CentOS 8 or Fedora 35+
 %else
 # For all other distributions, include gntp
 BuildRequires: python%{python3_pkgversion}-gntp
@@ -157,8 +157,8 @@ Requires: python%{python3_pkgversion}-requests-oauthlib
 Requires: python%{python3_pkgversion}-six
 Requires: python%{python3_pkgversion}-markdown
 Requires: python%{python3_pkgversion}-cryptography
-%if 0%{?rhel} && 0%{?rhel} >= 8
-# gntp isn't available from EPEL for RHEL/CentOS 8
+%if (0%{?rhel} && 0%{?rhel} >= 8) || (0%{?fedora} && 0%{?fedora} <= 35)
+# gntp isn't available from EPEL for RHEL/CentOS 8 or Fedora 35+
 %else
 # For all other distributions, include gntp
 Requires: python%{python3_pkgversion}-gntp


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #421

Apprise supports Fedora 35

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
