### PR TITLE
Twitter supports x:// to align with it's new re-branding

### DIFF
--- a/apprise/plugins/NotifyTwitter.py
+++ b/apprise/plugins/NotifyTwitter.py
@@ -83,7 +83,7 @@ class NotifyTwitter(NotifyBase):
     service_url = 'https://twitter.com/'
 
     # The default secure protocol is twitter.
-    secure_protocol = ('twitter', 'tweet')
+    secure_protocol = ('x', 'twitter', 'tweet')
 
     # A URL that takes you to the setup/help of the specific protocol
     setup_url = 'https://github.com/caronc/apprise/wiki/Notify_twitter'

--- a/test/test_plugin_twitter.py
+++ b/test/test_plugin_twitter.py
@@ -87,7 +87,7 @@ apprise_url_tests = (
         'notify_response': False,
 
         # Our expected url(privacy=True) startswith() response:
-        'privacy_url': 'twitter://c...y/****/a...2/****',
+        'privacy_url': 'x://c...y/****/a...2/****',
     }),
     ('twitter://consumer_key/consumer_secret/atoken3/access_secret'
         '?cache=no', {


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #962

Added `x://` in this PR to align with the new re-branding of the Twitter service. The `twitter://` and `tweet://` are now aliases of `x://` and completely supported (no breaking changes here).

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@962-twitter-to-x-update

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "x://credentials"

```

