### PR TITLE
Bugfix: avoid duplicate target call signs

### DIFF
--- a/apprise/plugins/NotifyDapnet.py
+++ b/apprise/plugins/NotifyDapnet.py
@@ -201,8 +201,10 @@ class NotifyDapnet(NotifyBase):
                 )
                 continue
 
-            # Store callsign
-            self.targets.append(result['callsign'])
+            # Store callsign without SSID and
+            # ignore duplicates
+            if result['callsign'] not in self.targets:
+                self.targets.append(result['callsign'])
 
         return
 

--- a/apprise/plugins/NotifyDapnet.py
+++ b/apprise/plugins/NotifyDapnet.py
@@ -358,7 +358,8 @@ class NotifyDapnet(NotifyBase):
         # Support the 'to' variable so that we can support rooms this way too
         # The 'to' makes it easier to use yaml configuration
         if 'to' in results['qsd'] and len(results['qsd']['to']):
-            results['targets'] += parse_call_sign(results['qsd']['to'])
+            results['targets'] += \
+                NotifyDapnet.parse_list(results['qsd']['to'])
 
         # Check for priority
         if 'priority' in results['qsd'] and len(results['qsd']['priority']):

--- a/test/test_plugin_dapnet.py
+++ b/test/test_plugin_dapnet.py
@@ -59,6 +59,15 @@ apprise_url_tests = (
         'instance': plugins.NotifyDapnet,
         'requests_response_code': requests.codes.created,
     }),
+    ('dapnet://user:pass@DF1ABC-1/DF1ABC/DF1ABC-15', {
+        # valid call signs; but a few are duplicates;
+        # at the end there will only be 1 entry
+        'instance': plugins.NotifyDapnet,
+        'requests_response_code': requests.codes.created,
+        # Our expected url(privacy=True) startswith() response:
+        # Note that only 1 entry is saved (as other 2 are duplicates)
+        'privacy_url': 'dapnet://user:****@D...C?',
+    }),
     ('dapnet://user:pass@?to={},{}'.format('DF1ABC', 'DF1DEF'), {
         # support the to= argument
         'instance': plugins.NotifyDapnet,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** not applicable

Detect and remove duplicate base call signs (e.g. after processing a list of call signs with the same base call sign but with different SSID's)

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [X] The code change is tested and works locally.
* [X] There is no commented out code in this PR.
* [X] No lint errors (use `flake8`)
* [X] 100% test coverage
