### PR TITLE
Fixed PagerDuty notify url assigned to method instead of string

### DIFF
--- a/apprise/plugins/NotifyPagerDuty.py
+++ b/apprise/plugins/NotifyPagerDuty.py
@@ -329,10 +329,10 @@ class NotifyPagerDuty(NotifyBase):
                 payload['payload']['custom_details'][k] = v
 
         # Prepare our URL based on region
-        url = PAGERDUTY_API_LOOKUP[self.region_name]
+        notify_url = PAGERDUTY_API_LOOKUP[self.region_name]
 
         self.logger.debug('Pager Duty POST URL: %s (cert_verify=%r)' % (
-            url, self.verify_certificate,
+            notify_url, self.verify_certificate,
         ))
         self.logger.debug('Pager Duty Payload: %s' % str(payload))
 
@@ -341,7 +341,7 @@ class NotifyPagerDuty(NotifyBase):
 
         try:
             r = requests.post(
-                self.url,
+                notify_url,
                 data=dumps(payload),
                 headers=headers,
                 verify=self.verify_certificate,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #643<!--apprise issue number goes here-->

<!-- Have anything else to describe? Define it here -->

## New Service Completion Status
<!-- This section is only applicable if you're adding a new service -->
* [x] apprise/plugins/Notify<!--ServiceName goes here-->.py
* [x] KEYWORDS
    - add new service into this file (alphabetically).
* [x] README.md
    - add entry for new service to table (as a quick reference)
* [x] packaging/redhat/python-apprise.spec
    - add new service into the `%global common_description`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:

1. Create a free PagerDuty account.
2. On your PagerDuty page, create the API access key from `Integrations -> API Access Keys`
3. Get the integration access key using the steps described in [PagerDuty Events API V2 docs](https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTgw-events-api-v2-overview).
4. Pull the changes and test as follows

```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@<this.branch-name>

# Test out the changes with the following command:
apprise -vv -t "Test Message Title" -b "Test Message Body" \
   "pagerduty://integration_key@api_key"

```

