### PR TITLE
Telegram: enhance bot owner detection and avoid exception

### DIFF
--- a/apprise/plugins/NotifyTelegram.py
+++ b/apprise/plugins/NotifyTelegram.py
@@ -485,13 +485,14 @@ class NotifyTelegram(NotifyBase):
 
         if 'ok' in response and response['ok'] is True \
                 and 'result' in response and len(response['result']):
-            entry = response['result'][0]
-            _id = entry['message']['from'].get('id', 0)
-            _user = entry['message']['from'].get('first_name')
-            self.logger.info('Detected Telegram user %s (userid=%d)' % (
-                _user, _id))
-            # Return our detected userid
-            return _id
+            for entry in response['result']: 
+                if 'message' in entry and 'from' in entry['message']:
+                    _id = entry['message']['from'].get('id', 0)
+                    _user = entry['message']['from'].get('first_name')
+                    self.logger.info('Detected Telegram user %s (userid=%d)' % (
+                        _user, _id))
+                    # Return our detected userid
+                    return _id
 
         self.logger.warning(
             'Failed to detect a Telegram user; '

--- a/apprise/plugins/NotifyTelegram.py
+++ b/apprise/plugins/NotifyTelegram.py
@@ -483,14 +483,13 @@ class NotifyTelegram(NotifyBase):
         #      "text":"/start",
         #      "entities":[{"offset":0,"length":6,"type":"bot_command"}]}}]
 
-        if 'ok' in response and response['ok'] is True \
-                and 'result' in response and len(response['result']):
-            for entry in response['result']: 
+        if response.get('ok', False):
+            for entry in response.get('result', []):
                 if 'message' in entry and 'from' in entry['message']:
                     _id = entry['message']['from'].get('id', 0)
                     _user = entry['message']['from'].get('first_name')
-                    self.logger.info('Detected Telegram user %s (userid=%d)' % (
-                        _user, _id))
+                    self.logger.info(
+                        'Detected Telegram user %s (userid=%d)' % (_user, _id))
                     # Return our detected userid
                     return _id
 


### PR DESCRIPTION
The /getupdates verb on Telegram may return a result where the first entry is a channel post (so no 'message' key: this triggers an exception on line 489).

This commit makes the function parse all results in the response array and returns the bot owner when an entry with 'message' and 'from' keys is found. Generally, this should mean skipping the first result.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
