### PR TITLE
Ntfy inline images displayed 

### DIFF
--- a/apprise/plugins/NotifyNtfy.py
+++ b/apprise/plugins/NotifyNtfy.py
@@ -490,7 +490,7 @@ class NotifyNtfy(NotifyBase):
             data['topic'] = topic
             virt_payload = data
 
-            if not self.attach:
+            if self.attach:
                 virt_payload['attach'] = self.attach
 
                 if self.filename:

--- a/apprise/plugins/NotifyNtfy.py
+++ b/apprise/plugins/NotifyNtfy.py
@@ -528,7 +528,8 @@ class NotifyNtfy(NotifyBase):
             params['filename'] = attach.name
 
             # prepare our files object
-            files = {'file': (attach.name, open(attach.path, 'rb'))}
+            files = {'file': (
+                attach.name, open(attach.path, 'rb'), attach.mimetype)}
 
         elif self.attach is not None:
             data['attach'] = self.attach


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #888 

Inline images are not displayed.

```bash
# This works:
curl -T test/var/apprise-test.jpeg \
   localhost:8080/test?filename=apprise-test.jpeg -vvv
```

Server Response
- mime-type get's set to `image/jpeg` as expected
    ```json
    {"id":"jhMKlWLVdsno","time":1687709611,"expires":1687752811,"event":"message","topic":"test","message":"You received a file: apprise-test.jpeg","attachment":{"name":"apprise-test.jpeg","type":"image/jpeg","size":73667,"expires":1687720411,"url":"http://localhost:8080/file/jhMKlWLVdsno.jpg"}}
    ```
- ![Screenshot from 2023-06-25 12-39-27](https://github.com/caronc/apprise/assets/850374/72f0509b-629d-4f33-a223-931d077fd5d9)

```bash
# This doesn't work:
bin/apprise -vv ntfy://localhost:8080/test -b test \
  --attach test/var/apprise-test.jpeg

```

Server Response
- mime-type get's set to `application/octet-stream` for some reason
    ```json
    {"id": "tAv3ijYRHTeX", "time": 1687709905, "expires": 1687753105, "event": "message", "topic": "test", "message": "test", "icon": "https://github.com/caronc/apprise/raw/master/apprise/assets/themes/default/apprise-info-256x256.png", "attachment": {"name": "apprise-test.jpeg", "type": "application/octet-stream", "size": 73846, "expires": 1687720705, "url": "http://localhost:8080/file/tAv3ijYRHTeX.bin"}}
    ```
-  ![Screenshot from 2023-06-25 12-39-05](https://github.com/caronc/apprise/assets/850374/b6b815d0-4c6d-4266-a4e6-648743888989)

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@888-ntfy-image-inline-display

# Create a ntfy configuration to test against (set with attachment support)
cat << _EOF > ~/ntfy.server.yml
base-url: "http://localhost:8080"
attachment-cache-dir: "/var/cache/ntfy/attachments"
_EOF

# Start ntfy with Attachment support
docker run -p 8080:80 -v ~/ntfy.server.yml:/etc/ntfy/server.yml:ro -it binwiederhier/ntfy:v2.5.0 serve

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message"  "ntfy://localhost:8080/test"

```

 