### PR TITLE
Removed formatting of title when not blended with body

### DIFF
--- a/test/test_plugin_title_maxlen.py
+++ b/test/test_plugin_title_maxlen.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+# BSD 3-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2023, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import os
+from json import loads
+from inspect import cleandoc
+
+import pytest
+import requests
+from apprise import Apprise
+from apprise.config.ConfigBase import ConfigBase
+
+# Disable logging for a cleaner testing output
+import logging
+logging.disable(logging.CRITICAL)
+
+# Attachment Directory
+TEST_VAR_DIR = os.path.join(os.path.dirname(__file__), 'var')
+
+
+@pytest.fixture
+def request_mock(mocker):
+    """
+    Prepare requests mock.
+    """
+    mock_post = mocker.patch("requests.post")
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+    mock_post.return_value.content = ""
+    return mock_post
+
+
+def test_plugin_title_maxlen(request_mock):
+    """
+    plugin title maxlen blending support
+
+    """
+    # Load our configuration
+    result, config = ConfigBase.config_parse_yaml(cleandoc("""
+    urls:
+
+      # Our JSON plugin allows for a title definition; we enforce a html format
+      - json://user:pass@example.ca?format=html
+      # Telegram has a title_maxlen of 0
+      - tgram://123456789:AABCeFGhIJKLmnOPqrStUvWxYZ12345678U/987654321
+    """))
+
+    # Verify we loaded correctly
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert len(result[0].tags) == 0
+
+    aobj = Apprise()
+    aobj.add(result)
+    assert len(aobj) == 2
+
+    title = "Hello World"
+    body = "Foo Bar"
+    assert aobj.notify(title=title, body=body)
+
+    # If a batch, there is only 1 post
+    assert request_mock.call_count == 2
+
+    details = request_mock.call_args_list[0]
+    assert details[0][0] == 'http://example.ca'
+    payload = loads(details[1]['data'])
+    assert payload['message'] == body
+    assert payload['title'] == "Hello World"
+
+    details = request_mock.call_args_list[1]
+    assert details[0][0] == \
+        'https://api.telegram.org/bot123456789:' \
+        'AABCeFGhIJKLmnOPqrStUvWxYZ12345678U/sendMessage'
+    payload = loads(details[1]['data'])
+    # HTML in Title is escaped
+    assert payload['text'] == "<b>Hello World</b>\r\nFoo Bar"


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #913 

A bug was detected causing the title of some messages to be escaped with HTML characters in circumstances when it should.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@913-title-html-characters

# Create ourselves a config file that causes he clash:
cat < _EOF >> apprise-913-title-html-characters.yml
urls:
  - tgram://{{ token }}/{{ chat }}/
  - mailtos://{{ username }}:{{ password }}@{{ domain }}:{{ port }}?smtp={{ smtp_host }}&from=Paperless<{{ smtp_email }}>&to={{ email }}
_EOF

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" -c  apprise-913-title-html-characters.yml

```

