### PR TITLE
Added Slack URL Support

### DIFF
--- a/apprise/plugins/NotifySlack.py
+++ b/apprise/plugins/NotifySlack.py
@@ -449,20 +449,17 @@ class NotifySlack(NotifyBase):
                 )
 
                 # Support <url|desc>, <url> entries
-                urlfix = []
                 for match in self._re_url_support.findall(body):
                     # Swap back any ampersands previously updaated
                     url = match[1].replace('&amp;', '&')
                     desc = match[2].strip()
-                    urlfix.append({
-                        'replace': re.escape(match[0]),
-                        'with': '<{url}|{desc}>'.format(url=url, desc=desc)
-                        if desc else '<{url}>'.format(url=url)
-                    })
 
-                for entry in urlfix:
+                    # Update our string
                     body = re.sub(
-                        entry['replace'], entry['with'], body,
+                        re.escape(match[0]),
+                        '<{url}|{desc}>'.format(url=url, desc=desc)
+                        if desc else '<{url}>'.format(url=url),
+                        body,
                         re.IGNORECASE)
 
             # Perform Formatting on title here; this is not needed for block

--- a/apprise/plugins/NotifySlack.py
+++ b/apprise/plugins/NotifySlack.py
@@ -347,6 +347,15 @@ class NotifySlack(NotifyBase):
             r'>': '&gt;',
         }
 
+        # The markdown in slack isn't [desc](url), it's <url|desc>
+        #
+        # To accomodate this, we need to ensure we don't escape URLs that match
+        self._re_url_support = re.compile(
+            r'(?P<match>(?:<|\&lt;)?[ \t]*'
+            r'(?P<url>(?:https?|mailto)://[^| \n]+)'
+            r'(?:[ \t]*\|[ \t]*(?:(?P<val>[^\n]+?)[ \t]*)?(?:>|\&gt;)'
+            r'|(?:>|\&gt;)))', re.IGNORECASE)
+
         # Iterate over above list and store content accordingly
         self._re_formatting_rules = re.compile(
             r'(' + '|'.join(self._re_formatting_map.keys()) + r')',
@@ -438,6 +447,23 @@ class NotifySlack(NotifyBase):
                 body = self._re_formatting_rules.sub(  # pragma: no branch
                     lambda x: self._re_formatting_map[x.group()], body,
                 )
+
+                # Support <url|desc>, <url> entries
+                urlfix = []
+                for match in self._re_url_support.findall(body):
+                    # Swap back any ampersands previously updaated
+                    url = match[1].replace('&amp;', '&')
+                    desc = match[2].strip()
+                    urlfix.append({
+                        'replace': re.escape(match[0]),
+                        'with': '<{url}|{desc}>'.format(url=url, desc=desc)
+                        if desc else '<{url}>'.format(url=url)
+                    })
+
+                for entry in urlfix:
+                    body = re.sub(
+                        entry['replace'], entry['with'], body,
+                        re.IGNORECASE)
 
             # Perform Formatting on title here; this is not needed for block
             # mode above
@@ -803,7 +829,7 @@ class NotifySlack(NotifyBase):
             # The text 'ok' is returned if this is a Webhook request
             # So the below captures that as well.
             status_okay = (response and response.get('ok', False)) \
-                if self.mode is SlackMode.BOT else r.text == 'ok'
+                if self.mode is SlackMode.BOT else r.content == 'ok'
 
             if r.status_code != requests.codes.ok or not status_okay:
                 # We had a problem


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #721
Slack to not escape any provided data that resembles:
- `<http://example.com/|desc>`
- `<http://example.com>`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@721-slack-url-support

# Test out the changes with the following command:
apprise  -b "<http://example.com|description>" \
  "slack://credentials"

```

