### PR TITLE
Add global support for port= directive when URL parsing

### DIFF
--- a/apprise/URLBase.py
+++ b/apprise/URLBase.py
@@ -677,6 +677,9 @@ class URLBase(object):
         if 'cto' in results['qsd']:
             results['socket_connect_timeout'] = results['qsd']['cto']
 
+        if 'port' in results['qsd']:
+            results['port'] = results['qsd']['port']
+
         return results
 
     @staticmethod

--- a/test/test_plugin_email.py
+++ b/test/test_plugin_email.py
@@ -863,3 +863,30 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
         'mailtos://user:pass123@hotmail.com')
     obj = Apprise.instantiate(results, suppress_exceptions=False)
     assert isinstance(obj, plugins.NotifyEmail) is True
+
+    #
+    # Test Port Over-Riding
+    #
+    results = plugins.NotifyEmail.parse_url(
+        "mailtos://abc:password@xyz.cn:465?"
+        "smtp=smtp.exmail.qq.com&mode=ssl")
+    obj = Apprise.instantiate(results, suppress_exceptions=False)
+    assert isinstance(obj, plugins.NotifyEmail) is True
+
+    # Verify our over-rides are in place
+    assert obj.smtp_host == 'smtp.exmail.qq.com'
+    assert obj.port == 465
+    assert obj.from_addr == 'abc@xyz.cn'
+    assert obj.secure_mode == 'ssl'
+
+    results = plugins.NotifyEmail.parse_url(
+        "mailtos://abc:password@xyz.cn?"
+        "smtp=smtp.exmail.qq.com&mode=ssl&port=465")
+    obj = Apprise.instantiate(results, suppress_exceptions=False)
+    assert isinstance(obj, plugins.NotifyEmail) is True
+
+    # Verify our over-rides are in place
+    assert obj.smtp_host == 'smtp.exmail.qq.com'
+    assert obj.port == 465
+    assert obj.from_addr == 'abc@xyz.cn'
+    assert obj.secure_mode == 'ssl'


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #635 

Support `port=` directive found in the Apprise URL's globally.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@635-email-port-override

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "mailtos://abc:password@xyz.cn?smtp=smtp.exmail.qq.com&mode=ssl&port=465"

```

