### PR TITLE
Improve behavior and efficiency of `NotifyEmail` plugin

### DIFF
--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -22,10 +22,11 @@ The contributors have been listed in chronological order:
 * Hitesh Sondhi <hitesh@cropsly.com>
   * Mar 2019 - Added Flock Support
 
-* Andreas Motl <andreas@getkotori.org>
+* Andreas Motl <andreas.motl@panodata.org>
   * Mar 2020 - Fix XMPP Support
   * Oct 2022 - Drop support for Python 2
   * Oct 2022 - Add support for Python 3.11
+  * Oct 2022 - Improve efficiency of NotifyEmail
 
 * Joey Espinosa <@particledecay>
   * Apr 3rd 2022 - Added Ntfy Support

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 certifi
 
 # Application dependencies.
+dataclasses; python_version<"3.7"
 requests
 requests-oauthlib
 click >= 5.0


### PR DESCRIPTION
Dear Chris,

we have been able to discover a small glitch with the `NotifyEmail` plugin, this patch will hopefully resolve it right away.

With kind regards,
Andreas.

### About
At https://github.com/jpmens/mqttwarn/pull/604, we discovered that the `NotifyEmail` plugin, when used with multiple recipients, would setup and teardown a separate SMTP connection per recipient. We think its efficiency can be improved.

### Description
When addressing multiple recipients, use the same session to the SMTP server as designated with the Apprise URL. In this way, subsequent full connection setup/teardown roundtrips will be saved.

As many SMTP servers are employing connection rate limiting, as well as connection accept delays, this will considerably improve both robustness and performance.

### Before
```python
    assert mock_smtp.mock_calls == [
        call("mail.example.org", 587, None, timeout=15),
        call().starttls(),
        call().login("smtp_username", "smtp_password"),
        call().sendmail("smtp_username@mail.example.org", ["foo@example.org"], mock.ANY),
        call().quit(),
        call("mail.example.org", 587, None, timeout=15),
        call().starttls(),
        call().login("smtp_username", "smtp_password"),
        call().sendmail("smtp_username@mail.example.org", ["bar@example.org"], mock.ANY),
        call().quit(),
    ]
```

### After
```python
    assert mock_smtp.mock_calls == [
        call("mail.example.org", 587, None, timeout=15),
        call().starttls(),
        call().login("smtp_username", "smtp_password"),
        call().sendmail("smtp_username@mail.example.org", ["foo@example.org"], mock.ANY),
        call().sendmail("smtp_username@mail.example.org", ["bar@example.org"], mock.ANY),
        call().quit(),
    ]
```
