### PR TITLE
Phone Number Min Length changed to 10 characters

### DIFF
--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -294,7 +294,7 @@ def is_uuid(uuid):
     return True if match else False
 
 
-def is_phone_no(phone, min_len=11):
+def is_phone_no(phone, min_len=10):
     """Determine if the specified entry is a phone number
 
     Args:

--- a/test/test_plugin_clicksend.py
+++ b/test/test_plugin_clicksend.py
@@ -39,7 +39,7 @@ apprise_url_tests = (
         # We failed to identify any valid authentication
         'instance': TypeError,
     }),
-    ('clicksend://user:pass@{}/{}/{}'.format('1' * 10, '2' * 15, 'a' * 13), {
+    ('clicksend://user:pass@{}/{}/{}'.format('1' * 9, '2' * 15, 'a' * 13), {
         # invalid target numbers; we'll fail to notify anyone
         'instance': plugins.NotifyClickSend,
         'notify_response': False,

--- a/test/test_plugin_d7networks.py
+++ b/test/test_plugin_d7networks.py
@@ -39,7 +39,7 @@ apprise_url_tests = (
         # We failed to identify any valid authentication
         'instance': TypeError,
     }),
-    ('d7sms://user:pass@{}/{}/{}'.format('1' * 10, '2' * 15, 'a' * 13), {
+    ('d7sms://user:pass@{}/{}/{}'.format('1' * 9, '2' * 15, 'a' * 13), {
         # No valid targets to notify
         'instance': plugins.NotifyD7Networks,
         # Since there are no targets specified we expect a False return on


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #588

Allow a 10 character minimum length on phone numbers (previously 11)

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@588-signal-phone-length

# Be sure you're running your Signal API Server and query it like so
apprise -t "Test Title" -b "Test Message" "signal://host/10-0char-phone-no/

```

