### PR TITLE
XMPP Refactoring

### DIFF
--- a/all-plugin-requirements.txt
+++ b/all-plugin-requirements.txt
@@ -6,7 +6,7 @@
 cryptography
 
 # Provides xmpp:// support
-slixmpp; python_version >= '3.7'
+slixmpp >= 1.8.2; python_version >= '3.7'
 
 # Provides growl:// support
 gntp

--- a/apprise/plugins/NotifyMQTT.py
+++ b/apprise/plugins/NotifyMQTT.py
@@ -150,6 +150,8 @@ class NotifyMQTT(NotifyBase):
         "/etc/pki/tls/cacert.pem",
         # CentOS/RHEL 7
         "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+        # Alpine Linux
+        "/etc/ssl/cert.pem",
     ]
 
     # Define object templates

--- a/apprise/plugins/NotifyXMPP/SliXmppAdapter.py
+++ b/apprise/plugins/NotifyXMPP/SliXmppAdapter.py
@@ -74,6 +74,8 @@ class SliXmppAdapter(object):
         "/etc/pki/tls/cacert.pem",
         # CentOS/RHEL 7
         "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+        # Alpine Linux
+        "/etc/ssl/cert.pem",
     ]
 
     # This entry is a bit hacky, but it allows us to unit-test this library
@@ -175,6 +177,10 @@ class SliXmppAdapter(object):
         self.override_connection = \
             None if not self.port else (self.host, self.port)
 
+        # Instruct slixmpp to connect to the XMPP service at the time process()
+        # is called later on
+        self.xmpp.connect(self.override_connection, use_ssl=self.secure)
+
         # We're good
         return True
 
@@ -183,11 +189,6 @@ class SliXmppAdapter(object):
         Thread that handles the server/client i/o
 
         """
-
-        # Instruct slixmpp to connect to the XMPP service.
-        if not self.xmpp.connect(
-                self.override_connection, use_ssl=self.secure):
-            return False
 
         # Run the asyncio event loop, and return once disconnected,
         # for any reason.
@@ -204,6 +205,13 @@ class SliXmppAdapter(object):
         if not targets:
             # We always default to notifying ourselves
             targets.append(self.jid)
+
+        if not self.xmpp.is_connected():
+            # Ensure we're set to not handle this
+            self.success = False
+
+            # We're done
+            return
 
         while len(targets) > 0:
 
@@ -224,3 +232,6 @@ class SliXmppAdapter(object):
 
         # Toggle our success flag
         self.success = True
+
+        # We're done
+        return

--- a/apprise/plugins/NotifyXMPP/__init__.py
+++ b/apprise/plugins/NotifyXMPP/__init__.py
@@ -206,7 +206,6 @@ class NotifyXMPP(NotifyBase):
         # By default we send ourselves a message
         if targets:
             self.targets = parse_list(targets)
-            self.targets[0] = self.targets[0][1:]
 
         else:
             self.targets = list()
@@ -292,7 +291,7 @@ class NotifyXMPP(NotifyBase):
 
         # Get our targets; we ignore path slashes since they identify
         # our resources
-        results['targets'] = NotifyXMPP.parse_list(results['fullpath'])
+        results['targets'] = NotifyXMPP.split_path(results['fullpath'])
 
         # Over-ride the xep plugins
         if 'xep' in results['qsd'] and len(results['qsd']['xep']):

--- a/test/test_plugin_xmpp.py
+++ b/test/test_plugin_xmpp.py
@@ -207,10 +207,14 @@ def test_plugin_xmpp_general(tmpdir):
         with mock.patch('slixmpp.ClientXMPP') as mock_stream:
             client_stream = mock.Mock()
             client_stream.connect.return_value = False
+            client_stream.is_connected.return_value = False
             mock_stream.return_value = client_stream
 
-            # test notifications
-            assert obj.notify(
+            aobj = apprise.Apprise()
+            assert aobj.add(url) is True
+
+            # test notification
+            assert aobj.notify(
                 title='title', body='body',
                 notify_type=apprise.NotifyType.INFO) is False
 
@@ -299,6 +303,7 @@ def test_plugin_xmpp_slixmpp_callbacks():
     with mock.patch('slixmpp.ClientXMPP') as mock_stream:
         client_stream = mock.Mock()
         client_stream.send_message.return_value = True
+        client_stream.is_connected.return_value = True
         mock_stream.return_value = client_stream
 
         adapter = apprise.plugins.SliXmppAdapter(**kwargs)
@@ -313,16 +318,19 @@ def test_plugin_xmpp_slixmpp_callbacks():
 
     # Now we'll do a test with no one to notify
     kwargs['targets'] = []
-    adapter = apprise.plugins.SliXmppAdapter(**kwargs)
-    assert isinstance(adapter, apprise.plugins.SliXmppAdapter)
-
-    # success flag should be back to a False state
-    assert adapter.success is False
 
     with mock.patch('slixmpp.ClientXMPP') as mock_stream:
         client_stream = mock.Mock()
+        client_stream.is_connected.return_value = True
         client_stream.send_message.return_value = True
         mock_stream.return_value = client_stream
+
+        adapter = apprise.plugins.SliXmppAdapter(**kwargs)
+        assert isinstance(adapter, apprise.plugins.SliXmppAdapter)
+
+        # success flag should be back to a False state
+        assert adapter.success is False
+
         adapter.session_start()
         # success flag changes to True
         assert adapter.success is True


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #497 

Re-factored the way the connections are handled.

## Deadlocks and Crashes:


I spent hours trying different things and haven't gotten to far.  I may have fixed just the connection issue you were receiving earlier though @drequivalent.

**The Issues**:
- The biggest issue i see with `slixmpp` is that that there seems to be [incompatibilities with Python >=3.8](https://lab.louiz.org/poezio/slixmpp/-/issues/3467). This made it tough to troubleshoot timeouts and forever values for me. The `asyncio.loop` seems to deadlock from time to time under certain conditions.
   - One of which is easily reproduced if the hostname in the `jid` can't be resolved (something like `?jid=user@405c5318a47031`) The built in DNS feature seems to block indefinitely if it fails to resolve. This may also just be related to my Python version incompatibilities.  I can't seem to find an easy way to just completely disable DNS.  Most exploits always come down to DNS anyhow (such as the recent Apache `log4j2` issue in the news).  Ideally this should be turned off.
 
@linkmauve do you have any suggestions?  Perhaps you could review my PR and let me know if you spot anything unusual?

# Side Notes
I know very little about XMPP; this is one of those features i was hoping to just adopt through a 3rd party library. The concerns i have with the deadlocks is that they introduce a denial of service attack for people hosting this via the [Apprise API](https://github.com/caronc/apprise-api).  I may need to disable XMPP there _by default_ for the time being.

# Going forward:
There is the thought of maybe switching to a different library; possibly:
- [nbxmpp](https://dev.gajim.org/gajim/python-nbxmpp): Seems basic; but that is all Apprise offers is a simple gateway to each upstream provider.  So maybe this is enough? It would be a significant downgrade in features when compared with slixmpp.  Perhaps more Python version compatibility instead of Just Python v3.7 thought?
- [xmpppy](https://github.com/xmpppy/xmpppy) seems very active as well with a release just 2 days ago (Release 0.7.0).  @amotl do you have any comments here? I see you're getting 18K downloads a month which is great. I don't see to many tickets open either so I presume you've got the messaging of servers down pat?  Is there support for Secure connections as well?
- Alternatively we just keep going with `silxmpp` and clean up the issues we're having.  I see leveraging the creation of a second `asyncio.loop` and putting all of the calls to this library in it's own thread.  This will allow it to avoid deadlocking in the main loop and it will also allow me to put a async timeout on the entire call to it when/if the deadlocks continue. Will definitely want your thoughts feedback here @linkmauve (if you have time)
- Anyone have any other thoughts/views as to possible ways forward?  I know @drequivalent referenced a very young application (without much global feedback yet) running Go ([here](https://salsa.debian.org/mdosch/go-sendxmpp)).   Calling a 3rd party tool via Apprise is also a possibility too.

Any advice would be welcome :pray: 

# Testing
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in
# This way you can just destroy it after when it's all over.
# The below will create a directory called apprise
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@497-xmpp-refactor

# Give it a go:
apprise -vv -b "test" -t "test" "xmpp://user:pass@hostname?jid=user@host"
```

# Additional
- @drequivalent, do you think you could check out this branch and test it for me? See Testing section above. :+1: 

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] 100% test coverage
