### PR TITLE
Hardening of custom plugin loading by ignore non-Python files

### DIFF
--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -63,7 +63,13 @@ def import_module(path, name):
 
     except Exception as e:
         # module isn't loadable
-        del sys.modules[name]
+        try:
+            del sys.modules[name]
+
+        except KeyError:
+            # nothing to clean up
+            pass
+
         module = None
 
         logger.debug(
@@ -1579,6 +1585,11 @@ def module_detection(paths, cache=True):
 
             # Reset
             del common.NOTIFY_CUSTOM_MODULE_MAP[module_pyname]
+
+        if not (path and path.endswith('.py')):
+            # Ignore file/module type
+            logger.debug('Ignoring: %s', _path)
+            return None
 
         # Load our module
         module = import_module(path, module_pyname)

--- a/test/test_apprise_utils.py
+++ b/test/test_apprise_utils.py
@@ -2015,6 +2015,20 @@ def test_parse_list():
     ])
 
 
+def test_import_module(tmpdir):
+    """utils: imort_module testing
+    """
+    # Prepare ourselves a file to work with
+    bad_file_base = tmpdir.mkdir('a')
+    bad_file = bad_file_base.join('README.md')
+    bad_file.write(cleandoc("""
+    I'm a README file, not a Python one.
+
+    I can't be loaded
+    """))
+    assert utils.import_module(str(bad_file), 'invalidfile') is None
+
+
 def test_module_detection(tmpdir):
     """utils: test_module_detection() testing
     """
@@ -2039,6 +2053,11 @@ def test_module_detection(tmpdir):
     @notify(on="clihook")
     def mywrapper(body, title, notify_type, *args, **kwargs):
         pass
+    """))
+
+    notify_ignore = notify_hook_a_base.join('README.md')
+    notify_ignore.write(cleandoc("""
+    We're not a .py file, so this file gets gracefully skipped
     """))
 
     # Not previously loaded


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** [here](https://github.com/caronc/apprise-api/compare/108-custom-plugin-support)

When Adding Plugin Support to the Apprise API, I learned that the Apprise service can't handle cases where it finds a plugin module that isn't a Python file.  It tries to open it and blows up :).  This shouldn't happen and has been corrected in this PR.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@plugin-module-load-filter-bugfix

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  <apprise url related to ticket>

```

