### PR TITLE
Add notification body conversion for HTML to plain text

### DIFF
--- a/apprise/Apprise.py
+++ b/apprise/Apprise.py
@@ -26,11 +26,11 @@
 import re
 import os
 import six
-from markdown import markdown
 from itertools import chain
 from .common import NotifyType
 from .common import NotifyFormat
 from .common import MATCH_ALL_TAG
+from .conversion import convert_between
 from .utils import is_exclusive_match
 from .utils import parse_list
 from .utils import parse_urls
@@ -516,50 +516,8 @@ class Apprise(object):
             # was set to None), or we did define a tag and the logic above
             # determined we need to notify the service it's associated with
             if server.notify_format not in conversion_map:
-                if body_format == NotifyFormat.MARKDOWN and \
-                        server.notify_format == NotifyFormat.HTML:
-
-                    # Apply Markdown
-                    conversion_map[server.notify_format] = markdown(body)
-
-                elif body_format == NotifyFormat.TEXT and \
-                        server.notify_format == NotifyFormat.HTML:
-
-                    # Basic TEXT to HTML format map; supports keys only
-                    re_map = {
-                        # Support Ampersand
-                        r'&': '&amp;',
-
-                        # Spaces to &nbsp; for formatting purposes since
-                        # multiple spaces are treated as one an this may
-                        # not be the callers intention
-                        r' ': '&nbsp;',
-
-                        # Tab support
-                        r'\t': '&nbsp;&nbsp;&nbsp;',
-
-                        # Greater than and Less than Characters
-                        r'>': '&gt;',
-                        r'<': '&lt;',
-                    }
-
-                    # Compile our map
-                    re_table = re.compile(
-                        r'(' + '|'.join(
-                            map(re.escape, re_map.keys())) + r')',
-                        re.IGNORECASE,
-                    )
-
-                    # Execute our map against our body in addition to
-                    # swapping out new lines and replacing them with <br/>
-                    conversion_map[server.notify_format] = \
-                        re.sub(r'\r*\n', '<br/>\r\n',
-                               re_table.sub(
-                                   lambda x: re_map[x.group()], body))
-
-                else:
-                    # Store entry directly
-                    conversion_map[server.notify_format] = body
+                conversion_map[server.notify_format] = \
+                    convert_between(body_format, server.notify_format, body)
 
             if interpret_escapes:
                 #

--- a/apprise/Apprise.py
+++ b/apprise/Apprise.py
@@ -23,12 +23,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import re
 import os
 import six
 from itertools import chain
 from .common import NotifyType
-from .common import NotifyFormat
 from .common import MATCH_ALL_TAG
 from .conversion import convert_between
 from .utils import is_exclusive_match

--- a/apprise/conversion.py
+++ b/apprise/conversion.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+
+import re
+from markdown import markdown
+from .common import NotifyFormat
+
+
+def convert_between(from_format, to_format, body):
+    """
+    Converts between different notification formats. If no conversion exists,
+    or the selected one fails, the original text will be returned.
+    """
+
+    if from_format == NotifyFormat.MARKDOWN and to_format == NotifyFormat.HTML:
+        return markdown(body)
+
+    if from_format == NotifyFormat.TEXT and to_format == NotifyFormat.HTML:
+        return text_to_html(body)
+
+    return body
+
+
+def text_to_html(body):
+    """
+    Converts a notification body from plain text to HTML.
+    """
+
+    # Basic TEXT to HTML format map; supports keys only
+    re_map = {
+        # Support Ampersand
+        r'&': '&amp;',
+
+        # Spaces to &nbsp; for formatting purposes since
+        # multiple spaces are treated as one an this may
+        # not be the callers intention
+        r' ': '&nbsp;',
+
+        # Tab support
+        r'\t': '&nbsp;&nbsp;&nbsp;',
+
+        # Greater than and Less than Characters
+        r'>': '&gt;',
+        r'<': '&lt;',
+    }
+
+    # Compile our map
+    re_table = re.compile(
+        r'(' + '|'.join(
+            map(re.escape, re_map.keys())) + r')',
+        re.IGNORECASE,
+    )
+
+    # Execute our map against our body in addition to
+    # swapping out new lines and replacing them with <br/>
+    return re.sub(r'\r*\n', '<br/>\r\n',
+        re_table.sub(
+            lambda x: re_map[x.group()], body))

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from apprise import NotifyFormat
+from apprise.conversion import convert_between
+
+# Disable logging for a cleaner testing output
+import logging
+logging.disable(logging.CRITICAL)
+
+
+def test_html_to_text():
+    """conversion: Test HTML to plain text
+    """
+
+    def convert(body):
+        return convert_between(NotifyFormat.HTML, NotifyFormat.TEXT, body)
+
+    assert convert("No HTML code here.") == "No HTML code here."
+
+    clist = convert("<ul><li>Lots and lots</li><li>of lists.</li></ul>")
+    assert "Lots and lots" in clist
+    assert "of lists." in clist
+
+    assert "To be or not to be." in convert(
+        "<blockquote>To be or not to be.</blockquote>")
+
+    cspace = convert(
+        "<h2>Fancy heading</h2>"
+        "<p>And a paragraph too.<br>Plus line break.</p>")
+    assert "Fancy heading" in cspace
+    assert "And a paragraph too.\nPlus line break." in cspace
+
+    assert convert(
+        "<style>body { font: 200%; }</style>"
+        "<p>Some obnoxious text here.</p>") == "Some obnoxious text here."


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** https://github.com/YoRyan/mailrise/pull/11

Mailrise often receives HTML mail, and the resulting notifications look rather unappealing with the markup embedded directly into the text. @IncognitoCoding proposed building a converter into Mailrise that would strip markup from HTML mail, but I thought it should be a part of Apprise, so that other applications would benefit. Here is his code integrated into Apprise for your consideration.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage