### PR TITLE
Matrix HTML and Markdown Support

### DIFF
--- a/test/test_matrix_plugin.py
+++ b/test/test_matrix_plugin.py
@@ -28,7 +28,6 @@ import mock
 import requests
 from apprise import plugins
 from apprise import AppriseAsset
-# from apprise import Apprise
 from json import dumps
 
 # Disable logging for a cleaner testing output
@@ -85,6 +84,31 @@ def test_notify_matrix_plugin_general(mock_post, mock_get):
     assert isinstance(obj, plugins.NotifyMatrix) is True
     # Registration Successful
     assert obj.send(body="test") is True
+
+    # Test sending other format types
+    kwargs = plugins.NotifyMatrix.parse_url(
+        'matrix://user:passwd@hostname/#abcd?format=html')
+    obj = plugins.NotifyMatrix(**kwargs)
+    assert isinstance(obj.url(), six.string_types) is True
+    assert isinstance(obj, plugins.NotifyMatrix) is True
+    obj.send(body="test") is True
+    obj.send(title="title", body="test") is True
+
+    kwargs = plugins.NotifyMatrix.parse_url(
+        'matrix://user:passwd@hostname/#abcd/#abcd:localhost?format=markdown')
+    obj = plugins.NotifyMatrix(**kwargs)
+    assert isinstance(obj.url(), six.string_types) is True
+    assert isinstance(obj, plugins.NotifyMatrix) is True
+    obj.send(body="test") is True
+    obj.send(title="title", body="test") is True
+
+    kwargs = plugins.NotifyMatrix.parse_url(
+        'matrix://user:passwd@hostname/#abcd/!abcd:localhost?format=text')
+    obj = plugins.NotifyMatrix(**kwargs)
+    assert isinstance(obj.url(), six.string_types) is True
+    assert isinstance(obj, plugins.NotifyMatrix) is True
+    obj.send(body="test") is True
+    obj.send(title="title", body="test") is True
 
     # Force a failed login
     ro = response_obj.copy()
@@ -392,16 +416,36 @@ def test_notify_matrix_plugin_rooms(mock_post, mock_get):
 
     assert obj._register() is True
     assert obj.access_token is not None
+
+    assert obj._room_join('!abc123') == response_obj['room_id']
+    # Use cache to get same results
+    assert len(obj._room_cache) == 1
     assert obj._room_join('!abc123') == response_obj['room_id']
 
     obj._room_cache = {}
     assert obj._room_join('!abc123:localhost') == response_obj['room_id']
+    # Use cache to get same results
+    assert len(obj._room_cache) == 1
+    assert obj._room_join('!abc123:localhost') == response_obj['room_id']
+
     obj._room_cache = {}
     assert obj._room_join('abc123') == response_obj['room_id']
+    # Use cache to get same results
+    assert len(obj._room_cache) == 1
+    assert obj._room_join('abc123') == response_obj['room_id']
+
     obj._room_cache = {}
     assert obj._room_join('abc123:localhost') == response_obj['room_id']
+    # Use cache to get same results
+    assert len(obj._room_cache) == 1
+    assert obj._room_join('abc123:localhost') == response_obj['room_id']
+
     obj._room_cache = {}
     assert obj._room_join('#abc123:localhost') == response_obj['room_id']
+    # Use cache to get same results
+    assert len(obj._room_cache) == 1
+    assert obj._room_join('#abc123:localhost') == response_obj['room_id']
+
     obj._room_cache = {}
     assert obj._room_join('%') is None
     assert obj._room_join(None) is None

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -1948,7 +1948,7 @@ TEST_URLS = (
      .format('a' * 64), {
          # user and token specified; image set to True
          'instance': plugins.NotifyMatrix}),
-    ('matrix://user@{}?mode=t2bot&format=markdown&image=False'
+    ('matrix://user@{}?mode=t2bot&format=html&image=False'
      .format('z' * 64), {
          # user and token specified; image set to True
          'instance': plugins.NotifyMatrix}),


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #430

Added HTML and Markdown Support for the Matrix Plugin.  It works the same way as the other plugins that support these formats.  You simply just add `?format=html` or `?format=markdown` to your Apprise URL.

Another thing to consider with this new enhancement is  that the Matrix Endpoints (server, webhook, t2bot, etc) do not support a `title` field.  In the past, this was just tagged onto the message.  This isn't really possible with HTML and Markdown formatted messages.  So if you want the specified title to be visible in your body, reference `{{app_title}}` anywhere in the body.  Think of `{{app_title}}` as a template token.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

# Testing
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in
# This way you can just destroy it after when it's all over.
# The below will create a directory called apprise
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@430-matrix-html-support
# Give it a go:
# HTML Example (if you want to see the Title, you'll need to include it as part of your payload)
# The {{app_title}} is completely optional
apprise -t "Title" -b "<strong>{{app_title}}</strong><p>body</p>" "matrix://{user}:{pass}@{host}/?format=html"

# Markdown Example:
cat << _EOF | apprise -t "Egg Details" -b "matrix://{user}:{pass}@{host}/?format=markdown"
# {{app_title}}
## Ways to Prepare Eggs
* Scrambled
* Sunny Side Up
* Over Easy

There is more, but I want to keep my message short. :)
_EOF

```