### PR TITLE
Add paho-mqtt to install dependencies.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ six
 click >= 5.0
 markdown
 PyYAML
+paho-mqtt


### PR DESCRIPTION
## Description:
With the recent addition of MQTT support in version v0.9.5.1, apprise is missing `paho-mqtt` from the `requirements.txt` 