### PR TITLE
Support -open arg with terminal-notifier (macosx://)

### DIFF
--- a/apprise/plugins/NotifyMacOSX.py
+++ b/apprise/plugins/NotifyMacOSX.py
@@ -121,9 +121,13 @@ class NotifyMacOSX(NotifyBase):
             'name': _('Sound'),
             'type': 'string',
         },
+        'click': {
+            'name': _('Open/Click URL'),
+            'type': 'string',
+        },
     })
 
-    def __init__(self, sound=None, include_image=True, **kwargs):
+    def __init__(self, sound=None, include_image=True, click=None, **kwargs):
         """
         Initialize MacOSX Object
         """
@@ -136,6 +140,10 @@ class NotifyMacOSX(NotifyBase):
         # Acquire the path to the `terminal-notifier` program.
         self.notify_path = next(  # pragma: no branch
             (p for p in self.notify_paths if os.access(p, os.X_OK)), None)
+
+        # Click URL
+        # Allow user to provide the `--open` argument on the notify wrapper
+        self.click = click
 
         # Set sound object (no q/a for now)
         self.sound = sound
@@ -161,6 +169,9 @@ class NotifyMacOSX(NotifyBase):
         # Title is an optional switch
         if title:
             cmd.extend(['-title', title])
+
+        if self.click:
+            cmd.extend(['-open', self.click])
 
         # The sound to play
         if self.sound:
@@ -203,6 +214,9 @@ class NotifyMacOSX(NotifyBase):
             'image': 'yes' if self.include_image else 'no',
         }
 
+        if self.click:
+            params['click'] = self.click
+
         # Extend our parameters
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
 
@@ -229,6 +243,10 @@ class NotifyMacOSX(NotifyBase):
         # Include images with our message
         results['include_image'] = \
             parse_bool(results['qsd'].get('image', True))
+
+        # Support 'click'
+        if 'click' in results['qsd'] and len(results['qsd']['click']):
+            results['click'] = NotifyMacOSX.unquote(results['qsd']['click'])
 
         # Support 'sound'
         if 'sound' in results['qsd'] and len(results['qsd']['sound']):

--- a/test/test_plugin_macosx.py
+++ b/test/test_plugin_macosx.py
@@ -126,6 +126,15 @@ def test_plugin_macosx_general_success(macos_notify_environment):
     assert obj.notify(title='title', body='body',
                       notify_type=apprise.NotifyType.INFO) is True
 
+    # Test Click (-open support)
+    obj = apprise.Apprise.instantiate(
+        'macosx://_/?click=http://google.com', suppress_exceptions=False)
+    assert isinstance(obj, NotifyMacOSX) is True
+    assert obj.click == 'http://google.com'
+    assert isinstance(obj.url(), str) is True
+    assert obj.notify(title='title', body='body',
+                      notify_type=apprise.NotifyType.INFO) is True
+
 
 def test_plugin_macosx_terminal_notifier_not_executable(
         pretend_macos, terminal_notifier):


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #786

Support: `macosx://_/click=url` to leverage the `-open` argument supported by the `terminal-notifier` tool.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@786-terminal-notifier-open-support

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "macosx://_/?click=https://google.com"

```

