### PR TITLE
Windows notifications: Correct WM_DESTROY return value

### DIFF
--- a/apprise/plugins/NotifyWindows.py
+++ b/apprise/plugins/NotifyWindows.py
@@ -142,7 +142,7 @@ class NotifyWindows(NotifyBase):
         win32gui.Shell_NotifyIcon(win32gui.NIM_DELETE, nid)
         win32api.PostQuitMessage(0)
 
-        return None
+        return 0
 
     def send(self, body, title='', notify_type=NotifyType.INFO, **kwargs):
         """


### PR DESCRIPTION
## Description:

Fixes this error with Windows notifications:
```
>apprise -v -b Test windows://
WNDPROC return value cannot be converted to LRESULT
TypeError: WPARAM is simple, so must be an int object (got NoneType)
```

The WM_DESTROY handler should return 0:
https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-destroy#return-value


## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [X] The code change is tested and works locally.
* [X] There is no commented out code in this PR.
* [X] No lint errors (use `flake8`)
* [X] 100% test coverage
