### PR TITLE
AWS SNS PhoneNumber parameter

### DIFF
--- a/apprise/plugins/NotifySNS.py
+++ b/apprise/plugins/NotifySNS.py
@@ -210,7 +210,7 @@ class NotifySNS(NotifyBase):
             result = is_phone_no(target)
             if result:
                 # store valid phone number
-                self.phone.append('+{}'.format(result))
+                self.phone.append('+{}'.format(result['full']))
                 continue
 
             result = IS_TOPIC.match(target)

--- a/apprise/plugins/NotifySNS.py
+++ b/apprise/plugins/NotifySNS.py
@@ -209,7 +209,7 @@ class NotifySNS(NotifyBase):
         for target in parse_list(targets):
             result = is_phone_no(target)
             if result:
-                # store valid phone number
+                # store valid phone number in E.164 format
                 self.phone.append('+{}'.format(result['full']))
                 continue
 
@@ -585,8 +585,8 @@ class NotifySNS(NotifyBase):
                 region=NotifySNS.quote(self.aws_region_name, safe=''),
                 targets='/'.join(
                     [NotifySNS.quote(x) for x in chain(
-                        # Phone # are prefixed with a plus symbol
-                        ['+{}'.format(x) for x in self.phone],
+                        # Phone # are already prefixed with a plus symbol
+                        self.phone,
                         # Topics are prefixed with a pound/hashtag symbol
                         ['#{}'.format(x) for x in self.topics],
                     )]),


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #501 
Instead of sending the phone number as a string in E.164 format the phone number is being sent as a dictionary object representing the phone number.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [] No lint errors (use `flake8`)
* [] 100% test coverage
