### PR TITLE
Tests: Speed up test suite by invoking tests in parallel, using `pytest-xdist`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,8 @@
 [run]
 disable_warnings = no-data-collected
+data_file = .coverage-reports/.coverage
 branch = True
+parallel = True
 source =
     apprise
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,4 @@
 [run]
-disable_warnings = no-data-collected
 data_file = .coverage-reports/.coverage
 branch = True
 parallel = True

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,5 +2,6 @@ coverage
 flake8
 pytest
 pytest-cov
+pytest-xdist
 tox
 babel

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ builtins = _
 test=pytest
 
 [tool:pytest]
-addopts = --verbose -ra
+addopts = --verbosity=3 -ra
 python_files = test/test_*.py
 norecursedirs=test/helpers
 filterwarnings =

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps=
     -r{toxinidir}/dev-requirements.txt
 commands =
     python setup.py compile_catalog
-    coverage run --parallel -m pytest {posargs}
+    coverage run -m pytest {posargs}
     flake8 . --count --show-source --statistics
 
 [testenv:py36]
@@ -23,7 +23,7 @@ deps=
    -r{toxinidir}/all-plugin-requirements.txt
 commands =
     python setup.py compile_catalog
-    coverage run --parallel -m pytest {posargs}
+    coverage run -m pytest {posargs}
     flake8 . --count --show-source --statistics
 
 [testenv:py37]
@@ -34,7 +34,7 @@ deps=
    -r{toxinidir}/all-plugin-requirements.txt
 commands =
     python setup.py compile_catalog
-    coverage run --parallel -m pytest {posargs}
+    coverage run -m pytest {posargs}
 
 [testenv:py38]
 deps=
@@ -44,7 +44,7 @@ deps=
    -r{toxinidir}/all-plugin-requirements.txt
 commands =
     python setup.py compile_catalog
-    coverage run --parallel -m pytest {posargs}
+    coverage run -m pytest {posargs}
     flake8 . --count --show-source --statistics
 
 [testenv:py39]
@@ -55,7 +55,7 @@ deps=
    -r{toxinidir}/all-plugin-requirements.txt
 commands =
     python setup.py compile_catalog
-    coverage run --parallel -m pytest {posargs}
+    coverage run -m pytest {posargs}
     flake8 . --count --show-source --statistics
 
 [testenv:py310]
@@ -66,7 +66,7 @@ deps=
    -r{toxinidir}/all-plugin-requirements.txt
 commands =
     python setup.py compile_catalog
-    coverage run --parallel -m pytest {posargs}
+    coverage run -m pytest {posargs}
     flake8 . --count --show-source --statistics
 
 
@@ -76,7 +76,7 @@ deps=
    -r{toxinidir}/dev-requirements.txt
 commands =
     python setup.py compile_catalog
-    coverage run --parallel -m pytest {posargs}
+    coverage run -m pytest {posargs}
     flake8 . --count --show-source --statistics
 
 [testenv:pypy36]
@@ -88,7 +88,7 @@ deps=
    -r{toxinidir}/all-plugin-requirements.txt
 commands =
     python setup.py compile_catalog
-    coverage run --parallel -m pytest {posargs}
+    coverage run -m pytest {posargs}
     flake8 . --count --show-source --statistics
 
 [testenv:pypy37]
@@ -100,7 +100,7 @@ deps=
    -r{toxinidir}/all-plugin-requirements.txt
 commands =
     python setup.py compile_catalog
-    coverage run --parallel -m pytest {posargs}
+    coverage run -m pytest {posargs}
 
 [testenv:pypy38]
 deps=
@@ -111,7 +111,7 @@ deps=
    -r{toxinidir}/all-plugin-requirements.txt
 commands =
     python setup.py compile_catalog
-    coverage run --parallel -m pytest {posargs}
+    coverage run -m pytest {posargs}
     flake8 . --count --show-source --statistics
 
 [testenv:pypy39]
@@ -123,7 +123,7 @@ deps=
    -r{toxinidir}/all-plugin-requirements.txt
 commands =
     python setup.py compile_catalog
-    coverage run --parallel -m pytest {posargs}
+    coverage run -m pytest {posargs}
     flake8 . --count --show-source --statistics
 
 [testenv:coverage-report]

--- a/tox.ini
+++ b/tox.ini
@@ -131,4 +131,5 @@ deps = coverage
 skip_install = true
 commands=
    coverage combine
+   coverage xml
    coverage report


### PR DESCRIPTION
By using the excellent `pytest-xdist` package, I was able to reduce the runtime of the test suite from 45 to 15 (no coverage) / 25 (with coverage) seconds, tested on machines with 8 and 16 CPUs.

```
# Tests only.
pytest --numprocesses=auto

# Tests, with coverage reporting.
pytest --numprocesses=auto --cov
```

It apparently also improves runtime on Travis CI, so it would be a big resource saver.

- Before: Ran for 6 min 58 sec; Total time 42 min 45 sec 
- After: Ran for 4 min 47 sec; Total time 30 min 59 sec 

Running the tests in parallel also ensures there are no spots where shared resources are not properly accessed in concurrent situations. It will reveal such shortcomings very quickly.
