### PR TITLE
Added WhatsApp Support

### DIFF
--- a/KEYWORDS
+++ b/KEYWORDS
@@ -85,6 +85,7 @@ Twist
 Twitter
 Vonage
 Webex
+WhatsApp
 Windows
 Voipms
 XBMC

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The table below identifies the services this tool supports and some example serv
 | [Twist](https://github.com/caronc/apprise/wiki/Notify_twist) | twist://  | (TCP) 443   | twist://pasword:login<br/>twist://password:login/#channel<br/>twist://password:login/#team:channel<br/>twist://password:login/#team:channel1/channel2/#team3:channel
 | [XBMC](https://github.com/caronc/apprise/wiki/Notify_xbmc) | xbmc:// or xbmcs://    | (TCP) 8080 or 443   | xbmc://hostname<br />xbmc://user@hostname<br />xbmc://user:password@hostname:port
 | [Webex Teams (Cisco)](https://github.com/caronc/apprise/wiki/Notify_wxteams) | wxteams://  | (TCP) 443   | wxteams://Token
+| [WhatsApp](https://github.com/caronc/apprise/wiki/Notify_whatsapp) | whatsapp://  | (TCP) 443   | whatsapp://AccessToken@FromPhoneID/ToPhoneNo<br/> whatsapp://Template:AccessToken@FromPhoneID/ToPhoneNo
 | [Zulip Chat](https://github.com/caronc/apprise/wiki/Notify_zulip) | zulip://  | (TCP) 443   | zulip://botname@Organization/Token<br />zulip://botname@Organization/Token/Stream<br />zulip://botname@Organization/Token/Email
 
 ## SMS Notifications

--- a/apprise/plugins/NotifyWhatsApp.py
+++ b/apprise/plugins/NotifyWhatsApp.py
@@ -1,0 +1,565 @@
+# -*- coding: utf-8 -*-
+# BSD 3-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2023, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# API Source:
+#   https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages
+#
+# 1. Register a developer account with Meta:
+#  https://developers.facebook.com/docs/whatsapp/cloud-api/get-started
+# 2. Enable 2 Factor Authentication (2FA) with your account (if not done
+#  already)
+# 3. Create a App using WhatsApp Product.  There are 2 to create an app from
+#   Do NOT chose the WhatsApp Webhook one (choose the other)
+#
+#  When you click on the API Setup section of your new app you need to record
+#  both the access token and the From Phone Number ID.  Note that this not the
+#  from phone number itself, but it's ID.  It's displayed below and contains
+#  way more numbers then your typical phone number
+
+import re
+import requests
+from json import loads, dumps
+from .NotifyBase import NotifyBase
+from ..URLBase import PrivacyMode
+from ..common import NotifyType
+from ..utils import is_phone_no
+from ..utils import parse_phone_no
+from ..utils import validate_regex
+from ..AppriseLocale import gettext_lazy as _
+
+
+class NotifyWhatsApp(NotifyBase):
+    """
+    A wrapper for WhatsApp Notifications
+    """
+
+    # The default descriptive name associated with the Notification
+    service_name = 'WhatsApp'
+
+    # The services URL
+    service_url = 'https://developer.facebook.com/'
+
+    # All notification requests are secure
+    secure_protocol = 'whatsapp'
+
+    # Allow 300 requests per minute.
+    # 60/300 = 0.2
+    request_rate_per_sec = 0.20
+
+    # Facebook Graph version
+    fb_graph_version = 'v17.0'
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = 'https://github.com/caronc/apprise/wiki/Notify_whatsapp'
+
+    # WhatsApp Message Notification URL
+    notify_url = 'https://graph.facebook.com/{fb_ver}/{phone_id}/messages'
+
+    # The maximum length of the body
+    body_maxlen = 1024
+
+    # A title can not be used for SMS Messages.  Setting this to zero will
+    # cause any title (if defined) to get placed into the message body.
+    title_maxlen = 0
+
+    # Define object templates
+    templates = (
+        '{schema}://{token}@{from_phone_id}/{targets}',
+        '{schema}://{template}:{token}@{from_phone_id}/{targets}',
+    )
+
+    # Define our template tokens
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'token': {
+            'name': _('Access Token'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+            'regex': (r'^[a-z0-9]+$', 'i'),
+        },
+        'template': {
+            'name': _('Template Name'),
+            'type': 'string',
+            'required': False,
+            'regex': (r'^[^\s]+$', 'i'),
+        },
+        'from_phone_id': {
+            'name': _('From Phone ID'),
+            'type': 'string',
+            'required': True,
+            'regex': (r'^[0-9]{14,}$', 'i'),
+            'map_to': 'source',
+        },
+        'target_phone': {
+            'name': _('Target Phone No'),
+            'type': 'string',
+            'prefix': '+',
+            'regex': (r'^[0-9\s)(+-]+$', 'i'),
+            'map_to': 'targets',
+        },
+        'targets': {
+            'name': _('Targets'),
+            'type': 'list:string',
+        },
+        'language': {
+            'name': _('Language'),
+            'type': 'string',
+            'default': 'en_US',
+            'regex': (r'^[^0-9\s]+$', 'i'),
+        },
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        'to': {
+            'alias_of': 'targets',
+        },
+        'from': {
+            'alias_of': 'from_phone_id',
+        },
+        'token': {
+            'alias_of': 'auth_token',
+        },
+        'template': {
+            'alias_of': 'template',
+        },
+        'lang': {
+            'alias_of': 'language',
+        },
+    })
+
+    # Our supported mappings and component keys
+    component_key_re = re.compile(
+        r'(?P<key>((?P<id>[1-9][0-9]*)|(?P<map>body|type)))', re.IGNORECASE)
+
+    # Define any kwargs we're using
+    template_kwargs = {
+        'template_mapping': {
+            'name': _('Template Mapping'),
+            'prefix': ':',
+        },
+    }
+
+    def __init__(self, token, from_phone_id, template=None, targets=None,
+                 language=None, template_mapping=None, **kwargs):
+        """
+        Initialize WhatsApp Object
+        """
+        super().__init__(**kwargs)
+
+        # The Access Token associated with the account
+        self.token = validate_regex(
+            token, *self.template_tokens['token']['regex'])
+        if not self.token:
+            msg = 'An invalid WhatsApp Access Token ' \
+                  '({}) was specified.'.format(token)
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # The From Phone ID associated with the account
+        self.from_phone_id = validate_regex(
+            from_phone_id, *self.template_tokens['from_phone_id']['regex'])
+        if not self.from_phone_id:
+            msg = 'An invalid WhatsApp From Phone ID ' \
+                  '({}) was specified.'.format(from_phone_id)
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # The template to associate with the message
+        if template:
+            self.template = validate_regex(
+                template, *self.template_tokens['template']['regex'])
+            if not self.template:
+                msg = 'An invalid WhatsApp Template Name ' \
+                      '({}) was specified.'.format(template)
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
+            # The Template language Code to use
+            if language:
+                self.language = validate_regex(
+                    language, *self.template_tokens['language']['regex'])
+                if not self.language:
+                    msg = 'An invalid WhatsApp Template Language Code ' \
+                          '({}) was specified.'.format(language)
+                    self.logger.warning(msg)
+                    raise TypeError(msg)
+            else:
+                self.language = self.template_tokens['language']['default']
+        else:
+            #
+            # Message Mode
+            #
+            self.template = None
+
+        # Parse our targets
+        self.targets = list()
+
+        for target in parse_phone_no(targets):
+            # Validate targets and drop bad ones:
+            result = is_phone_no(target)
+            if not result:
+                self.logger.warning(
+                    'Dropped invalid phone # '
+                    '({}) specified.'.format(target),
+                )
+                continue
+
+            # store valid phone number
+            self.targets.append('+{}'.format(result['full']))
+
+        self.template_mapping = {}
+        if template_mapping:
+            # Store our extra payload entries
+            self.template_mapping.update(template_mapping)
+
+        # Validate Mapping and prepare Components
+        self.components = dict()
+        self.component_keys = list()
+        for key, val in self.template_mapping.items():
+            matched = self.component_key_re.match(key)
+            if not matched:
+                msg = 'An invalid Template Component ID ' \
+                      '({}) was specified.'.format(key)
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
+            if matched.group('id'):
+                #
+                # Manual Component Assigment (by id)
+                #
+                index = matched.group('id')
+                map_to = {
+                    "type": "text",
+                    "text": val,
+                }
+
+            else:  # matched.group('map')
+                map_to = matched.group('map').lower()
+                matched = self.component_key_re.match(val)
+                if not (matched and matched.group('id')):
+                    msg = 'An invalid Template Component Mapping ' \
+                        '(:{}={}) was specified.'.format(key, val)
+                    self.logger.warning(msg)
+                    raise TypeError(msg)
+                index = matched.group('id')
+
+            if index in self.components:
+                msg = 'The Template Component index ' \
+                      '({}) was already assigned.'.format(key)
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
+            self.components[index] = map_to
+            self.component_keys = self.components.keys()
+            # Adjust sorting and assume that the user put the order correctly;
+            # if not Facebook just won't be very happy and will reject the
+            # message
+            sorted(self.component_keys)
+
+        return
+
+    def send(self, body, title='', notify_type=NotifyType.INFO, **kwargs):
+        """
+        Perform WhatsApp Notification
+        """
+
+        if not self.targets:
+            self.logger.warning(
+                'There are no valid WhatsApp targets to notify.')
+            return False
+
+        # error tracking (used for function return)
+        has_error = False
+
+        # Prepare our URL
+        url = self.notify_url.format(
+            fb_ver=self.fb_graph_version,
+            phone_id=self.from_phone_id,
+        )
+
+        # Prepare our headers
+        headers = {
+            'User-Agent': self.app_id,
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'Authorization': f'Bearer {self.token}',
+        }
+
+        payload = {
+            'messaging_product': 'whatsapp',
+            # The To gets populated in the loop below
+            'to': None,
+        }
+
+        if not self.template:
+            #
+            # Send Message
+            #
+            payload.update({
+                'recipient_type': "individual",
+                'type': 'text',
+                'text': {"body": body},
+            })
+
+        else:
+            #
+            # Send Template
+            #
+            payload.update({
+                'type': 'template',
+                "template": {
+                    "name": self.template,
+                    "language": {"code": self.language},
+                },
+            })
+
+            if self.components:
+                payload['template']['components'] = [
+                    {
+                        "type": "body",
+                        "parameters": [],
+                    }
+                ]
+                for key in self.component_keys:
+                    if isinstance(self.components[key], dict):
+                        # Manual Assignment
+                        payload['template']['components'][0]["parameters"]\
+                            .append(self.components[key])
+                        continue
+
+                    # Mapping of body and/or notify type
+                    payload['template']['components'][0]["parameters"].append({
+                        "type": "text",
+                        "text": body if self.components[key] == 'body'
+                        else notify_type,
+                    })
+
+        # Create a copy of the targets list
+        targets = list(self.targets)
+
+        if len(targets) == 0:
+            # No sources specified, use our own phone no
+            targets.append(self.source)
+
+        while len(targets):
+            # Get our target to notify
+            target = targets.pop(0)
+
+            # Prepare our user
+            payload['to'] = target
+
+            # Some Debug Logging
+            self.logger.debug('WhatsApp POST URL: {} (cert_verify={})'.format(
+                url, self.verify_certificate))
+            self.logger.debug('WhatsApp Payload: {}' .format(payload))
+
+            # Always call throttle before any remote server i/o is made
+            self.throttle()
+            try:
+                r = requests.post(
+                    url,
+                    data=dumps(payload),
+                    headers=headers,
+                    verify=self.verify_certificate,
+                    timeout=self.request_timeout,
+                )
+
+                if r.status_code not in (
+                        requests.codes.created, requests.codes.ok):
+                    # We had a problem
+                    status_str = \
+                        NotifyBase.http_response_code_lookup(r.status_code)
+
+                    # set up our status code to use
+                    status_code = r.status_code
+
+                    try:
+                        # Update our status response if we can
+                        json_response = loads(r.content)
+                        status_code = \
+                            json_response['error'].get('code', status_code)
+                        status_str = \
+                            json_response['error'].get('message', status_str)
+
+                    except (AttributeError, TypeError, ValueError):
+                        # ValueError = r.content is Unparsable
+                        # TypeError = r.content is None
+                        # AttributeError = r is None
+
+                        # We could not parse JSON response.
+                        # We will just use the status we already have.
+                        pass
+
+                    self.logger.warning(
+                        'Failed to send WhatsApp notification to {}: '
+                        '{}{}error={}.'.format(
+                            target,
+                            status_str,
+                            ', ' if status_str else '',
+                            status_code))
+
+                    self.logger.debug(
+                        'Response Details:\r\n{}'.format(r.content))
+
+                    # Mark our failure
+                    has_error = True
+                    continue
+
+                else:
+                    self.logger.info(
+                        'Sent WhatsApp notification to {}.'.format(target))
+
+            except requests.RequestException as e:
+                self.logger.warning(
+                    'A Connection error occurred sending WhatsApp:%s ' % (
+                        target) + 'notification.'
+                )
+                self.logger.debug('Socket Exception: %s' % str(e))
+
+                # Mark our failure
+                has_error = True
+                continue
+
+        return not has_error
+
+    def url(self, privacy=False, *args, **kwargs):
+        """
+        Returns the URL built dynamically based on specified arguments.
+        """
+
+        # Define any URL parameters
+        params = {}
+        if self.template:
+            # Add language to our URL
+            params['lang'] = self.language
+
+        # Extend our parameters
+        params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
+
+        # Payload body extras prefixed with a ':' sign
+        # Append our payload extras into our parameters
+        params.update(
+            {':{}'.format(k): v for k, v in self.template_mapping.items()})
+
+        return '{schema}://{template}{token}@{from_id}/{targets}/?{params}'\
+            .format(
+                schema=self.secure_protocol,
+                from_id=self.pprint(
+                    self.from_phone_id, privacy, mode=PrivacyMode.Tail,
+                    safe=''),
+                token=self.pprint(self.token, privacy, safe=''),
+                template='' if not self.template
+                else '{}:'.format(self.pprint(
+                    self.template, privacy, safe='')),
+                targets='/'.join(
+                    [NotifyWhatsApp.quote(x, safe='') for x in self.targets]),
+                params=NotifyWhatsApp.urlencode(params))
+
+    def __len__(self):
+        """
+        Returns the number of targets associated with this notification
+        """
+        targets = len(self.targets)
+        return targets if targets > 0 else 1
+
+    @staticmethod
+    def parse_url(url):
+        """
+        Parses the URL and returns enough arguments that can allow
+        us to re-instantiate this object.
+
+        """
+        results = NotifyBase.parse_url(url, verify_host=False)
+
+        if not results:
+            # We're done early as we couldn't load the results
+            return results
+
+        # Get our entries; split_path() looks after unquoting content for us
+        # by default
+        results['targets'] = NotifyWhatsApp.split_path(results['fullpath'])
+
+        # The hostname is our From Phone ID
+        results['from_phone_id'] = NotifyWhatsApp.unquote(results['host'])
+
+        # Determine if we have a Template, otherwise load our token
+        if results['password']:
+            #
+            # Template Mode
+            #
+            results['template'] = NotifyWhatsApp.unquote(results['user'])
+            results['token'] = NotifyWhatsApp.unquote(results['password'])
+
+        else:
+            #
+            # Message Mode
+            #
+            results['token'] = NotifyWhatsApp.unquote(results['user'])
+
+        # Access token
+        if 'token' in results['qsd'] and len(results['qsd']['token']):
+            # Extract the account sid from an argument
+            results['token'] = \
+                NotifyWhatsApp.unquote(results['qsd']['token'])
+
+        # Template
+        if 'template' in results['qsd'] and len(results['qsd']['template']):
+            results['template'] = results['qsd']['template']
+
+        # Template Language
+        if 'lang' in results['qsd'] and len(results['qsd']['lang']):
+            results['language'] = results['qsd']['lang']
+
+        # Support the 'from'  and 'source' variable so that we can support
+        # targets this way too.
+        # The 'from' makes it easier to use yaml configuration
+        if 'from' in results['qsd'] and len(results['qsd']['from']):
+            results['source'] = \
+                NotifyWhatsApp.unquote(results['qsd']['from'])
+        if 'source' in results['qsd'] and len(results['qsd']['source']):
+            results['source'] = \
+                NotifyWhatsApp.unquote(results['qsd']['source'])
+
+        # Support the 'to' variable so that we can support targets this way too
+        # The 'to' makes it easier to use yaml configuration
+        if 'to' in results['qsd'] and len(results['qsd']['to']):
+            results['targets'] += \
+                NotifyWhatsApp.parse_phone_no(results['qsd']['to'])
+
+        # store any additional payload extra's defined
+        results['template_mapping'] = {
+            NotifyWhatsApp.unquote(x): NotifyWhatsApp.unquote(y)
+            for x, y in results['qsd:'].items()
+        }
+
+        return results

--- a/apprise/plugins/NotifyWhatsApp.py
+++ b/apprise/plugins/NotifyWhatsApp.py
@@ -66,7 +66,8 @@ class NotifyWhatsApp(NotifyBase):
     service_name = 'WhatsApp'
 
     # The services URL
-    service_url = 'https://developer.facebook.com/'
+    service_url = \
+        'https://developers.facebook.com/docs/whatsapp/cloud-api/get-started'
 
     # All notification requests are secure
     secure_protocol = 'whatsapp'
@@ -117,7 +118,6 @@ class NotifyWhatsApp(NotifyBase):
             'type': 'string',
             'required': True,
             'regex': (r'^[0-9]{14,}$', 'i'),
-            'map_to': 'source',
         },
         'target_phone': {
             'name': _('Target Phone No'),
@@ -147,7 +147,7 @@ class NotifyWhatsApp(NotifyBase):
             'alias_of': 'from_phone_id',
         },
         'token': {
-            'alias_of': 'auth_token',
+            'alias_of': 'token',
         },
         'template': {
             'alias_of': 'template',
@@ -367,10 +367,6 @@ class NotifyWhatsApp(NotifyBase):
         # Create a copy of the targets list
         targets = list(self.targets)
 
-        if len(targets) == 0:
-            # No sources specified, use our own phone no
-            targets.append(self.source)
-
         while len(targets):
             # Get our target to notify
             target = targets.pop(0)
@@ -544,11 +540,12 @@ class NotifyWhatsApp(NotifyBase):
         # targets this way too.
         # The 'from' makes it easier to use yaml configuration
         if 'from' in results['qsd'] and len(results['qsd']['from']):
-            results['source'] = \
+            results['from_phone_id'] = \
                 NotifyWhatsApp.unquote(results['qsd']['from'])
-        if 'source' in results['qsd'] and len(results['qsd']['source']):
-            results['source'] = \
-                NotifyWhatsApp.unquote(results['qsd']['source'])
+        if 'from_phone_id' in results['qsd'] and \
+                len(results['qsd']['from_phone_id']):
+            results['from_phone_id'] = \
+                NotifyWhatsApp.unquote(results['qsd']['from_phone_id'])
 
         # Support the 'to' variable so that we can support targets this way too
         # The 'to' makes it easier to use yaml configuration

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -53,7 +53,7 @@ Opsgenie, PagerDuty, PagerTree, ParsePlatform, PopcornNotify, Prowl, Pushalot,
 PushBullet, Pushjet, Pushover, PushSafer, Reddit, Rocket.Chat, SendGrid,
 ServerChan, Signal, SimplePush, Sinch, Slack, SMSEagle, SMTP2Go, Spontit,
 SparkPost, Super Toasty, Streamlabs, Stride, Syslog, Techulus Push, Telegram,
-Twilio, Twitter, Twist, XBMC, Voipms, Vonage, Webex Teams}
+Twilio, Twitter, Twist, XBMC, Voipms, Vonage, WhatsApp, Webex Teams}
 
 Name:           python-%{pypi_name}
 Version:        1.4.0

--- a/test/test_plugin_whatsapp.py
+++ b/test/test_plugin_whatsapp.py
@@ -1,0 +1,271 @@
+# -*- coding: utf-8 -*-
+# BSD 3-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2023, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from unittest import mock
+
+import requests
+import pytest
+from json import dumps, loads
+from apprise import Apprise
+from apprise.plugins.NotifyWhatsApp import NotifyWhatsApp
+from helpers import AppriseURLTester
+
+# Disable logging for a cleaner testing output
+import logging
+logging.disable(logging.CRITICAL)
+
+# Our Testing URLs
+apprise_url_tests = (
+    ('whatsapp://', {
+        # Not enough details
+        'instance': TypeError,
+    }),
+    ('whatsapp://:@/', {
+        # invalid Access Token
+        'instance': TypeError,
+    }),
+    ('whatsapp://{}@_'.format('a' * 32), {
+        # token provided but invalid from
+        'instance': TypeError,
+    }),
+    ('whatsapp://%20:{}@12345/{}'.format('e' * 32, '4' * 11), {
+        # Invalid template
+        'instance': TypeError,
+    }),
+    ('whatsapp://{}@{}'.format('b' * 32, 10**9), {
+        # token provided and from but no target no
+        'instance': NotifyWhatsApp,
+
+        # Response will fail due to no targets defined
+        'notify_response': False,
+    }),
+    ('whatsapp://{}:{}@{}/123/{}/abcd/'.format(
+        'a' * 32, 'b' * 32, '3' * 11, '9' * 15), {
+        # valid everything but target numbers
+        'instance': NotifyWhatsApp,
+
+        # Response will fail due to target not being loaded
+        'notify_response': False,
+    }),
+    ('whatsapp://{}@12345/{}'.format('e' * 32, '4' * 11), {
+        # simple message
+        'instance': NotifyWhatsApp,
+
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'whatsapp://e...e@1...5/%2B44444444444/',
+    }),
+    ('whatsapp://template:{}@12345/{}'.format('e' * 32, '4' * 11), {
+        # template
+        'instance': NotifyWhatsApp,
+
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'whatsapp://template:e...e@1...5/%2B44444444444/',
+    }),
+    ('whatsapp://template:{}@12345/{}?lang=fr_CA'.format('e' * 32, '4' * 11), {
+        # template with language over-ride
+        'instance': NotifyWhatsApp,
+
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'whatsapp://template:e...e@1...5/%2B44444444444/',
+    }),
+    ('whatsapp://{}@12345/{}?template=template&lang=fr_CA'.format(
+        'e' * 32, '4' * 11), {
+            # template specified as kwarg with language over-ride
+            'instance': NotifyWhatsApp,
+
+            # Our expected url(privacy=True) startswith() response:
+            'privacy_url': 'whatsapp://template:e...e@1...5/%2B44444444444/',
+    }),
+    ('whatsapp://template:{}@12345/{}?lang=1234'.format('e' * 32, '4' * 11), {
+        # template with invalid language over-ride
+        'instance': TypeError,
+    }),
+    ('whatsapp://template:{}@12345/{}?:1=test&:body=3&:type=2'.format(
+        'e' * 32, '4' * 11), {
+        # template with kwarg assignments
+        # {{1}} assigned test
+        # {{2}} assigned Apprise Message type (special keyword)
+        # {{3}} assigned Apprise Message body (special keyword)
+        'instance': NotifyWhatsApp,
+
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'whatsapp://template:e...e@1...5/%2B44444444444/',
+    }),
+    ('whatsapp://template:{}@12345/{}?:invalid=23'.format(
+        'e' * 32, '4' * 11), {
+        # template with kwarg assignments
+        # Invalid keyword specified; cna only be a digit OR `body' or 'type'
+        'instance': TypeError,
+    }),
+    ('whatsapp://template:{}@12345/{}?:body='.format(
+        'e' * 32, '4' * 11), {
+        # template with kwarg assignments
+        # No Body Assigment
+        'instance': TypeError,
+    }),
+    ('whatsapp://template:{}@12345/{}?:1=Test&:body=1'.format(
+        'e' * 32, '4' * 11), {
+        # template with kwarg assignments
+        # Ambiguious assignment {{1}} assigned twice
+        'instance': TypeError,
+    }),
+    ('whatsapp://{}:{}@123456/{}'.format('a' * 32, 'b' * 32, '4' * 11), {
+        # using short-code (6 characters)
+        'instance': NotifyWhatsApp,
+    }),
+    ('whatsapp://_?token={}&from={}&to={}'.format(
+        'd' * 32, '5' * 11, '6' * 11), {
+        # use get args to acomplish the same thing
+        'instance': NotifyWhatsApp,
+    }),
+    ('whatsapp://_?token={}&source={}&to={}'.format(
+        'd' * 32, '5' * 11, '6' * 11), {
+        # use get args to acomplish the same thing (use source instead of from)
+        'instance': NotifyWhatsApp,
+    }),
+    ('whatsapp://{}@12345/{}'.format('e' * 32, '4' * 11), {
+        'instance': NotifyWhatsApp,
+        # throw a bizzare code forcing us to fail to look it up
+        'response': False,
+        'requests_response_code': 999,
+    }),
+    ('whatsapp://{}@12345/{}'.format('e' * 32, '4' * 11), {
+        'instance': NotifyWhatsApp,
+        # Throws a series of connection and transfer exceptions when this flag
+        # is set and tests that we gracfully handle them
+        'test_requests_exceptions': True,
+    }),
+)
+
+
+def test_plugin_whatsapp_urls():
+    """
+    NotifyWhatsApp() Apprise URLs
+
+    """
+
+    # Run our general tests
+    AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+@mock.patch('requests.post')
+def test_plugin_whatsapp_auth(mock_post):
+    """
+    NotifyWhatsApp() Auth
+      - account-wide auth token
+      - API key and its own auth token
+
+    """
+
+    response = mock.Mock()
+    response.content = ''
+    response.status_code = requests.codes.ok
+
+    # Prepare Mock
+    mock_post.return_value = response
+
+    # Initialize some generic (but valid) tokens
+    token = '{}'.format('b' * 32)
+    from_phone_id = '123456787654321'
+    target = '+1 (555) 987-6543'
+    message_contents = "test"
+
+    # Variation of initialization without API key
+    obj = Apprise.instantiate(
+        'whatsapp://{}@{}/{}'
+        .format(token, from_phone_id, target))
+    assert isinstance(obj, NotifyWhatsApp) is True
+    assert isinstance(obj.url(), str) is True
+
+    # Send Notification
+    assert obj.send(body=message_contents) is True
+
+    # Validate expected call parameters
+    assert mock_post.call_count == 1
+    first_call = mock_post.call_args_list[0]
+
+    # URL and message parameters are the same for both calls
+    assert first_call[0][0] == \
+        'https://graph.facebook.com/v17.0/{}/messages'.format(
+            from_phone_id)
+    response = loads(first_call[1]['data'])
+    assert response['text']['body'] == message_contents
+    assert response['to'] == '+15559876543'
+    assert response['recipient_type'] == 'individual'
+
+
+@mock.patch('requests.post')
+def test_plugin_whatsapp_edge_cases(mock_post):
+    """
+    NotifyWhatsApp() Edge Cases
+
+    """
+
+    # Prepare our response
+    response = requests.Request()
+    response.status_code = requests.codes.ok
+
+    # Prepare Mock
+    mock_post.return_value = response
+
+    # Initialize some generic (but valid) tokens
+    token = 'b' * 32
+    from_phone_id = '123456787654321'
+    targets = ('+1 (555) 123-3456', )
+
+    # No token specified
+    with pytest.raises(TypeError):
+        NotifyWhatsApp(
+            token=None, from_phone_id=from_phone_id, targets=targets)
+
+    # No from_phone_id specified
+    with pytest.raises(TypeError):
+        NotifyWhatsApp(
+            token=token, from_phone_id=None, targets=targets)
+
+    # a error response
+    response.status_code = 400
+    response.content = dumps({
+        'error': {
+            'code': 21211,
+            'message': "The 'To' number +1234567 is not a valid phone number.",
+        },
+    })
+    mock_post.return_value = response
+
+    # Initialize our object
+    obj = NotifyWhatsApp(
+        token=token,
+        from_phone_id=from_phone_id, targets=targets)
+
+    # We will fail with the above error code
+    assert obj.notify('title', 'body', 'info') is False


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #808

Added WhatsApp support
* **Source**: https://developers.facebook.com/docs/whatsapp/cloud-api/get-started
* **Icon Support**: No
* **Attachment Support**: No
* **Message Format**: Text
* **Message Limit**: 1024 Characters per message

### Syntax
Valid syntax is as follows:
* `whatsapp://{token}@{from_phone_id}/{targets}`
* `whatsapp://{template}:{token}@{from_phone_id}/{targets}`

### Parameter Breakdown
| Variable    | Required | Description
| ----------- | -------- | -----------
| token | Yes      | This is the **Access Token** associated with your Meta WhatsApp App
| from | Yes      | This is the **From Phone ID** associated with your Meta WhatsApp App; this isn't to be confused with your actual phone number.  The ID is a separate assignment (about 14 digits long)
| targets |Yes| The target individuals on WhatsApp you wish to notify
| template | No | You can optionally specify a `template_name` here (such as `hello_world` which is the default one created once you set yourself up your Meta App).  This causes Apprise to pull from your template defined.
| lang | No | If you've defined a template to reference, you can optionally over-ride the default language of `en_US` to reference a different version of the template specified.

## Template Variables
The templates you generate allow you to specify `{{1}}` and `{{2}}`, etc which are substituted during the Apprise runtime.  To pre-set these values, simply leverage the `:` (colon) prefix in front of the index you wish to define.

`?:3=My Value` for example would assign `My Value` to `{{3}}` during the runtime.  You must identify all indexes defined or you will get an error from the upstream server. 

If you wish to assign the `body` or `type` from Apprise, these special keywords are specified instead with the `:` (colon) prefix providing the mapping/over-ride.  For example: `?:body=1` would be accepted and would assign `{{1}}` the contents of the `body` passed into Apprise.

## New Service Completion Status
<!-- This section is only applicable if you're adding a new service -->
* [x] apprise/plugins/NotifyWhatsApp.py
* [x] KEYWORDS
    - add new service into this file (alphabetically).
* [x] README.md
    - add entry for new service to table (as a quick reference)
* [x] packaging/redhat/python-apprise.spec
    - add new service into the `%global common_description`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@808-whatsapp-support

# Test out the changes with the following command:
apprise -b "Test Message" \
  "whatsapp://token@from_phone_id/to_phone_no/"

# Templates can be handled like so:
apprise -b "Test Message" \
  "whatsapp://template_name:token@from_phone_id/to_phone_no/"

# If you have defined {{1}} and {{2}} tokens, you can assign them values like so:
apprise -b "Test Message" \
  "whatsapp://template_name:token@from_phone_id/to_phone_no/?:1=the data i want put here&:2=more data here"

# The :<id> is how you map {{<id>}}elements. If you want to associated the body or 
# message type with an id, then there are 2 reserved keywords that you can use for this:
# The below would make sure the Apprise Body value would be placed in the {{1}} element:
apprise -b "Test Message" \
  "whatsapp://template_name:token@from_phone_id/to_phone_no/?:body=1"

# You can mix and match the keywords and types:
apprise -b "Test Message" \
  "whatsapp://template_name:token@from_phone_id/to_phone_no/?:body=2&:type=3&1:MyID1Value"

# It's up to the developer to make sure that all of the {{1}}, {{2}}, etc are assigned correctly

```

