### PR TITLE
rename url parameter for gh-476

### DIFF
--- a/apprise/plugins/NotifyPushover.py
+++ b/apprise/plugins/NotifyPushover.py
@@ -196,12 +196,12 @@ class NotifyPushover(NotifyBase):
             'regex': (r'^[a-z]{1,12}$', 'i'),
             'default': PushoverSound.PUSHOVER,
         },
-        'url': {
-            'name': _('URL'),
+        'supplemental_url': {
+            'name': _('Supplemental URL'),
             'type': 'string',
         },
-        'url_title': {
-            'name': _('URL Title'),
+        'supplemental_url_title': {
+            'name': _('Supplemental URL Title'),
             'type': 'string'
         },
         'retry': {
@@ -223,8 +223,8 @@ class NotifyPushover(NotifyBase):
     })
 
     def __init__(self, user_key, token, targets=None, priority=None,
-                 sound=None, retry=None, expire=None, url=None,
-                 url_title=None, **kwargs):
+                 sound=None, retry=None, expire=None, supplemental_url=None,
+                 supplemental_url_title=None, **kwargs):
         """
         Initialize Pushover Object
         """
@@ -251,8 +251,8 @@ class NotifyPushover(NotifyBase):
             self.targets = (PUSHOVER_SEND_TO_ALL, )
 
         # Setup supplemental url
-        self.supplemental_url = url
-        self.supplemental_url_title = url_title
+        self.supplemental_url = supplemental_url
+        self.supplemental_url_title = supplemental_url_title
 
         # Setup our sound
         self.sound = NotifyPushover.default_pushover_sound \
@@ -332,9 +332,12 @@ class NotifyPushover(NotifyBase):
                 'message': body,
                 'device': device,
                 'sound': self.sound,
-                'url': self.supplemental_url,
-                'url_title': self.supplemental_url_title
             }
+
+            if self.supplemental_url:
+                payload['url'] = self.supplemental_url
+            if self.supplemental_url_title:
+                payload['url_title'] = self.supplemental_url_title
 
             if self.notify_format == NotifyFormat.HTML:
                 # https://pushover.net/api#html
@@ -585,10 +588,18 @@ class NotifyPushover(NotifyBase):
                 NotifyPushover.unquote(results['qsd']['sound'])
 
         # Get the supplementary url
-        if 'url' in results['qsd'] and len(results['qsd']['url']):
-            results['url'] = NotifyPushover.unquote(results['qsd']['url'])
-        if 'url_title' in results['qsd'] and len(results['qsd']['url_title']):
-            results['url_title'] = results['qsd']['url_title']
+        if 'supplemental_url' in results['qsd'] and len(
+            results['qsd']['supplemental_url']
+        ):
+            results['supplemental_url'] = NotifyPushover.unquote(
+                results['qsd']['supplemental_url']
+            )
+        if 'supplemental_url_title' in results['qsd'] and len(
+            results['qsd']['supplemental_url_title']
+        ):
+            results['supplemental_url_title'] = results['qsd'][
+                'supplemental_url_title'
+            ]
 
         # Get expire and retry
         if 'expire' in results['qsd'] and len(results['qsd']['expire']):

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -3707,7 +3707,8 @@ TEST_URLS = (
         'instance': plugins.NotifyPushover,
     }),
     # API Key + valid url_title with url
-    ('pover://%s@%s?url=my-url&url_title=title' % ('u' * 30, 'a' * 30), {
+    ('pover://%s@%s?supplemental_url=my-url&supplemental_url_title=title' % (
+        'u' * 30, 'a' * 30), {
         'instance': plugins.NotifyPushover,
     }),
     # API Key + Valid User


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #<!--apprise issue number goes here-->

Resolves #476 

Renames the `url` parameter to `supplemental_url` to avoid name collision. Also changed for url_title to match API.

It's long and hard to type. Hard to to get into 79 character line length. But here we are.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] 100% test coverage
