### PR TITLE
Ntfy attachment support added

### DIFF
--- a/apprise/plugins/NotifyNtfy.py
+++ b/apprise/plugins/NotifyNtfy.py
@@ -29,7 +29,6 @@ import re
 import requests
 import six
 from json import loads
-from json import dumps
 from os.path import basename
 
 from .NotifyBase import NotifyBase
@@ -328,7 +327,7 @@ class NotifyNtfy(NotifyBase):
         if not isinstance(payload, AttachBase):
             # Send our payload as a JSON object
             headers['Content-Type'] = 'application/json'
-            data = dumps(payload) if payload else None
+            data = payload if payload else None
 
             if self.priority != NtfyPriority.NORMAL:
                 headers['X-Priority'] = self.priority

--- a/apprise/plugins/NotifyNtfy.py
+++ b/apprise/plugins/NotifyNtfy.py
@@ -355,7 +355,7 @@ class NotifyNtfy(NotifyBase):
 
         else:
             # Prepare our Header
-            headers['Filename'] = payload.name
+            headers['X-Filename'] = payload.name
 
             # prepare our files object
             files = {'file': (payload.name, open(payload.path, 'rb'))}

--- a/test/test_plugin_ntfy.py
+++ b/test/test_plugin_ntfy.py
@@ -388,3 +388,5 @@ def test_plugin_custom_ntfy_edge_cases(mock_post):
         'http://example.com/file.jpg'
     assert mock_post.call_args_list[0][1]['headers'].get('X-Filename') == \
         'smoke.jpg'
+    assert mock_post.call_args_list[0][1]['data'] == 'body'
+    assert mock_post.call_args_list[0][1]['headers']['X-Title'] == 'title'

--- a/test/test_plugin_ntfy.py
+++ b/test/test_plugin_ntfy.py
@@ -265,11 +265,13 @@ def test_plugin_ntfy_attachments(mock_post):
     assert mock_post.call_count == 1
 
     assert mock_post.call_args_list[0][0][0] == \
-        'http://localhost:8084/topic'
-    assert mock_post.call_args_list[0][1]['headers'].get('X-Filename') == \
-        'apprise-test.gif'
-    assert mock_post.call_args_list[0][1]['headers']['X-Message'] == 'test'
-    assert 'X-Title' not in mock_post.call_args_list[0][1]['headers']
+        'http://localhost:8084'
+
+    response = json.loads(mock_post.call_args_list[0][1]['data'])
+    assert response['topic'] == 'topic'
+    assert response['message'] == 'test'
+    assert 'title' not in response
+    assert response['filename'] == 'apprise-test.gif'
 
     # Reset our mock object
     mock_post.reset_mock()
@@ -285,19 +287,23 @@ def test_plugin_ntfy_attachments(mock_post):
     assert mock_post.call_count == 2
     # Image + Message sent
     assert mock_post.call_args_list[0][0][0] == \
-        'http://localhost:8084/topic'
-    assert mock_post.call_args_list[0][1]['headers'].get('X-Filename') == \
-        'apprise-test.gif'
-    assert mock_post.call_args_list[0][1]['headers']['X-Message'] == 'test'
-    assert mock_post.call_args_list[0][1]['headers']['X-Title'] == 'wonderful'
+        'http://localhost:8084'
+    response = json.loads(mock_post.call_args_list[0][1]['data'])
+    assert response['topic'] == 'topic'
+    assert response['message'] == 'test'
+    assert response['title'] == 'wonderful'
+    assert 'attach' not in response
+    assert response['filename'] == 'apprise-test.gif'
 
     # Image no2 Send
     assert mock_post.call_args_list[1][0][0] == \
-        'http://localhost:8084/topic'
-    assert mock_post.call_args_list[1][1]['headers'].get('X-Filename') == \
-        'apprise-test.png'
-    assert 'X-Message' not in mock_post.call_args_list[1][1]['headers']
-    assert 'X-Title' not in mock_post.call_args_list[1][1]['headers']
+        'http://localhost:8084'
+    response = json.loads(mock_post.call_args_list[1][1]['data'])
+    assert response['topic'] == 'topic'
+    assert 'title' not in response
+    assert 'message' not in response
+    assert 'attach' not in response
+    assert response['filename'] == 'apprise-test.png'
 
     # Reset our mock object
     mock_post.reset_mock()
@@ -389,11 +395,11 @@ def test_plugin_custom_ntfy_edge_cases(mock_post):
 
     # Test our call count
     assert mock_post.call_count == 1
-    assert mock_post.call_args_list[0][0][0] == \
-        'http://localhost/topic1'
-    assert mock_post.call_args_list[0][1]['headers'].get('X-Attach') == \
-        'http://example.com/file.jpg'
-    assert mock_post.call_args_list[0][1]['headers'].get('X-Filename') == \
-        'smoke.jpg'
-    assert mock_post.call_args_list[0][1]['headers']['X-Message'] == 'body'
-    assert mock_post.call_args_list[0][1]['headers']['X-Title'] == 'title'
+    assert mock_post.call_args_list[0][0][0] == 'http://localhost'
+
+    response = json.loads(mock_post.call_args_list[0][1]['data'])
+    assert response['topic'] == 'topic1'
+    assert response['message'] == 'body'
+    assert response['title'] == 'title'
+    assert response['attach'] == 'http://example.com/file.jpg'
+    assert response['filename'] == 'smoke.jpg'


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #520 

Apprise `--attach` (`-a`) ntfy support.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in
# This way you can just destroy it after when it's all over.
# The below will create a directory called apprise
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@520-ntfy-attachment-support

# Run your signal testing...
apprise -b "test" -t "title" "ntfy://topic --attach=/path/to/local/file"
```