### PR TITLE
Tests: Improve testing of `NotifyMQTT`

### DIFF
--- a/apprise/plugins/NotifyMQTT.py
+++ b/apprise/plugins/NotifyMQTT.py
@@ -145,6 +145,8 @@ class NotifyMQTT(NotifyBase):
         "/etc/pki/tls/cacert.pem",
         # CentOS/RHEL 7
         "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+        # macOS Homebrew; brew install ca-certificates
+        "/usr/local/etc/ca-certificates/cert.pem",
     ]
 
     # Define object templates

--- a/apprise/plugins/NotifyMQTT.py
+++ b/apprise/plugins/NotifyMQTT.py
@@ -133,6 +133,7 @@ class NotifyMQTT(NotifyBase):
     mqtt_inflight_messages = 200
 
     # Taken from https://golang.org/src/crypto/x509/root_linux.go
+    # TODO: Maybe migrate to a general utility function?
     CA_CERTIFICATE_FILE_LOCATIONS = [
         # Debian/Ubuntu/Gentoo etc.
         "/etc/ssl/certs/ca-certificates.crt",
@@ -264,6 +265,9 @@ class NotifyMQTT(NotifyBase):
         self.ca_certs = None
         if self.secure:
             # verify SSL key or abort
+            # TODO: There is no error reporting or aborting here?
+            #       It could be useful to inform the user _where_ Apprise
+            #       tried to find the root CA certificates file.
             self.ca_certs = next(
                 (cert for cert in self.CA_CERTIFICATE_FILE_LOCATIONS
                  if isfile(cert)), None)
@@ -316,9 +320,9 @@ class NotifyMQTT(NotifyBase):
 
                 if self.secure:
                     if self.ca_certs is None:
-                        self.logger.warning(
-                            'MQTT Secure comunication can not be verified; '
-                            'no local CA certificate file')
+                        self.logger.error(
+                            'MQTT secure communication can not be verified, '
+                            'CA certificates file missing')
                         return False
 
                     self.client.tls_set(

--- a/bin/checkdone.sh
+++ b/bin/checkdone.sh
@@ -47,6 +47,9 @@ if [ $FOUNDROOT -ne 0 ]; then
    exit 1
 fi
 
+# Tidy previous reports (if present)
+[ -d .coverage-reports ] && rm -rf .coverage-reports
+
 # This is a useful tool for checking for any lint errors and additionally
 # checking the overall coverage.
 which flake8 &>/dev/null
@@ -86,6 +89,12 @@ if [ $RET -ne 0 ]; then
    echo "Tests failed."
    exit 1
 fi
+
+# Build our report
+LANG=C.UTF-8 PYTHONPATH=$PYTHONPATH coverage combine
+
+# Prepare XML Reference
+LANG=C.UTF-8 PYTHONPATH=$PYTHONPATH coverage xml
 
 # Print our report
 LANG=C.UTF-8 PYTHONPATH=$PYTHONPATH coverage report --show-missing

--- a/test/test_plugin_mqtt.py
+++ b/test/test_plugin_mqtt.py
@@ -225,12 +225,7 @@ def test_plugin_mqtt_no_topic_failure(mqtt_client_mock):
 def test_plugin_mqtt_tls_connect_success(mqtt_client_mock):
     """
     Verify TLS encrypted connections work.
-
-    # TODO: Make it work on macOS.
     """
-
-    if sys.platform == "darwin":
-        raise pytest.xfail(reason="Fails on macOS")
 
     obj = apprise.Apprise.instantiate(
         'mqtts://user:pass@localhost/my/topic', suppress_exceptions=False)
@@ -259,14 +254,11 @@ def test_plugin_mqtt_tls_connect_success(mqtt_client_mock):
     ]
 
 
-    # TODO: Make it work on macOS.
 def test_plugin_mqtt_tls_no_certificates_failure(mqtt_client_mock, mocker):
     """
     Verify TLS does not work without access to CA root certificates.
     """
 
-    if sys.platform == "darwin":
-        raise pytest.xfail(reason="Fails on macOS")
     # Clear CA certificates.
     mocker.patch.object(NotifyMQTT, "CA_CERTIFICATE_FILE_LOCATIONS", [])
 
@@ -288,12 +280,7 @@ def test_plugin_mqtt_tls_no_certificates_failure(mqtt_client_mock, mocker):
 def test_plugin_mqtt_tls_no_verify_success(mqtt_client_mock):
     """
     Verify TLS encrypted connections work with `verify=False`.
-
-    # TODO: Make it work on macOS.
     """
-
-    if sys.platform == "darwin":
-        raise pytest.xfail(reason="Fails on macOS")
 
     # A single user (not password) + no verifying of host
     obj = apprise.Apprise.instantiate(


### PR DESCRIPTION
### Introduction

~While this patch does not intend to resolve the issue that NotifyMQTT tests using the `mqtts://` protocol currently fail on macOS (#695),~ Other than fixing #695 with a3c4bd03, this patch improves the test cases for the `NotifyMQTT` notifier significantly. It is intentionally focused and small, in order to anticipate some essential ingredients, and the style, from the other ever-growing patch #689, for the purpose of making the review process easier.

### In a nutshell

By using proper [`pytest` fixtures](https://docs.pytest.org/en/latest/explanation/fixtures.html) for context/environment setup, as well as [`pytest-mock`](https://pypi.org/project/pytest-mock/) for mocking, the patch significantly improves convenience and structure both when writing, and when reading and reasoning about test cases. More details about the benefits of this have been written at #689.

### Details

- Add `mqtt_client_mock` fixture for test case environment setup
- Use `mocker` for establishing `paho-mqtt` client and response mocks
- Dedicate each test case a separate test function
- Flag TLS-based tests with `mqtts://` protocol with XFAIL on macOS
