### PR TITLE
Googlechat thread feature

### DIFF
--- a/apprise/plugins/NotifyGoogleChat.py
+++ b/apprise/plugins/NotifyGoogleChat.py
@@ -201,9 +201,9 @@ class NotifyGoogleChat(NotifyBase):
         }
 
         path = (
-            f"spaces/{self.workspace}/messages?"
-            f"key={self.webhook_key}"
-            f"&token={self.webhook_token}"
+            f'spaces/{self.workspace}/messages?'
+            f'key={self.webhook_key}'
+            f'&token={self.webhook_token}'
         )
 
         path_and_params = (

--- a/apprise/plugins/NotifyGoogleChat.py
+++ b/apprise/plugins/NotifyGoogleChat.py
@@ -180,7 +180,7 @@ class NotifyGoogleChat(NotifyBase):
             self.threadkey = validate_regex(threadkey)
         except:
             msg = 'No valid threadKey found in provided URI.'
-            self.logger.warning(msg)
+            self.logger.debug(msg)
 
         return
 

--- a/apprise/plugins/NotifyGoogleChat.py
+++ b/apprise/plugins/NotifyGoogleChat.py
@@ -119,7 +119,7 @@ class NotifyGoogleChat(NotifyBase):
             'required': True,
         },
         'threadkey': {
-            'name': _('Webhook Thread Key'),
+            'name': _('Thread Key'),
             'type': 'string',
             'private': True,
             'required': False,
@@ -175,7 +175,7 @@ class NotifyGoogleChat(NotifyBase):
             self.logger.warning(msg)
             raise TypeError(msg)
 
-        # Webhook Thread Key (associated with thread)
+        # Thread Key (associated with thread)
         try:
             self.threadkey = validate_regex(threadkey)
         except:
@@ -321,7 +321,7 @@ class NotifyGoogleChat(NotifyBase):
         # Store our Webhook Token
         results['webhook_token'] = tokens.pop(0) if tokens else None
 
-        # Store our Webhook Thread Key
+        # Store our Thread Key
         results['threadkey'] = tokens.pop(0) if tokens else None
 
         # Support arguments as overrides (if specified)

--- a/apprise/plugins/NotifyGoogleChat.py
+++ b/apprise/plugins/NotifyGoogleChat.py
@@ -172,7 +172,7 @@ class NotifyGoogleChat(NotifyBase):
                   '({}) was specified.'.format(webhook_token)
             self.logger.warning(msg)
             raise TypeError(msg)
-        
+
         # Webhook Thread Key (associated with thread)
         try:
             self.webhook_threadkey = validate_regex(webhook_threadkey)
@@ -267,12 +267,14 @@ class NotifyGoogleChat(NotifyBase):
         params = self.url_parameters(privacy=privacy, *args, **kwargs)
 
         if self.webhook_threadkey:
-            return '{schema}://{workspace}/{key}/{token}/{threadkey}/?{params}'.format(
+            return \
+                '{schema}://{workspace}/{key}/{token}/{threadkey}/?{params}'.format(
                 schema=self.secure_protocol,
                 workspace=self.pprint(self.workspace, privacy, safe=''),
                 key=self.pprint(self.webhook_key, privacy, safe=''),
                 token=self.pprint(self.webhook_token, privacy, safe=''),
-                threadkey=self.pprint(self.webhook_threadkey, privacy, safe=''),
+                threadkey= \
+                    self.pprint(self.webhook_threadkey, privacy, safe=''),
                 params=NotifyGoogleChat.urlencode(params),
             )
 
@@ -329,7 +331,7 @@ class NotifyGoogleChat(NotifyBase):
         if 'token' in results['qsd']:
             results['webhook_token'] = \
                 NotifyGoogleChat.unquote(results['qsd']['token'])
-        
+
         if 'threadkey' in results['qsd']:
             results['webhook_threadkey'] = \
                 NotifyGoogleChat.unquote(results['qsd']['threadkey'])

--- a/apprise/plugins/NotifyGoogleChat.py
+++ b/apprise/plugins/NotifyGoogleChat.py
@@ -222,7 +222,7 @@ class NotifyGoogleChat(NotifyBase):
             )
 
         self.logger.debug('Google Chat POST URL: %s (cert_verify=%r)' % (
-                notify_url, self.verify_certificate,
+            notify_url, self.verify_certificate,
         ))
         self.logger.debug('Google Chat Payload: %s' % str(payload))
 
@@ -237,20 +237,17 @@ class NotifyGoogleChat(NotifyBase):
                 timeout=self.request_timeout,
             )
             if r.status_code not in (
-                requests.codes.ok,
-                requests.codes.no_content,
-            ):
+                requests.codes.ok, requests.codes.no_content):
 
                 # We had a problem
-                status_str = NotifyBase.http_response_code_lookup(
-                    r.status_code
-                )
+                status_str = \
+                    NotifyBase.http_response_code_lookup(r.status_code)
 
                 self.logger.warning(
                     'Failed to send Google Chat notification: '
                     '{}{}error={}.'.format(
-                        status_str, 
-                        ', ' if status_str else '', 
+                        status_str,
+                        ', ' if status_str else '',
                         r.status_code))
 
                 self.logger.debug('Response Details:\r\n{}'.format(r.content))
@@ -314,6 +311,7 @@ class NotifyGoogleChat(NotifyBase):
             # We're done early as we couldn't load the results
             return results
 
+        # Store our Workspace
         results['workspace'] = NotifyGoogleChat.unquote(results['host'])
 
         # Acquire our tokens
@@ -358,17 +356,13 @@ class NotifyGoogleChat(NotifyBase):
         result = re.match(
             r'^https://chat\.googleapis\.com/v1/spaces/'
             r'(?P<workspace>[a-zA-Z0-9_-]+)/messages/*(?P<params>.*)$',
-            url,
-            re.I,
-        )
+            url, re.I,)
 
         if result:
             return NotifyGoogleChat.parse_url(
                 '{schema}://{workspace}/{params}'.format(
                     schema=NotifyGoogleChat.secure_protocol,
                     workspace=result.group('workspace'),
-                    params=result.group('params'),
-                )
-            )
+                    params=result.group('params'),))
 
         return None

--- a/apprise/plugins/NotifyGoogleChat.py
+++ b/apprise/plugins/NotifyGoogleChat.py
@@ -77,11 +77,11 @@ class NotifyGoogleChat(NotifyBase):
     secure_protocol = 'gchat'
 
     # A URL that takes you to the setup/help of the specific protocol
-    setup_url = "https://github.com/caronc/apprise/wiki/Notify_googlechat"
+    setup_url = 'https://github.com/caronc/apprise/wiki/Notify_googlechat'
 
     # Google Chat Webhook
     notify_url = (
-        "https://chat.googleapis.com/v1/{}"
+        'https://chat.googleapis.com/v1/{}'
     )
 
     # Default Notify Format
@@ -96,37 +96,37 @@ class NotifyGoogleChat(NotifyBase):
 
     # Define object templates
     templates = (
-        "{schema}://{workspace}/{webhook_key}/{webhook_token}",
-        "{schema}://{workspace}/{webhook_key}/{webhook_token}/{webhook_threadkey}",
+        '{schema}://{workspace}/{webhook_key}/{webhook_token}',
+        '{schema}://{workspace}/{webhook_key}/{webhook_token}/{webhook_threadkey}',
         )
 
     # Define our template tokens
     template_tokens = dict(
         NotifyBase.template_tokens,
         **{
-            "workspace": {
-                "name": _("Workspace"),
-                "type": "string",
-                "private": True,
-                "required": True,
+            'workspace': {
+                'name': _('Workspace'),
+                'type': 'string',
+                'private': True,
+                'required': True,
             },
-            "webhook_key": {
-                "name": _("Webhook Key"),
-                "type": "string",
-                "private": True,
-                "required": True,
+            'webhook_key': {
+                'name': _('Webhook Key'),
+                'type': 'string',
+                'private': True,
+                'required': True,
             },
-            "webhook_token": {
-                "name": _("Webhook Token"),
-                "type": "string",
-                "private": True,
-                "required": True,
+            'webhook_token': {
+                'name': _('Webhook Token'),
+                'type': 'string',
+                'private': True,
+                'required': True,
             },
-            "webhook_threadkey": {
-                "name": _("Webhook Thread Key"),
-                "type": "string",
-                "private": True,
-                "required": False,
+            'webhook_threadkey': {
+                'name': _('Webhook Thread Key'),
+                'type': 'string',
+                'private': True,
+                'required': False,
             },
         }
     )
@@ -135,17 +135,17 @@ class NotifyGoogleChat(NotifyBase):
     template_args = dict(
         NotifyBase.template_args,
         **{
-            "workspace": {
-                "alias_of": "workspace",
+            'workspace': {
+                'alias_of': 'workspace',
             },
-            "key": {
-                "alias_of": "webhook_key",
+            'key': {
+                'alias_of': 'webhook_key',
             },
-            "token": {
-                "alias_of": "webhook_token",
+            'token': {
+                'alias_of': 'webhook_token',
             },
-            "threadkey": {
-                "alias_of": "webhook_threadkey",
+            'threadkey': {
+                'alias_of': 'webhook_threadkey',
             },
         }
     )
@@ -160,30 +160,24 @@ class NotifyGoogleChat(NotifyBase):
         # Workspace (associated with project)
         self.workspace = validate_regex(workspace)
         if not self.workspace:
-            msg = (
-                "An invalid Google Chat Workspace "
-                "({}) was specified.".format(workspace)
-            )
+            msg = 'An invalid Google Chat Workspace ' \
+                  '({}) was specified.'.format(workspace)
             self.logger.warning(msg)
             raise TypeError(msg)
 
         # Webhook Key (associated with project)
         self.webhook_key = validate_regex(webhook_key)
         if not self.webhook_key:
-            msg = (
-                "An invalid Google Chat Webhook Key "
-                "({}) was specified.".format(webhook_key)
-            )
+            msg = 'An invalid Google Chat Webhook Key ' \
+                  '({}) was specified.'.format(webhook_key)
             self.logger.warning(msg)
             raise TypeError(msg)
 
         # Webhook Token (associated with project)
         self.webhook_token = validate_regex(webhook_token)
         if not self.webhook_token:
-            msg = (
-                "An invalid Google Chat Webhook Token "
-                "({}) was specified.".format(webhook_token)
-            )
+            msg = 'An invalid Google Chat Webhook Token ' \
+                  '({}) was specified.'.format(webhook_token)
             self.logger.warning(msg)
             raise TypeError(msg)
         
@@ -191,52 +185,46 @@ class NotifyGoogleChat(NotifyBase):
         try:
             self.webhook_threadkey = validate_regex(webhook_threadkey)
         except:
-            msg = (
-                "No valid threadKey found in provided URI."
-            )
+            msg = 'No valid threadKey found in provided URI.'
             self.logger.warning(msg)
 
         return
 
-    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+    def send(self, body, title='', notify_type=NotifyType.INFO, **kwargs):
         """
         Perform Google Chat Notification
         """
 
         # Our headers
         headers = {
-            "User-Agent": self.app_id,
-            "Content-Type": "application/json; charset=utf-8",
+            'User-Agent': self.app_id,
+            'Content-Type': 'application/json; charset=utf-8',
         }
 
         payload = {
             # Our Message
-            "text": body,
+            'text': body,
         }
 
         # Construct Notify URL
         if self.webhook_threadkey:
             notify_url = self.notify_url.format(
-                f"spaces/{self.workspace}/messages?"
-                f"key={self.webhook_key}"
-                f"&token={self.webhook_token}"
-                f"&threadKey={self.webhook_threadkey}"
+                f'spaces/{self.workspace}/messages?'
+                f'key={self.webhook_key}'
+                f'&token={self.webhook_token}'
+                f'&threadKey={self.webhook_threadkey}'
             )
         else:
             notify_url = self.notify_url.format(
-                f"spaces/{self.workspace}/messages?"
-                f"key={self.webhook_key}"
-                f"&token={self.webhook_token}"
+                f'spaces/{self.workspace}/messages?'
+                f'key={self.webhook_key}'
+                f'&token={self.webhook_token}'
             )
 
-        self.logger.debug(
-            "Google Chat POST URL: %s (cert_verify=%r)"
-            % (
-                notify_url,
-                self.verify_certificate,
-            )
-        )
-        self.logger.debug("Google Chat Payload: %s" % str(payload))
+        self.logger.debug('Google Chat POST URL: %s (cert_verify=%r)' % (
+                notify_url, self.verify_certificate,
+        ))
+        self.logger.debug('Google Chat Payload: %s' % str(payload))
 
         # Always call throttle before any remote server i/o is made
         self.throttle()
@@ -259,25 +247,24 @@ class NotifyGoogleChat(NotifyBase):
                 )
 
                 self.logger.warning(
-                    "Failed to send Google Chat notification: "
-                    "{}{}error={}.".format(
-                        status_str, ", " if status_str else "", r.status_code
-                    )
-                )
+                    'Failed to send Google Chat notification: '
+                    '{}{}error={}.'.format(
+                        status_str, 
+                        ', ' if status_str else '', 
+                        r.status_code))
 
-                self.logger.debug("Response Details:\r\n{}".format(r.content))
+                self.logger.debug('Response Details:\r\n{}'.format(r.content))
 
                 # Return; we're done
                 return False
 
             else:
-                self.logger.info("Sent Google Chat notification.")
+                self.logger.info('Sent Google Chat notification.')
 
         except requests.RequestException as e:
             self.logger.warning(
-                "A Connection error occurred postingto Google Chat."
-            )
-            self.logger.debug("Socket Exception: %s" % str(e))
+                'A Connection error occurred postingto Google Chat.')
+            self.logger.debug('Socket Exception: %s' % str(e))
             return False
 
         return True
@@ -291,21 +278,21 @@ class NotifyGoogleChat(NotifyBase):
         params = self.url_parameters(privacy=privacy, *args, **kwargs)
 
         if self.webhook_threadkey:
-            return "{schema}://{workspace}/{key}/{token}/{threadkey}/?{params}".format(
+            return '{schema}://{workspace}/{key}/{token}/{threadkey}/?{params}'.format(
                 schema=self.secure_protocol,
-                workspace=self.pprint(self.workspace, privacy, safe=""),
-                key=self.pprint(self.webhook_key, privacy, safe=""),
-                token=self.pprint(self.webhook_token, privacy, safe=""),
-                threadkey=self.pprint(self.webhook_threadkey, privacy, safe=""),
+                workspace=self.pprint(self.workspace, privacy, safe=''),
+                key=self.pprint(self.webhook_key, privacy, safe=''),
+                token=self.pprint(self.webhook_token, privacy, safe=''),
+                threadkey=self.pprint(self.webhook_threadkey, privacy, safe=''),
                 params=NotifyGoogleChat.urlencode(params),
             )
 
         else:
-            return "{schema}://{workspace}/{key}/{token}/?{params}".format(
+            return '{schema}://{workspace}/{key}/{token}/?{params}'.format(
                 schema=self.secure_protocol,
-                workspace=self.pprint(self.workspace, privacy, safe=""),
-                key=self.pprint(self.webhook_key, privacy, safe=""),
-                token=self.pprint(self.webhook_token, privacy, safe=""),
+                workspace=self.pprint(self.workspace, privacy, safe=''),
+                key=self.pprint(self.webhook_key, privacy, safe=''),
+                token=self.pprint(self.webhook_token, privacy, safe=''),
                 params=NotifyGoogleChat.urlencode(params),
             )
 
@@ -316,9 +303,9 @@ class NotifyGoogleChat(NotifyBase):
         us to re-instantiate this object.
 
         Syntax:
-          gchatb://workspace/webhook_key/webhook_token
+          gchat://workspace/webhook_key/webhook_token
         Optionnaly:
-          gchatb://workspace/webhook_key/webhook_token/webhook_threadkey
+          gchat://workspace/webhook_key/webhook_token/webhook_threadkey
 
         """
         results = NotifyBase.parse_url(url, verify_host=False)
@@ -327,40 +314,36 @@ class NotifyGoogleChat(NotifyBase):
             # We're done early as we couldn't load the results
             return results
 
-        results["workspace"] = NotifyGoogleChat.unquote(results["host"])
+        results['workspace'] = NotifyGoogleChat.unquote(results['host'])
 
         # Acquire our tokens
-        tokens = NotifyGoogleChat.split_path(results["fullpath"])
+        tokens = NotifyGoogleChat.split_path(results['fullpath'])
 
         # Store our Webhook Key
-        results["webhook_key"] = tokens.pop(0) if tokens else None
+        results['webhook_key'] = tokens.pop(0) if tokens else None
 
         # Store our Webhook Token
-        results["webhook_token"] = tokens.pop(0) if tokens else None
+        results['webhook_token'] = tokens.pop(0) if tokens else None
 
         # Store our Webhook Thread Key
-        results["webhook_threadkey"] = tokens.pop(0) if tokens else None
+        results['webhook_threadkey'] = tokens.pop(0) if tokens else None
 
         # Support arguments as overrides (if specified)
-        if "workspace" in results["qsd"]:
-            results["workspace"] = NotifyGoogleChat.unquote(
-                results["qsd"]["workspace"]
-            )
+        if 'workspace' in results['qsd']:
+            results['workspace'] = \
+                NotifyGoogleChat.unquote(results['qsd']['workspace'])
 
-        if "key" in results["qsd"]:
-            results["webhook_key"] = NotifyGoogleChat.unquote(
-                results["qsd"]["key"]
-            )
+        if 'key' in results['qsd']:
+            results['webhook_key'] = \
+                NotifyGoogleChat.unquote(results['qsd']['key'])
 
-        if "token" in results["qsd"]:
-            results["webhook_token"] = NotifyGoogleChat.unquote(
-                results["qsd"]["token"]
-            )
+        if 'token' in results['qsd']:
+            results['webhook_token'] = \
+                NotifyGoogleChat.unquote(results['qsd']['token'])
         
-        if "threadkey" in results["qsd"]:
-            results["webhook_threadkey"] = NotifyGoogleChat.unquote(
-                results["qsd"]["threadkey"]
-            )
+        if 'threadkey' in results['qsd']:
+            results['webhook_threadkey'] = \
+                NotifyGoogleChat.unquote(results['qsd']['threadkey'])
 
         return results
 
@@ -373,18 +356,18 @@ class NotifyGoogleChat(NotifyBase):
         """
 
         result = re.match(
-            r"^https://chat\.googleapis\.com/v1/spaces/"
-            r"(?P<workspace>[a-zA-Z0-9_-]+)/messages/*(?P<params>.*)$",
+            r'^https://chat\.googleapis\.com/v1/spaces/'
+            r'(?P<workspace>[a-zA-Z0-9_-]+)/messages/*(?P<params>.*)$',
             url,
             re.I,
         )
 
         if result:
             return NotifyGoogleChat.parse_url(
-                "{schema}://{workspace}/{params}".format(
+                '{schema}://{workspace}/{params}'.format(
                     schema=NotifyGoogleChat.secure_protocol,
-                    workspace=result.group("workspace"),
-                    params=result.group("params"),
+                    workspace=result.group('workspace'),
+                    params=result.group('params'),
                 )
             )
 

--- a/apprise/plugins/NotifyGoogleChat.py
+++ b/apprise/plugins/NotifyGoogleChat.py
@@ -67,20 +67,21 @@ class NotifyGoogleChat(NotifyBase):
     A wrapper to Google Chat Notifications
 
     """
+
     # The default descriptive name associated with the Notification
-    service_name = 'Google Chat'
+    service_name = "Google Chat"
 
     # The services URL
-    service_url = 'https://chat.google.com/'
+    service_url = "https://chat.google.com/"
 
     # The default secure protocol
-    secure_protocol = 'gchat'
+    secure_protocol = "gchat"
 
     # A URL that takes you to the setup/help of the specific protocol
-    setup_url = 'https://github.com/caronc/apprise/wiki/Notify_googlechat'
+    setup_url = "https://github.com/caronc/apprise/wiki/Notify_googlechat"
 
     # Google Chat Webhook
-    notify_url = 'https://chat.googleapis.com/v1/{path_and_params}'
+    notify_url = "https://chat.googleapis.com/v1/{path_and_params}"
 
     # Default Notify Format
     notify_format = NotifyFormat.MARKDOWN
@@ -94,53 +95,59 @@ class NotifyGoogleChat(NotifyBase):
 
     # Define object templates
     templates = (
-        '{schema}://{workspace}/{webhook_key}/{webhook_token}',
-        '{schema}://{workspace}/{webhook_key}/{webhook_token}/{threadkey}',
+        "{schema}://{workspace}/{webhook_key}/{webhook_token}",
+        "{schema}://{workspace}/{webhook_key}/{webhook_token}/{threadkey}",
     )
 
     # Define our template tokens
-    template_tokens = dict(NotifyBase.template_tokens, **{
-        'workspace': {
-            'name': _('Workspace'),
-            'type': 'string',
-            'private': True,
-            'required': True,
+    template_tokens = dict(
+        NotifyBase.template_tokens,
+        **{
+            "workspace": {
+                "name": _("Workspace"),
+                "type": "string",
+                "private": True,
+                "required": True,
+            },
+            "webhook_key": {
+                "name": _("Webhook Key"),
+                "type": "string",
+                "private": True,
+                "required": True,
+            },
+            "webhook_token": {
+                "name": _("Webhook Token"),
+                "type": "string",
+                "private": True,
+                "required": True,
+            },
+            "threadkey": {
+                "name": _("Webhook Thread Key"),
+                "type": "string",
+                "private": True,
+                "required": False,
+            },
         },
-        'webhook_key': {
-            'name': _('Webhook Key'),
-            'type': 'string',
-            'private': True,
-            'required': True,
-        },
-        'webhook_token': {
-            'name': _('Webhook Token'),
-            'type': 'string',
-            'private': True,
-            'required': True,
-        },
-        'threadkey': {
-            'name': _('Webhook Thread Key'),
-            'type': 'string',
-            'private': True,
-            'required': False,
-        },
-    })
+    )
 
     # Define our template arguments
-    template_args = dict(NotifyBase.template_args, **{
-        'workspace': {
-            'alias_of': 'workspace',
+    template_args = dict(
+        NotifyBase.template_args,
+        **{
+            "workspace": {
+                "alias_of": "workspace",
+            },
+            "key": {
+                "alias_of": "webhook_key",
+            },
+            "token": {
+                "alias_of": "webhook_token",
+            },
+            "threadkey": {
+                "alias_of": "threadkey",
+            },
         },
-        'key': {
-            'alias_of': 'webhook_key',
-        },
-        'token': {
-            'alias_of': 'webhook_token',
-        },
-        'threadkey': {
-            'alias_of': 'threadkey',
-        },
-    })
+    )
 
     def __init__(
         self, workspace, webhook_key, webhook_token, threadkey=None, **kwargs
@@ -154,24 +161,30 @@ class NotifyGoogleChat(NotifyBase):
         # Workspace (associated with project)
         self.workspace = validate_regex(workspace)
         if not self.workspace:
-            msg = 'An invalid Google Chat Workspace ' \
-                  '({}) was specified.'.format(workspace)
+            msg = (
+                "An invalid Google Chat Workspace "
+                "({}) was specified.".format(workspace)
+            )
             self.logger.warning(msg)
             raise TypeError(msg)
 
         # Webhook Key (associated with project)
         self.webhook_key = validate_regex(webhook_key)
         if not self.webhook_key:
-            msg = 'An invalid Google Chat Webhook Key ' \
-                  '({}) was specified.'.format(webhook_key)
+            msg = (
+                "An invalid Google Chat Webhook Key "
+                "({}) was specified.".format(webhook_key)
+            )
             self.logger.warning(msg)
             raise TypeError(msg)
 
         # Webhook Token (associated with project)
         self.webhook_token = validate_regex(webhook_token)
         if not self.webhook_token:
-            msg = 'An invalid Google Chat Webhook Token ' \
-                  '({}) was specified.'.format(webhook_token)
+            msg = (
+                "An invalid Google Chat Webhook Token "
+                "({}) was specified.".format(webhook_token)
+            )
             self.logger.warning(msg)
             raise TypeError(msg)
 
@@ -179,47 +192,47 @@ class NotifyGoogleChat(NotifyBase):
         try:
             self.threadkey = validate_regex(threadkey)
         except:
-            msg = 'No valid threadKey found in provided URI.'
+            msg = "No valid threadKey found in provided URI."
             self.logger.warning(msg)
 
         return
 
-    def send(self, body, title='', notify_type=NotifyType.INFO, **kwargs):
+    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
         """
         Perform Google Chat Notification
         """
 
         # Our headers
         headers = {
-            'User-Agent': self.app_id,
-            'Content-Type': 'application/json; charset=utf-8',
+            "User-Agent": self.app_id,
+            "Content-Type": "application/json; charset=utf-8",
         }
 
         payload = {
             # Our Message
-            'text': body,
+            "text": body,
         }
 
         path = (
-            f'spaces/{self.workspace}/messages?'
-            f'key={self.webhook_key}'
-            f'&token={self.webhook_token}'
+            f"spaces/{self.workspace}/messages?"
+            f"key={self.webhook_key}"
+            f"&token={self.webhook_token}"
         )
 
         path_and_params = (
-            f'{path}&threadKey={self.threadkey}'
-            if self.threadkey
-            else path
+            f"{path}&threadKey={self.threadkey}" if self.threadkey else path
         )
 
-        notify_url = self.notify_url.format(
-            path_and_params=path_and_params
-        )
+        notify_url = self.notify_url.format(path_and_params=path_and_params)
 
-        self.logger.debug('Google Chat POST URL: %s (cert_verify=%r)' % (
-            notify_url, self.verify_certificate,
-        ))
-        self.logger.debug('Google Chat Payload: %s' % str(payload))
+        self.logger.debug(
+            "Google Chat POST URL: %s (cert_verify=%r)"
+            % (
+                notify_url,
+                self.verify_certificate,
+            )
+        )
+        self.logger.debug("Google Chat Payload: %s" % str(payload))
 
         # Always call throttle before any remote server i/o is made
         self.throttle()
@@ -232,31 +245,35 @@ class NotifyGoogleChat(NotifyBase):
                 timeout=self.request_timeout,
             )
             if r.status_code not in (
-                    requests.codes.ok, requests.codes.no_content):
+                requests.codes.ok,
+                requests.codes.no_content,
+            ):
 
                 # We had a problem
-                status_str = \
-                    NotifyBase.http_response_code_lookup(r.status_code)
+                status_str = NotifyBase.http_response_code_lookup(
+                    r.status_code
+                )
 
                 self.logger.warning(
-                    'Failed to send Google Chat notification: '
-                    '{}{}error={}.'.format(
-                        status_str,
-                        ', ' if status_str else '',
-                        r.status_code))
+                    "Failed to send Google Chat notification: "
+                    "{}{}error={}.".format(
+                        status_str, ", " if status_str else "", r.status_code
+                    )
+                )
 
-                self.logger.debug('Response Details:\r\n{}'.format(r.content))
+                self.logger.debug("Response Details:\r\n{}".format(r.content))
 
                 # Return; we're done
                 return False
 
             else:
-                self.logger.info('Sent Google Chat notification.')
+                self.logger.info("Sent Google Chat notification.")
 
         except requests.RequestException as e:
             self.logger.warning(
-                'A Connection error occurred postingto Google Chat.')
-            self.logger.debug('Socket Exception: %s' % str(e))
+                "A Connection error occurred postingto Google Chat."
+            )
+            self.logger.debug("Socket Exception: %s" % str(e))
             return False
 
         return True
@@ -271,24 +288,22 @@ class NotifyGoogleChat(NotifyBase):
 
         if self.threadkey:
             return (
-                '{schema}://{workspace}/{key}/{token}/{threadkey}/?{params}'
+                "{schema}://{workspace}/{key}/{token}/{threadkey}/?{params}"
             ).format(
                 schema=self.secure_protocol,
-                workspace=self.pprint(self.workspace, privacy, safe=''),
-                key=self.pprint(self.webhook_key, privacy, safe=''),
-                token=self.pprint(self.webhook_token, privacy, safe=''),
-                threadkey=self.pprint(
-                    self.threadkey, privacy, safe=''
-                ),
+                workspace=self.pprint(self.workspace, privacy, safe=""),
+                key=self.pprint(self.webhook_key, privacy, safe=""),
+                token=self.pprint(self.webhook_token, privacy, safe=""),
+                threadkey=self.pprint(self.threadkey, privacy, safe=""),
                 params=NotifyGoogleChat.urlencode(params),
             )
 
         else:
-            return '{schema}://{workspace}/{key}/{token}/?{params}'.format(
+            return "{schema}://{workspace}/{key}/{token}/?{params}".format(
                 schema=self.secure_protocol,
-                workspace=self.pprint(self.workspace, privacy, safe=''),
-                key=self.pprint(self.webhook_key, privacy, safe=''),
-                token=self.pprint(self.webhook_token, privacy, safe=''),
+                workspace=self.pprint(self.workspace, privacy, safe=""),
+                key=self.pprint(self.webhook_key, privacy, safe=""),
+                token=self.pprint(self.webhook_token, privacy, safe=""),
                 params=NotifyGoogleChat.urlencode(params),
             )
 
@@ -310,36 +325,40 @@ class NotifyGoogleChat(NotifyBase):
             return results
 
         # Store our Workspace
-        results['workspace'] = NotifyGoogleChat.unquote(results['host'])
+        results["workspace"] = NotifyGoogleChat.unquote(results["host"])
 
         # Acquire our tokens
-        tokens = NotifyGoogleChat.split_path(results['fullpath'])
+        tokens = NotifyGoogleChat.split_path(results["fullpath"])
 
         # Store our Webhook Key
-        results['webhook_key'] = tokens.pop(0) if tokens else None
+        results["webhook_key"] = tokens.pop(0) if tokens else None
 
         # Store our Webhook Token
-        results['webhook_token'] = tokens.pop(0) if tokens else None
+        results["webhook_token"] = tokens.pop(0) if tokens else None
 
         # Store our Webhook Thread Key
-        results['threadkey'] = tokens.pop(0) if tokens else None
+        results["threadkey"] = tokens.pop(0) if tokens else None
 
         # Support arguments as overrides (if specified)
-        if 'workspace' in results['qsd']:
-            results['workspace'] = \
-                NotifyGoogleChat.unquote(results['qsd']['workspace'])
+        if "workspace" in results["qsd"]:
+            results["workspace"] = NotifyGoogleChat.unquote(
+                results["qsd"]["workspace"]
+            )
 
-        if 'key' in results['qsd']:
-            results['webhook_key'] = \
-                NotifyGoogleChat.unquote(results['qsd']['key'])
+        if "key" in results["qsd"]:
+            results["webhook_key"] = NotifyGoogleChat.unquote(
+                results["qsd"]["key"]
+            )
 
-        if 'token' in results['qsd']:
-            results['webhook_token'] = \
-                NotifyGoogleChat.unquote(results['qsd']['token'])
+        if "token" in results["qsd"]:
+            results["webhook_token"] = NotifyGoogleChat.unquote(
+                results["qsd"]["token"]
+            )
 
-        if 'threadkey' in results['qsd']:
-            results['threadkey'] = \
-                NotifyGoogleChat.unquote(results['qsd']['threadkey'])
+        if "threadkey" in results["qsd"]:
+            results["threadkey"] = NotifyGoogleChat.unquote(
+                results["qsd"]["threadkey"]
+            )
 
         return results
 
@@ -352,15 +371,19 @@ class NotifyGoogleChat(NotifyBase):
         """
 
         result = re.match(
-            r'^https://chat\.googleapis\.com/v1/spaces/'
-            r'(?P<workspace>[a-zA-Z0-9_-]+)/messages/*(?P<params>.+)$',
-            url, re.I)
+            r"^https://chat\.googleapis\.com/v1/spaces/"
+            r"(?P<workspace>[A-Z0-9_-]+)/messages/*(?P<params>.+)$",
+            url,
+            re.I,
+        )
 
         if result:
             return NotifyGoogleChat.parse_url(
-                '{schema}://{workspace}/{params}'.format(
+                "{schema}://{workspace}/{params}".format(
                     schema=NotifyGoogleChat.secure_protocol,
-                    workspace=result.group('workspace'),
-                    params=result.group('params')))
+                    workspace=result.group("workspace"),
+                    params=result.group("params"),
+                )
+            )
 
         return None

--- a/apprise/plugins/NotifyGoogleChat.py
+++ b/apprise/plugins/NotifyGoogleChat.py
@@ -80,9 +80,7 @@ class NotifyGoogleChat(NotifyBase):
     setup_url = 'https://github.com/caronc/apprise/wiki/Notify_googlechat'
 
     # Google Chat Webhook
-    notify_url = (
-        'https://chat.googleapis.com/v1/{}'
-    )
+    notify_url = 'https://chat.googleapis.com/v1/{}'
 
     # Default Notify Format
     notify_format = NotifyFormat.MARKDOWN

--- a/apprise/plugins/NotifyGoogleChat.py
+++ b/apprise/plugins/NotifyGoogleChat.py
@@ -176,10 +176,10 @@ class NotifyGoogleChat(NotifyBase):
             raise TypeError(msg)
 
         # Thread Key (associated with thread)
-        try:
-            self.threadkey = validate_regex(threadkey)
-        except:
-            msg = 'No valid threadKey found in provided URI.'
+        self.threadkey = validate_regex(threadkey)
+        if not self.threadkey:
+            msg = 'No valid thread key could be found in ' \
+                  'provided url: {}.'.format(threadkey)
             self.logger.debug(msg)
 
         return

--- a/apprise/plugins/NotifyGoogleChat.py
+++ b/apprise/plugins/NotifyGoogleChat.py
@@ -77,11 +77,12 @@ class NotifyGoogleChat(NotifyBase):
     secure_protocol = 'gchat'
 
     # A URL that takes you to the setup/help of the specific protocol
-    setup_url = 'https://github.com/caronc/apprise/wiki/Notify_googlechat'
+    setup_url = "https://github.com/caronc/apprise/wiki/Notify_googlechat"
 
     # Google Chat Webhook
-    notify_url = 'https://chat.googleapis.com/v1/spaces/{workspace}/messages' \
-                 '?key={key}&token={token}'
+    notify_url = (
+        "https://chat.googleapis.com/v1/{}"
+    )
 
     # Default Notify Format
     notify_format = NotifyFormat.MARKDOWN
@@ -95,45 +96,61 @@ class NotifyGoogleChat(NotifyBase):
 
     # Define object templates
     templates = (
-        '{schema}://{workspace}/{webhook_key}/{webhook_token}',
-    )
+        "{schema}://{workspace}/{webhook_key}/{webhook_token}",
+        "{schema}://{workspace}/{webhook_key}/{webhook_token}/{webhook_threadkey}",
+        )
 
     # Define our template tokens
-    template_tokens = dict(NotifyBase.template_tokens, **{
-        'workspace': {
-            'name': _('Workspace'),
-            'type': 'string',
-            'private': True,
-            'required': True,
-        },
-        'webhook_key': {
-            'name': _('Webhook Key'),
-            'type': 'string',
-            'private': True,
-            'required': True,
-        },
-        'webhook_token': {
-            'name': _('Webhook Token'),
-            'type': 'string',
-            'private': True,
-            'required': True,
-        },
-    })
+    template_tokens = dict(
+        NotifyBase.template_tokens,
+        **{
+            "workspace": {
+                "name": _("Workspace"),
+                "type": "string",
+                "private": True,
+                "required": True,
+            },
+            "webhook_key": {
+                "name": _("Webhook Key"),
+                "type": "string",
+                "private": True,
+                "required": True,
+            },
+            "webhook_token": {
+                "name": _("Webhook Token"),
+                "type": "string",
+                "private": True,
+                "required": True,
+            },
+            "webhook_threadkey": {
+                "name": _("Webhook Thread Key"),
+                "type": "string",
+                "private": True,
+                "required": False,
+            },
+        }
+    )
 
     # Define our template arguments
-    template_args = dict(NotifyBase.template_args, **{
-        'workspace': {
-            'alias_of': 'workspace',
-        },
-        'key': {
-            'alias_of': 'webhook_key',
-        },
-        'token': {
-            'alias_of': 'webhook_token',
-        },
-    })
+    template_args = dict(
+        NotifyBase.template_args,
+        **{
+            "workspace": {
+                "alias_of": "workspace",
+            },
+            "key": {
+                "alias_of": "webhook_key",
+            },
+            "token": {
+                "alias_of": "webhook_token",
+            },
+            "threadkey": {
+                "alias_of": "webhook_threadkey",
+            },
+        }
+    )
 
-    def __init__(self, workspace, webhook_key, webhook_token, **kwargs):
+    def __init__(self, workspace, webhook_key, webhook_token, webhook_threadkey=None, **kwargs):
         """
         Initialize Google Chat Object
 
@@ -143,56 +160,83 @@ class NotifyGoogleChat(NotifyBase):
         # Workspace (associated with project)
         self.workspace = validate_regex(workspace)
         if not self.workspace:
-            msg = 'An invalid Google Chat Workspace ' \
-                  '({}) was specified.'.format(workspace)
+            msg = (
+                "An invalid Google Chat Workspace "
+                "({}) was specified.".format(workspace)
+            )
             self.logger.warning(msg)
             raise TypeError(msg)
 
         # Webhook Key (associated with project)
         self.webhook_key = validate_regex(webhook_key)
         if not self.webhook_key:
-            msg = 'An invalid Google Chat Webhook Key ' \
-                  '({}) was specified.'.format(webhook_key)
+            msg = (
+                "An invalid Google Chat Webhook Key "
+                "({}) was specified.".format(webhook_key)
+            )
             self.logger.warning(msg)
             raise TypeError(msg)
 
         # Webhook Token (associated with project)
         self.webhook_token = validate_regex(webhook_token)
         if not self.webhook_token:
-            msg = 'An invalid Google Chat Webhook Token ' \
-                  '({}) was specified.'.format(webhook_token)
+            msg = (
+                "An invalid Google Chat Webhook Token "
+                "({}) was specified.".format(webhook_token)
+            )
             self.logger.warning(msg)
             raise TypeError(msg)
+        
+        # Webhook Thread Key (associated with thread)
+        try:
+            self.webhook_threadkey = validate_regex(webhook_threadkey)
+        except:
+            msg = (
+                "No valid threadKey found in provided URI."
+            )
+            self.logger.warning(msg)
 
         return
 
-    def send(self, body, title='', notify_type=NotifyType.INFO, **kwargs):
+    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
         """
         Perform Google Chat Notification
         """
 
         # Our headers
         headers = {
-            'User-Agent': self.app_id,
-            'Content-Type': 'application/json; charset=utf-8',
+            "User-Agent": self.app_id,
+            "Content-Type": "application/json; charset=utf-8",
         }
 
         payload = {
             # Our Message
-            'text': body,
+            "text": body,
         }
 
         # Construct Notify URL
-        notify_url = self.notify_url.format(
-            workspace=self.workspace,
-            key=self.webhook_key,
-            token=self.webhook_token,
-        )
+        if self.webhook_threadkey:
+            notify_url = self.notify_url.format(
+                f"spaces/{self.workspace}/messages?"
+                f"key={self.webhook_key}"
+                f"&token={self.webhook_token}"
+                f"&threadKey={self.webhook_threadkey}"
+            )
+        else:
+            notify_url = self.notify_url.format(
+                f"spaces/{self.workspace}/messages?"
+                f"key={self.webhook_key}"
+                f"&token={self.webhook_token}"
+            )
 
-        self.logger.debug('Google Chat POST URL: %s (cert_verify=%r)' % (
-            notify_url, self.verify_certificate,
-        ))
-        self.logger.debug('Google Chat Payload: %s' % str(payload))
+        self.logger.debug(
+            "Google Chat POST URL: %s (cert_verify=%r)"
+            % (
+                notify_url,
+                self.verify_certificate,
+            )
+        )
+        self.logger.debug("Google Chat Payload: %s" % str(payload))
 
         # Always call throttle before any remote server i/o is made
         self.throttle()
@@ -205,31 +249,35 @@ class NotifyGoogleChat(NotifyBase):
                 timeout=self.request_timeout,
             )
             if r.status_code not in (
-                    requests.codes.ok, requests.codes.no_content):
+                requests.codes.ok,
+                requests.codes.no_content,
+            ):
 
                 # We had a problem
-                status_str = \
-                    NotifyBase.http_response_code_lookup(r.status_code)
+                status_str = NotifyBase.http_response_code_lookup(
+                    r.status_code
+                )
 
                 self.logger.warning(
-                    'Failed to send Google Chat notification: '
-                    '{}{}error={}.'.format(
-                        status_str,
-                        ', ' if status_str else '',
-                        r.status_code))
+                    "Failed to send Google Chat notification: "
+                    "{}{}error={}.".format(
+                        status_str, ", " if status_str else "", r.status_code
+                    )
+                )
 
-                self.logger.debug('Response Details:\r\n{}'.format(r.content))
+                self.logger.debug("Response Details:\r\n{}".format(r.content))
 
                 # Return; we're done
                 return False
 
             else:
-                self.logger.info('Sent Google Chat notification.')
+                self.logger.info("Sent Google Chat notification.")
 
         except requests.RequestException as e:
             self.logger.warning(
-                'A Connection error occurred postingto Google Chat.')
-            self.logger.debug('Socket Exception: %s' % str(e))
+                "A Connection error occurred postingto Google Chat."
+            )
+            self.logger.debug("Socket Exception: %s" % str(e))
             return False
 
         return True
@@ -242,13 +290,24 @@ class NotifyGoogleChat(NotifyBase):
         # Set our parameters
         params = self.url_parameters(privacy=privacy, *args, **kwargs)
 
-        return '{schema}://{workspace}/{key}/{token}/?{params}'.format(
-            schema=self.secure_protocol,
-            workspace=self.pprint(self.workspace, privacy, safe=''),
-            key=self.pprint(self.webhook_key, privacy, safe=''),
-            token=self.pprint(self.webhook_token, privacy, safe=''),
-            params=NotifyGoogleChat.urlencode(params),
-        )
+        if self.webhook_threadkey:
+            return "{schema}://{workspace}/{key}/{token}/{threadkey}/?{params}".format(
+                schema=self.secure_protocol,
+                workspace=self.pprint(self.workspace, privacy, safe=""),
+                key=self.pprint(self.webhook_key, privacy, safe=""),
+                token=self.pprint(self.webhook_token, privacy, safe=""),
+                threadkey=self.pprint(self.webhook_threadkey, privacy, safe=""),
+                params=NotifyGoogleChat.urlencode(params),
+            )
+
+        else:
+            return "{schema}://{workspace}/{key}/{token}/?{params}".format(
+                schema=self.secure_protocol,
+                workspace=self.pprint(self.workspace, privacy, safe=""),
+                key=self.pprint(self.webhook_key, privacy, safe=""),
+                token=self.pprint(self.webhook_token, privacy, safe=""),
+                params=NotifyGoogleChat.urlencode(params),
+            )
 
     @staticmethod
     def parse_url(url):
@@ -257,38 +316,51 @@ class NotifyGoogleChat(NotifyBase):
         us to re-instantiate this object.
 
         Syntax:
-          gchat://workspace/webhook_key/webhook_token
+          gchatb://workspace/webhook_key/webhook_token
+        Optionnaly:
+          gchatb://workspace/webhook_key/webhook_token/webhook_threadkey
 
         """
         results = NotifyBase.parse_url(url, verify_host=False)
+
         if not results:
             # We're done early as we couldn't load the results
             return results
 
-        # Store our Workspace
-        results['workspace'] = NotifyGoogleChat.unquote(results['host'])
+        results["workspace"] = NotifyGoogleChat.unquote(results["host"])
 
         # Acquire our tokens
-        tokens = NotifyGoogleChat.split_path(results['fullpath'])
+        tokens = NotifyGoogleChat.split_path(results["fullpath"])
 
         # Store our Webhook Key
-        results['webhook_key'] = tokens.pop(0) if tokens else None
+        results["webhook_key"] = tokens.pop(0) if tokens else None
 
         # Store our Webhook Token
-        results['webhook_token'] = tokens.pop(0) if tokens else None
+        results["webhook_token"] = tokens.pop(0) if tokens else None
+
+        # Store our Webhook Thread Key
+        results["webhook_threadkey"] = tokens.pop(0) if tokens else None
 
         # Support arguments as overrides (if specified)
-        if 'workspace' in results['qsd']:
-            results['workspace'] = \
-                NotifyGoogleChat.unquote(results['qsd']['workspace'])
+        if "workspace" in results["qsd"]:
+            results["workspace"] = NotifyGoogleChat.unquote(
+                results["qsd"]["workspace"]
+            )
 
-        if 'key' in results['qsd']:
-            results['webhook_key'] = \
-                NotifyGoogleChat.unquote(results['qsd']['key'])
+        if "key" in results["qsd"]:
+            results["webhook_key"] = NotifyGoogleChat.unquote(
+                results["qsd"]["key"]
+            )
 
-        if 'token' in results['qsd']:
-            results['webhook_token'] = \
-                NotifyGoogleChat.unquote(results['qsd']['token'])
+        if "token" in results["qsd"]:
+            results["webhook_token"] = NotifyGoogleChat.unquote(
+                results["qsd"]["token"]
+            )
+        
+        if "threadkey" in results["qsd"]:
+            results["webhook_threadkey"] = NotifyGoogleChat.unquote(
+                results["qsd"]["threadkey"]
+            )
 
         return results
 
@@ -301,15 +373,19 @@ class NotifyGoogleChat(NotifyBase):
         """
 
         result = re.match(
-            r'^https://chat\.googleapis\.com/v1/spaces/'
-            r'(?P<workspace>[A-Z0-9_-]+)/messages/*(?P<params>.+)$',
-            url, re.I)
+            r"^https://chat\.googleapis\.com/v1/spaces/"
+            r"(?P<workspace>[a-zA-Z0-9_-]+)/messages/*(?P<params>.*)$",
+            url,
+            re.I,
+        )
 
         if result:
             return NotifyGoogleChat.parse_url(
-                '{schema}://{workspace}/{params}'.format(
+                "{schema}://{workspace}/{params}".format(
                     schema=NotifyGoogleChat.secure_protocol,
-                    workspace=result.group('workspace'),
-                    params=result.group('params')))
+                    workspace=result.group("workspace"),
+                    params=result.group("params"),
+                )
+            )
 
         return None

--- a/apprise/plugins/NotifyGoogleChat.py
+++ b/apprise/plugins/NotifyGoogleChat.py
@@ -67,21 +67,20 @@ class NotifyGoogleChat(NotifyBase):
     A wrapper to Google Chat Notifications
 
     """
-
     # The default descriptive name associated with the Notification
-    service_name = "Google Chat"
+    service_name = 'Google Chat'
 
     # The services URL
-    service_url = "https://chat.google.com/"
+    service_url = 'https://chat.google.com/'
 
     # The default secure protocol
-    secure_protocol = "gchat"
+    secure_protocol = 'gchat'
 
     # A URL that takes you to the setup/help of the specific protocol
-    setup_url = "https://github.com/caronc/apprise/wiki/Notify_googlechat"
+    setup_url = 'https://github.com/caronc/apprise/wiki/Notify_googlechat'
 
     # Google Chat Webhook
-    notify_url = "https://chat.googleapis.com/v1/{path_and_params}"
+    notify_url = 'https://chat.googleapis.com/v1/{path_and_params}'
 
     # Default Notify Format
     notify_format = NotifyFormat.MARKDOWN
@@ -95,59 +94,53 @@ class NotifyGoogleChat(NotifyBase):
 
     # Define object templates
     templates = (
-        "{schema}://{workspace}/{webhook_key}/{webhook_token}",
-        "{schema}://{workspace}/{webhook_key}/{webhook_token}/{threadkey}",
+        '{schema}://{workspace}/{webhook_key}/{webhook_token}',
+        '{schema}://{workspace}/{webhook_key}/{webhook_token}/{threadkey}',
     )
 
     # Define our template tokens
-    template_tokens = dict(
-        NotifyBase.template_tokens,
-        **{
-            "workspace": {
-                "name": _("Workspace"),
-                "type": "string",
-                "private": True,
-                "required": True,
-            },
-            "webhook_key": {
-                "name": _("Webhook Key"),
-                "type": "string",
-                "private": True,
-                "required": True,
-            },
-            "webhook_token": {
-                "name": _("Webhook Token"),
-                "type": "string",
-                "private": True,
-                "required": True,
-            },
-            "threadkey": {
-                "name": _("Webhook Thread Key"),
-                "type": "string",
-                "private": True,
-                "required": False,
-            },
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'workspace': {
+            'name': _('Workspace'),
+            'type': 'string',
+            'private': True,
+            'required': True,
         },
-    )
+        'webhook_key': {
+            'name': _('Webhook Key'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+        },
+        'webhook_token': {
+            'name': _('Webhook Token'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+        },
+        'threadkey': {
+            'name': _('Webhook Thread Key'),
+            'type': 'string',
+            'private': True,
+            'required': False,
+        },
+    })
 
     # Define our template arguments
-    template_args = dict(
-        NotifyBase.template_args,
-        **{
-            "workspace": {
-                "alias_of": "workspace",
-            },
-            "key": {
-                "alias_of": "webhook_key",
-            },
-            "token": {
-                "alias_of": "webhook_token",
-            },
-            "threadkey": {
-                "alias_of": "threadkey",
-            },
+    template_args = dict(NotifyBase.template_args, **{
+        'workspace': {
+            'alias_of': 'workspace',
         },
-    )
+        'key': {
+            'alias_of': 'webhook_key',
+        },
+        'token': {
+            'alias_of': 'webhook_token',
+        },
+        'threadkey': {
+            'alias_of': 'threadkey',
+        },
+    })
 
     def __init__(
         self, workspace, webhook_key, webhook_token, threadkey=None, **kwargs
@@ -161,30 +154,24 @@ class NotifyGoogleChat(NotifyBase):
         # Workspace (associated with project)
         self.workspace = validate_regex(workspace)
         if not self.workspace:
-            msg = (
-                "An invalid Google Chat Workspace "
-                "({}) was specified.".format(workspace)
-            )
+            msg = 'An invalid Google Chat Workspace ' \
+                  '({}) was specified.'.format(workspace)
             self.logger.warning(msg)
             raise TypeError(msg)
 
         # Webhook Key (associated with project)
         self.webhook_key = validate_regex(webhook_key)
         if not self.webhook_key:
-            msg = (
-                "An invalid Google Chat Webhook Key "
-                "({}) was specified.".format(webhook_key)
-            )
+            msg = 'An invalid Google Chat Webhook Key ' \
+                  '({}) was specified.'.format(webhook_key)
             self.logger.warning(msg)
             raise TypeError(msg)
 
         # Webhook Token (associated with project)
         self.webhook_token = validate_regex(webhook_token)
         if not self.webhook_token:
-            msg = (
-                "An invalid Google Chat Webhook Token "
-                "({}) was specified.".format(webhook_token)
-            )
+            msg = 'An invalid Google Chat Webhook Token ' \
+                  '({}) was specified.'.format(webhook_token)
             self.logger.warning(msg)
             raise TypeError(msg)
 
@@ -192,47 +179,47 @@ class NotifyGoogleChat(NotifyBase):
         try:
             self.threadkey = validate_regex(threadkey)
         except:
-            msg = "No valid threadKey found in provided URI."
+            msg = 'No valid threadKey found in provided URI.'
             self.logger.warning(msg)
 
         return
 
-    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+    def send(self, body, title='', notify_type=NotifyType.INFO, **kwargs):
         """
         Perform Google Chat Notification
         """
 
         # Our headers
         headers = {
-            "User-Agent": self.app_id,
-            "Content-Type": "application/json; charset=utf-8",
+            'User-Agent': self.app_id,
+            'Content-Type': 'application/json; charset=utf-8',
         }
 
         payload = {
             # Our Message
-            "text": body,
+            'text': body,
         }
 
         path = (
-            f"spaces/{self.workspace}/messages?"
-            f"key={self.webhook_key}"
-            f"&token={self.webhook_token}"
+            f'spaces/{self.workspace}/messages?'
+            f'key={self.webhook_key}'
+            f'&token={self.webhook_token}'
         )
 
         path_and_params = (
-            f"{path}&threadKey={self.threadkey}" if self.threadkey else path
+            f'{path}&threadKey={self.threadkey}'
+            if self.threadkey
+            else path
         )
 
-        notify_url = self.notify_url.format(path_and_params=path_and_params)
-
-        self.logger.debug(
-            "Google Chat POST URL: %s (cert_verify=%r)"
-            % (
-                notify_url,
-                self.verify_certificate,
-            )
+        notify_url = self.notify_url.format(
+            path_and_params=path_and_params
         )
-        self.logger.debug("Google Chat Payload: %s" % str(payload))
+
+        self.logger.debug('Google Chat POST URL: %s (cert_verify=%r)' % (
+            notify_url, self.verify_certificate,
+        ))
+        self.logger.debug('Google Chat Payload: %s' % str(payload))
 
         # Always call throttle before any remote server i/o is made
         self.throttle()
@@ -245,35 +232,31 @@ class NotifyGoogleChat(NotifyBase):
                 timeout=self.request_timeout,
             )
             if r.status_code not in (
-                requests.codes.ok,
-                requests.codes.no_content,
-            ):
+                    requests.codes.ok, requests.codes.no_content):
 
                 # We had a problem
-                status_str = NotifyBase.http_response_code_lookup(
-                    r.status_code
-                )
+                status_str = \
+                    NotifyBase.http_response_code_lookup(r.status_code)
 
                 self.logger.warning(
-                    "Failed to send Google Chat notification: "
-                    "{}{}error={}.".format(
-                        status_str, ", " if status_str else "", r.status_code
-                    )
-                )
+                    'Failed to send Google Chat notification: '
+                    '{}{}error={}.'.format(
+                        status_str,
+                        ', ' if status_str else '',
+                        r.status_code))
 
-                self.logger.debug("Response Details:\r\n{}".format(r.content))
+                self.logger.debug('Response Details:\r\n{}'.format(r.content))
 
                 # Return; we're done
                 return False
 
             else:
-                self.logger.info("Sent Google Chat notification.")
+                self.logger.info('Sent Google Chat notification.')
 
         except requests.RequestException as e:
             self.logger.warning(
-                "A Connection error occurred postingto Google Chat."
-            )
-            self.logger.debug("Socket Exception: %s" % str(e))
+                'A Connection error occurred postingto Google Chat.')
+            self.logger.debug('Socket Exception: %s' % str(e))
             return False
 
         return True
@@ -288,22 +271,24 @@ class NotifyGoogleChat(NotifyBase):
 
         if self.threadkey:
             return (
-                "{schema}://{workspace}/{key}/{token}/{threadkey}/?{params}"
+                '{schema}://{workspace}/{key}/{token}/{threadkey}/?{params}'
             ).format(
                 schema=self.secure_protocol,
-                workspace=self.pprint(self.workspace, privacy, safe=""),
-                key=self.pprint(self.webhook_key, privacy, safe=""),
-                token=self.pprint(self.webhook_token, privacy, safe=""),
-                threadkey=self.pprint(self.threadkey, privacy, safe=""),
+                workspace=self.pprint(self.workspace, privacy, safe=''),
+                key=self.pprint(self.webhook_key, privacy, safe=''),
+                token=self.pprint(self.webhook_token, privacy, safe=''),
+                threadkey=self.pprint(
+                    self.threadkey, privacy, safe=''
+                ),
                 params=NotifyGoogleChat.urlencode(params),
             )
 
         else:
-            return "{schema}://{workspace}/{key}/{token}/?{params}".format(
+            return '{schema}://{workspace}/{key}/{token}/?{params}'.format(
                 schema=self.secure_protocol,
-                workspace=self.pprint(self.workspace, privacy, safe=""),
-                key=self.pprint(self.webhook_key, privacy, safe=""),
-                token=self.pprint(self.webhook_token, privacy, safe=""),
+                workspace=self.pprint(self.workspace, privacy, safe=''),
+                key=self.pprint(self.webhook_key, privacy, safe=''),
+                token=self.pprint(self.webhook_token, privacy, safe=''),
                 params=NotifyGoogleChat.urlencode(params),
             )
 
@@ -325,40 +310,36 @@ class NotifyGoogleChat(NotifyBase):
             return results
 
         # Store our Workspace
-        results["workspace"] = NotifyGoogleChat.unquote(results["host"])
+        results['workspace'] = NotifyGoogleChat.unquote(results['host'])
 
         # Acquire our tokens
-        tokens = NotifyGoogleChat.split_path(results["fullpath"])
+        tokens = NotifyGoogleChat.split_path(results['fullpath'])
 
         # Store our Webhook Key
-        results["webhook_key"] = tokens.pop(0) if tokens else None
+        results['webhook_key'] = tokens.pop(0) if tokens else None
 
         # Store our Webhook Token
-        results["webhook_token"] = tokens.pop(0) if tokens else None
+        results['webhook_token'] = tokens.pop(0) if tokens else None
 
         # Store our Webhook Thread Key
-        results["threadkey"] = tokens.pop(0) if tokens else None
+        results['threadkey'] = tokens.pop(0) if tokens else None
 
         # Support arguments as overrides (if specified)
-        if "workspace" in results["qsd"]:
-            results["workspace"] = NotifyGoogleChat.unquote(
-                results["qsd"]["workspace"]
-            )
+        if 'workspace' in results['qsd']:
+            results['workspace'] = \
+                NotifyGoogleChat.unquote(results['qsd']['workspace'])
 
-        if "key" in results["qsd"]:
-            results["webhook_key"] = NotifyGoogleChat.unquote(
-                results["qsd"]["key"]
-            )
+        if 'key' in results['qsd']:
+            results['webhook_key'] = \
+                NotifyGoogleChat.unquote(results['qsd']['key'])
 
-        if "token" in results["qsd"]:
-            results["webhook_token"] = NotifyGoogleChat.unquote(
-                results["qsd"]["token"]
-            )
+        if 'token' in results['qsd']:
+            results['webhook_token'] = \
+                NotifyGoogleChat.unquote(results['qsd']['token'])
 
-        if "threadkey" in results["qsd"]:
-            results["threadkey"] = NotifyGoogleChat.unquote(
-                results["qsd"]["threadkey"]
-            )
+        if 'threadkey' in results['qsd']:
+            results['threadkey'] = \
+                NotifyGoogleChat.unquote(results['qsd']['threadkey'])
 
         return results
 
@@ -371,19 +352,15 @@ class NotifyGoogleChat(NotifyBase):
         """
 
         result = re.match(
-            r"^https://chat\.googleapis\.com/v1/spaces/"
-            r"(?P<workspace>[A-Z0-9_-]+)/messages/*(?P<params>.+)$",
-            url,
-            re.I,
-        )
+            r'^https://chat\.googleapis\.com/v1/spaces/'
+            r'(?P<workspace>[A-Z0-9_-]+)/messages/*(?P<params>.+)$',
+            url, re.I)
 
         if result:
             return NotifyGoogleChat.parse_url(
-                "{schema}://{workspace}/{params}".format(
+                '{schema}://{workspace}/{params}'.format(
                     schema=NotifyGoogleChat.secure_protocol,
-                    workspace=result.group("workspace"),
-                    params=result.group("params"),
-                )
-            )
+                    workspace=result.group('workspace'),
+                    params=result.group('params')))
 
         return None

--- a/apprise/plugins/NotifyGoogleChat.py
+++ b/apprise/plugins/NotifyGoogleChat.py
@@ -98,57 +98,51 @@ class NotifyGoogleChat(NotifyBase):
     templates = (
         '{schema}://{workspace}/{webhook_key}/{webhook_token}',
         '{schema}://{workspace}/{webhook_key}/{webhook_token}/{webhook_threadkey}',
-        )
+    )
 
     # Define our template tokens
-    template_tokens = dict(
-        NotifyBase.template_tokens,
-        **{
-            'workspace': {
-                'name': _('Workspace'),
-                'type': 'string',
-                'private': True,
-                'required': True,
-            },
-            'webhook_key': {
-                'name': _('Webhook Key'),
-                'type': 'string',
-                'private': True,
-                'required': True,
-            },
-            'webhook_token': {
-                'name': _('Webhook Token'),
-                'type': 'string',
-                'private': True,
-                'required': True,
-            },
-            'webhook_threadkey': {
-                'name': _('Webhook Thread Key'),
-                'type': 'string',
-                'private': True,
-                'required': False,
-            },
-        }
-    )
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'workspace': {
+            'name': _('Workspace'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+        },
+        'webhook_key': {
+            'name': _('Webhook Key'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+        },
+        'webhook_token': {
+            'name': _('Webhook Token'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+        },
+        'webhook_threadkey': {
+            'name': _('Webhook Thread Key'),
+            'type': 'string',
+            'private': True,
+            'required': False,
+        },
+    })
 
     # Define our template arguments
-    template_args = dict(
-        NotifyBase.template_args,
-        **{
-            'workspace': {
-                'alias_of': 'workspace',
-            },
-            'key': {
-                'alias_of': 'webhook_key',
-            },
-            'token': {
-                'alias_of': 'webhook_token',
-            },
-            'threadkey': {
-                'alias_of': 'webhook_threadkey',
-            },
-        }
-    )
+    template_args = dict(NotifyBase.template_args, **{
+        'workspace': {
+            'alias_of': 'workspace',
+        },
+        'key': {
+            'alias_of': 'webhook_key',
+        },
+        'token': {
+            'alias_of': 'webhook_token',
+        },
+        'threadkey': {
+            'alias_of': 'webhook_threadkey',
+        },
+    })
 
     def __init__(self, workspace, webhook_key, webhook_token, webhook_threadkey=None, **kwargs):
         """
@@ -237,7 +231,7 @@ class NotifyGoogleChat(NotifyBase):
                 timeout=self.request_timeout,
             )
             if r.status_code not in (
-                requests.codes.ok, requests.codes.no_content):
+                    requests.codes.ok, requests.codes.no_content):
 
                 # We had a problem
                 status_str = \
@@ -306,7 +300,6 @@ class NotifyGoogleChat(NotifyBase):
 
         """
         results = NotifyBase.parse_url(url, verify_host=False)
-
         if not results:
             # We're done early as we couldn't load the results
             return results
@@ -363,6 +356,6 @@ class NotifyGoogleChat(NotifyBase):
                 '{schema}://{workspace}/{params}'.format(
                     schema=NotifyGoogleChat.secure_protocol,
                     workspace=result.group('workspace'),
-                    params=result.group('params'),))
+                    params=result.group('params')))
 
         return None

--- a/apprise/plugins/__init__.py
+++ b/apprise/plugins/__init__.py
@@ -518,7 +518,6 @@ def url_to_dict(url, secure_logging=True):
 
     # Ensure our schema is always in lower case
     schema = schema.group('schema').lower()
-
     if schema not in common.NOTIFY_SCHEMA_MAP:
         # Give the user the benefit of the doubt that the user may be using
         # one of the URLs provided to them by their notification service.

--- a/apprise/plugins/__init__.py
+++ b/apprise/plugins/__init__.py
@@ -518,7 +518,7 @@ def url_to_dict(url, secure_logging=True):
 
     # Ensure our schema is always in lower case
     schema = schema.group('schema').lower()
-    schema = "gchatb"
+
     if schema not in common.NOTIFY_SCHEMA_MAP:
         # Give the user the benefit of the doubt that the user may be using
         # one of the URLs provided to them by their notification service.

--- a/test/test_plugin_google_chat.py
+++ b/test/test_plugin_google_chat.py
@@ -39,29 +39,44 @@ apprise_url_tests = (
     ('gchat://:@/', {
         'instance': TypeError,
     }),
-    # Workspace, but not Key or Token
+    # Workspace, but not Key, Token or threadKey
     ('gchat://workspace', {
         'instance': TypeError,
     }),
-    # Workspace and key, but no Token
+    # Workspace and key, but no Token or threadKey
     ('gchat://workspace/key/', {
         'instance': TypeError,
     }),
-    # Credentials are good
+    # Credentials are good without threadKey
     ('gchat://workspace/key/token', {
         'instance': NotifyGoogleChat,
         'privacy_url': 'gchat://w...e/k...y/t...n',
     }),
-    # Test arguments
+    # Credentials are good with threadKey
+    ('gchat://workspace/key/token/treadKey', {
+        'instance': NotifyGoogleChat,
+        'privacy_url': 'gchat://w...e/k...y/t...n/t...y',
+    }),
+    # Test arguments without threadKey
     ('gchat://?workspace=ws&key=mykey&token=mytoken', {
         'instance': NotifyGoogleChat,
         'privacy_url': 'gchat://w...s/m...y/m...n',
+    }),
+    # Test arguments with threadKey
+    ('gchat://?workspace=ws&key=mykey&token=mytoken&threadKey=mythreadKey', {
+        'instance': NotifyGoogleChat,
+        'privacy_url': 'gchat://w...s/m...y/m...n/t...y',
     }),
     # Google Native Webhohok URL
     ('https://chat.googleapis.com/v1/spaces/myworkspace/messages'
      '?key=mykey&token=mytoken', {
          'instance': NotifyGoogleChat,
          'privacy_url': 'gchat://m...e/m...y/m...n'}),
+    # Google Native Webhohok URL with manually added threadKey
+    ('https://chat.googleapis.com/v1/spaces/myworkspace/messages'
+     '?key=mykey&token=mytoken&threadKey=mythreadKey', {
+         'instance': NotifyGoogleChat,
+         'privacy_url': 'gchat://m...e/m...y/m...n/y...y'}),
 
     ('gchat://workspace/key/token', {
         'instance': NotifyGoogleChat,
@@ -76,6 +91,26 @@ apprise_url_tests = (
         'requests_response_code': 999,
     }),
     ('gchat://workspace/key/token', {
+        'instance': NotifyGoogleChat,
+        # Throws a series of connection and transfer exceptions when this flag
+        # is set and tests that we gracfully handle them
+        'test_requests_exceptions': True,
+    }),
+
+    # Redo with threadkey
+    ('gchat://workspace/key/token/threadKey', {
+        'instance': NotifyGoogleChat,
+        # force a failure
+        'response': False,
+        'requests_response_code': requests.codes.internal_server_error,
+    }),
+    ('gchat://workspace/key/token/threadKey', {
+        'instance': NotifyGoogleChat,
+        # throw a bizzare code forcing us to fail to look it up
+        'response': False,
+        'requests_response_code': 999,
+    }),
+    ('gchat://workspace/key/token/threadKey', {
         'instance': NotifyGoogleChat,
         # Throws a series of connection and transfer exceptions when this flag
         # is set and tests that we gracfully handle them


### PR DESCRIPTION
## Description

While using apprise for Google chat, I wasn't able to thread messages by simply provide the URL/URI of the thread.
Here is the feature that allows to thread different messages by simply providing on of the two following:
- https://chat.googleapis.com/v1/spaces/{$WORKSPACE$}/messages/?key={$KEY$}&token={$TOKEN$}&threadKey={$THREADKEY$}
- gchat://{$WORKSPACE$}/{$KEY$}/{$TOKEN$}/{$THREADKEY$}

Note that sending gchat://{$WORKSPACE$}/{$KEY$}/{$TOKEN$} still correctly send the notification to the chatroom and send different thread if used for threaded chatrooms.

## New Service Completion Status
This patch doesn't apply a new service yet imply modification in the README.md of Google Chat such as:
- Syntax section shall take into account new syntaxes above with the specification that the threadkey can be any string matching "[a-zA-Z0-9_-]" which is especially convenient with uuid. As long as the $THREADKEY$ argument is the same, it posts in the same thread
- Parameters breakdown section by adding thread_key | No | The thread key associated with a given thread.
- Example sections with code such as:

```
# Assuming our {workspace} is AAAAkM
# Assuming our {webhook_key} is AIzaSSjMm-WEfqKqqsHI
# Assuming our {webhook_token} is O7bnyri_WEXKcyFk%3D
# Assuming our {thread_key} is cc124654-aee3-4856-a236-4afd489dfd9d

apprise -vv -t "Test Message Title" -b "Test Message Body" \
   gchat://AAAAkM/AIzaSSjMm-WEfqKqqsHI/O7bnyri_WEXKcyFk%3D/cc124654-aee3-4856-a236-4afd489dfd9d
```
or
```
# Assuming our {workspace} is AAAAkM
# Assuming our {webhook_key} is AIzaSSjMm-WEfqKqqsHI
# Assuming our {webhook_token} is O7bnyri_WEXKcyFk%3D
# Assuming our {thread_key} is cc124654-aee3-4856-a236-4afd489dfd9d

apprise -vv -t "Test Message Title" -b "Test Message Body" \
   https://chat.googleapis.com/v1/spaces/AAAAkM/messages?key=AIzaSSjMm-WEfqKqqsHI&token=O7bnyri_WEXKcyFk%3D&threadKey=cc124654-aee3-4856-a236-4afd489dfd9d
```

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage *i suppose*




