### PR TITLE
Tests: Fix tests for `NotifyDBus`

### DIFF
--- a/test/test_plugin_glib.py
+++ b/test/test_plugin_glib.py
@@ -375,8 +375,8 @@ def test_plugin_dbus_missing_icon(mocker, dbus_glib_environment):
         title='title', body='body',
         notify_type=apprise.NotifyType.INFO) is True
     assert logger.mock_calls == [
-        call.warning('Could not load notification icon (%s). '
-                     'Reason: Something failed', ANY),
+        call.warning('Could not load notification icon (%s).', ANY),
+        call.debug('DBus Exception: Something failed'),
         call.info('Sent DBus notification.'),
     ]
 
@@ -511,7 +511,6 @@ def test_plugin_dbus_interface_notify_croaks(mocker):
         title='title', body='body',
         notify_type=apprise.NotifyType.INFO) is False
     assert [
-        call.warning('Failed to send DBus notification. '
-                     'Reason: Something failed'),
-        call.exception('DBus Exception')
+        call.warning('Failed to send DBus notification.'),
+        call.debug('DBus Exception: Something failed'),
     ] in logger.mock_calls


### PR DESCRIPTION
Last-minute change efe2a7e3 on #689 needed some adjustments on the test cases. This is similar to #703. Apparently, I missed it before.

The patch is needed to unblock a few subsequent patches, because CI will not signal success otherwise.