### PR TITLE
pagerduty:// severity= override; detected if not specified

### DIFF
--- a/test/test_plugin_pagerduty.py
+++ b/test/test_plugin_pagerduty.py
@@ -59,6 +59,10 @@ apprise_url_tests = (
         # invalid region
         'instance': TypeError,
     }),
+    ('pagerduty://myroutekey@myapikey?severity=invalid', {
+        # invalid severity
+        'instance': TypeError,
+    }),
     ('pagerduty://myroutekey@myapikey', {
         # minimum requirements met
         'instance': NotifyPagerDuty,
@@ -72,6 +76,14 @@ apprise_url_tests = (
     }),
     ('pagerduty://myroutekey@myapikey?region=eu', {
         # european region
+        'instance': NotifyPagerDuty,
+    }),
+    ('pagerduty://myroutekey@myapikey?severity=critical', {
+        # Severity over-ride
+        'instance': NotifyPagerDuty,
+    }),
+    ('pagerduty://myroutekey@myapikey?severity=err', {
+        # Severity over-ride (short-form)
         'instance': NotifyPagerDuty,
     }),
     # Custom values


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #657 

The Pager Duty `severity` is always automatically detected, but for those who wish to force it's value to a specific type can do so now by specifying `?severity=<value>` as part of the Apprise URL.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@657-pagerduty-severity

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "pagerduty://credentials/?severity=error"
```

