### PR TITLE
Custom XML Key improvements

### DIFF
--- a/apprise/plugins/NotifyXML.py
+++ b/apprise/plugins/NotifyXML.py
@@ -216,9 +216,6 @@ class NotifyXML(NotifyBase):
             # Store our extra headers
             self.headers.update(headers)
 
-        # Set our xsd url
-        self.xsd_url = self.xsd_default_url.format(version=self.xsd_ver)
-
         self.payload_overrides = {}
         self.payload_extras = {}
         if payload:
@@ -240,11 +237,13 @@ class NotifyXML(NotifyBase):
                     self.payload_map[key] = v
                     self.payload_overrides[key] = v
 
-                    # Over-ride XSD URL as data is no longer known
-                    self.xsd_url = None
-
                 else:
                     self.payload_extras[key] = v
+
+        # Set our xsd url
+        self.xsd_url = None if self.payload_overrides or self.payload_extras \
+            else self.xsd_default_url.format(version=self.xsd_ver)
+
         return
 
     def url(self, privacy=False, *args, **kwargs):


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #908

Improvements to the XML Key Handling (and Test Cases) based on some minor bugs found in the JSON version.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@908-custom-xml-service-improvements

# Test out the changes with the following command:
# The below renames the Message Stanza to Body
apprise -t "Test Title" -b "Test Message" \
  "xml://localhost/:Message:Body

```

