### PR TITLE
Fixed outlook.com email template

### DIFF
--- a/apprise/plugins/NotifyEmail.py
+++ b/apprise/plugins/NotifyEmail.py
@@ -112,10 +112,25 @@ EMAIL_TEMPLATES = (
         'Microsoft Hotmail',
         re.compile(
             r'^((?P<label>[^+]+)\+)?(?P<id>[^@]+)@'
-            r'(?P<domain>(outlook|hotmail|live)\.com(\.au)?)$', re.I),
+            r'(?P<domain>(hotmail|live)\.com(\.au)?)$', re.I),
         {
             'port': 587,
             'smtp_host': 'smtp-mail.outlook.com',
+            'secure': True,
+            'secure_mode': SecureMailMode.STARTTLS,
+            'login_type': (WebBaseLogin.EMAIL, )
+        },
+    ),
+
+    # Microsoft Outlook
+    (
+        'Microsoft Outlook',
+        re.compile(
+            r'^((?P<label>[^+]+)\+)?(?P<id>[^@]+)@'
+            r'(?P<domain>(smtp\.)?outlook\.com(\.au)?)$', re.I),
+        {
+            'port': 587,
+            'smtp_host': 'smtp.outlook.com',
             'secure': True,
             'secure_mode': SecureMailMode.STARTTLS,
             'login_type': (WebBaseLogin.EMAIL, )

--- a/test/test_plugin_email.py
+++ b/test/test_plugin_email.py
@@ -971,7 +971,7 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
         'mailtos://user:pass123@outlook.com')
     obj = Apprise.instantiate(results, suppress_exceptions=False)
     assert isinstance(obj, NotifyEmail) is True
-    assert obj.smtp_host == 'smtp-mail.outlook.com'
+    assert obj.smtp_host == 'smtp.outlook.com'
     # No entries in the reply_to
     assert not obj.reply_to
 
@@ -979,9 +979,31 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
         'mailtos://user:pass123@outlook.com.au')
     obj = Apprise.instantiate(results, suppress_exceptions=False)
     assert isinstance(obj, NotifyEmail) is True
-    assert obj.smtp_host == 'smtp-mail.outlook.com'
+    assert obj.smtp_host == 'smtp.outlook.com'
     # No entries in the reply_to
     assert not obj.reply_to
+
+    # Consisitency Checks
+    results = NotifyEmail.parse_url(
+        'mailtos://outlook.com?smtp=smtp.outlook.com'
+        '&user=user@outlook.com&pass=app.pw')
+    obj1 = Apprise.instantiate(results, suppress_exceptions=False)
+    assert isinstance(obj1, NotifyEmail) is True
+    assert obj1.smtp_host == 'smtp.outlook.com'
+    assert obj1.user == 'user@outlook.com'
+    assert obj1.password == 'app.pw'
+    assert obj1.secure_mode == 'starttls'
+    assert obj1.port == 587
+
+    results = NotifyEmail.parse_url(
+        'mailtos://user:app.pw@outlook.com')
+    obj2 = Apprise.instantiate(results, suppress_exceptions=False)
+    assert isinstance(obj2, NotifyEmail) is True
+    assert obj2.smtp_host == obj1.smtp_host
+    assert obj2.user == obj1.user
+    assert obj2.password == obj1.password
+    assert obj2.secure_mode == obj1.secure_mode
+    assert obj2.port == obj1.port
 
     results = NotifyEmail.parse_url(
         'mailtos://user:pass123@live.com')


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #736

Users who have an `outlook.com` email address need to use `smtp.outlook.com` as an SMTP server. Prior to this PR, these users were assigned the same domain as `hotmail.com` users.  This has now been fixed.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@736-outlook-email-consistency

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "mailto://user:pass@outlook.com"
```

