### PR TITLE
Increased Pushover soft message limit to 1024 characters

### DIFF
--- a/apprise/plugins/NotifyPushover.py
+++ b/apprise/plugins/NotifyPushover.py
@@ -165,7 +165,7 @@ class NotifyPushover(NotifyBase):
     notify_url = 'https://api.pushover.net/1/messages.json'
 
     # The maximum allowable characters allowed in the body per message
-    body_maxlen = 512
+    body_maxlen = 1024
 
     # Default Pushover sound
     default_pushover_sound = PushoverSound.PUSHOVER


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #809 

Increased Pushover's message (soft) limit to 1024.


## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@809-pushover-msg-limit

# Test out the changes with the following command
# truncate: forces messages exceeding the soft-limit to be dropped
apprise -t "Test Title" -b "Test Message" \
  "pover://credentials?overflow=truncate"

# split: forces messages exceeding the soft-limit to be split into smaller messages
# no larger then the soft limit
apprise -t "Test Title" -b "Test Message" \
  "pover://credentials?overflow=smaller"
```

