### PR TITLE
Port is correctly placed in Bark URL if provided

### DIFF
--- a/apprise/plugins/NotifyBark.py
+++ b/apprise/plugins/NotifyBark.py
@@ -208,13 +208,12 @@ class NotifyBark(NotifyBase):
         super(NotifyBark, self).__init__(**kwargs)
 
         # Prepare our URL
-        self.notify_url = '%s://%s/push' % (
+        self.notify_url = '%s://%s%s/push' % (
             'https' if self.secure else 'http',
             self.host,
+            ':{}'.format(self.port)
+            if (self.port and isinstance(self.port, int)) else '',
         )
-
-        if isinstance(self.port, int):
-            self.notify_url += ':%d' % self.port
 
         # Assign our category
         self.category = \


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #671

Fix issue with Bark Notification plugin not correctly setting the port number in the correct part of the URL.


## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@671-bark-port-fix

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  <apprise url related to ticket>

```

