### PR TITLE
Bugfix: Could not send messages to groups ending in "="

### DIFF
--- a/apprise/plugins/NotifySignalAPI.py
+++ b/apprise/plugins/NotifySignalAPI.py
@@ -38,7 +38,7 @@ from ..AppriseLocale import gettext_lazy as _
 
 
 GROUP_REGEX = re.compile(
-    r'^\s*((\@|\%40)?(group\.)|\@|\%40)(?P<group>[a-z0-9_-]+)', re.I)
+    r'^\s*((\@|\%40)?(group\.)|\@|\%40)(?P<group>[a-z0-9_=-]+)', re.I)
 
 
 class NotifySignalAPI(NotifyBase):
@@ -123,7 +123,7 @@ class NotifySignalAPI(NotifyBase):
             'name': _('Target Group ID'),
             'type': 'string',
             'prefix': '@',
-            'regex': (r'^[a-z0-9_-]+$', 'i'),
+            'regex': (r'^[a-z0-9_=-]+$', 'i'),
             'map_to': 'targets',
         },
         'targets': {


### PR DESCRIPTION
## Description:
A lot of signal groups end in "=" as they are base64 encoded. The = isn't matched and therefore stripped before passing it to the api, resulting in the group not being recognized. The fix is extremely simple.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage