### PR TITLE
Consistent Status Display on All Supported Services

### DIFF
--- a/apprise/plugins/NotifySignalAPI.py
+++ b/apprise/plugins/NotifySignalAPI.py
@@ -158,7 +158,7 @@ class NotifySignalAPI(NotifyBase):
         'status': {
             'name': _('Show Status'),
             'type': 'bool',
-            'default': False,
+            'default': True,
         },
     })
 
@@ -490,6 +490,6 @@ class NotifySignalAPI(NotifyBase):
 
         # Get status switch
         results['status'] = \
-            parse_bool(results['qsd'].get('status', False))
+            parse_bool(results['qsd'].get('status', True))
 
         return results

--- a/test/test_plugin_signal.py
+++ b/test/test_plugin_signal.py
@@ -199,7 +199,7 @@ def test_plugin_signal_edge_cases(request_mock):
     details = request_mock.call_args_list[0]
     assert details[0][0] == 'https://localhost:231/v2/send'
     payload = loads(details[1]['data'])
-    assert payload['message'] == 'My Title\r\ntest body'
+    assert payload['message'] == '[i] My Title\r\ntest body'
 
     # Reset our mock object
     request_mock.reset_mock()
@@ -279,7 +279,7 @@ def test_plugin_signal_based_on_feedback(request_mock):
     aobj = Apprise()
     aobj.add(
         'signal://10.0.0.112:8080/+12512222222/+12513333333/'
-        '12514444444?batch=yes')
+        '12514444444?batch=yes&status=no')
 
     assert aobj.notify(title=title, body=body)
 
@@ -302,7 +302,7 @@ def test_plugin_signal_based_on_feedback(request_mock):
     aobj = Apprise()
     aobj.add(
         'signal://10.0.0.112:8080/+12512222222/+12513333333/'
-        '12514444444?batch=no')
+        '12514444444?batch=no&status=no')
 
     assert aobj.notify(title=title, body=body)
 
@@ -333,7 +333,7 @@ def test_plugin_signal_based_on_feedback(request_mock):
     aobj = Apprise()
     aobj.add(
         'signal://10.0.0.112:8080/+12513333333/@group1/@group2/'
-        '12514444444?batch=yes')
+        '12514444444?batch=yes&status=no')
 
     assert aobj.notify(title=title, body=body)
 
@@ -365,7 +365,7 @@ def test_notify_signal_plugin_attachments(request_mock):
 
     obj = Apprise.instantiate(
         'signal://10.0.0.112:8080/+12512222222/+12513333333/'
-        '12514444444?batch=no')
+        '12514444444?batch=no&status=no')
     assert isinstance(obj, NotifySignalAPI)
 
     # Test Valid Attachment


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #691 

Apprise carries a few entries as part of it's payload.  The optional `title`, the `body`, and the `type` (whether it's an `info`, `warning`, `error`, etc).

The problem is the `info` doesn't get carried forward on a lot of different platforms, yet it does on others.  due to the varying degree of support from one service to another, some support icons that change colors, but others are very text driven (like SMS messages).

For consistency, these text forms should share a means of passing along the message status.  those who don't wnat to see it can turn it off with `?status=off`.  

The Ascii layout is as follows:
| Notification Type    | Text Representation | Image | Ascii Alternative
| -------------------- | ------------------- | ----- | ----- |
| **NotifyType.INFO** | _info_ | [![Build Status](https://raw.githubusercontent.com/caronc/apprise/master/apprise/assets/themes/default/apprise-info-32x32.png)](https://github.com/caronc/apprise/tree/master/apprise/assets/themes/default) | `[i]`
| **NotifyType.SUCCESS** | _success_ | [![Build Status](https://raw.githubusercontent.com/caronc/apprise/master/apprise/assets/themes/default/apprise-success-32x32.png)](https://github.com/caronc/apprise/tree/master/apprise/assets/themes/default) | `[+]`
| **NotifyType.WARNING** | _warning_ | [![Build Status](https://raw.githubusercontent.com/caronc/apprise/master/apprise/assets/themes/default/apprise-warning-32x32.png)](https://github.com/caronc/apprise/tree/master/apprise/assets/themes/default) | `[~]`
| **NotifyType.FAILURE** | _failure_ | [![Build Status](https://raw.githubusercontent.com/caronc/apprise/master/apprise/assets/themes/default/apprise-failure-32x32.png)](https://github.com/caronc/apprise/tree/master/apprise/assets/themes/default) | `[!]`


The following systems have been detected to not properly pass along the status:
* [x] SignalAPI
* [ ] ... still need to iterate over the `/plugins` and get remaining impacted plugins

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@show-status-consistency

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  <apprise url related to ticket>

```

