### PR TITLE
Tests: Use global `no_throttling_everywhere` fixture

### DIFF
--- a/apprise/common.pyi
+++ b/apprise/common.pyi
@@ -1,3 +1,7 @@
+import types
+import typing as t
+
+
 class NotifyType:
     INFO: NotifyType
     SUCCESS: NotifyType
@@ -13,3 +17,6 @@ class ContentLocation:
     LOCAL: ContentLocation
     HOSTED: ContentLocation
     INACCESSIBLE: ContentLocation
+
+
+NOTIFY_MODULE_MAP: t.Dict[str, t.Dict[str, t.Union[t.Type["NotifyBase"], types.ModuleType]]]

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,7 @@ coverage
 flake8
 pytest
 pytest-cov
+pytest-mock
 pytest-xdist
 tox
 babel

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -27,22 +27,17 @@ import os
 
 import pytest
 
-from apprise import NotifyBase
-from apprise.plugins.NotifyPushBullet import NotifyPushBullet
+from apprise.common import NOTIFY_MODULE_MAP
 
 sys.path.append(os.path.join(os.path.dirname(__file__), 'helpers'))
 
 
-@pytest.fixture
-def no_throttling():
+@pytest.fixture(scope="session", autouse=True)
+def no_throttling_everywhere(session_mocker):
     """
-    A pytest fixture which disables Apprise throttling.
+    A pytest session fixture which disables throttling on all notifiers.
+    It is automatically enabled.
     """
-    backup = {}
-    backup["NotifyBase"] = NotifyBase.request_rate_per_sec
-    backup["NotifyPushBullet"] = NotifyPushBullet.request_rate_per_sec
-    NotifyBase.request_rate_per_sec = 0
-    NotifyPushBullet.request_rate_per_sec = 0
-    yield
-    NotifyBase.request_rate_per_sec = backup["NotifyBase"]
-    NotifyPushBullet.request_rate_per_sec = backup["NotifyPushBullet"]
+    for notifier in NOTIFY_MODULE_MAP.values():
+        plugin = notifier["plugin"]
+        session_mocker.patch.object(plugin, "request_rate_per_sec", 0)

--- a/test/helpers/rest.py
+++ b/test/helpers/rest.py
@@ -115,8 +115,6 @@ class AppriseURLTester:
         """
         Run a specific test
         """
-        # Disable Throttling to speed testing
-        NotifyBase.request_rate_per_sec = 0
 
         # Our expected instance
         instance = meta.get('instance', None)
@@ -387,8 +385,6 @@ class AppriseURLTester:
 
         try:
             if test_requests_exceptions is False:
-                # Disable throttling
-                obj.request_rate_per_sec = 0
 
                 # check that we're as expected
                 assert obj.notify(
@@ -472,8 +468,6 @@ class AppriseURLTester:
                         attach=attach) == attach_response
 
             else:
-                # Disable throttling
-                obj.request_rate_per_sec = 0
 
                 for _exception in self.req_exceptions:
                     mock_post.side_effect = _exception

--- a/test/test_plugin_boxcar.py
+++ b/test/test_plugin_boxcar.py
@@ -119,7 +119,7 @@ def test_plugin_boxcar_urls():
 
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_boxcar_edge_cases(mock_post, mock_get, no_throttling):
+def test_plugin_boxcar_edge_cases(mock_post, mock_get):
     """
     NotifyBoxcar() Edge Cases
 

--- a/test/test_plugin_bulksms.py
+++ b/test/test_plugin_bulksms.py
@@ -132,7 +132,7 @@ def test_plugin_bulksms_urls():
 
 
 @mock.patch('requests.post')
-def test_plugin_bulksms_edge_cases(mock_post, no_throttling):
+def test_plugin_bulksms_edge_cases(mock_post):
     """
     NotifyBulkSMS() Edge Cases
 

--- a/test/test_plugin_custom_form.py
+++ b/test/test_plugin_custom_form.py
@@ -153,7 +153,7 @@ def test_plugin_custom_form_urls():
 
 
 @mock.patch('requests.post')
-def test_plugin_custom_form_attachments(mock_post, no_throttling):
+def test_plugin_custom_form_attachments(mock_post):
     """
     NotifyForm() Attachments
 
@@ -225,7 +225,7 @@ def test_plugin_custom_form_attachments(mock_post, no_throttling):
 
 @mock.patch('requests.post')
 @mock.patch('requests.get')
-def test_plugin_custom_form_edge_cases(mock_get, mock_post, no_throttling):
+def test_plugin_custom_form_edge_cases(mock_get, mock_post):
     """
     NotifyForm() Edge Cases
 

--- a/test/test_plugin_custom_json.py
+++ b/test/test_plugin_custom_json.py
@@ -151,7 +151,7 @@ def test_plugin_custom_json_urls():
 
 @mock.patch('requests.post')
 @mock.patch('requests.get')
-def test_plugin_custom_json_edge_cases(mock_get, mock_post, no_throttling):
+def test_plugin_custom_json_edge_cases(mock_get, mock_post):
     """
     NotifyJSON() Edge Cases
 
@@ -209,7 +209,7 @@ def test_plugin_custom_json_edge_cases(mock_get, mock_post, no_throttling):
 
 
 @mock.patch('requests.post')
-def test_notify_json_plugin_attachments(mock_post, no_throttling):
+def test_notify_json_plugin_attachments(mock_post):
     """
     NotifyJSON() Attachments
 

--- a/test/test_plugin_custom_xml.py
+++ b/test/test_plugin_custom_xml.py
@@ -165,7 +165,7 @@ def test_plugin_custom_xml_urls():
 
 
 @mock.patch('requests.post')
-def test_notify_xml_plugin_attachments(mock_post, no_throttling):
+def test_notify_xml_plugin_attachments(mock_post):
     """
     NotifyXML() Attachments
 
@@ -225,7 +225,7 @@ def test_notify_xml_plugin_attachments(mock_post, no_throttling):
 
 @mock.patch('requests.post')
 @mock.patch('requests.get')
-def test_plugin_custom_xml_edge_cases(mock_get, mock_post, no_throttling):
+def test_plugin_custom_xml_edge_cases(mock_get, mock_post):
     """
     NotifyXML() Edge Cases
 

--- a/test/test_plugin_dapnet.py
+++ b/test/test_plugin_dapnet.py
@@ -161,9 +161,6 @@ def test_plugin_dapnet_config_files(mock_post):
             tag: dapnet_str emerg
     """
 
-    # Disable Throttling to speed testing
-    NotifyDapnet.request_rate_per_sec = 0
-
     # Prepare Mock
     mock_post.return_value = requests.Request()
     mock_post.return_value.status_code = requests.codes.created

--- a/test/test_plugin_discord.py
+++ b/test/test_plugin_discord.py
@@ -169,7 +169,7 @@ def test_plugin_discord_urls():
 
 
 @mock.patch('requests.post')
-def test_plugin_discord_general(mock_post, no_throttling):
+def test_plugin_discord_general(mock_post):
     """
     NotifyDiscord() General Checks
 
@@ -363,7 +363,7 @@ def test_plugin_discord_general(mock_post, no_throttling):
 
 
 @mock.patch('requests.post')
-def test_plugin_discord_attachments(mock_post, no_throttling):
+def test_plugin_discord_attachments(mock_post):
     """
     NotifyDiscord() Attachment Checks
 

--- a/test/test_plugin_email.py
+++ b/test/test_plugin_email.py
@@ -250,7 +250,7 @@ TEST_URLS = (
 
 @mock.patch('smtplib.SMTP')
 @mock.patch('smtplib.SMTP_SSL')
-def test_plugin_email(mock_smtp, mock_smtpssl, no_throttling):
+def test_plugin_email(mock_smtp, mock_smtpssl):
     """
     NotifyEmail() General Checks
 
@@ -450,7 +450,7 @@ def test_plugin_email_webbase_lookup(mock_smtp, mock_smtpssl):
 
 
 @mock.patch('smtplib.SMTP')
-def test_plugin_email_smtplib_init_fail(mock_smtplib, no_throttling):
+def test_plugin_email_smtplib_init_fail(mock_smtplib):
     """
     NotifyEmail() Test exception handling when calling smtplib.SMTP()
 
@@ -473,7 +473,7 @@ def test_plugin_email_smtplib_init_fail(mock_smtplib, no_throttling):
 
 
 @mock.patch('smtplib.SMTP')
-def test_plugin_email_smtplib_send_okay(mock_smtplib, no_throttling):
+def test_plugin_email_smtplib_send_okay(mock_smtplib):
     """
     NotifyEmail() Test a successfully sent email
 
@@ -539,7 +539,7 @@ def test_plugin_email_smtplib_send_okay(mock_smtplib, no_throttling):
 
 
 @mock.patch('smtplib.SMTP')
-def test_plugin_email_smtplib_internationalization(mock_smtp, no_throttling):
+def test_plugin_email_smtplib_internationalization(mock_smtp):
     """
     NotifyEmail() Internationalization Handling
 
@@ -735,7 +735,7 @@ def test_plugin_email_dict_variations():
 
 @mock.patch('smtplib.SMTP_SSL')
 @mock.patch('smtplib.SMTP')
-def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl, no_throttling):
+def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
     """
     NotifyEmail() Test email url parsing
 

--- a/test/test_plugin_emby.py
+++ b/test/test_plugin_emby.py
@@ -88,7 +88,7 @@ def test_plugin_template_urls():
 @mock.patch('requests.get')
 @mock.patch('requests.post')
 def test_plugin_emby_general(mock_post, mock_get, mock_logout,
-                             mock_login, mock_sessions, no_throttling):
+                             mock_login, mock_sessions):
     """
     NotifyEmby General Tests
 
@@ -162,7 +162,7 @@ def test_plugin_emby_general(mock_post, mock_get, mock_logout,
 
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_emby_login(mock_post, mock_get, no_throttling):
+def test_plugin_emby_login(mock_post, mock_get):
     """
     NotifyEmby() login()
 
@@ -276,8 +276,7 @@ def test_plugin_emby_login(mock_post, mock_get, no_throttling):
 @mock.patch('apprise.plugins.NotifyEmby.NotifyEmby.logout')
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_emby_sessions(mock_post, mock_get, mock_logout, mock_login,
-                              no_throttling):
+def test_plugin_emby_sessions(mock_post, mock_get, mock_logout, mock_login):
     """
     NotifyEmby() sessions()
 
@@ -372,7 +371,7 @@ def test_plugin_emby_sessions(mock_post, mock_get, mock_logout, mock_login,
 @mock.patch('apprise.plugins.NotifyEmby.NotifyEmby.login')
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_emby_logout(mock_post, mock_get, mock_login, no_throttling):
+def test_plugin_emby_logout(mock_post, mock_get, mock_login):
     """
     NotifyEmby() logout()
 

--- a/test/test_plugin_fcm.py
+++ b/test/test_plugin_fcm.py
@@ -207,7 +207,7 @@ def test_plugin_fcm_urls():
 @pytest.mark.skipif(
     hasattr(sys, "pypy_version_info"), reason="Does not work reliably on PyPy")
 @mock.patch('requests.post')
-def test_plugin_fcm_general_legacy(mock_post, no_throttling):
+def test_plugin_fcm_general_legacy(mock_post):
     """
     NotifyFCM() General Legacy/APIKey Checks
 
@@ -332,7 +332,7 @@ def test_plugin_fcm_general_legacy(mock_post, no_throttling):
 @pytest.mark.skipif(
     'cryptography' not in sys.modules, reason="Requires cryptography")
 @mock.patch('requests.post')
-def test_plugin_fcm_general_oauth(mock_post, no_throttling):
+def test_plugin_fcm_general_oauth(mock_post):
     """
     NotifyFCM() General OAuth Checks
 
@@ -848,7 +848,7 @@ def test_plugin_fcm_cryptography_import_error():
 @pytest.mark.skipif(
     'cryptography' not in sys.modules, reason="Requires cryptography")
 @mock.patch('requests.post')
-def test_plugin_fcm_edge_cases(mock_post, no_throttling):
+def test_plugin_fcm_edge_cases(mock_post):
     """
     NotifyFCM() Edge Cases
 

--- a/test/test_plugin_flock.py
+++ b/test/test_plugin_flock.py
@@ -164,7 +164,7 @@ def test_plugin_flock_urls():
 
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_flock_edge_cases(mock_post, mock_get, no_throttling):
+def test_plugin_flock_edge_cases(mock_post, mock_get):
     """
     NotifyFlock() Edge Cases
 

--- a/test/test_plugin_gitter.py
+++ b/test/test_plugin_gitter.py
@@ -115,7 +115,7 @@ def test_plugin_gitter_urls():
 
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_gitter_general(mock_post, mock_get, no_throttling):
+def test_plugin_gitter_general(mock_post, mock_get):
     """
     NotifyGitter() General Tests
 

--- a/test/test_plugin_gotify.py
+++ b/test/test_plugin_gotify.py
@@ -155,9 +155,6 @@ def test_plugin_gotify_config_files(mock_post):
             tag: gotify_str emerg
     """ % ('a' * 16, 'b' * 16)
 
-    # Disable Throttling to speed testing
-    NotifyGotify.request_rate_per_sec = 0
-
     # Prepare Mock
     mock_post.return_value = requests.Request()
     mock_post.return_value.status_code = requests.codes.ok

--- a/test/test_plugin_growl.py
+++ b/test/test_plugin_growl.py
@@ -324,7 +324,7 @@ def test_plugin_growl_general(mock_gntp):
 @pytest.mark.skipif(
     'gntp' not in sys.modules, reason="Requires gntp")
 @mock.patch('gntp.notifier.GrowlNotifier')
-def test_plugin_growl_config_files(mock_gntp, no_throttling):
+def test_plugin_growl_config_files(mock_gntp):
     """
     NotifyGrowl() Config File Cases
     """

--- a/test/test_plugin_guilded.py
+++ b/test/test_plugin_guilded.py
@@ -146,7 +146,7 @@ def test_plugin_guilded_urls():
 
 
 @mock.patch('requests.post')
-def test_plugin_guilded_general(mock_post, no_throttling):
+def test_plugin_guilded_general(mock_post):
     """
     NotifyGuilded() General Checks
 

--- a/test/test_plugin_homeassistant.py
+++ b/test/test_plugin_homeassistant.py
@@ -124,7 +124,7 @@ def test_plugin_homeassistant_urls():
 
 
 @mock.patch('requests.post')
-def test_plugin_homeassistant_general(mock_post, no_throttling):
+def test_plugin_homeassistant_general(mock_post):
     """
     NotifyHomeAssistant() General Checks
 

--- a/test/test_plugin_ifttt.py
+++ b/test/test_plugin_ifttt.py
@@ -111,7 +111,7 @@ def test_plugin_ifttt_urls():
 
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_ifttt_edge_cases(mock_post, mock_get, no_throttling):
+def test_plugin_ifttt_edge_cases(mock_post, mock_get):
     """
     NotifyIFTTT() Edge Cases
 

--- a/test/test_plugin_join.py
+++ b/test/test_plugin_join.py
@@ -128,7 +128,7 @@ def test_plugin_join_urls():
 
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_join_edge_cases(mock_post, mock_get, no_throttling):
+def test_plugin_join_edge_cases(mock_post, mock_get):
     """
     NotifyJoin() Edge Cases
 
@@ -169,7 +169,7 @@ def test_plugin_join_edge_cases(mock_post, mock_get, no_throttling):
 
 
 @mock.patch('requests.post')
-def test_plugin_join_config_files(mock_post, no_throttling):
+def test_plugin_join_config_files(mock_post):
     """
     NotifyJoin() Config File Cases
     """

--- a/test/test_plugin_kumulos.py
+++ b/test/test_plugin_kumulos.py
@@ -96,7 +96,7 @@ def test_plugin_kumulos_urls():
     AppriseURLTester(tests=apprise_url_tests).run_all()
 
 
-def test_plugin_kumulos_edge_cases(no_throttling):
+def test_plugin_kumulos_edge_cases():
     """
     NotifyKumulos() Edge Cases
 

--- a/test/test_plugin_mailgun.py
+++ b/test/test_plugin_mailgun.py
@@ -177,7 +177,7 @@ def test_plugin_mailgun_urls():
 
 
 @mock.patch('requests.post')
-def test_plugin_mailgun_attachments(mock_post, no_throttling):
+def test_plugin_mailgun_attachments(mock_post):
     """
     NotifyMailgun() Attachments
 

--- a/test/test_plugin_matrix.py
+++ b/test/test_plugin_matrix.py
@@ -197,7 +197,7 @@ def test_plugin_matrix_urls():
 
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_matrix_general(mock_post, mock_get, no_throttling):
+def test_plugin_matrix_general(mock_post, mock_get):
     """
     NotifyMatrix() General Tests
 
@@ -352,7 +352,7 @@ def test_plugin_matrix_general(mock_post, mock_get, no_throttling):
 
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_matrix_fetch(mock_post, mock_get, no_throttling):
+def test_plugin_matrix_fetch(mock_post, mock_get):
     """
     NotifyMatrix() Server Fetch/API Tests
 
@@ -454,7 +454,7 @@ def test_plugin_matrix_fetch(mock_post, mock_get, no_throttling):
 
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_matrix_auth(mock_post, mock_get, no_throttling):
+def test_plugin_matrix_auth(mock_post, mock_get):
     """
     NotifyMatrix() Server Authentication
 
@@ -548,7 +548,7 @@ def test_plugin_matrix_auth(mock_post, mock_get, no_throttling):
 
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_matrix_rooms(mock_post, mock_get, no_throttling):
+def test_plugin_matrix_rooms(mock_post, mock_get):
     """
     NotifyMatrix() Room Testing
 

--- a/test/test_plugin_mattermost.py
+++ b/test/test_plugin_mattermost.py
@@ -123,7 +123,7 @@ def test_plugin_mattermost_urls():
     AppriseURLTester(tests=apprise_url_tests).run_all()
 
 
-def test_plugin_mattermost_edge_cases(no_throttling):
+def test_plugin_mattermost_edge_cases():
     """
     NotifyMattermost() Edge Cases
 

--- a/test/test_plugin_messagebird.py
+++ b/test/test_plugin_messagebird.py
@@ -104,7 +104,7 @@ def test_plugin_messagebird_urls():
 
 
 @mock.patch('requests.post')
-def test_plugin_messagebird_edge_cases(mock_post, no_throttling):
+def test_plugin_messagebird_edge_cases(mock_post):
     """
     NotifyMessageBird() Edge Cases
 

--- a/test/test_plugin_mqtt.py
+++ b/test/test_plugin_mqtt.py
@@ -57,7 +57,7 @@ def test_plugin_mqtt_paho_import_error(mock_post):
 @pytest.mark.skipif(
     'paho' not in sys.modules, reason="Requires paho-mqtt")
 @mock.patch('paho.mqtt.client.Client')
-def test_plugin_mqtt_general(mock_client, no_throttling):
+def test_plugin_mqtt_general(mock_client):
     """
     NotifyMQTT() General Checks
 

--- a/test/test_plugin_msg91.py
+++ b/test/test_plugin_msg91.py
@@ -127,7 +127,7 @@ def test_plugin_msg91_urls():
 
 
 @mock.patch('requests.post')
-def test_plugin_msg91_edge_cases(mock_post, no_throttling):
+def test_plugin_msg91_edge_cases(mock_post):
     """
     NotifyMSG91() Edge Cases
 

--- a/test/test_plugin_msteams.py
+++ b/test/test_plugin_msteams.py
@@ -176,7 +176,7 @@ def test_plugin_msteams_urls():
 
 
 @mock.patch('requests.post')
-def test_plugin_msteams_templating(mock_post, tmpdir, no_throttling):
+def test_plugin_msteams_templating(mock_post, tmpdir):
     """
     NotifyMSTeams() Templating
 
@@ -385,7 +385,7 @@ def test_plugin_msteams_templating(mock_post, tmpdir, no_throttling):
 @pytest.mark.skipif(
     hasattr(sys, "pypy_version_info"), reason="Does not work reliably on PyPy")
 @mock.patch('requests.post')
-def test_msteams_yaml_config(mock_post, tmpdir, no_throttling):
+def test_msteams_yaml_config(mock_post, tmpdir):
     """
     NotifyMSTeams() YAML Configuration Entries
 

--- a/test/test_plugin_nextcloud.py
+++ b/test/test_plugin_nextcloud.py
@@ -131,7 +131,7 @@ def test_plugin_nextcloud_urls():
 
 
 @mock.patch('requests.post')
-def test_plugin_nextcloud_edge_cases(mock_post, no_throttling):
+def test_plugin_nextcloud_edge_cases(mock_post):
     """
     NotifyNextcloud() Edge Cases
 

--- a/test/test_plugin_nextcloudtalk.py
+++ b/test/test_plugin_nextcloudtalk.py
@@ -121,7 +121,7 @@ def test_plugin_nextcloudtalk_urls():
 
 
 @mock.patch('requests.post')
-def test_plugin_nextcloudtalk_edge_cases(mock_post, no_throttling):
+def test_plugin_nextcloudtalk_edge_cases(mock_post):
     """
     NotifyNextcloud() Edge Cases
 

--- a/test/test_plugin_ntfy.py
+++ b/test/test_plugin_ntfy.py
@@ -233,7 +233,7 @@ def test_plugin_ntfy_chat_urls():
 
 
 @mock.patch('requests.post')
-def test_plugin_ntfy_attachments(mock_post, no_throttling):
+def test_plugin_ntfy_attachments(mock_post):
     """
     NotifyNtfy() Attachment Checks
 
@@ -348,7 +348,7 @@ def test_plugin_ntfy_attachments(mock_post, no_throttling):
 
 
 @mock.patch('requests.post')
-def test_plugin_custom_ntfy_edge_cases(mock_post, no_throttling):
+def test_plugin_custom_ntfy_edge_cases(mock_post):
     """
     NotifyNtfy() Edge Cases
 
@@ -425,7 +425,7 @@ def test_plugin_custom_ntfy_edge_cases(mock_post, no_throttling):
 
 @mock.patch('requests.post')
 @mock.patch('requests.get')
-def test_plugin_ntfy_config_files(mock_post, mock_get, no_throttling):
+def test_plugin_ntfy_config_files(mock_post, mock_get):
     """
     NotifyNtfy() Config File Cases
     """

--- a/test/test_plugin_office365.py
+++ b/test/test_plugin_office365.py
@@ -183,7 +183,7 @@ def test_plugin_office365_urls():
 
 
 @mock.patch('requests.post')
-def test_plugin_office365_general(mock_post, no_throttling):
+def test_plugin_office365_general(mock_post):
     """
     NotifyOffice365() General Testing
 
@@ -299,7 +299,7 @@ def test_plugin_office365_general(mock_post, no_throttling):
 
 
 @mock.patch('requests.post')
-def test_plugin_office365_authentication(mock_post, no_throttling):
+def test_plugin_office365_authentication(mock_post):
     """
     NotifyOffice365() Authentication Testing
 

--- a/test/test_plugin_opsgenie.py
+++ b/test/test_plugin_opsgenie.py
@@ -135,9 +135,6 @@ def test_plugin_opsgenie_urls():
 
     """
 
-    # Disable Throttling to speed testing
-    NotifyOpsgenie.request_rate_per_sec = 0
-
     # Run our general tests
     AppriseURLTester(tests=apprise_url_tests).run_all()
 
@@ -173,9 +170,6 @@ def test_plugin_opsgenie_config_files(mock_post):
           - priority: emergency
             tag: opsgenie_str emerg
     """
-
-    # Disable Throttling to speed testing
-    NotifyOpsgenie.request_rate_per_sec = 0
 
     # Prepare Mock
     mock_post.return_value = requests.Request()

--- a/test/test_plugin_prowl.py
+++ b/test/test_plugin_prowl.py
@@ -173,9 +173,6 @@ def test_plugin_prowl_config_files(mock_post):
             tag: prowl_str emerg
     """ % ('a' * 40, 'b' * 40)
 
-    # Disable Throttling to speed testing
-    NotifyProwl.request_rate_per_sec = 0
-
     # Prepare Mock
     mock_post.return_value = requests.Request()
     mock_post.return_value.status_code = requests.codes.ok

--- a/test/test_plugin_pushbullet.py
+++ b/test/test_plugin_pushbullet.py
@@ -192,7 +192,7 @@ def test_plugin_pushbullet_urls():
 
 
 @mock.patch('requests.post')
-def test_plugin_pushbullet_attachments(mock_post, no_throttling):
+def test_plugin_pushbullet_attachments(mock_post):
     """
     NotifyPushBullet() Attachment Checks
 
@@ -333,7 +333,7 @@ def test_plugin_pushbullet_attachments(mock_post, no_throttling):
 
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_pushbullet_edge_cases(mock_post, mock_get, no_throttling):
+def test_plugin_pushbullet_edge_cases(mock_post, mock_get):
     """
     NotifyPushBullet() Edge Cases
 

--- a/test/test_plugin_pushed.py
+++ b/test/test_plugin_pushed.py
@@ -146,7 +146,7 @@ def test_plugin_pushed_urls():
 
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_pushed_edge_cases(mock_post, mock_get, no_throttling):
+def test_plugin_pushed_edge_cases(mock_post, mock_get):
     """
     NotifyPushed() Edge Cases
 

--- a/test/test_plugin_pushjet.py
+++ b/test/test_plugin_pushjet.py
@@ -97,7 +97,7 @@ def test_plugin_pushjet_urls():
     AppriseURLTester(tests=apprise_url_tests).run_all()
 
 
-def test_plugin_pushjet_edge_cases(no_throttling):
+def test_plugin_pushjet_edge_cases():
     """
     NotifyPushjet() Edge Cases
 

--- a/test/test_plugin_pushover.py
+++ b/test/test_plugin_pushover.py
@@ -196,8 +196,6 @@ def test_plugin_pushover_attachments(mock_post, tmpdir):
     NotifyPushover() Attachment Checks
 
     """
-    # Disable Throttling to speed testing
-    NotifyPushover.request_rate_per_sec = 0
 
     # Initialize some generic (but valid) tokens
     user_key = 'u' * 30
@@ -315,8 +313,6 @@ def test_plugin_pushover_edge_cases(mock_post):
     NotifyPushover() Edge Cases
 
     """
-    # Disable Throttling to speed testing
-    NotifyPushover.request_rate_per_sec = 0
 
     # No token
     with pytest.raises(TypeError):
@@ -406,9 +402,6 @@ def test_plugin_pushover_config_files(mock_post):
           - priority: emergency
             tag: pushover_str emerg
     """
-
-    # Disable Throttling to speed testing
-    NotifyPushover.request_rate_per_sec = 0
 
     # Prepare Mock
     mock_post.return_value = requests.Request()

--- a/test/test_plugin_pushsafer.py
+++ b/test/test_plugin_pushsafer.py
@@ -226,8 +226,6 @@ def test_plugin_pushsafer_general(mock_post):
     NotifyPushSafer() General Tests
 
     """
-    # Disable Throttling to speed testing
-    NotifyPushSafer.request_rate_per_sec = 0
 
     # Private Key
     privatekey = 'abc123'

--- a/test/test_plugin_reddit.py
+++ b/test/test_plugin_reddit.py
@@ -226,7 +226,7 @@ def test_plugin_reddit_urls():
 
 
 @mock.patch('requests.post')
-def test_plugin_reddit_general(mock_post, no_throttling):
+def test_plugin_reddit_general(mock_post):
     """
     NotifyReddit() General Tests
 

--- a/test/test_plugin_rocket_chat.py
+++ b/test/test_plugin_rocket_chat.py
@@ -228,7 +228,7 @@ def test_plugin_rocket_chat_urls():
 
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_rocketchat_edge_cases(mock_post, mock_get, no_throttling):
+def test_plugin_rocketchat_edge_cases(mock_post, mock_get):
     """
     NotifyRocketChat() Edge Cases
 

--- a/test/test_plugin_ryver.py
+++ b/test/test_plugin_ryver.py
@@ -123,7 +123,7 @@ def test_plugin_ryver_urls():
     AppriseURLTester(tests=apprise_url_tests).run_all()
 
 
-def test_plugin_ryver_edge_cases(no_throttling):
+def test_plugin_ryver_edge_cases():
     """
     NotifyRyver() Edge Cases
 

--- a/test/test_plugin_sendgrid.py
+++ b/test/test_plugin_sendgrid.py
@@ -127,7 +127,7 @@ def test_plugin_sendgrid_urls():
 
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_sendgrid_edge_cases(mock_post, mock_get, no_throttling):
+def test_plugin_sendgrid_edge_cases(mock_post, mock_get):
     """
     NotifySendGrid() Edge Cases
 

--- a/test/test_plugin_ses.py
+++ b/test/test_plugin_ses.py
@@ -377,8 +377,6 @@ def test_plugin_ses_attachments(mock_post):
     NotifySES() Attachment Checks
 
     """
-    # Disable Throttling to speed testing
-    NotifySES.request_rate_per_sec = 0
 
     # Prepare Mock return object
     response = mock.Mock()

--- a/test/test_plugin_signal.py
+++ b/test/test_plugin_signal.py
@@ -154,7 +154,7 @@ def test_plugin_signal_urls():
 
 
 @mock.patch('requests.post')
-def test_plugin_signal_edge_cases(mock_post, no_throttling):
+def test_plugin_signal_edge_cases(mock_post):
     """
     NotifySignalAPI() Edge Cases
 
@@ -207,7 +207,7 @@ def test_plugin_signal_edge_cases(mock_post, no_throttling):
 
 
 @mock.patch('requests.post')
-def test_plugin_signal_test_based_on_feedback(mock_post, no_throttling):
+def test_plugin_signal_test_based_on_feedback(mock_post):
     """
     NotifySignalAPI() User Feedback Test
 
@@ -305,7 +305,7 @@ def test_plugin_signal_test_based_on_feedback(mock_post, no_throttling):
 
 
 @mock.patch('requests.post')
-def test_notify_signal_plugin_attachments(mock_post, no_throttling):
+def test_notify_signal_plugin_attachments(mock_post):
     """
     NotifySignalAPI() Attachments
 

--- a/test/test_plugin_simplepush.py
+++ b/test/test_plugin_simplepush.py
@@ -130,7 +130,7 @@ def test_plugin_fcm_cryptography_import_error():
 
 @pytest.mark.skipif(
     'cryptography' not in sys.modules, reason="Requires cryptography")
-def test_plugin_simplepush_edge_cases(no_throttling):
+def test_plugin_simplepush_edge_cases():
     """
     NotifySimplePush() Edge Cases
 
@@ -154,7 +154,7 @@ def test_plugin_simplepush_edge_cases(no_throttling):
 @pytest.mark.skipif(
     'cryptography' not in sys.modules, reason="Requires cryptography")
 @mock.patch('requests.post')
-def test_plugin_simplepush_general(mock_post, no_throttling):
+def test_plugin_simplepush_general(mock_post):
     """
     NotifySimplePush() General Tests
     """

--- a/test/test_plugin_sinch.py
+++ b/test/test_plugin_sinch.py
@@ -134,7 +134,7 @@ def test_plugin_sinch_urls():
 
 
 @mock.patch('requests.post')
-def test_plugin_sinch_edge_cases(mock_post, no_throttling):
+def test_plugin_sinch_edge_cases(mock_post):
     """
     NotifySinch() Edge Cases
 

--- a/test/test_plugin_slack.py
+++ b/test/test_plugin_slack.py
@@ -267,8 +267,6 @@ def test_plugin_slack_oauth_access_token(mock_post):
     NotifySlack() OAuth Access Token Tests
 
     """
-    # Disable Throttling to speed testing
-    NotifySlack.request_rate_per_sec = 0
 
     # Generate an invalid bot token
     token = 'xo-invalid'
@@ -390,8 +388,6 @@ def test_plugin_slack_webhook_mode(mock_post):
     NotifySlack() Webhook Mode Tests
 
     """
-    # Disable Throttling to speed testing
-    NotifySlack.request_rate_per_sec = 0
 
     # Prepare Mock
     mock_post.return_value = requests.Request()
@@ -438,8 +434,6 @@ def test_plugin_slack_send_by_email(mock_get, mock_post):
     NotifySlack() Send by Email Tests
 
     """
-    # Disable Throttling to speed testing
-    NotifySlack.request_rate_per_sec = 0
 
     # Generate a (valid) bot token
     token = 'xoxb-1234-1234-abc124'

--- a/test/test_plugin_smseagle.py
+++ b/test/test_plugin_smseagle.py
@@ -269,7 +269,7 @@ def test_plugin_smseagle_urls():
 
 
 @mock.patch('requests.post')
-def test_plugin_smseagle_edge_cases(mock_post, no_throttling):
+def test_plugin_smseagle_edge_cases(mock_post):
     """
     NotifySMSEagle() Edge Cases
 
@@ -319,7 +319,7 @@ def test_plugin_smseagle_edge_cases(mock_post, no_throttling):
 
 
 @mock.patch('requests.post')
-def test_plugin_smseagle_result_set(mock_post, no_throttling):
+def test_plugin_smseagle_result_set(mock_post):
     """
     NotifySMSEagle() Result Sets
 
@@ -535,7 +535,7 @@ def test_plugin_smseagle_result_set(mock_post, no_throttling):
 
 
 @mock.patch('requests.post')
-def test_notify_smseagle_plugin_result_list(mock_post, no_throttling):
+def test_notify_smseagle_plugin_result_list(mock_post):
     """
     NotifySMSEagle() Result List Response
 
@@ -577,7 +577,7 @@ def test_notify_smseagle_plugin_result_list(mock_post, no_throttling):
 
 
 @mock.patch('requests.post')
-def test_notify_smseagle_plugin_attachments(mock_post, no_throttling):
+def test_notify_smseagle_plugin_attachments(mock_post):
     """
     NotifySMSEagle() Attachments
 

--- a/test/test_plugin_smtp2go.py
+++ b/test/test_plugin_smtp2go.py
@@ -155,7 +155,7 @@ def test_plugin_smtp2go_urls():
 
 
 @mock.patch('requests.post')
-def test_plugin_smtp2go_attachments(mock_post, no_throttling):
+def test_plugin_smtp2go_attachments(mock_post):
     """
     NotifySMTP2Go() Attachments
 

--- a/test/test_plugin_sns.py
+++ b/test/test_plugin_sns.py
@@ -329,8 +329,6 @@ def test_plugin_sns_aws_topic_handling(mock_post):
     NotifySNS() AWS Topic Handling
 
     """
-    # Disable Throttling to speed testing
-    NotifySNS.request_rate_per_sec = 0
 
     arn_response = \
         """

--- a/test/test_plugin_sparkpost.py
+++ b/test/test_plugin_sparkpost.py
@@ -263,7 +263,7 @@ def test_plugin_sparkpost_urls():
 
 
 @mock.patch('requests.post')
-def test_plugin_sparkpost_throttling(mock_post, no_throttling):
+def test_plugin_sparkpost_throttling(mock_post):
     """
     NotifySparkPost() Throttling
 
@@ -332,7 +332,7 @@ def test_plugin_sparkpost_throttling(mock_post, no_throttling):
 
 
 @mock.patch('requests.post')
-def test_plugin_sparkpost_attachments(mock_post, no_throttling):
+def test_plugin_sparkpost_attachments(mock_post):
     """
     NotifySparkPost() Attachments
 

--- a/test/test_plugin_telegram.py
+++ b/test/test_plugin_telegram.py
@@ -212,9 +212,6 @@ def test_plugin_telegram_urls():
 
     """
 
-    # Disable Throttling to speed testing
-    NotifyTelegram.request_rate_per_sec = 0
-
     # Run our general tests
     AppriseURLTester(tests=apprise_url_tests).run_all()
 
@@ -225,9 +222,6 @@ def test_plugin_telegram_general(mock_post):
     NotifyTelegram() General Tests
 
     """
-
-    # Disable Throttling to speed testing
-    NotifyTelegram.request_rate_per_sec = 0
 
     # Bot Token
     bot_token = '123456789:abcdefg_hijklmnop'
@@ -541,9 +535,6 @@ def test_plugin_telegram_formatting(mock_post):
     """
     NotifyTelegram() formatting tests
     """
-
-    # Disable Throttling to speed testing
-    NotifyTelegram.request_rate_per_sec = 0
 
     # Prepare Mock
     mock_post.return_value = requests.Request()
@@ -884,9 +875,6 @@ def test_plugin_telegram_html_formatting(mock_post):
 
     """
     # on't send anything other than <b>, <i>, <a>,<code> and <pre>
-
-    # Disable Throttling to speed testing
-    NotifyTelegram.request_rate_per_sec = 0
 
     # Prepare Mock
     mock_post.return_value = requests.Request()

--- a/test/test_plugin_twilio.py
+++ b/test/test_plugin_twilio.py
@@ -128,7 +128,7 @@ def test_plugin_twilio_urls():
 
 
 @mock.patch('requests.post')
-def test_plugin_twilio_auth(mock_post, no_throttling):
+def test_plugin_twilio_auth(mock_post):
     """
     NotifyTwilio() Auth
       - account-wide auth token
@@ -197,7 +197,7 @@ def test_plugin_twilio_auth(mock_post, no_throttling):
 
 
 @mock.patch('requests.post')
-def test_plugin_twilio_edge_cases(mock_post, no_throttling):
+def test_plugin_twilio_edge_cases(mock_post):
     """
     NotifyTwilio() Edge Cases
 

--- a/test/test_plugin_twist.py
+++ b/test/test_plugin_twist.py
@@ -164,7 +164,7 @@ def test_plugin_twist_init():
 
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_twist_auth(mock_post, mock_get, no_throttling):
+def test_plugin_twist_auth(mock_post, mock_get):
     """
     NotifyTwist() login/logout()
 
@@ -266,7 +266,7 @@ def test_plugin_twist_auth(mock_post, mock_get, no_throttling):
 
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_twist_cache(mock_post, mock_get, no_throttling):
+def test_plugin_twist_cache(mock_post, mock_get):
     """
     NotifyTwist() Cache Handling
 
@@ -351,7 +351,7 @@ def test_plugin_twist_cache(mock_post, mock_get, no_throttling):
 
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_twist_fetch(mock_post, mock_get, no_throttling):
+def test_plugin_twist_fetch(mock_post, mock_get):
     """
     NotifyTwist() fetch()
 

--- a/test/test_plugin_twitter.py
+++ b/test/test_plugin_twitter.py
@@ -212,7 +212,7 @@ def test_plugin_twitter_urls():
 
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_twitter_general(mock_post, mock_get, no_throttling):
+def test_plugin_twitter_general(mock_post, mock_get):
     """
     NotifyTwitter() General Tests
 
@@ -420,7 +420,7 @@ def test_plugin_twitter_edge_cases():
 
 @mock.patch('requests.post')
 @mock.patch('requests.get')
-def test_plugin_twitter_dm_attachments(mock_get, mock_post, no_throttling):
+def test_plugin_twitter_dm_attachments(mock_get, mock_post):
     """
     NotifyTwitter() DM Attachment Checks
 
@@ -636,7 +636,7 @@ def test_plugin_twitter_dm_attachments(mock_get, mock_post, no_throttling):
 
 @mock.patch('requests.post')
 @mock.patch('requests.get')
-def test_plugin_twitter_tweet_attachments(mock_get, mock_post, no_throttling):
+def test_plugin_twitter_tweet_attachments(mock_get, mock_post):
     """
     NotifyTwitter() Tweet Attachment Checks
 

--- a/test/test_plugin_vonage.py
+++ b/test/test_plugin_vonage.py
@@ -181,7 +181,7 @@ def test_plugin_vonage_urls():
 
 
 @mock.patch('requests.post')
-def test_plugin_vonage_edge_cases(mock_post, no_throttling):
+def test_plugin_vonage_edge_cases(mock_post):
     """
     NotifyVonage() Edge Cases
 

--- a/test/test_plugin_zulip.py
+++ b/test/test_plugin_zulip.py
@@ -121,7 +121,7 @@ def test_plugin_zulip_urls():
     AppriseURLTester(tests=apprise_url_tests).run_all()
 
 
-def test_plugin_zulip_edge_cases(no_throttling):
+def test_plugin_zulip_edge_cases():
     """
     NotifyZulip() Edge Cases
 

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -37,7 +37,7 @@ import logging
 logging.disable(logging.CRITICAL)
 
 
-def test_notify_overflow_truncate(no_throttling):
+def test_notify_overflow_truncate():
     """
     API: Overflow Truncate Functionality Testing
 
@@ -206,7 +206,7 @@ def test_notify_overflow_truncate(no_throttling):
     assert title[0:TestNotification.body_maxlen] == chunks[0].get('body')
 
 
-def test_notify_overflow_split(no_throttling):
+def test_notify_overflow_split():
     """
     API: Overflow Split Functionality Testing
 
@@ -379,7 +379,7 @@ def test_notify_overflow_split(no_throttling):
         offset += len(_body)
 
 
-def test_notify_overflow_general(no_throttling):
+def test_notify_overflow_general():
     """
     API: Overflow General Testing
 


### PR DESCRIPTION
#687 added a `no_throttling` function-scoped fixture, which needed to be individually attached to specific test cases.

Instead of needing to individually disable throttling on a per-plugin basis, the new `no_throttling_everywhere` session-scoped fixture takes care of all notifiers in `NOTIFY_MODULE_MAP` automatically. With `autouse=True`, there is no need to activate it manually.

I've broke this away from #689, in order to make the review of each patch a bit easier.