### PR TITLE
Fix Zulip 401 when bot name contains a dash

### DIFF
--- a/apprise/plugins/NotifyZulip.py
+++ b/apprise/plugins/NotifyZulip.py
@@ -63,10 +63,11 @@ from ..common import NotifyType
 from ..utils import parse_list
 from ..utils import validate_regex
 from ..utils import is_email
+from ..utils import remove_suffix
 from ..AppriseLocale import gettext_lazy as _
 
 # A Valid Bot Name
-VALIDATE_BOTNAME = re.compile(r'(?P<name>[A-Z0-9_]{1,32})(-bot)?', re.I)
+VALIDATE_BOTNAME = re.compile(r'(?P<name>[A-Z0-9_-]{1,32})', re.I)
 
 # Organization required as part of the API request
 VALIDATE_ORG = re.compile(
@@ -122,7 +123,7 @@ class NotifyZulip(NotifyBase):
         'botname': {
             'name': _('Bot Name'),
             'type': 'string',
-            'regex': (r'^[A-Z0-9_]{1,32}(-bot)?$', 'i'),
+            'regex': (r'^[A-Z0-9_-]{1,32}$', 'i'),
         },
         'organization': {
             'name': _('Organization'),
@@ -183,7 +184,9 @@ class NotifyZulip(NotifyBase):
                 raise TypeError
 
             # The botname
-            self.botname = match.group('name')
+            botname = match.group('name')
+            botname = remove_suffix(botname, '-bot')
+            self.botname = botname
 
         except (TypeError, AttributeError):
             msg = 'The Zulip botname specified ({}) is invalid.'\

--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -1379,3 +1379,10 @@ def apply_template(template, app_mode=TemplateType.RAW, **kwargs):
     # to drop the '{{' and '}}' surrounding our match so that we can
     # re-index it back into our list
     return mask_r.sub(lambda x: fn(kwargs[x.group()[2:-2].strip()]), template)
+
+
+def remove_suffix(value, suffix):
+    """
+    Removes a suffix from the end of a string.
+    """
+    return value[:-len(suffix)] if value.endswith(suffix) else value

--- a/test/test_plugin_zulip.py
+++ b/test/test_plugin_zulip.py
@@ -55,6 +55,11 @@ apprise_url_tests = (
     ('zulip://....@apprise/{}'.format('a' * 32), {
         'instance': TypeError,
     }),
+    # Valid everything - botname with a dash
+    ('zulip://bot-name@apprise/{}'.format('a' * 32), {
+        'instance': plugins.NotifyZulip,
+        'privacy_url': 'zulip://bot-name@apprise/a...a/',
+    }),
     # Valid everything - no target so default is used
     ('zulip://botname@apprise/{}'.format('a' * 32), {
         'instance': plugins.NotifyZulip,


### PR DESCRIPTION
## Description

Sending a message to Zulip failed with my setup:

```sh
> docker run --entrypoint=apprise --rm caronc/apprise -vv -t "Test title" -b "Test body" "zulip://some-name@someorganization.zulipchat.com/<token>/Alerts"
2022-05-02 14:14:33,816 - INFO - Notifying 1 service(s) asynchronously.
2022-05-02 14:14:34,047 - WARNING - Failed to send Zulip notification to Alerts: Unauthorized - Invalid Token., error=401.
```

The error is caused because the regex used to parse the bot name only considered the part before the first dash leading to an invalid user name being sent in the request's basic auth.

This pull request fixes the issue by making the bot name regex more permissive and manually stripping off the `-bot` suffix instead of doing it in the regex.

## Checklist

* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
