### PR TITLE
Accept single alpha characters as part of valid hostname

### DIFF
--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -246,9 +246,10 @@ def is_hostname(hostname, ipv4=True, ipv6=True, underscore=True):
     #   being able to address services in other stacks, we also allow
     #   underscores in hostnames (if flag is set accordingly)
     # - labels can not exceed 63 characters
+    # - allow single character alpha characters
     allowed = re.compile(
-        r'^[a-z0-9][a-z0-9_-]{1,62}(?<![_-])$' if underscore else
-        r'^[a-z0-9][a-z0-9-]{1,62}(?<!-)$',
+        r'^([a-z0-9][a-z0-9_-]{1,62}|[a-z_-])(?<![_-])$' if underscore else
+        r'^([a-z0-9][a-z0-9-]{1,62}|[a-z-])(?<!-)$',
         re.IGNORECASE,
     )
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -605,6 +605,10 @@ def test_is_hostname():
     assert utils.is_hostname(
         '2001:0db8:85a3:0000:0000:8a2e:0370:7334', ipv6=False) is False
 
+    # Test hostnames with a single character hostname
+    assert utils.is_hostname(
+        'cloud.a.example.com', ipv4=False, ipv6=False) == 'cloud.a.example.com'
+
 
 def test_is_ipaddr():
     """


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #474

It was identified that single alpha characters were not accepted in hostnames (and deemed valid).  This has been fixed.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
