### PR TITLE
Matrix login URL updated to accomodate newer API

### DIFF
--- a/apprise/plugins/NotifyMatrix.py
+++ b/apprise/plugins/NotifyMatrix.py
@@ -780,12 +780,23 @@ class NotifyMatrix(NotifyBase):
                 'user/pass combo is missing.')
             return False
 
-        # Prepare our Registration Payload
-        payload = {
-            'type': 'm.login.password',
-            'user': self.user,
-            'password': self.password,
-        }
+        # Prepare our Authentication Payload
+        if self.version == MatrixVersion.V3:
+            payload = {
+                'type': 'm.login.password',
+                'identifier': {
+                    'type': 'm.id.user',
+                    'user': self.user,
+                },
+                'password': self.password,
+            }
+
+        else:
+            payload = {
+                'type': 'm.login.password',
+                'user': self.user,
+                'password': self.password,
+            }
 
         # Build our URL
         postokay, response = self._fetch('/login', payload=payload)

--- a/test/test_plugin_matrix.py
+++ b/test/test_plugin_matrix.py
@@ -27,7 +27,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from unittest import mock
-
 import os
 import requests
 import pytest
@@ -228,9 +227,10 @@ def test_plugin_matrix_urls():
     AppriseURLTester(tests=apprise_url_tests).run_all()
 
 
+@mock.patch('requests.put')
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_matrix_general(mock_post, mock_get):
+def test_plugin_matrix_general(mock_post, mock_get, mock_put):
     """
     NotifyMatrix() General Tests
 
@@ -250,6 +250,7 @@ def test_plugin_matrix_general(mock_post, mock_get):
     # Prepare Mock
     mock_get.return_value = request
     mock_post.return_value = request
+    mock_put.return_value = request
 
     # Variation Initializations
     obj = NotifyMatrix(host='host', targets='#abcd')
@@ -383,9 +384,10 @@ def test_plugin_matrix_general(mock_post, mock_get):
     assert obj.send(user='test', password='passwd', body="test") is True
 
 
+@mock.patch('requests.put')
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_matrix_fetch(mock_post, mock_get):
+def test_plugin_matrix_fetch(mock_post, mock_get, mock_put):
     """
     NotifyMatrix() Server Fetch/API Tests
 
@@ -419,6 +421,7 @@ def test_plugin_matrix_fetch(mock_post, mock_get):
 
         return request
 
+    mock_put.side_effect = fetch_failed
     mock_get.side_effect = fetch_failed
     mock_post.side_effect = fetch_failed
 
@@ -449,12 +452,14 @@ def test_plugin_matrix_fetch(mock_post, mock_get):
     # Default configuration
     mock_get.side_effect = None
     mock_post.side_effect = None
+    mock_put.side_effect = None
 
     request = mock.Mock()
     request.status_code = requests.codes.ok
     request.content = dumps(response_obj)
     mock_post.return_value = request
     mock_get.return_value = request
+    mock_put.return_value = request
 
     obj = NotifyMatrix(host='host', include_image=True)
     assert isinstance(obj, NotifyMatrix) is True
@@ -467,6 +472,7 @@ def test_plugin_matrix_fetch(mock_post, mock_get):
     request.content = dumps({
         'retry_after_ms': 1,
     })
+
     code, response = obj._fetch('/retry/apprise/unit/test')
     assert code is False
 
@@ -485,9 +491,10 @@ def test_plugin_matrix_fetch(mock_post, mock_get):
     assert code is False
 
 
+@mock.patch('requests.put')
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_matrix_auth(mock_post, mock_get):
+def test_plugin_matrix_auth(mock_post, mock_get, mock_put):
     """
     NotifyMatrix() Server Authentication
 
@@ -506,6 +513,7 @@ def test_plugin_matrix_auth(mock_post, mock_get):
     request.content = dumps(response_obj)
     mock_post.return_value = request
     mock_get.return_value = request
+    mock_put.return_value = request
 
     obj = NotifyMatrix(host='localhost')
     assert isinstance(obj, NotifyMatrix) is True
@@ -579,9 +587,10 @@ def test_plugin_matrix_auth(mock_post, mock_get):
     assert obj.access_token is None
 
 
+@mock.patch('requests.put')
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_matrix_rooms(mock_post, mock_get):
+def test_plugin_matrix_rooms(mock_post, mock_get, mock_put):
     """
     NotifyMatrix() Room Testing
 
@@ -606,6 +615,7 @@ def test_plugin_matrix_rooms(mock_post, mock_get):
     request.content = dumps(response_obj)
     mock_post.return_value = request
     mock_get.return_value = request
+    mock_put.return_value = request
 
     obj = NotifyMatrix(host='host')
     assert isinstance(obj, NotifyMatrix) is True
@@ -789,9 +799,10 @@ def test_plugin_matrix_url_parsing():
     assert '#room3' in result['targets']
 
 
+@mock.patch('requests.put')
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_matrix_image_errors(mock_post, mock_get):
+def test_plugin_matrix_image_errors(mock_post, mock_get, mock_put):
     """
     NotifyMatrix() Image Error Handling
 
@@ -822,8 +833,9 @@ def test_plugin_matrix_image_errors(mock_post, mock_get):
     # Prepare Mock
     mock_get.side_effect = mock_function_handing
     mock_post.side_effect = mock_function_handing
+    mock_put.side_effect = mock_function_handing
 
-    obj = NotifyMatrix(host='host', include_image=True)
+    obj = NotifyMatrix(host='host', include_image=True, version='2')
     assert isinstance(obj, NotifyMatrix) is True
     assert obj.access_token is None
 
@@ -831,7 +843,7 @@ def test_plugin_matrix_image_errors(mock_post, mock_get):
     # we had post errors (of any kind) we still report a failure.
     assert obj.notify('test', 'test') is False
 
-    obj = NotifyMatrix(host='host', include_image=False)
+    obj = NotifyMatrix(host='host', include_image=False, version='2')
     assert isinstance(obj, NotifyMatrix) is True
     assert obj.access_token is None
 
@@ -862,6 +874,7 @@ def test_plugin_matrix_image_errors(mock_post, mock_get):
 
     # Prepare Mock
     mock_get.side_effect = mock_function_handing
+    mock_put.side_effect = mock_function_handing
     mock_post.side_effect = mock_function_handing
     obj = NotifyMatrix(host='host', include_image=True)
     assert isinstance(obj, NotifyMatrix) is True
@@ -879,9 +892,10 @@ def test_plugin_matrix_image_errors(mock_post, mock_get):
     del obj
 
 
+@mock.patch('requests.put')
 @mock.patch('requests.get')
 @mock.patch('requests.post')
-def test_plugin_matrix_attachments_api_v3(mock_post, mock_get):
+def test_plugin_matrix_attachments_api_v3(mock_post, mock_get, mock_put):
     """
     NotifyMatrix() Attachment Checks (v3)
 
@@ -899,6 +913,7 @@ def test_plugin_matrix_attachments_api_v3(mock_post, mock_get):
     # Prepare Mock return object
     mock_post.return_value = response
     mock_get.return_value = response
+    mock_put.return_value = response
 
     # Instantiate our object
     obj = Apprise.instantiate('matrix://user:pass@localhost/#general?v=3')
@@ -913,7 +928,8 @@ def test_plugin_matrix_attachments_api_v3(mock_post, mock_get):
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, 'apprise-test.gif'))
 
     # Test our call count
-    assert mock_post.call_count == 5
+    assert mock_put.call_count == 1
+    assert mock_post.call_count == 4
     assert mock_post.call_args_list[0][0][0] == \
         'http://localhost/_matrix/client/v3/login'
     assert mock_post.call_args_list[1][0][0] == \
@@ -922,10 +938,10 @@ def test_plugin_matrix_attachments_api_v3(mock_post, mock_get):
         'http://localhost/_matrix/client/v3/join/%23general%3Alocalhost'
     assert mock_post.call_args_list[3][0][0] == \
         'http://localhost/_matrix/client/v3/rooms/%21abc123%3Alocalhost/' \
-        'send/m.room.message'
-    assert mock_post.call_args_list[4][0][0] == \
+        'send/m.room.message/0'
+    assert mock_put.call_args_list[0][0][0] == \
         'http://localhost/_matrix/client/v3/rooms/%21abc123%3Alocalhost/' \
-        'send/m.room.message'
+        'send/m.room.message/0'
 
     # Attach an unsupported file type
     attach = AppriseAttachment(
@@ -993,7 +1009,7 @@ def test_plugin_matrix_attachments_api_v2(mock_post, mock_get):
     mock_get.return_value = response
 
     # Instantiate our object
-    obj = Apprise.instantiate('matrix://user:pass@localhost/#general?v=3')
+    obj = Apprise.instantiate('matrix://user:pass@localhost/#general?v=2')
 
     # attach our content
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, 'apprise-test.gif'))
@@ -1013,12 +1029,12 @@ def test_plugin_matrix_attachments_api_v2(mock_post, mock_get):
     # Force a object removal (thus a logout call)
     del obj
 
+    # Instantiate our object
+    obj = Apprise.instantiate('matrixs://user:pass@localhost/#general?v=2')
+
     # Reset our object
     mock_post.reset_mock()
     mock_get.reset_mock()
-
-    # Instantiate our object
-    obj = Apprise.instantiate('matrixs://user:pass@localhost/#general?v=2')
 
     assert obj.notify(
         body='body', title='title', notify_type=NotifyType.INFO,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #968

Basing fix on related issue and [Matrix API Login Docs](https://spec.matrix.org/v1.8/client-server-api/#password-based)

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@968-matrix-api-v3-support

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "matrix://credentials"

```

