### PR TITLE
Foxmail/qq.com and 163.com email template support

### DIFF
--- a/apprise/plugins/NotifyEmail.py
+++ b/apprise/plugins/NotifyEmail.py
@@ -235,7 +235,6 @@ EMAIL_TEMPLATES = (
         },
     ),
 
-
     # SendGrid (Email Server)
     # You must specify an authenticated sender address in the from= settings
     # and a valid email in the to= to deliver your emails to
@@ -250,6 +249,36 @@ EMAIL_TEMPLATES = (
             'secure': True,
             'secure_mode': SecureMailMode.SSL,
             'login_type': (WebBaseLogin.USERID, )
+        },
+    ),
+
+    # 163.com
+    (
+        '163.com',
+        re.compile(
+            r'^((?P<label>[^+]+)\+)?(?P<id>[^@]+)@'
+            r'(?P<domain>163\.com)$', re.I),
+        {
+            'port': 465,
+            'smtp_host': 'smtp.163.com',
+            'secure': True,
+            'secure_mode': SecureMailMode.SSL,
+            'login_type': (WebBaseLogin.EMAIL, )
+        },
+    ),
+
+    # Foxmail.com
+    (
+        'Foxmail.com',
+        re.compile(
+            r'^((?P<label>[^+]+)\+)?(?P<id>[^@]+)@'
+            r'(?P<domain>(foxmail|qq)\.com)$', re.I),
+        {
+            'port': 587,
+            'smtp_host': 'smtp.qq.com',
+            'secure': True,
+            'secure_mode': SecureMailMode.STARTTLS,
+            'login_type': (WebBaseLogin.EMAIL, )
         },
     ),
 


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #496 

Added:
- **Foxmail.com** (or **qq.com**) Email Support added based on this screenshot (taken from their website):<br/>![image](https://user-images.githubusercontent.com/850374/151628002-d2d67bfc-fb4a-446b-9b55-54c4a6481fef.png)
- **163.com** Email Support based on this screenshot (taken from their website):<br/>![image](https://user-images.githubusercontent.com/850374/151628090-53d0e93d-c7c3-4bd5-8e91-0644f1314e0a.png)

Sending an email for these service provides is now as simple as:
- `mailto://user:pass@qq.com`
- `mailto://user:pass@163.com`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
```bash
# Create a virtual environment to work in
# This way you can just destroy it after when it's all over.
# The below will create a directory called apprise
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@496-mailto-extra-templates

# Give it a go:
apprise -vv -b "test" -t "subject" \
   "mailto://user:pass@qq.com"

# or:
apprise -vv -b "test" -t "subject" \
   "mailto://user:pass@163.com"
```
