### PR TITLE
`dnf clean` after `dnf install` in Dockerfiles

### DIFF
--- a/Dockerfile.el8
+++ b/Dockerfile.el8
@@ -48,13 +48,15 @@ RUN ( \
    dnf install -y rpm-build rpmlint python3-pip python3-virtualenv rubygem-ronn \
                   dnf-plugins-core 'dnf-command(config-manager)' \
                  'dnf-command(builddep)' sudo rsync rpmdevtools; \
-   dnf config-manager --set-enabled powertools;
+   dnf config-manager --set-enabled powertools; \
+   dnf clean all;
 
 COPY packaging/redhat/python-apprise.spec /
 # Place our build file into the path
 COPY bin/build-rpm.sh /usr/bin
 RUN rpmspec -q --buildrequires /python-apprise.spec | cut -f1 -d' ' | \
-    xargs dnf install -y
+    xargs dnf install -y; \
+    dnf clean all;
 
 # RPM Build Structure Setup
 ENV FLAVOR=rpmbuild OS=centos DIST=el8

--- a/Dockerfile.el9
+++ b/Dockerfile.el9
@@ -48,13 +48,15 @@ RUN ( \
    dnf install -y rpm-build rpmlint python3-pip rubygem-ronn \
                   dnf-plugins-core 'dnf-command(config-manager)' \
                  'dnf-command(builddep)' sudo rsync rpmdevtools; \
-   dnf config-manager --set-enabled crb;
+   dnf config-manager --set-enabled crb; \
+   dnf clean all;
 
 COPY packaging/redhat/python-apprise.spec /
 # Place our build file into the path
 COPY bin/build-rpm.sh /usr/bin
 RUN rpmspec -q --buildrequires /python-apprise.spec | cut -f1 -d' ' | \
-    xargs dnf install -y
+    xargs dnf install -y; \
+    dnf clean all;
 
 # RPM Build Structure Setup
 ENV FLAVOR=rpmbuild OS=centos DIST=el8

--- a/Dockerfile.f37
+++ b/Dockerfile.f37
@@ -45,13 +45,15 @@ RUN \
    dnf install -y epel-release; \
    dnf install -y rpm-build rpmlint python3-pip rubygem-ronn \
                   dnf-plugins-core 'dnf-command(config-manager)' \
-                 'dnf-command(builddep)' sudo rsync rpmdevtools;
+                 'dnf-command(builddep)' sudo rsync rpmdevtools; \
+   dnf clean all;
 
 COPY packaging/redhat/python-apprise.spec /
 # Place our build file into the path
 COPY bin/build-rpm.sh /usr/bin
 RUN rpmspec -q --buildrequires /python-apprise.spec | cut -f1 -d' ' | \
-    xargs dnf install -y
+    xargs dnf install -y; \
+    dnf clean all;
 
 # RPM Build Structure Setup
 ENV FLAVOR=rpmbuild OS=centos DIST=el8

--- a/Dockerfile.f39
+++ b/Dockerfile.f39
@@ -60,13 +60,15 @@ RUN \
    dnf install -y \
         rpm-build rpmlint python3-pip rubygem-ronn \
         dnf-plugins-core 'dnf-command(config-manager)' \
-        'dnf-command(builddep)' sudo rsync rpmdevtools;
+        'dnf-command(builddep)' sudo rsync rpmdevtools; \
+   dnf clean all;
 
 COPY packaging/redhat/python-apprise.spec /
 # Place our build file into the path
 COPY bin/build-rpm.sh /usr/bin
 RUN rpmspec -q --buildrequires /python-apprise.spec | cut -f1 -d' ' | \
-    xargs dnf install -y
+    xargs dnf install -y; \
+    dnf clean all;
 
 # RPM Build Structure Setup
 ENV FLAVOR=rpmbuild OS=centos DIST=f39

--- a/Dockerfile.rawhide
+++ b/Dockerfile.rawhide
@@ -60,13 +60,15 @@ RUN \
    dnf install -y \
         rpm-build rpmlint python3-pip rubygem-ronn \
         dnf-plugins-core 'dnf-command(config-manager)' \
-        'dnf-command(builddep)' sudo rsync rpmdevtools;
+        'dnf-command(builddep)' sudo rsync rpmdevtools; \
+   dnf clean all;
 
 COPY packaging/redhat/python-apprise.spec /
 # Place our build file into the path
 COPY bin/build-rpm.sh /usr/bin
 RUN rpmspec -q --buildrequires /python-apprise.spec | cut -f1 -d' ' | \
-    xargs dnf install -y
+    xargs dnf install -y; \
+    dnf clean all;
 
 # RPM Build Structure Setup
 ENV FLAVOR=rpmbuild OS=centos DIST=rawhide


### PR DESCRIPTION
This ensures that `dnf` doesn't leave unnecessary temporary files in the Docker images, thereby reducing their size.

Regarding the change in image size, it seems there isn't much difference for the rawhide and f39 builds. However, the f38 and el8 builds have shown significant improvement.

For the image size changes, see the result below.

Before:
```
REPOSITORY                                   TAG                  IMAGE ID       CREATED             SIZE
dockerfile.rawhide                           latest               2df081b6ec73   About an hour ago   519MB
dockerfile.f39                               latest               1d39a1d366ac   About an hour ago   519MB
dockerfile.f37                               latest               f86a5711c973   About an hour ago   832MB
dockerfile.el8                               latest               7ac668a725be   About an hour ago   571MB
```

After:

```
REPOSITORY                                   TAG                  IMAGE ID       CREATED             SIZE
dockerfile.rawhide-dnf-clean                 latest               e035b545c15b   About an hour ago   519MB
dockerfile.f39-dnf-clean                     latest               c35b262f3830   About an hour ago   519MB
dockerfile.f37-dnf-clean                     latest               15e78792159d   About an hour ago   441MB
dockerfile.el8-dnf-clean                     latest               59fa63bde3fe   About an hour ago   405MB
```

