### PR TITLE
Refactored Slack plugin to allow users to switch between payload types

### DIFF
--- a/apprise/plugins/NotifySlack.py
+++ b/apprise/plugins/NotifySlack.py
@@ -373,19 +373,14 @@ class NotifySlack(NotifyBase):
         # error tracking (used for function return)
         has_error = False
 
-
-        if self.notify_format == NotifyFormat.MARKDOWN:
-            body = self._re_formatting_rules.sub(  # pragma: no branch
-                lambda x: self._re_formatting_map[x.group()], body,
-            )
-
         #
         # Prepare JSON Object (applicable to both WEBHOOK and BOT mode)
         #
         if self.use_blocks:
             # Our slack format
             _slack_format = 'mrkdwn' \
-                if self.notify_format == NotifyFormat.MARKDOWN else 'plain_text'
+                if self.notify_format == NotifyFormat.MARKDOWN \
+                else 'plain_text'
 
             payload = {
                 'username': self.user if self.user else self.app_id,
@@ -419,33 +414,37 @@ class NotifySlack(NotifyBase):
                 image_url = None if not self.include_image \
                     else self.image_url(notify_type)
 
-                if self.use_blocks:
-                    # Prepare our footer based on the block structure
-                    _footer = {
-                        'type': 'context',
-                        'elements': [{
-                            'type': _slack_format,
-                            'text': self.app_id
-                        }]
-                    }
+                # Prepare our footer based on the block structure
+                _footer = {
+                    'type': 'context',
+                    'elements': [{
+                        'type': _slack_format,
+                        'text': self.app_id
+                    }]
+                }
 
-                    if image_url:
-                        payload['icon_url'] = image_url
+                if image_url:
+                    payload['icon_url'] = image_url
 
-                        _footer['elements'].insert(0, {
-                            'type': 'image',
-                            'image_url': image_url,
-                            'alt_text': notify_type
-                        })
+                    _footer['elements'].insert(0, {
+                        'type': 'image',
+                        'image_url': image_url,
+                        'alt_text': notify_type
+                    })
 
-                    payload['attachments'][0]['blocks'].append(_footer)
+                payload['attachments'][0]['blocks'].append(_footer)
 
         else:
             #
             # Legacy API Formatting
             #
+            if self.notify_format == NotifyFormat.MARKDOWN:
+                body = self._re_formatting_rules.sub(  # pragma: no branch
+                    lambda x: self._re_formatting_map[x.group()], body,
+                )
 
-            # Perform Formatting on title here; this is not needed for block mode above
+            # Perform Formatting on title here; this is not needed for block
+            # mode above
             title = self._re_formatting_rules.sub(  # pragma: no branch
                 lambda x: self._re_formatting_map[x.group()], title,
             )

--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -694,10 +694,7 @@ def parse_url(url, default_schema='http', verify_host=True):
 
 def parse_bool(arg, default=False):
     """
-    NZBGet uses 'yes' and 'no' as well as other strings such as 'on' or
-    'off' etch to handle boolean operations from it's control interface.
-
-    This method can just simplify checks to these variables.
+    Support string based boolean settings.
 
     If the content could not be parsed, then the default is returned.
     """

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -4859,6 +4859,33 @@ TEST_URLS = (
             },
         },
     }),
+    # Test blocks mode
+    ('slack://?token=T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/'
+     '&to=#chan&blocks=yes&footer=yes',
+        {
+            'instance': plugins.NotifySlack,
+            'requests_response_text': 'ok'}),
+    ('slack://?token=T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/'
+     '&to=#chan&blocks=yes&footer=no',
+        {
+            'instance': plugins.NotifySlack,
+            'requests_response_text': 'ok'}),
+    ('slack://?token=T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/'
+     '&to=#chan&blocks=yes&footer=yes&image=no',
+        {
+            'instance': plugins.NotifySlack,
+            'requests_response_text': 'ok'}),
+    ('slack://?token=T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/'
+     '&to=#chan&blocks=yes&format=text',
+        {
+            'instance': plugins.NotifySlack,
+            'requests_response_text': 'ok'}),
+    ('slack://?token=T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/'
+     '&to=#chan&blocks=no&format=text',
+        {
+            'instance': plugins.NotifySlack,
+            'requests_response_text': 'ok'}),
+
     # Test using a bot-token as argument
     ('slack://?token=xoxb-1234-1234-abc124&to=#nuxref&footer=no&user=test', {
         'instance': plugins.NotifySlack,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #412

Re-factored the new block format into a `?blocks=yes` directive.  Mobile support doesn't show notifications quite the way they used to as per #473 .

The Slack plugin will basically go back to working the way it was, but those who wish to leverage the new format can simply add `?blocks=yes` to their Apprise URL.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
