### PR TITLE
Clean up apt lists after installation in Dockerfile

### DIFF
--- a/Dockerfile.py310
+++ b/Dockerfile.py310
@@ -33,7 +33,8 @@
 # Base
 FROM python:3.10-buster
 RUN apt-get update && \
-    apt-get install -y libdbus-1-dev libgirepository1.0-dev build-essential musl-dev bash
+    apt-get install -y libdbus-1-dev libgirepository1.0-dev build-essential musl-dev bash && \
+    rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir dbus-python PyGObject
 
 # Apprise Setup

--- a/Dockerfile.py311
+++ b/Dockerfile.py311
@@ -33,7 +33,8 @@
 # Base
 FROM python:3.11-buster
 RUN apt-get update && \
-    apt-get install -y libdbus-1-dev libgirepository1.0-dev build-essential musl-dev bash
+    apt-get install -y libdbus-1-dev libgirepository1.0-dev build-essential musl-dev bash && \
+    rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir dbus-python PyGObject
 
 # Apprise Setup

--- a/Dockerfile.py36
+++ b/Dockerfile.py36
@@ -33,7 +33,8 @@
 # Base
 FROM python:3.6-buster
 RUN apt-get update && \
-    apt-get install -y libdbus-1-dev libgirepository1.0-dev build-essential musl-dev bash
+    apt-get install -y libdbus-1-dev libgirepository1.0-dev build-essential musl-dev bash && \
+    rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir dbus-python PyGObject
 
 # Apprise Setup


### PR DESCRIPTION
This is a follow up of #939, which makes the Docker images much smaller!

Before:
```
REPOSITORY                               TAG                  IMAGE ID       CREATED         SIZE
dockerfile.py36-pip-no-cache-dir         latest               70dc5e0db273   4 hours ago     979MB
dockerfile.py311-pip-no-cache-dir        latest               5ba32a8507e5   4 hours ago     1.02GB
dockerfile.py310-pip-no-cache-dir        latest               effd0595f035   4 hours ago     996MB
```

After:
```
REPOSITORY                               TAG                  IMAGE ID       CREATED         SIZE
dockerfile.py36-delete-apt-lists         latest               a89aff9d354e   2 hours ago     961MB
dockerfile.py311-delete-apt-lists        latest               81d19c55cb4d   2 hours ago     999MB
dockerfile.py310-delete-apt-lists        latest               d09266ce3fc2   4 hours ago     978MB
```

