### PR TITLE
Corrected port for Matrix Plugin

### DIFF
--- a/apprise/plugins/NotifyMatrix.py
+++ b/apprise/plugins/NotifyMatrix.py
@@ -991,11 +991,11 @@ class NotifyMatrix(NotifyBase):
         default_port = 443 if self.secure else 80
 
         url = \
-            '{schema}://{hostname}:{port}{matrix_api}{path}'.format(
+            '{schema}://{hostname}{port}{matrix_api}{path}'.format(
                 schema='https' if self.secure else 'http',
                 hostname=self.host,
                 port='' if self.port is None
-                or self.port == default_port else self.port,
+                or self.port == default_port else f':{self.port}',
                 matrix_api=MATRIX_V2_API_PATH,
                 path=path)
 
@@ -1031,6 +1031,7 @@ class NotifyMatrix(NotifyBase):
                     timeout=self.request_timeout,
                 )
 
+                self.logger.debug('Matrix Response: %s' % str(r.content))
                 response = loads(r.content)
 
                 if r.status_code == 429:


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** n/a

A small bug with the Matrix plugin prevented it from generating the proper upstream URL when no port is specified. 

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@matrix-cleanup

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "matrixs://mylocalserver/#channel"

```

