### PR TITLE
Added Ntfy Icon/Avatar support

### DIFF
--- a/test/test_plugin_ntfy.py
+++ b/test/test_plugin_ntfy.py
@@ -140,6 +140,16 @@ apprise_url_tests = (
         'instance': NotifyNtfy,
         'requests_response_text': GOOD_RESPONSE_TEXT,
     }),
+    # No images
+    ('ntfy://localhost/topic1/?image=False', {
+        'instance': NotifyNtfy,
+        'requests_response_text': GOOD_RESPONSE_TEXT,
+    }),
+    # Over-ride Image Path
+    ('ntfy://localhost/topic1/?avatar_url=ttp://localhost/test.jpg', {
+        'instance': NotifyNtfy,
+        'requests_response_text': GOOD_RESPONSE_TEXT,
+    }),
     # Attach
     ('ntfy://localhost/topic1/?attach=http://example.com/file.jpg', {
         'instance': NotifyNtfy,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #806 

Added Ntfy Icon support.

### Parameter Breakdown
| Variable    | Required | Description
| ----------- | -------- | -----------
| image | No      | This defaults to 'Yes' and hauls in the image associated with the notification
| avatar_url | No       | Optionally over-ride the Apprise Icon notifications and explicitly identify your own


## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@806-ntfy-icon-support

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message"  "ntfy://credentials

# If you want to provide your own custom URL/Icon:
apprise -t "Test Title" -b "Test Message"  \
    "ntfy://credentials?avatar_url=http://host/path/to/your/avatar.jpg"

```

