### PR TITLE
Reddit posts to work without title specified

### DIFF
--- a/apprise/plugins/NotifyReddit.py
+++ b/apprise/plugins/NotifyReddit.py
@@ -465,7 +465,7 @@ class NotifyReddit(NotifyBase):
                 'api_type': 'json',
                 'extension': 'json',
                 'sr': subreddit,
-                'title': title,
+                'title': title if title else self.app_desc,
                 'kind': kind,
                 'nsfw': True if self.nsfw else False,
                 'resubmit': True if self.resubmit else False,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #499

I am unable to reproduce the issue identified in the related ticket, however I add slight bulletproofing so that you can post to Reddit without having to specify a title (which is required upstream)

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
