### PR TITLE
Fix parsing integer priorities in Pushover

### DIFF
--- a/apprise/plugins/NotifyPushover.py
+++ b/apprise/plugins/NotifyPushover.py
@@ -571,14 +571,14 @@ class NotifyPushover(NotifyBase):
                 'h': PushoverPriority.HIGH,
                 'e': PushoverPriority.EMERGENCY,
 
-                # Entries to additionally support (so more like PushOver's API
+                # Entries to additionally support (so more like PushOver's API)
                 '-2': PushoverPriority.LOW,
                 '-1': PushoverPriority.MODERATE,
                 '0': PushoverPriority.NORMAL,
                 '1': PushoverPriority.HIGH,
                 '2': PushoverPriority.EMERGENCY,
             }
-            priority = results['qsd']['priority'][0].lower()
+            priority = results['qsd']['priority'].lower()
             results['priority'] = \
                 next((
                     v for k, v in _map.items() if priority.startswith(k)),


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #597

This is to fix parsing negative integer priorities.

## New Service Completion Status
<!-- This section is only applicable if you're adding a new service -->
* [ ] apprise/plugins/Notify<!--ServiceName goes here-->.py
* [ ] KEYWORDS
    - add new service into this file (alphabetically).
* [ ] README.md
    - add entry for new service to table (as a quick reference)
* [ ] packaging/redhat/python-apprise.spec
    - add new service into the `%global common_description`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@fix-pushover-priority-int-parsing

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  pover://<configuration>?priority=-2

```

