### PR TITLE
Webex Life Cycle Support

### DIFF
--- a/apprise/plugins/NotifyWebexTeams.py
+++ b/apprise/plugins/NotifyWebexTeams.py
@@ -124,7 +124,7 @@ class NotifyWebexTeams(NotifyBase):
             'type': 'string',
             'private': True,
             'required': True,
-            'regex': (r'^[a-z0-9]{80}$', 'i'),
+            'regex': (r'^[a-z0-9]{80,160}$', 'i'),
         },
     })
 
@@ -249,7 +249,8 @@ class NotifyWebexTeams(NotifyBase):
         """
 
         result = re.match(
-            r'^https?://api\.ciscospark\.com/v[1-9][0-9]*/webhooks/incoming/'
+            r'^https?://(api\.ciscospark\.com|webexapis\.com)'
+            r'/v[1-9][0-9]*/webhooks/incoming/'
             r'(?P<webhook_token>[A-Z0-9_-]+)/?'
             r'(?P<params>\?.+)?$', url, re.I)
 

--- a/apprise/plugins/NotifyWebexTeams.py
+++ b/apprise/plugins/NotifyWebexTeams.py
@@ -95,7 +95,7 @@ class NotifyWebexTeams(NotifyBase):
     service_url = 'https://webex.teams.com/'
 
     # The default secure protocol
-    secure_protocol = 'wxteams'
+    secure_protocol = ('wxteams', 'webex')
 
     # A URL that takes you to the setup/help of the specific protocol
     setup_url = 'https://github.com/caronc/apprise/wiki/Notify_wxteams'
@@ -220,7 +220,7 @@ class NotifyWebexTeams(NotifyBase):
         params = self.url_parameters(privacy=privacy, *args, **kwargs)
 
         return '{schema}://{token}/?{params}'.format(
-            schema=self.secure_protocol,
+            schema=self.secure_protocol[0],
             token=self.pprint(self.token, privacy, safe=''),
             params=NotifyWebexTeams.urlencode(params),
         )
@@ -257,7 +257,7 @@ class NotifyWebexTeams(NotifyBase):
         if result:
             return NotifyWebexTeams.parse_url(
                 '{schema}://{webhook_token}/{params}'.format(
-                    schema=NotifyWebexTeams.secure_protocol,
+                    schema=NotifyWebexTeams.secure_protocol[0],
                     webhook_token=result.group('webhook_token'),
                     params='' if not result.group('params')
                     else result.group('params')))

--- a/test/test_plugin_webex_teams.py
+++ b/test/test_plugin_webex_teams.py
@@ -62,6 +62,11 @@ apprise_url_tests = (
         # token provided - we're good
         'instance': NotifyWebexTeams,
     }),
+    # Support New Native URLs
+    ('https://webexapis.com/v1/webhooks/incoming/{}'.format('a' * 100), {
+        # token provided - we're good
+        'instance': NotifyWebexTeams,
+    }),
     # Support Native URLs with arguments
     ('https://api.ciscospark.com/v1/webhooks/incoming/{}?format=text'.format(
         'a' * 80), {

--- a/test/test_plugin_webex_teams.py
+++ b/test/test_plugin_webex_teams.py
@@ -57,6 +57,13 @@ apprise_url_tests = (
         # Our expected url(privacy=True) startswith() response:
         'privacy_url': 'wxteams://a...a/',
     }),
+    ('webex://{}'.format('a' * 140), {
+        # token provided - we're good
+        'instance': NotifyWebexTeams,
+
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'wxteams://a...a/',
+    }),
     # Support Native URLs
     ('https://api.ciscospark.com/v1/webhooks/incoming/{}'.format('a' * 80), {
         # token provided - we're good


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #815

Thanks to @benlu1986, this Pull Request is to allow continued life cycle support for Webex:
- Increased token size max-limit from 80 to (80 to) 160 characters
- Added support for the new native Webhook URL `http://webexapis.com` while still remaining backwards compatible with the old one.
- Added support for the protocol `webex://` (in addition to the already supported `wxteams://`) for better mainstream reference.
- Improved [Wiki](https://github.com/caronc/apprise/wiki/Notify_wxteams) to reflect some of these changes.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@815-webex-bulletproofing

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "webex://<credentials>
```

