### PR TITLE
Pushover to support numerical priority values

### DIFF
--- a/apprise/plugins/NotifyPushover.py
+++ b/apprise/plugins/NotifyPushover.py
@@ -564,19 +564,25 @@ class NotifyPushover(NotifyBase):
         # Set our priority
         if 'priority' in results['qsd'] and len(results['qsd']['priority']):
             _map = {
+                # Keep for backwards compatibility
                 'l': PushoverPriority.LOW,
                 'm': PushoverPriority.MODERATE,
                 'n': PushoverPriority.NORMAL,
                 'h': PushoverPriority.HIGH,
                 'e': PushoverPriority.EMERGENCY,
-            }
-            try:
-                results['priority'] = \
-                    _map[results['qsd']['priority'][0].lower()]
 
-            except KeyError:
-                # No priority was set
-                pass
+                # Entries to additionally support (so more like PushOver's API
+                '-2': PushoverPriority.LOW,
+                '-1': PushoverPriority.MODERATE,
+                '0': PushoverPriority.NORMAL,
+                '1': PushoverPriority.HIGH,
+                '2': PushoverPriority.EMERGENCY,
+            }
+            priority = results['qsd']['priority'][0].lower()
+            results['priority'] = \
+                next((
+                    v for k, v in _map.items() if priority.startswith(k)),
+                    NotifyPushover.template_args['priority']['default'])
 
         # Retrieve all of our targets
         results['targets'] = NotifyPushover.split_path(results['fullpath'])

--- a/test/test_plugin_pushover.py
+++ b/test/test_plugin_pushover.py
@@ -115,6 +115,10 @@ apprise_url_tests = (
     ('pover://%s@%s?priority=emergency' % ('u' * 30, 'a' * 30), {
         'instance': plugins.NotifyPushover,
     }),
+    # API Key + emergency(2) priority setting (via numeric value
+    ('pover://%s@%s?priority=2' % ('u' * 30, 'a' * 30), {
+        'instance': plugins.NotifyPushover,
+    }),
     # API Key + emergency priority setting with retry and expire
     ('pover://%s@%s?priority=emergency&%s&%s' % ('u' * 30,
                                                  'a' * 30,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #596 

Pushover can now support the numerical values identified on it's [API website](https://pushover.net/api#priority) in addition to `emergency` (2),  `high` (1),  `normal` (0), `moderate` (-1),  and `low` (-2).

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@596-pushover-priorities

# Test out the changes with the following command (emergency example below)
apprise -t "Test Title" -b "Test Message" pover://<configuration>?priority=2

```

