### PR TITLE
fix: cto= and rto= lines now work from YAML config

### DIFF
--- a/apprise/URLBase.py
+++ b/apprise/URLBase.py
@@ -194,7 +194,7 @@ class URLBase:
             asset if isinstance(asset, AppriseAsset) else AppriseAsset()
 
         # Certificate Verification (for SSL calls); default to being enabled
-        self.verify_certificate = kwargs.get('verify', True)
+        self.verify_certificate = parse_bool(kwargs.get('verify', True))
 
         # Secure Mode
         self.secure = kwargs.get('secure', False)
@@ -222,24 +222,22 @@ class URLBase:
             self.password = URLBase.unquote(self.password)
 
         # Store our Timeout Variables
-        if 'socket_read_timeout' in kwargs:
+        if 'rto' in kwargs:
             try:
-                self.socket_read_timeout = \
-                    float(kwargs.get('socket_read_timeout'))
+                self.socket_read_timeout = float(kwargs.get('rto'))
             except (TypeError, ValueError):
                 self.logger.warning(
                     'Invalid socket read timeout (rto) was specified {}'
-                    .format(kwargs.get('socket_read_timeout')))
+                    .format(kwargs.get('rto')))
 
-        if 'socket_connect_timeout' in kwargs:
+        if 'cto' in kwargs:
             try:
-                self.socket_connect_timeout = \
-                    float(kwargs.get('socket_connect_timeout'))
+                self.socket_connect_timeout = float(kwargs.get('cto'))
 
             except (TypeError, ValueError):
                 self.logger.warning(
                     'Invalid socket connect timeout (cto) was specified {}'
-                    .format(kwargs.get('socket_connect_timeout')))
+                    .format(kwargs.get('cto')))
 
         if 'tag' in kwargs:
             # We want to associate some tags with our notification service.
@@ -647,11 +645,11 @@ class URLBase:
 
         # Store our socket read timeout if specified
         if 'rto' in results['qsd']:
-            results['socket_read_timeout'] = results['qsd']['rto']
+            results['rto'] = results['qsd']['rto']
 
         # Store our socket connect timeout if specified
         if 'cto' in results['qsd']:
-            results['socket_connect_timeout'] = results['qsd']['cto']
+            results['cto'] = results['qsd']['cto']
 
         if 'port' in results['qsd']:
             results['port'] = results['qsd']['port']

--- a/test/test_config_base.py
+++ b/test/test_config_base.py
@@ -995,6 +995,7 @@ def test_config_base_config_parse_yaml_globals():
         assert entry.socket_read_timeout == 30
         assert entry.socket_connect_timeout == 30
 
+
 # This test fails on CentOS 8.x so it was moved into it's own function
 # so it could be bypassed. The ability to use lists in YAML files didn't
 # appear to happen until later on; it's certainly not available in v3.12

--- a/test/test_config_base.py
+++ b/test/test_config_base.py
@@ -27,6 +27,7 @@ import pytest
 from apprise.AppriseAsset import AppriseAsset
 from apprise.config.ConfigBase import ConfigBase
 from apprise import ConfigFormat
+from inspect import cleandoc
 import yaml
 
 # Disable logging for a cleaner testing output
@@ -956,6 +957,43 @@ def test_yaml_vs_text_tagging():
     assert 'mytag' in text_result[0]
     assert 'mytag' in yaml_result[0]
 
+
+def test_config_base_config_parse_yaml_globals():
+    """
+    API: ConfigBase.config_parse_yaml globals
+
+    """
+
+    # general reference used below
+    asset = AppriseAsset()
+
+    # Invalid Syntax (throws a ScannerError)
+    results, config = ConfigBase.config_parse_yaml(cleandoc("""
+    urls:
+      - jsons://localhost1:
+         - to: jeff@gmail.com
+           tag: jeff, customer
+           cto: 30
+           rto: 30
+           verify: no
+
+      - jsons://localhost2?cto=30&rto=30&verify=no:
+         - to: json@gmail.com
+           tag: json, customer
+    """), asset=asset)
+
+    # Invalid data gets us an empty result set
+    assert isinstance(results, list)
+
+    # Our results loaded
+    assert len(results) == 2
+    assert len(config) == 0
+
+    # Now verify that our global variables correctly initialized
+    for entry in results:
+        assert entry.verify_certificate is False
+        assert entry.socket_read_timeout == 30
+        assert entry.socket_connect_timeout == 30
 
 # This test fails on CentOS 8.x so it was moved into it's own function
 # so it could be bypassed. The ability to use lists in YAML files didn't


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #653

Prior to this PR, you could not set the `cto` (Connect Timeout) or `rto` (Read Timeout) from the YAML configuration files.

This officially resolves this bug. :lady_beetle: 

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@653-cto-rto-config-timeout

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" -c /path/to/yaml/file with `cto' and/or `rto` over-rides.
```

## Config Example
```yaml
urls:
  - jsons://localhost1:
     - to: jeff@gmail.com
       # Over-ride our values
       cto: 30
       rto: 30

  # Values can also be over-ridden through the URL:
  - jsons://localhost2?cto=30&rto=30&verify=no:
     - to: json@gmail.com
       tag: json, customer
```
