### PR TITLE
Ntfy Authentication Token support added

### DIFF
--- a/test/test_plugin_ntfy.py
+++ b/test/test_plugin_ntfy.py
@@ -165,6 +165,22 @@ apprise_url_tests = (
         'instance': NotifyNtfy,
         'requests_response_text': GOOD_RESPONSE_TEXT,
     }),
+    # Auth Token Types (tk_ gets detected as a auth=token)
+    ('ntfy://tk_abcd123456@localhost/topic1', {
+        'instance': NotifyNtfy,
+        'requests_response_text': GOOD_RESPONSE_TEXT,
+    }),
+    # Force an auth token since tk_ prevents auto-detection
+    ('ntfy://abcd123456@localhost/topic1?auth=token', {
+        'instance': NotifyNtfy,
+        'requests_response_text': GOOD_RESPONSE_TEXT,
+    }),
+    # Token mode force, but there was no token provided
+    ('ntfy://localhost/topic1?auth=token', {
+        'instance': NotifyNtfy,
+        # We'll out-right fail to send the notification
+        'response': False,
+    }),
     # Priority
     ('ntfy://localhost/topic1/?priority=default', {
         'instance': NotifyNtfy,
@@ -211,6 +227,10 @@ apprise_url_tests = (
     }),
     ('ntfys://user:web/token@localhost/topic/?mode=invalid', {
         # Invalid mode
+        'instance': TypeError,
+    }),
+    ('ntfys://token@localhost/topic/?auth=invalid', {
+        # Invalid Authentication type
         'instance': TypeError,
     }),
     # Invalid hostname on localhost/private mode

--- a/test/test_plugin_ntfy.py
+++ b/test/test_plugin_ntfy.py
@@ -99,6 +99,8 @@ apprise_url_tests = (
     ('ntfy://user@localhost/topic/', {
         'instance': NotifyNtfy,
         'requests_response_text': GOOD_RESPONSE_TEXT,
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'ntfy://user@localhost/topic',
     }),
     # Ntfy cloud mode (enforced)
     ('ntfy://ntfy.sh/topic1/topic2/', {
@@ -169,22 +171,51 @@ apprise_url_tests = (
     ('ntfy://tk_abcd123456@localhost/topic1', {
         'instance': NotifyNtfy,
         'requests_response_text': GOOD_RESPONSE_TEXT,
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'ntfy://t...6@localhost/topic1',
     }),
-    # Force an auth token since tk_ prevents auto-detection
+    # Force an auth token since lack of tk_ prevents auto-detection
     ('ntfy://abcd123456@localhost/topic1?auth=token', {
         'instance': NotifyNtfy,
         'requests_response_text': GOOD_RESPONSE_TEXT,
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'ntfy://a...6@localhost/topic1',
+    }),
+    # Force an auth token since lack of tk_ prevents auto-detection
+    ('ntfy://:abcd123456@localhost/topic1?auth=token', {
+        'instance': NotifyNtfy,
+        'requests_response_text': GOOD_RESPONSE_TEXT,
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'ntfy://a...6@localhost/topic1',
+    }),
+    # Token detection already implied when token keyword is set
+    ('ntfy://localhost/topic1?token=abc1234', {
+        'instance': NotifyNtfy,
+        'requests_response_text': GOOD_RESPONSE_TEXT,
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'ntfy://a...4@localhost/topic1',
+    }),
+    # Token enforced, but since a user/pass provided, only the pass is kept
+    ('ntfy://user:token@localhost/topic1?auth=token', {
+        'instance': NotifyNtfy,
+        'requests_response_text': GOOD_RESPONSE_TEXT,
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'ntfy://t...n@localhost/topic1',
     }),
     # Token mode force, but there was no token provided
     ('ntfy://localhost/topic1?auth=token', {
         'instance': NotifyNtfy,
         # We'll out-right fail to send the notification
         'response': False,
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'ntfy://localhost/topic1',
     }),
     # Priority
     ('ntfy://localhost/topic1/?priority=default', {
         'instance': NotifyNtfy,
         'requests_response_text': GOOD_RESPONSE_TEXT,
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'ntfy://localhost/topic1',
     }),
     # Priority higher
     ('ntfy://localhost/topic1/?priority=high', {


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #828 

Added Authentication Token support to the Ntfy Service

The service should automatically detect the tokens provided `tk_xyz...` with the URL criteria of:
- `ntfy://{token}@{hostname}/{targets}`

However, to avoid any ambiguity, a new argument called `auth`  has been introduced.  It defaults to `basic` (which is your legacy user/pass combination) but can also be set to `token` which enforces the `{token}` authentication.

| Variable    | Required | Description
| ----------- | -------- | -----------
| auth | No | Can be set to either `basic` (default) or `token` . `basic` is for User/Password authentication with the Ntfy server while `token` assumes that the provided credentials was a Authorization Token and authenticates in a different fashion.|
| token | No | This is detected, but can otherwise be explicitly specified as a parameter. |

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@828-ntfy-authtoken-support

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "ntfy://token@hostname/targets"

```

