### PR TITLE
Inconsistent Notification Plugin Information Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ sdist/
 
 # Generated from Docker Instance
 .bash_history
+.python_history
 
 # Installer logs
 pip-log.txt

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ sdist/
 .installed.cfg
 *.egg
 
+# Generated from Docker Instance
+.bash_history
+
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt

--- a/apprise/plugins/NotifyBark.py
+++ b/apprise/plugins/NotifyBark.py
@@ -127,10 +127,10 @@ class NotifyBark(NotifyBase):
 
     # Define object templates
     templates = (
+        '{schema}://{host}/{targets}',
         '{schema}://{host}:{port}/{targets}',
         '{schema}://{user}:{password}@{host}/{targets}',
         '{schema}://{user}:{password}@{host}:{port}/{targets}',
-        '{schema}://{user}:{password}@{host}/{targets}',
     )
 
     # Define our template arguments
@@ -163,6 +163,7 @@ class NotifyBark(NotifyBase):
         'targets': {
             'name': _('Targets'),
             'type': 'list:string',
+            'required': True,
         },
     })
 

--- a/apprise/plugins/NotifyBoxcar.py
+++ b/apprise/plugins/NotifyBoxcar.py
@@ -151,6 +151,12 @@ class NotifyBoxcar(NotifyBase):
         'to': {
             'alias_of': 'targets',
         },
+        'access': {
+            'alias_of': 'access_key',
+        },
+        'secret': {
+            'alias_of': 'secret_key',
+        },
     })
 
     def __init__(self, access, secret, targets=None, include_image=True,
@@ -380,6 +386,16 @@ class NotifyBoxcar(NotifyBase):
         if 'to' in results['qsd'] and len(results['qsd']['to']):
             results['targets'] += \
                 NotifyBoxcar.parse_list(results['qsd'].get('to'))
+
+        # Access
+        if 'access' in results['qsd'] and results['qsd']['access']:
+            results['access'] = NotifyBoxcar.unquote(
+                results['qsd']['access'].strip())
+
+        # Secret
+        if 'secret' in results['qsd'] and results['qsd']['secret']:
+            results['secret'] = NotifyBoxcar.unquote(
+                results['qsd']['secret'].strip())
 
         # Include images with our message
         results['include_image'] = \

--- a/apprise/plugins/NotifyBulkSMS.py
+++ b/apprise/plugins/NotifyBulkSMS.py
@@ -121,11 +121,13 @@ class NotifyBulkSMS(NotifyBase):
         'user': {
             'name': _('User Name'),
             'type': 'string',
+            'required': True,
         },
         'password': {
             'name': _('Password'),
             'type': 'string',
             'private': True,
+            'required': True,
         },
         'target_phone': {
             'name': _('Target Phone No'),
@@ -144,6 +146,7 @@ class NotifyBulkSMS(NotifyBase):
         'targets': {
             'name': _('Targets'),
             'type': 'list:string',
+            'required': True,
         },
     })
 

--- a/apprise/plugins/NotifyD7Networks.py
+++ b/apprise/plugins/NotifyD7Networks.py
@@ -114,6 +114,7 @@ class NotifyD7Networks(NotifyBase):
         'targets': {
             'name': _('Targets'),
             'type': 'list:string',
+            'required': True,
         },
     })
 

--- a/apprise/plugins/NotifyDingTalk.py
+++ b/apprise/plugins/NotifyDingTalk.py
@@ -103,13 +103,18 @@ class NotifyDingTalk(NotifyBase):
             'regex': (r'^[a-z0-9]+$', 'i'),
         },
         'secret': {
-            'name': _('Token'),
+            'name': _('Secret'),
             'type': 'string',
             'private': True,
             'regex': (r'^[a-z0-9]+$', 'i'),
         },
-        'targets': {
+        'target_phone_no': {
             'name': _('Target Phone No'),
+            'type': 'string',
+            'map_to': 'targets',
+        },
+        'targets': {
+            'name': _('Targets'),
             'type': 'list:string',
         },
     })

--- a/apprise/plugins/NotifyEmail.py
+++ b/apprise/plugins/NotifyEmail.py
@@ -385,8 +385,13 @@ class NotifyEmail(NotifyBase):
             'min': 1,
             'max': 65535,
         },
+        'target_email': {
+            'name': _('Target Email'),
+            'type': 'string',
+            'map_to': 'targets',
+        },
         'targets': {
-            'name': _('Target Emails'),
+            'name': _('Targets'),
             'type': 'list:string',
         },
     })

--- a/apprise/plugins/NotifyFCM/__init__.py
+++ b/apprise/plugins/NotifyFCM/__init__.py
@@ -157,7 +157,6 @@ class NotifyFCM(NotifyBase):
         'project': {
             'name': _('Project ID'),
             'type': 'string',
-            'required': True,
         },
         'target_device': {
             'name': _('Target Device'),
@@ -173,6 +172,7 @@ class NotifyFCM(NotifyBase):
         'targets': {
             'name': _('Targets'),
             'type': 'list:string',
+            'required': True,
         },
     })
 

--- a/apprise/plugins/NotifyFlock.py
+++ b/apprise/plugins/NotifyFlock.py
@@ -97,8 +97,8 @@ class NotifyFlock(NotifyBase):
     # Define object templates
     templates = (
         '{schema}://{token}',
-        '{schema}://{user}@{token}',
-        '{schema}://{user}@{token}/{targets}',
+        '{schema}://{botname}@{token}',
+        '{schema}://{botname}@{token}/{targets}',
         '{schema}://{token}/{targets}',
     )
 
@@ -111,9 +111,10 @@ class NotifyFlock(NotifyBase):
             'private': True,
             'required': True,
         },
-        'user': {
+        'botname': {
             'name': _('Bot Name'),
             'type': 'string',
+            'map_to': 'user',
         },
         'to_user': {
             'name': _('To User ID'),

--- a/apprise/plugins/NotifyGitter.py
+++ b/apprise/plugins/NotifyGitter.py
@@ -122,9 +122,15 @@ class NotifyGitter(NotifyBase):
             'required': True,
             'regex': (r'^[a-z0-9]{40}$', 'i'),
         },
+        'target_room': {
+            'name': _('Target Room'),
+            'type': 'string',
+            'map_to': 'targets',
+        },
         'targets': {
-            'name': _('Rooms'),
+            'name': _('Targets'),
             'type': 'list:string',
+            'required': True,
         },
     })
 

--- a/apprise/plugins/NotifyGotify.py
+++ b/apprise/plugins/NotifyGotify.py
@@ -134,7 +134,6 @@ class NotifyGotify(NotifyBase):
             'type': 'string',
             'map_to': 'fullpath',
             'default': '/',
-            'required': True,
         },
         'port': {
             'name': _('Port'),

--- a/apprise/plugins/NotifyJoin.py
+++ b/apprise/plugins/NotifyJoin.py
@@ -174,7 +174,6 @@ class NotifyJoin(NotifyBase):
         'targets': {
             'name': _('Targets'),
             'type': 'list:string',
-            'required': True,
         },
     })
 

--- a/apprise/plugins/NotifyLametric.py
+++ b/apprise/plugins/NotifyLametric.py
@@ -370,6 +370,7 @@ class NotifyLametric(NotifyBase):
 
         # Device Mode
         '{schema}://{apikey}@{host}',
+        '{schema}://{user}:{apikey}@{host}',
         '{schema}://{apikey}@{host}:{port}',
         '{schema}://{user}:{apikey}@{host}:{port}',
     )
@@ -404,7 +405,6 @@ class NotifyLametric(NotifyBase):
         'host': {
             'name': _('Hostname'),
             'type': 'string',
-            'required': True,
         },
         'port': {
             'name': _('Port'),

--- a/apprise/plugins/NotifyLine.py
+++ b/apprise/plugins/NotifyLine.py
@@ -102,6 +102,7 @@ class NotifyLine(NotifyBase):
         'targets': {
             'name': _('Targets'),
             'type': 'list:string',
+            'required': True
         },
     })
 

--- a/apprise/plugins/NotifyMSG91.py
+++ b/apprise/plugins/NotifyMSG91.py
@@ -133,6 +133,7 @@ class NotifyMSG91(NotifyBase):
         'targets': {
             'name': _('Targets'),
             'type': 'list:string',
+            'required': True,
         },
         'sender': {
             'name': _('Sender ID'),

--- a/apprise/plugins/NotifyMailgun.py
+++ b/apprise/plugins/NotifyMailgun.py
@@ -152,8 +152,13 @@ class NotifyMailgun(NotifyBase):
             'private': True,
             'required': True,
         },
+        'target_email': {
+            'name': _('Target Email'),
+            'type': 'string',
+            'map_to': 'targets',
+        },
         'targets': {
-            'name': _('Target Emails'),
+            'name': _('Targets'),
             'type': 'list:string',
         },
     })

--- a/apprise/plugins/NotifyMatrix.py
+++ b/apprise/plugins/NotifyMatrix.py
@@ -175,7 +175,6 @@ class NotifyMatrix(NotifyBase):
         'host': {
             'name': _('Hostname'),
             'type': 'string',
-            'required': True,
         },
         'port': {
             'name': _('Port'),
@@ -194,6 +193,7 @@ class NotifyMatrix(NotifyBase):
         },
         'token': {
             'name': _('Access Token'),
+            'private': True,
             'map_to': 'password',
         },
         'target_user': {

--- a/apprise/plugins/NotifyMattermost.py
+++ b/apprise/plugins/NotifyMattermost.py
@@ -91,11 +91,11 @@ class NotifyMattermost(NotifyBase):
     # Define object templates
     templates = (
         '{schema}://{host}/{token}',
-        '{schema}://{host}/{token}:{port}',
+        '{schema}://{host}:{port}/{token}',
+        '{schema}://{host}/{fullpath}/{token}',
+        '{schema}://{host}:{port}/{fullpath}/{token}',
         '{schema}://{botname}@{host}/{token}',
         '{schema}://{botname}@{host}:{port}/{token}',
-        '{schema}://{host}/{fullpath}/{token}',
-        '{schema}://{host}/{fullpath}{token}:{port}',
         '{schema}://{botname}@{host}/{fullpath}/{token}',
         '{schema}://{botname}@{host}:{port}/{fullpath}/{token}',
     )

--- a/apprise/plugins/NotifyNextcloud.py
+++ b/apprise/plugins/NotifyNextcloud.py
@@ -67,6 +67,8 @@ class NotifyNextcloud(NotifyBase):
 
     # Define object templates
     templates = (
+        '{schema}://{host}/{targets}',
+        '{schema}://{host}:{port}/{targets}',
         '{schema}://{user}:{password}@{host}/{targets}',
         '{schema}://{user}:{password}@{host}:{port}/{targets}',
     )

--- a/apprise/plugins/NotifyNextcloudTalk.py
+++ b/apprise/plugins/NotifyNextcloudTalk.py
@@ -96,6 +96,11 @@ class NotifyNextcloudTalk(NotifyBase):
             'private': True,
             'required': True,
         },
+        'target_room_id': {
+            'name': _('Room ID'),
+            'type': 'string',
+            'map_to': 'targets',
+        },
         'targets': {
             'name': _('Targets'),
             'type': 'list:string',

--- a/apprise/plugins/NotifyNotica.py
+++ b/apprise/plugins/NotifyNotica.py
@@ -112,12 +112,12 @@ class NotifyNotica(NotifyBase):
         '{schema}://{user}:{password}@{host}:{port}/{token}',
 
         # Self-hosted notica servers (with custom path)
-        '{schema}://{host}{path}{token}',
-        '{schema}://{host}:{port}{path}{token}',
-        '{schema}://{user}@{host}{path}{token}',
-        '{schema}://{user}@{host}:{port}{path}{token}',
-        '{schema}://{user}:{password}@{host}{path}{token}',
-        '{schema}://{user}:{password}@{host}:{port}{path}{token}',
+        '{schema}://{host}{path}/{token}',
+        '{schema}://{host}:{port}/{path}/{token}',
+        '{schema}://{user}@{host}/{path}/{token}',
+        '{schema}://{user}@{host}:{port}{path}/{token}',
+        '{schema}://{user}:{password}@{host}{path}/{token}',
+        '{schema}://{user}:{password}@{host}:{port}/{path}/{token}',
     )
 
     # Define our template tokens

--- a/apprise/plugins/NotifyOffice365.py
+++ b/apprise/plugins/NotifyOffice365.py
@@ -148,9 +148,10 @@ class NotifyOffice365(NotifyBase):
             'private': True,
             'required': True,
         },
-        'targets': {
+        'target_email': {
             'name': _('Target Email'),
             'type': 'string',
+            'map_to': 'targets',
         },
         'targets': {
             'name': _('Targets'),

--- a/apprise/plugins/NotifyOffice365.py
+++ b/apprise/plugins/NotifyOffice365.py
@@ -149,7 +149,11 @@ class NotifyOffice365(NotifyBase):
             'required': True,
         },
         'targets': {
-            'name': _('Target Emails'),
+            'name': _('Target Email'),
+            'type': 'string',
+        },
+        'targets': {
+            'name': _('Targets'),
             'type': 'list:string',
         },
     })

--- a/apprise/plugins/NotifyOneSignal.py
+++ b/apprise/plugins/NotifyOneSignal.py
@@ -146,6 +146,7 @@ class NotifyOneSignal(NotifyBase):
         'targets': {
             'name': _('Targets'),
             'type': 'list:string',
+            'required': True,
         },
     })
 

--- a/apprise/plugins/NotifyPagerDuty.py
+++ b/apprise/plugins/NotifyPagerDuty.py
@@ -142,7 +142,7 @@ class NotifyPagerDuty(NotifyBase):
         },
         # Optional but triggers V2 API
         'integrationkey': {
-            'name': _('Routing Key'),
+            'name': _('Integration Key'),
             'type': 'string',
             'private': True,
             'required': True

--- a/apprise/plugins/NotifyPopcornNotify.py
+++ b/apprise/plugins/NotifyPopcornNotify.py
@@ -93,6 +93,7 @@ class NotifyPopcornNotify(NotifyBase):
         'targets': {
             'name': _('Targets'),
             'type': 'list:string',
+            'required': True,
         }
     })
 

--- a/apprise/plugins/NotifyReddit.py
+++ b/apprise/plugins/NotifyReddit.py
@@ -186,6 +186,7 @@ class NotifyReddit(NotifyBase):
         'targets': {
             'name': _('Targets'),
             'type': 'list:string',
+            'required': True,
         },
     })
 

--- a/apprise/plugins/NotifyRyver.py
+++ b/apprise/plugins/NotifyRyver.py
@@ -91,7 +91,7 @@ class NotifyRyver(NotifyBase):
     # Define object templates
     templates = (
         '{schema}://{organization}/{token}',
-        '{schema}://{user}@{organization}/{token}',
+        '{schema}://{botname}@{organization}/{token}',
     )
 
     # Define our template tokens
@@ -109,9 +109,10 @@ class NotifyRyver(NotifyBase):
             'private': True,
             'regex': (r'^[A-Z0-9]{15}$', 'i'),
         },
-        'user': {
+        'botname': {
             'name': _('Bot Name'),
             'type': 'string',
+            'map_to': 'user',
         },
     })
 

--- a/apprise/plugins/NotifySES.py
+++ b/apprise/plugins/NotifySES.py
@@ -174,6 +174,7 @@ class NotifySES(NotifyBase):
             'name': _('Region'),
             'type': 'string',
             'regex': (r'^[a-z]{2}-[a-z-]+?-[0-9]+$', 'i'),
+            'required': True,
             'map_to': 'region_name',
         },
         'targets': {

--- a/apprise/plugins/NotifySMSEagle.py
+++ b/apprise/plugins/NotifySMSEagle.py
@@ -145,6 +145,7 @@ class NotifySMSEagle(NotifyBase):
         'token': {
             'name': _('Access Token'),
             'type': 'string',
+            'required': True,
         },
         'target_phone': {
             'name': _('Target Phone No'),
@@ -170,6 +171,7 @@ class NotifySMSEagle(NotifyBase):
         'targets': {
             'name': _('Targets'),
             'type': 'list:string',
+            'required': True,
         }
     })
 

--- a/apprise/plugins/NotifySNS.py
+++ b/apprise/plugins/NotifySNS.py
@@ -103,7 +103,7 @@ class NotifySNS(NotifyBase):
 
     # Define object templates
     templates = (
-        '{schema}://{access_key_id}/{secret_access_key}{region}/{targets}',
+        '{schema}://{access_key_id}/{secret_access_key}/{region}/{targets}',
     )
 
     # Define our template tokens
@@ -125,6 +125,7 @@ class NotifySNS(NotifyBase):
             'type': 'string',
             'required': True,
             'regex': (r'^[a-z]{2}-[a-z-]+?-[0-9]+$', 'i'),
+            'required': True,
             'map_to': 'region_name',
         },
         'target_phone_no': {

--- a/apprise/plugins/NotifyServerChan.py
+++ b/apprise/plugins/NotifyServerChan.py
@@ -68,7 +68,7 @@ class NotifyServerChan(NotifyBase):
 
     # Define object templates
     templates = (
-        '{schema}://{token}/',
+        '{schema}://{token}',
     )
 
     # Define our template tokens

--- a/apprise/plugins/NotifySimplePush.py
+++ b/apprise/plugins/NotifySimplePush.py
@@ -109,12 +109,12 @@ class NotifySimplePush(NotifyBase):
 
         # Used for encrypted logins
         'password': {
-            'name': _('Encrypted Password'),
+            'name': _('Password'),
             'type': 'string',
             'private': True,
         },
         'salt': {
-            'name': _('Encrypted Salt'),
+            'name': _('Salt'),
             'type': 'string',
             'private': True,
             'map_to': 'user',

--- a/apprise/plugins/NotifySlack.py
+++ b/apprise/plugins/NotifySlack.py
@@ -165,10 +165,10 @@ class NotifySlack(NotifyBase):
     # Define object templates
     templates = (
         # Webhook
-        '{schema}://{token_a}/{token_b}{token_c}',
+        '{schema}://{token_a}/{token_b}/{token_c}',
         '{schema}://{botname}@{token_a}/{token_b}{token_c}',
-        '{schema}://{token_a}/{token_b}{token_c}/{targets}',
-        '{schema}://{botname}@{token_a}/{token_b}{token_c}/{targets}',
+        '{schema}://{token_a}/{token_b}/{token_c}/{targets}',
+        '{schema}://{botname}@{token_a}/{token_b}/{token_c}/{targets}',
 
         # Bot
         '{schema}://{access_token}/',
@@ -198,7 +198,6 @@ class NotifySlack(NotifyBase):
             'name': _('Token A'),
             'type': 'string',
             'private': True,
-            'required': True,
             'regex': (r'^[A-Z0-9]+$', 'i'),
         },
         # Token required as part of the Webhook request
@@ -207,7 +206,6 @@ class NotifySlack(NotifyBase):
             'name': _('Token B'),
             'type': 'string',
             'private': True,
-            'required': True,
             'regex': (r'^[A-Z0-9]+$', 'i'),
         },
         # Token required as part of the Webhook request
@@ -216,7 +214,6 @@ class NotifySlack(NotifyBase):
             'name': _('Token C'),
             'type': 'string',
             'private': True,
-            'required': True,
             'regex': (r'^[A-Za-z0-9]+$', 'i'),
         },
         'target_encoded_id': {

--- a/apprise/plugins/NotifySpontit.py
+++ b/apprise/plugins/NotifySpontit.py
@@ -135,7 +135,6 @@ class NotifySpontit(NotifyBase):
         'targets': {
             'name': _('Targets'),
             'type': 'list:string',
-            'required': True,
         },
     })
 

--- a/apprise/plugins/NotifySyslog.py
+++ b/apprise/plugins/NotifySyslog.py
@@ -165,7 +165,6 @@ class NotifySyslog(NotifyBase):
         'host': {
             'name': _('Hostname'),
             'type': 'string',
-            'required': True,
         },
         'port': {
             'name': _('Port'),

--- a/apprise/plugins/NotifyTwist.py
+++ b/apprise/plugins/NotifyTwist.py
@@ -106,10 +106,12 @@ class NotifyTwist(NotifyBase):
             'name': _('Password'),
             'type': 'string',
             'private': True,
+            'required': True,
         },
         'email': {
             'name': _('Email'),
             'type': 'string',
+            'required': True,
         },
         'target_channel': {
             'name': _('Target Channel'),

--- a/apprise/plugins/NotifyTwitter.py
+++ b/apprise/plugins/NotifyTwitter.py
@@ -132,6 +132,7 @@ class NotifyTwitter(NotifyBase):
     ratelimit_remaining = 1
 
     templates = (
+        '{schema}://{ckey}/{csecret}/{akey}/{asecret}',
         '{schema}://{ckey}/{csecret}/{akey}/{asecret}/{targets}',
     )
 

--- a/apprise/plugins/NotifyVoipms.py
+++ b/apprise/plugins/NotifyVoipms.py
@@ -78,7 +78,6 @@ class NotifyVoipms(NotifyBase):
 
     # Define object templates
     templates = (
-        '{schema}://{password}:{email}',
         '{schema}://{password}:{email}/{from_phone}/{targets}',
     )
 
@@ -111,6 +110,7 @@ class NotifyVoipms(NotifyBase):
         'targets': {
             'name': _('Targets'),
             'type': 'list:string',
+            'required': True,
         },
     })
 

--- a/apprise/plugins/NotifyZulip.py
+++ b/apprise/plugins/NotifyZulip.py
@@ -131,6 +131,7 @@ class NotifyZulip(NotifyBase):
             'name': _('Bot Name'),
             'type': 'string',
             'regex': (r'^[A-Z0-9_-]{1,32}$', 'i'),
+            'required': True,
         },
         'organization': {
             'name': _('Organization'),

--- a/apprise/plugins/__init__.py
+++ b/apprise/plugins/__init__.py
@@ -198,11 +198,12 @@ def _sanitize_token(tokens, default_delimiter):
                 # Default list delimiter (if not otherwise specified)
                 tokens[key]['delim'] = default_delimiter
 
-            if key in group_map[tokens[key]['map_to']]:
+            if key in group_map[tokens[key]['map_to']]:  # pragma: no branch
                 # Remove ourselves from the list
                 group_map[tokens[key]['map_to']].remove(key)
 
-            # Pointing to the set directly so we can dynamically update ourselves
+            # Pointing to the set directly so we can dynamically update
+            # ourselves
             tokens[key]['group'] = group_map[tokens[key]['map_to']]
 
         elif tokens[key]['type'].startswith('choice') \
@@ -281,9 +282,11 @@ def details(plugin):
     #            # Identifies if the entry specified is required or not
     #            'required': True,
     #
-    #            # Identifies all tokens detected to be associated with the list:string
-    #            # This is ony present in list:string objects and is only set if there
-    #            # are groups defined
+    #            # Identifies all tokens detected to be associated with the
+    #            # list:string
+    #            # This is ony present in list:string objects and is only set
+    #            # if this element acts as an alias for several other
+    #            # kwargs/fields.
     #            'group': [],
     #
     #            # Identify a default value

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1486,6 +1486,7 @@ def test_apprise_details_plugin_verification():
     valid_schema_keys = (
         'name', 'private', 'required', 'type', 'values', 'min', 'max',
         'regex', 'default', 'list', 'delim', 'prefix', 'map_to', 'alias_of',
+        'group',
     )
     for entry in details['schemas']:
 

--- a/test/test_plugin_boxcar.py
+++ b/test/test_plugin_boxcar.py
@@ -89,6 +89,12 @@ apprise_url_tests = (
         'instance': NotifyBoxcar,
         'requests_response_code': requests.codes.created,
     }),
+    ('boxcar://?access=%s&secret=%s&to=tag5' % ('d' * 64, 'b' * 64), {
+        # Test access and secret kwargs
+        'privacy_url': 'boxcar://d...d/****/',
+        'instance': NotifyBoxcar,
+        'requests_response_code': requests.codes.created,
+    }),
     # An invalid tag
     ('boxcar://%s/%s/@%s' % ('a' * 64, 'b' * 64, 't' * 64), {
         'instance': NotifyBoxcar,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #886

Kudos to @Casvt who has done a phenomenal job in identifying a lot of inconsistencies for those who are building around the `details()` (Apprise) function ([found here](https://github.com/Casvt/MIND/issues/3)).

This Merge Request is in efforts to identify and fix what can be done.

AWS SES
1. Same problem as error 18. :heavy_check_mark: - Fixed
1. The token "From Email" is set as not required, but it is. :heavy_check_mark: - Fixed

AWS SNS
1. The token "Region" maps to "region_name" but in the template it's called "region".  :heavy_check_mark: - Fixed

1. A / is missing between {secret_access_key} and {region} in the template. :heavy_check_mark: - Fixed

Bark
1. Index 1 and 3 are the same.  :heavy_check_mark: - Fixed
1. Also, index 1 suggests that the port isn't required, and in the token list the port is also not marked as required, but there is no template with just the host and targets ({schema}://{host}/{targets}).  :heavy_check_mark: - Fixed
1. The token "targets" is set as not required, but it is.  :heavy_check_mark: - Fixed
1. Resulting from 68, following 10, the token "Target Device" should be set as required. :rocket: - This is intended behavior.  Target Device inherits from `targets` (`alias_of`) which is now updated as per your point before.

Boxcar
1. The token with the name "Access Key" maps to "access", but in the templates it's called "access_key".  :heavy_check_mark: - Fixed
1. The token with the name "Secret Key" maps to "secret", but in the templates it's called "secret_key".  :heavy_check_mark: - Fixed
1. :star: added `access` and `secret` kwargs for consistency with other plugins

BulkSMS
1. All tokens are marked as not required, but they're all required. :heavy_check_mark: - Fixed

ClickSend
1. [In the wiki](https://github.com/caronc/apprise/wiki/Notify_clicksend#syntax), the first syntax should have it's last / removed. It should be `clicksend://{user}:{password}@{PhoneNo}`  :heavy_check_mark: - Fixed

1. The wiki says that PhoneNo (targets) needs at least one value. That's why the token "targets" is set as required, but the token "Target Phone No", which is what "targets" consists of, should also be set as required then. :rocket: - This is intended behavior.  Target Phone inherits from `targets` (`alias_of`)

D7 Networks
1. [In the wiki](https://github.com/caronc/apprise/wiki/Notify_d7networks#syntax), there are erroneous `/` (forward-slashes) that should be removed.  :heavy_check_mark: - Fixed
1. The token "Target Phone No" is marked as not required, even though it is (similar to ClickSend Error 2 above).  :rocket: - This is intended behavior (for same reason)
1. The token "targets" is marked as not required, even though it is.   :heavy_check_mark: - Fixed

Dapnet
1. The token "Target Callsign" is marked as not required, even though it is (similar to ClickSend Error 2 above).  :rocket: - This is intended behavior (for same reason)

DingTalk
1. Both tokens have the name "Token", which is confusing. The second token should have the name "Secret".  :heavy_check_mark: - Fixed
1. Expand on `{targets}` for consistency with other plugins  :heavy_check_mark: - Fixed

Discord
1. The token with the name "Bot Name" maps to "user", but in the templates it's called "botname". :rocket: - This is intended behavior.  This is somewhat poorly documented with Apprise, but the keywords `user` and `password` are mapped to absolutely every single Apprise Plugin there is.  The same goes for `host` and `port`.  These are tied directly to just the straight definition to a URL.  So in some places i'll `map_to` `host`, `port`, `user`, or `password` because of the internal inheritance.  I thought `botname` was a better way to present to the user what needs to be entered there, and internally i'm mapping it to the `user` field.  I can see (based on what you're building) how this could be convoluted.   I would say though (for front end... just fully out ignore `map_to`.  focus only on `alias_of` entries as they tie back and forth between the args, kwargs, and url definitions.

Email
1. Expand on `{targets}` for consistency with other plugins  :heavy_check_mark: - Fixed

Emby
1. [In the wiki](https://github.com/caronc/apprise/wiki/Notify_emby), the syntax `emby://{userid}:{password}@{hostname}` is missing. :heavy_check_mark: - Fixed

1. [In the wiki](https://github.com/caronc/apprise/wiki/Notify_emby), the syntax `embys://{userid}:{password}@{hostname}` is missing. :heavy_check_mark: - Fixed

Enigma2
1. [In the wiki](https://github.com/caronc/apprise/wiki/Notify_enigma2), there is no documentation for `{fullpath}` :heavy_check_mark: - Fixed

FCM (Firebase Cloud Messaging)
1. The token "project" is set as required but the second template doesn't require it, so it should not be required. :heavy_check_mark: - Fixed

1. The token "targets" is set as not required, but all templates require it, so it should be required. :heavy_check_mark: - Fixed

Flock
1. The token "Bot Name" maps to "user". This is correct because in the templates, the name "{user}" is used. So it's correct but a bit strange... why not "{botname}"? The wiki also uses "{botname}".  :heavy_check_mark: - Fixed

FORM
1. [In the wiki](https://github.com/caronc/apprise/wiki/Notify_Custom_Form), reference to the templates `{schema}://{user}@{host}` and `{schema}://{user}@{host}:{port}` is missing.  :heavy_check_mark: - Fixed

Gitter

1. The token "targets" is set as not required but actually is required.  :heavy_check_mark: - Fixed
1. Expand on `{targets}` for consistency with other plugins  :heavy_check_mark: - Fixed

This plugin needs a rewrite; see #835; but for now it has been updated for it's inconsistencies

Gotify

1. The token "Path" maps to `fullpath` but in the templates the variable is "{path}". :rocket: - This is intended behavior. See Discord bullet above.
1. The token "Path" is marked as required but it isn't.  :heavy_check_mark: - Fixed

Guilded
1. The token "Bot Name" maps to "user" but in the templates the variable is "{botname}".  :heavy_check_mark: - Fixed

IFTTT
1. Expand on `{targets}` for consistency with other plugins  :question: - I'm not sure if i want to change this.  IFTTT is so simple; it will never contain other types of targets beyond events.  So having a single list of `{events}` (as is) seems a bit more ideal.  But I'm open to discussion

Join

1. According to the wiki, the token "Targets" is not required, but it is marked as required in the details output.  :heavy_check_mark: - Fixed
1. I've never used Join before so I'm not sure if I'm correct but the token "Group" gives select options for a platform while the wiki makes it seem to me that you need to supply an ID. :bulb: The `group` is just another optional `target`. So no worries here (or change required).

Kavenegar

1. The token "Target Phone No" is marked as not required, even though it is (similar to ClickSend Error 2 above). :rocket: - This is intended behavior (for same reason)

Kodi

1. The following template is missing in the wiki: `{schema}://{user}:{password}@{host}`.  :heavy_check_mark: - Fixed

LaMetric

1. The following template is missing in the details output: `{schema}://{user}:{apikey}@{host}`.  :heavy_check_mark: - Fixed
1. The token "Hostname" is marked as required, but isn't.  :heavy_check_mark: - Fixed

Line

1. The token "targets" is not marked as required, but it is. :heavy_check_mark: - Fixed
1. Resulting from 38, following 10, the token "Target User" should be set as required. :rocket: - This is intended behavior 

Mailgun

1. Expand on `{targets}` for consistency with other plugins  :heavy_check_mark: - Fixed

Matrix

1. (Not completely sure) The token "Access Token" should map to "token", not "password". :rocket: - This is intended behavior.  I think the `map_to` variable needs to be revisited; perhaps a third variable needs to be introduced due to it's confusion to help with the mapping you're doing.
1. The token "host" is set as required, but isn't.  :heavy_check_mark: - Fixed

Mattermost

1. The templates with indexes 1 and 5 have the "port" token at the wrong place. :heavy_check_mark: - Fixed
1. A / is missing at index 5 between "fullpath" and "token".   :heavy_check_mark: - Fixed
1. The token "Bot Name" maps to "user" but should instead map to "botname".  :rocket: - This is intended behavior.

MSG91

1. The `targets` token is set as not required, but it is. :heavy_check_mark: - Fixed
1. Resulting from previous point, the token "Target Phone" should be set as required.  :rocket: - This is intended behavior.

MSTeams

1. The token "Team Name" is set as required but isn't.  :rocket: - This is intended behavior. The old schema is deprecated and all new accounts require a team name to be specified.

NextCloud

1. The token "Target User" should be set as required.  :rocket: - This is intended behavior.
1. Templates that don't contain the "user" token and "password" token are missing.  :heavy_check_mark: - Fixed

NextCloud Talk

1. Expand on `{targets}` for consistency with other plugins  :heavy_check_mark: - Fixed

Notica

1. The token "Path" maps to "fullpath" but should map to "path". However, the wiki doesn't mention this variable so maybe it's not supported anymore and should be removed from the details output?  :rocket: - This is intended behavior. `fullpath` is a poorly undocumented variable that is mappable. 
1. Should there be a / between the "path" token and the "token" token in the templates?  :heavy_check_mark: - Fixed

Office 365

1. Expand on `{targets}` for consistency with other plugins  :heavy_check_mark: - Fixed

OneSignal

1. The token "targets" is set as not required, even though it is. :heavy_check_mark: - Fixed

Pager Duty
1. rename the token "Routing Key" to "Integration Key"  :heavy_check_mark: - Fixed

PopcornNotify
1. The token "targets" is set as not required, but it is. :heavy_check_mark: - Fixed

Pushjet
1. The wiki is missing the template `{schema}://{user}:{password}@{host}:{port}/{secret_key}`  :heavy_check_mark:  - Fixed

Reddit
1. The token "targets" should be required. :heavy_check_mark:  - Fixed
1. Resulting from 59, following 10, the token "Target Subreddit" should be required. :rocket: - This is intended behavior.

Ryver
1. The token "Bot Name" maps to "user". This is correct because in the templates, the name "{user}" is used. So it's correct but a bit strange... why not "{botname}"? The wiki also uses "{botname}".  :heavy_check_mark: - Fixed

ServerChan
1. Both in the wiki and in the details output, the trailing / in the template can be removed.  :heavy_check_mark: - Fixed

Signal API
1. The token `From Phone No` maps to `source` but should instead map to `from_phone`.  :rocket: - This is intended behavior.

SimplePush

1. The token "Encrypted Salt" maps to "user" but should instead map to "salt". :rocket: - This is intended behavior.
1. It's unclear in the wiki if the password and salt are used for encryption or if they're encrypted themselves.  :heavy_check_mark: - Fixed; The word "Encrypted" has been dropped the description in the Plugin to hopefully eliminate the confusion.
1. In the wiki -> Parameter Breakdown -> Variable = password -> Description is a typo ppassword -> password. :heavy_check_mark: - Fixed

Sinch

The token "From Phone No" maps to "source" but should instead map to "from_phone". :rocket: - This is intended behavior.

Slack

1. A `/` is missing in the templates between the tokens "token_b" and "token_c".  :heavy_check_mark: - Fixed
1. The tokens `token_a`, `token_b` and `token_c` are marked as required, but actually aren't. :heavy_check_mark: - Fixed
1. The token "Bot Name" maps to "user" but should instead map to "botname". :rocket: - This is intended behavior.

SMS Eagle
1. The token "token" is set as not required, but it is. :heavy_check_mark: - Fixed
1. The token "targets" is set as not required, but it is. :heavy_check_mark: - Fixed
1. The tokens "Target Phone No", "Target Group ID" and "Target Contact" should also be set as required. :rocket: - This is intended behavior.

SMTP2Go
1. Expand on `{targets}` for consistency with other plugins  :rocket: - This change was made already in several places, but the intent of the separation is only for cases where you accept multiple types (such as a group, user, etc).  When the list cwill only ever consist of a single type, I'm not sure if the expansion of the code is nessisary.  It should just be implied there is no grouping.  I do however feel that the ones that have been expanded above will take advantage of new `group` keyword discussed

SparkPost

1. Expand on `{targets}` for consistency with other plugins  :rocket: - See SMTP2Go (above) discussion

Spontit

1. The token `targets` is marked as required but isn't.  :heavy_check_mark:  - Fixed

Syslog

1. The token "host" is set as required, but isn't.  :heavy_check_mark:  - Fixed

Twilio
1. The token "From Phone No" maps to "source" but should instead map to "from_phone".  :rocket: - This is intended behavior.

Twist
1. The token "password" is set as not required, but it is. :heavy_check_mark:  - Fixed
1. The token "email" is set as not required, but it is. :heavy_check_mark:  - Fixed
1. The following is not present in the details output:
        Twist always associates your account with a *default team*.  Apprise determines this for you and by default notifies the channels you specify from within it. However, since it is possible to have your login/password associated with more then one **Team**. You can use the colon (:) as a delimiter to explicitly identify which team/channel you wish to message.
        
        * **twist**://**{password}**:**{email}**/#**{team}**:**{channel}**
        * **twist**://**{email}**/**{password}**/#**{team}**:**{channel}**

For the last bullet above, this information comes from the targets.  I'm not sure how to capture something like this outside of the wiki documentation?

Twitter

The token "targets" can not be found in the wiki. :heavy_check_mark:  - Fixed.  I also updated the Service to allow for a URL without the `target` defined since it's not required

VoIPms

1. At the parameter breakdown -> Variable = to | from -> Required, the star is never explained. It references nothing. :heavy_check_mark:  - Fixed
1. In the wiki, "fromPhoneNo" ("from_phone") is required in each template, but in the details output there is a template without it.  :heavy_check_mark:  - Fixed
1. The token "From Phone No" maps to "source" but should instead map to "from_phone".  :rocket: - This is intended behavior.

Vonage

1. The token "From Phone No" maps to "source" but should instead map to "from_phone".  :rocket: - This is intended behavior.

Zulip

1. The token "botname" is set as not required, but it is.  :heavy_check_mark:  - Fixed

### Group Keyword Addon
Now the `apprise.details()` will additionally return a new keyword called `group` for all `list:*` types.  The `group` will contain a set of all the elements it comprises of.

The `group` list will never hold the id of the `list:string` itself.  So in the event the `group` list is empty, it simply implies there is no grouping.  The entry should be considered a simple list.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@886-inconsistent-details
```

Now you can access the details:
```python
import apprise
import json

apobj = apprise.Apprise()

# Print our output
apobj.details()
```
