### PR TITLE
Use Gotify X-Gotify-Key Header vs params token

### DIFF
--- a/apprise/plugins/NotifyGotify.py
+++ b/apprise/plugins/NotifyGotify.py
@@ -170,11 +170,6 @@ class NotifyGotify(NotifyBase):
         # Append our remaining path
         url += '{fullpath}message'.format(fullpath=self.fullpath)
 
-        # Define our parameteers
-        params = {
-            'token': self.token,
-        }
-
         # Prepare Gotify Object
         payload = {
             'priority': self.priority,
@@ -193,6 +188,7 @@ class NotifyGotify(NotifyBase):
         headers = {
             'User-Agent': self.app_id,
             'Content-Type': 'application/json',
+            'X-Gotify-Key': self.token,
         }
 
         self.logger.debug('Gotify POST URL: %s (cert_verify=%r)' % (
@@ -206,7 +202,6 @@ class NotifyGotify(NotifyBase):
         try:
             r = requests.post(
                 url,
-                params=params,
                 data=dumps(payload),
                 headers=headers,
                 verify=self.verify_certificate,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #556

With respect to documentation [here](https://gotify.net/api-docs) and the related issue above, this request updates Apprise's integration with Gotify to use the HTTP Headers to pass the `token` along instead of the `querystring`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

# Testing
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in
# This way you can just destroy it after when it's all over.
# The below will create a directory called apprise
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@556-gotify-header-token

# Run your Gotify Tests
apprise gotify://credentials
```