### PR TITLE
Discord user/role ping/notification support added

### DIFF
--- a/apprise/plugins/NotifyDiscord.py
+++ b/apprise/plugins/NotifyDiscord.py
@@ -349,15 +349,24 @@ class NotifyDiscord(NotifyBase):
                     'users': [],
                     'roles': [],
                 }
+
+                _content = []
                 for (is_role, no, value) in results:
                     if value:
                         payload['allow_mentions']['parse'].append(value)
+                        _content.append(f'@{value}')
 
                     elif is_role:
                         payload['allow_mentions']['roles'].append(no)
+                        _content.append(f'<@&{no}>')
 
                     else:  # is_user
                         payload['allow_mentions']['users'].append(no)
+                        _content.append(f'<@{no}>')
+
+                if self.notify_format == NotifyFormat.MARKDOWN:
+                    # Add pingable elements to content field
+                    payload['content'] = '👉 ' + ' '.join(_content)
 
             if not self._send(payload, params=params):
                 # We failed to post our message

--- a/test/test_plugin_discord.py
+++ b/test/test_plugin_discord.py
@@ -672,6 +672,26 @@ def test_plugin_discord_attachments(mock_post):
         'https://discord.com/api/webhooks/{}/{}'.format(
             webhook_id, webhook_token)
 
+    # Reset our object
+    mock_post.reset_mock()
+
+    # Test notifications with mentions and attachments in it
+    assert obj.notify(
+        body='Say hello to <@1234>!', notify_type=NotifyType.INFO,
+        attach=attach) is True
+
+    # Test our call count
+    assert mock_post.call_count == 2
+    assert mock_post.call_args_list[0][0][0] == \
+        'https://discord.com/api/webhooks/{}/{}'.format(
+            webhook_id, webhook_token)
+    assert mock_post.call_args_list[1][0][0] == \
+        'https://discord.com/api/webhooks/{}/{}'.format(
+            webhook_id, webhook_token)
+
+    # Reset our object
+    mock_post.reset_mock()
+
     # An invalid attachment will cause a failure
     path = os.path.join(TEST_VAR_DIR, '/invalid/path/to/an/invalid/file.jpg')
     attach = AppriseAttachment(path)


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #989

Added *PING* support to Discord related notifications.  Syntax supported is as follows:
- *user*: `<@123>`
- *role*: `<@&456>`
- *tag*: `@everyone`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@989-discord-notifications

# Test out the changes with the following command:
apprise -vv -b "@everyone and @admin, wake and meet our new user <@123>; <@&456>" \
  "discord://credentials"
```

