### PR TITLE
CI: Add configuration for Codecov, relaxing the constraints a bit

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+# https://docs.codecov.com/docs/common-recipe-list
+# https://docs.codecov.com/docs/commit-status#patch-status
+
+coverage:
+  status:
+
+    project:
+      default:
+        target: auto    # the required coverage value
+        threshold: 2%   # the leniency in hitting the target
+
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Hi Chris,

if you think the CI outcome from, for example, GH-797, is annoying, you may like that kind of configuration for Codecov. Otherwise, if you like the default settings, in order to keep the stronger validation rules, feel free to reject this change.

With kind regards,
Andreas.

----

![image](https://user-images.githubusercontent.com/453543/233627032-27f0d9e6-62b8-46a7-934b-1498ac99bd72.png)
