### PR TITLE
URLBase() supports calls to url() for generic responses

### DIFF
--- a/apprise/plugins/NotifyAppriseAPI.py
+++ b/apprise/plugins/NotifyAppriseAPI.py
@@ -167,10 +167,6 @@ class NotifyAppriseAPI(NotifyBase):
         """
         super().__init__(**kwargs)
 
-        self.fullpath = kwargs.get('fullpath')
-        if not isinstance(self.fullpath, str):
-            self.fullpath = '/'
-
         self.token = validate_regex(
             token, *self.template_tokens['token']['regex'])
         if not self.token:
@@ -334,8 +330,8 @@ class NotifyAppriseAPI(NotifyBase):
             url += ':%d' % self.port
 
         fullpath = self.fullpath.strip('/')
-        url += '/{}/'.format(fullpath) if fullpath else '/'
-        url += 'notify/{}'.format(self.token)
+        url += '{}'.format('/' + fullpath) if fullpath else ''
+        url += '/notify/{}'.format(self.token)
 
         # Some entries can not be over-ridden
         headers.update({

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -741,6 +741,49 @@ def test_apprise_schemas(tmpdir):
         assert len(schemas) == 0
 
 
+def test_apprise_urlbase_object():
+    """
+    API: Apprise() URLBase object testing
+
+    """
+    results = URLBase.parse_url('https://localhost/path/?cto=3.0&verify=no')
+    assert results.get('user') is None
+    assert results.get('password') is None
+    assert results.get('path') == '/path/'
+    assert results.get('secure') is True
+    assert results.get('verify') is False
+    base = URLBase(**results)
+    assert base.request_timeout == (3.0, 4.0)
+    assert base.request_auth is None
+    assert base.request_url == 'https://localhost/path/'
+    assert base.url().startswith('https://localhost/')
+
+    results = URLBase.parse_url(
+        'http://user:pass@localhost:34/path/here?rto=3.0&verify=yes')
+    assert results.get('user') == 'user'
+    assert results.get('password') == 'pass'
+    assert results.get('fullpath') == '/path/here'
+    assert results.get('secure') is False
+    assert results.get('verify') is True
+    base = URLBase(**results)
+    assert base.request_timeout == (4.0, 3.0)
+    assert base.request_auth == ('user', 'pass')
+    assert base.request_url == 'http://localhost:34/path/here'
+    assert base.url().startswith('http://user:pass@localhost:34/path/here')
+
+    results = URLBase.parse_url('http://user@127.0.0.1/path/')
+    assert results.get('user') == 'user'
+    assert results.get('password') is None
+    assert results.get('fullpath') == '/path/'
+    assert results.get('secure') is False
+    assert results.get('verify') is True
+    base = URLBase(**results)
+    assert base.request_timeout == (4.0, 4.0)
+    assert base.request_auth == ('user', None)
+    assert base.request_url == 'http://127.0.0.1/path/'
+    assert base.url().startswith('http://user@127.0.0.1/path/')
+
+
 def test_apprise_notify_formats(tmpdir):
     """
     API: Apprise() Input Formats tests

--- a/test/test_attach_base.py
+++ b/test/test_attach_base.py
@@ -70,9 +70,8 @@ def test_attach_base():
     # Create an object with no mimetype over-ride
     obj = AttachBase()
 
-    # Get our string object
-    with pytest.raises(NotImplementedError):
-        str(obj)
+    # Get our url object
+    str(obj)
 
     # We can not process name/path/mimetype at a Base level
     with pytest.raises(NotImplementedError):

--- a/test/test_notify_base.py
+++ b/test/test_notify_base.py
@@ -65,15 +65,8 @@ def test_notify_base():
     nb = NotifyBase(port=10)
     assert nb.port == 10
 
-    try:
-        nb.url()
-        assert False
-
-    except NotImplementedError:
-        # Each sub-module is that inherits this as a parent is required to
-        # over-ride this function. So direct calls to this throws a not
-        # implemented error intentionally
-        assert True
+    assert isinstance(nb.url(), str)
+    assert str(nb) == nb.url()
 
     try:
         nb.send('test message')

--- a/test/test_plugin_apprise_api.py
+++ b/test/test_plugin_apprise_api.py
@@ -265,4 +265,10 @@ def test_notify_apprise_api_attachments(mock_post):
             body='body', title='title', notify_type=NotifyType.INFO,
             attach=attach) is True
         assert mock_post.call_count == 1
+
+        details = mock_post.call_args_list[0]
+        assert details[0][0] == 'http://localhost/notify/mytoken1'
+        assert obj.url(privacy=False).startswith(
+            'apprise://user@localhost/mytoken1/')
+
         mock_post.reset_mock()


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** [apprise-api/101](https://github.com/caronc/apprise-api/issues/101)

In preparation for webhook support with the Apprise API, it only makes sense to re-leverage all of the URL parsing and handling done in the Apprise base library (instead of writing it all again).

This merge request will make it easy to Parse a defined webhook URL a lot like an Apprise based one (grabbing options, user/pass combos, timeouts, and everything else) when defined.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
No functional testing  required as it is covered in the added unit tests which test what is expected.

