### PR TITLE
form:// attachment bugfix

### DIFF
--- a/apprise/plugins/NotifyForm.py
+++ b/apprise/plugins/NotifyForm.py
@@ -267,12 +267,6 @@ class NotifyForm(NotifyBase):
                     self.logger.debug('I/O Exception: %s' % str(e))
                     return False
 
-                finally:
-                    for file in files:
-                        # Ensure all files are closed
-                        if file[1][1]:
-                            file[1][1].close()
-
         # prepare Form Object
         payload = {
             # Version: Major.Minor,  Major is only updated if the entire


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #823 

Fixed crashing issue when `form://` included an attachment in it's payload.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->

Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@823-custom-schema-valueerror-exception

# Generate a new webhook URL on https://webhook.site/

# Test out the changes with the following command:
apprise --attach file:///path/to/some.pdf -b "test body" \
  "forms://webhook.site/<your_webhook_url> "

```

