### PR TITLE
Tests: Remove usage of `session_mocker`

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -32,12 +32,12 @@ from apprise.common import NOTIFY_MODULE_MAP
 sys.path.append(os.path.join(os.path.dirname(__file__), 'helpers'))
 
 
-@pytest.fixture(scope="session", autouse=True)
-def no_throttling_everywhere(session_mocker):
+@pytest.fixture(autouse=True)
+def no_throttling_everywhere(mocker):
     """
     A pytest session fixture which disables throttling on all notifiers.
     It is automatically enabled.
     """
     for notifier in NOTIFY_MODULE_MAP.values():
         plugin = notifier["plugin"]
-        session_mocker.patch.object(plugin, "request_rate_per_sec", 0)
+        mocker.patch.object(plugin, "request_rate_per_sec", 0)


### PR DESCRIPTION
Improves: #757
Alternative: #762

### Introduction
At #757, @caronc reported that my recent refactorings and improvements to the test suite broke the RPM package building. Apologies.

### Alternative: Just fix the offending thing
`session_mocker` may be missing from older versions of pytest. While it will probably make the fixture less efficient, this patch formulates it by using a regular `mocker`, and a `function`-scoped fixture.
