### PR TITLE
Use `pip install` with `--no-cache-dir` inside Docker

### DIFF
--- a/Dockerfile.py310
+++ b/Dockerfile.py310
@@ -34,7 +34,7 @@
 FROM python:3.10-buster
 RUN apt-get update && \
     apt-get install -y libdbus-1-dev libgirepository1.0-dev build-essential musl-dev bash
-RUN pip install dbus-python PyGObject
+RUN pip install --no-cache-dir dbus-python PyGObject
 
 # Apprise Setup
 VOLUME ["/apprise"]
@@ -44,7 +44,7 @@ COPY dev-requirements.txt /
 ENV PYTHONPATH /apprise
 ENV PYTHONPYCACHEPREFIX /apprise/__pycache__/py310
 
-RUN pip install -r /requirements.txt -r /dev-requirements.txt
+RUN pip install --no-cache-dir -r /requirements.txt -r /dev-requirements.txt
 
 RUN addgroup --gid ${USER_GID:-1000} apprise
 RUN adduser --system --uid ${USER_UID:-1000} --ingroup apprise --home /apprise --no-create-home --disabled-password apprise

--- a/Dockerfile.py311
+++ b/Dockerfile.py311
@@ -34,7 +34,7 @@
 FROM python:3.11-buster
 RUN apt-get update && \
     apt-get install -y libdbus-1-dev libgirepository1.0-dev build-essential musl-dev bash
-RUN pip install dbus-python PyGObject
+RUN pip install --no-cache-dir dbus-python PyGObject
 
 # Apprise Setup
 VOLUME ["/apprise"]
@@ -44,7 +44,7 @@ COPY dev-requirements.txt /
 ENV PYTHONPATH /apprise
 ENV PYTHONPYCACHEPREFIX /apprise/__pycache__/py311
 
-RUN pip install -r /requirements.txt -r /dev-requirements.txt
+RUN pip install --no-cache-dir -r /requirements.txt -r /dev-requirements.txt
 
 RUN addgroup --gid ${USER_GID:-1000} apprise
 RUN adduser --system --uid ${USER_UID:-1000} --ingroup apprise --home /apprise --no-create-home --disabled-password apprise

--- a/Dockerfile.py36
+++ b/Dockerfile.py36
@@ -34,7 +34,7 @@
 FROM python:3.6-buster
 RUN apt-get update && \
     apt-get install -y libdbus-1-dev libgirepository1.0-dev build-essential musl-dev bash
-RUN pip install dbus-python PyGObject
+RUN pip install --no-cache-dir dbus-python PyGObject
 
 # Apprise Setup
 VOLUME ["/apprise"]
@@ -45,4 +45,4 @@ ENV PYTHONPATH /apprise
 ENV PYTHONPYCACHEPREFIX /apprise/__pycache__/py36
 
 
-RUN pip install -r /requirements.txt -r /dev-requirements.txt
+RUN pip install --no-cache-dir -r /requirements.txt -r /dev-requirements.txt


### PR DESCRIPTION
## Description:

Use `pip install` with `--no-cache-dir` inside Docker to minimize the Docker image size

Before:
```
REPOSITORY                               TAG                  IMAGE ID       CREATED              SIZE
dockerfile.py36                          latest               e188c4af3c0a   23 minutes ago       996MB
dockerfile.py311                         latest               284ae3a53022   25 minutes ago       1.03GB
dockerfile.py310                         latest               72d0eeb54f5c   27 minutes ago       1.01GB
```

After:
```
REPOSITORY                               TAG                  IMAGE ID       CREATED              SIZE
dockerfile.py36-pip-no-cache-dir         latest               70dc5e0db273   13 minutes ago       979MB
dockerfile.py311-pip-no-cache-dir        latest               5ba32a8507e5   15 minutes ago       1.02GB
dockerfile.py310-pip-no-cache-dir        latest               effd0595f035   17 minutes ago       996MB
```

