### PR TITLE
CI: Use `CODECOV_TOKEN` directly from `secrets` again

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,7 +80,6 @@ jobs:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
       BARE: ${{ matrix.bare }}
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} ${{ matrix.bare && '(bare)' || '' }}
     steps:
@@ -154,3 +153,4 @@ jobs:
       with:
         files: ./coverage.xml
         fail_ci_if_error: false
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
It will not be available on PRs submitted by non-owners anyway. [1] is a CI run on a PR submitted by @caronc. [2] is a CI run on a PR submitted by @amotl.

The first one says _Token found by environment variables_, and the second one says _No token specified or token is empty_.

[1] https://github.com/caronc/apprise/actions/runs/3357515509/jobs/5563373006#step:12:34
[2] https://github.com/caronc/apprise/actions/runs/3357954099/jobs/5564267408#step:12:34
