### PR TITLE
Nextcloud versioning support added

### DIFF
--- a/apprise/plugins/NotifyNextcloud.py
+++ b/apprise/plugins/NotifyNextcloud.py
@@ -268,8 +268,11 @@ class NotifyNextcloud(NotifyBase):
         # Create URL parameters from our headers
         params = {'+{}'.format(k): v for k, v in self.headers.items()}
 
-        # Our URL parameters
-        params = self.url_parameters(privacy=privacy, *args, **kwargs)
+        # Set our version
+        params['version'] = str(self.version)
+
+        # Extend our parameters
+        params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
 
         # Determine Authentication
         auth = ''

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -2461,6 +2461,18 @@ TEST_URLS = (
         # No user specified
         'instance': TypeError,
     }),
+    ('ncloud://user@localhost?to=user1,user2&version=invalid', {
+        # An invalid version was specified
+        'instance': TypeError,
+    }),
+    ('ncloud://user@localhost?to=user1,user2&version=0', {
+        # An invalid version was specified
+        'instance': TypeError,
+    }),
+    ('ncloud://user@localhost?to=user1,user2&version=-23', {
+        # An invalid version was specified
+        'instance': TypeError,
+    }),
     ('ncloud://localhost/admin', {
         'instance': plugins.NotifyNextcloud,
     }),
@@ -2468,6 +2480,12 @@ TEST_URLS = (
         'instance': plugins.NotifyNextcloud,
     }),
     ('ncloud://user@localhost?to=user1,user2', {
+        'instance': plugins.NotifyNextcloud,
+    }),
+    ('ncloud://user@localhost?to=user1,user2&version=20', {
+        'instance': plugins.NotifyNextcloud,
+    }),
+    ('ncloud://user@localhost?to=user1,user2&version=21', {
         'instance': plugins.NotifyNextcloud,
     }),
     ('ncloud://user:pass@localhost/user1/user2', {


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #395 and #371.  Additionally PR #429 

Added `?version=` value to Nextcloud URL.  It will default to `21` if not otherwise specified.  Those using an earlier version can identify it. 

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

# Testing
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in
# This way you can just destroy it after when it's all over.
# The below will create a directory called apprise
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@371-nextcloud-version-support
# Give it a go:
# The following will run for version 21 (default):
apprise -t "Title" -b "Body" "ncloud://{user}:{pass}@{host}"

# But you can optionally over-ride this and access the older API calls by doing the following:
apprise -t "Title" -b "Body" "ncloud://{user}:{pass}@{host}/?version=20"
```