### PR TITLE
PushMe Support Added

### DIFF
--- a/apprise/plugins/NotifyPushMe.py
+++ b/apprise/plugins/NotifyPushMe.py
@@ -121,8 +121,8 @@ class NotifyPushMe(NotifyBase):
         # Prepare our payload
         params = {
             'push_key': self.token,
-            'title': title if not self.status else '{} {}'.format(
-                self.asset.ascii(notify_type), title),
+            'title': title if not self.status
+            else '{} {}'.format(self.asset.ascii(notify_type), title),
             'content': body,
             'type': 'markdown'
             if self.notify_format == NotifyFormat.MARKDOWN else 'text'
@@ -207,10 +207,6 @@ class NotifyPushMe(NotifyBase):
             # We're done early as we couldn't load the results
             return results
 
-        # Get status switch
-        results['status'] = \
-            parse_bool(results['qsd'].get('status', True))
-
         # Store our token using the host
         results['token'] = NotifyPushMe.unquote(results['host'])
 
@@ -221,5 +217,9 @@ class NotifyPushMe(NotifyBase):
         elif 'push_key' in results['qsd'] and len(results['qsd']['push_key']):
             # Support 'push_key' if specified
             results['token'] = NotifyPushMe.unquote(results['qsd']['push_key'])
+
+        # Get status switch
+        results['status'] = \
+            parse_bool(results['qsd'].get('status', True))
 
         return results

--- a/test/test_plugin_pushme.py
+++ b/test/test_plugin_pushme.py
@@ -55,7 +55,7 @@ apprise_url_tests = (
         'privacy_url': 'pushme://a...a/',
     }),
     # Token specified
-    ('pushme://?token=%s' % ('b' * 6), {
+    ('pushme://?token=%s&status=yes' % ('b' * 6), {
         'instance': NotifyPushMe,
 
         # Our expected url(privacy=True) startswith() response:
@@ -76,7 +76,7 @@ apprise_url_tests = (
         'privacy_url': 'pushme://b...b/',
     }),
     # Token specified
-    ('pushme://?push_key=%s' % ('p' * 6), {
+    ('pushme://?push_key=%s&status=no' % ('p' * 6), {
         'instance': NotifyPushMe,
 
         # Our expected url(privacy=True) startswith() response:

--- a/test/test_plugin_pushme.py
+++ b/test/test_plugin_pushme.py
@@ -61,6 +61,20 @@ apprise_url_tests = (
         # Our expected url(privacy=True) startswith() response:
         'privacy_url': 'pushme://b...b/',
     }),
+    # Status setting
+    ('pushme://?token=%s&status=no' % ('b' * 6), {
+        'instance': NotifyPushMe,
+
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'pushme://b...b/',
+    }),
+    # Status setting
+    ('pushme://?token=%s&status=True' % ('b' * 6), {
+        'instance': NotifyPushMe,
+
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'pushme://b...b/',
+    }),
     # Token specified
     ('pushme://?push_key=%s' % ('p' * 6), {
         'instance': NotifyPushMe,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #907

PushMe Support Added

* **Source**: https://push.i-i.me/
* **Icon Support**: No
* **Attachment Support**: No
* **Message Format**: Text
* **Message Limit**: 32768 Characters per message

You need to have an account with [PushMe](https://push.i-i.me/) and have downloaded the Phone App.

**Note:** The `token` is also referred to as the `push_key`

### Parameter Breakdown
| Variable    | Required | Description
| ----------- | -------- | -----------
| token  | Yes      | This is the **push_key** associated with your PushMe Account
| status     |  No  | Optionally include a small little ASCII string representing the notification status being sent (inline with it)  by default this is set to `yes`.

### Syntax
Valid syntax is as follows:
* `pushme://{token}/`

## New Service Completion Status

* [x] apprise/plugins/NotifyPushMe.py
* [x] KEYWORDS
    - add new service into this file (alphabetically).
* [x] README.md
    - add entry for new service to table (as a quick reference)
* [x] packaging/redhat/python-apprise.spec
    - add new service into the `%global common_description`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@907-pushme-support

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "pushme://push_key"

```

