### PR TITLE
Add support for CPython 3.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
       env: TOXENV=py39
     - python: "3.10"
       env: TOXENV=py310
+    - python: "3.11-dev"
+      env: TOXENV=py311
     # PyPy Environments
     - python: "pypy3.6-7.3.3"
       env: TOXENV=pypy36

--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -24,6 +24,8 @@ The contributors have been listed in chronological order:
 
 * Andreas Motl <andreas@getkotori.org>
   * Mar 2020 - Fix XMPP Support
+  * Oct 2022 - Drop support for Python 2
+  * Oct 2022 - Add support for Python 3.11
 
 * Joey Espinosa <@particledecay>
   * Apr 3rd 2022 - Added Ntfy Support

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'License :: OSI Approved :: MIT License',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310,pypy36,pypy37,pypy38,pypy39,bare,coverage-report
+envlist = py36,py37,py38,py39,py310,py311,pypy36,pypy37,pypy38,pypy39,bare,coverage-report
 
 
 [testenv]
@@ -69,6 +69,16 @@ commands =
     coverage run -m pytest {posargs}
     flake8 . --count --show-source --statistics
 
+[testenv:py311]
+deps=
+   dbus-python
+   -r{toxinidir}/requirements.txt
+   -r{toxinidir}/dev-requirements.txt
+   -r{toxinidir}/all-plugin-requirements.txt
+commands =
+    python setup.py compile_catalog
+    coverage run --parallel -m pytest {posargs}
+    flake8 . --count --show-source --statistics
 
 [testenv:bare]
 deps=


### PR DESCRIPTION
Dear Chris,

after modernizing the CI environment with #680, this patch aims to add CPython 3.11 to the test matrix. Python 3.11 will be released in about a month, on 2022-10-24.

With kind regards,
Andreas.