### PR TITLE
Add Python 3.10 and drop Python 3.5 from CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,py38,py39,py39-dev,pypy,pypy3,coverage-report
+envlist = py27,py36,py37,py38,py39,py310,py311-dev,pypy,pypy3,coverage-report
 
 
 [testenv]
@@ -20,16 +20,6 @@ deps=
     dbus-python
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev-requirements.txt
-commands =
-    python setup.py compile_catalog
-    coverage run --parallel -m pytest {posargs}
-    flake8 . --count --show-source --statistics
-
-[testenv:py35]
-deps=
-   dbus-python
-   -r{toxinidir}/requirements.txt
-   -r{toxinidir}/dev-requirements.txt
 commands =
     python setup.py compile_catalog
     coverage run --parallel -m pytest {posargs}
@@ -75,7 +65,17 @@ commands =
     coverage run --parallel -m pytest {posargs}
     flake8 . --count --show-source --statistics
 
-[testenv:py39-dev]
+[testenv:py310]
+deps=
+   dbus-python
+   -r{toxinidir}/requirements.txt
+   -r{toxinidir}/dev-requirements.txt
+commands =
+    python setup.py compile_catalog
+    coverage run --parallel -m pytest {posargs}
+    flake8 . --count --show-source --statistics
+
+[testenv:py311-dev]
 deps=
    dbus-python
    -r{toxinidir}/requirements.txt


### PR DESCRIPTION
## Description:
3.10 is the default Python in some distributions already, and 3.5 has been EOL’d last year.  3.6 will be EOL’d in exactly one month, so maybe it’d be useful to also drop it right now?

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
