### PR TITLE
Reply-To is not put in E-Mail header if not specified

### DIFF
--- a/test/test_plugin_email.py
+++ b/test/test_plugin_email.py
@@ -859,6 +859,8 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
     # Test that our template over-ride worked
     assert 'mode=ssl' in obj.url()
     assert 'smtp=override.com' in obj.url()
+    # No reply address specified
+    assert 'reply=' not in obj.url()
 
     mock_smtp.reset_mock()
     response.reset_mock()
@@ -871,22 +873,30 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
     obj = Apprise.instantiate(results, suppress_exceptions=False)
     assert isinstance(obj, plugins.NotifyEmail) is True
     assert obj.smtp_host == 'smtp-mail.outlook.com'
+    # No entries in the reply_to
+    assert not obj.reply_to
 
     results = plugins.NotifyEmail.parse_url(
         'mailtos://user:pass123@outlook.com.au')
     obj = Apprise.instantiate(results, suppress_exceptions=False)
     assert isinstance(obj, plugins.NotifyEmail) is True
     assert obj.smtp_host == 'smtp-mail.outlook.com'
+    # No entries in the reply_to
+    assert not obj.reply_to
 
     results = plugins.NotifyEmail.parse_url(
         'mailtos://user:pass123@live.com')
     obj = Apprise.instantiate(results, suppress_exceptions=False)
     assert isinstance(obj, plugins.NotifyEmail) is True
+    # No entries in the reply_to
+    assert not obj.reply_to
 
     results = plugins.NotifyEmail.parse_url(
         'mailtos://user:pass123@hotmail.com')
     obj = Apprise.instantiate(results, suppress_exceptions=False)
     assert isinstance(obj, plugins.NotifyEmail) is True
+    # No entries in the reply_to
+    assert not obj.reply_to
 
     #
     # Test Port Over-Riding
@@ -902,6 +912,8 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
     assert obj.port == 465
     assert obj.from_addr == 'abc@xyz.cn'
     assert obj.secure_mode == 'ssl'
+    # No entries in the reply_to
+    assert not obj.reply_to
 
     results = plugins.NotifyEmail.parse_url(
         "mailtos://abc:password@xyz.cn?"
@@ -914,3 +926,21 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
     assert obj.port == 465
     assert obj.from_addr == 'abc@xyz.cn'
     assert obj.secure_mode == 'ssl'
+    # No entries in the reply_to
+    assert not obj.reply_to
+
+    #
+    # Test Reply-To Email
+    #
+    results = plugins.NotifyEmail.parse_url(
+        "mailtos://user:pass@example.com?reply=noreply@example.com")
+    obj = Apprise.instantiate(results, suppress_exceptions=False)
+    assert isinstance(obj, plugins.NotifyEmail) is True
+    # Verify our over-rides are in place
+    assert obj.smtp_host == 'example.com'
+    assert obj.from_addr == 'user@example.com'
+    assert obj.secure_mode == 'starttls'
+    assert obj.url().startswith(
+        'mailtos://user:pass@example.com')
+    # Test that our template over-ride worked
+    assert 'reply=noreply%40example.com' in obj.url()


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #651 (extension of #660)

Small update to ensure the Reply-To header is not placed into the E-Mail if not otherwise specified.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@email-replyto-enhancement

# Test out the changes with the following command:
# The following would set the Reply-To header
apprise -t "Test Title" -b "Test Message" \
 mailto://user:pass@hostname?reply=myreply@hostname

# The following would not:
apprise -t "Test Title" -b "Test Message" \
 mailto://user:pass@hostname
```

