### PR TITLE
Signal supports a HTTP 201 Response

### DIFF
--- a/apprise/plugins/NotifySignalAPI.py
+++ b/apprise/plugins/NotifySignalAPI.py
@@ -320,7 +320,8 @@ class NotifySignalAPI(NotifyBase):
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
                 )
-                if r.status_code != requests.codes.ok:
+                if r.status_code not in (
+                        requests.codes.ok, requests.codes.created):
                     # We had a problem
                     status_str = \
                         NotifySignalAPI.http_response_code_lookup(

--- a/test/test_plugin_signal.py
+++ b/test/test_plugin_signal.py
@@ -112,6 +112,11 @@ apprise_url_tests = (
         # use get args to acomplish the same thing (use source instead of from)
         'instance': plugins.NotifySignalAPI,
     }),
+    ('signals://user:password@localhost/{}/{}'.format('1' * 11, '3' * 11), {
+        'instance': plugins.NotifySignalAPI,
+        # Test that a 201 response code is still accepted
+        'requests_response_code': 201,
+    }),
     ('signals://localhost/{}/{}/{}?batch=True'.format(
         '1' * 11, '3' * 11, '4' * 11), {
             # test batch mode


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #590

Signal returns a 201 response code in addition to 200; both should be accepted by Apprise.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@590-signal-http-response-201

# Be sure you're running your Signal API Server and query it like so
apprise -t "Test Title" -b "Test Message" signal://hostname/phoneno

```

