### PR TITLE
Dropped Python 2.7 testing from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ addons:
 
 matrix:
   include:
-    - python: "2.7"
-      env: TOXENV=py27
     - python: "3.6"
       env: TOXENV=py36
     - python: "3.7"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37,py38,py39,py39-dev,pypy,pypy3,bare,coverage-report
+envlist = py36,py37,py38,py39,py39-dev,pypy,pypy3,bare,coverage-report
 
 
 [testenv]
@@ -10,17 +10,6 @@ setenv =
 deps=
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/dev-requirements.txt
-commands =
-    python setup.py compile_catalog
-    coverage run --parallel -m pytest {posargs}
-    flake8 . --count --show-source --statistics
-
-[testenv:py27]
-deps=
-    dbus-python
-    -r{toxinidir}/requirements.txt
-    -r{toxinidir}/dev-requirements.txt
-    -r{toxinidir}/all-plugin-requirements.txt
 commands =
     python setup.py compile_catalog
     coverage run --parallel -m pytest {posargs}


### PR DESCRIPTION
## Description:
Travis CI Python 2.7 Support appears to have just stopped working as of Dec 2nd, 2021

I opened a [community help ticket here](https://travis-ci.community/t/python-2-7-oserror-errno-40-too-many-levels-of-symbolic-links/12436) without any luck :slightly_frowning_face: . 

I'm not quite sure what the fix is but this PR will just remove Python v2.7 testing from  future checks. There is still Python 2.7 testing taking place for PyPy at least.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
