### PR TITLE
Fix Travis-CI Python 3.7 build support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
   include:
     - python: "3.6"
       env: TOXENV=py36
-    - python: "3.7"
+    - python: "3.7.7"
       env: TOXENV=py37
     - python: "3.8"
       env: TOXENV=py38


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** n/a/

Python 3.7 support seems to no longer work with xenial.  Xenial is providing an older version of Python 3.7 that doesn't support the enhancements newer packages depend on. [Here is the community ticket](https://travis-ci.community/t/python-v3-7-ci-runner-dbus-python-cant-be-installed/13273/2) that helped me.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
Travis CI Passes on branch is all the testing that is needed.

