### PR TITLE
Use label to distinguish new notification requests from general enhan…

### DIFF
--- a/.github/ISSUE_TEMPLATE/3_new-notification-request.md
+++ b/.github/ISSUE_TEMPLATE/3_new-notification-request.md
@@ -2,7 +2,7 @@
 name: 📣 New Notification Request
 about: Suggest a new notification service that you'd like to see Apprise support
 title: ''
-labels: 'enhancement'
+labels: ['enhancement', 'new-notification']
 assignees: ''
 
 ---


### PR DESCRIPTION
IMHO a new label would be useful to distinguish new notification requests from general enhancements, would not it?

If not, just decline it hehe… I just thought I could better filter for what notification service requests there are. Also I have just used/tried to keep to your term used here in the label name. If you want a different one (like `notification-service-request`) feel free to use that one.
