### PR TITLE
SMSEagle message limit changed from 160 to 1200 chars

### DIFF
--- a/apprise/plugins/NotifySMSEagle.py
+++ b/apprise/plugins/NotifySMSEagle.py
@@ -90,7 +90,9 @@ class NotifySMSEagle(NotifyBase):
     notify_path = '/jsonrpc/sms'
 
     # The maxumum length of the text message
-    body_maxlen = 160
+    # The actual limit is 160 but SMSEagle looks after the handling
+    # of large messages in it's upstream service
+    body_maxlen = 1200
 
     # The maximum targets to include when doing batch transfers
     default_batch_size = 10


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #661 

SMSEagle can handle 1200 characters and manages the handling of large messages on it's own.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@smseagle-limit-update

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  smseagle://credentials

```

