### PR TITLE
Fixed parsing of custom nid for Home Assistant plugin

### DIFF
--- a/apprise/plugins/NotifyHomeAssistant.py
+++ b/apprise/plugins/NotifyHomeAssistant.py
@@ -107,7 +107,7 @@ class NotifyHomeAssistant(NotifyBase):
             # Optional Unique Notification ID
             'name': _('Notification ID'),
             'type': 'string',
-            'regex': (r'^[a-f0-9_-]+$', 'i'),
+            'regex': (r'^[a-z0-9_-]+$', 'i'),
         },
     })
 


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #626

Fixed bug where `?nid=<value>` was not correctly parsed on the Home Assistant URL

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@626-home-assistant-nid-fix

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  <apprise url related to ticket>

```

