### PR TITLE
CI: Remove testing on PyPy 3.6 and 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,10 +66,6 @@ jobs:
 
           # Test more available versions of PyPy on Linux.
           - os: "ubuntu-latest"
-            python-version: "pypy3.6"
-          - os: "ubuntu-latest"
-            python-version: "pypy3.7"
-          - os: "ubuntu-latest"
             python-version: "pypy3.8"
           - os: "ubuntu-latest"
             python-version: "pypy3.9"


### PR DESCRIPTION
If PyPy 3.6 and 3.7 have problems on CI/GHA, let's disable them until we find time to investigate.