### PR TITLE
Improved rocketchat:// privacy and added test cases

### DIFF
--- a/apprise/plugins/NotifyRocketChat.py
+++ b/apprise/plugins/NotifyRocketChat.py
@@ -48,10 +48,6 @@ RC_HTTP_ERROR_MAP = {
     401: 'Authentication tokens provided is invalid or missing.',
 }
 
-# Used to break apart list of potential tags by their delimiter
-# into a usable list.
-LIST_DELIM = re.compile(r'[ \t\r\n,\\/]+')
-
 
 class RocketChatAuthMode:
     """
@@ -320,7 +316,8 @@ class NotifyRocketChat(NotifyBase):
             auth = '{user}{webhook}@'.format(
                 user='{}:'.format(NotifyRocketChat.quote(self.user, safe=''))
                 if self.user else '',
-                webhook=self.pprint(self.webhook, privacy, safe=''),
+                webhook=self.pprint(self.webhook, privacy,
+                                    mode=PrivacyMode.Secret, safe=''),
             )
 
         default_port = 443 if self.secure else 80
@@ -333,7 +330,7 @@ class NotifyRocketChat(NotifyBase):
             port='' if self.port is None or self.port == default_port
                  else ':{}'.format(self.port),
             targets='/'.join(
-                [NotifyRocketChat.quote(x, safe='') for x in chain(
+                [NotifyRocketChat.quote(x, safe='@#') for x in chain(
                     # Channels are prefixed with a pound/hashtag symbol
                     ['#{}'.format(x) for x in self.channels],
                     # Rooms are as is

--- a/test/helpers/rest.py
+++ b/test/helpers/rest.py
@@ -247,6 +247,7 @@ class AppriseURLTester:
             if privacy_url:
                 # Assess that our privacy url is as expected
                 if not obj.url(privacy=True).startswith(privacy_url):
+                    print('Provided %s' % url)
                     raise AssertionError(
                         "Privacy URL: '{}' != expected '{}'".format(
                             obj.url(privacy=True)[:len(privacy_url)],

--- a/test/test_plugin_rocket_chat.py
+++ b/test/test_plugin_rocket_chat.py
@@ -75,6 +75,7 @@ apprise_url_tests = (
                 'userId': 'user',
             },
         },
+        'privacy_url': 'rocket://user:****@localhost',
     }),
     # A channel (using the to=)
     ('rockets://user:pass@localhost?to=#channel', {
@@ -87,6 +88,7 @@ apprise_url_tests = (
                 'userId': 'user',
             },
         },
+        'privacy_url': 'rockets://user:****@localhost',
     }),
     # A channel
     ('rockets://user:pass@localhost/#channel', {
@@ -99,6 +101,7 @@ apprise_url_tests = (
                 'userId': 'user',
             },
         },
+        'privacy_url': 'rockets://user:****@localhost',
     }),
     # Several channels
     ('rocket://user:pass@localhost/#channel1/#channel2/?avatar=Yes', {
@@ -111,6 +114,7 @@ apprise_url_tests = (
                 'userId': 'user',
             },
         },
+        'privacy_url': 'rocket://user:****@localhost',
     }),
     # Several Rooms
     ('rocket://user:pass@localhost/room1/room2', {
@@ -123,6 +127,7 @@ apprise_url_tests = (
                 'userId': 'user',
             },
         },
+        'privacy_url': 'rocket://user:****@localhost',
     }),
     # A room and channel
     ('rocket://user:pass@localhost/room/#channel?mode=basic&avatar=Yes', {
@@ -151,6 +156,7 @@ apprise_url_tests = (
                 'userId': 'user',
             },
         },
+        'privacy_url': 'rockets://user:****@localhost',
     }),
     # A room and channel
     ('rockets://user:pass@localhost/rooma/#channela', {
@@ -168,9 +174,11 @@ apprise_url_tests = (
     # A web token
     ('rockets://web/token@localhost/@user/#channel/roomid', {
         'instance': NotifyRocketChat,
+        'privacy_url': 'rockets://****@localhost/#channel/roomid',
     }),
     ('rockets://user:web/token@localhost/@user/?mode=webhook', {
         'instance': NotifyRocketChat,
+        'privacy_url': 'rockets://user:****@localhost',
     }),
     ('rockets://user:web/token@localhost?to=@user2,#channel2', {
         'instance': NotifyRocketChat,
@@ -180,10 +188,11 @@ apprise_url_tests = (
         'instance': NotifyRocketChat,
 
         # Our expected url(privacy=True) startswith() response:
-        'privacy_url': 'rockets://w...n@localhost',
+        'privacy_url': 'rockets://****@localhost/',
     }),
     ('rockets://localhost/@user/?mode=webhook&webhook=web/token', {
         'instance': NotifyRocketChat,
+        'privacy_url': 'rockets://****@localhost/@user'
     }),
     ('rockets://user:web/token@localhost/@user/?mode=invalid', {
         # invalid mode
@@ -228,7 +237,7 @@ def test_plugin_rocket_chat_urls():
 
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_rocketchat_edge_cases(mock_post, mock_get):
+def test_plugin_rocket_chat_edge_cases(mock_post, mock_get):
     """
     NotifyRocketChat() Edge Cases
 


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** n/a

Just a small update to the Rocket.Chat `url()` function so that it properly hides a webtoken if defined.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@rocketchat-webhook-privacy

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
    "rocketchat://webtoken@host/targets

```