### PR TITLE
Apprise HTML/MARKDOWN/TEXT Translation Handling Refactoring

### DIFF
--- a/apprise/conversion.py
+++ b/apprise/conversion.py
@@ -36,13 +36,12 @@ else:
     from html.parser import HTMLParser
 
 
-def convert_between(from_format, to_format, body, title=None,
-                    title_format=NotifyFormat.TEXT):
+def convert_between(from_format, to_format, content):
     """
-    Converts between different notification formats. If no conversion exists,
+    Converts between different suported formats. If no conversion exists,
     or the selected one fails, the original text will be returned.
 
-    This function returns a tuple as (title, body)
+    This function returns the content translated (if required)
     """
 
     converters = {
@@ -53,41 +52,21 @@ def convert_between(from_format, to_format, body, title=None,
         (NotifyFormat.HTML, NotifyFormat.MARKDOWN): html_to_text,
     }
 
-    if NotifyFormat.MARKDOWN in (from_format, to_format):
-        # Tidy any exising pre-formating configuration
-        title = '' if not title else title.lstrip('\r\n \t\v\b*#-')
-
-    else:
-        title = '' if not title else title
-
     convert = converters.get((from_format, to_format))
-    title, body = convert(title=title, body=body, title_format=title_format) \
-        if convert is not None else (title, body)
-
-    return (title, body)
+    return convert(content) if convert else content
 
 
-def markdown_to_html(body, title=None, title_format=None):
+def markdown_to_html(content):
     """
-    Handle Markdown conversions
+    Converts specified content from markdown to HTML.
     """
 
-    if title_format == NotifyFormat.HTML and title:
-        # perform conversion if otherwise told to do so
-        title = markdown(title)
-
-    return (
-        # Title
-        '' if not title else title,
-
-        # Body
-        markdown(body),
-    )
+    return markdown(content)
 
 
-def text_to_html(body, title=None, title_format=None):
+def text_to_html(content):
     """
-    Converts a notification body from plain text to HTML.
+    Converts specified content from plain text to HTML.
     """
 
     # Basic TEXT to HTML format map; supports keys only
@@ -115,44 +94,26 @@ def text_to_html(body, title=None, title_format=None):
         re.IGNORECASE,
     )
 
-    # Execute our map against our body in addition to
+    # Execute our map against our content in addition to
     # swapping out new lines and replacing them with <br/>
-    return (
-        # Title; swap whitespace with space
-        '' if not title else re.sub(
-            r'[\r\n]+', ' ', re_table.sub(
-                lambda x: re_map[x.group()], title)),
-
-        # Body Formatting
-        re.sub(
-            r'\r*\n', '<br/>\n', re_table.sub(
-                lambda x: re_map[x.group()], body)))
+    return re.sub(
+        r'\r*\n', '<br/>\n',
+        re_table.sub(lambda x: re_map[x.group()], content))
 
 
-def html_to_text(body, title=None, title_format=None):
+def html_to_text(content):
     """
-    Converts a notification body from HTML to plain text.
+    Converts a content from HTML to plain text.
     """
 
     parser = HTMLConverter()
     if six.PY2:
         # Python 2.7 requires an additional parsing to un-escape characters
-        body = parser.unescape(body)
+        content = parser.unescape(content)
 
-    if title:
-        if six.PY2:
-            # Python 2.7 requires an additional parsing to un-escape characters
-            title = parser.unescape(title)
-
-        parser.feed(title)
-        parser.close()
-        title = parser.converted
-
-    parser.feed(body)
+    parser.feed(content)
     parser.close()
-    body = parser.converted
-
-    return ('' if not title else title, body)
+    return parser.converted
 
 
 class HTMLConverter(HTMLParser, object):

--- a/apprise/conversion.py
+++ b/apprise/conversion.py
@@ -28,6 +28,7 @@ import re
 import six
 from markdown import markdown
 from .common import NotifyFormat
+from .URLBase import URLBase
 
 if six.PY2:
     from HTMLParser import HTMLParser
@@ -69,36 +70,7 @@ def text_to_html(content):
     Converts specified content from plain text to HTML.
     """
 
-    # Basic TEXT to HTML format map; supports keys only
-    re_map = {
-        # Support Ampersand
-        r'&': '&amp;',
-
-        # Spaces to &nbsp; for formatting purposes since
-        # multiple spaces are treated as one an this may
-        # not be the callers intention
-        r' ': '&nbsp;',
-
-        # Tab support
-        r'\t': '&nbsp;&nbsp;&nbsp;',
-
-        # Greater than and Less than Characters
-        r'>': '&gt;',
-        r'<': '&lt;',
-    }
-
-    # Compile our map
-    re_table = re.compile(
-        r'(' + '|'.join(
-            map(re.escape, re_map.keys())) + r')',
-        re.IGNORECASE,
-    )
-
-    # Execute our map against our content in addition to
-    # swapping out new lines and replacing them with <br/>
-    return re.sub(
-        r'\r*\n', '<br/>\n',
-        re_table.sub(lambda x: re_map[x.group()], content))
+    return URLBase.escape_html(content)
 
 
 def html_to_text(content):

--- a/apprise/plugins/NotifyBase.py
+++ b/apprise/plugins/NotifyBase.py
@@ -344,8 +344,6 @@ class NotifyBase(BASE_OBJECT):
                 body = '<{open_tag}>{title}</{close_tag}>' \
                     '<br />\r\n{body}'.format(
                         open_tag=self.default_html_tag_id,
-                        # We only escape our title if the source provided was
-                        # of TEXT formatting
                         title=title,
                         close_tag=self.default_html_tag_id,
                         body=body)

--- a/apprise/plugins/NotifyBase.py
+++ b/apprise/plugins/NotifyBase.py
@@ -346,12 +346,12 @@ class NotifyBase(BASE_OBJECT):
                         open_tag=self.default_html_tag_id,
                         # We only escape our title if the source provided was
                         # of TEXT formatting
-                        title=self.escape_html(title)
-                        if body_format == NotifyFormat.TEXT else title,
+                        title=title,
                         close_tag=self.default_html_tag_id,
                         body=body)
 
-            elif self.notify_format == NotifyFormat.MARKDOWN:
+            elif self.notify_format == NotifyFormat.MARKDOWN and \
+                    body_format == NotifyFormat.TEXT:
                 # Content is appended to body as markdown
                 title = title.lstrip('\r\n \t\v\f#-')
                 if title:

--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -702,7 +702,7 @@ def parse_url(url, default_schema='http', verify_host=True, strict_port=False):
 
     # Port Parsing
     pmatch = re.search(
-        r'^(?P<host>([[0-9a-f:]+]|[^:]+)):(?P<port>[^:]*)$',
+        r'^(?P<host>(\[[0-9a-f:]+\]|[^:]+)):(?P<port>[^:]*)$',
         result['host'])
 
     if pmatch:

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -32,7 +32,7 @@ import logging
 logging.disable(logging.CRITICAL)
 
 
-def test_html_to_text():
+def test_conversion_html_to_text():
     """conversion: Test HTML to plain text
     """
 
@@ -134,3 +134,16 @@ def test_html_to_text():
     with pytest.raises(TypeError):
         # Invalid input
         assert to_html(object)
+
+
+def test_conversion_text_to():
+    """conversion: Test Text to all types
+    """
+
+    response = convert_between(
+        NotifyFormat.TEXT, NotifyFormat.HTML,
+        "<title>Test Message</title><body>Body</body>")
+
+    assert response == \
+        '&lt;title&gt;Test&nbsp;Message&lt;/title&gt;&lt;body&gt;Body&lt;'\
+        '/body&gt;'

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -40,7 +40,7 @@ def test_html_to_text():
         """
         A function to simply html conversion tests
         """
-        return convert_between(NotifyFormat.HTML, NotifyFormat.TEXT, body)[1]
+        return convert_between(NotifyFormat.HTML, NotifyFormat.TEXT, body)
 
     assert to_html("No HTML code here.") == "No HTML code here."
 

--- a/test/test_plugin_telegram.py
+++ b/test/test_plugin_telegram.py
@@ -722,6 +722,43 @@ def test_plugin_telegram_formating_py3(mock_post):
         '</b></b>\r\n<i><a href="http://localhost">Apprise Body Title</a>' \
         '</i> had <a href="http://127.0.0.2">a change</a>\r\n'
 
+    # Now we'll test an edge case where a title was defined, but after
+    # processing it, it was determiend there really wasn't anything there
+    # at all at the end of the day.
+
+    # Reset our values
+    mock_post.reset_mock()
+
+    # Upstream to use HTML but input specified as Markdown
+    aobj = Apprise()
+    aobj.add('tgram://987654321:abcdefg_hijklmnop/?format=markdown')
+    assert len(aobj) == 1
+
+    # Now test our MARKDOWN Handling (no title defined... not really anyway)
+    title = '# '
+    body = '_[Apprise Body Title](http://localhost)_' \
+           ' had [a change](http://127.0.0.2)'
+
+    # MARKDOWN forced by the command line, but TEXT spacified as
+    # upstream mode
+    assert aobj.notify(
+        title=title, body=body, body_format=NotifyFormat.TEXT)
+
+    # Test our calls
+    assert mock_post.call_count == 2
+
+    assert mock_post.call_args_list[0][0][0] == \
+        'https://api.telegram.org/bot987654321:abcdefg_hijklmnop/getUpdates'
+    assert mock_post.call_args_list[1][0][0] == \
+        'https://api.telegram.org/bot987654321:abcdefg_hijklmnop/sendMessage'
+
+    payload = loads(mock_post.call_args_list[1][1]['data'])
+
+    # Test that everything is escaped properly in a HTML mode
+    assert payload['text'] == \
+        '_[Apprise Body Title](http://localhost)_ had ' \
+        '[a change](http://127.0.0.2)'
+
 
 @pytest.mark.skipif(sys.version_info.major >= 3, reason="Requires Python 2.x+")
 @mock.patch('requests.post')
@@ -953,6 +990,43 @@ def test_plugin_telegram_formating_py2(mock_post):
         '<b>\xd7\x9b\xd7\x95\xd7\xaa\xd7\xa8\xd7\xaa '\
         '\xd7\xa0\xd7\xa4\xd7\x9c\xd7\x90\xd7\x94</b>\r\n[_[\xd7\x96\xd7\x95 '\
         '\xd7\x94\xd7\x95\xd7\x93\xd7\xa2\xd7\x94](http://localhost)_'
+
+    # Now we'll test an edge case where a title was defined, but after
+    # processing it, it was determiend there really wasn't anything there
+    # at all at the end of the day.
+
+    # Reset our values
+    mock_post.reset_mock()
+
+    # Upstream to use HTML but input specified as Markdown
+    aobj = Apprise()
+    aobj.add('tgram://987654321:abcdefg_hijklmnop/?format=markdown')
+    assert len(aobj) == 1
+
+    # Now test our MARKDOWN Handling (no title defined... not really anyway)
+    title = '# '
+    body = '_[Apprise Body Title](http://localhost)_' \
+           ' had [a change](http://127.0.0.2)'
+
+    # MARKDOWN forced by the command line, but TEXT spacified as
+    # upstream mode
+    assert aobj.notify(
+        title=title, body=body, body_format=NotifyFormat.TEXT)
+
+    # Test our calls
+    assert mock_post.call_count == 2
+
+    assert mock_post.call_args_list[0][0][0] == \
+        'https://api.telegram.org/bot987654321:abcdefg_hijklmnop/getUpdates'
+    assert mock_post.call_args_list[1][0][0] == \
+        'https://api.telegram.org/bot987654321:abcdefg_hijklmnop/sendMessage'
+
+    payload = loads(mock_post.call_args_list[1][1]['data'])
+
+    # Test that everything is escaped properly in a HTML mode
+    assert payload['text'] == \
+        '_[Apprise Body Title](http://localhost)_ had ' \
+        '[a change](http://127.0.0.2)'
 
 
 @mock.patch('requests.post')

--- a/test/test_plugin_telegram.py
+++ b/test/test_plugin_telegram.py
@@ -311,10 +311,6 @@ def test_plugin_telegram_general(mock_post):
     # ensures our plugin inheritance is working properly
     assert obj.body_maxlen == plugins.NotifyTelegram.body_maxlen
 
-    # We don't override the title maxlen so we should be set to the same
-    # as our parent class in this case
-    assert obj.title_maxlen == plugins.NotifyBase.title_maxlen
-
     # This tests erroneous messages involving multiple chat ids
     assert obj.notify(
         body='body', title='title', notify_type=NotifyType.INFO) is False
@@ -629,10 +625,10 @@ def test_plugin_telegram_formating_py3(mock_post):
 
     # Test that everything is escaped properly in a TEXT mode
     assert payload['text'] == \
-        '<b>🚨 Change detected&nbsp;for&nbsp;&lt;i&gt;Apprise&nbsp;Test' \
-        '&nbsp;Title&lt;/i&gt;</b>\r\n&lt;a href="http://localhost"&gt;' \
-        '&lt;i&gt;Apprise Body&nbsp;Title&lt;/i&gt;&lt;/a&gt;&nbsp;had' \
-        '&nbsp;&lt;a&nbsp;href="http://127.0.0.1"&gt;a&nbsp;change&lt;/a&gt;'
+        '<b>🚨 Change detected for <i>Apprise Test Title</i></b>' \
+        '\r\n&lt;a href="http://localhost"&gt;&lt;i&gt;Apprise ' \
+        'Body&nbsp;Title&lt;/i&gt;&lt;/a&gt;&nbsp;had&nbsp;&lt;a' \
+        '&nbsp;href="http://127.0.0.1"&gt;a&nbsp;change&lt;/a&gt;'
 
     # Reset our values
     mock_post.reset_mock()
@@ -699,6 +695,11 @@ def test_plugin_telegram_formating_py3(mock_post):
     aobj.add('tgram://987654321:abcdefg_hijklmnop/?format=html')
     assert len(aobj) == 1
 
+    # Now test our MARKDOWN Handling
+    title = '# 🚨 Another Change detected for _Apprise Test Title_'
+    body = '_[Apprise Body Title](http://localhost)_' \
+           ' had [a change](http://127.0.0.2)'
+
     # HTML forced by the command line, but MARKDOWN spacified as
     # upstream mode
     assert aobj.notify(
@@ -716,9 +717,9 @@ def test_plugin_telegram_formating_py3(mock_post):
 
     # Test that everything is escaped properly in a HTML mode
     assert payload['text'] == \
-        '<b>🚨 Change detected for <i>Apprise Test Title</i></b>\r\n<i>' \
-        '<a href="http://localhost">Apprise Body Title</a></i> ' \
-        'had <a href="http://127.0.0.1">a change</a>'
+        '<b>🚨 Another Change detected for <i>Apprise Test Title</i>' \
+        '</b>\r\n<i><a href="http://localhost">Apprise Body Title</a>' \
+        '</i> had <a href="http://127.0.0.2">a change</a>'
 
 
 @pytest.mark.skipif(sys.version_info.major >= 3, reason="Requires Python 2.x+")
@@ -1020,8 +1021,8 @@ def test_plugin_telegram_html_formatting(mock_post):
 
     # Test that everything is escaped properly in a HTML mode
     assert payload['text'] == \
-        '<b><b>\'information\'</b></b>\r\n<i>"This is in Italic"</i>' \
-        '<b>      Headings are dropped and converted to bold</b>'
+        '<b><b>\'information\'</b></b>\r\n<i>"This is in Italic"' \
+        '</i>\r\n<b>      Headings are dropped and converted to bold</b>'
 
     mock_post.reset_mock()
 
@@ -1033,7 +1034,7 @@ def test_plugin_telegram_html_formatting(mock_post):
     payload = loads(mock_post.call_args_list[0][1]['data'])
 
     assert payload['text'] == \
-        '<b>&lt;title&gt;&amp;apos;information&amp;apos&lt;/title&gt;</b>' \
-        '\r\n&lt;em&gt;&amp;quot;This is in&nbsp;Italic&amp;quot&lt;/em&gt;' \
-        '&lt;br/&gt;&lt;h5&gt;&amp;emsp;&amp;emspHeadings&amp;nbsp;are' \
-        '&nbsp;dropped&nbsp;and&amp;nbspconverted&nbsp;to&nbsp;bold&lt;/h5&gt;'
+        "<b><b>'information'</b></b>\r\n&lt;em&gt;&amp;quot;This is in" \
+        "&nbsp;Italic&amp;quot&lt;/em&gt;&lt;br/&gt;&lt;h5&gt;&amp;" \
+        "emsp;&amp;emspHeadings&amp;nbsp;are&nbsp;dropped&nbsp;and" \
+        "&amp;nbspconverted&nbsp;to&nbsp;bold&lt;/h5&gt;"

--- a/test/test_plugin_telegram.py
+++ b/test/test_plugin_telegram.py
@@ -701,7 +701,7 @@ def test_plugin_telegram_formating_py3(mock_post):
     body = '_[Apprise Body Title](http://localhost)_' \
            ' had [a change](http://127.0.0.2)'
 
-    # HTML forced by the command line, but MARKDOWN spacified as
+    # HTML forced by the command line, but MARKDOWN specified as
     # upstream mode
     assert aobj.notify(
         title=title, body=body, body_format=NotifyFormat.MARKDOWN)
@@ -739,7 +739,7 @@ def test_plugin_telegram_formating_py3(mock_post):
     body = '_[Apprise Body Title](http://localhost)_' \
            ' had [a change](http://127.0.0.2)'
 
-    # MARKDOWN forced by the command line, but TEXT spacified as
+    # MARKDOWN forced by the command line, but TEXT specified as
     # upstream mode
     assert aobj.notify(
         title=title, body=body, body_format=NotifyFormat.TEXT)
@@ -757,6 +757,39 @@ def test_plugin_telegram_formating_py3(mock_post):
     # Test that everything is escaped properly in a HTML mode
     assert payload['text'] == \
         '_[Apprise Body Title](http://localhost)_ had ' \
+        '[a change](http://127.0.0.2)'
+
+    # Reset our values
+    mock_post.reset_mock()
+
+    # Upstream to use HTML but input specified as Markdown
+    aobj = Apprise()
+    aobj.add('tgram://987654321:abcdefg_hijklmnop/?format=markdown')
+    assert len(aobj) == 1
+
+    # Set an actual title this time
+    title = '# A Great Title'
+    body = '_[Apprise Body Title](http://localhost)_' \
+           ' had [a change](http://127.0.0.2)'
+
+    # MARKDOWN forced by the command line, but TEXT specified as
+    # upstream mode
+    assert aobj.notify(
+        title=title, body=body, body_format=NotifyFormat.TEXT)
+
+    # Test our calls
+    assert mock_post.call_count == 2
+
+    assert mock_post.call_args_list[0][0][0] == \
+        'https://api.telegram.org/bot987654321:abcdefg_hijklmnop/getUpdates'
+    assert mock_post.call_args_list[1][0][0] == \
+        'https://api.telegram.org/bot987654321:abcdefg_hijklmnop/sendMessage'
+
+    payload = loads(mock_post.call_args_list[1][1]['data'])
+
+    # Test that everything is escaped properly in a HTML mode
+    assert payload['text'] == \
+        '# A Great Title\r\n_[Apprise Body Title](http://localhost)_ had ' \
         '[a change](http://127.0.0.2)'
 
 
@@ -919,7 +952,7 @@ def test_plugin_telegram_formating_py2(mock_post):
     aobj.add('tgram://987654321:abcdefg_hijklmnop/?format=html')
     assert len(aobj) == 1
 
-    # HTML forced by the command line, but MARKDOWN spacified as
+    # HTML forced by the command line, but MARKDOWN specified as
     # upstream mode
     assert aobj.notify(
         title=title, body=body, body_format=NotifyFormat.MARKDOWN)
@@ -1008,7 +1041,7 @@ def test_plugin_telegram_formating_py2(mock_post):
     body = '_[Apprise Body Title](http://localhost)_' \
            ' had [a change](http://127.0.0.2)'
 
-    # MARKDOWN forced by the command line, but TEXT spacified as
+    # MARKDOWN forced by the command line, but TEXT specified as
     # upstream mode
     assert aobj.notify(
         title=title, body=body, body_format=NotifyFormat.TEXT)
@@ -1026,6 +1059,39 @@ def test_plugin_telegram_formating_py2(mock_post):
     # Test that everything is escaped properly in a HTML mode
     assert payload['text'] == \
         '_[Apprise Body Title](http://localhost)_ had ' \
+        '[a change](http://127.0.0.2)'
+
+    # Reset our values
+    mock_post.reset_mock()
+
+    # Upstream to use HTML but input specified as Markdown
+    aobj = Apprise()
+    aobj.add('tgram://987654321:abcdefg_hijklmnop/?format=markdown')
+    assert len(aobj) == 1
+
+    # Set an actual title this time
+    title = '# A Great Title'
+    body = '_[Apprise Body Title](http://localhost)_' \
+           ' had [a change](http://127.0.0.2)'
+
+    # MARKDOWN forced by the command line, but TEXT specified as
+    # upstream mode
+    assert aobj.notify(
+        title=title, body=body, body_format=NotifyFormat.TEXT)
+
+    # Test our calls
+    assert mock_post.call_count == 2
+
+    assert mock_post.call_args_list[0][0][0] == \
+        'https://api.telegram.org/bot987654321:abcdefg_hijklmnop/getUpdates'
+    assert mock_post.call_args_list[1][0][0] == \
+        'https://api.telegram.org/bot987654321:abcdefg_hijklmnop/sendMessage'
+
+    payload = loads(mock_post.call_args_list[1][1]['data'])
+
+    # Test that everything is escaped properly in a HTML mode
+    assert payload['text'] == \
+        '# A Great Title\r\n_[Apprise Body Title](http://localhost)_ had ' \
         '[a change](http://127.0.0.2)'
 
 

--- a/test/test_plugin_telegram.py
+++ b/test/test_plugin_telegram.py
@@ -403,7 +403,7 @@ def test_plugin_telegram_general(mock_post):
 
     # Test our payload
     assert payload['text'] == \
-        '<b>special characters</b>\r\n\'"This can\'t\t\r\nfail us"\''
+        '<b>special characters</b>\r\n\'"This can\'t\t\r\nfail us"\'\r\n'
 
     # Test sending attachments
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, 'apprise-test.gif'))
@@ -625,10 +625,11 @@ def test_plugin_telegram_formating_py3(mock_post):
 
     # Test that everything is escaped properly in a TEXT mode
     assert payload['text'] == \
-        '<b>🚨 Change detected for <i>Apprise Test Title</i></b>' \
-        '\r\n&lt;a href="http://localhost"&gt;&lt;i&gt;Apprise ' \
-        'Body&nbsp;Title&lt;/i&gt;&lt;/a&gt;&nbsp;had&nbsp;&lt;a' \
-        '&nbsp;href="http://127.0.0.1"&gt;a&nbsp;change&lt;/a&gt;'
+        '<b>🚨 Change detected&nbsp;for&nbsp;&lt;i&gt;Apprise&nbsp;' \
+        'Test&nbsp;Title&lt;/i&gt;</b>\r\n&lt;a&nbsp;href=' \
+        '"http://localhost"&gt;&lt;i&gt;Apprise&nbsp;Body&nbsp;Title&lt;' \
+        '/i&gt;&lt;/a&gt;&nbsp;had&nbsp;&lt;a&nbsp;href=&quot;http://' \
+        '127.0.0.1&quot;&gt;a&nbsp;change&lt;/a&gt;'
 
     # Reset our values
     mock_post.reset_mock()
@@ -717,9 +718,9 @@ def test_plugin_telegram_formating_py3(mock_post):
 
     # Test that everything is escaped properly in a HTML mode
     assert payload['text'] == \
-        '<b>🚨 Another Change detected for <i>Apprise Test Title</i>' \
-        '</b>\r\n<i><a href="http://localhost">Apprise Body Title</a>' \
-        '</i> had <a href="http://127.0.0.2">a change</a>'
+        '<b><b>🚨 Another Change detected for <i>Apprise Test Title</i>' \
+        '</b></b>\r\n<i><a href="http://localhost">Apprise Body Title</a>' \
+        '</i> had <a href="http://127.0.0.2">a change</a>\r\n'
 
 
 @pytest.mark.skipif(sys.version_info.major >= 3, reason="Requires Python 2.x+")
@@ -810,11 +811,11 @@ def test_plugin_telegram_formating_py2(mock_post):
 
     # Test that everything is escaped properly in a TEXT mode
     assert payload['text'].encode('utf-8') == \
-        '<b>\xf0\x9f\x9a\xa8 Change detected&nbsp;for&nbsp;' \
-        '&lt;i&gt;Apprise&nbsp;Test&nbsp;Title&lt;/i&gt;</b>\r\n' \
-        '&lt;a href="http://localhost"&gt;&lt;i&gt;Apprise Body&nbsp;' \
-        'Title&lt;/i&gt;&lt;/a&gt;&nbsp;had&nbsp;&lt;a&nbsp;' \
-        'href="http://127.0.0.1"&gt;a&nbsp;change&lt;/a&gt;'
+        '<b>\xf0\x9f\x9a\xa8 Change detected&nbsp;for&nbsp;&lt;i&gt;' \
+        'Apprise&nbsp;Test&nbsp;Title&lt;/i&gt;</b>\r\n&lt;a&nbsp;' \
+        'href="http://localhost"&gt;&lt;i&gt;Apprise&nbsp;Body&nbsp;' \
+        'Title&lt;/i&gt;&lt;/a&gt;&nbsp;had&nbsp;&lt;a&nbsp;href=&quot;' \
+        'http://127.0.0.1&quot;&gt;a&nbsp;change&lt;/a&gt;'
 
     # Reset our values
     mock_post.reset_mock()
@@ -898,9 +899,10 @@ def test_plugin_telegram_formating_py2(mock_post):
 
     # Test that everything is escaped properly in a HTML mode
     assert payload['text'].encode('utf-8') == \
-        '<b>\xf0\x9f\x9a\xa8 Change detected for <i>Apprise Test Title</i>' \
-        '</b>\r\n<i><a href="http://localhost">Apprise Body Title</a></i> ' \
-        'had <a href="http://127.0.0.1">a change</a>'
+        '<b><b>\xf0\x9f\x9a\xa8 Change detected for ' \
+        '<i>Apprise Test Title</i></b></b>\r\n<i>' \
+        '<a href="http://localhost">Apprise Body Title</a>'\
+        '</i> had <a href="http://127.0.0.1">a change</a>\r\n'
 
     # Reset our values
     mock_post.reset_mock()
@@ -1034,7 +1036,8 @@ def test_plugin_telegram_html_formatting(mock_post):
     payload = loads(mock_post.call_args_list[0][1]['data'])
 
     assert payload['text'] == \
-        "<b><b>'information'</b></b>\r\n&lt;em&gt;&amp;quot;This is in" \
-        "&nbsp;Italic&amp;quot&lt;/em&gt;&lt;br/&gt;&lt;h5&gt;&amp;" \
-        "emsp;&amp;emspHeadings&amp;nbsp;are&nbsp;dropped&nbsp;and" \
-        "&amp;nbspconverted&nbsp;to&nbsp;bold&lt;/h5&gt;"
+        '<b>&lt;title&gt;&amp;apos;information&amp;apos&lt;/title&gt;</b>' \
+        '\r\n&lt;em&gt;&amp;quot;This is in&nbsp;Italic&amp;quot&lt;/em' \
+        '&gt;&lt;br/&gt;&lt;h5&gt;&amp;emsp;&amp;emspHeadings&amp;nbsp;' \
+        'are&nbsp;dropped&nbsp;and&amp;nbspconverted&nbsp;to&nbsp;bold&lt;' \
+        '/h5&gt;'


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #573 

This really all ties back to #565 (and PR #566);  This was a rather destructive event unfortunately that i was not prepared for.

I spent all day today debugging it and made some progress (still a ways to go).  I may just revert at some point, but i'd like to see if i can iron this out and make some sense out of the HTML/TEXT/MARKDOWN inter-conversions a bit better.

This also addresses all comments made in: #577, #576, #572.

It continues onto PR #574 and unfortunately all stems back to #565 which blew up Apprise attempting to accommodate it. :astonished: 

I'm hoping I've almost nailed this all now in this release. I tested it with Mail and resigned in with my Telegram account as well to verify how things looked there.  So far so good.

The biggest change here, is that after all this, the default Telegram Posting is in HTML now not TEXT.  One sure-fire-way to roll back would be to just switch it back to TEXT.  But i think it would be great to correctly support all formats and all the transitions between them.  Telegram proved to be a pain only because while it accepts HTML, it's so restrictive that there is a lot of extra leg-work to convert True HTML -> Telegram HTML.

Please let me know if this works for people; the instructions to test this are below. If we're satisfied i'll push another Apprise release ASAP and fix this once and for all.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in
# This way you can just destroy it after when it's all over.
# The below will create a directory called apprise
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@573-text-formatting

# Run your telegram testing...
apprise -b "test" -t "title" "tgram://credentials

# For those with mailto: issues... same command above. just use your mailto url instead
```
