### PR TITLE
Add custom sound support to pushover

### DIFF
--- a/apprise/plugins/NotifyPushover.py
+++ b/apprise/plugins/NotifyPushover.py
@@ -288,9 +288,8 @@ class NotifyPushover(NotifyBase):
         self.sound = NotifyPushover.default_pushover_sound \
             if not isinstance(sound, str) else sound.lower()
         if self.sound and self.sound not in PUSHOVER_SOUNDS:
-            msg = 'The sound specified ({}) is invalid.'.format(sound)
-            self.logger.warning(msg)
-            raise TypeError(msg)
+            msg = 'The sound specified ({}) is not a default sound. Ensure you have a custom sound with this name defined.'.format(sound)
+            self.logger.info(msg)
 
         # The Priority of the message
         self.priority = int(

--- a/apprise/plugins/NotifyPushover.py
+++ b/apprise/plugins/NotifyPushover.py
@@ -288,7 +288,9 @@ class NotifyPushover(NotifyBase):
         self.sound = NotifyPushover.default_pushover_sound \
             if not isinstance(sound, str) else sound.lower()
         if self.sound and self.sound not in PUSHOVER_SOUNDS:
-            msg = 'The sound specified ({}) is not a default sound. Ensure you have a custom sound with this name defined.'.format(sound)
+            msg = 'The sound specified ({}) is not a default sound. ' \
+                  'Ensure you have a custom sound with this name defined.' \
+                  .format(sound)
             self.logger.info(msg)
 
         # The Priority of the message

--- a/apprise/plugins/NotifyPushover.py
+++ b/apprise/plugins/NotifyPushover.py
@@ -288,10 +288,8 @@ class NotifyPushover(NotifyBase):
         self.sound = NotifyPushover.default_pushover_sound \
             if not isinstance(sound, str) else sound.lower()
         if self.sound and self.sound not in PUSHOVER_SOUNDS:
-            msg = 'The sound specified ({}) is not a default sound. ' \
-                  'Ensure you have a custom sound with this name defined.' \
-                  .format(sound)
-            self.logger.info(msg)
+            msg = 'Using custom sound specified ({}). '.format(sound)
+            self.logger.debug(msg)
 
         # The Priority of the message
         self.priority = int(

--- a/test/test_plugin_pushover.py
+++ b/test/test_plugin_pushover.py
@@ -60,9 +60,9 @@ apprise_url_tests = (
     ('pover://%s' % ('a' * 30), {
         'instance': TypeError,
     }),
-    # API Key + invalid sound setting
-    ('pover://%s@%s?sound=invalid' % ('u' * 30, 'a' * 30), {
-        'instance': TypeError,
+    # API Key + custom sound setting
+    ('pover://%s@%s?sound=mysound' % ('u' * 30, 'a' * 30), {
+        'instance': NotifyPushover,
     }),
     # API Key + valid alternate sound picked
     ('pover://%s@%s?sound=spacealarm' % ('u' * 30, 'a' * 30), {


### PR DESCRIPTION
## Description:
Pushover integration constrains notification sounds to a predefined list. This change adds support for custom sound in notifications, which must be uploaded and given a name. This change updates the pushover integration to allow for that name to be specified instead of throwing an error.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
(I performed these steps)
1. Go to Settings -> Alert Settings -> Manage custom sounds -> Upload a sound
2. Upload a sound and specify a name (e.g. "mysound").
3. Validate the sound is accessible and present in the sounds list for your app via https://api.pushover.net/1/sounds.json?token={app-token}
4. Specify a sound in your pover call, i.e. apprise -vv -t "title" -b "test message" pover://user@app?sound=mysound

You should hear your custom sound on the notification. In cases where the custom sound name is not found, the default pushover notification sound will play.


```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@<this.branch-name>

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  <apprise url related to ticket>

```

