### PR TITLE
Added HTML support for Pushover plugin

### DIFF
--- a/apprise/plugins/NotifyPushover.py
+++ b/apprise/plugins/NotifyPushover.py
@@ -29,6 +29,7 @@ import requests
 
 from .NotifyBase import NotifyBase
 from ..common import NotifyType
+from ..common import NotifyFormat
 from ..utils import parse_list
 from ..utils import validate_regex
 from ..AppriseLocale import gettext_lazy as _
@@ -319,6 +320,10 @@ class NotifyPushover(NotifyBase):
                 'device': device,
                 'sound': self.sound,
             }
+
+            if self.notify_format == NotifyFormat.HTML:
+                # https://pushover.net/api#html
+                payload['html'] = 1
 
             if self.priority == PushoverPriority.EMERGENCY:
                 payload.update({'retry': self.retry, 'expire': self.expire})

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -3533,6 +3533,10 @@ TEST_URLS = (
     ('pover://%s@%s?priority=high' % ('u' * 30, 'a' * 30), {
         'instance': plugins.NotifyPushover,
     }),
+    # API Key + priority setting + html mode
+    ('pover://%s@%s?priority=high&format=html' % ('u' * 30, 'a' * 30), {
+        'instance': plugins.NotifyPushover,
+    }),
     # API Key + invalid priority setting
     ('pover://%s@%s?priority=invalid' % ('u' * 30, 'a' * 30), {
         'instance': plugins.NotifyPushover,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #435 

Added support for `?format=html` to Pushover plugin (`pover://`)

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
