### PR TITLE
Amazon SNS Subject support

### DIFF
--- a/apprise/plugins/NotifySNS.py
+++ b/apprise/plugins/NotifySNS.py
@@ -60,8 +60,11 @@ IS_REGION = re.compile(
 
 # Extend HTTP Error Messages
 AWS_HTTP_ERROR_MAP = {
-    403: 'Unauthorized - Invalid Access/Secret Key Combination, or insufficient IAM Permissions [`sns:Publish`,`sns:CreateTopic`]',
+    403: 'Unauthorized - Invalid Access/Secret Key Combination, or \
+        insufficient IAM Permissions: \
+        [`sns:Publish`,`sns:CreateTopic`]',
 }
+
 
 class NotifySNS(NotifyBase):
     """

--- a/apprise/plugins/NotifySNS.py
+++ b/apprise/plugins/NotifySNS.py
@@ -60,9 +60,8 @@ IS_REGION = re.compile(
 
 # Extend HTTP Error Messages
 AWS_HTTP_ERROR_MAP = {
-    403: 'Unauthorized - Invalid Access/Secret Key Combination.',
+    403: 'Unauthorized - Invalid Access/Secret Key Combination, or insufficient IAM Permissions [`sns:Publish`,`sns:CreateTopic`]',
 }
-
 
 class NotifySNS(NotifyBase):
     """


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** `n/a`

Added support for Amazon SNS to handle Subjects as titles where the target is an SNS Topic, rather than phone number for an SMS message.

Increased the `title_maxlen` to the limit for the Amazon SNS where used for topics. Extended the logic to ensure backwards compatibility, so that the title is still added to the SMS messages, and retained in the body of messages sent to a Topic as well. Newer versions will still produce the same as the original output, with the sole exception being that the title will be used as the Subject for any email endpoints in topics. SMS endpoints within topics also behave as expected, with no change.

Minor update to `AWS_HTTP_ERROR_MAP` to cover insufficient IAM permissions, specifically that `sns:CreateTopic` is also needed along with `sns:Publish`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@sns-subject-support

# Test out the changes with the following commands:

# 1. SNS Topic - Title and Body
./bin/apprise -vv -t "Testing the Title" -b "Body Test" sns://AccessKeyID/AccessSecretKey/RegionName/Topic

# 2. SMS Message - Title and Body
./bin/apprise -vv -t "Testing the Title" -b "Body Test" sns://AccessKeyID/AccessSecretKey/RegionName/+PhoneNo

# 3. SNS Topic - Body Only
./bin/apprise -vv -b "Body Test" sns://AccessKeyID/AccessSecretKey/RegionName/Topic

# 4. SMS Message - Body Only
./bin/apprise -vv -b "Body Test" sns://AccessKeyID/AccessSecretKey/RegionName/+PhoneNo

# 5. Error message - Should fail and proceduce error using ineffective access key
./bin/apprise -vv -b "Body Test" sns://AKIA0000000000000000/A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0/us-east-1/doesntexisttopic

```

