### PR TITLE
Google Chat Thread-Key support

### DIFF
--- a/apprise/plugins/NotifyGoogleChat.py
+++ b/apprise/plugins/NotifyGoogleChat.py
@@ -135,7 +135,7 @@ class NotifyGoogleChat(NotifyBase):
             'name': _('Thread Key'),
             'type': 'string',
             'private': True,
-            'alias_of': 'thread_key',
+            'map_to': 'thread_key',
         },
     })
 

--- a/test/test_plugin_google_chat.py
+++ b/test/test_plugin_google_chat.py
@@ -23,7 +23,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 import requests
-
+import pytest
 from apprise.plugins.NotifyGoogleChat import NotifyGoogleChat
 from helpers import AppriseURLTester
 
@@ -54,6 +54,11 @@ apprise_url_tests = (
     }),
     # Test arguments
     ('gchat://?workspace=ws&key=mykey&token=mytoken', {
+        'instance': NotifyGoogleChat,
+        'privacy_url': 'gchat://w...s/m...y/m...n',
+    }),
+    ('gchat://?workspace=ws&key=mykey&token=mytoken&thread=abc123', {
+        # Test our thread key
         'instance': NotifyGoogleChat,
         'privacy_url': 'gchat://w...s/m...y/m...n',
     }),
@@ -92,3 +97,12 @@ def test_plugin_google_chat_urls():
 
     # Run our general tests
     AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+def test_plugin_google_chat_edge_case():
+    """
+    NotifyGoogleChat() Edge Cases
+
+    """
+    with pytest.raises(TypeError):
+        NotifyGoogleChat('workspace', 'webhook', 'token', thread_key=object())

--- a/test/test_plugin_google_chat.py
+++ b/test/test_plugin_google_chat.py
@@ -60,14 +60,22 @@ apprise_url_tests = (
     ('gchat://?workspace=ws&key=mykey&token=mytoken&thread=abc123', {
         # Test our thread key
         'instance': NotifyGoogleChat,
-        'privacy_url': 'gchat://w...s/m...y/m...n',
+        'privacy_url': 'gchat://w...s/m...y/m...n/a...3',
     }),
-    # Google Native Webhohok URL
+    ('gchat://?workspace=ws&key=mykey&token=mytoken&threadKey=abc345', {
+        # Test our thread key
+        'instance': NotifyGoogleChat,
+        'privacy_url': 'gchat://w...s/m...y/m...n/a...5',
+    }),
+    # Google Native Webhook URL
     ('https://chat.googleapis.com/v1/spaces/myworkspace/messages'
      '?key=mykey&token=mytoken', {
          'instance': NotifyGoogleChat,
          'privacy_url': 'gchat://m...e/m...y/m...n'}),
-
+    ('https://chat.googleapis.com/v1/spaces/myworkspace/messages'
+     '?key=mykey&token=mytoken&threadKey=mythreadkey', {
+         'instance': NotifyGoogleChat,
+         'privacy_url': 'gchat://m...e/m...y/m...n/m...y'}),
     ('gchat://workspace/key/token', {
         'instance': NotifyGoogleChat,
         # force a failure


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #739 

Google Chat Thread-Key support.

- `gchat://credentials/?thread=YourThreadKey`


## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@googlechat-thread-key

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "gchat://credentials/?thread=YourThreadKey"

```