### PR TITLE
Pagertree Support

### DIFF
--- a/KEYWORDS
+++ b/KEYWORDS
@@ -49,6 +49,7 @@ Office365
 OneSignal
 Opsgenie
 PagerDuty
+PagerTree
 ParsePlatform
 PopcornNotify
 Prowl

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The table below identifies the services this tool supports and some example serv
 | [OneSignal](https://github.com/caronc/apprise/wiki/Notify_onesignal) | onesignal:// | (TCP) 443 | onesignal://AppID@APIKey/PlayerID<br/>onesignal://TemplateID:AppID@APIKey/UserID<br/>onesignal://AppID@APIKey/#IncludeSegment<br/>onesignal://AppID@APIKey/Email
 | [Opsgenie](https://github.com/caronc/apprise/wiki/Notify_opsgenie) | opsgenie:// | (TCP) 443 | opsgenie://APIKey<br/>opsgenie://APIKey/UserID<br/>opsgenie://APIKey/#Team<br/>opsgenie://APIKey/\*Schedule<br/>opsgenie://APIKey/^Escalation
 | [PagerDuty](https://github.com/caronc/apprise/wiki/Notify_pagerduty) | pagerduty:// | (TCP) 443 | pagerduty://IntegrationKey@ApiKey<br/>pagerduty://IntegrationKey@ApiKey/Source/Component
+| [PagerTree](https://github.com/caronc/apprise/wiki/Notify_pagertree) | pagertree:// | (TCP) 443 | pagertree://integration_id
 | [ParsePlatform](https://github.com/caronc/apprise/wiki/Notify_parseplatform) | parsep:// or parseps:// | (TCP) 80 or 443 | parsep://AppID:MasterKey@Hostname<br/>parseps://AppID:MasterKey@Hostname
 | [PopcornNotify](https://github.com/caronc/apprise/wiki/Notify_popcornnotify) | popcorn://  | (TCP) 443   | popcorn://ApiKey/ToPhoneNo<br/>popcorn://ApiKey/ToPhoneNo1/ToPhoneNo2/ToPhoneNoN/<br/>popcorn://ApiKey/ToEmail<br/>popcorn://ApiKey/ToEmail1/ToEmail2/ToEmailN/<br/>popcorn://ApiKey/ToPhoneNo1/ToEmail1/ToPhoneNoN/ToEmailN
 | [Prowl](https://github.com/caronc/apprise/wiki/Notify_prowl) | prowl://   | (TCP) 443    | prowl://apikey<br />prowl://apikey/providerkey

--- a/apprise/plugins/NotifyPagerTree.py
+++ b/apprise/plugins/NotifyPagerTree.py
@@ -1,0 +1,366 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import requests
+from json import dumps
+
+from uuid import uuid4
+
+from .NotifyBase import NotifyBase
+from ..URLBase import PrivacyMode
+from ..common import NotifyType
+from ..common import NotifyFormat
+from ..utils import parse_list
+from ..utils import validate_regex
+from ..AppriseLocale import gettext_lazy as _
+
+# Actions
+class PagerTreeAction:
+    CREATE = 'create'
+    ACKNOWLEDGE = 'acknowledge'
+    RESOLVE = 'resolve'
+
+PAGERTREE_ACTIONS = {
+    PagerTreeAction.CREATE: 'create',
+    PagerTreeAction.ACKNOWLEDGE: 'acknowledge',
+    PagerTreeAction.RESOLVE: 'resolve',
+}
+
+# Urgencies
+class PagerTreeUrgency:
+    SILENT = "silent"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+PAGERTREE_URGENCIES = {
+    # Note: This also acts as a reverse lookup mapping
+    PagerTreeUrgency.SILENT: 'silent',
+    PagerTreeUrgency.LOW: 'low',
+    PagerTreeUrgency.MEDIUM: 'medium',
+    PagerTreeUrgency.HIGH: 'high',
+    PagerTreeUrgency.CRITICAL: 'critical',
+}
+# Extend HTTP Error Messages
+PAGERTREE_HTTP_ERROR_MAP = {
+    402: 'Payment Required - Please subscribe or upgrade',
+    403: 'Forbidden - Blocked',
+    404: 'Not Found - Invalid Integration ID',
+    405: 'Method Not Allowed - Integration Disabled',
+    429: 'Too Many Requests - Rate Limit Exceeded',
+}
+
+
+class NotifyPagerTree(NotifyBase):
+    """
+    A wrapper for PagerTree Notifications
+    """
+
+    # The default descriptive name associated with the Notification
+    service_name = 'PagerTree'
+
+    # The services URL
+    service_url = 'https://pagertree.com/'
+
+    # All PagerTree requests are secure
+    secure_protocol = 'pagertree'
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = 'https://github.com/caronc/apprise/wiki/Notify_pagertree'
+
+    # PagerTree uses the http protocol with JSON requests
+    notify_url = 'https://api.pagertree.com/integration/{}'
+
+    # Define object templates
+    templates = (
+        '{schema}://{integration_id}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'integration_id': {
+            'name': _('Integration ID'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+        }
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'action': {
+            'name': _('Action'),
+            'type': 'choice:string',
+            'values': PAGERTREE_ACTIONS,
+            'default': PagerTreeAction.CREATE,
+        },
+        'thirdparty_id': {
+            'name': _('Third Party ID'),
+            'type': 'string',
+            'default': None,
+        },
+        'urgency': {
+            'name': _('Urgency'),
+            'type': 'choice:string',
+            'values': PAGERTREE_URGENCIES,
+            'default': None,
+        },
+        'tags': {
+            'name': _('Tags'),
+            'type': 'string',
+        },
+    })
+
+    # Define any kwargs we're using
+    template_kwargs = {
+        'headers': {
+            'name': _('HTTP Header'),
+            'prefix': '+',
+        },
+        'payload_extras': {
+            'name': _('Payload Extras'),
+            'prefix': ':',
+        },
+        'meta_extras': {
+            'name': _('Meta Extras'),
+            'prefix': '-',
+        },
+    }
+
+    def __init__(self, integration_id, action=None, thirdparty_id=None, 
+                urgency=None, tags=None, meta=None, headers=None, payload_extras=None, 
+                meta_extras=None, **kwargs):
+        """
+        Initialize PagerTree Object
+        """
+        super().__init__(**kwargs)
+
+        # Integration ID (associated with account)
+        self.integration_id = validate_regex(integration_id)
+        if not self.integration_id:
+            msg = 'An invalid PagerTree Integration ID ' \
+                  '({}) was specified.'.format(integration_id)
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        self.headers = {}
+        if headers:
+            # Store our extra headers
+            self.headers.update(headers)
+
+        self.payload_extras = {}
+        if payload_extras:
+            # Store our extra payload entries
+            self.payload_extras.update(payload_extras)
+
+        self.meta_extras = {}
+        if meta_extras:
+            # Store our extra payload entries
+            self.meta_extras.update(meta_extras)
+
+        # thirdparty_id (optional, in case they want to pass the acknowledge or resolve action)
+        self.thirdparty_id = validate_regex(thirdparty_id) if thirdparty_id is not None else str(uuid4())
+
+
+        # Setup our action
+        self.action = NotifyPagerTree.template_args['action']['default'] if action not in PAGERTREE_ACTIONS else PAGERTREE_ACTIONS[action]
+
+        # Setup our urgency
+        self.urgency = None if urgency not in PAGERTREE_URGENCIES else PAGERTREE_URGENCIES[urgency]
+
+        # Any optional tags to attach to the notification
+        self.__tags = parse_list(tags)
+
+        return
+
+    def send(self, body, title='', notify_type=NotifyType.INFO, **kwargs):
+        """
+        Perform PagerTree Notification
+        """
+
+        # Prepare our headers
+        headers = {
+            'User-Agent': self.app_id,
+            'Content-Type': 'application/json',
+        }
+
+        # Apply any/all header over-rides defined
+        headers.update(self.headers)
+
+        # prepare JSON Object
+        payload = {
+            'event_type': self.action,
+            'title': title if title else self.app_desc,
+            'description': body,
+        }
+
+        if self.thirdparty_id is not None:
+            payload['id'] = self.thirdparty_id
+
+        if self.urgency is not None:
+            payload['urgency'] = self.urgency
+
+        if self.__tags is not None:
+            payload['tags'] = self.__tags
+
+        if self.meta_extras is not None:
+            payload['meta'] = self.meta_extras
+
+        # Apply any/all payload over-rides defined
+        payload.update(self.payload_extras)
+
+        # Prepare our URL based on integration_id
+        notify_url = self.notify_url.format(self.integration_id)
+
+        self.logger.debug('PagerTree POST URL: %s (cert_verify=%r)' % (
+            notify_url, self.verify_certificate,
+        ))
+        self.logger.debug('PagerTree Payload: %s' % str(payload))
+
+        # Always call throttle before any remote server i/o is made
+        self.throttle()
+
+        try:
+            r = requests.post(
+                notify_url,
+                data=dumps(payload),
+                headers=headers,
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+            )
+            if r.status_code not in (
+                    requests.codes.ok, requests.codes.created,
+                    requests.codes.accepted):
+                # We had a problem
+                status_str = \
+                    NotifyPagerTree.http_response_code_lookup(
+                        r.status_code)
+
+                self.logger.warning(
+                    'Failed to send PagerTree notification: '
+                    '{}{}error={}.'.format(
+                        status_str,
+                        ', ' if status_str else '',
+                        r.status_code))
+
+                self.logger.debug('Response Details:\r\n{}'.format(r.content))
+
+                # Return; we're done
+                return False
+
+            else:
+                self.logger.info('Sent PagerTree notification.')
+
+        except requests.RequestException as e:
+            self.logger.warning(
+                'A Connection error occurred sending PagerTree '
+                'notification to %s.' % self.host)
+            self.logger.debug('Socket Exception: %s' % str(e))
+
+            # Return; we're done
+            return False
+
+        return True
+
+    def url(self, privacy=False, *args, **kwargs):
+        """
+        Returns the URL built dynamically based on specified arguments.
+        """
+
+        params = self.url_parameters(privacy=privacy, *args, **kwargs)
+
+        # Append our headers into our parameters
+        params.update({'+{}'.format(k): v for k, v in self.headers.items()})
+
+        # Append our meta extras into our parameters
+        params.update({'-{}'.format(k): v for k, v in self.meta_extras.items()})
+
+        # Append our payload extras into our parameters
+        params.update({':{}'.format(k): v for k, v in self.payload_extras.items()})
+
+        return '{schema}://{integration_id}'.format(
+            schema=self.secure_protocol,
+            # never encode hostname since we're expecting it to be a valid one
+            integration_id=self.pprint(self.integration_id, privacy, safe=''),
+            params=NotifyPagerTree.urlencode(params),
+        )
+
+    @staticmethod
+    def parse_url(url):
+        """
+        Parses the URL and returns enough arguments that can allow
+        us to re-instantiate this object.
+
+        """
+        results = NotifyBase.parse_url(url, verify_host=False)
+
+        if not results:
+            # We're done early as we couldn't load the results
+            return results
+
+        # Add our headers that the user can potentially over-ride if they wish
+        # to to our returned result set and tidy entries by unquoting them
+        results['headers'] = {NotifyPagerTree.unquote(x): NotifyPagerTree.unquote(y)
+                              for x, y in results['qsd+'].items()}
+
+        # store any additional payload extra's defined
+        results['payload_extras'] = {NotifyPagerTree.unquote(x): NotifyPagerTree.unquote(y)
+                              for x, y in results['qsd:'].items()}
+
+        # store any additional meta extra's defined
+        results['meta_extras'] = {NotifyPagerTree.unquote(x): NotifyPagerTree.unquote(y)
+                              for x, y in results['qsd-'].items()}
+
+        # Integration ID
+        if 'integration_id' in results['qsd'] and \
+                len(results['qsd']['integration_id']):
+            results['integration_id'] = \
+                NotifyPagerTree.unquote(results['qsd']['integration_id'])
+        else:
+            results['integration_id'] = \
+                NotifyPagerTree.unquote(results['host'])
+
+        # Set our thirdparty_id
+        if 'thirdparty_id' in results['qsd'] and len(results['qsd']['thirdparty_id']):
+            results['thirdparty_id'] = \
+                NotifyPagerTree.unquote(results['qsd']['thirdparty_id'])
+
+        # Set our urgency
+        if 'action' in results['qsd'] and len(results['qsd']['action']):
+            results['action'] = \
+                NotifyPagerTree.unquote(results['qsd']['action'])
+
+        # Set our urgency
+        if 'urgency' in results['qsd'] and len(results['qsd']['urgency']):
+            results['urgency'] = \
+                NotifyPagerTree.unquote(results['qsd']['urgency'])
+
+        # Set our tags
+        if 'tags' in results['qsd'] and len(results['qsd']['tags']):
+            results['tags'] = \
+                parse_list(NotifyPagerTree.unquote(results['qsd']['tags']))
+
+        return results

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -41,9 +41,9 @@ Gotify, Growl, Guilded, Home Assistant, IFTTT, Join, Kavenegar, KODI, Kumulos,
 LaMetric, Line, MacOSX, Mailgun, Mattermost, Matrix, Microsoft Windows,
 Mastodon, Microsoft Teams, MessageBird, MQTT, MSG91, MyAndroid, Nexmo,
 Nextcloud, NextcloudTalk, Notica, Notifico, ntfy, Office365, OneSignal,
-Opsgenie, PagerDuty, ParsePlatform, PopcornNotify, Prowl, Pushalot, PushBullet,
-Pushjet, Pushover, PushSafer, Reddit, Rocket.Chat, SendGrid, ServerChan, Signal,
-SimplePush, Sinch, Slack, SMSEagle, SMTP2Go, Spontit, SparkPost, Super Toasty,
+Opsgenie, PagerDuty, PagerTree, ParsePlatform, PopcornNotify, Prowl, Pushalot,
+PushBullet, Pushjet, Pushover, PushSafer, Reddit, Rocket.Chat, SendGrid, ServerChan,
+Signal, SimplePush, Sinch, Slack, SMSEagle, SMTP2Go, Spontit, SparkPost, Super Toasty,
 Streamlabs, Stride, Syslog, Techulus Push, Telegram, Twilio, Twitter, Twist,
 XBMC, Vonage, Webex Teams}
 

--- a/test/test_plugin_pagertree.py
+++ b/test/test_plugin_pagertree.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Chris Caron <lead2gold@gmail.com>
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+import requests
+
+from apprise.plugins.NotifyPagerTree import NotifyPagerTree
+from helpers import AppriseURLTester
+
+# Disable logging for a cleaner testing output
+import logging
+logging.disable(logging.CRITICAL)
+
+# a test UUID we can use
+INTEGRATION_ID = 'int_xxxxxxxxxxx'
+
+# Our Testing URLs
+apprise_url_tests = (
+    ('pagertree://', {
+        # Missing Integration ID
+        'instance': TypeError,
+    }),
+    # Invalid Integration ID
+    ('pagertree://%s' % ('+' * 24), {
+        'instance': TypeError,
+    }),
+    # Minimum requirements met
+    ('pagertree://%s' % INTEGRATION_ID, {
+        'instance': NotifyPagerTree,
+
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'pagertree://i...x?',
+    }),
+    # change the integration id
+    ('pagertree://%s?integration_id=int_yyyyyyyyyy' % INTEGRATION_ID, {
+        'instance': NotifyPagerTree,
+
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'pagertree://i...y?',
+    }),
+    # Integration ID + bad url
+    ('pagertree://:@/', {
+        'instance': TypeError,
+    }),
+    ('pagertree://%s' % INTEGRATION_ID, {
+        'instance': NotifyPagerTree,
+        # force a failure
+        'response': False,
+        'requests_response_code': requests.codes.internal_server_error,
+    }),
+    ('pagertree://%s' % INTEGRATION_ID, {
+        'instance': NotifyPagerTree,
+        # throw a bizzare code forcing us to fail to look it up
+        'response': False,
+        'requests_response_code': 999,
+    }),
+    ('pagertree://%s' % INTEGRATION_ID, {
+        'instance': NotifyPagerTree,
+        # Throws a series of connection and transfer exceptions when this flag
+        # is set and tests that we gracfully handle them
+        'test_requests_exceptions': True,
+    }),
+    ('pagertree://%s?urgency=low' % INTEGRATION_ID, {
+        # urgency override
+        'instance': NotifyPagerTree,
+    }),
+    ('pagertree://%s?tags=production,web' % INTEGRATION_ID, {
+        # tags
+        'instance': NotifyPagerTree,
+    }),
+    ('pagertree://%s?action=resolve&thirdparty_id=123' % INTEGRATION_ID, {
+        # urgency override
+        'instance': NotifyPagerTree,
+    }),
+    # Custom values
+    ('pagertree://%s?+pagertree-token=123&:env=prod&-m=v' % INTEGRATION_ID, {
+        # minimum requirements and support custom key/value pairs
+        'instance': NotifyPagerTree,
+    }),
+)
+
+
+def test_plugin_pagertree_urls():
+    """
+    NotifyPagerTree() Apprise URLs
+
+    """
+
+    # Run our general tests
+    AppriseURLTester(tests=apprise_url_tests).run_all()


### PR DESCRIPTION
## Description:
1. For this to work, you'll need to signup for a [PagerTree](https://pagertree.com) account (free trial is fine). Make sure you follow the setup wizard (you'll want to be on-call for the team the integration is pointed to in Step 2)
2. Create a [webhook integration](https://pagertree.com/docs/integration-guides/webhook) and point it to the team (default: "Devops Team")
3. From the integration page, copy the integration Prefix ID (used for the apprise url) 
![image](https://user-images.githubusercontent.com/9020194/217587441-cfbf0f43-f736-4b9d-85dc-18acc6cc418c.png)
4. Use the Prefix ID for the apprise URL `./bin/apprise -t test -b message "pagertree://int_xxxxxxxxxx"`

🙋 Lastly, I couldn't find where to edit the wiki, so I will post it below in the section titled "Wiki Content".


## New Service Completion Status
* [x] apprise/plugins/NotifyPagerTree.py
* [x] KEYWORDS
    - add new service into this file (alphabetically).
* [x] README.md
    - add entry for new service to table (as a quick reference)
* [x] packaging/redhat/python-apprise.spec
    - add new service into the `%global common_description`

## Checklist
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/pagertree/apprise.git@pagertree-support

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  pagertree://int_xxxxxxxxxx

```

## Wiki Content
## PagerTree Notifications
* **Source**: https://pagertree.com
* **Icon Support**: No
* **Attachment Support**: No
* **Message Format**: Text
* **Message Limit**: 32768 Characters per message

You need to have an account with [PagerTree](https://pagertree.com) and create a [webhook integration](https://pagertree.com/docs/integration-guides/webhook).

### Syntax
Valid syntax is as follows:
* `pagertree://{integration_id}`
* `pagertree://{integration_id}?action=resolve&thirdparty_id=abc123`
* `pagertree://{integration_id}?+pagertree-token=123&:env=prod&-incident=true&-incident_severity=SEV-1&-incident-message=Please join the bridge&tags=prod,server,outage`

### Parameter Breakdown
| Variable    | Required | Description
| ----------- | -------- | -----------
| integration_id | Yes      | This is the Prefix ID of your webhook integration. Found at the top of the integration page.
| action | No       | The action for the webhook. Possible values are `create`, `acknowledge`, and `resolve`. When using acknowledge or resolve, please use the `thirdparty_id` parameter to indicate to PagerTree which alert should be actioned.
| thirdparty_id | No | An Id PagerTree uses to map thirdparty applications to alerts. You can specify your own, or if not, a random UUID will be generated for you. |
| urgency | No | Urgency of the alert to be generated. Possible values `silent`, `low`, `medium`, `high`, or `critical`. If not provided, PagerTree will use the integration's default. |
| tags | No | Comma seperated list of tags. (ex: "prod,server,outage") |

#### Example
Send a PagerTree create command.
```bash

# Assuming our {integration_id} is int_0123456789
apprise -vv -t "Test Message Title" -b "Test Message Body" \
   "pagertree://int_0123456789"
```

### Payload Manipulation
Making use of the `:` on the Apprise URL allows you to alter and add to the body content posted upstream to PagerTree. This is useful when using the [Capture Additional Data feature](https://pagertree.com/docs/integration-guides/webhook#integration-options).

```bash
# Add to the payload delivered to PagerTree
#
# Assuming our {integration_id} is int_xxxxxxxxxx
# Assuming we want to include "server": "blue-ranger-2" as part of the existing payload:
apprise -vv -t "Test Message Title" -b "Test Message Body" \
   "pagertree://int_xxxxxxxxxx/?:server=blue-ranger-2"
```

The above would post a message such as:
```json
{
   "id": "0f85aa1c-711e-4873-95b6-e441c291537d",
   "action": "create",
   "title": "Test Message Title",
   "message": "Test Message Body",
   "server": "blue-ranger-2"
}
```

### Header Manipulation
Some users may require special HTTP headers to be present when they post their data to PagerTree.  This can be accomplished by just sticking a plus symbol (**+**) in front of any parameter you specify on your URL string. This is useful when making use of the [PagerTree Token feature](https://pagertree.com/docs/integration-guides/webhook#integration-options).
```bash
# Below would set the header:
#    pagertree-token: abcdefg
#
# Assuming our {integration_id} is int_xxxxxxxxxx
apprise -vv -t "Test Message Title" -b "Test Message Body" \
   "pagertree://int_xxxxxxxxxx?+pagertree-token=abcdefg"

```

### Meta Manipulation
Some PagerTree functionality (like incidents) lives in the `meta` property of the payload. To add to the meta property you just need to prefix your entries with a minus (`-`) symbol. [See example.](https://pagertree.com/docs/integration-guides/webhook#example-request-2)
```bash
# Indicate to PagerTree this alert should be marked as an incident
# The `-` symbol will get stripped off when the upstream post takes place
# Apprise knows not to do anything with the argument at all and pass it along as is.
apprise -vv -t "Test Message Title" -b "Test Message Body" \
   "pagertree://int_xxxxxxxxxx?-incident=true&-incident_severity=SEV-1&-incident_message=Join the war room"
```

