### PR TITLE
FCM Plugin Supports more Payload Options

### DIFF
--- a/apprise/plugins/NotifyFCM/__init__.py
+++ b/apprise/plugins/NotifyFCM/__init__.py
@@ -396,8 +396,8 @@ class NotifyFCM(NotifyBase):
 
                 if self.color:
                     # Acquire our color
-                    payload['message']['notification']['color'] = \
-                        self.color.get(notify_type)
+                    payload['message']['android'] = {
+                        'notification': {'color': self.color.get(notify_type)}}
 
                 if self.include_image and image:
                     payload['message']['notification']['image'] = image

--- a/apprise/plugins/NotifyFCM/__init__.py
+++ b/apprise/plugins/NotifyFCM/__init__.py
@@ -419,13 +419,15 @@ class NotifyFCM(NotifyBase):
             else:  # FCMMode.Legacy
                 payload = {
                     'notification': {
-                        'title': title,
-                        'body': body,
+                        'notification': {
+                            'title': title,
+                            'body': body,
+                        }
                     }
                 }
 
                 if self.include_image and image:
-                    payload['notification']['image'] = image
+                    payload['notification']['notification']['image'] = image
 
                 if self.data_kwargs:
                     payload['data'] = self.data_kwargs

--- a/apprise/plugins/NotifyFCM/__init__.py
+++ b/apprise/plugins/NotifyFCM/__init__.py
@@ -174,10 +174,6 @@ class NotifyFCM(NotifyBase):
             'values': FCM_MODES,
             'default': FCMMode.Legacy,
         },
-        'image_src': {
-            'name': _('Image URL'),
-            'type': 'string',
-        },
         'project': {
             'name': _('Project ID'),
             'type': 'string',
@@ -207,12 +203,12 @@ class NotifyFCM(NotifyBase):
         'image_url': {
             'name': _('Custom Image URL'),
             'type': 'string',
-            'map_to': 'image_url',
         },
         'image': {
             'name': _('Include Image'),
             'type': 'bool',
             'default': False,
+            'map_to': 'include_image',
         },
     })
 

--- a/apprise/plugins/NotifyFCM/color.py
+++ b/apprise/plugins/NotifyFCM/color.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+# New priorities are defined here:
+# - https://firebase.google.com/docs/reference/fcm/rest/v1/\
+#       projects.messages#NotificationPriority
+
+# Legacy color payload example here:
+# https://firebase.google.com/docs/reference/fcm/rest/v1/\
+#       projects.messages#androidnotification
+import re
+import six
+from ...utils import parse_bool
+from ...common import NotifyType
+from ...AppriseAsset import AppriseAsset
+
+
+class FCMColorManager(object):
+    """
+    A Simple object to accept either a boolean value
+      - True: Use colors provided by Apprise
+      - False: Do not use colors at all
+      - rrggbb: where you provide the rgb values (hence #333333)
+      - rgb: is also accepted as rgb values (hence #333)
+
+      For RGB colors, the hashtag is optional
+    """
+
+    __color_rgb = re.compile(
+        r'#?((?P<r1>[0-9A-F]{2})(?P<g1>[0-9A-F]{2})(?P<b1>[0-9A-F]{2})'
+        r'|(?P<r2>[0-9A-F])(?P<g2>[0-9A-F])(?P<b2>[0-9A-F]))', re.IGNORECASE)
+
+    def __init__(self, color, asset=None):
+        """
+        Parses the color object accordingly
+        """
+
+        # Initialize an asset object if one isn't otherwise defined
+        self.asset = asset \
+            if isinstance(asset, AppriseAsset) else AppriseAsset()
+
+        # Prepare our color
+        self.color = color
+        if isinstance(color, six.string_types):
+            self.color = self.__color_rgb.match(color)
+            if self.color:
+                # Store our RGB value as #rrggbb
+                self.color = '{red}{green}{blue}'.format(
+                    red=self.color.group('r1'),
+                    green=self.color.group('g1'),
+                    blue=self.color.group('b1')).lower() \
+                    if self.color.group('r1') else \
+                    '{red1}{red2}{green1}{green2}{blue1}{blue2}'.format(
+                    red1=self.color.group('r2'),
+                    red2=self.color.group('r2'),
+                    green1=self.color.group('g2'),
+                    green2=self.color.group('g2'),
+                    blue1=self.color.group('b2'),
+                    blue2=self.color.group('b2')).lower()
+
+        if self.color is None:
+            # Color not determined, so base it on boolean parser
+            self.color = parse_bool(color)
+
+    def get(self, notify_type=NotifyType.INFO):
+        """
+        Returns color or true/false value based on configuration
+        """
+
+        if isinstance(self.color, bool) and self.color:
+            # We want to use the asset value
+            return self.asset.color(notify_type=notify_type)
+
+        elif self.color:
+            # return our color as is
+            return '#' + self.color
+
+        # No color to return
+        return None
+
+    def __str__(self):
+        """
+        our color representation
+        """
+        if isinstance(self.color, bool):
+            return 'yes' if self.color else 'no'
+
+        # otherwise return our color
+        return self.color
+
+    def __bool__(self):
+        """
+        Allows this object to be wrapped in an Python 3.x based 'if
+        statement'.  True is returned if a color was loaded
+        """
+        return True if self.color is True or \
+            isinstance(self.color, six.string_types) else False
+
+    def __nonzero__(self):
+        """
+        Allows this object to be wrapped in an Python 2.x based 'if
+        statement'.  True is returned if a color was loaded
+        """
+        return True if self.color is True or \
+            isinstance(self.color, six.string_types) else False

--- a/apprise/plugins/NotifyFCM/common.py
+++ b/apprise/plugins/NotifyFCM/common.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+class FCMMode(object):
+    """
+    Define the Firebase Cloud Messaging Modes
+    """
+    # The legacy way of sending a message
+    Legacy = "legacy"
+
+    # The new API
+    OAuth2 = "oauth2"
+
+
+# FCM Modes
+FCM_MODES = (
+    # Legacy API
+    FCMMode.Legacy,
+    # HTTP v1 URL
+    FCMMode.OAuth2,
+)

--- a/apprise/plugins/NotifyFCM/priority.py
+++ b/apprise/plugins/NotifyFCM/priority.py
@@ -37,44 +37,30 @@ class NotificationPriority(object):
     """
     Defines the Notification Priorities as described on:
     https://firebase.google.com/docs/reference/fcm/rest/v1/\
-            projects.messages#notificationpriority
+            projects.messages#androidmessagepriority
 
-        0 - PRIORITY_UNSPECIFIED:
-            If priority is unspecified, notification priority is set to
-            PRIORITY_DEFAULT. <- not used here
+        NORMAL:
+            Default priority for data messages. Normal priority messages won't
+            open network connections on a sleeping device, and their delivery
+            may be delayed to conserve the battery. For less time-sensitive
+            messages, such as notifications of new email or other data to sync,
+            choose normal delivery priority.
 
-        1 - PRIORITY_MIN:
-            Lowest notification priority. Notifications with this PRIORITY_MIN
-            might not be shown to the user except under special circumstances,
-            such as detailed notification logs.
-
-        2 - PRIORITY_LOW:
-            Lower notification priority. The UI may choose to show the
-            notifications smaller, or at a different position in the list,
-            compared with notifications with PRIORITY_DEFAULT.
-
-        3 - PRIORITY_DEFAULT:
-            Default notification priority. If the application does not
-            prioritize its own notifications, use this value for all
-            notifications.
-
-        4 - PRIORITY_HIGH:
-            Higher notification priority. Use this for more important
-            notifications or alerts. The UI may choose to show these
-            notifications larger, or at a different position in the
-            notification lists, compared with notifications with
-            PRIORITY_DEFAULT.
-
-        5 - PRIORITY_MAX:
-            Highest notification priority. Use this for the application's most
-            important items that require the user's prompt attention or input.
+        HIGH:
+            Default priority for notification messages. FCM attempts to
+            deliver high priority messages immediately, allowing the FCM
+            service to wake a sleeping device when possible and open a network
+            connection to your app server. Apps with instant messaging, chat,
+            or voice call alerts, for example, generally need to open a
+            network connection and make sure FCM delivers the message to the
+            device without delay. Set high priority if the message is
+            time-critical and requires the user's immediate interaction, but
+            beware that setting your messages to high priority contributes
+            more to battery drain compared with normal priority messages.
     """
 
-    PRIORITY_MIN = 'PRIORITY_MIN'
-    PRIORITY_LOW = 'PRIORITY_LOW'
-    PRIORITY_DEFAULT = 'PRIORITY_DEFAULT'
-    PRIORITY_HIGH = 'PRIORITY_HIGH'
-    PRIORITY_MAX = 'PRIORITY_MAX'
+    NORMAL = 'NORMAL'
+    HIGH = 'HIGH'
 
 
 class FCMPriority(object):
@@ -111,7 +97,7 @@ class FCMPriorityManager(object):
             FCMMode.OAuth2: {
                 'message': {
                     'android': {
-                        'priority': 'normal'
+                        'priority': NotificationPriority.NORMAL
                     },
                     'apns': {
                         'headers': {
@@ -123,10 +109,6 @@ class FCMPriorityManager(object):
                             'Urgency': 'very-low'
                         }
                     },
-                    'notification': {
-                        'notification_priority':
-                        NotificationPriority.PRIORITY_MIN,
-                    }
                 }
             },
             FCMMode.Legacy: {
@@ -137,7 +119,7 @@ class FCMPriorityManager(object):
             FCMMode.OAuth2: {
                 'message': {
                     'android': {
-                        'priority': 'normal'
+                        'priority': NotificationPriority.NORMAL
                     },
                     'apns': {
                         'headers': {
@@ -148,10 +130,6 @@ class FCMPriorityManager(object):
                         'headers': {
                             'Urgency': 'low'
                         }
-                    },
-                    'notification': {
-                        'notification_priority':
-                        NotificationPriority.PRIORITY_LOW,
                     }
                 }
             },
@@ -163,7 +141,7 @@ class FCMPriorityManager(object):
             FCMMode.OAuth2: {
                 'message': {
                     'android': {
-                        'priority': 'normal'
+                        'priority': NotificationPriority.NORMAL
                     },
                     'apns': {
                         'headers': {
@@ -174,10 +152,6 @@ class FCMPriorityManager(object):
                         'headers': {
                             'Urgency': 'normal'
                         }
-                    },
-                    'notification': {
-                        'notification_priority':
-                        NotificationPriority.PRIORITY_DEFAULT,
                     }
                 }
             },
@@ -189,7 +163,7 @@ class FCMPriorityManager(object):
             FCMMode.OAuth2: {
                 'message': {
                     'android': {
-                        'priority': 'high'
+                        'priority': NotificationPriority.HIGH
                     },
                     'apns': {
                         'headers': {
@@ -200,10 +174,6 @@ class FCMPriorityManager(object):
                         'headers': {
                             'Urgency': 'high'
                         }
-                    },
-                    'notification': {
-                        'notification_priority':
-                        NotificationPriority.PRIORITY_HIGH,
                     }
                 }
             },
@@ -215,7 +185,7 @@ class FCMPriorityManager(object):
             FCMMode.OAuth2: {
                 'message': {
                     'android': {
-                        'priority': 'high'
+                        'priority': NotificationPriority.HIGH
                     },
                     'apns': {
                         'headers': {
@@ -226,10 +196,6 @@ class FCMPriorityManager(object):
                         'headers': {
                             'Urgency': 'high'
                         }
-                    },
-                    'notification': {
-                        'notification_priority':
-                        NotificationPriority.PRIORITY_MAX,
                     }
                 }
             },

--- a/apprise/plugins/NotifyFCM/priority.py
+++ b/apprise/plugins/NotifyFCM/priority.py
@@ -1,0 +1,289 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+# New priorities are defined here:
+# - https://firebase.google.com/docs/reference/fcm/rest/v1/\
+#       projects.messages#NotificationPriority
+
+# Legacy priorities are defined here:
+# - https://firebase.google.com/docs/cloud-messaging/http-server-ref
+from .common import (FCMMode, FCM_MODES)
+from ...logger import logger
+
+
+class NotificationPriority(object):
+    """
+    Defines the Notification Priorities as described on:
+    https://firebase.google.com/docs/reference/fcm/rest/v1/\
+            projects.messages#notificationpriority
+
+        0 - PRIORITY_UNSPECIFIED:
+            If priority is unspecified, notification priority is set to
+            PRIORITY_DEFAULT. <- not used here
+
+        1 - PRIORITY_MIN:
+            Lowest notification priority. Notifications with this PRIORITY_MIN
+            might not be shown to the user except under special circumstances,
+            such as detailed notification logs.
+
+        2 - PRIORITY_LOW:
+            Lower notification priority. The UI may choose to show the
+            notifications smaller, or at a different position in the list,
+            compared with notifications with PRIORITY_DEFAULT.
+
+        3 - PRIORITY_DEFAULT:
+            Default notification priority. If the application does not
+            prioritize its own notifications, use this value for all
+            notifications.
+
+        4 - PRIORITY_HIGH:
+            Higher notification priority. Use this for more important
+            notifications or alerts. The UI may choose to show these
+            notifications larger, or at a different position in the
+            notification lists, compared with notifications with
+            PRIORITY_DEFAULT.
+
+        5 - PRIORITY_MAX:
+            Highest notification priority. Use this for the application's most
+            important items that require the user's prompt attention or input.
+    """
+
+    PRIORITY_MIN = 'PRIORITY_MIN'
+    PRIORITY_LOW = 'PRIORITY_LOW'
+    PRIORITY_DEFAULT = 'PRIORITY_DEFAULT'
+    PRIORITY_HIGH = 'PRIORITY_HIGH'
+    PRIORITY_MAX = 'PRIORITY_MAX'
+
+
+class FCMPriority(object):
+    """
+    Defines our accepted priorites
+    """
+    MIN = "min"
+
+    LOW = "low"
+
+    NORMAL = "normal"
+
+    HIGH = "high"
+
+    MAX = "max"
+
+
+FCM_PRIORITIES = (
+    FCMPriority.MIN,
+    FCMPriority.LOW,
+    FCMPriority.NORMAL,
+    FCMPriority.HIGH,
+    FCMPriority.MAX,
+)
+
+
+class FCMPriorityManager(object):
+    """
+    A Simple object to make it easier to work with FCM set priorities
+    """
+
+    priority_map = {
+        FCMPriority.MIN: {
+            FCMMode.OAuth2: {
+                'message': {
+                    'android': {
+                        'priority': 'normal'
+                    },
+                    'apns': {
+                        'headers': {
+                            'apns-priority': "5"
+                        }
+                    },
+                    'webpush': {
+                        'headers': {
+                            'Urgency': 'very-low'
+                        }
+                    },
+                    'notification': {
+                        'notification_priority':
+                        NotificationPriority.PRIORITY_MIN,
+                    }
+                }
+            },
+            FCMMode.Legacy: {
+                'priority': 'normal',
+            }
+        },
+        FCMPriority.LOW: {
+            FCMMode.OAuth2: {
+                'message': {
+                    'android': {
+                        'priority': 'normal'
+                    },
+                    'apns': {
+                        'headers': {
+                            'apns-priority': "5"
+                        }
+                    },
+                    'webpush': {
+                        'headers': {
+                            'Urgency': 'low'
+                        }
+                    },
+                    'notification': {
+                        'notification_priority':
+                        NotificationPriority.PRIORITY_LOW,
+                    }
+                }
+            },
+            FCMMode.Legacy: {
+                'priority': 'normal',
+            }
+        },
+        FCMPriority.NORMAL: {
+            FCMMode.OAuth2: {
+                'message': {
+                    'android': {
+                        'priority': 'normal'
+                    },
+                    'apns': {
+                        'headers': {
+                            'apns-priority': "5"
+                        }
+                    },
+                    'webpush': {
+                        'headers': {
+                            'Urgency': 'normal'
+                        }
+                    },
+                    'notification': {
+                        'notification_priority':
+                        NotificationPriority.PRIORITY_DEFAULT,
+                    }
+                }
+            },
+            FCMMode.Legacy: {
+                'priority': 'normal',
+            }
+        },
+        FCMPriority.HIGH: {
+            FCMMode.OAuth2: {
+                'message': {
+                    'android': {
+                        'priority': 'high'
+                    },
+                    'apns': {
+                        'headers': {
+                            'apns-priority': "10"
+                        }
+                    },
+                    'webpush': {
+                        'headers': {
+                            'Urgency': 'high'
+                        }
+                    },
+                    'notification': {
+                        'notification_priority':
+                        NotificationPriority.PRIORITY_HIGH,
+                    }
+                }
+            },
+            FCMMode.Legacy: {
+                'priority': 'high',
+            }
+        },
+        FCMPriority.MAX: {
+            FCMMode.OAuth2: {
+                'message': {
+                    'android': {
+                        'priority': 'high'
+                    },
+                    'apns': {
+                        'headers': {
+                            'apns-priority': "10"
+                        }
+                    },
+                    'webpush': {
+                        'headers': {
+                            'Urgency': 'high'
+                        }
+                    },
+                    'notification': {
+                        'notification_priority':
+                        NotificationPriority.PRIORITY_MAX,
+                    }
+                }
+            },
+            FCMMode.Legacy: {
+                'priority': 'high',
+            }
+        }
+    }
+
+    def __init__(self, mode, priority=None):
+        """
+        Takes a FCMMode and Priority
+        """
+
+        self.mode = mode
+        if self.mode not in FCM_MODES:
+            msg = 'The FCM mode specified ({}) is invalid.'.format(mode)
+            logger.warning(msg)
+            raise TypeError(msg)
+
+        self.priority = None
+        if priority:
+            self.priority = \
+                next((p for p in FCM_PRIORITIES
+                      if p.startswith(priority[:2].lower())), None)
+            if not self.priority:
+                msg = 'An invalid FCM Priority ' \
+                      '({}) was specified.'.format(priority)
+                logger.warning(msg)
+                raise TypeError(msg)
+
+    def payload(self):
+        """
+        Returns our payload depending on our mode
+        """
+        return self.priority_map[self.priority][self.mode] \
+            if self.priority else {}
+
+    def __str__(self):
+        """
+        our priority representation
+        """
+        return self.priority if self.priority else ''
+
+    def __bool__(self):
+        """
+        Allows this object to be wrapped in an Python 3.x based 'if
+        statement'.  True is returned if a priority was loaded
+        """
+        return True if self.priority else False
+
+    def __nonzero__(self):
+        """
+        Allows this object to be wrapped in an Python 2.x based 'if
+        statement'.  True is returned if a priority was loaded
+        """
+        return True if self.priority else False

--- a/test/test_plugin_fcm.py
+++ b/test/test_plugin_fcm.py
@@ -237,8 +237,10 @@ def test_plugin_fcm_general_legacy(mock_post):
 
     assert 'notification' in data
     assert isinstance(data['notification'], dict)
-    assert 'image' in data['notification']
-    assert data['notification']['image'] == \
+    assert 'notification' in data['notification']
+    assert isinstance(data['notification']['notification'], dict)
+    assert 'image' in data['notification']['notification']
+    assert data['notification']['notification']['image'] == \
         'https://example.com/interesting.png'
 
 

--- a/test/test_plugin_fcm.py
+++ b/test/test_plugin_fcm.py
@@ -687,3 +687,26 @@ def test_plugin_fcm_cryptography_import_error():
 
     # It's not possible because our cryptography depedancy is missing
     assert obj is None
+
+
+@pytest.mark.skipif(
+    'cryptography' not in sys.modules, reason="Requires cryptography")
+@mock.patch('requests.post')
+def test_plugin_fcm_edge_cases(mock_post):
+    """
+    NotifyFCM() Edge Cases
+
+    """
+    # Disable Throttling to speed testing
+    plugins.NotifyBase.request_rate_per_sec = 0
+
+    # Prepare a good response
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    # this tests an edge case where verify if the data_kwargs is a dictionary
+    # or not.  Below, we don't even define it, so it will be None (causing
+    # the check to go).  We'll still correctly instantiate a plugin:
+    obj = plugins.NotifyFCM("project", "api:123", targets='device')
+    assert obj is not None

--- a/test/test_plugin_fcm.py
+++ b/test/test_plugin_fcm.py
@@ -828,6 +828,15 @@ def test_plugin_fcm_colors():
     # str() response does not include hashtag
     assert str(instance) == 'a2b3a4'
 
+    # Custom color (no hashtag) but only using 3 letter rgb values
+    instance = FCMColorManager('AC4')
+    assert isinstance(instance.get(), six.string_types)
+    # Hashtag is always part of output
+    assert instance.get() == '#aacc44'
+    assert bool(instance) is True
+    # str() response does not include hashtag
+    assert str(instance) == 'aacc44'
+
 
 @pytest.mark.skipif(
     'cryptography' in sys.modules,

--- a/test/test_plugin_fcm.py
+++ b/test/test_plugin_fcm.py
@@ -481,9 +481,7 @@ def test_plugin_fcm_general_oauth(mock_post):
     assert 'image' not in data['message']['notification']
     assert data['message']['apns']['headers']['apns-priority'] == "10"
     assert data['message']['webpush']['headers']['Urgency'] == "high"
-    assert data['message']['android']['priority'] == "high"
-    assert data['message']['notification']['notification_priority'] \
-        == "PRIORITY_HIGH"
+    assert data['message']['android']['priority'] == "HIGH"
 
     #
     # Test colors
@@ -536,8 +534,8 @@ def test_plugin_fcm_general_oauth(mock_post):
     assert 'data' not in data['message']
     assert 'notification' in data['message']
     assert isinstance(data['message']['notification'], dict)
-    assert 'color' in data['message']['notification']
-    assert data['message']['notification']['color'] == '#12aabb'
+    assert 'color' in data['message']['android']['notification']
+    assert data['message']['android']['notification']['color'] == '#12aabb'
 
 
 @pytest.mark.skipif(

--- a/test/test_plugin_fcm.py
+++ b/test/test_plugin_fcm.py
@@ -101,6 +101,11 @@ apprise_url_tests = (
         # Test apikey= to=
         'instance': plugins.NotifyFCM,
     }),
+    ('fcm://?apikey=abc123&to=device'
+        '&image=http://example.com/interesting.jpg', {
+            # Test apikey= to=
+            'instance': plugins.NotifyFCM}),
+
     ('fcm://?apikey=abc123&to=device&+key=value&+key2=value2', {
         # Test apikey= to= and data arguments
         'instance': plugins.NotifyFCM,
@@ -242,7 +247,8 @@ def test_plugin_fcm_general(mock_post):
     # Now we test using a valid Project ID and data parameters
     obj = Apprise.instantiate(
         'fcm://mock-project-id/device/#topic/?keyfile={}'
-        '&+key=value&+key2=value2'.format(str(path)))
+        '&+key=value&+key2=value2'
+        '&image=https://example.com/interesting.png'.format(str(path)))
 
     # we'll fail as a result
     assert obj.notify("test") is True
@@ -264,6 +270,12 @@ def test_plugin_fcm_general(mock_post):
     assert data['message']['data']['key'] == 'value'
     assert 'key2' in data['message']['data']
     assert data['message']['data']['key2'] == 'value2'
+
+    assert 'notification' in data['message']
+    assert isinstance(data['message']['notification'], dict)
+    assert 'image' in data['message']['notification']
+    assert data['message']['notification']['image'] == \
+        'https://example.com/interesting.png'
 
     assert mock_post.call_args_list[2][0][0] == \
         'https://fcm.googleapis.com/v1/projects/mock-project-id/messages:send'


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #484 

- support the `data` payload option as part of the FCM message (both Legacy and OAuth formatted messages)
- support the `image` directive as part of the `notification` payload.  You can optionally pass in `image_url=<web url>` to have it included as part of the notification payload. By default the `image_url` points to those provided by Apprise (fitting in with other plugins)
    - Additionally there is a Boolean flag `image=` which defaults to `no`  to save on bandwidth or extra costs; you may optionally set this to `yes`.
    - If you specify your own custom `image_url`, it is assumed that `image=yes` so you don't need to imply that.  You an however optionally specify and `image_url` and set `image=no` to not display it (as a means of suppressing/debugging something if need be)
 - Added the ability the provide a message priority of `min`, `low`, `normal`, `high`, or `max` which will  attempt to set several sections of the payload to accommodate this.
 - Added ability to control the notification color (defined by an #RGB value). This is set via the `color=`.  You can either set this to a custom `RGB` color of your own (such as \#AABBCC) or you can set this to `yes` or `no` as well.  When set to `no`, the payload simply will not include the `color` value.  When set to `yes` (also the default) it will use the color associated with the message category (such as info, warning, etc) provided by Apprise.

### The FCM Data Payload
The FCM Protocol allows you to specify freely key/value pairs nested in a `data` block as part of the upstream payload ([source](https://firebase.google.com/docs/cloud-messaging/concept-options#data_messages)).  This is supported in Apprise as well by leveraging the `+` (plus/addition) character.

An example might be:
* **OAuth2**: `fcm://mock-project-id/device/#topic/?keyfile=/path/to/keyfile&+key=value&+key2=value2`
* **Legacy/APIKey**: `fcm://?apikey=abc123&to=device&+key=value&+key2=value2`

With respect to the above examples, this would produce your payload to additionally contain a data block such as:
```json
{
  .... regular payload ...
  "data": {
    "key": "value",
    "key2": "value2"
  }
}
```

### Parameter Breakdown
| Variable    | Required | Description
| ----------- | -------- | -----------
| priority     | No      | The FCM Priority.  By default the priority isn't passed into the payload so it takes on all upstream defaults. Valid options here are `min`, `low`, `normal`, `high`, and `max`.
| image     | No      | Set this to `yes` if you want to include an image as part of the payload. Depending on your firebase subscription; this may or may not incur charges.  By default this is set to `no`
| image_url     | No      | Specify your own custom image_url to include as part of the payload.  If this is provided, it is assumed `image` is `yes`.  You an additionally set `image=no` to enforce that this assumption does not happen.
| color     | No      | Identify the colour of your notification by specifying your own custom RGB value (in format \#RRGGBB where the hashtag (`#`) is optional.  The other options are `yes` and `no`.  When set to `no`, the `color` argument simply is not part of the payload at all.  When set to `yes` (default), Apprise chooses the color based on the message type (info, warning, etc).

#### Example
Send a Legacy FCM notification:
```bash
# Assuming our {APIKey} is bu1dHSdO22pfaaVy
# Assuming our {Device} is ABCD:12345

# Turn images on:
apprise -vv -t "Test Message Title" -b "Test Message Body" \
   "fcm://bu1dHSdO22pfaaVy/ABCD:12345?image=yes"

# Set a higher priority with our message:
apprise -vv -t "Test Message Title" -b "Test Message Body" \
   "fcm://bu1dHSdO22pfaaVy/ABCD:12345?priority=high"

#  Provide our own custom image:
apprise -vv -t "Test Message Title" -b "Test Message Body" \
   "fcm://bu1dHSdO22pfaaVy/ABCD:12345?image_url=https://path/to/image.jpg"

# Disable coloured notifications:
apprise -vv -t "Test Message Title" -b "Test Message Body" \
   "fcm://bu1dHSdO22pfaaVy/ABCD:12345?color=no"

# Provide your own custom color (use #rrggbb syntax)
apprise -vv -t "Test Message Title" -b "Test Message Body" \
   "fcm://bu1dHSdO22pfaaVy/ABCD:12345?color=#AACC11"
```

Send a OAuth2 FCM notification:
```bash
# Assuming our {Project} is Apprise
# Assuming the path to our JSON  {Keyfile} is /etc/apprise/fcm/keyfile.json
# Assuming our {Device} is ABCD:12345

# Turn on images
apprise -vv -t "Test Message Title" -b "Test Message Body" \
   "fcm://Apprise/ABCD:12345/?image=yes&keyfile=/etc/apprise/fcm/keyfile.json"

# Set a higher priority with our message:
apprise -vv -t "Test Message Title" -b "Test Message Body" \
  "fcm://Apprise/ABCD:12345/?priority=max&keyfile=/etc/apprise/fcm/keyfile.json"

#  Provide our own custom image:
apprise -vv -t "Test Message Title" -b "Test Message Body" \
  "fcm://Apprise/ABCD:12345/?image_url=https://path/to/image.jpg&keyfile=/etc/apprise/fcm/keyfile.json"

# Disable coloured notifications:
apprise -vv -t "Test Message Title" -b "Test Message Body" \
  "fcm://Apprise/ABCD:12345/?color=no&keyfile=/etc/apprise/fcm/keyfile.json"

# Provide your own custom color (use #rrggbb syntax)
# the hash tag is not required and rgb is also supported e.g:
apprise -vv -t "Test Message Title" -b "Test Message Body" \
  "fcm://Apprise/ABCD:12345/?color=f00&keyfile=/etc/apprise/fcm/keyfile.json"
```

# Testing
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in
# This way you can just destroy it after when it's all over.
# The below will create a directory called apprise
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@484-fcm-enhancments

# Give it a go:
apprise -vv -b "test" \
   "fcm://Apprise/ABCD:12345/?priority=max&keyfile=/etc/apprise/fcm/keyfile.json"
```

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
