### PR TITLE
CI: Clean up `codecov-action` configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,7 +124,4 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         files: ./coverage.xml
-        flags: unittests
-        env_vars: OS,PYTHON,BARE
-        name: codecov-umbrella
         fail_ci_if_error: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,7 @@ jobs:
     - name: Install prerequisites (Linux)
       if: runner.os == 'Linux'
       run: |
+        sudo apt-get update
         sudo apt-get install libdbus-1-dev
 
     - name: Setup Python


### PR DESCRIPTION
Hi again,

this is a followup to #716, in order to hopefully solve #715.

The Codecov uploader recipe did not pick up the `CODECOV_TOKEN` environment variable yet. Maybe it was masked by the `env_vars` configuration setting?

With kind regards,
Andreas.
