### PR TITLE
CLI --interpret-escapes works without --title specified

### DIFF
--- a/apprise/Apprise.py
+++ b/apprise/Apprise.py
@@ -558,22 +558,24 @@ class Apprise(object):
                     logger.error('Failed to escape message body')
                     raise TypeError
 
-                try:
-                    # Added overhead required due to Python 3 Encoding Bug
-                    # identified here: https://bugs.python.org/issue21331
-                    title = title\
-                        .encode('ascii', 'backslashreplace')\
-                        .decode('unicode-escape')
+                if title:
+                    try:
+                        # Added overhead required due to Python 3 Encoding Bug
+                        # identified here: https://bugs.python.org/issue21331
+                        title = title\
+                            .encode('ascii', 'backslashreplace')\
+                            .decode('unicode-escape')
 
-                except UnicodeDecodeError:  # pragma: no cover
-                    # This occurs using a very old verion of Python 2.7 such
-                    # as the one that ships with CentOS/RedHat 7.x (v2.7.5).
-                    title = title.decode('string_escape')
+                    except UnicodeDecodeError:  # pragma: no cover
+                        # This occurs using a very old verion of Python 2.7
+                        # such as the one that ships with CentOS/RedHat 7.x
+                        # (v2.7.5).
+                        title = title.decode('string_escape')
 
-                except AttributeError:
-                    # Must be of string type
-                    logger.error('Failed to escape message title')
-                    raise TypeError
+                    except AttributeError:
+                        # Must be of string type
+                        logger.error('Failed to escape message title')
+                        raise TypeError
 
             yield handler(
                 server,

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -576,6 +576,23 @@ def test_apprise_cli_nux_env(tmpdir):
     ])
     assert result.exit_code == 1
 
+    # Test Escaping:
+    result = runner.invoke(cli.main, [
+        '-e',
+        '-t', 'test\ntitle',
+        '-b', 'test\nbody',
+        'good://localhost',
+    ])
+    assert result.exit_code == 0
+
+    # Test Escaping (without title)
+    result = runner.invoke(cli.main, [
+        '--interpret-escapes',
+        '-b', 'test\nbody',
+        'good://localhost',
+    ])
+    assert result.exit_code == 0
+
 
 @mock.patch('platform.system')
 def test_apprise_cli_windows_env(mock_system):

--- a/test/test_escapes.py
+++ b/test/test_escapes.py
@@ -191,13 +191,13 @@ def test_apprise_escaping_py3(mock_post):
     # the body only.  Now we run similar tests but only make the title
     # bad and always mark the body good
     assert a.notify(
-        title=None, body="valid", interpret_escapes=True) is False
+        title=None, body="valid", interpret_escapes=True) is True
     assert a.notify(
         title=4, body="valid", interpret_escapes=True) is False
     assert a.notify(
         title=object(), body="valid", interpret_escapes=True) is False
     assert a.notify(
-        title=False, body="valid", interpret_escapes=True) is False
+        title=False, body="valid", interpret_escapes=True) is True
     assert a.notify(
         title=b'byte title', body="valid", interpret_escapes=True) is False
 
@@ -320,10 +320,10 @@ def test_apprise_escaping_py2(mock_post):
     # the body only.  Now we run similar tests but only make the title
     # bad and always mark the body good
     assert a.notify(
-        title=None, body="valid", interpret_escapes=True) is False
+        title=None, body="valid", interpret_escapes=True) is True
     assert a.notify(
         title=4, body="valid", interpret_escapes=True) is False
     assert a.notify(
         title=object(), body="valid", interpret_escapes=True) is False
     assert a.notify(
-        title=False, body="valid", interpret_escapes=True) is False
+        title=False, body="valid", interpret_escapes=True) is True


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #452 

It was observed that the `--interpret-escapes` (`-e`) switch does not work on the CLI if no `--title` (`-t`) is specified.

This should never have been the case and is fixed in this PR.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
