### PR TITLE
Bugfix: Telegram attachments respect topic thread

### DIFF
--- a/apprise/plugins/NotifyTelegram.py
+++ b/apprise/plugins/NotifyTelegram.py
@@ -471,11 +471,14 @@ class NotifyTelegram(NotifyBase):
         # content can arrive together.
         self.throttle()
 
+        payload = {'chat_id': chat_id}
+        if self.topic:
+            payload['message_thread_id'] = self.topic
+
         try:
             with open(path, 'rb') as f:
                 # Configure file payload (for upload)
                 files = {key: (file_name, f)}
-                payload = {'chat_id': chat_id}
 
                 self.logger.debug(
                     'Telegram attachment POST URL: %s (cert_verify=%r)' % (


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #881

Bugfix to allow attachments to properly get posted to the topic they were specified for.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@881-telegram-images-in-thread

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "tgram://credentials/?topic=setme" \
  --attach=/a/path/to/a/file/to/attach

```

