### PR TITLE
Discord Apprise URL supports thread= directive

### DIFF
--- a/apprise/plugins/NotifyDiscord.py
+++ b/apprise/plugins/NotifyDiscord.py
@@ -128,6 +128,12 @@ class NotifyDiscord(NotifyBase):
             'name': _('Avatar URL'),
             'type': 'string',
         },
+        # Send a message to the specified thread within a webhook's channel.
+        # The thread will automatically be unarchived.
+        'thread': {
+            'name': _('Thread ID'),
+            'type': 'string',
+        },
         'footer': {
             'name': _('Display Footer'),
             'type': 'bool',
@@ -153,7 +159,7 @@ class NotifyDiscord(NotifyBase):
 
     def __init__(self, webhook_id, webhook_token, tts=False, avatar=True,
                  footer=False, footer_logo=True, include_image=False,
-                 fields=True, avatar_url=None, **kwargs):
+                 fields=True, avatar_url=None, thread=None, **kwargs):
         """
         Initialize Discord Object
 
@@ -193,6 +199,9 @@ class NotifyDiscord(NotifyBase):
 
         # Use Fields
         self.fields = fields
+
+        # Specified Thread ID
+        self.thread_id = thread
 
         # Avatar URL
         # This allows a user to provide an over-ride to the otherwise
@@ -273,6 +282,9 @@ class NotifyDiscord(NotifyBase):
             # not markdown
             payload['content'] = \
                 body if not title else "{}\r\n{}".format(title, body)
+
+        if self.thread_id:
+            payload['thread_id'] = self.thread_id
 
         if self.avatar and (image_url or self.avatar_url):
             payload['avatar_url'] = \
@@ -447,6 +459,9 @@ class NotifyDiscord(NotifyBase):
         if self.avatar_url:
             params['avatar_url'] = self.avatar_url
 
+        if self.thread_id:
+            params['thread'] = self.thread_id
+
         # Extend our parameters
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
 
@@ -514,6 +529,13 @@ class NotifyDiscord(NotifyBase):
         if 'avatar_url' in results['qsd']:
             results['avatar_url'] = \
                 NotifyDiscord.unquote(results['qsd']['avatar_url'])
+
+        # Extract thread id if it was specified
+        if 'thread' in results['qsd']:
+            results['thread'] = \
+                NotifyDiscord.unquote(results['qsd']['thread'])
+
+        return results
 
         return results
 

--- a/apprise/plugins/NotifyDiscord.py
+++ b/apprise/plugins/NotifyDiscord.py
@@ -537,8 +537,6 @@ class NotifyDiscord(NotifyBase):
 
         return results
 
-        return results
-
     @staticmethod
     def parse_native_url(url):
         """

--- a/test/test_plugin_discord.py
+++ b/test/test_plugin_discord.py
@@ -113,6 +113,12 @@ apprise_url_tests = (
         'instance': plugins.NotifyDiscord,
         'requests_response_code': requests.codes.no_content,
     }),
+    # Thread ID
+    ('discord://%s/%s?format=markdown&thread=abc123' % (
+        'i' * 24, 't' * 64), {
+            'instance': plugins.NotifyDiscord,
+            'requests_response_code': requests.codes.no_content,
+    }),
     ('discord://%s/%s?format=text' % ('i' * 24, 't' * 64), {
         'instance': plugins.NotifyDiscord,
         'requests_response_code': requests.codes.no_content,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #628

Added support to be able to Send a message to the specified thread within a webhook's channel if you know the `thread_id`. The thread will automatically be unarchived.

### Parameter Breakdown
| Variable        | Required | Description
| --------------- | -------- | -----------
| thread     | No      | Send a message to the specified thread within a webhook's channel. The thread will automatically be unarchived.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@628-discord-thread-id

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  discord://config/thread=12345

```

