### PR TITLE
Improved TEXT configuration parsing

### DIFF
--- a/apprise/config/ConfigBase.py
+++ b/apprise/config/ConfigBase.py
@@ -548,7 +548,7 @@ class ConfigBase(URLBase):
         # Define what a valid line should look like
         valid_line_re = re.compile(
             r'^\s*(?P<line>([;#]+(?P<comment>.*))|'
-            r'(\s*(?P<tags>[^=]+)=|=)?\s*'
+            r'(\s*(?P<tags>[a-z0-9, \t_-]+)\s*=|=)?\s*'
             r'(?P<url>[a-z0-9]{2,9}://.*)|'
             r'include\s+(?P<config>.+))?\s*$', re.I)
 

--- a/test/test_config_base.py
+++ b/test/test_config_base.py
@@ -325,7 +325,7 @@ def test_config_base_config_parse_text():
     assert isinstance(result, list)
     assert len(result) == 0
 
-    # There was 1 valid entry
+    # There were no include entries defined
     assert len(config) == 0
 
     # Test case where a comment is on it's own line with nothing else
@@ -335,6 +335,56 @@ def test_config_base_config_parse_text():
     assert len(result) == 0
 
     # There were no include entries defined
+    assert len(config) == 0
+
+    # Verify our tagging works when multiple tags are provided
+    result, config = ConfigBase.config_parse_text("""
+    tag1, tag2, tag3=json://user:pass@localhost
+    """)
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert len(result[0].tags) == 3
+    assert 'tag1' in result[0].tags
+    assert 'tag2' in result[0].tags
+    assert 'tag3' in result[0].tags
+
+
+def test_config_base_config_parse_text_with_url():
+    """
+    API: ConfigBase.config_parse_text object_with_url
+
+    """
+    # Here is a similar result set however this one has an invalid line
+    # in it which invalidates the entire file
+    result, config = ConfigBase.config_parse_text("""
+    # Test a URL that has a URL as an argument
+    json://user:pass@localhost?+arg=http://example.com?arg2=1&arg3=3
+    """)
+
+    # No tag is parsed, but our URL successfully parses as is
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert len(result[0].tags) == 0
+
+    # Verify our URL is correctly captured
+    assert '%2Barg=http%3A%2F%2Fexample.com%3Farg2%3D1' in result[0].url()
+    assert 'json://user:pass@localhost/' in result[0].url()
+
+    # There were no include entries defined
+    assert len(config) == 0
+
+    # Pass in our configuration again
+    result, config = ConfigBase.config_parse_text(result[0].url())
+
+    # Verify that our results repeat themselves
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert len(result[0].tags) == 0
+    assert '%2Barg=http%3A%2F%2Fexample.com%3Farg2%3D1' in result[0].url()
+    assert 'json://user:pass@localhost/' in result[0].url()
+
     assert len(config) == 0
 
 


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #767

URL parsing from TEXT Files has been improved to better identify a tag from it's URL.    Previously the regular expression that did this got confused.
```bash
# previously.....
discord://credentials?avatar_url=https://i.imgur.com/FsEpmwg.jpeg
#                               ^
#                               |
#      this would get picked up as a tag delimiter
```

Using this new code, the above is correctly treated as a whole URL.   The new code still also allows for proper tag delimiters as well... hence this would be valid as well:
```bash
tag=discord://credentials?avatar_url=https://i.imgur.com/FsEpmwg.jpeg
#  ^
#  |
#  this would get picked up as a tag delimiter correctly
```

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@767-improved-text-parsing

# Create a configuration file that uses TEXT based Config Parsing
# This is the same configuration parsing used via the Apprise API where this MR
# originally spawned from:
cat << _EOF > my_test_config.txt
discord://4174216298/JHMHI8qBe7bk2ZwO5U711o3dV_js?avatar_url=https://i.imgur.com/FsEpmwg.jpeg
_EOF

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" --config my_test_config.txt

```
