### PR TITLE
Title now correctly applied to Matrix messages

### DIFF
--- a/apprise/plugins/NotifyMatrix.py
+++ b/apprise/plugins/NotifyMatrix.py
@@ -42,7 +42,6 @@ from ..common import NotifyImageSize
 from ..common import NotifyFormat
 from ..utils import parse_bool
 from ..utils import parse_list
-from ..utils import apply_template
 from ..utils import is_hostname
 from ..utils import validate_regex
 from ..AppriseLocale import gettext_lazy as _
@@ -470,21 +469,16 @@ class NotifyMatrix(NotifyBase):
         }
 
         if self.notify_format == NotifyFormat.HTML:
-            # Add additional information to our content; use {{app_title}}
-            # to apply the title to the html body
-            tokens = {
-                'app_title': NotifyMatrix.escape_html(
-                    title, whitespace=False),
-            }
-            payload['text'] = apply_template(body, **tokens)
+            payload['text'] = '{title}{body}'.format(
+                title='' if not title else '<h1>{}</h1>'.format(
+                    NotifyMatrix.escape_html(title)),
+                body=body)
 
         elif self.notify_format == NotifyFormat.MARKDOWN:
-            # Add additional information to our content; use {{app_title}}
-            # to apply the title to the html body
-            tokens = {
-                'app_title': title,
-            }
-            payload['text'] = markdown(apply_template(body, **tokens))
+            payload['text'] = '{title}{body}'.format(
+                title='' if not title else '<h1>{}</h1>'.format(
+                    NotifyMatrix.escape_html(title)),
+                body=markdown(body))
 
         else:  # NotifyFormat.TEXT
             payload['text'] = \
@@ -583,32 +577,29 @@ class NotifyMatrix(NotifyBase):
             payload = {
                 'msgtype': 'm.{}'.format(self.msgtype),
                 'body': '{title}{body}'.format(
-                    title='' if not title else '{}\r\n'.format(title),
+                    title='' if not title else '# {}\r\n'.format(title),
                     body=body),
             }
 
             # Update our payload advance formatting for the services that
             # support them.
             if self.notify_format == NotifyFormat.HTML:
-                # Add additional information to our content; use {{app_title}}
-                # to apply the title to the html body
-                tokens = {
-                    'app_title': NotifyMatrix.escape_html(
-                        title, whitespace=False),
-                }
-
                 payload.update({
                     'format': 'org.matrix.custom.html',
-                    'formatted_body': apply_template(body, **tokens),
+                    'formatted_body': '{title}{body}'.format(
+                        title='' if not title else '<h1>{}</h1>'.format(title),
+                        body=body,
+                    )
                 })
 
             elif self.notify_format == NotifyFormat.MARKDOWN:
-                tokens = {
-                    'app_title': title,
-                }
                 payload.update({
                     'format': 'org.matrix.custom.html',
-                    'formatted_body': markdown(apply_template(body, **tokens))
+                    'formatted_body': '{title}{body}'.format(
+                        title='' if not title else '<h1>{}</h1>'.format(
+                            NotifyMatrix.escape_html(title, whitespace=False)),
+                        body=markdown(body),
+                    )
                 })
 
             # Build our path


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #542 

Matrix Titles were being stripped off of HTML/Markdown posts.  This has been fixed.

For consistency, the title has been added to all message types (so it's always apples-to-apples)

Finally, there was some overhead removed with templating as was a bit of overkill.  If we need to do this down the road, it can be implemented again but to attach to a greater scope like other services that do this (such as MSTeams).

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

# Testing
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in
# This way you can just destroy it after when it's all over.
# The below will create a directory called apprise
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@542-matrix-title-formatting-lost

# Run your matrix tests:
apprise matrix://credentials
```
