### PR TITLE
CI: Add GHA setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,128 @@
+name: Tests
+
+on:
+
+  # On which repository actions to trigger the build.
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allow job to be triggered manually.
+  workflow_dispatch:
+
+# Cancel in-progress jobs when pushing to the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+
+  tests:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+
+      # Run all jobs to completion (false), or cancel
+      # all jobs once the first one fails (true).
+      fail-fast: true
+
+      matrix:
+        os: [
+          "ubuntu-latest",
+          # "macos-latest",
+          # "windows-latest",
+        ]
+        python-version: [
+          "3.6", "3.7", "3.8", "3.9", "3.10", "3.11-dev",
+          "pypy3.6", "pypy3.7", "pypy3.8", "pypy3.9",
+        ]
+        bare: [false]
+
+        # Add another single item to the test matrix. It is the `bare` environment,
+        # where `all-plugin-requirements.txt` will NOT be installed, in order to
+        # verify the application also works well without those optional dependencies.
+        include:
+          - os: "ubuntu-latest"
+            python-version: "3.10"
+            bare: true
+
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
+      BARE: ${{ matrix.bare }}
+
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }} (bare=${{ matrix.bare }})
+    steps:
+
+    - name: Acquire sources
+      uses: actions/checkout@v3
+
+    - name: Install prerequisites (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get install libdbus-1-dev
+
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: x64
+        cache: 'pip'
+        cache-dependency-path: |
+          setup.py
+          requirements.txt
+          dev-requirements.txt
+          all-plugin-requirements.txt
+          win-requirements.txt
+
+    - name: Install project dependencies (Baseline)
+      run: |
+        pip install wheel
+        pip install -r requirements.txt -r dev-requirements.txt
+
+    - name: Install project dependencies (All plugins)
+      if: matrix.bare != true
+      run: |
+        pip install -r all-plugin-requirements.txt
+        
+        # Installing `dbus-python` will croak on PyPy, so skip it.
+        [[ $PYTHON != 'pypy'* ]] && pip install dbus-python || true
+
+    - name: Install project dependencies (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        pip install -r win-requirements.txt
+
+    # Install package in editable mode,
+    # and run project-specific tasks.
+    - name: Setup project
+      run: |
+        pip install --editable=.
+        python setup.py compile_catalog
+
+    # For saving resources, code style checking is
+    # only invoked within the `bare` environment.
+    - name: Check code style
+      if: matrix.bare == true
+      run: |
+        flake8 . --count --show-source --statistics
+
+    - name: Run tests
+      run: |
+        coverage run -m pytest
+
+    - name: Process coverage data
+      run: |
+        coverage combine
+        coverage xml
+        coverage report
+
+    - name: Upload coverage data
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./coverage.xml
+        flags: unittests
+        env_vars: OS,PYTHON,BARE
+        name: codecov-umbrella
+        fail_ci_if_error: false

--- a/test/test_plugin_msteams.py
+++ b/test/test_plugin_msteams.py
@@ -175,6 +175,9 @@ def test_plugin_msteams_urls():
     AppriseURLTester(tests=apprise_url_tests).run_all()
 
 
+@pytest.mark.skipif(
+    hasattr(sys, "pypy_version_info") and sys.version_info < (3, 7),
+    reason="Does not work or is flaky on PyPy 3.6")
 @mock.patch('requests.post')
 def test_plugin_msteams_templating(mock_post, tmpdir):
     """

--- a/test/test_plugin_twitter.py
+++ b/test/test_plugin_twitter.py
@@ -24,6 +24,7 @@
 # THE SOFTWARE.
 
 import os
+import sys
 from unittest import mock
 
 import pytest
@@ -418,6 +419,9 @@ def test_plugin_twitter_edge_cases():
             targets='%G@rB@g3')
 
 
+@pytest.mark.skipif(
+    hasattr(sys, "pypy_version_info") and sys.version_info < (3, 7),
+    reason="Does not work or is flaky on PyPy 3.6")
 @mock.patch('requests.post')
 @mock.patch('requests.get')
 def test_plugin_twitter_dm_attachments(mock_get, mock_post):


### PR DESCRIPTION
Dear Chris,

after learning that CI builds regularly exhaust credits on Travis CI (I think that also currently happened at #700), this patch adds a corresponding configuration for GHA. It may save some credits, and aims to mitigate the hassle having to renew them regularly, and manually.

The builds just succeeded for the first time at [1-4], looking good so far. I think GHA performs well, with a total runtime of ~30 minutes, where it takes ~40 minutes on Travis CI.

With kind regards,
Andreas.

[1] https://github.com/panodata/apprise/actions/runs/3257301254/usage (33 minutes runtime)
[2] https://github.com/caronc/apprise/actions/runs/3257334731/usage (34 minutes runtime)
[3] https://github.com/caronc/apprise/actions/runs/3257397087/usage (29 minutes runtime)
[4] https://github.com/caronc/apprise/actions/runs/3257501205/usage (30 minutes runtime)
