### PR TITLE
Support Matrix Notice Message Types

### DIFF
--- a/test/test_matrix_plugin.py
+++ b/test/test_matrix_plugin.py
@@ -26,6 +26,7 @@
 import six
 import mock
 import requests
+import pytest
 from apprise import plugins
 from apprise import AppriseAsset
 from json import dumps
@@ -109,6 +110,21 @@ def test_notify_matrix_plugin_general(mock_post, mock_get):
     assert isinstance(obj, plugins.NotifyMatrix) is True
     obj.send(body="test") is True
     obj.send(title="title", body="test") is True
+
+    # Test notice type notifications
+    kwargs = plugins.NotifyMatrix.parse_url(
+        'matrix://user:passwd@hostname/#abcd?msgtype=notice')
+    obj = plugins.NotifyMatrix(**kwargs)
+    assert isinstance(obj.url(), six.string_types) is True
+    assert isinstance(obj, plugins.NotifyMatrix) is True
+    obj.send(body="test") is True
+    obj.send(title="title", body="test") is True
+
+    with pytest.raises(TypeError):
+        # invalid message type specified
+        kwargs = plugins.NotifyMatrix.parse_url(
+            'matrix://user:passwd@hostname/#abcd?msgtype=invalid')
+        obj = plugins.NotifyMatrix(**kwargs)
 
     # Force a failed login
     ro = response_obj.copy()


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #458

The ability to add `?msgtype=notice` to the `matrix://` URL and create a `m.notice` instead of the default `m.text`.

The only supported types you can specify on the new `msgtype` enhancement is `text` or `notice`.   By default `text` is implied, so there should be no visible changes to existing users already leveraging this plugin.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

# Testing
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in
# This way you can just destroy it after when it's all over.
# The below will create a directory called apprise
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@458-matrix-notice-msgtype

# A message type set to `notice`
apprise -b "test" "matrix://user:pass@matrix.server.tld#channel/?msgtype=notice"
```
