### PR TITLE
Nextcloud and Nextcloud Talk URL prefix support

### DIFF
--- a/apprise/plugins/NotifyNextcloud.py
+++ b/apprise/plugins/NotifyNextcloud.py
@@ -138,11 +138,8 @@ class NotifyNextcloud(NotifyBase):
         """
         super().__init__(**kwargs)
 
+        # Store our targets
         self.targets = parse_list(targets)
-        if len(self.targets) == 0:
-            msg = 'At least one Nextcloud target user must be specified.'
-            self.logger.warning(msg)
-            raise TypeError(msg)
 
         self.version = self.template_args['version']['default']
         if version is not None:
@@ -158,9 +155,9 @@ class NotifyNextcloud(NotifyBase):
                 self.logger.warning(msg)
                 raise TypeError(msg)
 
-        # Support URL Prefixes
+        # Support URL Prefix
         self.url_prefix = '' if not url_prefix \
-            else '{}'.join(url_prefix.strip('/'))
+            else url_prefix.strip('/')
 
         self.headers = {}
         if headers:
@@ -173,6 +170,11 @@ class NotifyNextcloud(NotifyBase):
         """
         Perform Nextcloud Notification
         """
+
+        if len(self.targets) == 0:
+            # There were no services to notify
+            self.logger.warning('There were no Nextcloud targets to notify.')
+            return False
 
         # Prepare our Header
         headers = {
@@ -327,7 +329,8 @@ class NotifyNextcloud(NotifyBase):
         """
         Returns the number of targets associated with this notification
         """
-        return len(self.targets)
+        targets = len(self.targets)
+        return targets if targets else 1
 
     @staticmethod
     def parse_url(url):

--- a/apprise/plugins/NotifyNextcloudTalk.py
+++ b/apprise/plugins/NotifyNextcloudTalk.py
@@ -131,15 +131,12 @@ class NotifyNextcloudTalk(NotifyBase):
             self.logger.warning(msg)
             raise TypeError(msg)
 
+        # Store our targets
         self.targets = parse_list(targets)
-        if len(self.targets) == 0:
-            msg = 'At least one Nextcloud Talk Room ID must be specified.'
-            self.logger.warning(msg)
-            raise TypeError(msg)
 
-        # Support URL Prefixes
+        # Support URL Prefix
         self.url_prefix = '' if not url_prefix \
-            else '{}'.join(url_prefix.strip('/'))
+            else url_prefix.strip('/')
 
         self.headers = {}
         if headers:
@@ -152,6 +149,12 @@ class NotifyNextcloudTalk(NotifyBase):
         """
         Perform Nextcloud Talk Notification
         """
+
+        if len(self.targets) == 0:
+            # There were no services to notify
+            self.logger.warning(
+                'There were no Nextcloud Talk targets to notify.')
+            return False
 
         # Prepare our Header
         headers = {
@@ -214,7 +217,8 @@ class NotifyNextcloudTalk(NotifyBase):
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
                 )
-                if r.status_code != requests.codes.created:
+                if r.status_code not in (
+                        requests.codes.created, requests.codes.ok):
                     # We had a problem
                     status_str = \
                         NotifyNextcloudTalk.http_response_code_lookup(
@@ -290,7 +294,8 @@ class NotifyNextcloudTalk(NotifyBase):
         """
         Returns the number of targets associated with this notification
         """
-        return len(self.targets)
+        targets = len(self.targets)
+        return targets if targets else 1
 
     @staticmethod
     def parse_url(url):

--- a/test/test_plugin_nextcloud.py
+++ b/test/test_plugin_nextcloud.py
@@ -81,6 +81,12 @@ apprise_url_tests = (
     ('ncloud://user@localhost?to=user1,user2&version=21', {
         'instance': NotifyNextcloud,
     }),
+    ('ncloud://user@localhost?to=user1&version=20&url_prefix=/abcd', {
+        'instance': NotifyNextcloud,
+    }),
+    ('ncloud://user@localhost?to=user1&version=21&url_prefix=/abcd', {
+        'instance': NotifyNextcloud,
+    }),
     ('ncloud://user:pass@localhost/user1/user2', {
         'instance': NotifyNextcloud,
 

--- a/test/test_plugin_nextcloudtalk.py
+++ b/test/test_plugin_nextcloudtalk.py
@@ -77,6 +77,10 @@ apprise_url_tests = (
         'instance': NotifyNextcloudTalk,
         'requests_response_code': requests.codes.created,
     }),
+    ('nctalk://user:pass@localhost:8080/roomid?url_prefix=/prefix', {
+        'instance': NotifyNextcloudTalk,
+        'requests_response_code': requests.codes.created,
+    }),
     ('nctalks://user:pass@localhost/roomid', {
         'instance': NotifyNextcloudTalk,
         'requests_response_code': requests.codes.created,

--- a/test/test_plugin_nextcloudtalk.py
+++ b/test/test_plugin_nextcloudtalk.py
@@ -27,7 +27,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from unittest import mock
-
+from apprise import Apprise
+from apprise import NotifyType
 import requests
 from apprise.plugins.NotifyNextcloudTalk import NotifyNextcloudTalk
 from helpers import AppriseURLTester
@@ -38,7 +39,7 @@ logging.disable(logging.CRITICAL)
 
 apprise_url_tests = (
     ##################################
-    # NotifyNextcloud
+    # NotifyNextcloudTalk
     ##################################
     ('nctalk://:@/', {
         'instance': None,
@@ -64,7 +65,10 @@ apprise_url_tests = (
     }),
     ('nctalk://user:pass@localhost', {
         # No roomid specified
-        'instance': TypeError,
+        'instance': NotifyNextcloudTalk,
+        # Since there are no targets specified we expect a False return on
+        # send()
+        'notify_response': False,
     }),
     ('nctalk://user:pass@localhost/roomid1/roomid2', {
         'instance': NotifyNextcloudTalk,
@@ -119,7 +123,7 @@ apprise_url_tests = (
 
 def test_plugin_nextcloudtalk_urls():
     """
-    NotifyNextcloud() Apprise URLs
+    NotifyNextcloudTalk() Apprise URLs
 
     """
 
@@ -130,7 +134,7 @@ def test_plugin_nextcloudtalk_urls():
 @mock.patch('requests.post')
 def test_plugin_nextcloudtalk_edge_cases(mock_post):
     """
-    NotifyNextcloud() Edge Cases
+    NotifyNextcloudTalk() Edge Cases
 
     """
 
@@ -152,3 +156,45 @@ def test_plugin_nextcloudtalk_edge_cases(mock_post):
     assert obj.send(body="") is True
     assert 'data' in mock_post.call_args_list[0][1]
     assert 'message' in mock_post.call_args_list[0][1]['data']
+
+
+@mock.patch('requests.post')
+def test_plugin_nextcloud_talk_url_prefix(mock_post):
+    """
+    NotifyNextcloudTalk() URL Prefix Testing
+    """
+
+    response = mock.Mock()
+    response.content = ''
+    response.status_code = requests.codes.created
+
+    # Prepare our mock object
+    mock_post.return_value = response
+
+    # instantiate our object (without a batch mode)
+    obj = Apprise.instantiate(
+        'nctalk://user:pass@localhost/admin/?url_prefix=/abcd')
+
+    assert obj.notify(
+        body='body', title='title', notify_type=NotifyType.INFO) is True
+
+    # Not set to batch, so we send 2 different messages
+    assert mock_post.call_count == 1
+    assert mock_post.call_args_list[0][0][0] == \
+        'http://localhost/abcd/ocs/v2.php/apps/spreed/api/v1/chat/admin'
+
+    mock_post.reset_mock()
+
+    # instantiate our object (without a batch mode)
+    obj = Apprise.instantiate(
+        'nctalk://user:pass@localhost/admin/?'
+        'url_prefix=a/longer/path/abcd/')
+
+    assert obj.notify(
+        body='body', title='title', notify_type=NotifyType.INFO) is True
+
+    # Not set to batch, so we send 2 different messages
+    assert mock_post.call_count == 1
+    assert mock_post.call_args_list[0][0][0] == \
+        'http://localhost/a/longer/path/abcd/' \
+        'ocs/v2.php/apps/spreed/api/v1/chat/admin'


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #974

Added support for `url_prefix` for Nextcloud Talk

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@974-nextcloud-talk-prefix

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "nctalk://credentials@host?url_prefix=/path"

```

