### PR TITLE
Custom Form/Encoding Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Apprise have some email services built right into it (such as yahoo, fastmail, h
 ### Custom Notifications
 | Post Method          | Service ID | Default Port | Example Syntax |
 | -------------------- | ---------- | ------------ | -------------- |
+| [Form](https://github.com/caronc/apprise/wiki/Notify_Custom_Form)       | form:// or form://   | (TCP) 80 or 443 | form://hostname<br />form://user@hostname<br />form://user:password@hostname:port<br />form://hostname/a/path/to/post/to
 | [JSON](https://github.com/caronc/apprise/wiki/Notify_Custom_JSON)       | json:// or jsons://   | (TCP) 80 or 443 | json://hostname<br />json://user@hostname<br />json://user:password@hostname:port<br />json://hostname/a/path/to/post/to
 | [XML](https://github.com/caronc/apprise/wiki/Notify_Custom_XML)         | xml:// or xmls://   | (TCP) 80 or 443 | xml://hostname<br />xml://user@hostname<br />xml://user:password@hostname:port<br />xml://hostname/a/path/to/post/to
 

--- a/test/helpers/rest.py
+++ b/test/helpers/rest.py
@@ -298,7 +298,11 @@ class AppriseURLTester(object):
 
     @mock.patch('requests.get')
     @mock.patch('requests.post')
-    def __notify(self, url, obj, meta, asset, mock_post, mock_get):
+    @mock.patch('requests.head')
+    @mock.patch('requests.put')
+    @mock.patch('requests.delete')
+    def __notify(self, url, obj, meta, asset, mock_del, mock_put, mock_head,
+                 mock_post, mock_get):
         """
         Perform notification testing against object specified
         """
@@ -344,20 +348,36 @@ class AppriseURLTester(object):
         robj.content = u''
         mock_get.return_value = robj
         mock_post.return_value = robj
+        mock_head.return_value = robj
+        mock_del.return_value = robj
+        mock_put.return_value = robj
 
         if test_requests_exceptions is False:
             # Handle our default response
+            mock_put.return_value.status_code = requests_response_code
+            mock_head.return_value.status_code = requests_response_code
+            mock_del.return_value.status_code = requests_response_code
             mock_post.return_value.status_code = requests_response_code
             mock_get.return_value.status_code = requests_response_code
 
             # Handle our default text response
             mock_get.return_value.content = requests_response_text
             mock_post.return_value.content = requests_response_text
+            mock_del.return_value.content = requests_response_text
+            mock_put.return_value.content = requests_response_text
+            mock_head.return_value.content = requests_response_text
+
             mock_get.return_value.text = requests_response_text
             mock_post.return_value.text = requests_response_text
+            mock_put.return_value.text = requests_response_text
+            mock_del.return_value.text = requests_response_text
+            mock_head.return_value.text = requests_response_text
 
             # Ensure there is no side effect set
             mock_post.side_effect = None
+            mock_del.side_effect = None
+            mock_put.side_effect = None
+            mock_head.side_effect = None
             mock_get.side_effect = None
 
         else:
@@ -457,6 +477,9 @@ class AppriseURLTester(object):
 
                 for _exception in self.req_exceptions:
                     mock_post.side_effect = _exception
+                    mock_head.side_effect = _exception
+                    mock_del.side_effect = _exception
+                    mock_put.side_effect = _exception
                     mock_get.side_effect = _exception
 
                     try:
@@ -498,6 +521,9 @@ class AppriseURLTester(object):
             else:
                 for _exception in self.req_exceptions:
                     mock_post.side_effect = _exception
+                    mock_del.side_effect = _exception
+                    mock_put.side_effect = _exception
+                    mock_head.side_effect = _exception
                     mock_get.side_effect = _exception
 
                     try:

--- a/test/test_plugin_custom_form.py
+++ b/test/test_plugin_custom_form.py
@@ -1,0 +1,226 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+import os
+import sys
+import mock
+import requests
+from apprise import plugins
+from helpers import AppriseURLTester
+from apprise import Apprise
+from apprise import NotifyType
+from apprise import AppriseAttachment
+
+# Disable logging for a cleaner testing output
+import logging
+logging.disable(logging.CRITICAL)
+
+# Attachment Directory
+TEST_VAR_DIR = os.path.join(os.path.dirname(__file__), 'var')
+
+# Our Testing URLs
+apprise_url_tests = (
+    ('form://:@/', {
+        'instance': None,
+    }),
+    ('form://', {
+        'instance': None,
+    }),
+    ('forms://', {
+        'instance': None,
+    }),
+    ('form://localhost', {
+        'instance': plugins.NotifyForm,
+    }),
+    ('form://user@localhost?method=invalid', {
+        'instance': TypeError,
+    }),
+    ('form://user:pass@localhost', {
+        'instance': plugins.NotifyForm,
+
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'form://user:****@localhost',
+    }),
+    ('form://user@localhost', {
+        'instance': plugins.NotifyForm,
+    }),
+
+    # Test method variations
+    ('form://user@localhost?method=put', {
+        'instance': plugins.NotifyForm,
+    }),
+    ('form://user@localhost?method=get', {
+        'instance': plugins.NotifyForm,
+    }),
+    ('form://user@localhost?method=post', {
+        'instance': plugins.NotifyForm,
+    }),
+    ('form://user@localhost?method=head', {
+        'instance': plugins.NotifyForm,
+    }),
+    ('form://user@localhost?method=delete', {
+        'instance': plugins.NotifyForm,
+    }),
+
+    # Custom payload options
+    ('form://localhost:8080?:key=value&:key2=value2', {
+        'instance': plugins.NotifyForm,
+    }),
+
+    # Continue testing other cases
+    ('form://localhost:8080', {
+        'instance': plugins.NotifyForm,
+    }),
+    ('form://user:pass@localhost:8080', {
+        'instance': plugins.NotifyForm,
+    }),
+    ('forms://localhost', {
+        'instance': plugins.NotifyForm,
+    }),
+    ('forms://user:pass@localhost', {
+        'instance': plugins.NotifyForm,
+    }),
+    ('forms://localhost:8080/path/', {
+        'instance': plugins.NotifyForm,
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'forms://localhost:8080/path/',
+    }),
+    ('forms://user:password@localhost:8080', {
+        'instance': plugins.NotifyForm,
+
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'forms://user:****@localhost:8080',
+    }),
+    ('form://localhost:8080/path?-HeaderKey=HeaderValue', {
+        'instance': plugins.NotifyForm,
+    }),
+    ('form://user:pass@localhost:8081', {
+        'instance': plugins.NotifyForm,
+        # force a failure
+        'response': False,
+        'requests_response_code': requests.codes.internal_server_error,
+    }),
+    ('form://user:pass@localhost:8082', {
+        'instance': plugins.NotifyForm,
+        # throw a bizzare code forcing us to fail to look it up
+        'response': False,
+        'requests_response_code': 999,
+    }),
+    ('form://user:pass@localhost:8083', {
+        'instance': plugins.NotifyForm,
+        # Throws a series of connection and transfer exceptions when this flag
+        # is set and tests that we gracfully handle them
+        'test_requests_exceptions': True,
+    }),
+)
+
+
+def test_plugin_custom_form_urls():
+    """
+    NotifyForm() Apprise URLs
+
+    """
+
+    # Run our general tests
+    AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+@mock.patch('requests.post')
+def test_plugin_custom_form_attachments(mock_post):
+    """
+    NotifyForm() Attachments
+
+    """
+    # Disable Throttling to speed testing
+    plugins.NotifyBase.request_rate_per_sec = 0
+
+    okay_response = requests.Request()
+    okay_response.status_code = requests.codes.ok
+    okay_response.content = ""
+
+    # Assign our mock object our return value
+    mock_post.return_value = okay_response
+
+    obj = Apprise.instantiate(
+        'form://user@localhost.localdomain/?method=post')
+    assert isinstance(obj, plugins.NotifyForm)
+
+    # Test Valid Attachment
+    path = os.path.join(TEST_VAR_DIR, 'apprise-test.gif')
+    attach = AppriseAttachment(path)
+    assert obj.notify(
+        body='body', title='title', notify_type=NotifyType.INFO,
+        attach=attach) is True
+
+    # Test invalid attachment
+    path = os.path.join(TEST_VAR_DIR, '/invalid/path/to/an/invalid/file.jpg')
+    assert obj.notify(
+        body='body', title='title', notify_type=NotifyType.INFO,
+        attach=path) is False
+
+    mock_post.return_value = None
+    mock_post.side_effect = OSError()
+    # We can't send the message if we can't read the attachment
+    assert obj.notify(
+        body='body', title='title', notify_type=NotifyType.INFO,
+        attach=attach) is False
+
+    # Get a appropriate "builtin" module name for pythons 2/3.
+    if sys.version_info.major >= 3:
+        builtin_open_function = 'builtins.open'
+
+    else:
+        builtin_open_function = '__builtin__.open'
+
+    # Test Valid Attachment (load 3)
+    path = (
+        os.path.join(TEST_VAR_DIR, 'apprise-test.gif'),
+        os.path.join(TEST_VAR_DIR, 'apprise-test.gif'),
+        os.path.join(TEST_VAR_DIR, 'apprise-test.gif'),
+    )
+    attach = AppriseAttachment(path)
+
+    # Return our good configuration
+    mock_post.side_effect = None
+    mock_post.return_value = okay_response
+    with mock.patch(builtin_open_function, side_effect=OSError()):
+        # We can't send the message we can't open the attachment for reading
+        assert obj.notify(
+            body='body', title='title', notify_type=NotifyType.INFO,
+            attach=attach) is False
+
+    # Fail on the 2nd attempt (but not the first)
+    with mock.patch(builtin_open_function,
+                    side_effect=[None, OSError(), None]):
+        # We can't send the message we can't open the attachment for reading
+        assert obj.notify(
+            body='body', title='title', notify_type=NotifyType.INFO,
+            attach=attach) is False
+
+    # Test file exception handling when performing post
+    mock_post.return_value = None
+    mock_post.side_effect = OSError()
+    assert obj.notify(
+        body='body', title='title', notify_type=NotifyType.INFO,
+        attach=attach) is False

--- a/test/test_plugin_custom_json.py
+++ b/test/test_plugin_custom_json.py
@@ -44,6 +44,9 @@ apprise_url_tests = (
     ('json://localhost', {
         'instance': plugins.NotifyJSON,
     }),
+    ('json://user@localhost?method=invalid', {
+        'instance': TypeError,
+    }),
     ('json://user:pass@localhost', {
         'instance': plugins.NotifyJSON,
 
@@ -53,6 +56,25 @@ apprise_url_tests = (
     ('json://user@localhost', {
         'instance': plugins.NotifyJSON,
     }),
+
+    # Test method variations
+    ('json://user@localhost?method=put', {
+        'instance': plugins.NotifyJSON,
+    }),
+    ('json://user@localhost?method=get', {
+        'instance': plugins.NotifyJSON,
+    }),
+    ('json://user@localhost?method=post', {
+        'instance': plugins.NotifyJSON,
+    }),
+    ('json://user@localhost?method=head', {
+        'instance': plugins.NotifyJSON,
+    }),
+    ('json://user@localhost?method=delete', {
+        'instance': plugins.NotifyJSON,
+    }),
+
+    # Continue testing other cases
     ('json://localhost:8080', {
         'instance': plugins.NotifyJSON,
     }),

--- a/test/test_plugin_custom_xml.py
+++ b/test/test_plugin_custom_xml.py
@@ -47,12 +47,34 @@ apprise_url_tests = (
     ('xml://user@localhost', {
         'instance': plugins.NotifyXML,
     }),
+    ('xml://user@localhost?method=invalid', {
+        'instance': TypeError,
+    }),
     ('xml://user:pass@localhost', {
         'instance': plugins.NotifyXML,
 
         # Our expected url(privacy=True) startswith() response:
         'privacy_url': 'xml://user:****@localhost',
     }),
+
+    # Test method variations
+    ('xml://user@localhost?method=put', {
+        'instance': plugins.NotifyXML,
+    }),
+    ('xml://user@localhost?method=get', {
+        'instance': plugins.NotifyXML,
+    }),
+    ('xml://user@localhost?method=post', {
+        'instance': plugins.NotifyXML,
+    }),
+    ('xml://user@localhost?method=head', {
+        'instance': plugins.NotifyXML,
+    }),
+    ('xml://user@localhost?method=delete', {
+        'instance': plugins.NotifyXML,
+    }),
+
+    # Continue testing other cases
     ('xml://localhost:8080', {
         'instance': plugins.NotifyXML,
     }),
@@ -64,9 +86,25 @@ apprise_url_tests = (
     }),
     ('xmls://user:pass@localhost', {
         'instance': plugins.NotifyXML,
-
+    }),
+    # Continue testing other cases
+    ('xml://localhost:8080', {
+        'instance': plugins.NotifyXML,
+    }),
+    ('xml://user:pass@localhost:8080', {
+        'instance': plugins.NotifyXML,
+    }),
+    ('xml://localhost', {
+        'instance': plugins.NotifyXML,
+    }),
+    ('xmls://user:pass@localhost', {
+        'instance': plugins.NotifyXML,
         # Our expected url(privacy=True) startswith() response:
         'privacy_url': 'xmls://user:****@localhost',
+    }),
+    ('xml://user@localhost:8080/path/', {
+        'instance': plugins.NotifyXML,
+        'privacy_url': 'xml://user@localhost:8080/path',
     }),
     ('xmls://localhost:8080/path/', {
         'instance': plugins.NotifyXML,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #452 and  #507

The idea is to support HTTP Form Formatting)
 - Attachments produce a `multipart/form-data` header type and are all included in the same request.  the default (if no attachments are specified is `application/x-www-form-urlencoded`.

The other change with this PR is `JSON`, `XML` and this new `FORM` custom type support a new keyword called `method` allowing you to override the `POST` (and have it be a `PUT`, `DELETE`, `GET`, or `HEAD` instead if you wish).


## New Service Completion Status
<!-- This section is only applicable if you're adding a new service -->
* [x] apprise/plugins/NotifyForm.py
* [x] README.md
    - add entry for new service to table (as a quick reference)

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
