### PR TITLE
added attach-as option to form:// for upstream filename over-ride

### DIFF
--- a/apprise/plugins/NotifyForm.py
+++ b/apprise/plugins/NotifyForm.py
@@ -30,6 +30,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import re
 import requests
 
 from .NotifyBase import NotifyBase
@@ -45,7 +46,8 @@ METHODS = (
     'GET',
     'DELETE',
     'PUT',
-    'HEAD'
+    'HEAD',
+    'PATCH'
 )
 
 
@@ -53,6 +55,26 @@ class NotifyForm(NotifyBase):
     """
     A wrapper for Form Notifications
     """
+
+    # Support
+    # - file*
+    # - file?
+    # - file*name
+    # - file?name
+    # - ?file
+    # - *file
+    # - file
+    # The code will convert the ? or * to the digit increments
+    __attach_as_re = re.compile(
+        r'((?P<match1>(?P<id1a>[a-z0-9_-]+)?'
+        r'(?P<wc1>[*?+$:.%]+)(?P<id1b>[a-z0-9_-]+))'
+        r'|(?P<match2>(?P<id2>[a-z0-9_-]+)(?P<wc2>[*?+$:.%]?)))', re.IGNORECASE)
+
+    # Our count
+    attach_as_count = '{:02d}'
+
+    # the default attach_as value
+    attach_as_default = f'file{attach_as_count}'
 
     # The default descriptive name associated with the Notification
     service_name = 'Form'
@@ -118,6 +140,12 @@ class NotifyForm(NotifyBase):
             'values': METHODS,
             'default': METHODS[0],
         },
+        'attach-as': {
+            'name': _('Attach File As'),
+            'type': 'string',
+            'default': 'file*',
+            'map_to': 'attach_as',
+        },
     })
 
     # Define any kwargs we're using
@@ -137,7 +165,7 @@ class NotifyForm(NotifyBase):
     }
 
     def __init__(self, headers=None, method=None, payload=None, params=None,
-                 **kwargs):
+                 attach_as=None, **kwargs):
         """
         Initialize Form Object
 
@@ -158,6 +186,39 @@ class NotifyForm(NotifyBase):
             msg = 'The method specified ({}) is invalid.'.format(method)
             self.logger.warning(msg)
             raise TypeError(msg)
+
+        # Custom File Attachment Over-Ride Support
+        if not isinstance(attach_as, str):
+            # Default value
+            self.attach_as = self.attach_as_default
+            self.attach_multi_support = True
+
+        else:
+            result = self.__attach_as_re.match(attach_as.strip())
+            if not result:
+                msg = 'The attach-as specified ({}) is invalid.'.format(
+                    attach_as)
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
+            self.attach_as = ''
+            self.attach_multi_support = False
+            if result.group('match1'):
+                if result.group('id1a'):
+                    self.attach_as += result.group('id1a')
+
+                if result.group('wc1'):
+                    self.attach_as += self.attach_as_count
+                    self.attach_multi_support = True
+
+                if result.group('id1b'):
+                    self.attach_as += result.group('id1b')
+
+            else:  # result.group('match2'):
+                self.attach_as += result.group('id2')
+                if result.group('wc2'):
+                    self.attach_as += self.attach_as_count
+                    self.attach_multi_support = True
 
         self.params = {}
         if params:
@@ -198,6 +259,10 @@ class NotifyForm(NotifyBase):
         # Append our payload extra's into our parameters
         params.update(
             {':{}'.format(k): v for k, v in self.payload_extras.items()})
+
+        if self.attach_as != self.attach_as_default:
+            # Provide Attach-As extension details
+            params['attach-as'] = self.attach_as
 
         # Determine Authentication
         auth = ''
@@ -254,7 +319,8 @@ class NotifyForm(NotifyBase):
 
                 try:
                     files.append((
-                        'file{:02d}'.format(no), (
+                        self.attach_as.format(no)
+                        if self.attach_multi_support else self.attach_as, (
                             attachment.name,
                             open(attachment.path, 'rb'),
                             attachment.mimetype)
@@ -266,6 +332,11 @@ class NotifyForm(NotifyBase):
                             attachment.name if attachment else 'attachment'))
                     self.logger.debug('I/O Exception: %s' % str(e))
                     return False
+
+            if not self.attach_multi_support and no > 1:
+                self.logger.warning(
+                    'Multiple attachments provided while '
+                    'form:// Multi-Attachment Support not enabled')
 
         # prepare Form Object
         payload = {
@@ -308,6 +379,9 @@ class NotifyForm(NotifyBase):
 
         elif self.method == 'PUT':
             method = requests.put
+
+        elif self.method == 'PATCH':
+            method = requests.patch
 
         elif self.method == 'DELETE':
             method = requests.delete
@@ -396,6 +470,12 @@ class NotifyForm(NotifyBase):
         # Add our GET paramters in the event the user wants to pass these along
         results['params'] = {NotifyForm.unquote(x): NotifyForm.unquote(y)
                              for x, y in results['qsd-'].items()}
+
+        # Allow Attach-As Support which over-rides the name of the filename
+        # posted with the form://
+        # the default is file01, file02, file03, etc
+        if 'attach-as' in results['qsd'] and len(results['qsd']['attach-as']):
+            results['attach_as'] = results['qsd']['attach-as']
 
         # Set method if not otherwise set
         if 'method' in results['qsd'] and len(results['qsd']['method']):

--- a/apprise/plugins/NotifyForm.py
+++ b/apprise/plugins/NotifyForm.py
@@ -68,7 +68,8 @@ class NotifyForm(NotifyBase):
     __attach_as_re = re.compile(
         r'((?P<match1>(?P<id1a>[a-z0-9_-]+)?'
         r'(?P<wc1>[*?+$:.%]+)(?P<id1b>[a-z0-9_-]+))'
-        r'|(?P<match2>(?P<id2>[a-z0-9_-]+)(?P<wc2>[*?+$:.%]?)))', re.IGNORECASE)
+        r'|(?P<match2>(?P<id2>[a-z0-9_-]+)(?P<wc2>[*?+$:.%]?)))',
+        re.IGNORECASE)
 
     # Our count
     attach_as_count = '{:02d}'

--- a/apprise/plugins/NotifyForm.py
+++ b/apprise/plugins/NotifyForm.py
@@ -208,12 +208,9 @@ class NotifyForm(NotifyBase):
                 if result.group('id1a'):
                     self.attach_as += result.group('id1a')
 
-                if result.group('wc1'):
-                    self.attach_as += self.attach_as_count
-                    self.attach_multi_support = True
-
-                if result.group('id1b'):
-                    self.attach_as += result.group('id1b')
+                self.attach_as += self.attach_as_count
+                self.attach_multi_support = True
+                self.attach_as += result.group('id1b')
 
             else:  # result.group('match2'):
                 self.attach_as += result.group('id2')

--- a/apprise/plugins/NotifyJSON.py
+++ b/apprise/plugins/NotifyJSON.py
@@ -47,7 +47,8 @@ METHODS = (
     'GET',
     'DELETE',
     'PUT',
-    'HEAD'
+    'HEAD',
+    'PATCH'
 )
 
 
@@ -314,6 +315,9 @@ class NotifyJSON(NotifyBase):
 
         elif self.method == 'PUT':
             method = requests.put
+
+        elif self.method == 'PATCH':
+            method = requests.patch
 
         elif self.method == 'DELETE':
             method = requests.delete

--- a/apprise/plugins/NotifyVoipms.py
+++ b/apprise/plugins/NotifyVoipms.py
@@ -316,12 +316,7 @@ class NotifyVoipms(NotifyBase):
         """
 
         # Define any URL parameters
-        params = {
-            'method': 'sendSMS'
-        }
-
-        # Extend our parameters
-        params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
+        params = self.url_parameters(privacy=privacy, *args, **kwargs)
 
         schemaStr =  \
             '{schema}://{password}:{email}/{from_phone}/{targets}/?{params}'

--- a/apprise/plugins/NotifyXML.py
+++ b/apprise/plugins/NotifyXML.py
@@ -47,7 +47,8 @@ METHODS = (
     'GET',
     'DELETE',
     'PUT',
-    'HEAD'
+    'HEAD',
+    'PATCH'
 )
 
 
@@ -366,6 +367,9 @@ class NotifyXML(NotifyBase):
 
         elif self.method == 'PUT':
             method = requests.put
+
+        elif self.method == 'PATCH':
+            method = requests.patch
 
         elif self.method == 'DELETE':
             method = requests.delete

--- a/test/helpers/rest.py
+++ b/test/helpers/rest.py
@@ -268,8 +268,9 @@ class AppriseURLTester:
     @mock.patch('requests.head')
     @mock.patch('requests.put')
     @mock.patch('requests.delete')
-    def __notify(self, url, obj, meta, asset, mock_del, mock_put, mock_head,
-                 mock_post, mock_get):
+    @mock.patch('requests.patch')
+    def __notify(self, url, obj, meta, asset, mock_patch, mock_del, mock_put,
+                 mock_head, mock_post, mock_get):
         """
         Perform notification testing against object specified
         """
@@ -326,6 +327,7 @@ class AppriseURLTester:
         mock_get.return_value = robj
         mock_post.return_value = robj
         mock_head.return_value = robj
+        mock_patch.return_value = robj
         mock_del.return_value = robj
         mock_put.return_value = robj
 
@@ -336,6 +338,7 @@ class AppriseURLTester:
             mock_del.return_value.status_code = requests_response_code
             mock_post.return_value.status_code = requests_response_code
             mock_get.return_value.status_code = requests_response_code
+            mock_patch.return_value.status_code = requests_response_code
 
             # Handle our default text response
             mock_get.return_value.content = requests_response_content
@@ -343,12 +346,14 @@ class AppriseURLTester:
             mock_del.return_value.content = requests_response_content
             mock_put.return_value.content = requests_response_content
             mock_head.return_value.content = requests_response_content
+            mock_patch.return_value.content = requests_response_content
 
             mock_get.return_value.text = requests_response_text
             mock_post.return_value.text = requests_response_text
             mock_put.return_value.text = requests_response_text
             mock_del.return_value.text = requests_response_text
             mock_head.return_value.text = requests_response_text
+            mock_patch.return_value.text = requests_response_text
 
             # Ensure there is no side effect set
             mock_post.side_effect = None
@@ -356,6 +361,7 @@ class AppriseURLTester:
             mock_put.side_effect = None
             mock_head.side_effect = None
             mock_get.side_effect = None
+            mock_patch.side_effect = None
 
         else:
             # Handle exception testing; first we turn the boolean flag
@@ -454,6 +460,7 @@ class AppriseURLTester:
                     mock_del.side_effect = _exception
                     mock_put.side_effect = _exception
                     mock_get.side_effect = _exception
+                    mock_patch.side_effect = _exception
 
                     try:
                         assert obj.notify(
@@ -498,6 +505,7 @@ class AppriseURLTester:
                     mock_put.side_effect = _exception
                     mock_head.side_effect = _exception
                     mock_get.side_effect = _exception
+                    mock_patch.side_effect = _exception
 
                     try:
                         assert obj.notify(

--- a/test/test_plugin_custom_form.py
+++ b/test/test_plugin_custom_form.py
@@ -295,6 +295,10 @@ def test_plugin_custom_form_attachments(mock_post):
             body='body', title='title', notify_type=NotifyType.INFO,
             attach=attach) is True
 
+    # Test invalid attach-as input
+    obj = Apprise.instantiate(
+        'form://user@localhost.localdomain/?attach-as={')
+    assert obj is None
 
 @mock.patch('requests.post')
 @mock.patch('requests.get')

--- a/test/test_plugin_custom_form.py
+++ b/test/test_plugin_custom_form.py
@@ -91,6 +91,9 @@ apprise_url_tests = (
     ('form://user@localhost?method=delete', {
         'instance': NotifyForm,
     }),
+    ('form://user@localhost?method=patch', {
+        'instance': NotifyForm,
+    }),
 
     # Custom payload options
     ('form://localhost:8080?:key=value&:key2=value2', {
@@ -229,6 +232,68 @@ def test_plugin_custom_form_attachments(mock_post):
     assert obj.notify(
         body='body', title='title', notify_type=NotifyType.INFO,
         attach=attach) is False
+
+    #
+    # Test attach-as
+    #
+
+    # Assign our mock object our return value
+    mock_post.return_value = okay_response
+    mock_post.side_effect = None
+
+    obj = Apprise.instantiate(
+        'form://user@localhost.localdomain/attach-as=file')
+    assert isinstance(obj, NotifyForm)
+
+    # Test Single Valid Attachment
+    path = os.path.join(TEST_VAR_DIR, 'apprise-test.gif')
+    attach = AppriseAttachment(path)
+    assert obj.notify(
+        body='body', title='title', notify_type=NotifyType.INFO,
+        attach=attach) is True
+
+    # Test Valid Attachment (load 3) (produces a warning)
+    path = (
+        os.path.join(TEST_VAR_DIR, 'apprise-test.gif'),
+        os.path.join(TEST_VAR_DIR, 'apprise-test.gif'),
+        os.path.join(TEST_VAR_DIR, 'apprise-test.gif'),
+    )
+    attach = AppriseAttachment(path)
+    assert obj.notify(
+        body='body', title='title', notify_type=NotifyType.INFO,
+        attach=attach) is True
+
+    # Test our other variations of accepted values
+    # we support *, :, ?, ., +, %, and $
+    for attach_as in (
+            'file*', '*file', 'file*file',
+            'file:', ':file', 'file:file',
+            'file?', '?file', 'file?file',
+            'file.', '.file', 'file.file',
+            'file+', '+file', 'file+file',
+            'file$', '$file', 'file$file'):
+
+        obj = Apprise.instantiate(
+            'form://user@localhost.localdomain/attach-as=file')
+        assert isinstance(obj, NotifyForm)
+
+        # Test Single Valid Attachment
+        path = os.path.join(TEST_VAR_DIR, 'apprise-test.gif')
+        attach = AppriseAttachment(path)
+        assert obj.notify(
+            body='body', title='title', notify_type=NotifyType.INFO,
+            attach=attach) is True
+
+        # Test Valid Attachment (load 3) (produces a warning)
+        path = (
+            os.path.join(TEST_VAR_DIR, 'apprise-test.gif'),
+            os.path.join(TEST_VAR_DIR, 'apprise-test.gif'),
+            os.path.join(TEST_VAR_DIR, 'apprise-test.gif'),
+        )
+        attach = AppriseAttachment(path)
+        assert obj.notify(
+            body='body', title='title', notify_type=NotifyType.INFO,
+            attach=attach) is True
 
 
 @mock.patch('requests.post')

--- a/test/test_plugin_custom_form.py
+++ b/test/test_plugin_custom_form.py
@@ -242,7 +242,7 @@ def test_plugin_custom_form_attachments(mock_post):
     mock_post.side_effect = None
 
     obj = Apprise.instantiate(
-        'form://user@localhost.localdomain/attach-as=file')
+        'form://user@localhost.localdomain/?attach-as=file')
     assert isinstance(obj, NotifyForm)
 
     # Test Single Valid Attachment
@@ -274,7 +274,7 @@ def test_plugin_custom_form_attachments(mock_post):
             'file$', '$file', 'file$file'):
 
         obj = Apprise.instantiate(
-            'form://user@localhost.localdomain/attach-as=file')
+            f'form://user@localhost.localdomain/?attach-as={attach_as}')
         assert isinstance(obj, NotifyForm)
 
         # Test Single Valid Attachment

--- a/test/test_plugin_custom_form.py
+++ b/test/test_plugin_custom_form.py
@@ -300,6 +300,7 @@ def test_plugin_custom_form_attachments(mock_post):
         'form://user@localhost.localdomain/?attach-as={')
     assert obj is None
 
+
 @mock.patch('requests.post')
 @mock.patch('requests.get')
 def test_plugin_custom_form_edge_cases(mock_get, mock_post):

--- a/test/test_plugin_custom_json.py
+++ b/test/test_plugin_custom_json.py
@@ -93,6 +93,9 @@ apprise_url_tests = (
     ('json://user@localhost?method=delete', {
         'instance': NotifyJSON,
     }),
+    ('json://user@localhost?method=patch', {
+        'instance': NotifyJSON,
+    }),
 
     # Continue testing other cases
     ('json://localhost:8080', {

--- a/test/test_plugin_custom_xml.py
+++ b/test/test_plugin_custom_xml.py
@@ -92,6 +92,9 @@ apprise_url_tests = (
     ('xml://user@localhost?method=delete', {
         'instance': NotifyXML,
     }),
+    ('xml://user@localhost?method=patch', {
+        'instance': NotifyXML,
+    }),
 
     # Continue testing other cases
     ('xml://localhost:8080', {


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #824

The request came for the ability to over-ride the name of the attachment when posted to the server.

The new argument is `attach-as`

Simply add this to the URL: such as:
```bash
# apply the override of `file{:02d}` to be `document`
bin/apprise -vvvv 'forms://webhook.site/<webhook>?attach-as=document' \
   --attach test/var/apprise-test.png -b test 
```

In order to support other variations, you can do : 
```bash
# creates a hook as `{:02d}meta`
bin/apprise -vvvv 'forms://webhook.site/<webhook>?attach-as=*meta' \
   --attach test/var/apprise-test.png -b test 

# creates a hook as `meta{:02d}`
bin/apprise -vvvv 'forms://webhook.site/<webhook>?attach-as=meta*' \
   --attach test/var/apprise-test.png -b test 

# creates a hook as `meta{:02d}file`
bin/apprise -vvvv 'forms://webhook.site/<webhook>?attach-as=meta*file' \
   --attach test/var/apprise-test.png -b test 
```

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@823-form-attachment-name

# Create a webhook at https://webhook.site

# Test out the changes with the following command:
apprise -vvvv 'forms://webhook.site/<webhook>?attach-as=document' \
   --attach test/var/apprise-test.png -b test 
```

