### PR TITLE
adds Markdown support to Pushover

### DIFF
--- a/apprise/plugins/NotifyPushover.py
+++ b/apprise/plugins/NotifyPushover.py
@@ -30,6 +30,7 @@ import requests
 from .NotifyBase import NotifyBase
 from ..common import NotifyType
 from ..common import NotifyFormat
+from ..conversion import convert_between
 from ..utils import parse_list
 from ..utils import validate_regex
 from ..AppriseLocale import gettext_lazy as _
@@ -366,6 +367,10 @@ class NotifyPushover(NotifyBase):
 
             if self.notify_format == NotifyFormat.HTML:
                 # https://pushover.net/api#html
+                payload['html'] = 1
+            elif self.notify_format == NotifyFormat.MARKDOWN:
+                payload['message'] = convert_between(
+                    NotifyFormat.MARKDOWN, NotifyFormat.HTML, body)
                 payload['html'] = 1
 
             if self.priority == PushoverPriority.EMERGENCY:


### PR DESCRIPTION
## Description:
This PR adds Markdown support to the Pushover notification plugin. When identified as a `markdown` formatted message the text is converted to HTML and the `html` tag set on the message payload.

## Checklist
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
Test with a notification config like: `pover://USER@TOKEN?format=markdown` and use a Markdown style payload: 
~~~~
# heading
_bold_
[a link](http://example.com)
~~~~
