### PR TITLE
Eliminate `/` from appearing in XMPP targets

### DIFF
--- a/apprise/plugins/NotifyXMPP/__init__.py
+++ b/apprise/plugins/NotifyXMPP/__init__.py
@@ -201,7 +201,6 @@ class NotifyXMPP(NotifyBase):
         # By default we send ourselves a message
         if targets:
             self.targets = parse_list(targets)
-            self.targets[0] = self.targets[0][1:]
 
         else:
             self.targets = list()
@@ -307,7 +306,7 @@ class NotifyXMPP(NotifyBase):
 
         # Get our targets; we ignore path slashes since they identify
         # our resources
-        results['targets'] = NotifyXMPP.parse_list(results['fullpath'])
+        results['targets'] = NotifyXMPP.split_path(results['fullpath'])
 
         # Over-ride the xep plugins
         if 'xep' in results['qsd'] and len(results['qsd']['xep']):


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #455

This is a follow up to Merge request #485 (thanks so much to @linkmauve).

This slight update addresses just one small comment found post-code-review.

It should properly prevent any XMPP targets from starting with a `/` (slash)



## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] 100% test coverage
