### PR TITLE
/opt/homebrew/bin/terminal-notify added to MacOSX

### DIFF
--- a/apprise/plugins/NotifyMacOSX.py
+++ b/apprise/plugins/NotifyMacOSX.py
@@ -91,8 +91,11 @@ class NotifyMacOSX(NotifyBase):
     # content to display
     body_max_line_count = 10
 
-    # The path to the terminal-notifier
-    notify_path = '/usr/local/bin/terminal-notifier'
+    # The possible paths to the terminal-notifier
+    notify_paths = (
+        '/opt/homebrew/bin/terminal-notify',
+        '/usr/local/bin/terminal-notifier',
+    )
 
     # Define object templates
     templates = (
@@ -127,6 +130,10 @@ class NotifyMacOSX(NotifyBase):
         # or not.
         self.include_image = include_image
 
+        # Acquire the notify path
+        self.notify_path = \
+            next((p for p in self.notify_paths if os.access(p, os.X_OK)), None)
+
         # Set sound object (no q/a for now)
         self.sound = sound
         return
@@ -136,10 +143,11 @@ class NotifyMacOSX(NotifyBase):
         Perform MacOSX Notification
         """
 
-        if not os.access(self.notify_path, os.X_OK):
+        if not (self.notify_path and os.access(self.notify_path, os.X_OK)):
             self.logger.warning(
-                "MacOSX Notifications require '{}' to be in place."
-                .format(self.notify_path))
+                "MacOSX Notifications requires one of the following to "
+                "be in place: '{}'.".format(
+                    '\', \''.join(self.notify_paths)))
             return False
 
         # Start with our notification path

--- a/apprise/plugins/NotifyMacOSX.py
+++ b/apprise/plugins/NotifyMacOSX.py
@@ -131,8 +131,8 @@ class NotifyMacOSX(NotifyBase):
         self.include_image = include_image
 
         # Acquire the notify path
-        self.notify_path = \
-            next((p for p in self.notify_paths if os.access(p, os.X_OK)), None)
+        self.notify_path = next(  # pragma: no branch
+            (p for p in self.notify_paths if os.access(p, os.X_OK)), None)
 
         # Set sound object (no q/a for now)
         self.sound = sound

--- a/test/test_plugin_macosx.py
+++ b/test/test_plugin_macosx.py
@@ -77,7 +77,7 @@ def test_plugin_macosx_general(mock_macver, mock_system, mock_popen, tmpdir):
     reload(sys.modules['apprise'])
 
     # Point our object to our new temporary existing file
-    apprise.plugins.NotifyMacOSX.notify_path = str(script)
+    apprise.plugins.NotifyMacOSX.notify_paths = (str(script), )
 
     obj = apprise.Apprise.instantiate(
         'macosx://_/?image=True', suppress_exceptions=False)
@@ -150,7 +150,7 @@ def test_plugin_macosx_general(mock_macver, mock_system, mock_popen, tmpdir):
     reload(sys.modules['apprise'])
 
     # Point our object to our new temporary existing file
-    apprise.plugins.NotifyMacOSX.notify_path = str(script)
+    apprise.plugins.NotifyMacOSX.notify_paths = (str(script), )
 
     # Our object is disabled
     obj = apprise.Apprise.instantiate(
@@ -168,7 +168,7 @@ def test_plugin_macosx_general(mock_macver, mock_system, mock_popen, tmpdir):
     reload(sys.modules['apprise'])
 
     # Point our object to our new temporary existing file
-    apprise.plugins.NotifyMacOSX.notify_path = str(script)
+    apprise.plugins.NotifyMacOSX.notify_paths = (str(script), )
 
     obj = apprise.Apprise.instantiate(
         'macosx://_/?sound=default', suppress_exceptions=False)
@@ -182,7 +182,7 @@ def test_plugin_macosx_general(mock_macver, mock_system, mock_popen, tmpdir):
     reload(sys.modules['apprise'])
 
     # Point our object to our new temporary existing file
-    apprise.plugins.NotifyMacOSX.notify_path = str(script)
+    apprise.plugins.NotifyMacOSX.notify_paths = (str(script), )
 
     # This is just to test that the the minor (in this case .12)
     # is only weighed with respect to the major number as wel


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #508

MacOSX plugin now supports the handling of multiple notifier paths (it will use whatever matches first).  Additionally added `/opt/homebrew/bin/terminal-notify` to the head of this list.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
