### PR TITLE
Mailgun to support `from=` for consistency with `email://`

### DIFF
--- a/apprise/plugins/NotifyMailgun.py
+++ b/apprise/plugins/NotifyMailgun.py
@@ -160,6 +160,9 @@ class NotifyMailgun(NotifyBase):
             'type': 'string',
             'map_to': 'from_name',
         },
+        'from': {
+            'alias_of': 'name',
+        },
         'region': {
             'name': _('Region Name'),
             'type': 'choice:string',
@@ -638,6 +641,12 @@ class NotifyMailgun(NotifyBase):
             results['apikey'] = None
 
         if 'name' in results['qsd'] and len(results['qsd']['name']):
+            # Extract from name to associate with from address
+            results['from_name'] = \
+                NotifyMailgun.unquote(results['qsd']['name'])
+
+        # Support from= for consistency with `mail://`
+        elif 'from' in results['qsd'] and len(results['qsd']['from']):
             # Extract from name to associate with from address
             results['from_name'] = \
                 NotifyMailgun.unquote(results['qsd']['name'])

--- a/test/test_plugin_mailgun.py
+++ b/test/test_plugin_mailgun.py
@@ -107,6 +107,12 @@ apprise_url_tests = (
             'a' * 32, 'b' * 8, 'c' * 8), {
                 'instance': NotifyMailgun,
         }),
+    # We can use the `from=` directive as well:
+    ('mailgun://user@localhost.localdomain/{}-{}-{}'
+        '?:from=Chris&:status=admin'.format(
+            'a' * 32, 'b' * 8, 'c' * 8), {
+                'instance': NotifyMailgun,
+        }),
     # bcc and cc
     ('mailgun://user@localhost.localdomain/{}-{}-{}'
         '?bcc=user@example.com&cc=user2@example.com'.format(


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #709

Mailgun allows you to change the `From` email by specifying the keyword `name=`.  However up until this issue (above) was created, it was documented on the wiki to use `from=`.

This PR just allows the `from=` to also work as this is more consistent with the `email://` plugin as well as many other plugins.

To prevent from breaking people configurations, the `name=` will continue to perform the same task. The wiki has been updated to correct for the `name=` reference.  But after the next release of Apprise, this can flip back to `from=`.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@709-mailgun-to-support-from

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
 "mailgun://credentials?from=Chris"

```

