### PR TITLE
Refactored token parsing; moved to __init__()

### DIFF
--- a/apprise/config/ConfigBase.py
+++ b/apprise/config/ConfigBase.py
@@ -927,6 +927,14 @@ class ConfigBase(URLBase):
                 # Grab our first item
                 _results = results.pop(0)
 
+                if _results['schema'] not in plugins.SCHEMA_MAP:
+                    # the arguments are invalid or can not be used.
+                    ConfigBase.logger.warning(
+                        'An invalid Apprise schema ({}) in YAML configuration '
+                        'entry #{}, item #{}'
+                        .format(_results['schema'], no + 1, entry))
+                    continue
+
                 # tag is a special keyword that is managed by Apprise object.
                 # The below ensures our tags are set correctly
                 if 'tag' in _results:
@@ -958,6 +966,7 @@ class ConfigBase(URLBase):
                 # Prepare our Asset Object
                 _results['asset'] = asset
 
+                # Now we generate our plugin
                 try:
                     # Attempt to create an instance of our plugin using the
                     # parsed URL information
@@ -1088,7 +1097,7 @@ class ConfigBase(URLBase):
 
             # Detect if we're dealign with a list or not
             is_list = re.search(
-                r'^(list|choice):.*',
+                r'^list:.*',
                 meta.get('type'),
                 re.IGNORECASE)
 

--- a/apprise/plugins/NotifyGotify.py
+++ b/apprise/plugins/NotifyGotify.py
@@ -273,10 +273,10 @@ class NotifyGotify(NotifyBase):
 
         # Define any URL parameters
         params = {
-            'priority': str(
+            'priority':
                 GOTIFY_PRIORITIES[self.template_args['priority']['default']]
                 if self.priority not in GOTIFY_PRIORITIES
-                else GOTIFY_PRIORITIES[self.priority]),
+                else GOTIFY_PRIORITIES[self.priority],
         }
 
         # Extend our parameters

--- a/apprise/plugins/NotifyGotify.py
+++ b/apprise/plugins/NotifyGotify.py
@@ -49,13 +49,37 @@ class GotifyPriority(object):
     EMERGENCY = 10
 
 
-GOTIFY_PRIORITIES = (
-    GotifyPriority.LOW,
-    GotifyPriority.MODERATE,
-    GotifyPriority.NORMAL,
-    GotifyPriority.HIGH,
-    GotifyPriority.EMERGENCY,
-)
+GOTIFY_PRIORITIES = {
+    # Note: This also acts as a reverse lookup mapping
+    GotifyPriority.LOW: 'low',
+    GotifyPriority.MODERATE: 'moderate',
+    GotifyPriority.NORMAL: 'normal',
+    GotifyPriority.HIGH: 'high',
+    GotifyPriority.EMERGENCY: 'emergency',
+}
+
+GOTIFY_PRIORITY_MAP = {
+    # Maps against string 'low'
+    'l': GotifyPriority.LOW,
+    # Maps against string 'moderate'
+    'm': GotifyPriority.MODERATE,
+    # Maps against string 'normal'
+    'n': GotifyPriority.NORMAL,
+    # Maps against string 'high'
+    'h': GotifyPriority.HIGH,
+    # Maps against string 'emergency'
+    'e': GotifyPriority.EMERGENCY,
+
+    # Entries to additionally support (so more like Gotify's API)
+    '10': GotifyPriority.EMERGENCY,
+    # ^ 10 needs to be checked before '1' below or it will match the wrong
+    # priority
+    '0': GotifyPriority.LOW, '1': GotifyPriority.LOW, '2': GotifyPriority.LOW,
+    '3': GotifyPriority.MODERATE, '4': GotifyPriority.MODERATE,
+    '5': GotifyPriority.NORMAL, '6': GotifyPriority.NORMAL,
+    '7': GotifyPriority.NORMAL,
+    '8': GotifyPriority.HIGH, '9': GotifyPriority.HIGH,
+}
 
 
 class NotifyGotify(NotifyBase):
@@ -144,11 +168,14 @@ class NotifyGotify(NotifyBase):
         # prepare our fullpath
         self.fullpath = kwargs.get('fullpath', '/')
 
-        if priority not in GOTIFY_PRIORITIES:
-            self.priority = GotifyPriority.NORMAL
-
-        else:
-            self.priority = priority
+        # The Priority of the message
+        self.priority = int(
+            NotifyGotify.template_args['priority']['default']
+            if priority is None else
+            next((
+                v for k, v in GOTIFY_PRIORITY_MAP.items()
+                if str(priority).lower().startswith(k)),
+                NotifyGotify.template_args['priority']['default']))
 
         if self.secure:
             self.schema = 'https'
@@ -246,7 +273,10 @@ class NotifyGotify(NotifyBase):
 
         # Define any URL parameters
         params = {
-            'priority': self.priority,
+            'priority': str(
+                GOTIFY_PRIORITIES[self.template_args['priority']['default']]
+                if self.priority not in GOTIFY_PRIORITIES
+                else GOTIFY_PRIORITIES[self.priority]),
         }
 
         # Extend our parameters
@@ -294,20 +324,9 @@ class NotifyGotify(NotifyBase):
         results['fullpath'] = \
             '/' if not entries else '/{}/'.format('/'.join(entries))
 
+        # Set our priority
         if 'priority' in results['qsd'] and len(results['qsd']['priority']):
-            _map = {
-                'l': GotifyPriority.LOW,
-                'm': GotifyPriority.MODERATE,
-                'n': GotifyPriority.NORMAL,
-                'h': GotifyPriority.HIGH,
-                'e': GotifyPriority.EMERGENCY,
-            }
-            try:
-                results['priority'] = \
-                    _map[results['qsd']['priority'][0].lower()]
-
-            except KeyError:
-                # No priority was set
-                pass
+            results['priority'] = \
+                NotifyGotify.unquote(results['qsd']['priority'])
 
         return results

--- a/apprise/plugins/NotifyGrowl.py
+++ b/apprise/plugins/NotifyGrowl.py
@@ -197,7 +197,7 @@ class NotifyGrowl(NotifyBase):
             if not priority else \
             next((
                 v for k, v in GROWL_PRIORITY_MAP.items()
-                if str(priority).startswith(k)),
+                if str(priority).lower().startswith(k)),
                 NotifyGrowl.template_args['priority']['default'])
 
         # Our Registered object

--- a/apprise/plugins/NotifyOpsgenie.py
+++ b/apprise/plugins/NotifyOpsgenie.py
@@ -277,7 +277,7 @@ class NotifyOpsgenie(NotifyBase):
             if not priority else \
             next((
                 v for k, v in OPSGENIE_PRIORITY_MAP.items()
-                if str(priority).startswith(k)),
+                if str(priority).lower().startswith(k)),
                 NotifyOpsgenie.template_args['priority']['default'])
 
         # Store our region

--- a/apprise/plugins/NotifyOpsgenie.py
+++ b/apprise/plugins/NotifyOpsgenie.py
@@ -101,13 +101,40 @@ class OpsgeniePriority(object):
     EMERGENCY = 5
 
 
-OPSGENIE_PRIORITIES = (
-    OpsgeniePriority.LOW,
-    OpsgeniePriority.MODERATE,
-    OpsgeniePriority.NORMAL,
-    OpsgeniePriority.HIGH,
-    OpsgeniePriority.EMERGENCY,
-)
+OPSGENIE_PRIORITIES = {
+    # Note: This also acts as a reverse lookup mapping
+    OpsgeniePriority.LOW: 'low',
+    OpsgeniePriority.MODERATE: 'moderate',
+    OpsgeniePriority.NORMAL: 'normal',
+    OpsgeniePriority.HIGH: 'high',
+    OpsgeniePriority.EMERGENCY: 'emergency',
+}
+
+OPSGENIE_PRIORITY_MAP = {
+    # Maps against string 'low'
+    'l': OpsgeniePriority.LOW,
+    # Maps against string 'moderate'
+    'm': OpsgeniePriority.MODERATE,
+    # Maps against string 'normal'
+    'n': OpsgeniePriority.NORMAL,
+    # Maps against string 'high'
+    'h': OpsgeniePriority.HIGH,
+    # Maps against string 'emergency'
+    'e': OpsgeniePriority.EMERGENCY,
+
+    # Entries to additionally support (so more like Opsgenie's API)
+    '1': OpsgeniePriority.LOW,
+    '2': OpsgeniePriority.MODERATE,
+    '3': OpsgeniePriority.NORMAL,
+    '4': OpsgeniePriority.HIGH,
+    '5': OpsgeniePriority.EMERGENCY,
+    # Support p-prefix
+    'p1': OpsgeniePriority.LOW,
+    'p2': OpsgeniePriority.MODERATE,
+    'p3': OpsgeniePriority.NORMAL,
+    'p4': OpsgeniePriority.HIGH,
+    'p5': OpsgeniePriority.EMERGENCY,
+}
 
 
 class NotifyOpsgenie(NotifyBase):
@@ -246,11 +273,12 @@ class NotifyOpsgenie(NotifyBase):
             raise TypeError(msg)
 
         # The Priority of the message
-        if priority not in OPSGENIE_PRIORITIES:
-            self.priority = OpsgeniePriority.NORMAL
-
-        else:
-            self.priority = priority
+        self.priority = NotifyOpsgenie.template_args['priority']['default'] \
+            if not priority else \
+            next((
+                v for k, v in OPSGENIE_PRIORITY_MAP.items()
+                if str(priority).startswith(k)),
+                NotifyOpsgenie.template_args['priority']['default'])
 
         # Store our region
         try:
@@ -450,20 +478,13 @@ class NotifyOpsgenie(NotifyBase):
         Returns the URL built dynamically based on specified arguments.
         """
 
-        _map = {
-            OpsgeniePriority.LOW: 'low',
-            OpsgeniePriority.MODERATE: 'moderate',
-            OpsgeniePriority.NORMAL: 'normal',
-            OpsgeniePriority.HIGH: 'high',
-            OpsgeniePriority.EMERGENCY: 'emergency',
-        }
-
         # Define any URL parameters
         params = {
             'region': self.region_name,
             'priority':
-                _map[OpsgeniePriority.NORMAL] if self.priority not in _map
-                else _map[self.priority],
+                OPSGENIE_PRIORITIES[self.template_args['priority']['default']]
+                if self.priority not in OPSGENIE_PRIORITIES
+                else OPSGENIE_PRIORITIES[self.priority],
             'batch': 'yes' if self.batch_size > 1 else 'no',
         }
 
@@ -530,38 +551,10 @@ class NotifyOpsgenie(NotifyBase):
         results['details'] = {NotifyBase.unquote(x): NotifyBase.unquote(y)
                               for x, y in results['qsd+'].items()}
 
+        # Set our priority
         if 'priority' in results['qsd'] and len(results['qsd']['priority']):
-            _map = {
-                # Letter Assignnments
-                'l': OpsgeniePriority.LOW,
-                'm': OpsgeniePriority.MODERATE,
-                'n': OpsgeniePriority.NORMAL,
-                'h': OpsgeniePriority.HIGH,
-                'e': OpsgeniePriority.EMERGENCY,
-                'lo': OpsgeniePriority.LOW,
-                'me': OpsgeniePriority.MODERATE,
-                'no': OpsgeniePriority.NORMAL,
-                'hi': OpsgeniePriority.HIGH,
-                'em': OpsgeniePriority.EMERGENCY,
-                # Support 3rd Party API Documented Scale
-                '1': OpsgeniePriority.LOW,
-                '2': OpsgeniePriority.MODERATE,
-                '3': OpsgeniePriority.NORMAL,
-                '4': OpsgeniePriority.HIGH,
-                '5': OpsgeniePriority.EMERGENCY,
-                'p1': OpsgeniePriority.LOW,
-                'p2': OpsgeniePriority.MODERATE,
-                'p3': OpsgeniePriority.NORMAL,
-                'p4': OpsgeniePriority.HIGH,
-                'p5': OpsgeniePriority.EMERGENCY,
-            }
-            try:
-                results['priority'] = \
-                    _map[results['qsd']['priority'][0:2].lower()]
-
-            except KeyError:
-                # No priority was set
-                pass
+            results['priority'] = \
+                NotifyOpsgenie.unquote(results['qsd']['priority'])
 
         # Get Batch Boolean (if set)
         results['batch'] = \

--- a/apprise/plugins/NotifyProwl.py
+++ b/apprise/plugins/NotifyProwl.py
@@ -40,13 +40,34 @@ class ProwlPriority(object):
     EMERGENCY = 2
 
 
-PROWL_PRIORITIES = (
-    ProwlPriority.LOW,
-    ProwlPriority.MODERATE,
-    ProwlPriority.NORMAL,
-    ProwlPriority.HIGH,
-    ProwlPriority.EMERGENCY,
-)
+PROWL_PRIORITIES = {
+    # Note: This also acts as a reverse lookup mapping
+    ProwlPriority.LOW: 'low',
+    ProwlPriority.MODERATE: 'moderate',
+    ProwlPriority.NORMAL: 'normal',
+    ProwlPriority.HIGH: 'high',
+    ProwlPriority.EMERGENCY: 'emergency',
+}
+
+PROWL_PRIORITY_MAP = {
+    # Maps against string 'low'
+    'l': ProwlPriority.LOW,
+    # Maps against string 'moderate'
+    'm': ProwlPriority.MODERATE,
+    # Maps against string 'normal'
+    'n': ProwlPriority.NORMAL,
+    # Maps against string 'high'
+    'h': ProwlPriority.HIGH,
+    # Maps against string 'emergency'
+    'e': ProwlPriority.EMERGENCY,
+
+    # Entries to additionally support (so more like Prowl's API)
+    '-2': ProwlPriority.LOW,
+    '-1': ProwlPriority.MODERATE,
+    '0': ProwlPriority.NORMAL,
+    '1': ProwlPriority.HIGH,
+    '2': ProwlPriority.EMERGENCY,
+}
 
 # Provide some known codes Prowl uses and what they translate to:
 PROWL_HTTP_ERROR_MAP = {
@@ -124,11 +145,13 @@ class NotifyProwl(NotifyBase):
         """
         super(NotifyProwl, self).__init__(**kwargs)
 
-        if priority not in PROWL_PRIORITIES:
-            self.priority = self.template_args['priority']['default']
-
-        else:
-            self.priority = priority
+        # The Priority of the message
+        self.priority = NotifyProwl.template_args['priority']['default'] \
+            if not priority else \
+            next((
+                v for k, v in PROWL_PRIORITY_MAP.items()
+                if str(priority).startswith(k)),
+                NotifyProwl.template_args['priority']['default'])
 
         # API Key (associated with project)
         self.apikey = validate_regex(
@@ -229,18 +252,12 @@ class NotifyProwl(NotifyBase):
         Returns the URL built dynamically based on specified arguments.
         """
 
-        _map = {
-            ProwlPriority.LOW: 'low',
-            ProwlPriority.MODERATE: 'moderate',
-            ProwlPriority.NORMAL: 'normal',
-            ProwlPriority.HIGH: 'high',
-            ProwlPriority.EMERGENCY: 'emergency',
-        }
-
         # Define any URL parameters
         params = {
-            'priority': 'normal' if self.priority not in _map
-                        else _map[self.priority],
+            'priority':
+                PROWL_PRIORITIES[self.template_args['priority']['default']]
+                if self.priority not in PROWL_PRIORITIES
+                else PROWL_PRIORITIES[self.priority],
         }
 
         # Extend our parameters
@@ -276,32 +293,9 @@ class NotifyProwl(NotifyBase):
         except IndexError:
             pass
 
+        # Set our priority
         if 'priority' in results['qsd'] and len(results['qsd']['priority']):
-            _map = {
-                # Letter Assignments
-                'l': ProwlPriority.LOW,
-                'm': ProwlPriority.MODERATE,
-                'n': ProwlPriority.NORMAL,
-                'h': ProwlPriority.HIGH,
-                'e': ProwlPriority.EMERGENCY,
-                'lo': ProwlPriority.LOW,
-                'me': ProwlPriority.MODERATE,
-                'no': ProwlPriority.NORMAL,
-                'hi': ProwlPriority.HIGH,
-                'em': ProwlPriority.EMERGENCY,
-                # Support 3rd Party Documented Scale
-                '-2': ProwlPriority.LOW,
-                '-1': ProwlPriority.MODERATE,
-                '0': ProwlPriority.NORMAL,
-                '1': ProwlPriority.HIGH,
-                '2': ProwlPriority.EMERGENCY,
-            }
-            try:
-                results['priority'] = \
-                    _map[results['qsd']['priority'][0:2].lower()]
-
-            except KeyError:
-                # No priority was set
-                pass
+            results['priority'] = \
+                NotifyProwl.unquote(results['qsd']['priority'])
 
         return results

--- a/apprise/plugins/NotifyProwl.py
+++ b/apprise/plugins/NotifyProwl.py
@@ -150,7 +150,7 @@ class NotifyProwl(NotifyBase):
             if not priority else \
             next((
                 v for k, v in PROWL_PRIORITY_MAP.items()
-                if str(priority).startswith(k)),
+                if str(priority).lower().startswith(k)),
                 NotifyProwl.template_args['priority']['default'])
 
         # API Key (associated with project)

--- a/apprise/plugins/NotifyPushover.py
+++ b/apprise/plugins/NotifyPushover.py
@@ -102,13 +102,14 @@ PUSHOVER_SOUNDS = (
     PushoverSound.NONE,
 )
 
-PUSHOVER_PRIORITIES = (
-    PushoverPriority.LOW,
-    PushoverPriority.MODERATE,
-    PushoverPriority.NORMAL,
-    PushoverPriority.HIGH,
-    PushoverPriority.EMERGENCY,
-)
+PUSHOVER_PRIORITIES = {
+    # Note: This also acts as a reverse lookup mapping
+    PushoverPriority.LOW: 'low',
+    PushoverPriority.MODERATE: 'moderate',
+    PushoverPriority.NORMAL: 'normal',
+    PushoverPriority.HIGH: 'high',
+    PushoverPriority.EMERGENCY: 'emergency',
+}
 
 PUSHOVER_PRIORITY_MAP = {
     # Maps against string 'low'
@@ -531,19 +532,12 @@ class NotifyPushover(NotifyBase):
         Returns the URL built dynamically based on specified arguments.
         """
 
-        _map = {
-            PushoverPriority.LOW: 'low',
-            PushoverPriority.MODERATE: 'moderate',
-            PushoverPriority.NORMAL: 'normal',
-            PushoverPriority.HIGH: 'high',
-            PushoverPriority.EMERGENCY: 'emergency',
-        }
-
         # Define any URL parameters
         params = {
             'priority':
-                _map[self.template_args['priority']['default']]
-                if self.priority not in _map else _map[self.priority],
+                PUSHOVER_PRIORITIES[self.template_args['priority']['default']]
+                if self.priority not in PUSHOVER_PRIORITIES
+                else PUSHOVER_PRIORITIES[self.priority],
         }
 
         # Only add expire and retry for emergency messages,

--- a/apprise/plugins/NotifyPushover.py
+++ b/apprise/plugins/NotifyPushover.py
@@ -286,12 +286,13 @@ class NotifyPushover(NotifyBase):
             raise TypeError(msg)
 
         # The Priority of the message
-        self.priority = NotifyPushover.template_args['priority']['default'] \
-            if not priority else \
+        self.priority = int(
+            NotifyPushover.template_args['priority']['default']
+            if priority is None else
             next((
                 v for k, v in PUSHOVER_PRIORITY_MAP.items()
                 if str(priority).lower().startswith(k)),
-                NotifyPushover.template_args['priority']['default'])
+                NotifyPushover.template_args['priority']['default']))
 
         # The following are for emergency alerts
         if self.priority == PushoverPriority.EMERGENCY:
@@ -535,9 +536,9 @@ class NotifyPushover(NotifyBase):
         # Define any URL parameters
         params = {
             'priority':
-                str(PUSHOVER_PRIORITIES[self.template_args['priority']['default']]
+                PUSHOVER_PRIORITIES[self.template_args['priority']['default']]
                 if self.priority not in PUSHOVER_PRIORITIES
-                else PUSHOVER_PRIORITIES[self.priority]),
+                else PUSHOVER_PRIORITIES[self.priority],
         }
 
         # Only add expire and retry for emergency messages,

--- a/apprise/plugins/NotifyPushover.py
+++ b/apprise/plugins/NotifyPushover.py
@@ -290,7 +290,7 @@ class NotifyPushover(NotifyBase):
             if not priority else \
             next((
                 v for k, v in PUSHOVER_PRIORITY_MAP.items()
-                if str(priority).startswith(k)),
+                if str(priority).lower().startswith(k)),
                 NotifyPushover.template_args['priority']['default'])
 
         # The following are for emergency alerts

--- a/apprise/plugins/NotifyPushover.py
+++ b/apprise/plugins/NotifyPushover.py
@@ -535,9 +535,9 @@ class NotifyPushover(NotifyBase):
         # Define any URL parameters
         params = {
             'priority':
-                PUSHOVER_PRIORITIES[self.template_args['priority']['default']]
+                str(PUSHOVER_PRIORITIES[self.template_args['priority']['default']]
                 if self.priority not in PUSHOVER_PRIORITIES
-                else PUSHOVER_PRIORITIES[self.priority],
+                else PUSHOVER_PRIORITIES[self.priority]),
         }
 
         # Only add expire and retry for emergency messages,

--- a/test/test_apprise_config.py
+++ b/test/test_apprise_config.py
@@ -31,9 +31,9 @@ import pytest
 from apprise import NotifyFormat
 from apprise import ConfigFormat
 from apprise import ContentIncludeMode
-from apprise.Apprise import Apprise
-from apprise.AppriseConfig import AppriseConfig
-from apprise.AppriseAsset import AppriseAsset
+from apprise import Apprise
+from apprise import AppriseConfig
+from apprise import AppriseAsset
 from apprise.config.ConfigBase import ConfigBase
 from apprise.plugins.NotifyBase import NotifyBase
 

--- a/test/test_plugin_growl.py
+++ b/test/test_plugin_growl.py
@@ -330,9 +330,9 @@ def test_plugin_growl_config_files(mock_gntp):
     content = """
     urls:
       - growl://pass@growl.server:
-          - priority: -1
+          - priority: -2
             tag: growl_int low
-          - priority: "-1"
+          - priority: "-2"
             tag: growl_str_int low
           - priority: low
             tag: growl_str low
@@ -344,7 +344,7 @@ def test_plugin_growl_config_files(mock_gntp):
       - growl://pass@growl.server:
           - priority: 2
             tag: growl_int emerg
-          - priority: 2
+          - priority: "2"
             tag: growl_str_int emerg
           - priority: emergency
             tag: growl_str emerg
@@ -373,7 +373,13 @@ def test_plugin_growl_config_files(mock_gntp):
     assert len(ac.servers()) == 7
     assert len(aobj) == 7
     assert len([x for x in aobj.find(tag='low')]) == 3
+    for s in aobj.find(tag='low'):
+        assert s.priority == GrowlPriority.LOW
+
     assert len([x for x in aobj.find(tag='emerg')]) == 3
+    for s in aobj.find(tag='emerg'):
+        assert s.priority == GrowlPriority.EMERGENCY
+
     assert len([x for x in aobj.find(tag='growl_str')]) == 2
     assert len([x for x in aobj.find(tag='growl_str_int')]) == 2
     assert len([x for x in aobj.find(tag='growl_int')]) == 2

--- a/test/test_plugin_growl.py
+++ b/test/test_plugin_growl.py
@@ -28,6 +28,7 @@ import mock
 import six
 import pytest
 import apprise
+from apprise.plugins.NotifyGrowl import GrowlPriority
 
 try:
     from gntp import errors
@@ -317,3 +318,66 @@ def test_plugin_growl_general(mock_gntp):
             print('%s / %s' % (url, str(e)))
             assert exception is not None
             assert isinstance(e, exception)
+
+
+@pytest.mark.skipif(
+    'gntp' not in sys.modules, reason="Requires gntp")
+@mock.patch('gntp.notifier.GrowlNotifier')
+def test_plugin_growl_config_files(mock_gntp):
+    """
+    NotifyGrowl() Config File Cases
+    """
+    content = """
+    urls:
+      - growl://pass@growl.server:
+          - priority: -1
+            tag: growl_int low
+          - priority: "-1"
+            tag: growl_str_int low
+          - priority: low
+            tag: growl_str low
+
+          # This will take on moderate (default) priority
+          - priority: invalid
+            tag: growl_invalid
+
+      - growl://pass@growl.server:
+          - priority: 2
+            tag: growl_int emerg
+          - priority: 2
+            tag: growl_str_int emerg
+          - priority: emergency
+            tag: growl_str emerg
+    """
+
+    # Disable Throttling to speed testing
+    apprise.plugins.NotifyGrowl.request_rate_per_sec = 0
+
+    mock_notifier = mock.Mock()
+    mock_gntp.return_value = mock_notifier
+    mock_notifier.notify.return_value = True
+
+    # Create ourselves a config object
+    ac = apprise.AppriseConfig()
+    assert ac.add_config(content=content) is True
+
+    aobj = apprise.Apprise()
+
+    # Add our configuration
+    aobj.add(ac)
+
+    # We should be able to read our 7 servers from that
+    # 3x low
+    # 3x emerg
+    # 1x invalid (so takes on normal priority)
+    assert len(ac.servers()) == 7
+    assert len(aobj) == 7
+    assert len([x for x in aobj.find(tag='low')]) == 3
+    assert len([x for x in aobj.find(tag='emerg')]) == 3
+    assert len([x for x in aobj.find(tag='growl_str')]) == 2
+    assert len([x for x in aobj.find(tag='growl_str_int')]) == 2
+    assert len([x for x in aobj.find(tag='growl_int')]) == 2
+
+    assert len([x for x in aobj.find(tag='growl_invalid')]) == 1
+    assert next(aobj.find(tag='growl_invalid')).priority == \
+        GrowlPriority.NORMAL

--- a/test/test_plugin_opsgenie.py
+++ b/test/test_plugin_opsgenie.py
@@ -22,7 +22,10 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-from apprise import plugins
+import mock
+import requests
+from apprise.plugins.NotifyOpsgenie import OpsgeniePriority
+import apprise
 from helpers import AppriseURLTester
 
 # Disable logging for a cleaner testing output
@@ -52,72 +55,72 @@ apprise_url_tests = (
     }),
     ('opsgenie://apikey/', {
         # No targets specified; this is allowed
-        'instance': plugins.NotifyOpsgenie,
+        'instance': apprise.plugins.NotifyOpsgenie,
     }),
     ('opsgenie://apikey/user', {
         # Valid user
-        'instance': plugins.NotifyOpsgenie,
+        'instance': apprise.plugins.NotifyOpsgenie,
         'privacy_url': 'opsgenie://a...y/%40user',
     }),
     ('opsgenie://apikey/@user?region=eu', {
         # European Region
-        'instance': plugins.NotifyOpsgenie,
+        'instance': apprise.plugins.NotifyOpsgenie,
     }),
     ('opsgenie://apikey/@user?entity=A%20Entity', {
         # Assign an entity
-        'instance': plugins.NotifyOpsgenie,
+        'instance': apprise.plugins.NotifyOpsgenie,
     }),
     ('opsgenie://apikey/@user?alias=An%20Alias', {
         # Assign an alias
-        'instance': plugins.NotifyOpsgenie,
+        'instance': apprise.plugins.NotifyOpsgenie,
     }),
     ('opsgenie://apikey/@user?priority=p3', {
         # Assign our priority
-        'instance': plugins.NotifyOpsgenie,
+        'instance': apprise.plugins.NotifyOpsgenie,
     }),
     ('opsgenie://apikey/?tags=comma,separated', {
         # Test our our 'tags' (tag is reserved in Apprise) but not 'tags'
         # Also test the fact we do not need to define a target
-        'instance': plugins.NotifyOpsgenie,
+        'instance': apprise.plugins.NotifyOpsgenie,
     }),
     ('opsgenie://apikey/@user?priority=invalid', {
         # Invalid priority (loads using default)
-        'instance': plugins.NotifyOpsgenie,
+        'instance': apprise.plugins.NotifyOpsgenie,
     }),
     ('opsgenie://apikey/user@email.com/#team/*sche/^esc/%20/a', {
         # Valid user (email), valid schedule, Escalated ID,
         # an invalid entry (%20), and too short of an entry (a)
-        'instance': plugins.NotifyOpsgenie,
+        'instance': apprise.plugins.NotifyOpsgenie,
     }),
     ('opsgenie://apikey/{}/@{}/#{}/*{}/^{}/'.format(
         UUID4, UUID4, UUID4, UUID4, UUID4), {
         # similar to the above, except we use the UUID's
-        'instance': plugins.NotifyOpsgenie,
+        'instance': apprise.plugins.NotifyOpsgenie,
     }),
     ('opsgenie://apikey?to=#team,user&+key=value&+type=override', {
         # Test to= and details (key/value pair) also override 'type'
-        'instance': plugins.NotifyOpsgenie,
+        'instance': apprise.plugins.NotifyOpsgenie,
     }),
     ('opsgenie://apikey/#team/@user/?batch=yes', {
         # Test batch=
-        'instance': plugins.NotifyOpsgenie,
+        'instance': apprise.plugins.NotifyOpsgenie,
     }),
     ('opsgenie://apikey/#team/@user/?batch=no', {
         # Test batch=
-        'instance': plugins.NotifyOpsgenie,
+        'instance': apprise.plugins.NotifyOpsgenie,
     }),
     ('opsgenie://?apikey=abc&to=user', {
         # Test Kwargs
-        'instance': plugins.NotifyOpsgenie,
+        'instance': apprise.plugins.NotifyOpsgenie,
     }),
     ('opsgenie://apikey/#team/user/', {
-        'instance': plugins.NotifyOpsgenie,
+        'instance': apprise.plugins.NotifyOpsgenie,
         # throw a bizzare code forcing us to fail to look it up
         'response': False,
         'requests_response_code': 999,
     }),
     ('opsgenie://apikey/#topic1/device/', {
-        'instance': plugins.NotifyOpsgenie,
+        'instance': apprise.plugins.NotifyOpsgenie,
         # Throws a series of connection and transfer exceptions when this flag
         # is set and tests that we gracfully handle them
         'test_requests_exceptions': True,
@@ -131,5 +134,80 @@ def test_plugin_opsgenie_urls():
 
     """
 
+    # Disable Throttling to speed testing
+    apprise.plugins.NotifyOpsgenie.request_rate_per_sec = 0
+
     # Run our general tests
     AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+@mock.patch('requests.post')
+def test_plugin_opsgenie_config_files(mock_post):
+    """
+    NotifyOpsgenie() Config File Cases
+    """
+    content = """
+    urls:
+      - opsgenie://apikey/user:
+          - priority: 1
+            tag: opsgenie_int low
+          - priority: "1"
+            tag: opsgenie_str_int low
+          - priority: "p1"
+            tag: opsgenie_pstr_int low
+          - priority: low
+            tag: opsgenie_str low
+
+          # This will take on moderate (default) priority
+          - priority: invalid
+            tag: opsgenie_invalid
+
+      - opsgenie://apikey2/user2:
+          - priority: 5
+            tag: opsgenie_int emerg
+          - priority: "5"
+            tag: opsgenie_str_int emerg
+          - priority: "p5"
+            tag: opsgenie_pstr_int emerg
+          - priority: emergency
+            tag: opsgenie_str emerg
+    """
+
+    # Disable Throttling to speed testing
+    apprise.plugins.NotifyOpsgenie.request_rate_per_sec = 0
+
+    # Prepare Mock
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    # Create ourselves a config object
+    ac = apprise.AppriseConfig()
+    assert ac.add_config(content=content) is True
+
+    aobj = apprise.Apprise()
+
+    # Add our configuration
+    aobj.add(ac)
+
+    # We should be able to read our 9 servers from that
+    # 4x low
+    # 4x emerg
+    # 1x invalid (so takes on normal priority)
+    assert len(ac.servers()) == 9
+    assert len(aobj) == 9
+    assert len([x for x in aobj.find(tag='low')]) == 4
+    for s in aobj.find(tag='low'):
+        assert s.priority == OpsgeniePriority.LOW
+
+    assert len([x for x in aobj.find(tag='emerg')]) == 4
+    for s in aobj.find(tag='emerg'):
+        assert s.priority == OpsgeniePriority.EMERGENCY
+
+    assert len([x for x in aobj.find(tag='opsgenie_str')]) == 2
+    assert len([x for x in aobj.find(tag='opsgenie_str_int')]) == 2
+    assert len([x for x in aobj.find(tag='opsgenie_pstr_int')]) == 2
+    assert len([x for x in aobj.find(tag='opsgenie_int')]) == 2
+
+    assert len([x for x in aobj.find(tag='opsgenie_invalid')]) == 1
+    assert next(aobj.find(tag='opsgenie_invalid')).priority == \
+        OpsgeniePriority.NORMAL

--- a/test/test_plugin_pushover.py
+++ b/test/test_plugin_pushover.py
@@ -440,3 +440,6 @@ def test_plugin_pushover_config_files(mock_post):
     assert len([x for x in aobj.find(tag='pushover_invalid')]) == 1
     assert next(aobj.find(tag='pushover_invalid')).priority == \
         PushoverPriority.NORMAL
+
+    # Notifications work
+    assert aobj.notify(title="title", body="body") is True

--- a/test/test_plugin_pushover.py
+++ b/test/test_plugin_pushover.py
@@ -28,12 +28,9 @@ import mock
 import requests
 import pytest
 from json import dumps
-from apprise import Apprise
-from apprise import NotifyType
-from apprise import AppriseConfig
-from apprise import AppriseAttachment
 from apprise.plugins.NotifyPushover import PushoverPriority
 from apprise import plugins
+import apprise
 from helpers import AppriseURLTester
 
 # Disable logging for a cleaner testing output
@@ -218,10 +215,11 @@ def test_plugin_pushover_attachments(mock_post, tmpdir):
     mock_post.return_value = response
 
     # prepare our attachment
-    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, 'apprise-test.gif'))
+    attach = apprise.AppriseAttachment(
+        os.path.join(TEST_VAR_DIR, 'apprise-test.gif'))
 
     # Instantiate our object
-    obj = Apprise.instantiate(
+    obj = apprise.Apprise.instantiate(
         'pover://{}@{}/'.format(user_key, api_token))
     assert isinstance(obj, plugins.NotifyPushover)
 
@@ -253,7 +251,7 @@ def test_plugin_pushover_attachments(mock_post, tmpdir):
     image = tmpdir.mkdir("pover_image").join("test.jpg")
     image.write('a' * plugins.NotifyPushover.attach_max_size_bytes)
 
-    attach = AppriseAttachment.instantiate(str(image))
+    attach = apprise.AppriseAttachment.instantiate(str(image))
     assert obj.notify(body="test", attach=attach) is True
 
     # Test our call count
@@ -265,16 +263,17 @@ def test_plugin_pushover_attachments(mock_post, tmpdir):
     mock_post.reset_mock()
 
     # Add 1 more byte to the file (putting it over the limit)
-    image.write('a' * (plugins.NotifyPushover.attach_max_size_bytes + 1))
+    image.write(
+        'a' * (plugins.NotifyPushover.attach_max_size_bytes + 1))
 
-    attach = AppriseAttachment.instantiate(str(image))
+    attach = apprise.AppriseAttachment.instantiate(str(image))
     assert obj.notify(body="test", attach=attach) is False
 
     # Test our call count
     assert mock_post.call_count == 0
 
     # Test case when file is missing
-    attach = AppriseAttachment.instantiate(
+    attach = apprise.AppriseAttachment.instantiate(
         'file://{}?cache=False'.format(str(image)))
     os.unlink(str(image))
     assert obj.notify(
@@ -286,13 +285,14 @@ def test_plugin_pushover_attachments(mock_post, tmpdir):
     # Test unsuported files:
     image = tmpdir.mkdir("pover_unsupported").join("test.doc")
     image.write('a' * 256)
-    attach = AppriseAttachment.instantiate(str(image))
+    attach = apprise.AppriseAttachment.instantiate(str(image))
 
     # Content is silently ignored
     assert obj.notify(body="test", attach=attach) is True
 
     # prepare our attachment
-    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, 'apprise-test.gif'))
+    attach = apprise.AppriseAttachment(
+        os.path.join(TEST_VAR_DIR, 'apprise-test.gif'))
 
     # Throw an exception on the first call to requests.post()
     for side_effect in (requests.RequestException(), OSError(), bad_response):
@@ -343,7 +343,7 @@ def test_plugin_pushover_edge_cases(mock_post):
     # This call fails because there is 1 invalid device
     assert obj.notify(
         body='body', title='title',
-        notify_type=NotifyType.INFO) is False
+        notify_type=apprise.NotifyType.INFO) is False
 
     obj = plugins.NotifyPushover(user_key=user_key, token=token)
     assert isinstance(obj, plugins.NotifyPushover) is True
@@ -353,9 +353,11 @@ def test_plugin_pushover_edge_cases(mock_post):
 
     # This call succeeds because all of the devices are valid
     assert obj.notify(
-        body='body', title='title', notify_type=NotifyType.INFO) is True
+        body='body', title='title',
+        notify_type=apprise.NotifyType.INFO) is True
 
-    obj = plugins.NotifyPushover(user_key=user_key, token=token, targets=set())
+    obj = plugins.NotifyPushover(
+        user_key=user_key, token=token, targets=set())
     assert isinstance(obj, plugins.NotifyPushover) is True
     # Default is to send to all devices, so there will be a
     # device defined here
@@ -409,10 +411,10 @@ def test_plugin_pushover_config_files(mock_post):
     mock_post.return_value.status_code = requests.codes.ok
 
     # Create ourselves a config object
-    ac = AppriseConfig()
+    ac = apprise.AppriseConfig()
     assert ac.add_config(content=content) is True
 
-    aobj = Apprise()
+    aobj = apprise.Apprise()
 
     # Add our configuration
     aobj.add(ac)

--- a/test/test_plugin_pushover.py
+++ b/test/test_plugin_pushover.py
@@ -390,7 +390,7 @@ def test_plugin_pushover_config_files(mock_post):
           - priority: low
             tag: pushover_str low
 
-          # This will take on moderate (default) priority
+          # This will take on normal (default) priority
           - priority: invalid
             tag: pushover_invalid
 

--- a/test/test_plugin_pushover.py
+++ b/test/test_plugin_pushover.py
@@ -381,9 +381,9 @@ def test_plugin_pushover_config_files(mock_post):
     content = """
     urls:
       - pover://USER@TOKEN:
-          - priority: -1
+          - priority: -2
             tag: pushover_int low
-          - priority: "-1"
+          - priority: "-2"
             tag: pushover_str_int low
           - priority: low
             tag: pushover_str low
@@ -395,7 +395,7 @@ def test_plugin_pushover_config_files(mock_post):
       - pover://USER2@TOKEN2:
           - priority: 2
             tag: pushover_int emerg
-          - priority: 2
+          - priority: "2"
             tag: pushover_str_int emerg
           - priority: emergency
             tag: pushover_str emerg
@@ -424,7 +424,13 @@ def test_plugin_pushover_config_files(mock_post):
     assert len(ac.servers()) == 7
     assert len(aobj) == 7
     assert len([x for x in aobj.find(tag='low')]) == 3
+    for s in aobj.find(tag='low'):
+        assert s.priority == PushoverPriority.LOW
+
     assert len([x for x in aobj.find(tag='emerg')]) == 3
+    for s in aobj.find(tag='emerg'):
+        assert s.priority == PushoverPriority.EMERGENCY
+
     assert len([x for x in aobj.find(tag='pushover_str')]) == 2
     assert len([x for x in aobj.find(tag='pushover_str_int')]) == 2
     assert len([x for x in aobj.find(tag='pushover_int')]) == 2


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #596 

Tokens passed via the Configuration files (yaml or text) skip the `parse_url()` function completely. Thus the additional processing that is actually done in `parse_url()` is never ran against certain tokens otherwise provided in a config file.  For this reason `parse_url()` should NEVER do any processing at all.  It should be moved into `__init__()` for a common and consistent handling.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@596-refactor-token-parsing

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  <apprise url related to ticket>

```

