### PR TITLE
GitHub Actions Python v3.6 Continued Support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,8 +49,10 @@ jobs:
             python-version: "3.10"
 
           # Test more available versions of CPython on Linux.
-          - os: "ubuntu-latest"
-            python-version: "3.6"
+          - os: "ubuntu-20.04"
+            # v3.6 (exclusively referenced) is not supported by GitHub anymore)
+            # v3.6.8 is fixed since it is the version CentOS/Rocky/RedHat v8 uses
+            python-version: "3.6.8"
           - os: "ubuntu-latest"
             python-version: "3.7"
           - os: "ubuntu-latest"


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #779 

While performing just general checking (and adding unit tests in another PR), GitHub Actions suddenly stopped passing due to the Python v3.6 runner.

As i do not want to drop Python 3.6 support since it is used in CentOS/RedHat/Rocky/Oracle 8 Linux , this PR is to just return the runners on track.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
n/a
