### PR TITLE
Updated hotmail.com SMTP server

### DIFF
--- a/apprise/plugins/NotifyEmail.py
+++ b/apprise/plugins/NotifyEmail.py
@@ -129,7 +129,7 @@ EMAIL_TEMPLATES = (
             r'(?P<domain>(hotmail|live)\.com)$', re.I),
         {
             'port': 587,
-            'smtp_host': 'smtp.live.com',
+            'smtp_host': 'smtp-mail.outlook.com',
             'secure': True,
             'secure_mode': SecureMailMode.STARTTLS,
             'login_type': (WebBaseLogin.EMAIL, )


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #555

Hotmail SMTP Service appears to have changed:
![image](https://user-images.githubusercontent.com/850374/160260725-5d2c728d-61b8-4499-930f-980ef4aa005e.png)

This PR changes Apprise from using `smtp.live.com` to `smtp-mail.outlook.com`. 

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in
# This way you can just destroy it after when it's all over.
# The below will create a directory called apprise
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@555-hotmail-smtp-server-update

# Run your matrix tests:
apprise mailto://user:password@hotmail.com
```