### PR TITLE
CI: Save resources by disabling builds on PyPy 3.7 and PyPy 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,6 @@ matrix:
     # PyPy Environments
     - python: "pypy3.6-7.3.3"
       env: TOXENV=pypy36
-    - python: "pypy3.7-7.3.9"
-      env: TOXENV=pypy37
-    - python: "pypy3.8-7.3.9"
-      env: TOXENV=pypy38
     - python: "pypy3.9-7.3.9"
       env: TOXENV=pypy39
     # An extra environment where additional packages are not installed

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310,pypy36,pypy37,pypy38,pypy39,bare,coverage-report
+envlist = py36,py37,py38,py39,py310,pypy36,pypy39,bare,coverage-report
 
 
 [testenv]


### PR DESCRIPTION
Dear Chris,

because I learned that CI currently is running out of credits very quickly, I propose to remove two of the PyPy builds from the build matrix.

Adding all variants recently, increased the total spent build minutes on CI from ~25 to ~45 minutes per build. PyPy builds take 5-7 minutes each, so it is a reasonable saving when omitting two of them. We still keep PyPy 3.6 and PyPy 3.9 for now.

Do you have any other suggestions or objections?

With kind regards,
Andreas.
