### PR TITLE
NC Talk change request to json to get correct 201 response

### DIFF
--- a/apprise/plugins/NotifyNextcloudTalk.py
+++ b/apprise/plugins/NotifyNextcloudTalk.py
@@ -134,7 +134,9 @@ class NotifyNextcloudTalk(NotifyBase):
         # Prepare our Header
         headers = {
             'User-Agent': self.app_id,
-            'OCS-APIREQUEST': 'true',
+            'OCS-APIRequest': 'true',
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
         }
 
         # Apply any/all header over-rides defined
@@ -183,7 +185,7 @@ class NotifyNextcloudTalk(NotifyBase):
             try:
                 r = requests.post(
                     notify_url,
-                    data=payload,
+                    json=payload,
                     headers=headers,
                     auth=(self.user, self.password),
                     verify=self.verify_certificate,

--- a/apprise/plugins/NotifyNextcloudTalk.py
+++ b/apprise/plugins/NotifyNextcloudTalk.py
@@ -24,6 +24,7 @@
 
 import requests
 
+from json import dumps
 from .NotifyBase import NotifyBase
 from ..URLBase import PrivacyMode
 from ..common import NotifyType
@@ -185,7 +186,7 @@ class NotifyNextcloudTalk(NotifyBase):
             try:
                 r = requests.post(
                     notify_url,
-                    json=payload,
+                    data=dumps(payload),
                     headers=headers,
                     auth=(self.user, self.password),
                     verify=self.verify_certificate,


### PR DESCRIPTION
## Description:
Small fix because i kept getting http response code 200 instead of 201, which ended in an error.
I do not know exactly why 200 suddenly gets returned when sending a x-www-form-urlencoded payload, maybe something changed in the API of Nextcloud Talk.
But sending a json payload results in the correct response of 201 (see https://nextcloud-talk.readthedocs.io/en/latest/chat/#sending-a-new-chat-message)

<!-- Have anything else to describe? Define it here -->

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage
