### PR TITLE
Email improvements; name= and from= now synonymous

### DIFF
--- a/apprise/URLBase.py
+++ b/apprise/URLBase.py
@@ -598,7 +598,7 @@ class URLBase:
         }
 
     @staticmethod
-    def parse_url(url, verify_host=True):
+    def parse_url(url, verify_host=True, plus_to_space=False):
         """Parses the URL and returns it broken apart into a dictionary.
 
         This is very specific and customized for Apprise.
@@ -618,7 +618,8 @@ class URLBase:
         """
 
         results = parse_url(
-            url, default_schema='unknown', verify_host=verify_host)
+            url, default_schema='unknown', verify_host=verify_host,
+            plus_to_space=plus_to_space)
 
         if not results:
             # We're done; we failed to parse our url

--- a/apprise/plugins/NotifyBase.py
+++ b/apprise/plugins/NotifyBase.py
@@ -429,7 +429,7 @@ class NotifyBase(BASE_OBJECT):
         return params
 
     @staticmethod
-    def parse_url(url, verify_host=True):
+    def parse_url(url, verify_host=True, plus_to_space=False):
         """Parses the URL and returns it broken apart into a dictionary.
 
         This is very specific and customized for Apprise.
@@ -447,7 +447,8 @@ class NotifyBase(BASE_OBJECT):
             A dictionary is returned containing the URL fully parsed if
             successful, otherwise None is returned.
         """
-        results = URLBase.parse_url(url, verify_host=verify_host)
+        results = URLBase.parse_url(
+            url, verify_host=verify_host, plus_to_space=plus_to_space)
 
         if not results:
             # We're done; we failed to parse our url

--- a/apprise/plugins/NotifyEmail.py
+++ b/apprise/plugins/NotifyEmail.py
@@ -710,8 +710,7 @@ class NotifyEmail(NotifyBase):
 
             self.logger.debug(
                 'Email From: {}'.format(
-                    '{} <{}>'.format(self.from_addr[0], self.from_addr[1])
-                    if self.from_addr[0] else '{}'.format(self.from_addr[1])))
+                    formataddr(self.from_addr, charset='utf-8')))
 
             self.logger.debug('Email To: {}'.format(to_addr))
             if cc:

--- a/apprise/plugins/NotifyEmail.py
+++ b/apprise/plugins/NotifyEmail.py
@@ -895,7 +895,8 @@ class NotifyEmail(NotifyBase):
             params['from'] = formataddr((False, from_addr), charset='utf-8')
 
         elif not self.user:
-            params['from'] = formataddr((False, self.from_addr[1]), charset='utf-8')
+            params['from'] = \
+                formataddr((False, self.from_addr[1]), charset='utf-8')
 
         if len(self.cc) > 0:
             # Handle our Carbon Copy Addresses

--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -519,7 +519,7 @@ def tidy_path(path):
     return path
 
 
-def parse_qsd(qs, simple=False):
+def parse_qsd(qs, simple=False, plus_to_space=False):
     """
     Query String Dictionary Builder
 
@@ -541,6 +541,11 @@ def parse_qsd(qs, simple=False):
 
     if simple is set to true, then a ONE dictionary is returned and is not
     sub-parsed for additional elements
+
+    plus_to_space will cause all `+` references to become a space as
+    per normal URL Encoded defininition. Normal URL parsing applies
+    this, but `+` is very actively used character with passwords,
+    api keys, tokens, etc.  So Apprise does not do this by default.
     """
 
     # Our return result set:
@@ -575,7 +580,7 @@ def parse_qsd(qs, simple=False):
         key = unquote(key)
         key = '' if not key else key
 
-        val = nv[1].replace('+', ' ')
+        val = nv[1].replace('+', ' ') if plus_to_space else nv[1]
         val = unquote(val)
         val = '' if not val else val.strip()
 
@@ -609,7 +614,7 @@ def parse_qsd(qs, simple=False):
 
 
 def parse_url(url, default_schema='http', verify_host=True, strict_port=False,
-              simple=False):
+              simple=False, plus_to_space=False):
     """A function that greatly simplifies the parsing of a url
     specified by the end user.
 
@@ -722,7 +727,8 @@ def parse_url(url, default_schema='http', verify_host=True, strict_port=False,
     # Parse Query Arugments ?val=key&key=val
     # while ensuring that all keys are lowercase
     if qsdata:
-        result.update(parse_qsd(qsdata, simple=simple))
+        result.update(parse_qsd(
+            qsdata, simple=simple, plus_to_space=plus_to_space))
 
     # Now do a proper extraction of data; http:// is just substitued in place
     # to allow urlparse() to function as expected, we'll swap this back to the

--- a/test/test_apprise_utils.py
+++ b/test/test_apprise_utils.py
@@ -396,6 +396,32 @@ def test_parse_url_general():
     assert result['qsd+']['KeY'] == 'ValueA'
     assert 'kEy' in result['qsd-']
     assert result['qsd-']['kEy'] == 'ValueB'
+    assert result['qsd']['key'] == 'Value +C'
+    assert result['qsd']['+key'] == result['qsd+']['KeY']
+    assert result['qsd']['-key'] == result['qsd-']['kEy']
+
+
+    result = utils.parse_url(
+        'http://hostname/?+KeY=ValueA&-kEy=ValueB&KEY=Value%20+C&:colon=y',
+        plus_to_space=True)
+    assert result['schema'] == 'http'
+    assert result['host'] == 'hostname'
+    assert result['port'] is None
+    assert result['user'] is None
+    assert result['password'] is None
+    assert result['fullpath'] == '/'
+    assert result['path'] == '/'
+    assert result['query'] is None
+    assert result['url'] == 'http://hostname/'
+    assert '+key' in result['qsd']
+    assert '-key' in result['qsd']
+    assert ':colon' in result['qsd']
+    assert result['qsd:']['colon'] == 'y'
+    assert 'key' in result['qsd']
+    assert 'KeY' in result['qsd+']
+    assert result['qsd+']['KeY'] == 'ValueA'
+    assert 'kEy' in result['qsd-']
+    assert result['qsd-']['kEy'] == 'ValueB'
     assert result['qsd']['key'] == 'Value  C'
     assert result['qsd']['+key'] == result['qsd+']['KeY']
     assert result['qsd']['-key'] == result['qsd-']['kEy']
@@ -893,7 +919,7 @@ def test_parse_url_simple():
     assert '-key' in result['qsd']
     assert ':colon' in result['qsd']
     assert result['qsd'][':colon'] == 'y'
-    assert result['qsd']['key'] == 'Value  C'
+    assert result['qsd']['key'] == 'Value +C'
     assert result['qsd']['+key'] == 'ValueA'
     assert result['qsd']['-key'] == 'ValueB'
 

--- a/test/test_apprise_utils.py
+++ b/test/test_apprise_utils.py
@@ -400,7 +400,6 @@ def test_parse_url_general():
     assert result['qsd']['+key'] == result['qsd+']['KeY']
     assert result['qsd']['-key'] == result['qsd-']['kEy']
 
-
     result = utils.parse_url(
         'http://hostname/?+KeY=ValueA&-kEy=ValueB&KEY=Value%20+C&:colon=y',
         plus_to_space=True)

--- a/test/test_plugin_email.py
+++ b/test/test_plugin_email.py
@@ -822,6 +822,24 @@ def test_plugin_email_url_variations():
     assert re.match(
         r'.*from=Charles\+%3Cfrom%40example.jp%3E.*', obj.url()) is not None
 
+    # Test Tagging under various urll encodings
+    for toaddr in ('/john.smith+mytag@domain.com',
+                   '?to=john.smith+mytag@domain.com',
+                   '/john.smith%2Bmytag@domain.com',
+                   '?to=john.smith%2Bmytag@domain.com'):
+
+        obj = Apprise.instantiate(
+            'mailto://user:pass@domain.com{}'.format(toaddr))
+        assert isinstance(obj, NotifyEmail) is True
+        assert obj.password == 'pass'
+        assert obj.user == 'user'
+        assert obj.host == 'domain.com'
+        assert obj.from_addr[0] == obj.app_id
+        assert obj.from_addr[1] == 'user@domain.com'
+        assert len(obj.targets) == 1
+        assert obj.targets[0][0] is False
+        assert obj.targets[0][1] == 'john.smith+mytag@domain.com'
+
 
 def test_plugin_email_dict_variations():
     """

--- a/test/test_plugin_mailgun.py
+++ b/test/test_plugin_mailgun.py
@@ -95,6 +95,12 @@ apprise_url_tests = (
         'a' * 32, 'b' * 8, 'c' * 8), {
             'instance': TypeError,
     }),
+    # Use of both 'name' and 'from' together; these are synonymous
+    ('mailgun://user@localhost.localdomain/{}-{}-{}?'
+     'from=jack@gmail.com&name=Jason<jason@gmail.com>'.format(
+         'a' * 32, 'b' * 8, 'c' * 8), {
+             'instance': NotifyMailgun}),
+
     # headers
     ('mailgun://user@localhost.localdomain/{}-{}-{}'
         '?+X-Customer-Campaign-ID=Apprise'.format(


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #732

both `mailgun://` and `email://` parameter arguments `name=` and `from=` are now  synonymous of each other.  If you want to over-ride the `from` email address you can provide the following:

- `from=Luke%20Skywalker`
- `from=luke@jedi.com`
- `from=Luke%20Skywalker<luke@jedi.com>`

As identified `name=` is now synonymous of the `from=`.  It was not removed so it wouldn't break any existing configuration from previous Apprise versions.
- `name=Luke%20Skywalker`
- `name=luke@jedi.com`
- `name=Luke%20Skywalker<luke@jedi.com>`

In previous version of a Apprise, the `from=` would accept the email address and `name=` would accept the over-ridden name.  This is still in effect; the following is perfectly valid:
- `name=Luke%20Skywalker&from=luke@jedi.com`

It's worth noting that providing both a `name=` and `from=` is still considered to be somewhat mutually exclusive (you should use one or the other) so Apprise will now generate a warning message if this occurs.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@732-from-email-improvements

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "mailto://user:pass@hostname?from=Luke<skywalker@gmail.com>"

```

@amotl this may break your changes in #679 a wee bit. 
