### PR TITLE
bugfix - slack:// webhook to return success when message sent

### DIFF
--- a/apprise/plugins/NotifySlack.py
+++ b/apprise/plugins/NotifySlack.py
@@ -826,7 +826,7 @@ class NotifySlack(NotifyBase):
             # The text 'ok' is returned if this is a Webhook request
             # So the below captures that as well.
             status_okay = (response and response.get('ok', False)) \
-                if self.mode is SlackMode.BOT else r.content == 'ok'
+                if self.mode is SlackMode.BOT else r.content == b'ok'
 
             if r.status_code != requests.codes.ok or not status_okay:
                 # We had a problem

--- a/test/helpers/rest.py
+++ b/test/helpers/rest.py
@@ -122,27 +122,12 @@ class AppriseURLTester:
         # Our expected server objects
         _self = meta.get('self', None)
 
-        # Our expected Query response (True, False, or exception type)
-        response = meta.get('response', True)
-
         # Our expected privacy url
         # Don't set this if don't need to check it's value
         privacy_url = meta.get('privacy_url')
 
         # Our regular expression
         url_matches = meta.get('url_matches')
-
-        # Allow us to force the server response code to be something other then
-        # the defaults
-        requests_response_code = meta.get(
-            'requests_response_code',
-            requests.codes.ok if response else requests.codes.not_found,
-        )
-
-        # Allow us to force the server response text to be something other then
-        # the defaults
-        requests_response_text = meta.get('requests_response_text', '')
-        requests_response_content = None
 
         # Whether or not we should include an image with our request; unless
         # otherwise specified, we assume that images are to be included

--- a/test/helpers/rest.py
+++ b/test/helpers/rest.py
@@ -141,10 +141,8 @@ class AppriseURLTester:
 
         # Allow us to force the server response text to be something other then
         # the defaults
-        requests_response_text = meta.get('requests_response_text')
-        if not isinstance(requests_response_text, str):
-            # Convert to string
-            requests_response_text = dumps(requests_response_text)
+        requests_response_text = meta.get('requests_response_text', '')
+        requests_response_content = None
 
         # Whether or not we should include an image with our request; unless
         # otherwise specified, we assume that images are to be included
@@ -158,34 +156,11 @@ class AppriseURLTester:
             asset = AppriseAsset(image_path_mask=False, image_url_mask=False)
             asset.image_url_logo = None
 
-        test_requests_exceptions = meta.get(
-            'test_requests_exceptions', False)
-
         # Mock our request object
         robj = mock.Mock()
         robj.content = u''
         mock_get.return_value = robj
         mock_post.return_value = robj
-
-        if test_requests_exceptions is False:
-            # Handle our default response
-            mock_post.return_value.status_code = requests_response_code
-            mock_get.return_value.status_code = requests_response_code
-
-            # Handle our default text response
-            mock_get.return_value.content = requests_response_text
-            mock_post.return_value.content = requests_response_text
-            mock_get.return_value.text = requests_response_text
-            mock_post.return_value.text = requests_response_text
-
-            # Ensure there is no side effect set
-            mock_post.side_effect = None
-            mock_get.side_effect = None
-
-        else:
-            # Handle exception testing; first we turn the boolean flag
-            # into a list of exceptions
-            test_requests_exceptions = self.req_exceptions
 
         try:
             # We can now instantiate our object:
@@ -338,9 +313,19 @@ class AppriseURLTester:
         # Allow us to force the server response text to be something other then
         # the defaults
         requests_response_text = meta.get('requests_response_text')
-        if not isinstance(requests_response_text, str):
+        requests_response_content = None
+
+        if isinstance(requests_response_text, str):
+            requests_response_content = requests_response_text.encode('utf-8')
+
+        elif isinstance(requests_response_text, bytes):
+            requests_response_content = requests_response_text
+            requests_response_text = requests_response_text.decode('utf-8')
+
+        elif not isinstance(requests_response_text, str):
             # Convert to string
             requests_response_text = dumps(requests_response_text)
+            requests_response_content = requests_response_text.encode('utf-8')
 
         # A request
         robj = mock.Mock()
@@ -360,11 +345,11 @@ class AppriseURLTester:
             mock_get.return_value.status_code = requests_response_code
 
             # Handle our default text response
-            mock_get.return_value.content = requests_response_text
-            mock_post.return_value.content = requests_response_text
-            mock_del.return_value.content = requests_response_text
-            mock_put.return_value.content = requests_response_text
-            mock_head.return_value.content = requests_response_text
+            mock_get.return_value.content = requests_response_content
+            mock_post.return_value.content = requests_response_content
+            mock_del.return_value.content = requests_response_content
+            mock_put.return_value.content = requests_response_content
+            mock_head.return_value.content = requests_response_content
 
             mock_get.return_value.text = requests_response_text
             mock_post.return_value.text = requests_response_text

--- a/test/test_plugin_slack.py
+++ b/test/test_plugin_slack.py
@@ -394,7 +394,7 @@ def test_plugin_slack_webhook_mode(mock_post):
     # Prepare Mock
     mock_post.return_value = requests.Request()
     mock_post.return_value.status_code = requests.codes.ok
-    mock_post.return_value.content = 'ok'
+    mock_post.return_value.content = b'ok'
     mock_post.return_value.text = 'ok'
 
     # Initialize some generic (but valid) tokens
@@ -653,7 +653,7 @@ def test_plugin_slack_markdown(mock_get, mock_post):
     """
 
     request = mock.Mock()
-    request.content = 'ok'
+    request.content = b'ok'
     request.status_code = requests.codes.ok
 
     # Prepare Mock


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #195

There is a case where the webhook returns 'ok' and this is a correct expected response but Apprise reports the failure of the message sent (to Slack).

This is fixed in this PR

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@slack-investigation

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" "slack://credentials"

```

