### PR TITLE
Notifiarr footer and icon attributes set

### DIFF
--- a/apprise/plugins/NotifyNotifiarr.py
+++ b/apprise/plugins/NotifyNotifiarr.py
@@ -140,11 +140,6 @@ class NotifyNotifiarr(NotifyBase):
             'name': _('Source'),
             'type': 'string',
         },
-        'footer': {
-            'name': _('Display Footer'),
-            'type': 'bool',
-            'default': False,
-        },
         'from': {
             'alias_of': 'source'
         },
@@ -154,7 +149,7 @@ class NotifyNotifiarr(NotifyBase):
     })
 
     def __init__(self, apikey=None, include_image=None,
-                 discord_user=None, footer=False, discord_role=None,
+                 discord_user=None, discord_role=None,
                  event=None, targets=None, source=None, **kwargs):
         """
         Initialize Notifiarr Object
@@ -176,9 +171,6 @@ class NotifyNotifiarr(NotifyBase):
         self.include_image = include_image \
             if isinstance(include_image, bool) \
             else self.template_args['image']['default']
-
-        # Place a footer
-        self.footer = footer
 
         # Set up our user if specified
         self.discord_user = 0
@@ -247,7 +239,6 @@ class NotifyNotifiarr(NotifyBase):
         # Define any URL parameters
         params = {
             'image': 'yes' if self.include_image else 'no',
-            'footer': 'yes' if self.footer else 'no',
         }
 
         if self.source:
@@ -319,6 +310,7 @@ class NotifyNotifiarr(NotifyBase):
                         'title': title,
                         'content': '',
                         'description': body,
+                        'footer': self.app_desc,
                     },
                     'ids': {
                         'channel': channel,
@@ -328,14 +320,9 @@ class NotifyNotifiarr(NotifyBase):
 
             if self.include_image and image_url:
                 payload['discord']['text']['icon'] = image_url
-
-            if self.footer:
-                payload['discord']['text']['footer'] = self.app_desc
-
-                if self.include_image and image_url:
-                    payload['discord']['images'] = {
-                        'thumbnail': image_url,
-                    }
+                payload['discord']['images'] = {
+                    'thumbnail': image_url,
+                }
 
             if not self._send(payload):
                 has_error = True
@@ -438,8 +425,6 @@ class NotifyNotifiarr(NotifyBase):
                 len(results['qsd']['event']):
             results['event'] = \
                 NotifyNotifiarr.unquote(results['qsd']['event'])
-        # Use Footer
-        results['footer'] = parse_bool(results['qsd'].get('footer', False))
 
         # Include images with our message
         results['include_image'] = \

--- a/test/test_plugin_notifiarr.py
+++ b/test/test_plugin_notifiarr.py
@@ -94,10 +94,10 @@ apprise_url_tests = (
         # Our expected url(privacy=True) startswith() response:
         'privacy_url': 'notifiarr://m...y/#123',
     }),
-    ('notifiarr://123/?apikey=myapikey&footer=yes&image=yes', {
+    ('notifiarr://123/?apikey=myapikey&image=yes', {
         'instance': NotifyNotifiarr,
     }),
-    ('notifiarr://123/?apikey=myapikey&footer=yes&image=no', {
+    ('notifiarr://123/?apikey=myapikey&image=no', {
         'instance': NotifyNotifiarr,
     }),
     ('notifiarr://123/?apikey=myapikey&source=My%20System', {

--- a/test/test_plugin_notifiarr.py
+++ b/test/test_plugin_notifiarr.py
@@ -94,6 +94,12 @@ apprise_url_tests = (
         # Our expected url(privacy=True) startswith() response:
         'privacy_url': 'notifiarr://m...y/#123',
     }),
+    ('notifiarr://123/?apikey=myapikey&footer=yes&image=yes', {
+        'instance': NotifyNotifiarr,
+    }),
+    ('notifiarr://123/?apikey=myapikey&footer=yes&image=no', {
+        'instance': NotifyNotifiarr,
+    }),
     ('notifiarr://123/?apikey=myapikey&source=My%20System', {
         'instance': NotifyNotifiarr,
         # Our expected url(privacy=True) startswith() response:


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #949 and #953

Added `footer` and image details as part of the notifiarr payload

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@949-notifiarr-extra-requests

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "notifiarr://credentials"
```

