### PR TITLE
Tests: Improve cache subsystem test case in `test_plugin_twitter`

### DIFF
--- a/test/test_plugin_twitter.py
+++ b/test/test_plugin_twitter.py
@@ -562,6 +562,12 @@ def test_plugin_twitter_dm_caching(
     assert mock_post.call_args_list[0][0][0] == \
         'https://api.twitter.com/1.1/direct_messages/events/new.json'
 
+    # Test cache contents.
+    assert NotifyTwitter._user_cache == \
+           {'apprise': 9876}
+    assert NotifyTwitter._whoami_cache == \
+           {'ckeycsecretakeyasecret': {'apprise': 9876}}
+
     # Reset the mocks to start counting calls from scratch.
     mock_get.reset_mock()
     mock_post.reset_mock()


### PR DESCRIPTION
This patch has been pulled from #728 because it started failing after other patches have been integrated beforehand, see also https://github.com/caronc/apprise/pull/728#discussion_r1022213736.

> After rebasing, it looks like this very safeguard check recently added (1353d858a) just caught a potential regression - maybe introduced by #750? The cache content validation fails exactly there. Thoughts?
