### PR TITLE
Improved YAML group support

### DIFF
--- a/apprise/config/ConfigBase.py
+++ b/apprise/config/ConfigBase.py
@@ -902,7 +902,7 @@ class ConfigBase(URLBase):
             #
             # Dictionary
             #
-            for no, (_groups, tags) in enumerate(groups.items()):
+            for _groups, tags in groups.items():
                 for group in parse_list(_groups, cast=str):
                     if isinstance(tags, (list, tuple)):
                         _tags = set()
@@ -959,7 +959,6 @@ class ConfigBase(URLBase):
                         else:
                             group_tags[group] |= tags
 
-        #
         # include root directive
         #
         includes = result.get('include', None)

--- a/apprise/config/ConfigBase.py
+++ b/apprise/config/ConfigBase.py
@@ -393,7 +393,11 @@ class ConfigBase(URLBase):
                 # Track our groups
                 groups.add(tag)
 
-                # Store what we know is worth keping
+                # Store what we know is worth keeping
+                if tag not in group_tags:  # pragma: no cover
+                    # handle cases where the tag doesn't exist
+                    group_tags[tag] = set()
+
                 results |= group_tags[tag] - tag_groups
 
                 # Get simple tag assignments

--- a/apprise/config/ConfigBase.py
+++ b/apprise/config/ConfigBase.py
@@ -898,19 +898,11 @@ class ConfigBase(URLBase):
         # groups root directive
         #
         groups = result.get('groups', None)
-        if not isinstance(groups, (list, tuple)):
-            # Not a problem; we simply have no group entry
-            groups = list()
-
-        # Iterate over each group defined and store it
-        for no, entry in enumerate(groups):
-            if not isinstance(entry, dict):
-                ConfigBase.logger.warning(
-                    'No assignment for group {}, entry #{}'.format(
-                        entry, no + 1))
-                continue
-
-            for _groups, tags in entry.items():
+        if isinstance(groups, dict):
+            #
+            # Dictionary
+            #
+            for no, (_groups, tags) in enumerate(groups.items()):
                 for group in parse_list(_groups, cast=str):
                     if isinstance(tags, (list, tuple)):
                         _tags = set()
@@ -931,6 +923,41 @@ class ConfigBase(URLBase):
 
                     else:
                         group_tags[group] |= tags
+
+        elif isinstance(groups, (list, tuple)):
+            #
+            # List of Dictionaries
+            #
+
+            # Iterate over each group defined and store it
+            for no, entry in enumerate(groups):
+                if not isinstance(entry, dict):
+                    ConfigBase.logger.warning(
+                        'No assignment for group {}, entry #{}'.format(
+                            entry, no + 1))
+                    continue
+
+                for _groups, tags in entry.items():
+                    for group in parse_list(_groups, cast=str):
+                        if isinstance(tags, (list, tuple)):
+                            _tags = set()
+                            for e in tags:
+                                if isinstance(e, dict):
+                                    _tags |= set(e.keys())
+                                else:
+                                    _tags |= set(parse_list(e, cast=str))
+
+                            # Final assignment
+                            tags = _tags
+
+                        else:
+                            tags = set(parse_list(tags, cast=str))
+
+                        if group not in group_tags:
+                            group_tags[group] = tags
+
+                        else:
+                            group_tags[group] |= tags
 
         #
         # include root directive

--- a/test/test_apprise_config.py
+++ b/test/test_apprise_config.py
@@ -1250,6 +1250,57 @@ def test_config_base_parse_yaml_file04(tmpdir):
     assert sum(1 for _ in a.find('test1, test3')) == 2
 
 
+def test_config_base_parse_yaml_file05(tmpdir):
+    """
+    API: ConfigBase.parse_yaml_file (#5)
+
+    Test groups
+
+    """
+    t = tmpdir.mkdir("always-keyword").join("apprise.yml")
+    t.write("""
+      version: 1
+      groups:
+        mygroup: user1, user2
+      
+      urls:
+        - json:///user:pass@localhost:
+          - to: user1@example.com
+            tag: user1
+          - to: user2@example.com
+            tag: user2
+    """)
+
+    # Create ourselves a config object
+    ac = AppriseConfig(paths=str(t))
+
+    # The number of configuration files that exist
+    assert len(ac) == 1
+
+    # no notifications are loaded
+    assert len(ac.servers()) == 2
+
+    # Test our ability to add Config objects to our apprise object
+    a = Apprise()
+
+    # Add our configuration object
+    assert a.add(servers=ac) is True
+
+    # Detect our 3 entry as they should have loaded successfully
+    assert len(a) == 2
+
+    # No match
+    assert sum(1 for _ in a.find('no-match')) == 0
+    # Match everything
+    assert sum(1 for _ in a.find('all')) == 2
+    # Match user1 entry
+    assert sum(1 for _ in a.find('user1')) == 1
+    # Match user2 entry
+    assert sum(1 for _ in a.find('user2')) == 1
+    # Match mygroup
+    assert sum(1 for _ in a.find('mygroup')) == 2
+
+
 def test_apprise_config_template_parse(tmpdir):
     """
     API: AppriseConfig parsing of templates

--- a/test/test_apprise_config.py
+++ b/test/test_apprise_config.py
@@ -1250,57 +1250,6 @@ def test_config_base_parse_yaml_file04(tmpdir):
     assert sum(1 for _ in a.find('test1, test3')) == 2
 
 
-def test_config_base_parse_yaml_file05(tmpdir):
-    """
-    API: ConfigBase.parse_yaml_file (#5)
-
-    Test groups
-
-    """
-    t = tmpdir.mkdir("always-keyword").join("apprise.yml")
-    t.write("""
-      version: 1
-      groups:
-        mygroup: user1, user2
-      
-      urls:
-        - json:///user:pass@localhost:
-          - to: user1@example.com
-            tag: user1
-          - to: user2@example.com
-            tag: user2
-    """)
-
-    # Create ourselves a config object
-    ac = AppriseConfig(paths=str(t))
-
-    # The number of configuration files that exist
-    assert len(ac) == 1
-
-    # no notifications are loaded
-    assert len(ac.servers()) == 2
-
-    # Test our ability to add Config objects to our apprise object
-    a = Apprise()
-
-    # Add our configuration object
-    assert a.add(servers=ac) is True
-
-    # Detect our 3 entry as they should have loaded successfully
-    assert len(a) == 2
-
-    # No match
-    assert sum(1 for _ in a.find('no-match')) == 0
-    # Match everything
-    assert sum(1 for _ in a.find('all')) == 2
-    # Match user1 entry
-    assert sum(1 for _ in a.find('user1')) == 1
-    # Match user2 entry
-    assert sum(1 for _ in a.find('user2')) == 1
-    # Match mygroup
-    assert sum(1 for _ in a.find('mygroup')) == 2
-
-
 def test_apprise_config_template_parse(tmpdir):
     """
     API: AppriseConfig parsing of templates

--- a/test/test_config_base.py
+++ b/test/test_config_base.py
@@ -1384,6 +1384,7 @@ urls:
     assert len([x for x in apobj.find('group6')]) == 1
     assert len([x for x in apobj.find('4')]) == 1
     assert len([x for x in apobj.find('groupN')]) == 1
+    assert len([x for x in apobj.find('groupK')]) == 0
 
 
 def test_config_base_config_parse_yaml_globals():


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #952, and [apprise-api/146](https://github.com/caronc/apprise-api/issues/146)

Current design of Tag Group handling works great as long as YAML definitions are in a list format only.  e.g:
```yaml
groups:
  - group1: tagB, tagC, tagNotAssigned
  - group2:
      - tagA
      - tagC
  - group3:
      - tagD: optional comment
      - tagA: optional comment #2
```

However the following is not supported (until this PR):
```yaml
groups:
  group1: tagB, tagC, tagNotAssigned
  group2:
     - tagA
     - tagC
  group3:
     - tagD: optional comment
     - tagA: optional comment #2
```

It is worth noting that the trade-off (or perk, however you see it) with the new `dict` approach is that you can not stack entries and have them all append to one another.  With the `dict`  approach, the last defined entry prevails:

For example:
```yaml
# duplicate group tags with the same name stack:
groups:
  - group: tagB, tagC
  - group: tagA

  # At this point, group == tagA, tagB and tagC
```
The new supported `dict` version behaves differently:
```yaml
# duplicate group tags with the same name stack:
groups:
  group: tagB, tagC
  group: tagA

  # At this point, group == tagA (because it was the last entry defined and replaces
  # the previous value)
```

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@952-group-handling-fix

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  <apprise url related to ticket>

```

