### PR TITLE
Escape new lines for TEXT->HTML conversions

### DIFF
--- a/apprise/URLBase.py
+++ b/apprise/URLBase.py
@@ -359,7 +359,7 @@ class URLBase(object):
                 .replace(u' ', u'&nbsp;')
 
         if convert_new_lines:
-            return escaped.replace(u'\n', u'&lt;br/&gt;')
+            return escaped.replace(u'\n', u'<br/>')
 
         return escaped
 

--- a/apprise/conversion.py
+++ b/apprise/conversion.py
@@ -70,7 +70,8 @@ def text_to_html(content):
     Converts specified content from plain text to HTML.
     """
 
-    return URLBase.escape_html(content)
+    # First eliminate any carriage returns
+    return URLBase.escape_html(content, convert_new_lines=True)
 
 
 def html_to_text(content):

--- a/test/test_notify_base.py
+++ b/test/test_notify_base.py
@@ -183,7 +183,7 @@ def test_notify_base():
 
     assert NotifyBase.escape_html(
         "<content>'\t \n</content>", convert_new_lines=True) == \
-        '&lt;content&gt;&apos;&emsp;&nbsp;&lt;br/&gt;&lt;/content&gt;'
+        '&lt;content&gt;&apos;&emsp;&nbsp;<br/>&lt;/content&gt;'
 
     # Test invalid data
     assert NotifyBase.split_path(None) == []


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #616

Bugfix introduced in Apprise v0.9.9 where `\n` is no longer correctly escaped when converting from TEXT -> HTML as a result of past code re-factoring.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@/616-text-to-html-crlf-fix

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "<apprise url>"
```

