### PR TITLE
Support Global System (Apprise) Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,18 +221,28 @@ No one wants to put their credentials out for everyone to see on the command lin
 #  ~/.apprise.yml
 #  ~/.config/apprise
 #  ~/.config/apprise.yml
+#  /etc/apprise
+#  /etc/apprise.yml
 
 # Also a subdirectory handling allows you to leverage plugins
 #  ~/.apprise/apprise
 #  ~/.apprise/apprise.yml
 #  ~/.config/apprise/apprise
 #  ~/.config/apprise/apprise.yml
+#  /etc/apprise/apprise
+#  /etc/apprise/apprise.yml
 
 # Windows users can store their default configuration files here:
 #  %APPDATA%/Apprise/apprise
 #  %APPDATA%/Apprise/apprise.yml
 #  %LOCALAPPDATA%/Apprise/apprise
 #  %LOCALAPPDATA%/Apprise/apprise.yml
+#  %ALLUSERSPROFILE%\Apprise\apprise
+#  %ALLUSERSPROFILE%\Apprise\apprise.yml
+#  %PROGRAMFILES%\Apprise\apprise
+#  %PROGRAMFILES%\Apprise\apprise.yml
+#  %COMMONPROGRAMFILES%\Apprise\apprise
+#  %COMMONPROGRAMFILES%\Apprise\apprise.yml
 
 # If you loaded one of those files, your command line gets really easy:
 apprise -vv -t 'my title' -b 'my notification body'
@@ -293,10 +303,14 @@ Once you've defined your custom hook, you just need to tell Apprise where it is 
 # all plugin files (if present) from the following directory paths:
 #  ~/.apprise/plugins
 #  ~/.config/apprise/plugins
+#  /var/lib/apprise/plugins
 
 # Windows users can store their default plugin files in these directories:
 #  %APPDATA%/Apprise/plugins
 #  %LOCALAPPDATA%/Apprise/plugins
+#  %ALLUSERSPROFILE%\Apprise\plugins
+#  %PROGRAMFILES%\Apprise\plugins
+#  %COMMONPROGRAMFILES%\Apprise\plugins
 
 # If you placed your plugin file within one of the directories already defined
 # above, then your call simply needs to look like:

--- a/apprise/cli.py
+++ b/apprise/cli.py
@@ -81,7 +81,9 @@ DEFAULT_CONFIG_PATHS = (
     '~/.config/apprise/apprise',
     '~/.config/apprise/apprise.yml',
 
-    # Global Support
+    # Global Configuration Support
+    '/etc/apprise',
+    '/etc/apprise.yml',
     '/etc/apprise/apprise',
     '/etc/apprise/apprise.yml',
 )
@@ -91,7 +93,7 @@ DEFAULT_PLUGIN_PATHS = (
     '~/.apprise/plugins',
     '~/.config/apprise/plugins',
 
-    # Global Support
+    # Global Plugin Support
     '/var/lib/apprise/plugins',
 )
 

--- a/apprise/cli.py
+++ b/apprise/cli.py
@@ -80,28 +80,62 @@ DEFAULT_CONFIG_PATHS = (
     '~/.apprise/apprise.yml',
     '~/.config/apprise/apprise',
     '~/.config/apprise/apprise.yml',
+
+    # Global Support
+    '/etc/apprise/apprise',
+    '/etc/apprise/apprise.yml',
 )
 
 # Define our paths to search for plugins
 DEFAULT_PLUGIN_PATHS = (
     '~/.apprise/plugins',
     '~/.config/apprise/plugins',
+
+    # Global Support
+    '/var/lib/apprise/plugins',
 )
 
 # Detect Windows
 if platform.system() == 'Windows':
     # Default Config Search Path for Windows Users
     DEFAULT_CONFIG_PATHS = (
-        expandvars('%APPDATA%/Apprise/apprise'),
-        expandvars('%APPDATA%/Apprise/apprise.yml'),
-        expandvars('%LOCALAPPDATA%/Apprise/apprise'),
-        expandvars('%LOCALAPPDATA%/Apprise/apprise.yml'),
+        expandvars('%APPDATA%\\Apprise\\apprise'),
+        expandvars('%APPDATA%\\Apprise\\apprise.yml'),
+        expandvars('%LOCALAPPDATA%\\Apprise\\apprise'),
+        expandvars('%LOCALAPPDATA%\\Apprise\\apprise.yml'),
+
+        #
+        # Global Support
+        #
+
+        # C:\ProgramData\Apprise\
+        expandvars('%ALLUSERSPROFILE%\\Apprise\\apprise'),
+        expandvars('%ALLUSERSPROFILE%\\Apprise\\apprise.yml'),
+
+        # C:\Program Files\Apprise
+        expandvars('%PROGRAMFILES%\\Apprise\\apprise'),
+        expandvars('%PROGRAMFILES%\\Apprise\\apprise.yml'),
+
+        # C:\Program Files\Common Files
+        expandvars('%COMMONPROGRAMFILES%\\Apprise\\apprise'),
+        expandvars('%COMMONPROGRAMFILES%\\Apprise\\apprise.yml'),
     )
 
     # Default Plugin Search Path for Windows Users
     DEFAULT_PLUGIN_PATHS = (
-        expandvars('%APPDATA%/Apprise/plugins'),
-        expandvars('%LOCALAPPDATA%/Apprise/plugins'),
+        expandvars('%APPDATA%\\Apprise\\plugins'),
+        expandvars('%LOCALAPPDATA%\\Apprise\\plugins'),
+
+        #
+        # Global Support
+        #
+
+        # C:\ProgramData\Apprise\plugins
+        expandvars('%ALLUSERSPROFILE%\\Apprise\\plugins'),
+        # C:\Program Files\Apprise\plugins
+        expandvars('%PROGRAMFILES%\\Apprise\\plugins'),
+        # C:\Program Files\Common Files
+        expandvars('%COMMONPROGRAMFILES%\\Apprise\\plugins'),
     )
 
 

--- a/packaging/man/apprise.md
+++ b/packaging/man/apprise.md
@@ -151,6 +151,7 @@ files and loads them:
 
     ~/.apprise/plugins
     ~/.config/apprise/plugins
+    /var/lib/apprise/plugins
 
 Simply create your own python file with the following bare minimum content in
 it:
@@ -192,6 +193,11 @@ in the following local locations for configuration files and loads them:
     ~/.config/apprise/apprise
     ~/.config/apprise/apprise.yaml
 
+    /etc/apprise
+    /etc/apprise.yml
+    /etc/apprise/apprise
+    /etc/apprise/apprise.yml
+
 If a default configuration file is referenced in any way by the **apprise**
 tool, you no longer need to provide it a Service URL.  Usage of the **apprise**
 tool simplifies to:
@@ -215,4 +221,4 @@ If you find any bugs, please make them known at:
 
 ## COPYRIGHT
 
-Apprise is Copyright (C) 2021 Chris Caron <lead2gold@gmail.com>
+Apprise is Copyright (C) 2023 Chris Caron <lead2gold@gmail.com>


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #872 

The request was to allow for global configuration references. This only impacts the CLI (`apprise`) and is only factored in alike the rest of the default configuration. Hence it is only applied if no other configuration wasn't otherwise specified.

All user bound configuration is always checked first before the information below is checked.

Added the following:
**For Linux:**
- Configuration:
   - `/etc/apprise`
   - `/etc/apprise.yml`
   - `/etc/apprise/apprise`
   - `/etc/apprise/apprise.yml`
- Plugin Path:
   - `/var/lib/apprise/plugins/`

**For Microsoft Windows:**
- Configuration (processed in the following order after not finding a local copy):
   - `%ALLUSERSPROFILE%\Apprise\apprise` (roughly translates to `C:\ProgramData\Apprise\apprise`)
   - `%ALLUSERSPROFILE%\Apprise\apprise.yml` (roughly translates to `C:\ProgramData\Apprise\apprise.yml`)
   - `%PROGRAMFILES%\Apprise\apprise` (roughly translates to `C:\Program Files\Apprise\apprise`)
   - `%PROGRAMFILES%\Apprise\apprise.yml` (roughly translates to `C:\Program Files\Apprise\apprise.yml`)
   - `%COMMONPROGRAMFILES%\Apprise\apprise` (roughly translates to `C:\Program Files\Common Files\Apprise\apprise`)
   - `%COMMONPROGRAMFILES%\Apprise\apprise.yml` (roughly translates to `C:\Program Files\Common Files\Apprise\apprise.yml`)
- Plugin Path: `/var/lib/apprise/plugins/`
   - `%ALLUSERSPROFILE%\Apprise\plugins` (roughly translates to `C:\ProgramData\Apprise\plugins`)
   - `%PROGRAMFILES%\Apprise\plugins` (roughly translates to `C:\Program Files\Apprise\apprise`)
   - `%COMMONPROGRAMFILES%\Apprise\plugins` (roughly translates to `C:\Program Files\Common Files\Apprise\plugins`)

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@872-global-configuration

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" "schema://"

```

