### PR TITLE
Test cases leverage unittest.mock when available

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 coverage
 flake8
-mock
+mock; python_version=='2.7'
 pytest
 pytest-cov
 tox

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -161,7 +161,12 @@ Requires: python%{python3_pkgversion}-cryptography
 Requires: python%{python3_pkgversion}-yaml
 
 %if %{with tests}
+%if 0%{?fedora} >= 37 || 0%{?rhel} >= 9
+# Do not import python3-mock
+%else
+# python-mock switched to unittest.mock
 BuildRequires: python%{python3_pkgversion}-mock
+%endif
 BuildRequires: python%{python3_pkgversion}-pytest
 BuildRequires: python%{python3_pkgversion}-pytest-runner
 %endif
@@ -181,6 +186,14 @@ rm -f apprise/py3compat/asyncio.py
 %if 0%{?rhel} && 0%{?rhel} <= 8
 # click v6.7 unit testing support
 %patch1 -p1
+%endif
+
+%if 0%{?fedora} >= 37 || 0%{?rhel} >= 9
+# Nothing to do
+%else
+# support python-mock (remain backwards compatible with older distributions)
+find text -type f -name '*.py' -exec \
+   sed -i -e 's|^from unittest import mock|import mock|g' {} \;
 %endif
 
 %build

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -60,7 +60,7 @@ Techulus Push, Telegram, Twilio, Twitter, Twist, XBMC, Vonage, Webex Teams}
 
 Name:           python-%{pypi_name}
 Version:        1.0.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A simple wrapper to many popular notification services used today
 License:        MIT
 URL:            https://github.com/caronc/%{pypi_name}
@@ -161,7 +161,7 @@ Requires: python%{python3_pkgversion}-cryptography
 Requires: python%{python3_pkgversion}-yaml
 
 %if %{with tests}
-%if 0%{?fedora} >= 37 || 0%{?rhel} >= 9
+%if 0%{?rhel} >= 9
 # Do not import python3-mock
 %else
 # python-mock switched to unittest.mock
@@ -188,11 +188,14 @@ rm -f apprise/py3compat/asyncio.py
 %patch1 -p1
 %endif
 
-%if 0%{?fedora} >= 37 || 0%{?rhel} >= 9
-# Nothing to do
+%if 0%{?rhel} >= 9
+# Nothing to do under normal circumstances; this line here allows legacy
+# copies of Apprise to still build against this one
+find test -type f -name '*.py' -exec \
+   sed -i -e 's|^import mock|from unittest import mock|g' {} \;
 %else
 # support python-mock (remain backwards compatible with older distributions)
-find text -type f -name '*.py' -exec \
+find test -type f -name '*.py' -exec \
    sed -i -e 's|^from unittest import mock|import mock|g' {} \;
 %endif
 
@@ -256,6 +259,9 @@ LANG=C.UTF-8 PYTHONPATH=%{buildroot}%{python3_sitelib} py.test-%{python3_version
 %endif
 
 %changelog
+* Wed Aug 31 2022 Chris Caron <lead2gold@gmail.com> - 1.0.0-2
+- Rebuilt for RHEL9 Support
+
 * Sat Aug  6 2022 Chris Caron <lead2gold@gmail.com> - 1.0.0-1
 - Updated to v1.0.0
 

--- a/test/helpers/rest.py
+++ b/test/helpers/rest.py
@@ -26,7 +26,14 @@ import re
 import os
 import six
 import requests
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 from json import dumps
 from random import choice
 from string import ascii_uppercase as str_alpha

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -29,7 +29,14 @@ import sys
 import six
 import pytest
 import requests
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 from os.path import dirname
 from os.path import join
 

--- a/test/test_apprise_config.py
+++ b/test/test_apprise_config.py
@@ -26,7 +26,14 @@
 import sys
 import six
 import io
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 from apprise import NotifyFormat
 from apprise import ConfigFormat

--- a/test/test_attach_base.py
+++ b/test/test_attach_base.py
@@ -23,7 +23,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 from apprise.attachment.AttachBase import AttachBase
 

--- a/test/test_attach_file.py
+++ b/test/test_attach_file.py
@@ -25,7 +25,14 @@
 
 import re
 import time
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 from os.path import dirname
 from os.path import join
 from apprise.attachment.AttachBase import AttachBase

--- a/test/test_attach_http.py
+++ b/test/test_attach_http.py
@@ -25,7 +25,14 @@
 
 import re
 import six
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import requests
 import mimetypes
 from os.path import join

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -24,7 +24,14 @@
 # THE SOFTWARE.
 from __future__ import print_function
 import re
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import requests
 import json
 from inspect import cleandoc

--- a/test/test_config_file.py
+++ b/test/test_config_file.py
@@ -24,7 +24,14 @@
 # THE SOFTWARE.
 
 import six
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 from apprise.config.ConfigFile import ConfigFile
 from apprise.plugins.NotifyBase import NotifyBase
 from apprise.AppriseAsset import AppriseAsset

--- a/test/test_config_http.py
+++ b/test/test_config_http.py
@@ -26,7 +26,14 @@
 import six
 import time
 import pytest
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import requests
 from apprise.common import ConfigFormat
 from apprise.config.ConfigHTTP import ConfigHTTP

--- a/test/test_custom_json_plugin.py
+++ b/test/test_custom_json_plugin.py
@@ -25,7 +25,14 @@
 
 import os
 import sys
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import requests
 from apprise import plugins
 from apprise import Apprise

--- a/test/test_escapes.py
+++ b/test/test_escapes.py
@@ -27,7 +27,14 @@ import sys
 from json import loads
 import pytest
 import requests
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import apprise
 
 

--- a/test/test_locale.py
+++ b/test/test_locale.py
@@ -24,7 +24,14 @@
 # THE SOFTWARE.
 
 import os
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import ctypes
 
 from apprise import AppriseLocale

--- a/test/test_logger.py
+++ b/test/test_logger.py
@@ -26,7 +26,14 @@
 import re
 import os
 import sys
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 import requests
 from apprise import Apprise

--- a/test/test_plugin_boxcar.py
+++ b/test/test_plugin_boxcar.py
@@ -23,7 +23,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 import pytest
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 from helpers import AppriseURLTester
 from apprise import plugins
 from apprise import NotifyType

--- a/test/test_plugin_custom_form.py
+++ b/test/test_plugin_custom_form.py
@@ -24,7 +24,14 @@
 # THE SOFTWARE.
 import os
 import sys
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import requests
 from apprise import plugins
 from helpers import AppriseURLTester

--- a/test/test_plugin_custom_json.py
+++ b/test/test_plugin_custom_json.py
@@ -23,7 +23,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 import json
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import requests
 from apprise import plugins
 from helpers import AppriseURLTester

--- a/test/test_plugin_custom_xml.py
+++ b/test/test_plugin_custom_xml.py
@@ -25,7 +25,14 @@
 import os
 import sys
 import re
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import requests
 from apprise import plugins
 from apprise import Apprise

--- a/test/test_plugin_dapnet.py
+++ b/test/test_plugin_dapnet.py
@@ -25,7 +25,14 @@
 # Disable logging for a cleaner testing output
 import logging
 import requests
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 
 import apprise
 from apprise.plugins.NotifyDapnet import DapnetPriority

--- a/test/test_plugin_discord.py
+++ b/test/test_plugin_discord.py
@@ -25,7 +25,14 @@
 
 import os
 import six
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 import requests
 from helpers import AppriseURLTester

--- a/test/test_plugin_email.py
+++ b/test/test_plugin_email.py
@@ -26,7 +26,14 @@
 import os
 import re
 import six
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import smtplib
 from email.header import decode_header
 

--- a/test/test_plugin_emby.py
+++ b/test/test_plugin_emby.py
@@ -22,7 +22,14 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 from json import dumps
 from apprise import Apprise
 from apprise import plugins

--- a/test/test_plugin_fcm.py
+++ b/test/test_plugin_fcm.py
@@ -33,7 +33,14 @@ import io
 import os
 import six
 import sys
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 import requests
 import json

--- a/test/test_plugin_flock.py
+++ b/test/test_plugin_flock.py
@@ -22,7 +22,14 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 import requests
 from apprise import plugins

--- a/test/test_plugin_gitter.py
+++ b/test/test_plugin_gitter.py
@@ -25,7 +25,14 @@
 
 import six
 import pytest
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import requests
 from helpers import AppriseURLTester
 from apprise import plugins

--- a/test/test_plugin_glib.py
+++ b/test/test_plugin_glib.py
@@ -26,7 +26,14 @@
 import re
 import six
 import pytest
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import sys
 import types
 import apprise

--- a/test/test_plugin_gnome.py
+++ b/test/test_plugin_gnome.py
@@ -24,7 +24,14 @@
 # THE SOFTWARE.
 
 import six
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import sys
 import types
 import pytest

--- a/test/test_plugin_gotify.py
+++ b/test/test_plugin_gotify.py
@@ -22,7 +22,14 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 import requests
 import apprise

--- a/test/test_plugin_growl.py
+++ b/test/test_plugin_growl.py
@@ -24,7 +24,14 @@
 # THE SOFTWARE.
 
 import sys
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import six
 import pytest
 import apprise

--- a/test/test_plugin_guilded.py
+++ b/test/test_plugin_guilded.py
@@ -25,7 +25,14 @@
 
 import os
 import six
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 import requests
 from helpers import AppriseURLTester

--- a/test/test_plugin_homeassistant.py
+++ b/test/test_plugin_homeassistant.py
@@ -24,7 +24,14 @@
 # THE SOFTWARE.
 
 import six
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import requests
 from apprise import plugins
 from apprise import Apprise

--- a/test/test_plugin_ifttt.py
+++ b/test/test_plugin_ifttt.py
@@ -23,7 +23,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 import pytest
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import requests
 from apprise import plugins
 from apprise import NotifyType

--- a/test/test_plugin_join.py
+++ b/test/test_plugin_join.py
@@ -22,7 +22,14 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 import requests
 import apprise

--- a/test/test_plugin_macosx.py
+++ b/test/test_plugin_macosx.py
@@ -25,7 +25,14 @@
 
 import os
 import six
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 from helpers import module_reload
 
 import apprise

--- a/test/test_plugin_mailgun.py
+++ b/test/test_plugin_mailgun.py
@@ -25,7 +25,14 @@
 
 import os
 import sys
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import requests
 from helpers import AppriseURLTester
 from apprise import plugins

--- a/test/test_plugin_matrix.py
+++ b/test/test_plugin_matrix.py
@@ -24,7 +24,14 @@
 # THE SOFTWARE.
 
 import six
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import requests
 import pytest
 from apprise import plugins

--- a/test/test_plugin_messagebird.py
+++ b/test/test_plugin_messagebird.py
@@ -22,7 +22,14 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 import requests
 from apprise import plugins

--- a/test/test_plugin_mqtt.py
+++ b/test/test_plugin_mqtt.py
@@ -23,7 +23,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import re
 import sys
 import ssl

--- a/test/test_plugin_msg91.py
+++ b/test/test_plugin_msg91.py
@@ -22,7 +22,14 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 import requests
 from apprise import plugins

--- a/test/test_plugin_msteams.py
+++ b/test/test_plugin_msteams.py
@@ -23,7 +23,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import json
 import requests
 import pytest

--- a/test/test_plugin_nextcloud.py
+++ b/test/test_plugin_nextcloud.py
@@ -24,7 +24,14 @@
 # THE SOFTWARE.
 
 import six
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import requests
 from apprise import plugins
 from helpers import AppriseURLTester

--- a/test/test_plugin_nextcloudtalk.py
+++ b/test/test_plugin_nextcloudtalk.py
@@ -24,7 +24,14 @@
 # THE SOFTWARE.
 
 import six
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import requests
 from apprise import plugins
 from helpers import AppriseURLTester

--- a/test/test_plugin_ntfy.py
+++ b/test/test_plugin_ntfy.py
@@ -24,7 +24,14 @@
 # THE SOFTWARE.
 import os
 import json
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import requests
 from apprise import plugins
 import apprise

--- a/test/test_plugin_office365.py
+++ b/test/test_plugin_office365.py
@@ -25,7 +25,14 @@
 
 import os
 import six
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 import requests
 from datetime import datetime

--- a/test/test_plugin_opsgenie.py
+++ b/test/test_plugin_opsgenie.py
@@ -22,7 +22,14 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import requests
 from apprise.plugins.NotifyOpsgenie import OpsgeniePriority
 import apprise

--- a/test/test_plugin_prowl.py
+++ b/test/test_plugin_prowl.py
@@ -22,7 +22,14 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 import requests
 from apprise.plugins.NotifyProwl import ProwlPriority

--- a/test/test_plugin_pushbullet.py
+++ b/test/test_plugin_pushbullet.py
@@ -24,7 +24,14 @@
 # THE SOFTWARE.
 
 import os
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 import requests
 from json import dumps

--- a/test/test_plugin_pushed.py
+++ b/test/test_plugin_pushed.py
@@ -22,7 +22,14 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 import requests
 from apprise import plugins

--- a/test/test_plugin_pushover.py
+++ b/test/test_plugin_pushover.py
@@ -24,7 +24,14 @@
 # THE SOFTWARE.
 
 import os
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import requests
 import pytest
 from json import dumps

--- a/test/test_plugin_pushsafer.py
+++ b/test/test_plugin_pushsafer.py
@@ -25,7 +25,14 @@
 
 import os
 import pytest
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import requests
 from json import dumps
 from apprise import AppriseAttachment

--- a/test/test_plugin_reddit.py
+++ b/test/test_plugin_reddit.py
@@ -25,7 +25,14 @@
 
 import six
 import requests
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 from apprise import plugins
 from helpers import AppriseURLTester
 

--- a/test/test_plugin_rocket_chat.py
+++ b/test/test_plugin_rocket_chat.py
@@ -22,7 +22,14 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 import requests
 from apprise import plugins

--- a/test/test_plugin_sendgrid.py
+++ b/test/test_plugin_sendgrid.py
@@ -22,7 +22,14 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 import requests
 from apprise import plugins

--- a/test/test_plugin_ses.py
+++ b/test/test_plugin_ses.py
@@ -24,7 +24,14 @@
 # THE SOFTWARE.
 
 import os
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 import requests
 from apprise import Apprise

--- a/test/test_plugin_signal.py
+++ b/test/test_plugin_signal.py
@@ -25,7 +25,14 @@
 import os
 import sys
 from json import loads
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 import requests
 from apprise import plugins

--- a/test/test_plugin_simplepush.py
+++ b/test/test_plugin_simplepush.py
@@ -23,7 +23,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 import sys
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 import requests
 import json

--- a/test/test_plugin_sinch.py
+++ b/test/test_plugin_sinch.py
@@ -22,7 +22,14 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 import requests
 from json import dumps

--- a/test/test_plugin_slack.py
+++ b/test/test_plugin_slack.py
@@ -25,7 +25,14 @@
 
 import os
 import six
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 import requests
 from apprise import plugins

--- a/test/test_plugin_smtp2go.py
+++ b/test/test_plugin_smtp2go.py
@@ -25,7 +25,14 @@
 
 import os
 import sys
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import requests
 from apprise import plugins
 from apprise import Apprise

--- a/test/test_plugin_sns.py
+++ b/test/test_plugin_sns.py
@@ -23,7 +23,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 import requests
 from apprise import plugins

--- a/test/test_plugin_sparkpost.py
+++ b/test/test_plugin_sparkpost.py
@@ -25,7 +25,14 @@
 
 import os
 import pytest
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import requests
 from json import dumps
 from apprise import plugins

--- a/test/test_plugin_syslog.py
+++ b/test/test_plugin_syslog.py
@@ -25,7 +25,14 @@
 
 import re
 import pytest
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import apprise
 import socket
 

--- a/test/test_plugin_telegram.py
+++ b/test/test_plugin_telegram.py
@@ -27,7 +27,14 @@ import os
 import six
 import sys
 import pytest
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import requests
 from json import dumps
 from json import loads

--- a/test/test_plugin_twilio.py
+++ b/test/test_plugin_twilio.py
@@ -24,7 +24,14 @@
 # THE SOFTWARE.
 
 import six
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import requests
 import pytest
 from json import dumps

--- a/test/test_plugin_twist.py
+++ b/test/test_plugin_twist.py
@@ -23,7 +23,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import requests
 from json import dumps
 from apprise import plugins

--- a/test/test_plugin_twitter.py
+++ b/test/test_plugin_twitter.py
@@ -25,7 +25,14 @@
 
 import os
 import six
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 import requests
 from json import dumps

--- a/test/test_plugin_vonage.py
+++ b/test/test_plugin_vonage.py
@@ -22,7 +22,14 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import pytest
 import requests
 from json import dumps

--- a/test/test_plugin_windows.py
+++ b/test/test_plugin_windows.py
@@ -24,7 +24,14 @@
 # THE SOFTWARE.
 
 import pytest
-import mock
+try:
+    # Python 3.x
+    from unittest import mock
+
+except ImportError:
+    # Python 2.7
+    import mock
+
 import sys
 import six
 import types


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #<!--apprise issue number goes here-->

Starting at Red Hat 9, `python3-mock` will no longer be an available package (Ref: [BZ2103435](https://bugzilla.redhat.com/show_bug.cgi?id=2103435)).  To allow Apprise to exist in this environment and newer ones, it's about time to conditionally drop it s a requirement.

This merge safely remains backwards compatible with Python v2.7 which requires the package to exist.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
```

