### PR TITLE
add ntfy plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The table below identifies the services this tool supports and some example serv
 | [NextcloudTalk](https://github.com/caronc/apprise/wiki/Notify_nextcloudtalk) | nctalk:// or nctalks:// | (TCP) 80 or 443 | nctalk://user:pass@host/RoomId<br/>nctalks://user:pass@host/RoomId1/RoomId2/RoomIdN
 | [Notica](https://github.com/caronc/apprise/wiki/Notify_notica) | notica://  | (TCP) 443   | notica://Token/
 | [Notifico](https://github.com/caronc/apprise/wiki/Notify_notifico) | notifico://  | (TCP) 443   | notifico://ProjectID/MessageHook/
+| [Ntfy](https://github.com/caronc/apprise/wiki/Notify_ntfy) | ntfy://  | (TCP) 80 or 443   | ntfy://topic/<br/>ntfys://topic/
 | [Office 365](https://github.com/caronc/apprise/wiki/Notify_office365) | o365://  | (TCP) 443   | o365://TenantID:AccountEmail/ClientID/ClientSecret<br />o365://TenantID:AccountEmail/ClientID/ClientSecret/TargetEmail<br />o365://TenantID:AccountEmail/ClientID/ClientSecret/TargetEmail1/TargetEmail2/TargetEmailN
 | [OneSignal](https://github.com/caronc/apprise/wiki/Notify_onesignal) | onesignal:// | (TCP) 443 | onesignal://AppID@APIKey/PlayerID<br/>onesignal://TemplateID:AppID@APIKey/UserID<br/>onesignal://AppID@APIKey/#IncludeSegment<br/>onesignal://AppID@APIKey/Email
 | [Opsgenie](https://github.com/caronc/apprise/wiki/Notify_opsgenie) | opsgenie:// | (TCP) 443 | opsgenie://APIKey<br/>opsgenie://APIKey/UserID<br/>opsgenie://APIKey/#Team<br/>opsgenie://APIKey/\*Schedule<br/>opsgenie://APIKey/^Escalation

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The table below identifies the services this tool supports and some example serv
 | [NextcloudTalk](https://github.com/caronc/apprise/wiki/Notify_nextcloudtalk) | nctalk:// or nctalks:// | (TCP) 80 or 443 | nctalk://user:pass@host/RoomId<br/>nctalks://user:pass@host/RoomId1/RoomId2/RoomIdN
 | [Notica](https://github.com/caronc/apprise/wiki/Notify_notica) | notica://  | (TCP) 443   | notica://Token/
 | [Notifico](https://github.com/caronc/apprise/wiki/Notify_notifico) | notifico://  | (TCP) 443   | notifico://ProjectID/MessageHook/
-| [Ntfy](https://github.com/caronc/apprise/wiki/Notify_ntfy) | ntfy://  | (TCP) 80 or 443   | ntfy://topic/<br/>ntfys://topic/
+| [ntfy](https://github.com/caronc/apprise/wiki/Notify_ntfy) | ntfy://  | (TCP) 80 or 443   | ntfy://topic/<br/>ntfys://topic/
 | [Office 365](https://github.com/caronc/apprise/wiki/Notify_office365) | o365://  | (TCP) 443   | o365://TenantID:AccountEmail/ClientID/ClientSecret<br />o365://TenantID:AccountEmail/ClientID/ClientSecret/TargetEmail<br />o365://TenantID:AccountEmail/ClientID/ClientSecret/TargetEmail1/TargetEmail2/TargetEmailN
 | [OneSignal](https://github.com/caronc/apprise/wiki/Notify_onesignal) | onesignal:// | (TCP) 443 | onesignal://AppID@APIKey/PlayerID<br/>onesignal://TemplateID:AppID@APIKey/UserID<br/>onesignal://AppID@APIKey/#IncludeSegment<br/>onesignal://AppID@APIKey/Email
 | [Opsgenie](https://github.com/caronc/apprise/wiki/Notify_opsgenie) | opsgenie:// | (TCP) 443 | opsgenie://APIKey<br/>opsgenie://APIKey/UserID<br/>opsgenie://APIKey/#Team<br/>opsgenie://APIKey/\*Schedule<br/>opsgenie://APIKey/^Escalation

--- a/apprise/plugins/NotifyNtfy.py
+++ b/apprise/plugins/NotifyNtfy.py
@@ -119,6 +119,10 @@ class NotifyNtfy(NotifyBase):
 
     # Define our template arguments
     template_args = dict(NotifyBase.template_args, **{
+        'attach': {
+            'name': _('Attach'),
+            'type': 'string',
+         },
         'click': {
             'name': _('Click'),
             'type': 'string',
@@ -143,8 +147,8 @@ class NotifyNtfy(NotifyBase):
         },
     })
 
-    def __init__(self, topic, click=None, delay=None, email=None,
-                 priority=None, tags=None, **kwargs):
+    def __init__(self, topic, attach=None, click=None, delay=None,
+                 email=None, priority=None, tags=None, **kwargs):
         """
         Initialize Ntfy Object
         """
@@ -155,6 +159,9 @@ class NotifyNtfy(NotifyBase):
             raise TypeError(msg)
 
         self.topic = topic
+
+        # Attach a file (URL supported)
+        self.attach = attach
 
         # A clickthrough option for notifications
         self.click = click
@@ -194,6 +201,8 @@ class NotifyNtfy(NotifyBase):
             headers['X-Priority'] = priority
         if title:
             headers['X-Title'] = title
+        if self.attach is not None:
+            headers['X-Attach'] = self.attach
         if self.click is not None:
             headers['X-Click'] = self.click
         if self.delay is not None:
@@ -304,6 +313,8 @@ class NotifyNtfy(NotifyBase):
             else NTFY_PRIORITIES.DEFAULT,
         }
 
+        if self.attach is not None:
+            params['attach'] = self.attach
         if self.click is not None:
             params['click'] = self.click
         if self.delay is not None:
@@ -349,6 +360,9 @@ class NotifyNtfy(NotifyBase):
                     NtfyPriority.get_priority(results['qsd']['priority'])
             except KeyError:  # no priority was set
                 pass
+
+        if 'attach' in results['qsd'] and len(results['qsd']['attach']):
+            results['attach'] = NotifyNtfy.unquote(results['qsd']['attach'])
 
         if 'click' in results['qsd'] and len(results['qsd']['click']):
             results['click'] = NotifyNtfy.unquote(results['qsd']['click'])

--- a/apprise/plugins/NotifyNtfy.py
+++ b/apprise/plugins/NotifyNtfy.py
@@ -119,6 +119,18 @@ class NotifyNtfy(NotifyBase):
 
     # Define our template arguments
     template_args = dict(NotifyBase.template_args, **{
+        'click': {
+            'name': _('Click'),
+            'type': 'string',
+         },
+        'delay': {
+            'name': _('Delay'),
+            'type': 'string',
+         },
+        'email': {
+            'name': _('Email'),
+            'type': 'string',
+         },
         'priority': {
             'name': _('Priority'),
             'type': 'choice:string',
@@ -131,7 +143,8 @@ class NotifyNtfy(NotifyBase):
         },
     })
 
-    def __init__(self, topic, priority=None, tags=None, **kwargs):
+    def __init__(self, topic, click=None, delay=None, email=None,
+                 priority=None, tags=None, **kwargs):
         """
         Initialize Ntfy Object
         """
@@ -142,6 +155,15 @@ class NotifyNtfy(NotifyBase):
             raise TypeError(msg)
 
         self.topic = topic
+
+        # A clickthrough option for notifications
+        self.click = click
+
+        # Time delay for notifications (various string formats)
+        self.delay = delay
+
+        # An email to forward notifications to
+        self.email = email
 
         # The priority of the message
         if priority not in NTFY_PRIORITIES:
@@ -172,6 +194,12 @@ class NotifyNtfy(NotifyBase):
             headers['X-Priority'] = priority
         if title:
             headers['X-Title'] = title
+        if self.click is not None:
+            headers['X-Click'] = self.click
+        if self.delay is not None:
+            headers['X-Delay'] = self.delay
+        if self.email is not None:
+            headers['X-Email'] = self.email
         if self.__tags:
             headers['X-Tags'] = ",".join(self.__tags)
 
@@ -276,6 +304,12 @@ class NotifyNtfy(NotifyBase):
             else NTFY_PRIORITIES.DEFAULT,
         }
 
+        if self.click is not None:
+            params['click'] = self.click
+        if self.delay is not None:
+            params['delay'] = self.delay
+        if self.email is not None:
+            params['email'] = self.email
         if self.__tags:
             params['tags'] = ','.join(self.__tags)
 
@@ -315,6 +349,15 @@ class NotifyNtfy(NotifyBase):
                     NtfyPriority.get_priority(results['qsd']['priority'])
             except KeyError:  # no priority was set
                 pass
+
+        if 'click' in results['qsd'] and len(results['qsd']['click']):
+            results['click'] = NotifyNtfy.unquote(results['qsd']['click'])
+
+        if 'delay' in results['qsd'] and len(results['qsd']['delay']):
+            results['delay'] = NotifyNtfy.unquote(results['qsd']['delay'])
+
+        if 'email' in results['qsd'] and len(results['qsd']['email']):
+            results['email'] = NotifyNtfy.unquote(results['qsd']['email'])
 
         if 'tags' in results['qsd'] and len(results['qsd']['tags']):
             results['tags'] = \

--- a/apprise/plugins/NotifyNtfy.py
+++ b/apprise/plugins/NotifyNtfy.py
@@ -1,0 +1,331 @@
+# MIT License
+
+# Copyright (c) 2022 Joey Espinosa <@particledecay>
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import requests
+import six
+from json import loads
+
+from .NotifyBase import NotifyBase
+from ..common import NotifyType
+from ..AppriseLocale import gettext_lazy as _
+from ..utils import parse_list
+
+
+# Priorities
+class NtfyPriority(object):
+    MAX = 'max'
+    HIGH = 'high'
+    DEFAULT = 'default'
+    LOW = 'low'
+    MIN = 'min'
+
+    VALUES = (
+        (MAX, 5),
+        (HIGH, 4),
+        (DEFAULT, 3),
+        (LOW, 2),
+        (MIN, 1),
+    )
+
+    @classmethod
+    def get_priority(cls, value):
+        priorities = [p[0] for p in NtfyPriority.VALUES if p[1] == value]
+        if priorities:
+            return priorities[0]
+        named_priorities = [p[0] for p in NtfyPriority.VALUES if p[0] == value]
+        if named_priorities:
+            return named_priorities[0]
+        return
+
+
+NTFY_PRIORITIES = (
+    NtfyPriority.MAX,
+    NtfyPriority.HIGH,
+    NtfyPriority.DEFAULT,
+    NtfyPriority.LOW,
+    NtfyPriority.MIN,
+)
+
+
+class NotifyNtfy(NotifyBase):
+    """
+    A wrapper for Ntfy Notifications
+    """
+
+    # The default descriptive name associated with the Notification
+    service_name = 'ntfy'
+
+    # The services URL
+    service_url = 'https://ntfy.sh/'
+
+    # Insecure protocol (for those self hosted requests)
+    protocol = 'ntfy'
+
+    # The default protocol
+    secure_protocol = 'ntfys'
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = 'https://github.com/caronc/apprise/wiki/Notify_ntfy'
+
+    # Default host if none is defined
+    default_host = 'ntfy.sh'
+
+    # Message time to live (if remote client isn't around to receive it)
+    time_to_live = 2419200
+
+    # Define object templates
+    templates = (
+        '{schema}://{topic}',
+        '{schema}://{host}/{topic}',
+        '{schema}://{host}:{port}/{topic}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'topic': {
+            'name': _('Topic'),
+            'type': 'string',
+            'required': True,
+        },
+        'host': {
+            'name': _('Hostname'),
+            'type': 'string',
+        },
+        'port': {
+            'name': _('Port'),
+            'type': 'int',
+            'min': 1,
+            'max': 65535,
+        },
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'priority': {
+            'name': _('Priority'),
+            'type': 'choice:string',
+            'values': NTFY_PRIORITIES,
+            'default': NtfyPriority.DEFAULT,
+        },
+        'tags': {
+            'name': _('Tags'),
+            'type': 'string',
+        },
+    })
+
+    def __init__(self, topic, priority=None, tags=None, **kwargs):
+        """
+        Initialize Ntfy Object
+        """
+        super(NotifyNtfy, self).__init__(**kwargs)
+        if not topic:
+            msg = 'A topic name must be provided.'
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        self.topic = topic
+
+        # The priority of the message
+        if priority not in NTFY_PRIORITIES:
+            self.priority = self.template_args['priority']['default']
+        else:
+            self.priority = priority
+
+        # Any optional tags to attach to the notification
+        self.__tags = parse_list(tags)
+
+        # prepare our fullpath
+        self.fullpath = kwargs.get('fullpath')
+        if not isinstance(self.fullpath, six.string_types):
+            self.fullpath = '/'
+
+    def send(self, body, title='', notify_type=NotifyType.INFO, **kwargs):
+        """
+        Perform Ntfy Notification
+        """
+
+        # error tracking (used for function return)
+        has_error = False
+
+        # Prepare our headers
+        headers = {}
+        priority = NtfyPriority.get_priority(self.priority)
+        if priority != NtfyPriority.DEFAULT:
+            headers['X-Priority'] = priority
+        if title:
+            headers['X-Title'] = title
+        if self.__tags:
+            headers['X-Tags'] = ",".join(self.__tags)
+
+        # Prepare our payload
+        payload = body
+
+        # Prepare our Ntfy URL
+        schema = 'https' if self.secure else 'http'
+
+        # Use default host if one is not defined
+        host = self.default_host
+        if self.host != self.default_host:
+            host = self.host
+
+        url = '%s://%s' % (schema, host)
+        if isinstance(self.port, int):
+            url += ':%d' % self.port
+
+        url += self.fullpath
+
+        self.logger.debug('ntfy POST URL: %s (cert_verify=%r)' % (
+            url, self.verify_certificate,
+        ))
+        self.logger.debug('ntfy Payload: %s' % str(payload))
+
+        # Always call throttle before any remote server i/o is made
+        self.throttle()
+
+        try:
+            r = requests.post(
+                url,
+                data=payload,
+                headers=headers,
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+            )
+
+            if r.status_code != requests.codes.ok:
+                # We had a problem
+                status_str = \
+                    NotifyBase.http_response_code_lookup(r.status_code)
+
+                # set up our status code to use
+                status_code = r.status_code
+
+                try:
+                    # Update our status response if we can
+                    json_response = loads(r.content)
+                    status_code = json_response.get('code', status_code)
+                    status_str = json_response.get('error', status_str)
+
+                except (AttributeError, TypeError, ValueError):
+                    # ValueError = r.content is Unparsable
+                    # TypeError = r.content is None
+                    # AttributeError = r is None
+
+                    # We could not parse JSON response.
+                    # We will just use the status we already have.
+                    pass
+
+                self.logger.warning(
+                    "Failed to send Ntfy notification to topic '{}': "
+                    '{}{}error={}.'.format(
+                        self.topic,
+                        status_str,
+                        ', ' if status_str else '',
+                        status_code))
+
+                self.logger.debug(
+                    'Response Details:\r\n{}'.format(r.content))
+
+                # Mark our failure
+                has_error = True
+
+            else:
+                self.logger.info(
+                    "Sent Ntfy notification to '{}'.".format(url))
+
+        except requests.RequestException as e:
+            self.logger.warning(
+                'A Connection error occurred sending Ntfy:%s ' % (
+                    url) + 'notification.'
+            )
+            self.logger.debug('Socket Exception: %s' % str(e))
+
+            # Mark our failure
+            has_error = True
+
+        return not has_error
+
+    def url(self, privacy=False, *args, **kwargs):
+        """
+        Returns the URL built dynamically based on specified arguments.
+        """
+
+        host = self.host or self.default_host
+        default_port = 443 if self.secure else 80
+
+        params = {
+            'priority': self.priority
+            if self.priority
+            else NTFY_PRIORITIES.DEFAULT,
+        }
+
+        if self.__tags:
+            params['tags'] = ','.join(self.__tags)
+
+        params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
+
+        # Examples:
+        # ntfys://my-topic
+        # ntfy://ntfy.local.domain/my-topic
+        # ntfys://ntfy.local.domain:8080/my-topic
+        # ntfy://ntfy.local.domain/?priority=max
+        return '{schema}://{host}{port}{topic}/?{params}'.format(
+            schema=self.secure_protocol if self.secure else self.protocol,
+            host='' if self.host == self.default_host else self.host,
+            port='' if self.port is None or self.port == default_port
+                 else ':{}'.format(self.port),
+            topic='{}{}'.format(
+                  '' if host == self.default_host and self.port == default_port
+                  else '/', self.topic),
+            params=NotifyNtfy.urlencode(params)
+        )
+
+    @staticmethod
+    def parse_url(url):
+        """
+        Parses the URL and returns enough arguments that can allow
+        us to re-instantiate this object.
+        """
+        results = NotifyBase.parse_url(url)
+
+        if not results:
+            # We're done early as we couldn't load the results
+            return results
+
+        if 'priority' in results['qsd'] and len(results['qsd']['priority']):
+            try:
+                results['priority'] = \
+                    NtfyPriority.get_priority(results['qsd']['priority'])
+            except KeyError:  # no priority was set
+                pass
+
+        if 'tags' in results['qsd'] and len(results['qsd']['tags']):
+            results['tags'] = \
+                parse_list(NotifyNtfy.unquote(results['qsd']['tags']))
+
+        try:
+            # Grab the topic from the URL
+            results['topic'] = NotifyNtfy.split_path(results['fullpath'])[-1]
+        except IndexError:  # Not enough paths, probably no host provided
+            results['topic'] = results['host']
+            results['host'] = NotifyNtfy.default_host
+            results['fullpath'] = '/{}'.format(results['topic'])
+
+        return results

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -51,11 +51,11 @@ Apprise API, AWS SES, AWS SNS, Boxcar, ClickSend, DAPNET, DingTalk, Discord, E-M
 Emby, Faast, FCM, Flock, Gitter, Google Chat, Gotify, Growl, Home Assistant,
 IFTTT, Join, Kavenegar, KODI, Kumulos, LaMetric, MacOSX, Mailgun, Mattermost,
 Matrix, Microsoft Windows, Microsoft Teams, MessageBird, MQTT, MSG91, MyAndroid,
-Nexmo, Nextcloud, NextcloudTalk, Notica, Notifico, Office365, OneSignal, Opsgenie,
-ParsePlatform, PopcornNotify, Prowl, Pushalot, PushBullet, Pushjet, Pushover,
-PushSafer, Reddit, Rocket.Chat, SendGrid, ServerChan, SimplePush, Sinch, Slack,
-SMTP2Go, Spontit, SparkPost, Super Toasty, Streamlabs, Stride, Syslog, Techulus Push,
-Telegram, Twilio, Twitter, Twist, XBMC, XMPP, Webex Teams}
+Nexmo, Nextcloud, NextcloudTalk, Notica, Notifico, ntfy, Office365, OneSignal,
+Opsgenie, ParsePlatform, PopcornNotify, Prowl, Pushalot, PushBullet, Pushjet,
+Pushover, PushSafer, Reddit, Rocket.Chat, SendGrid, ServerChan, SimplePush, Sinch,
+Slack, SMTP2Go, Spontit, SparkPost, Super Toasty, Streamlabs, Stride, Syslog,
+Techulus Push, Telegram, Twilio, Twitter, Twist, XBMC, XMPP, Webex Teams}
 
 Name:           python-%{pypi_name}
 Version:        0.9.6

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         'DAPNET Dingtalk Discord Dbus Emby Faast FCM Flock Gitter Gnome '
         'Google Chat Gotify Growl Home Assistant IFTTT Join Kavenegar KODI '
         'Kumulos LaMetric MacOS Mailgun Matrix Mattermost MessageBird MQTT '
-        'MSG91 Nexmo Nextcloud NextcloudTalk Notica Notifico Office365 '
+        'MSG91 Nexmo Nextcloud NextcloudTalk Notica Notifico Ntfy Office365 '
         'OneSignal Opsgenie ParsePlatform PopcornNotify Prowl PushBullet '
         'Pushjet Pushed Pushover PushSafer Reddit Rocket.Chat Ryver SendGrid '
         'ServerChan SimplePush Sinch Slack SMTP2Go SparkPost Spontit '

--- a/test/test_plugin_ntfy.py
+++ b/test/test_plugin_ntfy.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+import requests
+from apprise import plugins
+from helpers import AppriseURLTester
+
+# Disable logging for a cleaner testing output
+import logging
+logging.disable(logging.CRITICAL)
+
+# For testing our return response
+GOOD_RESPONSE_TEXT = {
+    'code': '0',
+    'error': 'success',
+}
+
+# Our Testing URLs
+apprise_url_tests = (
+    ('ntfy://', {
+        # Initializes okay (as cloud mode) but has no topics to notify
+        'instance': plugins.NotifyNtfy,
+        # invalid topics specified (nothing to notify)
+        # as a result the response type will be false
+        'response': False,
+    }),
+    ('ntfys://', {
+        # Initializes okay (as cloud mode) but has no topics to notify
+        'instance': plugins.NotifyNtfy,
+        # invalid topics specified (nothing to notify)
+        # as a result the response type will be false
+        'response': False,
+    }),
+    ('ntfy://:@/', {
+        # Initializes okay (as cloud mode) but has no topics to notify
+        'instance': plugins.NotifyNtfy,
+        # invalid topics specified (nothing to notify)
+        # as a result the response type will be false
+        'response': False,
+    }),
+    # No topics
+    ('ntfy://user:pass@localhost', {
+        'instance': plugins.NotifyNtfy,
+        # invalid topics specified (nothing to notify)
+        # as a result the response type will be false
+        'response': False,
+    }),
+    # No valid topics
+    ('ntfy://user:pass@localhost/#/!/@', {
+        'instance': plugins.NotifyNtfy,
+        # invalid topics specified (nothing to notify)
+        # as a result the response type will be false
+        'response': False,
+    }),
+    # user/pass combos
+    ('ntfy://user@localhost/topic/', {
+        'instance': plugins.NotifyNtfy,
+        'requests_response_text': GOOD_RESPONSE_TEXT,
+    }),
+    # No user/pass combo
+    ('ntfy://localhost/topic1/topic2/', {
+        'instance': plugins.NotifyNtfy,
+        'requests_response_text': GOOD_RESPONSE_TEXT,
+    }),
+    # A topic and port identifier
+    ('ntfy://user:pass@localhost:8080/topic/', {
+        'instance': plugins.NotifyNtfy,
+        # The response text is expected to be the following on a success
+        'requests_response_text': GOOD_RESPONSE_TEXT,
+    }),
+    # A topic (using the to=)
+    ('ntfys://user:pass@localhost?to=topic', {
+        'instance': plugins.NotifyNtfy,
+        # The response text is expected to be the following on a success
+        'requests_response_text': GOOD_RESPONSE_TEXT,
+    }),
+    # Several topics
+    ('ntfy://user:pass@localhost/topic/topic/?avatar=Yes', {
+        'instance': plugins.NotifyNtfy,
+        # The response text is expected to be the following on a success
+        'requests_response_text': {
+            'status': 'success',
+            'data': {
+                'authToken': 'abcd',
+                'userId': 'user',
+            },
+        },
+    }),
+    ('ntfys://user:web/token@localhost/topic/?mode=invalid', {
+        # Invalid mode
+        'instance': TypeError,
+    }),
+    ('ntfy://user:pass@localhost:8081/topic/topic2', {
+        'instance': plugins.NotifyNtfy,
+        # force a failure using basic mode
+        'response': False,
+        'requests_response_code': requests.codes.internal_server_error,
+    }),
+    ('ntfy://user:pass@localhost:8082/topic', {
+        'instance': plugins.NotifyNtfy,
+        # throw a bizzare code forcing us to fail to look it up
+        'response': False,
+        'requests_response_code': 999,
+    }),
+    ('ntfy://user:pass@localhost:8083/topic1/topic2/', {
+        'instance': plugins.NotifyNtfy,
+        # Throws a series of connection and transfer exceptions when this flag
+        # is set and tests that we gracfully handle them
+        'test_requests_exceptions': True,
+    }),
+)
+
+
+def test_plugin_ntfy_chat_urls():
+    """
+    NotifyNtfy() Apprise URLs
+
+    """
+
+    # Run our general tests
+    AppriseURLTester(tests=apprise_url_tests).run_all()


### PR DESCRIPTION
Add a plugin for the [Ntfy](https://ntfy.sh) notification service.

## Description:
**Related issue (if applicable):** #520 

<!-- Have anything else to describe? Define it here -->

## New Service Completion Status
<!-- This section is only applicable if you're adding a new service -->
* [x] apprise/plugins/NotifyNtfy.py
* [x] setup.py
    - add new service into the `keywords` section of the `setup()` declaration
* [x] README.md
    - add entry for new service to table (as a quick reference)
* [x] packaging/redhat/python-apprise.spec
    - add new service into the `%global common_description`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
