### PR TITLE
Improved Apprise general text conversion support

### DIFF
--- a/apprise/Apprise.py
+++ b/apprise/Apprise.py
@@ -514,8 +514,8 @@ class Apprise(object):
             # was set to None), or we did define a tag and the logic above
             # determined we need to notify the service it's associated with
             if server.notify_format not in conversion_map:
-                conversion_map[server.notify_format] = convert_between(
-                    body_format, server.notify_format, body)
+                title, conversion_map[server.notify_format] = convert_between(
+                    body_format, server.notify_format, body=body, title=title)
 
                 if interpret_escapes:
                     #

--- a/apprise/Apprise.py
+++ b/apprise/Apprise.py
@@ -578,29 +578,6 @@ class Apprise(object):
                         logger.error(msg)
                         raise TypeError(msg)
 
-                    if conversion_title_map[server.notify_format]:
-                        try:
-                            # Added overhead required due to Python 3 Encoding
-                            # Bug identified here:
-                            #  https://bugs.python.org/issue21331
-                            conversion_title_map[server.notify_format] = \
-                                conversion_title_map[server.notify_format]\
-                                .encode('ascii', 'backslashreplace')\
-                                .decode('unicode-escape')
-
-                        except UnicodeDecodeError:  # pragma: no cover
-                            # This occurs using a very old verion of Python 2.7
-                            # such as the one that ships with CentOS/RedHat 7.x
-                            # (v2.7.5).
-                            conversion_title_map[server.notify_format] = \
-                                conversion_title_map[server.notify_format]\
-                                .decode('string_escape')
-
-                        except AttributeError:
-                            # Must be of string type
-                            logger.error('Failed to escape message title')
-                            raise TypeError()
-
                 if six.PY2:
                     # Python 2.7 strings must be encoded as utf-8 for
                     # consistency across all platforms

--- a/apprise/Apprise.py
+++ b/apprise/Apprise.py
@@ -499,24 +499,12 @@ class Apprise(object):
                 if body and isinstance(body, str):  # noqa: F821
                     body = body.decode(self.asset.encoding)
 
-                elif not isinstance(body, unicode):  # noqa: F821
-                    # this occurs if a non-string was passed in
-                    msg = 'An invalid message body was provided to Apprise'
-                    logger.error(msg)
-                    raise TypeError(msg)
-
             else:  # Python 3+
                 if title and isinstance(title, bytes):  # noqa: F821
                     title = title.decode(self.asset.encoding)
 
                 if body and isinstance(body, bytes):  # noqa: F821
                     body = body.decode(self.asset.encoding)
-
-                elif not isinstance(body, str):  # noqa: F821
-                    # this occurs if a non-string was passed in
-                    msg = 'An invalid message body was provided to Apprise'
-                    logger.error(msg)
-                    raise TypeError(msg)
 
         except UnicodeDecodeError:
             msg = 'The content passed into Apprise was not of encoding ' \

--- a/apprise/AppriseAsset.py
+++ b/apprise/AppriseAsset.py
@@ -29,6 +29,7 @@ from os.path import join
 from os.path import dirname
 from os.path import isfile
 from os.path import abspath
+from locale import getpreferredencoding
 from .common import NotifyType
 
 
@@ -109,6 +110,9 @@ class AppriseAsset(object):
     # to passing it upstream. Such as converting \t to an actual tab and \n
     # to a new line.
     interpret_escapes = False
+
+    # Defines the encoding of the content passed into Apprise
+    encoding = getpreferredencoding()
 
     # For more detail see CWE-312 @
     #    https://cwe.mitre.org/data/definitions/312.html

--- a/apprise/conversion.py
+++ b/apprise/conversion.py
@@ -36,8 +36,7 @@ else:
     from html.parser import HTMLParser
 
 
-def convert_between(from_format, to_format, body, title=None,
-                    encoding_in='utf-8', encoding_out='utf-8'):
+def convert_between(from_format, to_format, body, title=None):
     """
     Converts between different notification formats. If no conversion exists,
     or the selected one fails, the original text will be returned.
@@ -53,14 +52,6 @@ def convert_between(from_format, to_format, body, title=None,
         (NotifyFormat.HTML, NotifyFormat.MARKDOWN): html_to_text,
     }
 
-    if six.PY2:
-        # Python 2.7 requires markdown to get unicode characters
-        if title and isinstance(title, str):  # noqa: F821
-            title = title.decode(encoding_in)
-
-        if body and isinstance(body, str):  # noqa: F821
-            body = body.decode(encoding_in)
-
     if NotifyFormat.MARKDOWN in (from_format, to_format):
         # Tidy any exising pre-formating configuration
         title = '' if not title else title.lstrip('\r\n \t\v\b*#-')
@@ -71,14 +62,6 @@ def convert_between(from_format, to_format, body, title=None,
     convert = converters.get((from_format, to_format))
     title, body = convert(title=title, body=body) \
         if convert is not None else (title, body)
-
-    if six.PY2:
-        # Python 2.7 requires markdown to get unicode characters
-        if title and isinstance(title, unicode):  # noqa: F821
-            title = title.encode(encoding_out)
-
-        if body and isinstance(body, unicode):  # noqa: F821
-            body = body.encode(encoding_out)
 
     return (title, body)
 

--- a/apprise/conversion.py
+++ b/apprise/conversion.py
@@ -56,6 +56,9 @@ def convert_between(from_format, to_format, body, title=None):
         # Tidy any exising pre-formating configuration
         title = '' if not title else title.lstrip('\r\n \t\v\b*#-')
 
+    else:
+        title = '' if not title else title
+
     convert = converters.get((from_format, to_format))
     return convert(title=title, body=body) \
         if convert is not None else (title, body)
@@ -133,7 +136,7 @@ def html_to_text(body, title=None):
     parser.close()
     result = parser.converted
 
-    return (title, result)
+    return ('' if not title else title, result)
 
 
 class HTMLConverter(HTMLParser, object):

--- a/apprise/plugins/NotifyTelegram.py
+++ b/apprise/plugins/NotifyTelegram.py
@@ -93,6 +93,9 @@ class NotifyTelegram(NotifyBase):
     # A URL that takes you to the setup/help of the specific protocol
     setup_url = 'https://github.com/caronc/apprise/wiki/Notify_telegram'
 
+    # Default Notify Format
+    notify_format = NotifyFormat.HTML
+
     # Telegram uses the http protocol with JSON requests
     notify_url = 'https://api.telegram.org/bot'
 
@@ -543,12 +546,11 @@ class NotifyTelegram(NotifyBase):
             payload['parse_mode'] = 'MARKDOWN'
 
             payload['text'] = '{}{}'.format(
-                '{}\r\n'.format(title) if title else '',
+                '# {}\r\n'.format(title) if title else '',
                 body,
             )
 
-        else:  # HTML or TEXT
-
+        else:  # TEXT or HTML
             # Use Telegram's HTML mode
             payload['parse_mode'] = 'HTML'
 
@@ -592,6 +594,7 @@ class NotifyTelegram(NotifyBase):
                         mo.string[mo.start():mo.end()][1:5]], title)
 
             if self.notify_format == NotifyFormat.TEXT:
+                # Further html escaping required...
                 telegram_escape_text_dict = {
                     # We need to escape characters that conflict with html
                     # entity blocks (< and >) when displaying text
@@ -615,8 +618,9 @@ class NotifyTelegram(NotifyBase):
                         lambda mo: telegram_escape_text_dict[
                             mo.string[mo.start():mo.end()]], title)
 
+            # prepare our payload based on HTML or TEXT
             payload['text'] = '{}{}'.format(
-                '<b>{}</b>\r\n'.format(title) if title else '',
+                '<h1>{}</h1>'.format(title) if title else '',
                 body,
             )
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -250,6 +250,11 @@ def apprise_test(do_notify):
     assert do_notify(a, title='', body=None) is False
     assert do_notify(a, title=None, body='') is False
 
+    assert do_notify(a, title=5, body=b'bytes') is False
+    assert do_notify(a, title=b"bytes", body=10) is False
+    assert do_notify(a, title=object(), body=b'bytes') is False
+    assert do_notify(a, title=b"bytes", body=object()) is False
+
     # As long as one is present, we're good
     assert do_notify(a, title=None, body='present') is True
     assert do_notify(a, title='present', body=None) is True

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -40,7 +40,7 @@ def test_html_to_text():
         """
         A function to simply html conversion tests
         """
-        return convert_between(NotifyFormat.HTML, NotifyFormat.TEXT, body)
+        return convert_between(NotifyFormat.HTML, NotifyFormat.TEXT, body)[1]
 
     assert to_html("No HTML code here.") == "No HTML code here."
 

--- a/test/test_escapes.py
+++ b/test/test_escapes.py
@@ -340,6 +340,8 @@ def test_apprise_escaping_py2(mock_post):
     assert a.notify(
         title=4, body=None, interpret_escapes=True) is False
     assert a.notify(
+        title=4, body="valid body", interpret_escapes=True) is False
+    assert a.notify(
         title=object(), body=False, interpret_escapes=True) is False
     assert a.notify(
         title=False, body=object(), interpret_escapes=True) is False

--- a/test/test_plugin_telegram.py
+++ b/test/test_plugin_telegram.py
@@ -808,11 +808,12 @@ def test_plugin_telegram_formating_py2(mock_post):
     payload = loads(mock_post.call_args_list[1][1]['data'])
 
     # Test that everything is escaped properly in a TEXT mode
-    assert payload['text'] == \
-        u'<h1>\U0001f6a8 Change detected for &lt;i&gt;Apprise Test Title' \
-        u'&lt;/i&gt;</h1>&lt;a href="http://localhost"&gt;&lt;i&gt;' \
-        u'Apprise Body Title&lt;/i&gt;&lt;/a&gt; had &lt;a ' \
-        u'href="http://127.0.0.1"&gt;a change&lt;/a&gt;'
+    assert payload['text'].encode('utf-8') == \
+        '<h1>\xf0\x9f\x9a\xa8 Change detected for &lt;i&gt;' \
+        'Apprise Test Title&lt;/i&gt;</h1>' \
+        '&lt;a href="http://localhost"&gt;&lt;i&gt;' \
+        'Apprise Body Title&lt;/i&gt;&lt;/a&gt; had &lt;a ' \
+        'href="http://127.0.0.1"&gt;a change&lt;/a&gt;'
 
     # Reset our values
     mock_post.reset_mock()
@@ -835,10 +836,10 @@ def test_plugin_telegram_formating_py2(mock_post):
     payload = loads(mock_post.call_args_list[1][1]['data'])
 
     # Test that everything is escaped properly in a HTML mode
-    assert payload['text'] == \
-        u'<h1>\U0001f6a8 Change detected for <i>Apprise Test Title</i></h1>' \
-        u'<a href="http://localhost"><i>Apprise Body Title</i></a> had ' \
-        u'<a href="http://127.0.0.1">a change</a>'
+    assert payload['text'].encode('utf-8') == \
+        '<h1>\xf0\x9f\x9a\xa8 Change detected for <i>Apprise Test Title</i>' \
+        '</h1><a href="http://localhost"><i>Apprise Body Title</i></a> had ' \
+        '<a href="http://127.0.0.1">a change</a>'
 
     # Reset our values
     mock_post.reset_mock()
@@ -866,10 +867,10 @@ def test_plugin_telegram_formating_py2(mock_post):
     payload = loads(mock_post.call_args_list[1][1]['data'])
 
     # Test that everything is escaped properly in a HTML mode
-    assert payload['text'] == \
-        u'# \U0001f6a8 Change detected for _Apprise Test Title_\r\n' \
-        u'_[Apprise Body Title](http://localhost)_ had ' \
-        u'[a change](http://127.0.0.1)'
+    assert payload['text'].encode('utf-8') == \
+        '# \xf0\x9f\x9a\xa8 Change detected for _Apprise Test Title_\r\n_' \
+        '[Apprise Body Title](http://localhost)_ had ' \
+        '[a change](http://127.0.0.1)'
 
     # Reset our values
     mock_post.reset_mock()
@@ -895,10 +896,11 @@ def test_plugin_telegram_formating_py2(mock_post):
     payload = loads(mock_post.call_args_list[1][1]['data'])
 
     # Test that everything is escaped properly in a HTML mode
-    assert payload['text'] == \
-        u'<h1><p>\U0001f6a8 Change detected for <em>Apprise Test Title</em>' \
-        u'</p></h1><p><em><a href="http://localhost">Apprise Body Title</a>' \
-        u'</em> had <a href="http://127.0.0.1">a change</a></p>'
+    assert payload['text'].encode('utf-8') == \
+        '<h1><p>\xf0\x9f\x9a\xa8 Change detected for ' \
+        '<em>Apprise Test Title</em></p></h1><p><em>' \
+        '<a href="http://localhost">Apprise Body Title</a></em>' \
+        ' had <a href="http://127.0.0.1">a change</a></p>'
 
     # Reset our values
     mock_post.reset_mock()
@@ -945,7 +947,7 @@ def test_plugin_telegram_formating_py2(mock_post):
     payload = loads(mock_post.call_args_list[1][1]['data'])
 
     # Test that everything is escaped properly in a HTML mode
-    assert payload['text'] == \
-        u'<h1>\u05db\u05d5\u05ea\u05e8\u05ea \u05e0\u05e4\u05dc\u05d0\u05d4' \
-        u'</h1>[_[\u05d6\u05d5 \u05d4\u05d5\u05d3\u05e2\u05d4]' \
-        u'(http://localhost)_'
+    assert payload['text'].encode('utf-8') == \
+        '<h1>\xd7\x9b\xd7\x95\xd7\xaa\xd7\xa8\xd7\xaa '\
+        '\xd7\xa0\xd7\xa4\xd7\x9c\xd7\x90\xd7\x94</h1>[_[\xd7\x96\xd7\x95 '\
+        '\xd7\x94\xd7\x95\xd7\x93\xd7\xa2\xd7\x94](http://localhost)_'

--- a/test/test_plugin_telegram.py
+++ b/test/test_plugin_telegram.py
@@ -404,10 +404,9 @@ def test_plugin_telegram_general(mock_post):
     assert mock_post.call_count == 1
     payload = loads(mock_post.call_args_list[0][1]['data'])
 
-    # Our special characters are escaped properly
+    # Test our payload
     assert payload['text'] == \
-        '<b>special characters</b>\r\n&lt;p&gt;'\
-        '\'"This can\'t\t\r\nfail us"\'&lt;/p&gt;'
+        '<h1>special characters</h1><p>\'"This can\'t\t\r\nfail us"\'</p>'
 
     # Test sending attachments
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, 'apprise-test.gif'))

--- a/test/test_plugin_telegram.py
+++ b/test/test_plugin_telegram.py
@@ -34,6 +34,7 @@ from apprise import Apprise
 from apprise import AppriseAttachment
 from apprise import AppriseAsset
 from apprise import NotifyType
+from apprise import NotifyFormat
 from apprise import plugins
 from helpers import AppriseURLTester
 
@@ -211,20 +212,22 @@ def test_plugin_telegram_urls():
 
     """
 
+    # Disable Throttling to speed testing
+    plugins.NotifyTelegram.request_rate_per_sec = 0
+
     # Run our general tests
     AppriseURLTester(tests=apprise_url_tests).run_all()
 
 
-@mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_telegram_general(mock_post, mock_get):
+def test_plugin_telegram_general(mock_post):
     """
     NotifyTelegram() General Tests
 
     """
 
     # Disable Throttling to speed testing
-    plugins.NotifyBase.request_rate_per_sec = 0
+    plugins.NotifyTelegram.request_rate_per_sec = 0
 
     # Bot Token
     bot_token = '123456789:abcdefg_hijklmnop'
@@ -234,11 +237,8 @@ def test_plugin_telegram_general(mock_post, mock_get):
     chat_ids = 'l2g, lead2gold'
 
     # Prepare Mock
-    mock_get.return_value = requests.Request()
     mock_post.return_value = requests.Request()
     mock_post.return_value.status_code = requests.codes.ok
-    mock_get.return_value.status_code = requests.codes.ok
-    mock_get.return_value.content = '{}'
     mock_post.return_value.content = '{}'
 
     # Exception should be thrown about the fact no bot token was specified
@@ -246,20 +246,17 @@ def test_plugin_telegram_general(mock_post, mock_get):
         plugins.NotifyTelegram(bot_token=None, targets=chat_ids)
 
     # Invalid JSON while trying to detect bot owner
-    mock_get.return_value.content = '{'
     mock_post.return_value.content = '}'
     obj = plugins.NotifyTelegram(bot_token=bot_token, targets=None)
     obj.notify(title='hello', body='world')
 
     # Invalid JSON while trying to detect bot owner + 400 error
-    mock_get.return_value.status_code = requests.codes.internal_server_error
     mock_post.return_value.status_code = requests.codes.internal_server_error
     obj = plugins.NotifyTelegram(bot_token=bot_token, targets=None)
     obj.notify(title='hello', body='world')
 
     # Return status back to how they were
     mock_post.return_value.status_code = requests.codes.ok
-    mock_get.return_value.status_code = requests.codes.ok
 
     # Exception should be thrown about the fact an invalid bot token was
     # specifed
@@ -280,9 +277,7 @@ def test_plugin_telegram_general(mock_post, mock_get):
     assert not obj.send_media(obj.targets[0], NotifyType.INFO)
 
     # Restore their entries
-    mock_get.side_effect = None
     mock_post.side_effect = None
-    mock_get.return_value.content = '{}'
     mock_post.return_value.content = '{}'
 
     # test url call
@@ -304,7 +299,6 @@ def test_plugin_telegram_general(mock_post, mock_get):
     response.content = dumps({
         'description': 'test',
     })
-    mock_get.return_value = response
     mock_post.return_value = response
 
     # No image asset
@@ -545,3 +539,182 @@ def test_plugin_telegram_general(mock_post, mock_get):
     assert isinstance(obj, plugins.NotifyTelegram)
     assert len(obj.targets) == 1
     assert '-123456789525' in obj.targets
+
+
+@mock.patch('requests.post')
+def test_plugin_telegram_formating(mock_post):
+    """
+    NotifyTelegram() Formatting Tests
+
+    """
+
+    # Disable Throttling to speed testing
+    plugins.NotifyTelegram.request_rate_per_sec = 0
+
+    # Prepare Mock
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+    mock_post.return_value.content = '{}'
+
+    # Simple success response
+    mock_post.return_value.content = dumps({
+        "ok": True,
+        "result": [{
+            "update_id": 645421321,
+            "message": {
+                "message_id": 2,
+                "from": {
+                    "id": 532389719,
+                    "is_bot": False,
+                    "first_name": "Chris",
+                    "language_code": "en-US"
+                },
+                "chat": {
+                    "id": 532389719,
+                    "first_name": "Chris",
+                    "type": "private"
+                },
+                "date": 1519694394,
+                "text": "/start",
+                "entities": [{
+                    "offset": 0,
+                    "length": 6,
+                    "type": "bot_command",
+                }],
+            }},
+        ],
+    })
+    mock_post.return_value.status_code = requests.codes.ok
+
+    results = plugins.NotifyTelegram.parse_url(
+        'tgram://123456789:abcdefg_hijklmnop/')
+
+    instance = plugins.NotifyTelegram(**results)
+    assert isinstance(instance, plugins.NotifyTelegram)
+
+    response = instance.send(title='title', body='body')
+    assert response is True
+    # 1 call to look up bot owner, and second for notification
+    assert mock_post.call_count == 2
+
+    assert mock_post.call_args_list[0][0][0] == \
+        'https://api.telegram.org/bot123456789:abcdefg_hijklmnop/getUpdates'
+    assert mock_post.call_args_list[1][0][0] == \
+        'https://api.telegram.org/bot123456789:abcdefg_hijklmnop/sendMessage'
+
+    # Reset our values
+    mock_post.reset_mock()
+
+    # Now test our HTML Conversion as TEXT)
+    aobj = Apprise()
+    aobj.add('tgram://123456789:abcdefg_hijklmnop/')
+    assert len(aobj) == 1
+
+    title = '🚨 Change detected for <i>Apprise Test Title</i>'
+    body = '<a href="http://localhost"><i>Apprise Body Title</i></a>' \
+           ' had <a href="http://127.0.0.1">a change</a>'
+
+    assert aobj.notify(title=title, body=body, body_format=NotifyFormat.TEXT)
+
+    # Test our calls
+    assert mock_post.call_count == 2
+
+    assert mock_post.call_args_list[0][0][0] == \
+        'https://api.telegram.org/bot123456789:abcdefg_hijklmnop/getUpdates'
+    assert mock_post.call_args_list[1][0][0] == \
+        'https://api.telegram.org/bot123456789:abcdefg_hijklmnop/sendMessage'
+
+    payload = loads(mock_post.call_args_list[1][1]['data'])
+
+    # Test that everything is escaped properly in a TEXT mode
+    assert payload['text'] == \
+        '<h1>🚨 Change detected for &lt;i&gt;Apprise Test Title&lt;/i&gt;' \
+        '</h1>&lt;a href="http://localhost"&gt;&lt;i&gt;Apprise Body Title' \
+        '&lt;/i&gt;&lt;/a&gt; had &lt;a href="http://127.0.0.1"&gt;a change' \
+        '&lt;/a&gt;'
+
+    # Reset our values
+    mock_post.reset_mock()
+
+    # Now test our HTML Conversion as TEXT)
+    aobj = Apprise()
+    aobj.add('tgram://123456789:abcdefg_hijklmnop/?format=html')
+    assert len(aobj) == 1
+
+    assert aobj.notify(title=title, body=body, body_format=NotifyFormat.HTML)
+
+    # Test our calls
+    assert mock_post.call_count == 2
+
+    assert mock_post.call_args_list[0][0][0] == \
+        'https://api.telegram.org/bot123456789:abcdefg_hijklmnop/getUpdates'
+    assert mock_post.call_args_list[1][0][0] == \
+        'https://api.telegram.org/bot123456789:abcdefg_hijklmnop/sendMessage'
+
+    payload = loads(mock_post.call_args_list[1][1]['data'])
+
+    # Test that everything is escaped properly in a HTML mode
+    assert payload['text'] == \
+        '<h1>🚨 Change detected for <i>Apprise Test Title</i></h1>' \
+        '<a href="http://localhost"><i>Apprise Body Title</i></a> had ' \
+        '<a href="http://127.0.0.1">a change</a>'
+
+    # Reset our values
+    mock_post.reset_mock()
+
+    # Now test our MARKDOWN Handling
+    title = '# 🚨 Change detected for _Apprise Test Title_'
+    body = '_[Apprise Body Title](http://localhost)_' \
+           ' had [a change](http://127.0.0.1)'
+
+    aobj = Apprise()
+    aobj.add('tgram://123456789:abcdefg_hijklmnop/?format=markdown')
+    assert len(aobj) == 1
+
+    assert aobj.notify(
+        title=title, body=body, body_format=NotifyFormat.MARKDOWN)
+
+    # Test our calls
+    assert mock_post.call_count == 2
+
+    assert mock_post.call_args_list[0][0][0] == \
+        'https://api.telegram.org/bot123456789:abcdefg_hijklmnop/getUpdates'
+    assert mock_post.call_args_list[1][0][0] == \
+        'https://api.telegram.org/bot123456789:abcdefg_hijklmnop/sendMessage'
+
+    payload = loads(mock_post.call_args_list[1][1]['data'])
+
+    # Test that everything is escaped properly in a HTML mode
+    assert payload['text'] == \
+        '# 🚨 Change detected for _Apprise Test Title_\r\n' \
+        '_[Apprise Body Title](http://localhost)_ had ' \
+        '[a change](http://127.0.0.1)'
+
+    # Reset our values
+    mock_post.reset_mock()
+
+    # Upstream to use HTML but input specified as Markdown
+    aobj = Apprise()
+    aobj.add('tgram://987654321:abcdefg_hijklmnop/?format=html')
+    assert len(aobj) == 1
+
+    # HTML forced by the command line, but MARKDOWN spacified as
+    # upstream mode
+    assert aobj.notify(
+        title=title, body=body, body_format=NotifyFormat.MARKDOWN)
+
+    # Test our calls
+    assert mock_post.call_count == 2
+
+    assert mock_post.call_args_list[0][0][0] == \
+        'https://api.telegram.org/bot987654321:abcdefg_hijklmnop/getUpdates'
+    assert mock_post.call_args_list[1][0][0] == \
+        'https://api.telegram.org/bot987654321:abcdefg_hijklmnop/sendMessage'
+
+    payload = loads(mock_post.call_args_list[1][1]['data'])
+
+    # Test that everything is escaped properly in a HTML mode
+    assert payload['text'] == \
+        '<h1><p>🚨 Change detected for <em>Apprise Test Title</em></p>' \
+        '</h1><p><em><a href="http://localhost">Apprise Body Title</a></em> ' \
+        'had <a href="http://127.0.0.1">a change</a></p>'


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #565

Greatly improved Telegram test cases to accommodate bug issue raised. Text Conversion enhanced to support titles.  

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in
# This way you can just destroy it after when it's all over.
# The below will create a directory called apprise
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@565-telegram-html-titles

# Run Telegram Tests
apprise telegram://credentials
```