### PR TITLE
updated nextcloud plugin to be compatible with version>=21.

### DIFF
--- a/apprise/plugins/NotifyNextcloud.py
+++ b/apprise/plugins/NotifyNextcloud.py
@@ -29,7 +29,7 @@ from ..URLBase import PrivacyMode
 from ..common import NotifyType
 from ..utils import parse_list
 from ..AppriseLocale import gettext_lazy as _
-
+import os
 
 class NotifyNextcloud(NotifyBase):
     """
@@ -52,7 +52,20 @@ class NotifyNextcloud(NotifyBase):
     setup_url = 'https://github.com/caronc/apprise/wiki/Notify_nextcloud'
 
     # Nextcloud URL
-    notify_url = '{schema}://{host}/ocs/v2.php/apps/admin_notifications/' \
+    '''The URL had to be changed when switching from Nextcloud 20 to 21:
+        - 20 and earlier: ocs/v2.php/apps/admin_notifications/api/v1/notifications/{user}
+        - 21 and later: ocs/v2.php/apps/notifications/api/v2/admin_notifications/{user}
+    '''
+    nextcloud_version = 21
+    notify_url = '{schema}://{host}/ocs/v2.php/apps/notifications/' \
+                 'api/v2/admin_notifications/{target}'
+
+    try:
+        nextcloud_version = int(os.environ.get("NEXTCLOUD_VERSION",21))
+    except ValueError:
+        pass
+    if nextcloud_version < 21:
+        notify_url = '{schema}://{host}/ocs/v2.php/apps/admin_notifications/' \
                  'api/v1/notifications/{target}'
 
     # Nextcloud does not support a title


### PR DESCRIPTION
## Description:
#### Update nextcloud plugin endpoint to be compatible with version 21 or higer
According to this [page](https://github.com/nextcloud/notifications/blob/master/docs/admin-notifications.md):

>  warning The URL had to be changed when switching from Nextcloud 20 to 21:
> - 20 and earlier: ocs/v2.php/apps/admin_notifications/api/v1/notifications/{user}
> - 21 and later: ocs/v2.php/apps/notifications/api/v2/admin_notifications/{user}

To use the old api endpoint user need to pass environment varible `NEXTCLOUD_VERSION` with value 20 or smaller (`NEXTCLOUD_VERSION=20`)

**Related issue (if applicable):** #395 and #371.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
