### PR TITLE
Added `always` special tag (will always notify)

### DIFF
--- a/apprise/AppriseConfig.py
+++ b/apprise/AppriseConfig.py
@@ -32,6 +32,7 @@ from . import URLBase
 from .AppriseAsset import AppriseAsset
 
 from .common import MATCH_ALL_TAG
+from .common import MATCH_ALWAYS_TAG
 from .utils import GET_SCHEMA_RE
 from .utils import parse_list
 from .utils import is_exclusive_match
@@ -266,7 +267,7 @@ class AppriseConfig(object):
         # Return our status
         return True
 
-    def servers(self, tag=MATCH_ALL_TAG, *args, **kwargs):
+    def servers(self, tag=MATCH_ALL_TAG, match_always=True, *args, **kwargs):
         """
         Returns all of our servers dynamically build based on parsed
         configuration.
@@ -277,7 +278,15 @@ class AppriseConfig(object):
         This is for filtering the configuration files polled for
         results.
 
+        If the anytag is set, then any notification that is found
+        set with that tag are included in the response.
+
         """
+
+        # A match_always flag allows us to pick up on our 'any' keyword
+        # and notify these services under all circumstances
+        match_always = MATCH_ALWAYS_TAG if match_always else None
+
         # Build our tag setup
         #   - top level entries are treated as an 'or'
         #   - second level (or more) entries are treated as 'and'
@@ -294,7 +303,8 @@ class AppriseConfig(object):
 
             # Apply our tag matching based on our defined logic
             if is_exclusive_match(
-                    logic=tag, data=entry.tags, match_all=MATCH_ALL_TAG):
+                    logic=tag, data=entry.tags, match_all=MATCH_ALL_TAG,
+                    match_always=match_always):
                 # Build ourselves a list of services dynamically and return the
                 # as a list
                 response.extend(entry.servers())

--- a/apprise/common.py
+++ b/apprise/common.py
@@ -187,3 +187,7 @@ CONTENT_LOCATIONS = (
 # This is a reserved tag that is automatically assigned to every
 # Notification Plugin
 MATCH_ALL_TAG = 'all'
+
+# Will cause notification to trigger under any circumstance even if an
+# exclusive tagging was provided.
+MATCH_ALWAYS_TAG = 'always'

--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -995,7 +995,7 @@ def parse_list(*args):
     return sorted([x for x in filter(bool, list(set(result)))])
 
 
-def is_exclusive_match(logic, data, match_all='all'):
+def is_exclusive_match(logic, data, match_all='all', match_always='always'):
     """
 
     The data variable should always be a set of strings that the logic can be
@@ -1011,6 +1011,9 @@ def is_exclusive_match(logic, data, match_all='all'):
         logic=['tagA', 'tagB']            = tagA or tagB
         logic=[('tagA', 'tagC'), 'tagB']  = (tagA and tagC) or tagB
         logic=[('tagB', 'tagC')]          = tagB and tagC
+
+    If `match_always` is not set to None, then its value is added as an 'or'
+    to all specified logic searches.
     """
 
     if isinstance(logic, six.string_types):
@@ -1025,6 +1028,14 @@ def is_exclusive_match(logic, data, match_all='all'):
     if not isinstance(logic, (list, tuple, set)):
         # garbage input
         return False
+
+    if isinstance(logic, (list, tuple)):
+        # Convert to set
+        logic = set(logic)
+
+    if match_always:
+        # Add our match_always to our logic searching if secified
+        logic.add(match_always)
 
     # Track what we match against; but by default we do not match
     # against anything

--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -28,8 +28,11 @@ import six
 import json
 import contextlib
 import os
+from itertools import chain
 from os.path import expanduser
 from functools import reduce
+from .common import MATCH_ALL_TAG
+from .common import MATCH_ALWAYS_TAG
 
 try:
     # Python 2.7
@@ -995,7 +998,8 @@ def parse_list(*args):
     return sorted([x for x in filter(bool, list(set(result)))])
 
 
-def is_exclusive_match(logic, data, match_all='all', match_always='always'):
+def is_exclusive_match(logic, data, match_all=MATCH_ALL_TAG,
+                       match_always=MATCH_ALWAYS_TAG):
     """
 
     The data variable should always be a set of strings that the logic can be
@@ -1029,13 +1033,9 @@ def is_exclusive_match(logic, data, match_all='all', match_always='always'):
         # garbage input
         return False
 
-    if isinstance(logic, (list, tuple)):
-        # Convert to set
-        logic = set(logic)
-
     if match_always:
         # Add our match_always to our logic searching if secified
-        logic.add(match_always)
+        logic = chain(logic, [match_always])
 
     # Track what we match against; but by default we do not match
     # against anything

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1591,7 +1591,7 @@ def test_exclusive_match():
     #
     # Update our data set so we can do more advance checks
     #
-    data = set(['always','entry1'])
+    data = set(['always', 'entry1'])
     # We'll always match on the with keyword always
     assert utils.is_exclusive_match(logic='always', data=data) is True
     assert utils.is_exclusive_match(logic='garbage', data=data) is True

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1588,6 +1588,17 @@ def test_exclusive_match():
     assert utils.is_exclusive_match(logic=['www'], data=data) is False
     assert utils.is_exclusive_match(logic='all', data=data) is True
 
+    #
+    # Update our data set so we can do more advance checks
+    #
+    data = set(['always','entry1'])
+    # We'll always match on the with keyword always
+    assert utils.is_exclusive_match(logic='always', data=data) is True
+    assert utils.is_exclusive_match(logic='garbage', data=data) is True
+    # However we will not match if we turn this feature off
+    assert utils.is_exclusive_match(
+        logic='garbage', data=data, match_always=False) is False
+
     # Change default value from 'all' to 'match_me'. Logic matches
     # so we pass
     assert utils.is_exclusive_match(


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #559

If notifications are tagged with the `always` keyword, they will be included in every notification sent regardless of how much tag filtering you provide.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
