### PR TITLE
Support custom field mappings for JSON, FORM and XML Services

### DIFF
--- a/apprise/plugins/NotifyXML.py
+++ b/apprise/plugins/NotifyXML.py
@@ -41,6 +41,16 @@ from ..common import NotifyType
 from ..AppriseLocale import gettext_lazy as _
 
 
+class XMLPayloadField:
+    """
+    Identifies the fields available in the JSON Payload
+    """
+    VERSION = 'Version'
+    TITLE = 'Subject'
+    MESSAGE = 'Message'
+    MESSAGETYPE = 'MessageType'
+
+
 # Defines the method to send the notification
 METHODS = (
     'POST',
@@ -187,10 +197,10 @@ class NotifyXML(NotifyBase):
         # if the key you specify is actually an internally mapped one,
         # then a re-mapping takes place using the value
         self.payload_map = {
-            'Version': 'Version',
-            'Subject': 'Subject',
-            'MessageType': 'MessageType',
-            'Message': 'Message',
+            XMLPayloadField.VERSION: XMLPayloadField.VERSION,
+            XMLPayloadField.TITLE: XMLPayloadField.TITLE,
+            XMLPayloadField.MESSAGE: XMLPayloadField.MESSAGE,
+            XMLPayloadField.MESSAGETYPE: XMLPayloadField.MESSAGETYPE,
         }
 
         self.params = {}
@@ -304,16 +314,21 @@ class NotifyXML(NotifyBase):
         # Our XML Attachmement subsitution
         xml_attachments = ''
 
-        # Our Payload Base
-        payload_base = {
-            self.payload_map['Version']: self.xsd_ver,
-            self.payload_map['Subject']: NotifyXML.escape_html(
-                title, whitespace=False),
-            self.payload_map['MessageType']: NotifyXML.escape_html(
-                notify_type, whitespace=False),
-            self.payload_map['Message']: NotifyXML.escape_html(
-                body, whitespace=False),
-        }
+        payload_base = {}
+
+        for key, value in (
+                (XMLPayloadField.VERSION, self.xsd_ver),
+                (XMLPayloadField.TITLE, NotifyXML.escape_html(
+                    title, whitespace=False)),
+                (XMLPayloadField.MESSAGE, NotifyXML.escape_html(
+                    body, whitespace=False)),
+                (XMLPayloadField.MESSAGETYPE, NotifyXML.escape_html(
+                    notify_type, whitespace=False))):
+
+            if not self.payload_map[key]:
+                # Do not store element in payload response
+                continue
+            payload_base[self.payload_map[key]] = value
 
         # Apply our payload extras
         payload_base.update(

--- a/test/test_plugin_custom_form.py
+++ b/test/test_plugin_custom_form.py
@@ -368,7 +368,7 @@ def test_plugin_custom_form_edge_cases(mock_get, mock_post):
     mock_get.reset_mock()
 
     results = NotifyForm.parse_url(
-        'form://localhost:8080/command?:message=msg&method=POST')
+        'form://localhost:8080/command?:type=&:message=msg&method=POST')
 
     assert isinstance(results, dict)
     assert results['user'] is None
@@ -395,6 +395,9 @@ def test_plugin_custom_form_edge_cases(mock_get, mock_post):
     assert details[0][0] == 'http://localhost:8080/command'
     assert 'title' in details[1]['data']
     assert details[1]['data']['title'] == 'title'
+
+    # type was removed from response object
+    assert 'type' not in details[1]['data']
 
     # message over-ride was provided; the body is now in `msg` and not
     # `message`

--- a/test/test_plugin_custom_form.py
+++ b/test/test_plugin_custom_form.py
@@ -318,7 +318,7 @@ def test_plugin_custom_form_edge_cases(mock_get, mock_post):
     mock_get.return_value = response
 
     results = NotifyForm.parse_url(
-        'form://localhost:8080/command?:abcd=test&method=POST')
+        'form://localhost:8080/command?:message=msg&:abcd=test&method=POST')
 
     assert isinstance(results, dict)
     assert results['user'] is None
@@ -332,6 +332,7 @@ def test_plugin_custom_form_edge_cases(mock_get, mock_post):
     assert results['url'] == 'form://localhost:8080/command'
     assert isinstance(results['qsd:'], dict) is True
     assert results['qsd:']['abcd'] == 'test'
+    assert results['qsd:']['message'] == 'msg'
 
     instance = NotifyForm(**results)
     assert isinstance(instance, NotifyForm)
@@ -347,8 +348,11 @@ def test_plugin_custom_form_edge_cases(mock_get, mock_post):
     assert details[1]['data']['abcd'] == 'test'
     assert 'title' in details[1]['data']
     assert details[1]['data']['title'] == 'title'
-    assert 'message' in details[1]['data']
-    assert details[1]['data']['message'] == 'body'
+    assert 'message' not in details[1]['data']
+    # message over-ride was provided; the body is now in `msg` and not
+    # `message`
+    assert 'msg' in details[1]['data']
+    assert details[1]['data']['msg'] == 'body'
 
     assert instance.url(privacy=False).startswith(
         'form://localhost:8080/command?')
@@ -364,7 +368,7 @@ def test_plugin_custom_form_edge_cases(mock_get, mock_post):
     mock_get.reset_mock()
 
     results = NotifyForm.parse_url(
-        'form://localhost:8080/command?:message=test&method=POST')
+        'form://localhost:8080/command?:message=msg&method=POST')
 
     assert isinstance(results, dict)
     assert results['user'] is None
@@ -377,7 +381,7 @@ def test_plugin_custom_form_edge_cases(mock_get, mock_post):
     assert results['schema'] == 'form'
     assert results['url'] == 'form://localhost:8080/command'
     assert isinstance(results['qsd:'], dict) is True
-    assert results['qsd:']['message'] == 'test'
+    assert results['qsd:']['message'] == 'msg'
 
     instance = NotifyForm(**results)
     assert isinstance(instance, NotifyForm)
@@ -391,9 +395,15 @@ def test_plugin_custom_form_edge_cases(mock_get, mock_post):
     assert details[0][0] == 'http://localhost:8080/command'
     assert 'title' in details[1]['data']
     assert details[1]['data']['title'] == 'title'
+
+    # message over-ride was provided; the body is now in `msg` and not
+    # `message`
+    assert details[1]['data']['msg'] == 'body'
+
     # 'body' is over-ridden by 'test' passed inline with the URL
-    assert 'message' in details[1]['data']
-    assert details[1]['data']['message'] == 'test'
+    assert 'message' not in details[1]['data']
+    assert 'msg' in details[1]['data']
+    assert details[1]['data']['msg'] == 'body'
 
     assert instance.url(privacy=False).startswith(
         'form://localhost:8080/command?')
@@ -438,8 +448,9 @@ def test_plugin_custom_form_edge_cases(mock_get, mock_post):
     assert 'title' in details[1]['params']
     assert details[1]['params']['title'] == 'title'
     # 'body' is over-ridden by 'test' passed inline with the URL
-    assert 'message' in details[1]['params']
-    assert details[1]['params']['message'] == 'test'
+    assert 'message' not in details[1]['params']
+    assert 'test' in details[1]['params']
+    assert details[1]['params']['test'] == 'body'
 
     assert instance.url(privacy=False).startswith(
         'form://localhost:8080/command?')

--- a/test/test_plugin_custom_json.py
+++ b/test/test_plugin_custom_json.py
@@ -176,8 +176,11 @@ def test_plugin_custom_json_edge_cases(mock_get, mock_post):
     mock_post.return_value = response
     mock_get.return_value = response
 
+    # This string also tests that type is set to nothing
     results = NotifyJSON.parse_url(
-        'json://localhost:8080/command?:message=msg&:test=value&method=GET')
+        'json://localhost:8080/command?'
+        ':message=msg&:test=value&method=GET'
+        '&:type=')
 
     assert isinstance(results, dict)
     assert results['user'] is None
@@ -191,6 +194,8 @@ def test_plugin_custom_json_edge_cases(mock_get, mock_post):
     assert results['url'] == 'json://localhost:8080/command'
     assert isinstance(results['qsd:'], dict) is True
     assert results['qsd:']['message'] == 'msg'
+    # empty special mapping
+    assert results['qsd:']['type'] == ''
 
     instance = NotifyJSON(**results)
     assert isinstance(instance, NotifyJSON)
@@ -207,6 +212,8 @@ def test_plugin_custom_json_edge_cases(mock_get, mock_post):
     assert dataset['title'] == 'title'
     assert 'message' not in dataset
     assert 'msg' in dataset
+    # type was set to nothing which implies it should be removed
+    assert 'type' not in dataset
     # message over-ride was provided; the body is now in `msg` and not
     # `message`
     assert dataset['msg'] == 'body'

--- a/test/test_plugin_custom_json.py
+++ b/test/test_plugin_custom_json.py
@@ -177,7 +177,7 @@ def test_plugin_custom_json_edge_cases(mock_get, mock_post):
     mock_get.return_value = response
 
     results = NotifyJSON.parse_url(
-        'json://localhost:8080/command?:message=test&method=GET')
+        'json://localhost:8080/command?:message=msg&:test=value&method=GET')
 
     assert isinstance(results, dict)
     assert results['user'] is None
@@ -190,7 +190,7 @@ def test_plugin_custom_json_edge_cases(mock_get, mock_post):
     assert results['schema'] == 'json'
     assert results['url'] == 'json://localhost:8080/command'
     assert isinstance(results['qsd:'], dict) is True
-    assert results['qsd:']['message'] == 'test'
+    assert results['qsd:']['message'] == 'msg'
 
     instance = NotifyJSON(**results)
     assert isinstance(instance, NotifyJSON)
@@ -205,9 +205,14 @@ def test_plugin_custom_json_edge_cases(mock_get, mock_post):
     assert 'title' in details[1]['data']
     dataset = json.loads(details[1]['data'])
     assert dataset['title'] == 'title'
-    assert 'message' in dataset
-    # message over-ride was provided
-    assert dataset['message'] == 'test'
+    assert 'message' not in dataset
+    assert 'msg' in dataset
+    # message over-ride was provided; the body is now in `msg` and not
+    # `message`
+    assert dataset['msg'] == 'body'
+
+    assert 'test' in dataset
+    assert dataset['test'] == 'value'
 
     assert instance.url(privacy=False).startswith(
         'json://localhost:8080/command?')

--- a/test/test_plugin_custom_xml.py
+++ b/test/test_plugin_custom_xml.py
@@ -251,7 +251,7 @@ def test_plugin_custom_xml_edge_cases(mock_get, mock_post):
     mock_get.return_value = response
 
     results = NotifyXML.parse_url(
-        'xml://localhost:8080/command?:Message=test&method=GET'
+        'xml://localhost:8080/command?:Message=Body&method=GET'
         '&:Key=value&:,=invalid')
 
     assert isinstance(results, dict)
@@ -265,12 +265,15 @@ def test_plugin_custom_xml_edge_cases(mock_get, mock_post):
     assert results['schema'] == 'xml'
     assert results['url'] == 'xml://localhost:8080/command'
     assert isinstance(results['qsd:'], dict) is True
-    assert results['qsd:']['Message'] == 'test'
+    assert results['qsd:']['Message'] == 'Body'
     assert results['qsd:']['Key'] == 'value'
     assert results['qsd:'][','] == 'invalid'
 
     instance = NotifyXML(**results)
     assert isinstance(instance, NotifyXML)
+
+    # XSD URL is disabled due to custom formatting
+    assert instance.xsd_url is None
 
     response = instance.send(title='title', body='body')
     assert response is True
@@ -292,7 +295,60 @@ def test_plugin_custom_xml_edge_cases(mock_get, mock_post):
     assert re.search(r'<Version>[1-9]+\.[0-9]+</Version>', details[1]['data'])
     assert re.search('<MessageType>info</MessageType>', details[1]['data'])
     assert re.search('<Subject>title</Subject>', details[1]['data'])
-    # Custom entry Message acts as Over-ride and kicks in here
-    assert re.search('<Message>test</Message>', details[1]['data'])
+
+    assert re.search('<Message>test</Message>', details[1]['data']) is None
+    assert re.search('<Message>', details[1]['data']) is None
+    # However we can find our mapped Message to the new value Body
+    assert re.search('<Body>body</Body>', details[1]['data'])
     # Custom entry
     assert re.search('<Key>value</Key>', details[1]['data'])
+
+    mock_post.reset_mock()
+    mock_get.reset_mock()
+
+    results = NotifyXML.parse_url(
+        'xml://localhost:8081/command?method=POST&:New=Value')
+
+    assert isinstance(results, dict)
+    assert results['user'] is None
+    assert results['password'] is None
+    assert results['port'] == 8081
+    assert results['host'] == 'localhost'
+    assert results['fullpath'] == '/command'
+    assert results['path'] == '/'
+    assert results['query'] == 'command'
+    assert results['schema'] == 'xml'
+    assert results['url'] == 'xml://localhost:8081/command'
+    assert isinstance(results['qsd:'], dict) is True
+    assert results['qsd:']['New'] == 'Value'
+
+    instance = NotifyXML(**results)
+    assert isinstance(instance, NotifyXML)
+
+    # XSD URL is disabled due to custom formatting
+    assert instance.xsd_url is not None
+
+    response = instance.send(title='title', body='body')
+    assert response is True
+    assert mock_post.call_count == 1
+    assert mock_get.call_count == 0
+
+    details = mock_post.call_args_list[0]
+    assert details[0][0] == 'http://localhost:8081/command'
+    assert instance.url(privacy=False).startswith(
+        'xml://localhost:8081/command?')
+
+    # Generate a new URL based on our last and verify key values are the same
+    new_results = NotifyXML.parse_url(instance.url(safe=False))
+    for k in ('user', 'password', 'port', 'host', 'fullpath', 'path', 'query',
+              'schema', 'url', 'method'):
+        assert new_results[k] == results[k]
+
+    # Test our data set for our key/value pair
+    assert re.search(r'<Version>[1-9]+\.[0-9]+</Version>', details[1]['data'])
+    assert re.search(r'<MessageType>info</MessageType>', details[1]['data'])
+    assert re.search(r'<Subject>title</Subject>', details[1]['data'])
+    # No over-ride
+    assert re.search(r'<Message>body</Message>', details[1]['data'])
+    # since there is no over-ride, an xmlns:xsi is provided
+    assert re.search(r'<Notification xmlns:xsi=', details[1]['data'])

--- a/test/test_plugin_custom_xml.py
+++ b/test/test_plugin_custom_xml.py
@@ -252,7 +252,7 @@ def test_plugin_custom_xml_edge_cases(mock_get, mock_post):
 
     results = NotifyXML.parse_url(
         'xml://localhost:8080/command?:Message=Body&method=GET'
-        '&:Key=value&:,=invalid')
+        '&:Key=value&:,=invalid&:MessageType=')
 
     assert isinstance(results, dict)
     assert results['user'] is None
@@ -293,11 +293,12 @@ def test_plugin_custom_xml_edge_cases(mock_get, mock_post):
 
     # Test our data set for our key/value pair
     assert re.search(r'<Version>[1-9]+\.[0-9]+</Version>', details[1]['data'])
-    assert re.search('<MessageType>info</MessageType>', details[1]['data'])
     assert re.search('<Subject>title</Subject>', details[1]['data'])
 
     assert re.search('<Message>test</Message>', details[1]['data']) is None
     assert re.search('<Message>', details[1]['data']) is None
+    # MessageType was removed from the payload
+    assert re.search('<MessageType>', details[1]['data']) is None
     # However we can find our mapped Message to the new value Body
     assert re.search('<Body>body</Body>', details[1]['data'])
     # Custom entry


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #842

Support custom field mappings for `XML`, `FORM`, and `JSON` Services.
### JSON
By default the following schema is outputted to the user:
```json
{
   "version": "1.0",
   "title": "Some Great Software Downloaded Successfully",
   "message": "Plenty of details here",
   "type": "info"
}
```

The service allows you to add `:` (colon) in front of your variables on the Apprise URL to add entries... For example the URL `json://localhost/?:sound=whatever.wav` would produce the following payload:
```json
{
   "version": "1.0",
   "title": "Some Great Software Downloaded Successfully",
   "message": "Plenty of details here",
   "type": "info",
   "sound": "whatever.wav"
}
```

However, there may be cases where you don't want `title` to be identified by that (but `subject` instead).  Or perhaps `message` should have been identified by the key `body`).  This can be accomplished now using this PR and still leveraging the `:` (colon) delimiter.  For example: `json://localhost/?:sound=whatever.wav&:message=body&:title=subject` would produce the following payload:
```json
{
   "version": "1.0",
   "subject": "Some Great Software Downloaded Successfully",
   "body": "Plenty of details here",
   "type": "info",
   "sound": "whatever.wav"
}
```

Mappings can also be removed; simply define an empty mapping to have the item removed. For example: `json://localhost/?:type=&version=` would produce:
```json
{
   "subject": "Some Great Software Downloaded Successfully",
   "body": "Plenty of details here"
}
```

XML and FORM work the same way.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@842-custom-field-mappings

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message"  "json://hostname/?:title=subject"

```

