### PR TITLE
Discord bugfix to better handle provided markdown

### DIFF
--- a/apprise/plugins/NotifyDiscord.py
+++ b/apprise/plugins/NotifyDiscord.py
@@ -580,7 +580,7 @@ class NotifyDiscord(NotifyBase):
         if description:
             # Strip description from our string since it has been handled
             # now.
-            markdown = re.sub(description, '', markdown, count=1)
+            markdown = re.sub(re.escape(description), '', markdown, count=1)
 
         regex = re.compile(
             r'\s*#[# \t\v]*(?P<name>[^\n]+)(\n|\s*$)'

--- a/test/test_plugin_discord.py
+++ b/test/test_plugin_discord.py
@@ -380,8 +380,8 @@ def test_plugin_discord_markdown_extra(mock_post):
     # Reset our apprise object
     a = Apprise()
 
-    # We want to further test our markdown support to accomodate bug rased on 2022.10.25
-    # see https://github.com/caronc/apprise/issues/717
+    # We want to further test our markdown support to accomodate bug rased on
+    # 2022.10.25; see https://github.com/caronc/apprise/issues/717
     assert a.add(
         'discord://{webhook_id}/{webhook_token}/'
         '?format=markdown&footer=Yes'.format(

--- a/test/test_plugin_discord.py
+++ b/test/test_plugin_discord.py
@@ -363,6 +363,43 @@ def test_plugin_discord_general(mock_post):
 
 
 @mock.patch('requests.post')
+def test_plugin_discord_markdown_extra(mock_post):
+    """
+    NotifyDiscord() Markdown Extra Checks
+
+    """
+
+    # Initialize some generic (but valid) tokens
+    webhook_id = 'A' * 24
+    webhook_token = 'B' * 64
+
+    # Prepare Mock
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    # Reset our apprise object
+    a = Apprise()
+
+    # We want to further test our markdown support to accomodate bug rased on 2022.10.25
+    # see https://github.com/caronc/apprise/issues/717
+    assert a.add(
+        'discord://{webhook_id}/{webhook_token}/'
+        '?format=markdown&footer=Yes'.format(
+            webhook_id=webhook_id,
+            webhook_token=webhook_token)) is True
+
+    test_markdown = "[green-blue](https://google.com)"
+
+    # This call includes an image with it's payload:
+    assert a.notify(body=test_markdown, title='title',
+                    notify_type=NotifyType.INFO,
+                    body_format=NotifyFormat.TEXT) is True
+
+    assert a.notify(
+        body='body', title='title', notify_type=NotifyType.INFO) is True
+
+
+@mock.patch('requests.post')
 def test_plugin_discord_attachments(mock_post):
     """
     NotifyDiscord() Attachment Checks


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #717 

Better handling of provided content

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@717-discord-markdown-bugfix

# Test out the changes with the following command:
apprise -t "Test Title" -b "[green-blue](https://google.com)" \
     "discord://credentials"
```
