### PR TITLE
Discord Thread ID Reference fixed

### DIFF
--- a/apprise/plugins/NotifyDiscord.py
+++ b/apprise/plugins/NotifyDiscord.py
@@ -290,9 +290,6 @@ class NotifyDiscord(NotifyBase):
             payload['content'] = \
                 body if not title else "{}\r\n{}".format(title, body)
 
-        if self.thread_id:
-            payload['thread_id'] = self.thread_id
-
         if self.avatar and (image_url or self.avatar_url):
             payload['avatar_url'] = \
                 self.avatar_url if self.avatar_url else image_url
@@ -301,7 +298,8 @@ class NotifyDiscord(NotifyBase):
             # Optionally override the default username of the webhook
             payload['username'] = self.user
 
-        if not self._send(payload):
+        params = {'thread_id': self.thread_id} if self.thread_id else None
+        if not self._send(payload, params=params):
             # We failed to post our message
             return False
 
@@ -345,7 +343,7 @@ class NotifyDiscord(NotifyBase):
         # Otherwise return
         return True
 
-    def _send(self, payload, attach=None, **kwargs):
+    def _send(self, payload, attach=None, params=None, **kwargs):
         """
         Wrapper to the requests (post) object
         """
@@ -396,6 +394,7 @@ class NotifyDiscord(NotifyBase):
 
             r = requests.post(
                 notify_url,
+                params=params,
                 data=payload if files else dumps(payload),
                 headers=headers,
                 files=files,

--- a/test/test_plugin_discord.py
+++ b/test/test_plugin_discord.py
@@ -368,6 +368,27 @@ def test_plugin_discord_general(mock_post):
     assert a.notify(
         body='body', title='title', notify_type=NotifyType.INFO) is True
 
+    # Create an apprise instance
+    a = Apprise()
+
+    # Reset our object
+    mock_post.reset_mock()
+
+    # Test our threading
+    assert a.add(
+        'discord://{webhook_id}/{webhook_token}/'
+        '?thread=12345'.format(
+            webhook_id=webhook_id,
+            webhook_token=webhook_token)) is True
+
+    # This call includes an image with it's payload:
+    assert a.notify(body='test', title='title') is True
+
+    assert mock_post.call_count == 1
+    response = mock_post.call_args_list[0][1]
+    assert 'params' in response
+    assert response['params'].get('thread_id') == '12345'
+
 
 @mock.patch('requests.post')
 def test_plugin_discord_markdown_extra(mock_post):


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #848 

This fix should restore Discord Thread Functionality reported to be broken.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@/848-discord-thread-bugfix

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
   "discord://credentials/?thread=ThreadID"

```

