### PR TITLE
Fix notify() failing when being called from an existing asynchronous event loop

### DIFF
--- a/apprise/Apprise.py
+++ b/apprise/Apprise.py
@@ -424,7 +424,7 @@ class Apprise(object):
 
         except TypeError:
             # No notifications sent, and there was an internal error.
-            return py3compat.asyncio.toasyncwrap(False)
+            return py3compat.asyncio.toasyncwrapvalue(False)
 
         else:
             if len(coroutines) > 0:
@@ -433,7 +433,7 @@ class Apprise(object):
 
             else:
                 # No notifications sent.
-                return py3compat.asyncio.toasyncwrap(None)
+                return py3compat.asyncio.toasyncwrapvalue(None)
 
     @staticmethod
     def _notifyhandler(server, **kwargs):
@@ -470,7 +470,7 @@ class Apprise(object):
             # Send the notification immediately, and wrap the result in a
             # coroutine.
             status = Apprise._notifyhandler(server, **kwargs)
-            return py3compat.asyncio.toasyncwrap(status)
+            return py3compat.asyncio.toasyncwrapvalue(status)
 
     def _notifyall(self, handler, body, title='', notify_type=NotifyType.INFO,
                    body_format=None, tag=MATCH_ALL_TAG, match_always=True,

--- a/test/test_asyncio.py
+++ b/test/test_asyncio.py
@@ -112,7 +112,7 @@ def test_apprise_asyncio_runtime_error():
         asyncio.set_event_loop(loop)
 
 
-@pytest.mark.skipif(sys.version_info.major <= 2 or sys.version_info <= (3, 6),
+@pytest.mark.skipif(sys.version_info.major <= 2 or sys.version_info < (3, 7),
                     reason="Requires Python 3.7+")
 def test_apprise_works_in_async_loop():
     """

--- a/test/test_asyncio.py
+++ b/test/test_asyncio.py
@@ -24,6 +24,7 @@
 # THE SOFTWARE.
 
 from __future__ import print_function
+import six
 import sys
 import pytest
 from apprise import Apprise
@@ -31,6 +32,9 @@ from apprise import NotifyBase
 from apprise import NotifyFormat
 
 from apprise.plugins import SCHEMA_MAP
+
+if not six.PY2:
+    import apprise.py3compat.asyncio as py3aio
 
 # Disable logging for a cleaner testing output
 import logging
@@ -106,3 +110,54 @@ def test_apprise_asyncio_runtime_error():
     finally:
         # Restore our event loop (in the event the above test failed)
         asyncio.set_event_loop(loop)
+
+
+@pytest.mark.skipif(sys.version_info.major <= 2 or sys.version_info <= (3, 6),
+                    reason="Requires Python 3.7+")
+def test_apprise_works_in_async_loop():
+    """
+    API: Apprise() can execute synchronously in an existing event loop
+
+    """
+    class GoodNotification(NotifyBase):
+        def __init__(self, **kwargs):
+            super(GoodNotification, self).__init__(
+                notify_format=NotifyFormat.HTML, **kwargs)
+
+        def url(self, **kwargs):
+            # Support URL
+            return ''
+
+        def send(self, **kwargs):
+            # Pretend everything is okay
+            return True
+
+        @staticmethod
+        def parse_url(url, *args, **kwargs):
+            # always parseable
+            return NotifyBase.parse_url(url, verify_host=False)
+
+    # Store our good notification in our schema map
+    SCHEMA_MAP['good'] = GoodNotification
+
+    # Create ourselves an Apprise object
+    a = Apprise()
+
+    # Add a few entries
+    for _ in range(25):
+        a.add('good://')
+
+    # To ensure backwards compatibility, it should be possible to call
+    # asynchronous Apprise methods from code that already uses an event loop,
+    # even when using the synchronous notify() method.
+    # see https://github.com/caronc/apprise/issues/610
+    import asyncio
+
+    def try_notify():
+        a.notify(title="title", body="body")
+
+    # Convert to a coroutine to run asynchronously.
+    cor = py3aio.toasyncwrap(try_notify)
+
+    # Should execute successfully.
+    asyncio.run(cor)


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #610

If an event loop is already in use, use it--instead of creating a new one, which fails with the high-level asyncio.run() function. Test included.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [X] The code change is tested and works locally.
* [X] There is no commented out code in this PR.
* [X] No lint errors (use `flake8`)
* [X] 100% test coverage