### PR TITLE
Verify that <br/> is properly escapped in telegram calls

### DIFF
--- a/test/test_plugin_telegram.py
+++ b/test/test_plugin_telegram.py
@@ -792,6 +792,35 @@ def test_plugin_telegram_formating_py3(mock_post):
         '# A Great Title\r\n_[Apprise Body Title](http://localhost)_ had ' \
         '[a change](http://127.0.0.2)'
 
+    # Reset our values
+    mock_post.reset_mock()
+
+    # Now test that <br/> is correctly escaped
+    title = 'Test Message Title'
+    body = 'Test Message Body <br/> ok</br>'
+
+    aobj = Apprise()
+    aobj.add('tgram://1234:aaaaaaaaa/-1123456245134')
+    assert len(aobj) == 1
+
+    assert aobj.notify(
+        title=title, body=body, body_format=NotifyFormat.MARKDOWN)
+
+    # Test our calls
+    assert mock_post.call_count == 1
+
+    assert mock_post.call_args_list[0][0][0] == \
+        'https://api.telegram.org/bot1234:aaaaaaaaa/sendMessage'
+
+    payload = loads(mock_post.call_args_list[0][1]['data'])
+
+    # Test that everything is escaped properly in a HTML mode
+    assert payload['text'] == \
+        '<b>Test Message Title\r\n' \
+        '</b>\r\n' \
+        'Test Message Body\r\n' \
+        'ok\r\n'
+
 
 @pytest.mark.skipif(sys.version_info.major >= 3, reason="Requires Python 2.x+")
 @mock.patch('requests.post')
@@ -1093,6 +1122,35 @@ def test_plugin_telegram_formating_py2(mock_post):
     assert payload['text'] == \
         '# A Great Title\r\n_[Apprise Body Title](http://localhost)_ had ' \
         '[a change](http://127.0.0.2)'
+
+    # Reset our values
+    mock_post.reset_mock()
+
+    # Now test that <br/> is correctly escaped
+    title = 'Test Message Title'
+    body = 'Test Message Body <br/> ok</br>'
+
+    aobj = Apprise()
+    aobj.add('tgram://1234:aaaaaaaaa/-1123456245134')
+    assert len(aobj) == 1
+
+    assert aobj.notify(
+        title=title, body=body, body_format=NotifyFormat.MARKDOWN)
+
+    # Test our calls
+    assert mock_post.call_count == 1
+
+    assert mock_post.call_args_list[0][0][0] == \
+        'https://api.telegram.org/bot1234:aaaaaaaaa/sendMessage'
+
+    payload = loads(mock_post.call_args_list[0][1]['data'])
+
+    # Test that everything is escaped properly in a HTML mode
+    assert payload['text'] == \
+        '<b>Test Message Title\r\n' \
+        '</b>\r\n' \
+        'Test Message Body\r\n' \
+        'ok\r\n'
 
 
 @mock.patch('requests.post')

--- a/test/test_plugin_telegram.py
+++ b/test/test_plugin_telegram.py
@@ -821,6 +821,34 @@ def test_plugin_telegram_formating_py3(mock_post):
         'Test Message Body\r\n' \
         'ok\r\n'
 
+    # Reset our values
+    mock_post.reset_mock()
+
+    # Now test that <br/> is correctly escaped as it would have been via the
+    # CLI mode where the body_format is TEXT
+    title = 'Test Message Title'
+    body = 'Test Message Body <br/> ok</br>'
+
+    aobj = Apprise()
+    aobj.add('tgram://1234:aaaaaaaaa/-1123456245134')
+    assert len(aobj) == 1
+
+    assert aobj.notify(
+        title=title, body=body, body_format=NotifyFormat.TEXT)
+
+    # Test our calls
+    assert mock_post.call_count == 1
+
+    assert mock_post.call_args_list[0][0][0] == \
+        'https://api.telegram.org/bot1234:aaaaaaaaa/sendMessage'
+
+    payload = loads(mock_post.call_args_list[0][1]['data'])
+
+    # Test that everything is escaped properly in a HTML mode
+    assert payload['text'] == \
+        '<b>Test Message Title</b>\r\n' \
+        'Test Message Body &lt;br/&gt; ok&lt;/br&gt;'
+
 
 @pytest.mark.skipif(sys.version_info.major >= 3, reason="Requires Python 2.x+")
 @mock.patch('requests.post')
@@ -1151,6 +1179,31 @@ def test_plugin_telegram_formating_py2(mock_post):
         '</b>\r\n' \
         'Test Message Body\r\n' \
         'ok\r\n'
+
+    # Now test that <br/> is correctly escaped as it would have been via the
+    # CLI mode where the body_format is TEXT
+    title = 'Test Message Title'
+    body = 'Test Message Body <br/> ok</br>'
+
+    aobj = Apprise()
+    aobj.add('tgram://1234:aaaaaaaaa/-1123456245134')
+    assert len(aobj) == 1
+
+    assert aobj.notify(
+        title=title, body=body, body_format=NotifyFormat.TEXT)
+
+    # Test our calls
+    assert mock_post.call_count == 1
+
+    assert mock_post.call_args_list[0][0][0] == \
+        'https://api.telegram.org/bot1234:aaaaaaaaa/sendMessage'
+
+    payload = loads(mock_post.call_args_list[0][1]['data'])
+
+    # Test that everything is escaped properly in a HTML mode
+    assert payload['text'] == \
+        '<b>Test Message Title</b>\r\n' \
+        'Test Message Body &lt;br/&gt; ok&lt;/br&gt;'
 
 
 @mock.patch('requests.post')

--- a/test/test_plugin_telegram.py
+++ b/test/test_plugin_telegram.py
@@ -795,7 +795,9 @@ def test_plugin_telegram_formating_py3(mock_post):
     # Reset our values
     mock_post.reset_mock()
 
+    #
     # Now test that <br/> is correctly escaped
+    #
     title = 'Test Message Title'
     body = 'Test Message Body <br/> ok</br>'
 
@@ -824,10 +826,10 @@ def test_plugin_telegram_formating_py3(mock_post):
     # Reset our values
     mock_post.reset_mock()
 
+    #
     # Now test that <br/> is correctly escaped as it would have been via the
     # CLI mode where the body_format is TEXT
-    title = 'Test Message Title'
-    body = 'Test Message Body <br/> ok</br>'
+    #
 
     aobj = Apprise()
     aobj.add('tgram://1234:aaaaaaaaa/-1123456245134')
@@ -848,6 +850,34 @@ def test_plugin_telegram_formating_py3(mock_post):
     assert payload['text'] == \
         '<b>Test Message Title</b>\r\n' \
         'Test Message Body &lt;br/&gt; ok&lt;/br&gt;'
+
+    # Reset our values
+    mock_post.reset_mock()
+
+    #
+    # Now test that <br/> is correctly escaped if fed as HTML
+    #
+
+    aobj = Apprise()
+    aobj.add('tgram://1234:aaaaaaaaa/-1123456245134')
+    assert len(aobj) == 1
+
+    assert aobj.notify(
+        title=title, body=body, body_format=NotifyFormat.HTML)
+
+    # Test our calls
+    assert mock_post.call_count == 1
+
+    assert mock_post.call_args_list[0][0][0] == \
+        'https://api.telegram.org/bot1234:aaaaaaaaa/sendMessage'
+
+    payload = loads(mock_post.call_args_list[0][1]['data'])
+
+    # Test that everything is escaped properly in a HTML mode
+    assert payload['text'] == \
+        '<b>Test Message Title</b>\r\n' \
+        'Test Message Body\r\n' \
+        'ok\r\n'
 
 
 @pytest.mark.skipif(sys.version_info.major >= 3, reason="Requires Python 2.x+")
@@ -1154,7 +1184,9 @@ def test_plugin_telegram_formating_py2(mock_post):
     # Reset our values
     mock_post.reset_mock()
 
+    #
     # Now test that <br/> is correctly escaped
+    #
     title = 'Test Message Title'
     body = 'Test Message Body <br/> ok</br>'
 
@@ -1180,10 +1212,13 @@ def test_plugin_telegram_formating_py2(mock_post):
         'Test Message Body\r\n' \
         'ok\r\n'
 
+    # Reset our values
+    mock_post.reset_mock()
+
+    #
     # Now test that <br/> is correctly escaped as it would have been via the
     # CLI mode where the body_format is TEXT
-    title = 'Test Message Title'
-    body = 'Test Message Body <br/> ok</br>'
+    #
 
     aobj = Apprise()
     aobj.add('tgram://1234:aaaaaaaaa/-1123456245134')
@@ -1204,6 +1239,34 @@ def test_plugin_telegram_formating_py2(mock_post):
     assert payload['text'] == \
         '<b>Test Message Title</b>\r\n' \
         'Test Message Body &lt;br/&gt; ok&lt;/br&gt;'
+
+    # Reset our values
+    mock_post.reset_mock()
+
+    #
+    # Now test that <br/> is correctly escaped if fed as HTML
+    #
+
+    aobj = Apprise()
+    aobj.add('tgram://1234:aaaaaaaaa/-1123456245134')
+    assert len(aobj) == 1
+
+    assert aobj.notify(
+        title=title, body=body, body_format=NotifyFormat.HTML)
+
+    # Test our calls
+    assert mock_post.call_count == 1
+
+    assert mock_post.call_args_list[0][0][0] == \
+        'https://api.telegram.org/bot1234:aaaaaaaaa/sendMessage'
+
+    payload = loads(mock_post.call_args_list[0][1]['data'])
+
+    # Test that everything is escaped properly in a HTML mode
+    assert payload['text'] == \
+        '<b>Test Message Title</b>\r\n' \
+        'Test Message Body\r\n' \
+        'ok\r\n'
 
 
 @mock.patch('requests.post')


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #606

Verified that Apprise is correctly escaping `<br/>` entries and converting them to `\r\n` as supported before posting them to Telegram.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@telegram-br-tokens

# Test out the changes with the following command:
apprise -vv -t "Test Message Title" -b "Test Message Body <br/> ok</br>" \
  "tgram://1234:aaaaaaaaa/-1001511191424"

```

