### PR TITLE
In synchronous mode, handle parallel notifications with a thread pool instead of asyncio

### DIFF
--- a/test/test_api.py
+++ b/test/test_api.py
@@ -32,6 +32,7 @@
 
 from __future__ import print_function
 import asyncio
+import concurrent.futures
 import re
 import sys
 import pytest
@@ -1781,7 +1782,9 @@ def test_apprise_details_plugin_verification():
 
 @mock.patch('requests.post')
 @mock.patch('asyncio.gather', wraps=asyncio.gather)
-def test_apprise_async_mode(mock_gather, mock_post, tmpdir):
+@mock.patch('concurrent.futures.ThreadPoolExecutor',
+            wraps=concurrent.futures.ThreadPoolExecutor)
+def test_apprise_async_mode(mock_threadpool, mock_gather, mock_post, tmpdir):
     """
     API: Apprise() async_mode tests
 
@@ -1814,9 +1817,9 @@ def test_apprise_async_mode(mock_gather, mock_post, tmpdir):
     # Send Notifications Asyncronously
     assert a.notify("async") is True
 
-    # Verify our async code got executed
-    assert mock_gather.call_count > 0
-    mock_gather.reset_mock()
+    # Verify our thread pool was created
+    assert mock_threadpool.call_count == 1
+    mock_threadpool.reset_mock()
 
     # Provide an over-ride now
     asset = AppriseAsset(async_mode=False)
@@ -1863,9 +1866,9 @@ def test_apprise_async_mode(mock_gather, mock_post, tmpdir):
     # Send 1 Notification Syncronously, the other Asyncronously
     assert a.notify("a mixed batch") is True
 
-    # Verify our async code got called
-    assert mock_gather.call_count > 0
-    mock_gather.reset_mock()
+    # Verify our thread pool was created
+    assert mock_threadpool.call_count == 1
+    mock_threadpool.reset_mock()
 
 
 def test_notify_matrix_dynamic_importing(tmpdir):

--- a/test/test_apprise_config.py
+++ b/test/test_apprise_config.py
@@ -561,7 +561,7 @@ def test_apprise_config_with_apprise_obj(tmpdir):
             super().__init__(
                 notify_format=NotifyFormat.HTML, **kwargs)
 
-        async def async_notify(self, **kwargs):
+        def notify(self, **kwargs):
             # Pretend everything is okay
             return True
 


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #838

This is a quick and dirty implementation of the proposed thread pool parallel notifier that aims to fix the issues with `apobj.notify()` being used in an existing event loop. Basically, depending on whether the caller used `apobj.notify()` or `await apobj.async_notify()` and depending on the value of `apobj.async_mode`, we divide queued notifications into three categories:
- Sequential
- Parallel with thread pool
- Parallel with asyncio

"async_mode" becomes a slight misnomer; a more accurate name would be "parallelize." But it continues to serve the same purpose: controlling whether notifications get sent in parallel.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [X] The code change is tested and works locally.
* [X] There is no commented out code in this PR.
* [X] No lint errors (use `flake8`)
* [X] 100% test coverage

## Testing
See the #838 test case.
