### PR TITLE
Added Telegram Topic Thread ID Support

### DIFF
--- a/apprise/plugins/NotifyTelegram.py
+++ b/apprise/plugins/NotifyTelegram.py
@@ -312,7 +312,7 @@ class NotifyTelegram(NotifyBase):
             'type': 'bool',
             'default': False,
         },
-        'thread': {
+        'topic': {
             'name': _('Topic Thread ID'),
             'type': 'int',
         },
@@ -322,7 +322,7 @@ class NotifyTelegram(NotifyBase):
     })
 
     def __init__(self, bot_token, targets, detect_owner=True,
-                 include_image=False, silent=None, preview=None, thread=None,
+                 include_image=False, silent=None, preview=None, topic=None,
                  **kwargs):
         """
         Initialize Telegram Object
@@ -349,19 +349,19 @@ class NotifyTelegram(NotifyBase):
         self.preview = self.template_args['preview']['default'] \
             if preview is None else bool(preview)
 
-        if thread:
+        if topic:
             try:
-                self.thread = int(thread)
+                self.topic = int(topic)
 
             except (TypeError, ValueError):
                 # Not a valid integer; ignore entry
-                err = 'The Telegram Topic specified ({}) is invalid.'.format(
-                    thread)
+                err = 'The Telegram Topic ID specified ({}) is invalid.'.format(
+                    topic)
                 self.logger.warning(err)
                 raise TypeError(err)
         else:
             # No Topic Thread
-            self.thread = None
+            self.topic = None
 
         # if detect_owner is set to True, we will attempt to determine who
         # the bot owner is based on the first person who messaged it.  This
@@ -654,8 +654,8 @@ class NotifyTelegram(NotifyBase):
             'disable_web_page_preview': not self.preview,
         }
 
-        if self.thread:
-            payload['message_thread_id'] = self.thread
+        if self.topic:
+            payload['message_thread_id'] = self.topic
 
         # Prepare Message Body
         if self.notify_format == NotifyFormat.MARKDOWN:
@@ -804,8 +804,8 @@ class NotifyTelegram(NotifyBase):
             'preview': 'yes' if self.preview else 'no',
         }
 
-        if self.thread:
-            params['thread'] = self.thread
+        if self.topic:
+            params['topic'] = self.topic
 
         # Extend our parameters
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
@@ -889,8 +889,8 @@ class NotifyTelegram(NotifyBase):
         results['bot_token'] = bot_token
 
         # Support Thread Topic
-        if 'thread' in results['qsd'] and len(results['qsd']['thread']):
-            results['thread'] = results['qsd']['thread']
+        if 'topic' in results['qsd'] and len(results['qsd']['topic']):
+            results['topic'] = results['qsd']['topic']
 
         # Silent (Sends the message Silently); users will receive
         # notification with no sound.

--- a/apprise/plugins/NotifyTelegram.py
+++ b/apprise/plugins/NotifyTelegram.py
@@ -355,8 +355,8 @@ class NotifyTelegram(NotifyBase):
 
             except (TypeError, ValueError):
                 # Not a valid integer; ignore entry
-                err = 'The Telegram Topic ID specified ({}) is invalid.'.format(
-                    topic)
+                err = 'The Telegram Topic ID specified ({}) is invalid.'\
+                    .format(topic)
                 self.logger.warning(err)
                 raise TypeError(err)
         else:

--- a/test/test_plugin_telegram.py
+++ b/test/test_plugin_telegram.py
@@ -98,6 +98,14 @@ apprise_url_tests = (
     ('tgram://bottest@123456789:abcdefg_hijklmnop/lead2gold/', {
         'instance': NotifyTelegram,
     }),
+    # Support Thread Topics
+    ('tgram://bottest@123456789:abcdefg_hijklmnop/id1/?thread=12345', {
+        'instance': NotifyTelegram,
+    }),
+    # Threads must be numeric
+    ('tgram://bottest@123456789:abcdefg_hijklmnop/id1/?thread=invalid', {
+        'instance': TypeError,
+    }),
     # Testing image
     ('tgram://123456789:abcdefg_hijklmnop/lead2gold/?image=Yes', {
         'instance': NotifyTelegram,

--- a/test/test_plugin_telegram.py
+++ b/test/test_plugin_telegram.py
@@ -99,11 +99,11 @@ apprise_url_tests = (
         'instance': NotifyTelegram,
     }),
     # Support Thread Topics
-    ('tgram://bottest@123456789:abcdefg_hijklmnop/id1/?thread=12345', {
+    ('tgram://bottest@123456789:abcdefg_hijklmnop/id1/?topic=12345', {
         'instance': NotifyTelegram,
     }),
     # Threads must be numeric
-    ('tgram://bottest@123456789:abcdefg_hijklmnop/id1/?thread=invalid', {
+    ('tgram://bottest@123456789:abcdefg_hijklmnop/id1/?topic=invalid', {
         'instance': TypeError,
     }),
     # Testing image


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #852 

Added support for Telegram Thread ID's

### Parameter Breakdown
| Variable    | Required | Description
| ----------- | -------- | -----------
| topic   | No      | The Topic Thread ID you wish your message to be posted to. [Here is a StackOverflow post on acquiring the Topic Thread ID](https://stackoverflow.com/questions/74773675/how-to-get-topic-id-for-telegram-group-chat)

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@852-telegram-topic-thread-support

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  'tgram://credentials?topic=12345'

```

