### PR TITLE
Optimization: Don't spin up a thread pool for a single notification

### DIFF
--- a/apprise/Apprise.py
+++ b/apprise/Apprise.py
@@ -583,9 +583,15 @@ class Apprise:
         Process a list of notify() calls in parallel and synchronously.
         """
 
+        n_calls = len(servers_kwargs)
+
         # 0-length case
-        if not servers_kwargs:
+        if n_calls == 0:
             return True
+
+        # There's no need to use a thread pool for just a single notification
+        if n_calls == 1:
+            return Apprise._notify_sequential(servers_kwargs[0])
 
         # Create log entry
         logger.info(
@@ -619,9 +625,15 @@ class Apprise:
         Process a list of async_notify() calls in parallel and asynchronously.
         """
 
+        n_calls = len(servers_kwargs)
+
         # 0-length case
-        if not servers_kwargs:
+        if n_calls == 0:
             return True
+
+        # (Unlike with the thread pool, we don't optimize for the single-
+        # notification case because asyncio can do useful work while waiting
+        # for that thread to complete)
 
         # Create log entry
         logger.info(

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1866,8 +1866,8 @@ def test_apprise_async_mode(mock_threadpool, mock_gather, mock_post, tmpdir):
     # Send 1 Notification Syncronously, the other Asyncronously
     assert a.notify("a mixed batch") is True
 
-    # Verify our thread pool was created
-    assert mock_threadpool.call_count == 1
+    # Verify we didn't use a thread pool for a single notification
+    assert mock_threadpool.call_count == 0
     mock_threadpool.reset_mock()
 
 


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** N/A

A quick optimization: If we're just sending a single notification, there's no need to spin up a thread pool. We can just send it like we would sequentially.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
pytest --cov=apprise
```

