### PR TITLE
Slack <!channel|desc> & <!channel> support added

### DIFF
--- a/test/test_plugin_slack.py
+++ b/test/test_plugin_slack.py
@@ -680,6 +680,10 @@ def test_plugin_slack_markdown(mock_get, mock_post):
        <https://slack.com?arg=val&arg2=val2|Slack Link>.
     We also want to be able to support <https://slack.com> links without the
     description.
+
+    Channel Testing
+    <!channelA>
+    <!channelA|Description>
     """)
 
     # Send our notification
@@ -700,4 +704,5 @@ def test_plugin_slack_markdown(mock_get, mock_post):
         "of it's\nmarkdown.\n\nThis one has arguments we want to preserve:"\
         "\n   <https://slack.com?arg=val&arg2=val2|Slack Link>.\n"\
         "We also want to be able to support <https://slack.com> "\
-        "links without the\ndescription."
+        "links without the\ndescription."\
+        "\n\nChannel Testing\n<!channelA>\n<!channelA|Description>"


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #849

Support `<!channel>` and `<!channel|desc>` directives

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@849-slack-channel-mention-support

# Test out the changes with the following command:
apprise -t "Test Title" -b "<!channel>" \
   "slack://credentials"

```

