### PR TITLE
Tests: Improve testing of `NotifyDBus`, `NotifyGnome`, and `NotifyMacOSX`

### DIFF
--- a/Dockerfile.py310
+++ b/Dockerfile.py310
@@ -1,8 +1,8 @@
 # Base
 FROM python:3.10-buster
 RUN apt-get update && \
-    apt-get install -y libdbus-1-dev build-essential musl-dev bash
-RUN pip install dbus-python
+    apt-get install -y libdbus-1-dev libgirepository1.0-dev build-essential musl-dev bash
+RUN pip install dbus-python PyGObject
 
 # Apprise Setup
 VOLUME ["/apprise"]

--- a/Dockerfile.py36
+++ b/Dockerfile.py36
@@ -1,8 +1,8 @@
 # Base
 FROM python:3.6-buster
 RUN apt-get update && \
-    apt-get install -y libdbus-1-dev build-essential musl-dev bash
-RUN pip install dbus-python
+    apt-get install -y libdbus-1-dev libgirepository1.0-dev build-essential musl-dev bash
+RUN pip install dbus-python PyGObject
 
 # Apprise Setup
 VOLUME ["/apprise"]

--- a/apprise/plugins/NotifyDBus.py
+++ b/apprise/plugins/NotifyDBus.py
@@ -280,11 +280,8 @@ class NotifyDBus(NotifyBase):
             self.x_axis = None
             self.y_axis = None
 
-        # Track whether or not we want to send an image with our notification
-        # or not.
+        # Track whether we want to add an image to the notification.
         self.include_image = include_image
-
-        return
 
     def send(self, body, title='', notify_type=NotifyType.INFO, **kwargs):
         """
@@ -350,8 +347,8 @@ class NotifyDBus(NotifyBase):
 
             except Exception as e:
                 self.logger.warning(
-                    "Could not load Gnome notification icon ({}): {}"
-                    .format(icon_path, e))
+                    f"Could not load notification icon (%s). "
+                    f"Reason: {e}", icon_path)
 
         try:
             # Always call throttle() before any remote execution is made
@@ -378,8 +375,9 @@ class NotifyDBus(NotifyBase):
 
             self.logger.info('Sent DBus notification.')
 
-        except Exception:
-            self.logger.warning('Failed to send DBus notification.')
+        except Exception as e:
+            self.logger.warning(f'Failed to send DBus notification. '
+                                f'Reason: {e}')
             self.logger.exception('DBus Exception')
             return False
 

--- a/apprise/plugins/NotifyDBus.py
+++ b/apprise/plugins/NotifyDBus.py
@@ -26,6 +26,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import sys
 from .NotifyBase import NotifyBase
 from ..common import NotifyImageSize
 from ..common import NotifyType
@@ -76,6 +77,13 @@ try:
     # We're good as long as at least one
     NOTIFY_DBUS_SUPPORT_ENABLED = (
         LOOP_GLIB is not None or LOOP_QT is not None)
+
+    # ImportError: When using gi.repository you must not import static modules
+    # like "gobject". Please change all occurrences of "import gobject" to
+    # "from gi.repository import GObject".
+    # See: https://bugzilla.gnome.org/show_bug.cgi?id=709183
+    if "gobject" in sys.modules:  # pragma: no cover
+        del sys.modules["gobject"]
 
     try:
         # The following is required for Image/Icon loading only

--- a/apprise/plugins/NotifyDBus.py
+++ b/apprise/plugins/NotifyDBus.py
@@ -291,10 +291,10 @@ class NotifyDBus(NotifyBase):
         try:
             session = SessionBus(mainloop=MAINLOOP_MAP[self.schema])
 
-        except DBusException:
+        except DBusException as e:
             # Handle exception
             self.logger.warning('Failed to send DBus notification.')
-            self.logger.exception('DBus Exception')
+            self.logger.debug(f'DBus Exception: {e}')
             return False
 
         # If there is no title, but there is a body, swap the two to get rid
@@ -347,8 +347,8 @@ class NotifyDBus(NotifyBase):
 
             except Exception as e:
                 self.logger.warning(
-                    f"Could not load notification icon (%s). "
-                    f"Reason: {e}", icon_path)
+                    "Could not load notification icon (%s).", icon_path)
+                self.logger.debug(f'DBus Exception: {e}')
 
         try:
             # Always call throttle() before any remote execution is made
@@ -376,9 +376,8 @@ class NotifyDBus(NotifyBase):
             self.logger.info('Sent DBus notification.')
 
         except Exception as e:
-            self.logger.warning(f'Failed to send DBus notification. '
-                                f'Reason: {e}')
-            self.logger.exception('DBus Exception')
+            self.logger.warning('Failed to send DBus notification.')
+            self.logger.debug(f'DBus Exception: {e}')
             return False
 
         return True

--- a/apprise/plugins/NotifyGnome.py
+++ b/apprise/plugins/NotifyGnome.py
@@ -211,16 +211,15 @@ class NotifyGnome(NotifyBase):
 
                 except Exception as e:
                     self.logger.warning(
-                        f"Could not load notification icon (%s). "
-                        f"Reason: {e}", icon_path)
+                        "Could not load notification icon (%s). ", icon_path)
+                    self.logger.debug(f'Gnome Exception: {e}')
 
             notification.show()
             self.logger.info('Sent Gnome notification.')
 
         except Exception as e:
-            self.logger.warning(f'Failed to send Gnome notification. '
-                                f'Reason: {e}')
-            self.logger.exception('Gnome Exception')
+            self.logger.warning('Failed to send Gnome notification.')
+            self.logger.debug(f'Gnome Exception: {e}')
             return False
 
         return True

--- a/apprise/plugins/NotifyGnome.py
+++ b/apprise/plugins/NotifyGnome.py
@@ -54,8 +54,8 @@ except (ImportError, ValueError, AttributeError):
     # be in microsoft windows, or we just don't have the python-gobject
     # library available to us (or maybe one we don't support)?
 
-    # Alternativey A ValueError will get thrown upon calling
-    # gi.require_version() if the requested Notify namespace isn't available
+    # Alternatively, a `ValueError` will get raised upon calling
+    # gi.require_version() if the requested Notify namespace isn't available.
     pass
 
 
@@ -175,11 +175,8 @@ class NotifyGnome(NotifyBase):
                 if str(urgency).lower().startswith(k)),
                 NotifyGnome.template_args['urgency']['default']))
 
-        # Track whether or not we want to send an image with our notification
-        # or not.
+        # Track whether we want to add an image to the notification.
         self.include_image = include_image
-
-        return
 
     def send(self, body, title='', notify_type=NotifyType.INFO, **kwargs):
         """
@@ -214,14 +211,15 @@ class NotifyGnome(NotifyBase):
 
                 except Exception as e:
                     self.logger.warning(
-                        "Could not load Gnome notification icon ({}): {}"
-                        .format(icon_path, e))
+                        f"Could not load notification icon (%s). "
+                        f"Reason: {e}", icon_path)
 
             notification.show()
             self.logger.info('Sent Gnome notification.')
 
-        except Exception:
-            self.logger.warning('Failed to send Gnome notification.')
+        except Exception as e:
+            self.logger.warning(f'Failed to send Gnome notification. '
+                                f'Reason: {e}')
             self.logger.exception('Gnome Exception')
             return False
 

--- a/apprise/plugins/NotifyMacOSX.py
+++ b/apprise/plugins/NotifyMacOSX.py
@@ -39,13 +39,15 @@ from ..AppriseLocale import gettext_lazy as _
 # Default our global support flag
 NOTIFY_MACOSX_SUPPORT_ENABLED = False
 
+
+# TODO: The module will be easier to test without module-level code.
 if platform.system() == 'Darwin':
     # Check this is Mac OS X 10.8, or higher
     major, minor = platform.mac_ver()[0].split('.')[:2]
 
-    # Toggle our enabled flag if verion is correct and executable
+    # Toggle our enabled flag, if version is correct and executable
     # found. This is done in such a way to provide verbosity to the
-    # end user so they know why it may or may not work for them.
+    # end user, so they know why it may or may not work for them.
     NOTIFY_MACOSX_SUPPORT_ENABLED = \
         (int(major) > 10 or (int(major) == 10 and int(minor) >= 8))
 
@@ -126,17 +128,15 @@ class NotifyMacOSX(NotifyBase):
 
         super().__init__(**kwargs)
 
-        # Track whether or not we want to send an image with our notification
-        # or not.
+        # Track whether we want to add an image to the notification.
         self.include_image = include_image
 
-        # Acquire the notify path
+        # Acquire the path to the `terminal-notifier` program.
         self.notify_path = next(  # pragma: no branch
             (p for p in self.notify_paths if os.access(p, os.X_OK)), None)
 
         # Set sound object (no q/a for now)
         self.sound = sound
-        return
 
     def send(self, body, title='', notify_type=NotifyType.INFO, **kwargs):
         """

--- a/apprise/plugins/NotifyMacOSX.py
+++ b/apprise/plugins/NotifyMacOSX.py
@@ -97,6 +97,8 @@ class NotifyMacOSX(NotifyBase):
     notify_paths = (
         '/opt/homebrew/bin/terminal-notifier',
         '/usr/local/bin/terminal-notifier',
+        '/usr/bin/terminal-notifier',
+        '/bin/terminal-notifier',
     )
 
     # Define object templates

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,7 @@ coverage
 flake8
 pytest
 pytest-cov
+pytest-mock
 pytest-xdist
 tox
 babel

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3.3"
 services:
-  test.py35:
+  test.py36:
     build:
       context: .
       dockerfile: Dockerfile.py36

--- a/test/helpers/module.py
+++ b/test/helpers/module.py
@@ -22,24 +22,18 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-
+from importlib import import_module, reload
 import sys
 
-from importlib import reload
 
-
-def reload_plugin(name):
+def reload_plugin(name, replace_in=None):
     """
-    Reload builtin plugin module, e.g. `NotifyGnome`.
-    set filename to plugin to be reloaded (for example NotifyGnome.py)
+    Reload built-in plugin module, e.g. `NotifyGnome`.
 
-    The following libraries need to be reloaded to prevent
-     TypeError: super(type, obj): obj must be an instance or subtype of type
-     This is better explained in this StackOverflow post:
-        https://stackoverflow.com/questions/31363311/\
-          any-way-to-manually-fix-operation-of-\
-             super-after-ipython-reload-avoiding-ty
+    Reloading plugin modules is needed when testing module-level code of
+    notification plugins.
 
+    See also https://stackoverflow.com/questions/31363311.
     """
 
     module_name = f"apprise.plugins.{name}"
@@ -53,3 +47,10 @@ def reload_plugin(name):
     reload(sys.modules['apprise.Apprise'])
     reload(sys.modules['apprise.utils'])
     reload(sys.modules['apprise'])
+
+    # Fix reference to new plugin class in given module.
+    # Needed for updating the module-level import reference like
+    # `from apprise.plugins.NotifyMacOSX import NotifyMacOSX`.
+    if replace_in is not None:
+        mod = import_module(module_name)
+        setattr(replace_in, name, getattr(mod, name))


### PR DESCRIPTION
Dear Chris,

while working on adjusting the test suite with #687, I discovered a few spots where I think the test cases may get improved.  I hope you still like my patches.

The spots are specifically those places where `reload_plugin` needs to be used, in order to examine module-level plugin code, specifically at the `NotifyDBus`, `NotifyGnome`, and `NotifyMacOSX` plugins.

With kind regards,
Andreas.

<sub>
P.S.: When you think the patch will be ready for merging, can I ask you to keep the commits as they are, instead of squashing them? In this manner, individual changes can be reverted much easier, keep their own commit message about the corresponding rationale, and are just so much easier to handle, followup on, or reference, for example when talking about code changes in retrospective.
</sub>



### In a nutshell

By using proper [`pytest` fixtures](https://docs.pytest.org/en/latest/explanation/fixtures.html) for context/environment setup, as well as [`pytest-mock`](https://pypi.org/project/pytest-mock/) for mocking, the patch significantly improves convenience and structure both when writing, and when reading and reasoning about test cases.


### Benefits

Because the test setup code is now available as fixtures, it is easy to use a dedicated function per test case, without the need to duplicate setup code.

It is now guaranteed that each test case gets a fresh and standardized context/environment, without the chance that something is leaked from a previous test, and without the need to manually run infrastructural code in between the test cases, which is both tedious and error-prone. Specifically, when writing test cases in such a manner, there is no need for manual "undo" code after mangling the underlying machinery, so it will never break on this aspect.

### My personal learning path

While I am a big fan of Python decorators in general, I would never want to look back before I learned about `pytest-mock`. It is just so much easier now to refactor and modularize test cases, and to provide setup/teardown code to them.

This is my stake on this topic.

- Manipulating object references back and forth directly: Not encouraged, too much can go wrong and leakage is imminent.
- Mocks with functional interface: No context, no guaranteed cleanup. Not much better than the first option.
- Mocks with decorator interface: Minimal amount of code needed, cleanup guaranteed; great if you really just need to slap it on. Difficult when needing to refactor test cases, as taking things on and off needs swapping out _both_ the decorator, as well as the corresponding function argument, which quickly gets boring and tedious.
- Mocks with context manager interface: More flexibility in setting up customized mocks, cleanup guaranteed. However, when needing to mock a bunch of objects, code with many indentation levels quickly and clearly feels like it gets entangled into Python syntax specialties.
- Mocks with `pytest-mock`: Very clean interface, cleanup guaranteed. Easy to edit, as it is just regular, imperative Python code, without using any idioms like decorators or dependency injection on the function argument level. In many cases which need more special attention when building and providing mocked objects, this keeps saving my life in many situations. [DWIM](https://en.wikipedia.org/wiki/DWIM).
