### PR TITLE
Handling getdefaultlocale() deprecation warnings

### DIFF
--- a/apprise/AppriseLocale.py
+++ b/apprise/AppriseLocale.py
@@ -203,6 +203,17 @@ class AppriseLocale:
                 # no detection enabled; we're done
                 return None
 
+            # Posix lookup
+            lookup = os.environ.get
+            localename = None
+            for variable in ('LC_ALL', 'LC_CTYPE', 'LANG', 'LANGUAGE'):
+                localename = lookup(variable, None)
+                if localename:
+                    result = AppriseLocale._local_re.match(localename)
+                    if result and result.group('lang'):
+                        return result.group('lang').lower()
+
+            # Windows handling
             if hasattr(ctypes, 'windll'):
                 windll = ctypes.windll.kernel32
                 try:
@@ -216,16 +227,7 @@ class AppriseLocale:
                     # Fallback to posix detection
                     pass
 
-            # Posix lookup
-            lookup = os.environ.get
-            localename = None
-            for variable in ('LC_ALL', 'LC_CTYPE', 'LANG', 'LANGUAGE'):
-                localename = lookup(variable, None)
-                if localename:
-                    result = AppriseLocale._local_re.match(localename)
-                    if result and result.group('lang'):
-                        return result.group('lang').lower()
-
+            # Linux Handling
             try:
                 # Acquire our locale
                 lang = locale.getlocale()[0]

--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -1498,8 +1498,13 @@ def environ(*remove, **update):
     finally:
         # Restore our snapshot
         os.environ = env_orig.copy()
-        # Restore locale
-        locale.setlocale(locale.LC_ALL, loc_orig)
+        try:
+            # Restore locale
+            locale.setlocale(locale.LC_ALL, loc_orig)
+
+        except locale.Error:
+            # Thrown in py3.6
+            pass
 
 
 def apply_template(template, app_mode=TemplateType.RAW, **kwargs):

--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -36,6 +36,7 @@ import json
 import contextlib
 import os
 import hashlib
+import locale
 from itertools import chain
 from os.path import expanduser
 from functools import reduce
@@ -1488,7 +1489,7 @@ def environ(*remove, **update):
 
     # Create a backup of our environment for restoration purposes
     env_orig = os.environ.copy()
-
+    loc_orig = locale.getlocale()
     try:
         os.environ.update(update)
         [os.environ.pop(k, None) for k in remove]
@@ -1497,6 +1498,8 @@ def environ(*remove, **update):
     finally:
         # Restore our snapshot
         os.environ = env_orig.copy()
+        # Restore locale
+        locale.setlocale(locale.LC_ALL, loc_orig)
 
 
 def apply_template(template, app_mode=TemplateType.RAW, **kwargs):

--- a/test/test_locale.py
+++ b/test/test_locale.py
@@ -144,6 +144,7 @@ def test_detect_language_windows_users():
 
     if hasattr(ctypes, 'windll'):
         from ctypes import windll
+
     else:
         windll = mock.Mock()
         # 4105 = en_CA
@@ -166,8 +167,7 @@ def test_detect_language_windows_users():
 
 def test_detect_language_using_env():
     """
-    When enabling CI testing on Windows, those tests did not produce the
-    correct results. They may want to be reviewed.
+    Test the reading of information from an environment variable
     """
 
     # The below accesses the windows fallback code and fail
@@ -203,7 +203,12 @@ def test_detect_language_locale(mock_getlocale):
     """
     # Handle case where getlocale() can't be detected
     mock_getlocale.return_value = None
-    assert AppriseLocale.AppriseLocale.detect_language() is None
+    with environ('LC_ALL', 'LC_CTYPE', 'LANG', 'LANGUAGE'):
+        assert AppriseLocale.AppriseLocale.detect_language() is None
+
+    mock_getlocale.return_value = (None, None)
+    with environ('LC_ALL', 'LC_CTYPE', 'LANG', 'LANGUAGE'):
+        assert AppriseLocale.AppriseLocale.detect_language() is None
 
     # if detect_language and windows env fail us, then we don't
     # set up a default language on first load

--- a/test/test_locale.py
+++ b/test/test_locale.py
@@ -174,8 +174,9 @@ def test_detect_language_windows_users_croaks_please_review():
     # The below accesses the windows fallback code and fail
     # then it will resort to the environment variables.
     with environ('LANG', 'LANGUAGE', 'LC_ALL', 'LC_CTYPE'):
-        # Language can't be detected
-        assert AppriseLocale.AppriseLocale.detect_language() is None
+        # Language can now be detected in this case
+        assert isinstance(
+            AppriseLocale.AppriseLocale.detect_language(), str)
 
     # Detect French language.
     with environ('LANGUAGE', 'LC_ALL', 'LC_CTYPE', LANG="fr_CA"):
@@ -187,21 +188,21 @@ def test_detect_language_windows_users_croaks_please_review():
     # dropped, but just to ensure this issue does not come back, we keep
     # this test:
     with environ(*list(os.environ.keys()), LC_CTYPE="UTF-8"):
-        assert AppriseLocale.AppriseLocale.detect_language() is None
+        assert isinstance(AppriseLocale.AppriseLocale.detect_language(), str)
 
     # Test with absolutely no environment variables what-so-ever
     with environ(*list(os.environ.keys())):
-        assert AppriseLocale.AppriseLocale.detect_language() is None
+        assert isinstance(AppriseLocale.AppriseLocale.detect_language(), str)
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Does not work on Windows")
-@mock.patch('locale.getdefaultlocale')
-def test_detect_language_defaultlocale(mock_getlocale):
+@mock.patch('locale.getlocale')
+def test_detect_language_locale(mock_getlocale):
     """
     API: Apprise() Default locale detection
 
     """
-    # Handle case where getdefaultlocale() can't be detected
+    # Handle case where getlocale() can't be detected
     mock_getlocale.return_value = None
     assert AppriseLocale.AppriseLocale.detect_language() is None
 

--- a/test/test_locale.py
+++ b/test/test_locale.py
@@ -164,8 +164,7 @@ def test_detect_language_windows_users():
         assert AppriseLocale.AppriseLocale.detect_language() == 'en'
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Does not work on Windows")
-def test_detect_language_windows_users_croaks_please_review():
+def test_detect_language_using_env():
     """
     When enabling CI testing on Windows, those tests did not produce the
     correct results. They may want to be reviewed.


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #659

Deprecation warnings of the locale handling in Apprise taken care of. Some backwards compatibility carried forward allowing users to set the `LC_ALL`, `LC_TYPE`  `LANG`, and `LANGUAGE` environment variables (in that order) to over-ride default settings.

This change will allow Apprise Locale to function correctly after Python v3.13 and eliminate deprecation warnings that show on Python v3.11+

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@659-locale-deprecation-handling

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" "schema://"

# No Deprecation warnings will now be displayed on versions of Apprise running Python v3.11 or newer. 

```

