### PR TITLE
Discord now supports href= (and alias url=) arguments

### DIFF
--- a/apprise/plugins/NotifyDiscord.py
+++ b/apprise/plugins/NotifyDiscord.py
@@ -633,7 +633,6 @@ class NotifyDiscord(NotifyBase):
             results['href'] = \
                 NotifyDiscord.unquote(results['qsd']['href'])
 
-
         elif 'url' in results['qsd']:
             results['href'] = \
                 NotifyDiscord.unquote(results['qsd']['url'])

--- a/apprise/plugins/NotifyDiscord.py
+++ b/apprise/plugins/NotifyDiscord.py
@@ -152,6 +152,13 @@ class NotifyDiscord(NotifyBase):
             'name': _('Avatar URL'),
             'type': 'string',
         },
+        'href': {
+            'name': _('URL'),
+            'type': 'string',
+        },
+        'url': {
+            'alias_of': 'href',
+        },
         # Send a message to the specified thread within a webhook's channel.
         # The thread will automatically be unarchived.
         'thread': {
@@ -183,7 +190,8 @@ class NotifyDiscord(NotifyBase):
 
     def __init__(self, webhook_id, webhook_token, tts=False, avatar=True,
                  footer=False, footer_logo=True, include_image=False,
-                 fields=True, avatar_url=None, thread=None, **kwargs):
+                 fields=True, avatar_url=None, href=None, thread=None,
+                 **kwargs):
         """
         Initialize Discord Object
 
@@ -231,6 +239,9 @@ class NotifyDiscord(NotifyBase):
         # This allows a user to provide an over-ride to the otherwise
         # dynamically generated avatar url images
         self.avatar_url = avatar_url
+
+        # A URL to have the title link to
+        self.href = href
 
         # For Tracking Purposes
         self.ratelimit_reset = datetime.now(timezone.utc).replace(tzinfo=None)
@@ -286,6 +297,9 @@ class NotifyDiscord(NotifyBase):
                     # Our color associated with our notification
                     'color': self.color(notify_type, int),
                 }]
+
+                if self.href:
+                    payload['embeds'][0]['url'] = self.href
 
                 if self.footer:
                     # Acquire logo URL
@@ -540,6 +554,9 @@ class NotifyDiscord(NotifyBase):
         if self.avatar_url:
             params['avatar_url'] = self.avatar_url
 
+        if self.href:
+            params['href'] = self.href
+
         if self.thread_id:
             params['thread'] = self.thread_id
 
@@ -611,10 +628,24 @@ class NotifyDiscord(NotifyBase):
             results['avatar_url'] = \
                 NotifyDiscord.unquote(results['qsd']['avatar_url'])
 
+        # Extract url if it was specified
+        if 'href' in results['qsd']:
+            results['href'] = \
+                NotifyDiscord.unquote(results['qsd']['href'])
+
+
+        elif 'url' in results['qsd']:
+            results['href'] = \
+                NotifyDiscord.unquote(results['qsd']['url'])
+            # Markdown is implied
+            results['format'] = NotifyFormat.MARKDOWN
+
         # Extract thread id if it was specified
         if 'thread' in results['qsd']:
             results['thread'] = \
                 NotifyDiscord.unquote(results['qsd']['thread'])
+            # Markdown is implied
+            results['format'] = NotifyFormat.MARKDOWN
 
         return results
 

--- a/test/test_plugin_discord.py
+++ b/test/test_plugin_discord.py
@@ -132,6 +132,18 @@ apprise_url_tests = (
         'instance': NotifyDiscord,
         'requests_response_code': requests.codes.no_content,
     }),
+    # Test with href (title link)
+    ('discord://%s/%s?hmarkdown=true&ref=http://localhost' % (
+        'i' * 24, 't' * 64), {
+            'instance': NotifyDiscord,
+            'requests_response_code': requests.codes.no_content,
+    }),
+    # Test with url (title link) - Alias of href
+    ('discord://%s/%s?markdown=true&url=http://localhost' % (
+        'i' * 24, 't' * 64), {
+            'instance': NotifyDiscord,
+            'requests_response_code': requests.codes.no_content,
+    }),
     # Test with avatar URL
     ('discord://%s/%s?avatar_url=http://localhost/test.jpg' % (
         'i' * 24, 't' * 64), {


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #905

### Parameter Breakdown
| Variable    | Required | Description
| ----------- | -------- | -----------
| href   | No      | Identify a URL the title should link to when posting the Discord Notification.  This forces the post into `markdown` format in order to leverage the `embeds` section of Discord.  You can also use `url=` as an alias of this as well.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@905-discord-enhancements

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "discord://credentials/?href=https://github.com/caronc/apprise"

# Another way of writing that is:
apprise -t "Test Title" -b "Test Message" \
  "discord://credentials/?url=https://github.com/caronc/apprise"

```
