### PR TITLE
Load Notifications and Emoji Engine on Demand

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       # expanded using subsequent `include` items.
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         bare: [false]
 
         include:
@@ -39,14 +39,14 @@ jobs:
           # Within the `bare` environment, `all-plugin-requirements.txt` will NOT be
           # installed, to verify the application also works without those dependencies.
           - os: "ubuntu-latest"
-            python-version: "3.10"
+            python-version: "3.11"
             bare: true
 
           # Let's save resources and only build a single slot on macOS- and Windows.
           - os: "macos-latest"
-            python-version: "3.10"
+            python-version: "3.11"
           - os: "windows-latest"
-            python-version: "3.10"
+            python-version: "3.11"
 
           # Test more available versions of CPython on Linux.
           - os: "ubuntu-20.04"

--- a/apprise/AppriseAsset.py
+++ b/apprise/AppriseAsset.py
@@ -33,7 +33,11 @@ from os.path import dirname
 from os.path import isfile
 from os.path import abspath
 from .common import NotifyType
-from .utils import module_detection
+from .NotificationManager import NotificationManager
+
+
+# Grant access to our Notification Manager Singleton
+N_MGR = NotificationManager()
 
 
 class AppriseAsset:
@@ -180,7 +184,7 @@ class AppriseAsset:
 
         if plugin_paths:
             # Load any decorated modules if defined
-            module_detection(plugin_paths)
+            N_MGR.module_detection(plugin_paths)
 
     def color(self, notify_type, color_type=None):
         """

--- a/apprise/AttachmentManager.py
+++ b/apprise/AttachmentManager.py
@@ -32,20 +32,20 @@ from os.path import join
 from .manager import PluginManager
 
 
-class NotificationManager(PluginManager):
+class AttachmentManager(PluginManager):
     """
-    Designed to be a singleton object to maintain all initialized notifications
-    in memory.
+    Designed to be a singleton object to maintain all initialized
+    attachment plugins/modules in memory.
     """
 
     # Description (used for logging)
-    name = 'Notification Plugin'
+    name = 'Attachment Plugin'
 
     # Filename Prefix to filter on
-    fname_prefix = 'Notify'
+    fname_prefix = 'Attach'
 
     # Memory Space
-    _id = 'plugins'
+    _id = 'attachment'
 
     # Our Module Python path name
     module_name_prefix = f'apprise.{_id}'

--- a/apprise/ConfigurationManager.py
+++ b/apprise/ConfigurationManager.py
@@ -32,20 +32,20 @@ from os.path import join
 from .manager import PluginManager
 
 
-class NotificationManager(PluginManager):
+class ConfigurationManager(PluginManager):
     """
-    Designed to be a singleton object to maintain all initialized notifications
-    in memory.
+    Designed to be a singleton object to maintain all initialized
+    configuration plugins/modules in memory.
     """
 
     # Description (used for logging)
-    name = 'Notification Plugin'
+    name = 'Configuration Plugin'
 
     # Filename Prefix to filter on
-    fname_prefix = 'Notify'
+    fname_prefix = 'Config'
 
     # Memory Space
-    _id = 'plugins'
+    _id = 'config'
 
     # Our Module Python path name
     module_name_prefix = f'apprise.{_id}'

--- a/apprise/NotificationManager.py
+++ b/apprise/NotificationManager.py
@@ -1,0 +1,665 @@
+# -*- coding: utf-8 -*-
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2023, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import re
+import sys
+import time
+import hashlib
+import inspect
+from .utils import import_module
+from os.path import dirname
+from os.path import abspath
+from os.path import join
+from importlib import reload
+
+from .logger import logger
+
+
+class Singleton(type):
+    """
+    Our Singleton MetaClass
+    """
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        """
+        instantiate our singleton meta entry
+        """
+        if cls not in cls._instances:
+            # we have not every built an instance before.  Build one now.
+            cls._instances[cls] = super().__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+
+class NotificationManager(metaclass=Singleton):
+    """
+    Designed to be a singleton object to maintain all initialized notifications
+    in memory.
+    """
+
+    # Our Module Python path name
+    module_name_prefix = 'apprise.plugins'
+
+    # The module path to scan
+    module_path = join(abspath(dirname(__file__)), 'plugins')
+
+    def __init__(self, *args, **kwargs):
+        """
+        Over-ride our class instantiation to provide a singleton
+        """
+
+        self._module_map = None
+        self._schema_map = None
+
+        # This contains a mapping of all plugins dynamicaly loaded at runtime
+        # from external modules such as the @notify decorator
+        #
+        # The elements here will be additionally added to the _schema_map if
+        # there is no conflict otherwise.
+        # The structure looks like the following:
+        # Module path, e.g. /usr/share/apprise/plugins/my_notify_hook.py
+        # {
+        #   'path': path,
+        #
+        #   'notify': {
+        #     'schema': {
+        #       'name': 'Custom schema name',
+        #       'fn_name': 'name_of_function_decorator_was_found_on',
+        #       'url': 'schema://any/additional/info/found/on/url'
+        #       'plugin': <CustomNotifyWrapperPlugin>
+        #    },
+        #     'schema2': {
+        #       'name': 'Custom schema name',
+        #       'fn_name': 'name_of_function_decorator_was_found_on',
+        #       'url': 'schema://any/additional/info/found/on/url'
+        #       'plugin': <CustomNotifyWrapperPlugin>
+        #    }
+        #  }
+        # Note: that the <CustomNotifyWrapperPlugin> inherits from
+        #       NotifyBase
+        self._custom_module_map = {}
+
+        # Track manually disabled modules (by their schema)
+        self._disabled = set()
+
+        # Hash of all paths previously scanned so we don't waste
+        # effort/overhead doing it again
+        self._paths_previously_scanned = set()
+
+    def unload_modules(self, disable_native=False):
+        """
+        Reset our object and unload all modules
+        """
+        if self._custom_module_map and self._custom_module_map:
+            # Handle Custom Module Assignments
+            for module_path in list(sys.modules.keys()):
+                for module_name, meta in self._custom_module_map.items():
+                    if module_path.startswith(meta['path']):
+                        del sys.modules[module_path]
+
+        # Reset our variables
+        self._module_map = None if not disable_native else {}
+        self._schema_map = {}
+        self._custom_module_map = {}
+
+        # Reset our internal tracking flags
+        self._paths_previously_scanned = set()
+        self._disabled = set()
+
+    def load_modules(self, path=None, name=None):
+        """
+        Load our modules into memory
+        """
+
+        # Default value
+        module_name_prefix = self.module_name_prefix if name is None else name
+        module_path = self.module_path if path is None else path
+
+        if not self:
+            # Initialize our maps
+            self._module_map = {}
+            self._schema_map = {}
+            self._custom_module_map = {}
+
+        # Used for the detection of additional Notify Services objects
+        # The .py extension is optional as we support loading directories too
+        module_re = re.compile(r'^(?P<name>Notify[a-z0-9]+)(\.py)?$', re.I)
+
+        t_start = time.time()
+        for f in os.listdir(module_path):
+            tl_start = time.time()
+            match = module_re.match(f)
+            if not match:
+                # keep going
+                continue
+
+            elif match.group('name') == 'NotifyBase':
+                # keep going
+                continue
+
+            # Store our notification/plugin name:
+            module_name = match.group('name')
+            module_pyname = '{}.{}'.format(module_name_prefix, module_name)
+
+            try:
+                module = __import__(
+                    module_pyname,
+                    globals(), locals(),
+                    fromlist=[module_name])
+
+            except ImportError:
+                # No problem, we can't use this object
+                continue
+
+            if not hasattr(module, module_name):
+                # Not a library we can load as it doesn't follow the simple
+                # rule that the class must bear the same name as the
+                # notification file itself.
+                continue
+
+            # Get our plugin
+            plugin = getattr(module, module_name)
+            if not hasattr(plugin, 'app_id'):
+                # Filter out non-notification modules
+                continue
+
+            elif module_name in self._module_map:
+                # we're already handling this object
+                continue
+
+            # Add our plugin name to our module map
+            self._module_map[module_name] = {
+                'plugin': set([plugin]),
+                'module': module,
+                'path': '{}.{}'.format(module_name_prefix, module_name),
+                'native': True,
+            }
+
+            fn = getattr(plugin, 'schemas', None)
+            schemas = set([]) if not callable(fn) else fn(plugin)
+
+            # map our schema to our plugin
+            for schema in schemas:
+                if schema in self._schema_map:
+                    logger.error(
+                        "Notification schema ({}) mismatch detected - {} to {}"
+                        .format(schema, self._schema_map, plugin))
+                    continue
+
+                # Assign plugin
+                self._schema_map[schema] = plugin
+
+            logger.trace(
+                'Plugin {} loaded in {:.6f}s'.format(
+                    module_name, (time.time() - tl_start)))
+        logger.debug(
+            '{} Plugin(s) and {} Schema(s) loaded in {:.4f}s'.format(
+                len(self._module_map), len(self._schema_map),
+                (time.time() - t_start)))
+
+    def module_detection(self, paths, cache=True):
+        """
+        Leverage the @notify decorator and load all objects found matching
+        this.
+        """
+        # A simple restriction that we don't allow periods in the filename at
+        # all so it can't be hidden (Linux OS's) and it won't conflict with
+        # Python path naming.  This also prevents us from loading any python
+        # file that starts with an underscore or dash
+        # We allow for __init__.py as well
+        module_re = re.compile(
+            r'^(?P<name>[_a-z0-9][a-z0-9._-]+)?(\.py)?$', re.I)
+
+        # Validate if we're a loadable Python file or not
+        valid_python_file_re = re.compile(r'.+\.py(o|c)?$', re.IGNORECASE)
+
+        if isinstance(paths, str):
+            paths = [paths, ]
+
+        if not paths or not isinstance(paths, (tuple, list)):
+            # We're done
+            return
+
+        def _import_module(path):
+            # Since our plugin name can conflict (as a module) with another
+            # we want to generate random strings to avoid steping on
+            # another's namespace
+            if not (path and valid_python_file_re.match(path)):
+                # Ignore file/module type
+                logger.trace('Plugin Scan: Skipping %s', path)
+                return
+
+            t_start = time.time()
+            module_name = hashlib.sha1(path.encode('utf-8')).hexdigest()
+            module_pyname = "{prefix}.{name}".format(
+                prefix='apprise.custom.module', name=module_name)
+
+            if module_pyname in self._custom_module_map:
+                # First clear out existing entries
+                for schema in \
+                        self._custom_module_map[module_pyname]['notify']\
+                        .keys():
+
+                    # Remove any mapped modules to this file
+                    del self._schema_map[schema]
+
+                # Reset
+                del self._custom_module_map[module_pyname]
+
+            # Load our module
+            module = import_module(path, module_pyname)
+            if not module:
+                # No problem, we can't use this object
+                logger.warning('Failed to load custom module: %s', _path)
+                return
+
+            # Print our loaded modules if any
+            if module_pyname in self._custom_module_map:
+                logger.debug(
+                    'Custom module %s - %d schema(s) (name=%s) '
+                    'loaded in {:.6f}s',
+                    _path, module_name,
+                    len(self._custom_module_map[module_pyname]['notify']),
+                    (time.time() - t_start))
+
+                # Add our plugin name to our module map
+                self._module_map[module_name] = {
+                    'plugin': set(),
+                    'module': module,
+                    'path': module_pyname,
+                    'native': False,
+                }
+
+                for schema, meta in\
+                        self._custom_module_map[module_pyname]['notify']\
+                        .items():
+
+                    # For mapping purposes; map our element in our main list
+                    self._module_map[module_name]['plugin'].add(
+                        self._schema_map[schema])
+
+                    # Log our success
+                    logger.info('Loaded custom notification: %s://', schema)
+            else:
+                # The code reaches here if we successfully loaded the Python
+                # module but no hooks/triggers were found. So we can safely
+                # just remove/ignore this entry
+                del sys.modules[module_pyname]
+                return
+
+            # end of _import_module()
+            return
+
+        for _path in paths:
+            path = os.path.abspath(os.path.expanduser(_path))
+            if (cache and path in self._paths_previously_scanned) \
+                    or not os.path.exists(path):
+                # We're done as we've already scanned this
+                continue
+
+            # Store our path as a way of hashing it has been handled
+            self._paths_previously_scanned.add(path)
+
+            if os.path.isdir(path) and not \
+                    os.path.isfile(os.path.join(path, '__init__.py')):
+
+                logger.debug('Scanning for custom plugins in: %s', path)
+                for entry in os.listdir(path):
+                    re_match = module_re.match(entry)
+                    if not re_match:
+                        # keep going
+                        logger.trace('Plugin Scan: Ignoring %s', entry)
+                        continue
+
+                    new_path = os.path.join(path, entry)
+                    if os.path.isdir(new_path):
+                        # Update our path
+                        new_path = os.path.join(path, entry, '__init__.py')
+                        if not os.path.isfile(new_path):
+                            logger.trace(
+                                'Plugin Scan: Ignoring %s',
+                                os.path.join(path, entry))
+                            continue
+
+                    if not cache or \
+                            (cache and
+                             new_path not in self._paths_previously_scanned):
+                        # Load our module
+                        _import_module(new_path)
+
+                        # Add our subdir path
+                        self._paths_previously_scanned.add(new_path)
+            else:
+                if os.path.isdir(path):
+                    # This logic is safe to apply because we already validated
+                    # the directories state above; update our path
+                    path = os.path.join(path, '__init__.py')
+                    if cache and path in self._paths_previously_scanned:
+                        continue
+
+                    self._paths_previously_scanned.add(path)
+
+                # directly load as is
+                re_match = module_re.match(os.path.basename(path))
+                # must be a match and must have a .py extension
+                if not re_match or not re_match.group(1):
+                    # keep going
+                    logger.trace('Plugin Scan: Ignoring %s', path)
+                    continue
+
+                # Load our module
+                _import_module(path)
+
+            return None
+
+    def add(self, schema, plugin, url=None, send_func=None):
+        """
+        Ability to manually add Notification services to our stack
+        """
+
+        if not self:
+            # Lazy load
+            self.load_modules()
+
+        if schema in self:
+            # we're already handling this schema
+            logger.warning(
+                'The schema (%s) is already defined and could not be '
+                'loaded from %s%s.',
+                schema,
+                'custom notify function ' if send_func else '',
+                send_func.__name__ if send_func else plugin.__class__.__name__)
+            return False
+
+        if send_func:
+            # Acquire the function name
+            fn_name = send_func.__name__
+
+            # Acquire the python filename path
+            path = inspect.getfile(send_func)
+
+            # Acquire our path to our module
+            module_name = str(send_func.__module__)
+
+            if module_name not in self._custom_module_map:
+                # Support non-dynamic includes as well...
+                self._custom_module_map[module_name] = {
+                    # Name can be useful for indexing back into the
+                    # _module_map object; this is the key to do it with:
+                    'name': module_name.split('.')[-1],
+
+                    # The path to the module loaded
+                    'path': path,
+
+                    # Initialize our template
+                    'notify': {},
+                }
+
+            self._custom_module_map[module_name]['notify'][schema] = {
+                # The name of the send function the @notify decorator wrapped
+                'fn_name': fn_name,
+                # The URL that was provided in the @notify decorator call
+                # associated with the 'on='
+                'url': url,
+            }
+
+        # Assign our mapping
+        self._schema_map[schema] = plugin
+
+        return True
+
+    def reload(self, module_name):
+        """
+        Reloads our module
+        """
+        if not self:
+            # Lazy load
+            self.load_modules()
+
+        module_pyname = '{}.{}'.format(self.module_name_prefix, module_name)
+        if module_name in self._module_map and module_pyname in sys.modules:
+            path = self._module_map[module_name]['path'] + '.'
+            for module_path in list(sys.modules.keys()):
+                if module_path.startswith(path):
+                    del sys.modules[module_path]
+
+            reload(sys.modules[module_pyname])
+
+            # Store our new values from the reload
+            module = sys.modules[module_pyname]
+            plugin = getattr(module, module_name)
+
+            # Update our Schema Map
+            for schema in self.schemas():
+                if self._schema_map[schema] \
+                        == self._module_map[module_name]['plugin']:
+                    # Update Plugin
+                    self._schema_map[schema] = plugin
+
+            # Update Module Map
+            self._module_map[module_name]['module'] = module
+            self._module_map[module_name]['plugin'].add(plugin)
+
+    def remove(self, *schemas):
+        """
+        Removes a loaded element (if defined)
+        """
+        if not self:
+            # Nothing to do
+            return
+
+        for schema in schemas:
+            if self and schema in self:
+                del self._schema_map[schema]
+
+    def plugins(self):
+        """
+        Return all of our loaded plugins
+        """
+        if not self:
+            # Lazy load
+            self.load_modules()
+
+        for module in self._module_map.values():
+            for plugin in module['plugin']:
+                yield plugin
+
+    def schemas(self):
+        """
+        Return all of our loaded schemas
+        """
+        if not self:
+            # Lazy load
+            self.load_modules()
+
+        return list(self._schema_map.keys())
+
+    def disable(self, *schemas):
+        """
+        Disables the modules associated with the specified schemas
+        """
+        if not self:
+            # Lazy load
+            self.load_modules()
+
+        for schema in schemas:
+            if schema not in self._schema_map:
+                continue
+
+            if not self._schema_map[schema].enabled:
+                continue
+
+            # Disable
+            self._schema_map[schema].enabled = False
+            self._disabled.add(schema)
+
+    def enable_only(self, *schemas):
+        """
+        Disables the modules associated with the specified schemas
+        """
+        if not self:
+            # Lazy load
+            self.load_modules()
+
+        # convert to set for faster indexing
+        schemas = set(schemas)
+
+        # Track plugins added since they share 1 or more schemas
+        _enabled = set()
+
+        for schema in self._schema_map:
+
+            if schema not in schemas:
+                if self._schema_map[schema].enabled and \
+                        self._schema_map[schema] not in _enabled:
+                    # Disable
+                    self._schema_map[schema].enabled = False
+                    self._disabled.add(schema)
+                continue
+
+            if schema in self._disabled:
+                self._disabled.remove(schema)
+                self._schema_map[schema].enabled = True
+                _enabled.add(self._schema_map[schema])
+
+    def __contains__(self, schema):
+        """
+        Checks if a schema exists
+        """
+        if not self:
+            # Lazy load
+            self.load_modules()
+
+        return schema in self._schema_map
+
+    def __delitem__(self, schema):
+        if not self:
+            # Lazy load
+            self.load_modules()
+
+        for key in list(self._module_map.keys()):
+            if key not in self._module_map:
+                continue
+
+            if self._schema_map[schema] in self._module_map[key]['plugin']:
+                self._module_map[key]['plugin']\
+                    .remove(self._schema_map[schema])
+
+                # Custom Plugin Entry; Clean up cross reference
+                module_pyname = self._module_map[key]['path']
+                if not self._module_map[key]['native'] and \
+                        module_pyname in self._custom_module_map:
+
+                    del self.\
+                        _custom_module_map[module_pyname]['notify'][schema]
+
+                    if not self._custom_module_map[module_pyname]['notify']:
+                        #
+                        # Last custom loaded element
+                        #
+
+                        # Free up custom object entry
+                        del self._custom_module_map[module_pyname]
+
+                if not self._module_map[key]['plugin']:
+                    #
+                    # Last element
+                    #
+
+                    # free system memory
+                    del sys.modules[self._module_map[key]['path']]
+
+                    # free last remaining pointer in module map
+                    del self._module_map[key]
+
+        del self._schema_map[schema]
+
+    def __setitem__(self, schema, plugin):
+        """
+        Support fast assigning of Plugin/Notification Objects
+        """
+        if not self:
+            # Lazy load
+            self.load_modules()
+
+        # Set default values if not otherwise set
+        if not plugin.service_name:
+            # Assign service name if one doesn't exist
+            plugin.service_name = f'{schema}://'
+
+        # Assignment
+        self._schema_map[schema] = plugin
+
+        module_name = hashlib.sha1(schema.encode('utf-8')).hexdigest()
+        module_pyname = "{prefix}.{name}".format(
+            prefix='apprise.adhoc.module', name=module_name)
+
+        # Add our plugin name to our module map
+        self._module_map[module_name] = {
+            'plugin': set([plugin]),
+            'module': None,
+            'path': '{}.{}'.format(module_pyname, module_name),
+            'native': False,
+        }
+
+    def __getitem__(self, schema):
+        """
+        Returns the indexed plugin identified by the schema specified
+        """
+        if not self:
+            # Lazy load
+            self.load_modules()
+
+        return self._schema_map[schema]
+
+    def __iter__(self):
+        """
+        Returns an iterator so we can iterate over our loaded modules
+        """
+        if self._module_map is None:
+            # Lazy load
+            self.load_modules()
+
+        return iter(self._module_map.values())
+
+    def __len__(self):
+        """
+        Returns the number of modules/plugins loaded
+        """
+        if not self:
+            # Lazy load
+            self.load_modules()
+
+        return len(self._module_map)
+
+    def __bool__(self):
+        """
+        Determines if object has loaded or not
+        """
+        return True if self._module_map is not None else False

--- a/apprise/attachment/__init__.py
+++ b/apprise/attachment/__init__.py
@@ -26,93 +26,14 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import re
-from os import listdir
-from os.path import dirname
-from os.path import abspath
-from ..common import ATTACHMENT_SCHEMA_MAP
+# Used for testing
+from .AttachBase import AttachBase
+from ..AttachmentManager import AttachmentManager
 
-__all__ = []
+# Initalize our Attachment Manager Singleton
+A_MGR = AttachmentManager()
 
-
-# Load our Lookup Matrix
-def __load_matrix(path=abspath(dirname(__file__)), name='apprise.attachment'):
-    """
-    Dynamically load our schema map; this allows us to gracefully
-    skip over modules we simply don't have the dependencies for.
-
-    """
-    # Used for the detection of additional Attachment Services objects
-    # The .py extension is optional as we support loading directories too
-    module_re = re.compile(r'^(?P<name>Attach[a-z0-9]+)(\.py)?$', re.I)
-
-    for f in listdir(path):
-        match = module_re.match(f)
-        if not match:
-            # keep going
-            continue
-
-        # Store our notification/plugin name:
-        plugin_name = match.group('name')
-        try:
-            module = __import__(
-                '{}.{}'.format(name, plugin_name),
-                globals(), locals(),
-                fromlist=[plugin_name])
-
-        except ImportError:
-            # No problem, we can't use this object
-            continue
-
-        if not hasattr(module, plugin_name):
-            # Not a library we can load as it doesn't follow the simple rule
-            # that the class must bear the same name as the notification
-            # file itself.
-            continue
-
-        # Get our plugin
-        plugin = getattr(module, plugin_name)
-        if not hasattr(plugin, 'app_id'):
-            # Filter out non-notification modules
-            continue
-
-        elif plugin_name in __all__:
-            # we're already handling this object
-            continue
-
-        # Add our module name to our __all__
-        __all__.append(plugin_name)
-
-        # Ensure we provide the class as the reference to this directory and
-        # not the module:
-        globals()[plugin_name] = plugin
-
-        # Load protocol(s) if defined
-        proto = getattr(plugin, 'protocol', None)
-        if isinstance(proto, str):
-            if proto not in ATTACHMENT_SCHEMA_MAP:
-                ATTACHMENT_SCHEMA_MAP[proto] = plugin
-
-        elif isinstance(proto, (set, list, tuple)):
-            # Support iterables list types
-            for p in proto:
-                if p not in ATTACHMENT_SCHEMA_MAP:
-                    ATTACHMENT_SCHEMA_MAP[p] = plugin
-
-        # Load secure protocol(s) if defined
-        protos = getattr(plugin, 'secure_protocol', None)
-        if isinstance(protos, str):
-            if protos not in ATTACHMENT_SCHEMA_MAP:
-                ATTACHMENT_SCHEMA_MAP[protos] = plugin
-
-        if isinstance(protos, (set, list, tuple)):
-            # Support iterables list types
-            for p in protos:
-                if p not in ATTACHMENT_SCHEMA_MAP:
-                    ATTACHMENT_SCHEMA_MAP[p] = plugin
-
-    return ATTACHMENT_SCHEMA_MAP
-
-
-# Dynamically build our schema base
-__load_matrix()
+__all__ = [
+    # Reference
+    'AttachBase',
+]

--- a/apprise/common.py
+++ b/apprise/common.py
@@ -26,44 +26,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# we mirror our base purely for the ability to reset everything; this
-# is generally only used in testing and should not be used by developers
-# It is also used as a means of preventing a module from being reloaded
-# in the event it already exists
-NOTIFY_MODULE_MAP = {}
-
-# Maintains a mapping of all of the Notification services
-NOTIFY_SCHEMA_MAP = {}
-
-# This contains a mapping of all plugins dynamicaly loaded at runtime from
-# external modules such as the @notify decorator
-#
-# The elements here will be additionally added to the NOTIFY_SCHEMA_MAP if
-# there is no conflict otherwise.
-# The structure looks like the following:
-# Module path, e.g. /usr/share/apprise/plugins/my_notify_hook.py
-# {
-#   'path': path,
-#
-#   'notify': {
-#     'schema': {
-#       'name': 'Custom schema name',
-#       'fn_name': 'name_of_function_decorator_was_found_on',
-#       'url': 'schema://any/additional/info/found/on/url'
-#       'plugin': <CustomNotifyWrapperPlugin>
-#    },
-#     'schema2': {
-#       'name': 'Custom schema name',
-#       'fn_name': 'name_of_function_decorator_was_found_on',
-#       'url': 'schema://any/additional/info/found/on/url'
-#       'plugin': <CustomNotifyWrapperPlugin>
-#    }
-#  }
-#
-# Note: that the <CustomNotifyWrapperPlugin> inherits from
-#       NotifyBase
-NOTIFY_CUSTOM_MODULE_MAP = {}
-
 # Maintains a mapping of all configuration schema's supported
 CONFIG_SCHEMA_MAP = {}
 

--- a/apprise/common.py
+++ b/apprise/common.py
@@ -26,12 +26,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# Maintains a mapping of all configuration schema's supported
-CONFIG_SCHEMA_MAP = {}
-
-# Maintains a mapping of all attachment schema's supported
-ATTACHMENT_SCHEMA_MAP = {}
-
 
 class NotifyType:
     """

--- a/apprise/config/ConfigBase.py
+++ b/apprise/config/ConfigBase.py
@@ -40,10 +40,14 @@ from ..utils import parse_list
 from ..utils import parse_bool
 from ..utils import parse_urls
 from ..utils import cwe312_url
+from ..NotificationManager import NotificationManager
 
 # Test whether token is valid or not
 VALID_TOKEN = re.compile(
     r'(?P<token>[a-z0-9][a-z0-9_]+)', re.I)
+
+# Grant access to our Notification Manager Singleton
+N_MGR = NotificationManager()
 
 
 class ConfigBase(URLBase):
@@ -765,8 +769,7 @@ class ConfigBase(URLBase):
             try:
                 # Attempt to create an instance of our plugin using the
                 # parsed URL information
-                plugin = common.NOTIFY_SCHEMA_MAP[
-                    results['schema']](**results)
+                plugin = N_MGR[results['schema']](**results)
 
                 # Create log entry of loaded URL
                 ConfigBase.logger.debug(
@@ -1094,7 +1097,7 @@ class ConfigBase(URLBase):
                                 del entries['schema']
 
                             # support our special tokens (if they're present)
-                            if schema in common.NOTIFY_SCHEMA_MAP:
+                            if schema in N_MGR:
                                 entries = ConfigBase._special_token_handler(
                                     schema, entries)
 
@@ -1106,7 +1109,7 @@ class ConfigBase(URLBase):
 
                 elif isinstance(tokens, dict):
                     # support our special tokens (if they're present)
-                    if schema in common.NOTIFY_SCHEMA_MAP:
+                    if schema in N_MGR:
                         tokens = ConfigBase._special_token_handler(
                             schema, tokens)
 
@@ -1140,7 +1143,7 @@ class ConfigBase(URLBase):
                 # Grab our first item
                 _results = results.pop(0)
 
-                if _results['schema'] not in common.NOTIFY_SCHEMA_MAP:
+                if _results['schema'] not in N_MGR:
                     # the arguments are invalid or can not be used.
                     ConfigBase.logger.warning(
                         'An invalid Apprise schema ({}) in YAML configuration '
@@ -1213,8 +1216,7 @@ class ConfigBase(URLBase):
             try:
                 # Attempt to create an instance of our plugin using the
                 # parsed URL information
-                plugin = common.\
-                    NOTIFY_SCHEMA_MAP[results['schema']](**results)
+                plugin = N_MGR[results['schema']](**results)
 
                 # Create log entry of loaded URL
                 ConfigBase.logger.debug(
@@ -1267,8 +1269,7 @@ class ConfigBase(URLBase):
         # Create a copy of our dictionary
         tokens = tokens.copy()
 
-        for kw, meta in common.NOTIFY_SCHEMA_MAP[schema]\
-                .template_kwargs.items():
+        for kw, meta in N_MGR[schema].template_kwargs.items():
 
             # Determine our prefix:
             prefix = meta.get('prefix', '+')
@@ -1311,8 +1312,7 @@ class ConfigBase(URLBase):
         #
         # This function here allows these mappings to take place within the
         # YAML file as independant arguments.
-        class_templates = \
-            plugins.details(common.NOTIFY_SCHEMA_MAP[schema])
+        class_templates = plugins.details(N_MGR[schema])
 
         for key in list(tokens.keys()):
 

--- a/apprise/config/ConfigBase.py
+++ b/apprise/config/ConfigBase.py
@@ -35,6 +35,7 @@ from .. import plugins
 from .. import common
 from ..AppriseAsset import AppriseAsset
 from ..URLBase import URLBase
+from ..ConfigurationManager import ConfigurationManager
 from ..utils import GET_SCHEMA_RE
 from ..utils import parse_list
 from ..utils import parse_bool
@@ -48,6 +49,9 @@ VALID_TOKEN = re.compile(
 
 # Grant access to our Notification Manager Singleton
 N_MGR = NotificationManager()
+
+# Grant access to our Configuration Manager Singleton
+C_MGR = ConfigurationManager()
 
 
 class ConfigBase(URLBase):
@@ -233,7 +237,7 @@ class ConfigBase(URLBase):
                     schema = schema.group('schema').lower()
 
                     # Some basic validation
-                    if schema not in common.CONFIG_SCHEMA_MAP:
+                    if schema not in C_MGR:
                         ConfigBase.logger.warning(
                             'Unsupported include schema {}.'.format(schema))
                         continue
@@ -244,7 +248,7 @@ class ConfigBase(URLBase):
 
                 # Parse our url details of the server object as dictionary
                 # containing all of the information parsed from our URL
-                results = common.CONFIG_SCHEMA_MAP[schema].parse_url(url)
+                results = C_MGR[schema].parse_url(url)
                 if not results:
                     # Failed to parse the server URL
                     self.logger.warning(
@@ -252,11 +256,10 @@ class ConfigBase(URLBase):
                     continue
 
                 # Handle cross inclusion based on allow_cross_includes rules
-                if (common.CONFIG_SCHEMA_MAP[schema].allow_cross_includes ==
+                if (C_MGR[schema].allow_cross_includes ==
                         common.ContentIncludeMode.STRICT
                         and schema not in self.schemas()
-                        and not self.insecure_includes) or \
-                        common.CONFIG_SCHEMA_MAP[schema] \
+                        and not self.insecure_includes) or C_MGR[schema] \
                         .allow_cross_includes == \
                         common.ContentIncludeMode.NEVER:
 
@@ -284,8 +287,7 @@ class ConfigBase(URLBase):
                 try:
                     # Attempt to create an instance of our plugin using the
                     # parsed URL information
-                    cfg_plugin = \
-                        common.CONFIG_SCHEMA_MAP[results['schema']](**results)
+                    cfg_plugin = C_MGR[results['schema']](**results)
 
                 except Exception as e:
                     # the arguments are invalid or can not be used.

--- a/apprise/config/__init__.py
+++ b/apprise/config/__init__.py
@@ -26,84 +26,14 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import re
-from os import listdir
-from os.path import dirname
-from os.path import abspath
-from ..logger import logger
-from ..common import CONFIG_SCHEMA_MAP
+# Used for testing
+from .ConfigBase import ConfigBase
+from ..ConfigurationManager import ConfigurationManager
 
-__all__ = []
+# Initalize our Config Manager Singleton
+C_MGR = ConfigurationManager()
 
-
-# Load our Lookup Matrix
-def __load_matrix(path=abspath(dirname(__file__)), name='apprise.config'):
-    """
-    Dynamically load our schema map; this allows us to gracefully
-    skip over modules we simply don't have the dependencies for.
-
-    """
-    # Used for the detection of additional Configuration Services objects
-    # The .py extension is optional as we support loading directories too
-    module_re = re.compile(r'^(?P<name>Config[a-z0-9]+)(\.py)?$', re.I)
-
-    for f in listdir(path):
-        match = module_re.match(f)
-        if not match:
-            # keep going
-            continue
-
-        # Store our notification/plugin name:
-        plugin_name = match.group('name')
-        try:
-            module = __import__(
-                '{}.{}'.format(name, plugin_name),
-                globals(), locals(),
-                fromlist=[plugin_name])
-
-        except ImportError:
-            # No problem, we can't use this object
-            continue
-
-        if not hasattr(module, plugin_name):
-            # Not a library we can load as it doesn't follow the simple rule
-            # that the class must bear the same name as the notification
-            # file itself.
-            continue
-
-        # Get our plugin
-        plugin = getattr(module, plugin_name)
-        if not hasattr(plugin, 'app_id'):
-            # Filter out non-notification modules
-            continue
-
-        elif plugin_name in __all__:
-            # we're already handling this object
-            continue
-
-        # Add our module name to our __all__
-        __all__.append(plugin_name)
-
-        # Ensure we provide the class as the reference to this directory and
-        # not the module:
-        globals()[plugin_name] = plugin
-
-        fn = getattr(plugin, 'schemas', None)
-        schemas = set([]) if not callable(fn) else fn(plugin)
-
-        # map our schema to our plugin
-        for schema in schemas:
-            if schema in CONFIG_SCHEMA_MAP:
-                logger.error(
-                    "Config schema ({}) mismatch detected - {} to {}"
-                    .format(schema, CONFIG_SCHEMA_MAP[schema], plugin))
-                continue
-
-            # Assign plugin
-            CONFIG_SCHEMA_MAP[schema] = plugin
-
-    return CONFIG_SCHEMA_MAP
-
-
-# Dynamically build our schema base
-__load_matrix()
+__all__ = [
+    # Reference
+    'ConfigBase',
+]

--- a/apprise/decorators/CustomNotifyPlugin.py
+++ b/apprise/decorators/CustomNotifyPlugin.py
@@ -28,6 +28,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from ..plugins.NotifyBase import NotifyBase
+from ..NotificationManager import NotificationManager
 from ..utils import URL_DETAILS_RE
 from ..utils import parse_url
 from ..utils import url_assembly
@@ -35,6 +36,9 @@ from ..utils import dict_full_update
 from .. import common
 from ..logger import logger
 import inspect
+
+# Grant access to our Notification Manager Singleton
+N_MGR = NotificationManager()
 
 
 class CustomNotifyPlugin(NotifyBase):
@@ -91,17 +95,17 @@ class CustomNotifyPlugin(NotifyBase):
             logger.warning(msg)
             return None
 
-        # Acquire our plugin name
-        plugin_name = re_match.group('schema').lower()
+        # Acquire our schema
+        schema = re_match.group('schema').lower()
 
         if not re_match.group('base'):
-            url = '{}://'.format(plugin_name)
+            url = '{}://'.format(schema)
 
         # Keep a default set of arguments to apply to all called references
         base_args = parse_url(
-            url, default_schema=plugin_name, verify_host=False, simple=True)
+            url, default_schema=schema, verify_host=False, simple=True)
 
-        if plugin_name in common.NOTIFY_SCHEMA_MAP:
+        if schema in N_MGR:
             # we're already handling this object
             msg = 'The schema ({}) is already defined and could not be ' \
                 'loaded from custom notify function {}.' \
@@ -117,10 +121,10 @@ class CustomNotifyPlugin(NotifyBase):
 
             # Our Service Name
             service_name = name if isinstance(name, str) \
-                and name else 'Custom - {}'.format(plugin_name)
+                and name else 'Custom - {}'.format(schema)
 
             # Store our matched schema
-            secure_protocol = plugin_name
+            secure_protocol = schema
 
             requirements = {
                 # Define our required packaging in order to work
@@ -181,51 +185,26 @@ class CustomNotifyPlugin(NotifyBase):
                     # Unhandled Exception
                     self.logger.warning(
                         'An exception occured sending a %s notification.',
-                        common.
-                        NOTIFY_SCHEMA_MAP[self.secure_protocol].service_name)
+                        N_MGR[self.secure_protocol].service_name)
                     self.logger.debug(
                         '%s Exception: %s',
-                        common.NOTIFY_SCHEMA_MAP[self.secure_protocol], str(e))
+                        N_MGR[self.secure_protocol], str(e))
                     return False
 
                 if response:
                     self.logger.info(
                         'Sent %s notification.',
-                        common.
-                        NOTIFY_SCHEMA_MAP[self.secure_protocol].service_name)
+                        N_MGR[self.secure_protocol].service_name)
                 else:
                     self.logger.warning(
                         'Failed to send %s notification.',
-                        common.
-                        NOTIFY_SCHEMA_MAP[self.secure_protocol].service_name)
+                        N_MGR[self.secure_protocol].service_name)
                 return response
 
         # Store our plugin into our core map file
-        common.NOTIFY_SCHEMA_MAP[plugin_name] = CustomNotifyPluginWrapper
-
-        # Update our custom plugin map
-        module_pyname = str(send_func.__module__)
-        if module_pyname not in common.NOTIFY_CUSTOM_MODULE_MAP:
-            # Support non-dynamic includes as well...
-            common.NOTIFY_CUSTOM_MODULE_MAP[module_pyname] = {
-                'path': inspect.getfile(send_func),
-
-                # Initialize our template
-                'notify': {},
-            }
-
-        common.\
-            NOTIFY_CUSTOM_MODULE_MAP[module_pyname]['notify'][plugin_name] = {
-                # Our Serivice Description (for API and CLI --details view)
-                'name': CustomNotifyPluginWrapper.service_name,
-                # The name of the send function the @notify decorator wrapped
-                'fn_name': send_func.__name__,
-                # The URL that was provided in the @notify decorator call
-                # associated with the 'on='
-                'url': url,
-                # The Initialized Plugin that was generated based on the above
-                # parameters
-                'plugin': CustomNotifyPluginWrapper}
-
-        # return our plugin
-        return common.NOTIFY_SCHEMA_MAP[plugin_name]
+        return N_MGR.add(
+            schema=schema,
+            plugin=CustomNotifyPluginWrapper,
+            send_func=send_func,
+            url=url,
+        )

--- a/apprise/decorators/CustomNotifyPlugin.py
+++ b/apprise/decorators/CustomNotifyPlugin.py
@@ -203,8 +203,8 @@ class CustomNotifyPlugin(NotifyBase):
 
         # Store our plugin into our core map file
         return N_MGR.add(
-            schema=schema,
             plugin=CustomNotifyPluginWrapper,
+            schemas=schema,
             send_func=send_func,
             url=url,
         )

--- a/apprise/emojis.py
+++ b/apprise/emojis.py
@@ -27,6 +27,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import re
+import time
+from .logger import logger
 
 # All Emoji's are wrapped in this character
 DELIM = ':'
@@ -2242,10 +2244,8 @@ EMOJI_MAP = {
     DELIM + r'wales' + DELIM: '🏴󠁧󠁢󠁷󠁬󠁳󠁿',
 }
 
-# Our compiled mapping
-EMOJI_COMPILED_MAP = re.compile(
-    r'(' + '|'.join(EMOJI_MAP.keys()) + r')',
-    re.IGNORECASE)
+# Define our singlton
+EMOJI_COMPILED_MAP = None
 
 
 def apply_emojis(content):
@@ -2253,6 +2253,17 @@ def apply_emojis(content):
     Takes the content and swaps any matched emoji's found with their
     utf-8 encoded mapping
     """
+
+    global EMOJI_COMPILED_MAP
+
+    if EMOJI_COMPILED_MAP is None:
+        t_start = time.time()
+        # Perform our compilation
+        EMOJI_COMPILED_MAP = re.compile(
+            r'(' + '|'.join(EMOJI_MAP.keys()) + r')',
+            re.IGNORECASE)
+        logger.trace(
+            'Emoji engine loaded in {:.4f}s'.format((time.time() - t_start)))
 
     try:
         return EMOJI_COMPILED_MAP.sub(lambda x: EMOJI_MAP[x.group()], content)

--- a/apprise/manager.py
+++ b/apprise/manager.py
@@ -1,0 +1,718 @@
+# -*- coding: utf-8 -*-
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2023, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import re
+import sys
+import time
+import hashlib
+import inspect
+from .utils import import_module
+from .utils import Singleton
+from .utils import parse_list
+from os.path import dirname
+from os.path import abspath
+from os.path import join
+
+from .logger import logger
+
+
+class PluginManager(metaclass=Singleton):
+    """
+    Designed to be a singleton object to maintain all initialized loading
+    of modules in memory.
+    """
+
+    # Description (used for logging)
+    name = 'Singleton Plugin'
+
+    # Memory Space
+    _id = 'undefined'
+
+    # Our Module Python path name
+    module_name_prefix = f'apprise.{_id}'
+
+    # The module path to scan
+    module_path = join(abspath(dirname(__file__)), _id)
+
+    def __init__(self, *args, **kwargs):
+        """
+        Over-ride our class instantiation to provide a singleton
+        """
+
+        self._module_map = None
+        self._schema_map = None
+
+        # This contains a mapping of all plugins dynamicaly loaded at runtime
+        # from external modules such as the @notify decorator
+        #
+        # The elements here will be additionally added to the _schema_map if
+        # there is no conflict otherwise.
+        # The structure looks like the following:
+        # Module path, e.g. /usr/share/apprise/plugins/my_notify_hook.py
+        # {
+        #   'path': path,
+        #
+        #   'notify': {
+        #     'schema': {
+        #       'name': 'Custom schema name',
+        #       'fn_name': 'name_of_function_decorator_was_found_on',
+        #       'url': 'schema://any/additional/info/found/on/url'
+        #       'plugin': <CustomNotifyWrapperPlugin>
+        #    },
+        #     'schema2': {
+        #       'name': 'Custom schema name',
+        #       'fn_name': 'name_of_function_decorator_was_found_on',
+        #       'url': 'schema://any/additional/info/found/on/url'
+        #       'plugin': <CustomNotifyWrapperPlugin>
+        #    }
+        #  }
+        # Note: that the <CustomNotifyWrapperPlugin> inherits from
+        #       NotifyBase
+        self._custom_module_map = {}
+
+        # Track manually disabled modules (by their schema)
+        self._disabled = set()
+
+        # Hash of all paths previously scanned so we don't waste
+        # effort/overhead doing it again
+        self._paths_previously_scanned = set()
+
+    def unload_modules(self, disable_native=False):
+        """
+        Reset our object and unload all modules
+        """
+
+        if self._custom_module_map:
+            # Handle Custom Module Assignments
+            for meta in self._custom_module_map.values():
+                if meta['name'] not in self._module_map:
+                    # Nothing to remove
+                    continue
+
+                # For the purpose of tidying up un-used modules in memory
+                loaded = [m for m in sys.modules.keys()
+                          if m.startswith(
+                              self._module_map[meta['name']]['path'])]
+
+                for module_path in loaded:
+                    del sys.modules[module_path]
+
+        # Reset disabled plugins (if any)
+        for schema in self._disabled:
+            self._schema_map[schema].enabled = True
+        self._disabled.clear()
+
+        # Reset our variables
+        self._module_map = None if not disable_native else {}
+        self._schema_map = {}
+        self._custom_module_map = {}
+
+        # Reset our path cache
+        self._paths_previously_scanned = set()
+
+    def load_modules(self, path=None, name=None):
+        """
+        Load our modules into memory
+        """
+
+        # Default value
+        module_name_prefix = self.module_name_prefix if name is None else name
+        module_path = self.module_path if path is None else path
+
+        if not self:
+            # Initialize our maps
+            self._module_map = {}
+            self._schema_map = {}
+            self._custom_module_map = {}
+
+        # Used for the detection of additional Notify Services objects
+        # The .py extension is optional as we support loading directories too
+        module_re = re.compile(
+            r'^(?P<name>' + self.fname_prefix + r'[a-z0-9]+)(\.py)?$', re.I)
+
+        t_start = time.time()
+        for f in os.listdir(module_path):
+            tl_start = time.time()
+            match = module_re.match(f)
+            if not match:
+                # keep going
+                continue
+
+            elif match.group('name') == f'{self.fname_prefix}Base':
+                # keep going
+                continue
+
+            # Store our notification/plugin name:
+            module_name = match.group('name')
+            module_pyname = '{}.{}'.format(module_name_prefix, module_name)
+
+            if module_name in self._module_map:
+                logger.warning(
+                    "%s(s) (%s) already loaded; ignoring %s",
+                    self.name, module_name, os.path.join(module_path, f))
+                continue
+
+            try:
+                module = __import__(
+                    module_pyname,
+                    globals(), locals(),
+                    fromlist=[module_name])
+
+            except ImportError:
+                # No problem, we can try again another way...
+                module = import_module(
+                    os.path.join(module_path, f), module_pyname)
+                if not module:
+                    # logging found in import_module and not needed here
+                    continue
+
+            if not hasattr(module, module_name):
+                # Not a library we can load as it doesn't follow the simple
+                # rule that the class must bear the same name as the
+                # notification file itself.
+                logger.trace(
+                    "%s (%s) import failed; no filename/Class "
+                    "match found in %s",
+                    self.name, module_name, os.path.join(module_path, f))
+                continue
+
+            # Get our plugin
+            plugin = getattr(module, module_name)
+            if not hasattr(plugin, 'app_id'):
+                # Filter out non-notification modules
+                logger.trace(
+                    "(%s) import failed; no app_id defined in %s",
+                    self.name, module_name, os.path.join(module_path, f))
+                continue
+
+            # Add our plugin name to our module map
+            self._module_map[module_name] = {
+                'plugin': set([plugin]),
+                'module': module,
+                'path': '{}.{}'.format(module_name_prefix, module_name),
+                'native': True,
+            }
+
+            fn = getattr(plugin, 'schemas', None)
+            schemas = set([]) if not callable(fn) else fn(plugin)
+
+            # map our schema to our plugin
+            for schema in schemas:
+                if schema in self._schema_map:
+                    logger.error(
+                        "{} schema ({}) mismatch detected - {} to {}"
+                        .format(self.name, schema, self._schema_map, plugin))
+                    continue
+
+                # Assign plugin
+                self._schema_map[schema] = plugin
+
+            logger.trace(
+                '{} {} loaded in {:.6f}s'.format(
+                    self.name, module_name, (time.time() - tl_start)))
+        logger.debug(
+            '{} {}(s) and {} Schema(s) loaded in {:.4f}s'
+            .format(
+                self.name, len(self._module_map), len(self._schema_map),
+                (time.time() - t_start)))
+
+    def module_detection(self, paths, cache=True):
+        """
+        Leverage the @notify decorator and load all objects found matching
+        this.
+        """
+        # A simple restriction that we don't allow periods in the filename at
+        # all so it can't be hidden (Linux OS's) and it won't conflict with
+        # Python path naming.  This also prevents us from loading any python
+        # file that starts with an underscore or dash
+        # We allow for __init__.py as well
+        module_re = re.compile(
+            r'^(?P<name>[_a-z0-9][a-z0-9._-]+)?(\.py)?$', re.I)
+
+        # Validate if we're a loadable Python file or not
+        valid_python_file_re = re.compile(r'.+\.py(o|c)?$', re.IGNORECASE)
+
+        if isinstance(paths, str):
+            paths = [paths, ]
+
+        if not paths or not isinstance(paths, (tuple, list)):
+            # We're done
+            return
+
+        def _import_module(path):
+            # Since our plugin name can conflict (as a module) with another
+            # we want to generate random strings to avoid steping on
+            # another's namespace
+            if not (path and valid_python_file_re.match(path)):
+                # Ignore file/module type
+                logger.trace('Plugin Scan: Skipping %s', path)
+                return
+
+            t_start = time.time()
+            module_name = hashlib.sha1(path.encode('utf-8')).hexdigest()
+            module_pyname = "{prefix}.{name}".format(
+                prefix='apprise.custom.module', name=module_name)
+
+            if module_pyname in self._custom_module_map:
+                # First clear out existing entries
+                for schema in \
+                        self._custom_module_map[module_pyname]['notify']\
+                        .keys():
+
+                    # Remove any mapped modules to this file
+                    del self._schema_map[schema]
+
+                # Reset
+                del self._custom_module_map[module_pyname]
+
+            # Load our module
+            module = import_module(path, module_pyname)
+            if not module:
+                # No problem, we can't use this object
+                logger.warning('Failed to load custom module: %s', _path)
+                return
+
+            # Print our loaded modules if any
+            if module_pyname in self._custom_module_map:
+                logger.debug(
+                    'Custom module %s - %d schema(s) (name=%s) '
+                    'loaded in {:.6f}s',
+                    _path, module_name,
+                    len(self._custom_module_map[module_pyname]['notify']),
+                    (time.time() - t_start))
+
+                # Add our plugin name to our module map
+                self._module_map[module_name] = {
+                    'plugin': set(),
+                    'module': module,
+                    'path': module_pyname,
+                    'native': False,
+                }
+
+                for schema, meta in\
+                        self._custom_module_map[module_pyname]['notify']\
+                        .items():
+
+                    # For mapping purposes; map our element in our main list
+                    self._module_map[module_name]['plugin'].add(
+                        self._schema_map[schema])
+
+                    # Log our success
+                    logger.info('Loaded custom notification: %s://', schema)
+            else:
+                # The code reaches here if we successfully loaded the Python
+                # module but no hooks/triggers were found. So we can safely
+                # just remove/ignore this entry
+                del sys.modules[module_pyname]
+                return
+
+            # end of _import_module()
+            return
+
+        for _path in paths:
+            path = os.path.abspath(os.path.expanduser(_path))
+            if (cache and path in self._paths_previously_scanned) \
+                    or not os.path.exists(path):
+                # We're done as we've already scanned this
+                continue
+
+            # Store our path as a way of hashing it has been handled
+            self._paths_previously_scanned.add(path)
+
+            if os.path.isdir(path) and not \
+                    os.path.isfile(os.path.join(path, '__init__.py')):
+
+                logger.debug('Scanning for custom plugins in: %s', path)
+                for entry in os.listdir(path):
+                    re_match = module_re.match(entry)
+                    if not re_match:
+                        # keep going
+                        logger.trace('Plugin Scan: Ignoring %s', entry)
+                        continue
+
+                    new_path = os.path.join(path, entry)
+                    if os.path.isdir(new_path):
+                        # Update our path
+                        new_path = os.path.join(path, entry, '__init__.py')
+                        if not os.path.isfile(new_path):
+                            logger.trace(
+                                'Plugin Scan: Ignoring %s',
+                                os.path.join(path, entry))
+                            continue
+
+                    if not cache or \
+                            (cache and
+                             new_path not in self._paths_previously_scanned):
+                        # Load our module
+                        _import_module(new_path)
+
+                        # Add our subdir path
+                        self._paths_previously_scanned.add(new_path)
+            else:
+                if os.path.isdir(path):
+                    # This logic is safe to apply because we already validated
+                    # the directories state above; update our path
+                    path = os.path.join(path, '__init__.py')
+                    if cache and path in self._paths_previously_scanned:
+                        continue
+
+                    self._paths_previously_scanned.add(path)
+
+                # directly load as is
+                re_match = module_re.match(os.path.basename(path))
+                # must be a match and must have a .py extension
+                if not re_match or not re_match.group(1):
+                    # keep going
+                    logger.trace('Plugin Scan: Ignoring %s', path)
+                    continue
+
+                # Load our module
+                _import_module(path)
+
+            return None
+
+    def add(self, plugin, schemas=None, url=None, send_func=None):
+        """
+        Ability to manually add Notification services to our stack
+        """
+
+        if not self:
+            # Lazy load
+            self.load_modules()
+
+        # Acquire a list of schemas
+        p_schemas = parse_list(plugin.secure_protocol, plugin.protocol)
+        if isinstance(schemas, str):
+            schemas = [schemas, ]
+
+        elif schemas is None:
+            # Default
+            schemas = p_schemas
+
+        if not schemas or not isinstance(schemas, (set, tuple, list)):
+            # We're done
+            logger.error(
+                'The schemas provided (type %s) is unsupported; '
+                'loaded from %s.',
+                type(schemas),
+                send_func.__name__ if send_func else plugin.__class__.__name__)
+            return False
+
+        # Convert our schemas into a set
+        schemas = set([s.lower() for s in schemas]) | set(p_schemas)
+
+        # Valdation
+        conflict = [s for s in schemas if s in self]
+        if conflict:
+            # we're already handling this schema
+            logger.warning(
+                'The schema(s) (%s) are already defined and could not be '
+                'loaded from %s%s.',
+                ', '.join(conflict),
+                'custom notify function ' if send_func else '',
+                send_func.__name__ if send_func else plugin.__class__.__name__)
+            return False
+
+        if send_func:
+            # Acquire the function name
+            fn_name = send_func.__name__
+
+            # Acquire the python filename path
+            path = inspect.getfile(send_func)
+
+            # Acquire our path to our module
+            module_name = str(send_func.__module__)
+
+            if module_name not in self._custom_module_map:
+                # Support non-dynamic includes as well...
+                self._custom_module_map[module_name] = {
+                    # Name can be useful for indexing back into the
+                    # _module_map object; this is the key to do it with:
+                    'name': module_name.split('.')[-1],
+
+                    # The path to the module loaded
+                    'path': path,
+
+                    # Initialize our template
+                    'notify': {},
+                }
+
+            for schema in schemas:
+                self._custom_module_map[module_name]['notify'][schema] = {
+                    # The name of the send function the @notify decorator
+                    # wrapped
+                    'fn_name': fn_name,
+                    # The URL that was provided in the @notify decorator call
+                    # associated with the 'on='
+                    'url': url,
+                }
+
+        else:
+            module_name = hashlib.sha1(
+                ''.join(schemas).encode('utf-8')).hexdigest()
+            module_pyname = "{prefix}.{name}".format(
+                prefix='apprise.adhoc.module', name=module_name)
+
+            # Add our plugin name to our module map
+            self._module_map[module_name] = {
+                'plugin': set([plugin]),
+                'module': None,
+                'path': module_pyname,
+                'native': False,
+            }
+
+        for schema in schemas:
+            # Assign our mapping
+            self._schema_map[schema] = plugin
+
+        return True
+
+    def remove(self, *schemas):
+        """
+        Removes a loaded element (if defined)
+        """
+        if not self:
+            # Lazy load
+            self.load_modules()
+
+        for schema in schemas:
+            try:
+                del self[schema]
+
+            except KeyError:
+                pass
+
+    def plugins(self, include_disabled=True):
+        """
+        Return all of our loaded plugins
+        """
+        if not self:
+            # Lazy load
+            self.load_modules()
+
+        for module in self._module_map.values():
+            for plugin in module['plugin']:
+                if not include_disabled and not plugin.enabled:
+                    continue
+                yield plugin
+
+    def schemas(self, include_disabled=True):
+        """
+        Return all of our loaded schemas
+
+        if include_disabled == True, then even disabled notifications are
+        returned
+        """
+        if not self:
+            # Lazy load
+            self.load_modules()
+
+        # Return our list
+        return list(self._schema_map.keys()) if include_disabled else \
+            [s for s in self._schema_map.keys() if self._schema_map[s].enabled]
+
+    def disable(self, *schemas):
+        """
+        Disables the modules associated with the specified schemas
+        """
+        if not self:
+            # Lazy load
+            self.load_modules()
+
+        for schema in schemas:
+            if schema not in self._schema_map:
+                continue
+
+            if not self._schema_map[schema].enabled:
+                continue
+
+            # Disable
+            self._schema_map[schema].enabled = False
+            self._disabled.add(schema)
+
+    def enable_only(self, *schemas):
+        """
+        Disables the modules associated with the specified schemas
+        """
+        if not self:
+            # Lazy load
+            self.load_modules()
+
+        # convert to set for faster indexing
+        schemas = set(schemas)
+
+        for plugin in self.plugins():
+            # Get our plugin's schema list
+            p_schemas = set(
+                parse_list(plugin.secure_protocol, plugin.protocol))
+
+            if not schemas & p_schemas:
+                if plugin.enabled:
+                    # Disable it (only if previously enabled); this prevents us
+                    # from adjusting schemas that were disabled due to missing
+                    # libraries or other environment reasons
+                    plugin.enabled = False
+                    self._disabled |= p_schemas
+                continue
+
+            # If we reach here, our schema was flagged to be enabled
+            if p_schemas & self._disabled:
+                # Previously disabled; no worries, let's clear this up
+                self._disabled -= p_schemas
+                plugin.enabled = True
+
+    def __contains__(self, schema):
+        """
+        Checks if a schema exists
+        """
+        if not self:
+            # Lazy load
+            self.load_modules()
+
+        return schema in self._schema_map
+
+    def __delitem__(self, schema):
+        if not self:
+            # Lazy load
+            self.load_modules()
+
+        # Get our plugin (otherwise we throw a KeyError) which is
+        # intended on del action that doesn't align
+        plugin = self._schema_map[schema]
+
+        # Our list of all schema entries
+        p_schemas = set([schema])
+
+        for key in list(self._module_map.keys()):
+            if plugin in self._module_map[key]['plugin']:
+                # Remove our plugin
+                self._module_map[key]['plugin'].remove(plugin)
+
+                # Custom Plugin Entry; Clean up cross reference
+                module_pyname = self._module_map[key]['path']
+                if not self._module_map[key]['native'] and \
+                        module_pyname in self._custom_module_map:
+
+                    del self.\
+                        _custom_module_map[module_pyname]['notify'][schema]
+
+                    if not self._custom_module_map[module_pyname]['notify']:
+                        #
+                        # Last custom loaded element
+                        #
+
+                        # Free up custom object entry
+                        del self._custom_module_map[module_pyname]
+
+                if not self._module_map[key]['plugin']:
+                    #
+                    # Last element
+                    #
+                    if self._module_map[key]['native']:
+                        # Get our plugin's schema list
+                        p_schemas = \
+                            set([s for s in parse_list(
+                                 plugin.secure_protocol, plugin.protocol)
+                                 if s in self._schema_map])
+
+                    # free system memory
+                    if self._module_map[key]['module']:
+                        del sys.modules[self._module_map[key]['path']]
+
+                    # free last remaining pointer in module map
+                    del self._module_map[key]
+
+        for schema in p_schemas:
+            # Final Tidy
+            del self._schema_map[schema]
+
+    def __setitem__(self, schema, plugin):
+        """
+        Support fast assigning of Plugin/Notification Objects
+        """
+        if not self:
+            # Lazy load
+            self.load_modules()
+
+        # Set default values if not otherwise set
+        if not plugin.service_name:
+            # Assign service name if one doesn't exist
+            plugin.service_name = f'{schema}://'
+
+        p_schemas = set(
+            parse_list(plugin.secure_protocol, plugin.protocol))
+        if not p_schemas:
+            # Assign our protocol
+            plugin.secure_protocol = schema
+            p_schemas.add(schema)
+
+        elif schema not in p_schemas:
+            # Add our others (if defined)
+            plugin.secure_protocol = \
+                set([schema] + parse_list(plugin.secure_protocol))
+            p_schemas.add(schema)
+
+        if not self.add(plugin, schemas=p_schemas):
+            raise KeyError('Conflicting Assignment')
+
+    def __getitem__(self, schema):
+        """
+        Returns the indexed plugin identified by the schema specified
+        """
+        if not self:
+            # Lazy load
+            self.load_modules()
+
+        return self._schema_map[schema]
+
+    def __iter__(self):
+        """
+        Returns an iterator so we can iterate over our loaded modules
+        """
+        if not self:
+            # Lazy load
+            self.load_modules()
+
+        return iter(self._module_map.values())
+
+    def __len__(self):
+        """
+        Returns the number of modules/plugins loaded
+        """
+        if not self:
+            # Lazy load
+            self.load_modules()
+
+        return len(self._module_map)
+
+    def __bool__(self):
+        """
+        Determines if object has loaded or not
+        """
+        return True if self._module_map is not None else False

--- a/apprise/plugins/NotifyMacOSX.py
+++ b/apprise/plugins/NotifyMacOSX.py
@@ -40,7 +40,6 @@ from ..AppriseLocale import gettext_lazy as _
 NOTIFY_MACOSX_SUPPORT_ENABLED = False
 
 
-# TODO: The module will be easier to test without module-level code.
 if platform.system() == 'Darwin':
     # Check this is Mac OS X 10.8, or higher
     major, minor = platform.mac_ver()[0].split('.')[:2]

--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -68,7 +68,7 @@ def import_module(path, name):
         module = None
 
         logger.debug(
-            'Custom module exception raised from %s (name=%s) %s',
+            'Module exception raised from %s (name=%s) %s',
             path, name, str(e))
 
     return module

--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -208,6 +208,22 @@ VALID_PYTHON_FILE_RE = re.compile(r'.+\.py(o|c)?$', re.IGNORECASE)
 REGEX_VALIDATE_LOOKUP = {}
 
 
+class Singleton(type):
+    """
+    Our Singleton MetaClass
+    """
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        """
+        instantiate our singleton meta entry
+        """
+        if cls not in cls._instances:
+            # we have not every built an instance before.  Build one now.
+            cls._instances[cls] = super().__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+
 class TemplateType:
     """
     Defines the different template types we can perform parsing on

--- a/packaging/redhat/apprise-no-macosx-testing.patch
+++ b/packaging/redhat/apprise-no-macosx-testing.patch
@@ -1,12 +1,15 @@
-diff -Naur apprise-1.2.0/test/test_plugin_macosx.py apprise-1.2.0.patched/test/test_plugin_macosx.py
---- apprise-1.2.0/test/test_plugin_macosx.py	2022-11-02 14:59:59.000000000 -0400
-+++ apprise-1.2.0.patched/test/test_plugin_macosx.py	2022-11-15 13:25:27.991284405 -0500
-@@ -38,7 +38,7 @@
+diff -Naur apprise-1.6.0/test/test_plugin_macosx.py apprise-1.6.0.patched/test/test_plugin_macosx.py
+--- apprise-1.6.0/test/test_plugin_macosx.py	2023-12-22 16:51:24.000000000 -0500
++++ apprise-1.6.0.patched/test/test_plugin_macosx.py	2023-12-22 17:38:35.720131819 -0500
+@@ -42,9 +42,8 @@
  logging.disable(logging.CRITICAL)
  
  
 -if sys.platform not in ["darwin", "linux"]:
-+if sys.platform not in ["darwin"]:
-     pytest.skip("Only makes sense on macOS, but also works on Linux",
-                 allow_module_level=True)
+-    pytest.skip("Only makes sense on macOS, but testable in Linux",
+-                allow_module_level=True)
++if sys.platform != "darwin":
++    pytest.skip("MacOS test only", allow_module_level=True)
  
+ 
+ @pytest.fixture

--- a/packaging/redhat/apprise-pytest-session_mocker-removal.patch
+++ b/packaging/redhat/apprise-pytest-session_mocker-removal.patch
@@ -1,8 +1,8 @@
-diff -Naur apprise-1.6.0/test/conftest.py apprise-1.6.0.patched/test/conftest.py
---- apprise-1.6.0/test/conftest.py	2023-12-22 15:46:50.000000000 -0500
-+++ apprise-1.6.0.patched/test/conftest.py	2023-12-22 17:24:28.229650303 -0500
-@@ -39,8 +39,8 @@
- N_MGR = NotificationManager()
+diff -Naur apprise-1.6.0/test/conftest.py apprise-1.6.0-patched/test/conftest.py
+--- apprise-1.6.0/test/conftest.py	2023-12-27 11:20:40.000000000 -0500
++++ apprise-1.6.0-patched/test/conftest.py	2023-12-27 13:43:22.583100037 -0500
+@@ -45,8 +45,8 @@
+ A_MGR = AttachmentManager()
  
  
 -@pytest.fixture(scope="function", autouse=True)
@@ -12,8 +12,8 @@ diff -Naur apprise-1.6.0/test/conftest.py apprise-1.6.0.patched/test/conftest.py
      """
      A pytest session fixture which disables throttling on all notifiers.
      It is automatically enabled.
-@@ -49,4 +49,4 @@
-     N_MGR.unload_modules()
+@@ -57,4 +57,4 @@
+     A_MGR.unload_modules()
  
      for plugin in N_MGR.plugins():
 -        session_mocker.patch.object(plugin, "request_rate_per_sec", 0)

--- a/packaging/redhat/apprise-pytest-session_mocker-removal.patch
+++ b/packaging/redhat/apprise-pytest-session_mocker-removal.patch
@@ -1,19 +1,20 @@
-diff -Naur apprise-1.2.0/test/conftest.py apprise-1.2.0.patched/test/conftest.py
---- apprise-1.2.0/test/conftest.py	2022-11-02 14:00:13.000000000 -0400
-+++ apprise-1.2.0.patched/test/conftest.py	2022-11-15 10:28:23.793969418 -0500
-@@ -32,12 +32,12 @@
- sys.path.append(os.path.join(os.path.dirname(__file__), 'helpers'))
+diff -Naur apprise-1.6.0/test/conftest.py apprise-1.6.0.patched/test/conftest.py
+--- apprise-1.6.0/test/conftest.py	2023-12-22 15:46:50.000000000 -0500
++++ apprise-1.6.0.patched/test/conftest.py	2023-12-22 17:24:28.229650303 -0500
+@@ -39,8 +39,8 @@
+ N_MGR = NotificationManager()
  
  
--@pytest.fixture(scope="session", autouse=True)
+-@pytest.fixture(scope="function", autouse=True)
 -def no_throttling_everywhere(session_mocker):
 +@pytest.fixture(autouse=True)
 +def no_throttling_everywhere(mocker):
      """
      A pytest session fixture which disables throttling on all notifiers.
      It is automatically enabled.
-     """
-     for notifier in NOTIFY_MODULE_MAP.values():
-         plugin = notifier["plugin"]
+@@ -49,4 +49,4 @@
+     N_MGR.unload_modules()
+ 
+     for plugin in N_MGR.plugins():
 -        session_mocker.patch.object(plugin, "request_rate_per_sec", 0)
 +        mocker.patch.object(plugin, "request_rate_per_sec", 0)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -32,11 +32,17 @@ import os
 import pytest
 
 from apprise.NotificationManager import NotificationManager
+from apprise.ConfigurationManager import ConfigurationManager
+from apprise.AttachmentManager import AttachmentManager
 
 sys.path.append(os.path.join(os.path.dirname(__file__), 'helpers'))
 
 # Grant access to our Notification Manager Singleton
 N_MGR = NotificationManager()
+# Grant access to our Config Manager Singleton
+C_MGR = ConfigurationManager()
+# Grant access to our Attachment Manager Singleton
+A_MGR = AttachmentManager()
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -47,6 +53,8 @@ def no_throttling_everywhere(session_mocker):
     """
     # Ensure we're working with a clean slate for each test
     N_MGR.unload_modules()
+    C_MGR.unload_modules()
+    A_MGR.unload_modules()
 
     for plugin in N_MGR.plugins():
         session_mocker.patch.object(plugin, "request_rate_per_sec", 0)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -31,17 +31,22 @@ import os
 
 import pytest
 
-from apprise.common import NOTIFY_MODULE_MAP
+from apprise.NotificationManager import NotificationManager
 
 sys.path.append(os.path.join(os.path.dirname(__file__), 'helpers'))
 
+# Grant access to our Notification Manager Singleton
+N_MGR = NotificationManager()
 
-@pytest.fixture(scope="session", autouse=True)
+
+@pytest.fixture(scope="function", autouse=True)
 def no_throttling_everywhere(session_mocker):
     """
     A pytest session fixture which disables throttling on all notifiers.
     It is automatically enabled.
     """
-    for notifier in NOTIFY_MODULE_MAP.values():
-        plugin = notifier["plugin"]
+    # Ensure we're working with a clean slate for each test
+    N_MGR.unload_modules()
+
+    for plugin in N_MGR.plugins():
         session_mocker.patch.object(plugin, "request_rate_per_sec", 0)

--- a/test/helpers/module.py
+++ b/test/helpers/module.py
@@ -26,13 +26,18 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from itertools import chain
 from importlib import import_module, reload
 from apprise.NotificationManager import NotificationManager
+from apprise.AttachmentManager import AttachmentManager
 import sys
 import re
 
 # Grant access to our Notification Manager Singleton
 N_MGR = NotificationManager()
+
+# Grant access to our Attachment Manager Singleton
+A_MGR = AttachmentManager()
 
 
 def reload_plugin(name):
@@ -45,13 +50,18 @@ def reload_plugin(name):
     See also https://stackoverflow.com/questions/31363311.
     """
 
+    A_MGR.unload_modules()
+
+    reload(sys.modules['apprise.attachment.AttachBase'])
+    reload(sys.modules['apprise.AppriseAttachment'])
+    new_apprise_attachment_mod = import_module('apprise.AppriseAttachment')
+    reload(sys.modules['apprise.AttachmentManager'])
+
     module_pyname = '{}.{}'.format(N_MGR.module_name_prefix, name)
-    reload(sys.modules['apprise.common'])
-    reload(sys.modules['apprise.attachment'])
-    reload(sys.modules['apprise.config'])
-    reload(sys.modules['apprise.plugins'])
     if module_pyname in sys.modules:
         reload(sys.modules[module_pyname])
+    new_notify_mod = import_module(module_pyname)
+
     reload(sys.modules['apprise.NotificationManager'])
     reload(sys.modules['apprise.Apprise'])
     reload(sys.modules['apprise.utils'])
@@ -59,7 +69,6 @@ def reload_plugin(name):
 
     # Filter our keys
     tests = [k for k in sys.modules.keys() if re.match(r'^test_.+$', k)]
-    new_mod = import_module(module_pyname)
     for module_name in tests:
         possible_matches = \
             [m for m in dir(sys.modules[module_name])
@@ -73,4 +82,40 @@ def reload_plugin(name):
         #
         # We reload NotifyABCDE and place it back in its spot
         test_mod = import_module(module_name)
-        setattr(test_mod, name, getattr(new_mod, name))
+        setattr(test_mod, name, getattr(new_notify_mod, name))
+
+    # Detect our Apprise Modules (include helpers)
+    apprise_modules = \
+        [k for k in sys.modules.keys()
+         if re.match(r'^(apprise|helpers)(\.|.+)$', k)]
+
+    for entry in A_MGR:
+        reload(sys.modules[entry['path']])
+        for module_pyname in chain(apprise_modules, tests):
+            detect = re.compile(
+                r'^(?P<name>(AppriseAttachment|AttachBase|' +
+                entry['path'].split('.')[-1] + r'))$')
+
+            possible_matches = \
+                [m for m in dir(sys.modules[module_pyname]) if detect.match(m)]
+            if not possible_matches:
+                continue
+
+            apprise_mod = import_module(module_pyname)
+            # Fix reference to new plugin class in given module.
+            # Needed for updating the module-level import reference
+            # like `from apprise.<etc> import NotifyABCDE`.
+            #
+            # We reload NotifyABCDE and place it back in its spot
+            # new_attach = import_module(entry['path'])
+            for name in possible_matches:
+                if name == 'AppriseAttachment':
+                    setattr(
+                        apprise_mod, name,
+                        getattr(new_apprise_attachment_mod, name))
+
+                else:
+                    module_pyname = '{}.{}'.format(
+                        A_MGR.module_name_prefix, name)
+                    new_attach_mod = import_module(module_pyname)
+                    setattr(apprise_mod, name, getattr(new_attach_mod, name))

--- a/test/helpers/module.py
+++ b/test/helpers/module.py
@@ -34,35 +34,6 @@ import re
 # Grant access to our Notification Manager Singleton
 N_MGR = NotificationManager()
 
-# def reload_plugin(name, replace_in=None):
-#     """
-#     Reload built-in plugin module, e.g. `NotifyGnome`.
-# 
-#     Reloading plugin modules is needed when testing module-level code of
-#     notification plugins.
-# 
-#     See also https://stackoverflow.com/questions/31363311.
-#     """
-# 
-#     module_name = f"apprise.plugins.{name}"
-# 
-#     reload(sys.modules['apprise.common'])
-#     reload(sys.modules['apprise.attachment'])
-#     reload(sys.modules['apprise.config'])
-#     reload(sys.modules['apprise.plugins.NotifyBase'])
-#     reload(sys.modules['apprise.NotificationManager'])
-#     N_MGR.reload(name)
-#     reload(sys.modules['apprise.Apprise'])
-#     reload(sys.modules['apprise.utils'])
-#     reload(sys.modules['apprise.cli'])
-#     reload(sys.modules['apprise'])
-# 
-#     # Fix reference to new plugin class in given module.
-#     # Needed for updating the module-level import reference like
-#     # `from apprise.plugins.NotifyMacOSX import NotifyMacOSX`.
-#     if replace_in is not None:
-#         mod = import_module(module_name)
-#         setattr(replace_in, name, getattr(mod, name))
 
 def reload_plugin(name):
     """
@@ -90,10 +61,9 @@ def reload_plugin(name):
     tests = [k for k in sys.modules.keys() if re.match(r'^test_.+$', k)]
     new_mod = import_module(module_pyname)
     for module_name in tests:
-        #possible_matches = [m for m in dir(sys.modules[module_name]) \
-        #    if m == name]
-        possible_matches = [m for m in dir(sys.modules[module_name]) \
-            if re.match(r'^(?P<name>Notify[a-z0-9]+)$', m, re.I)]
+        possible_matches = \
+            [m for m in dir(sys.modules[module_name])
+             if re.match(r'^(?P<name>Notify[a-z0-9]+)$', m, re.I)]
         if not possible_matches:
             continue
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -50,9 +50,7 @@ from apprise import PrivacyMode
 from apprise.AppriseLocale import LazyTranslation
 from apprise.AppriseLocale import gettext_lazy as _
 
-from apprise import common
-from apprise.plugins import __load_matrix
-from apprise.plugins import __reset_matrix
+from apprise.NotificationManager import NotificationManager
 from apprise.utils import parse_list
 from helpers import OuterEventLoop
 import inspect
@@ -64,8 +62,11 @@ logging.disable(logging.CRITICAL)
 # Attachment Directory
 TEST_VAR_DIR = join(dirname(__file__), 'var')
 
+# Grant access to our Notification Manager Singleton
+N_MGR = NotificationManager()
 
-def test_apprise():
+
+def test_apprise_object():
     """
     API: Apprise() object
 
@@ -90,11 +91,6 @@ def test_apprise_async():
 
 
 def apprise_test(do_notify):
-    # Caling load matix a second time which is an internal function causes it
-    # to skip over content already loaded into our matrix and thefore accesses
-    # other if/else parts of the code that aren't otherwise called
-    __load_matrix()
-
     a = Apprise()
 
     # no items
@@ -217,10 +213,10 @@ def apprise_test(do_notify):
             return NotifyBase.parse_url(url, verify_host=False)
 
     # Store our bad notification in our schema map
-    common.NOTIFY_SCHEMA_MAP['bad'] = BadNotification
+    N_MGR['bad'] = BadNotification
 
     # Store our good notification in our schema map
-    common.NOTIFY_SCHEMA_MAP['good'] = GoodNotification
+    N_MGR['good'] = GoodNotification
 
     # Just to explain what is happening here, we would have parsed the
     # url properly but failed when we went to go and create an instance
@@ -334,13 +330,13 @@ def apprise_test(do_notify):
             return ''
 
     # Store our bad notification in our schema map
-    common.NOTIFY_SCHEMA_MAP['throw'] = ThrowNotification
+    N_MGR['throw'] = ThrowNotification
 
     # Store our good notification in our schema map
-    common.NOTIFY_SCHEMA_MAP['fail'] = FailNotification
+    N_MGR['fail'] = FailNotification
 
     # Store our good notification in our schema map
-    common.NOTIFY_SCHEMA_MAP['runtime'] = RuntimeNotification
+    N_MGR['runtime'] = RuntimeNotification
 
     for async_mode in (True, False):
         # Create an Asset object
@@ -368,7 +364,7 @@ def apprise_test(do_notify):
             # Support URL
             return ''
 
-    common.NOTIFY_SCHEMA_MAP['throw'] = ThrowInstantiateNotification
+    N_MGR['throw'] = ThrowInstantiateNotification
 
     # Reset our object
     a.clear()
@@ -680,11 +676,7 @@ def test_apprise_schemas(tmpdir):
     API: Apprise().schema() tests
 
     """
-    # Caling load matix a second time which is an internal function causes it
-    # to skip over content already loaded into our matrix and thefore accesses
-    # other if/else parts of the code that aren't otherwise called
-    __load_matrix()
-
+    # Clear loaded modules
     a = Apprise()
 
     # no items
@@ -712,9 +704,9 @@ def test_apprise_schemas(tmpdir):
         secure_protocol = 'markdowns'
 
     # Store our notifications into our schema map
-    common.NOTIFY_SCHEMA_MAP['text'] = TextNotification
-    common.NOTIFY_SCHEMA_MAP['html'] = HtmlNotification
-    common.NOTIFY_SCHEMA_MAP['markdown'] = MarkDownNotification
+    N_MGR['text'] = TextNotification
+    N_MGR['html'] = HtmlNotification
+    N_MGR['markdown'] = MarkDownNotification
 
     schemas = URLBase.schemas(TextNotification)
     assert isinstance(schemas, set) is True
@@ -784,11 +776,6 @@ def test_apprise_notify_formats(tmpdir):
     API: Apprise() Input Formats tests
 
     """
-    # Caling load matix a second time which is an internal function causes it
-    # to skip over content already loaded into our matrix and thefore accesses
-    # other if/else parts of the code that aren't otherwise called
-    __load_matrix()
-
     # Need to set async_mode=False to call notify() instead of async_notify().
     asset = AppriseAsset(async_mode=False)
 
@@ -845,9 +832,9 @@ def test_apprise_notify_formats(tmpdir):
             return ''
 
     # Store our notifications into our schema map
-    common.NOTIFY_SCHEMA_MAP['text'] = TextNotification
-    common.NOTIFY_SCHEMA_MAP['html'] = HtmlNotification
-    common.NOTIFY_SCHEMA_MAP['markdown'] = MarkDownNotification
+    N_MGR['text'] = TextNotification
+    N_MGR['html'] = HtmlNotification
+    N_MGR['markdown'] = MarkDownNotification
 
     # Test Markdown; the above calls the markdown because our good://
     # defined plugin above was defined to default to HTML which triggers
@@ -1021,8 +1008,9 @@ def test_apprise_disabled_plugins():
     API: Apprise() Disabled Plugin States
 
     """
-    # Reset our matrix
-    __reset_matrix()
+    # Ensure there are no other drives loaded
+    N_MGR.unload_modules(disable_native=True)
+    assert len(N_MGR) == 0
 
     class TestDisabled01Notification(NotifyBase):
         """
@@ -1044,7 +1032,7 @@ def test_apprise_disabled_plugins():
             # Pretend everything is okay (so we don't break other tests)
             return True
 
-    common.NOTIFY_SCHEMA_MAP['na01'] = TestDisabled01Notification
+    N_MGR['na01'] = TestDisabled01Notification
 
     class TestDisabled02Notification(NotifyBase):
         """
@@ -1069,7 +1057,7 @@ def test_apprise_disabled_plugins():
             # Pretend everything is okay (so we don't break other tests)
             return True
 
-    common.NOTIFY_SCHEMA_MAP['na02'] = TestDisabled02Notification
+    N_MGR['na02'] = TestDisabled02Notification
 
     # Create our Apprise instance
     a = Apprise()
@@ -1127,7 +1115,7 @@ def test_apprise_disabled_plugins():
             # Pretend everything is okay (so we don't break other tests)
             return True
 
-    common.NOTIFY_SCHEMA_MAP['good'] = TesEnabled01Notification
+    N_MGR['good'] = TesEnabled01Notification
 
     # The last thing we'll simulate is a case where the plugin is just
     # disabled at a later time long into it's life.  this is just to allow
@@ -1148,9 +1136,8 @@ def test_apprise_disabled_plugins():
     # our notifications will go okay now
     assert plugin.notify("My Message") is True
 
-    # Reset our matrix
-    __reset_matrix()
-    __load_matrix()
+    # Restore our modules
+    N_MGR.unload_modules()
 
 
 def test_apprise_details():
@@ -1158,9 +1145,6 @@ def test_apprise_details():
     API: Apprise() Details
 
     """
-    # Reset our matrix
-    __reset_matrix()
-
     # This is a made up class that is just used to verify
     class TestDetailNotification(NotifyBase):
         """
@@ -1190,22 +1174,23 @@ def test_apprise_details():
         # previously defined in the base package and builds onto them
         template_tokens = dict(NotifyBase.template_tokens, **{
             'notype': {
-                # Nothing defined is still valid
+                # name is a minimum requirement
+                'name': _('no type'),
             },
             'regex_test01': {
                 'name': _('RegexTest'),
                 'type': 'string',
-                'regex': r'[A-Z0-9]',
+                'regex': r'^[A-Z0-9]$',
             },
             'regex_test02': {
                 'name': _('RegexTest'),
                 # Support regex options too
-                'regex': (r'[A-Z0-9]', 'i'),
+                'regex': (r'^[A-Z0-9]$', 'i'),
             },
             'regex_test03': {
                 'name': _('RegexTest'),
                 # Support regex option without a second option
-                'regex': (r'[A-Z0-9]'),
+                'regex': (r'^[A-Z0-9]$'),
             },
             'regex_test04': {
                 # this entry would just end up getting removed
@@ -1267,7 +1252,7 @@ def test_apprise_details():
             return True
 
     # Store our good detail notification in our schema map
-    common.NOTIFY_SCHEMA_MAP['details'] = TestDetailNotification
+    N_MGR['details'] = TestDetailNotification
 
     # This is a made up class that is just used to verify
     class TestReq01Notification(NotifyBase):
@@ -1292,7 +1277,7 @@ def test_apprise_details():
             # Pretend everything is okay (so we don't break other tests)
             return True
 
-    common.NOTIFY_SCHEMA_MAP['req01'] = TestReq01Notification
+    N_MGR['req01'] = TestReq01Notification
 
     # This is a made up class that is just used to verify
     class TestReq02Notification(NotifyBase):
@@ -1322,7 +1307,7 @@ def test_apprise_details():
             # Pretend everything is okay (so we don't break other tests)
             return True
 
-    common.NOTIFY_SCHEMA_MAP['req02'] = TestReq02Notification
+    N_MGR['req02'] = TestReq02Notification
 
     # This is a made up class that is just used to verify
     class TestReq03Notification(NotifyBase):
@@ -1348,7 +1333,7 @@ def test_apprise_details():
             # Pretend everything is okay (so we don't break other tests)
             return True
 
-    common.NOTIFY_SCHEMA_MAP['req03'] = TestReq03Notification
+    N_MGR['req03'] = TestReq03Notification
 
     # This is a made up class that is just used to verify
     class TestReq04Notification(NotifyBase):
@@ -1368,7 +1353,7 @@ def test_apprise_details():
             # Pretend everything is okay (so we don't break other tests)
             return True
 
-    common.NOTIFY_SCHEMA_MAP['req04'] = TestReq04Notification
+    N_MGR['req04'] = TestReq04Notification
 
     # This is a made up class that is just used to verify
     class TestReq05Notification(NotifyBase):
@@ -1390,7 +1375,7 @@ def test_apprise_details():
             # Pretend everything is okay (so we don't break other tests)
             return True
 
-    common.NOTIFY_SCHEMA_MAP['req05'] = TestReq05Notification
+    N_MGR['req05'] = TestReq05Notification
 
     # Create our Apprise instance
     a = Apprise()
@@ -1451,21 +1436,13 @@ def test_apprise_details():
         assert isinstance(entry['requirements']['packages_required'], list)
         assert isinstance(entry['requirements']['packages_recommended'], list)
 
-    # Reset our matrix
-    __reset_matrix()
-    __load_matrix()
-
 
 def test_apprise_details_plugin_verification():
     """
     API: Apprise() Details Plugin Verification
 
     """
-
-    # Reset our matrix
-    __reset_matrix()
-    __load_matrix()
-
+    # Prepare our object
     a = Apprise()
 
     # Details object
@@ -1757,7 +1734,7 @@ def test_apprise_details_plugin_verification():
                                 )
 
         spec = inspect.getfullargspec(
-            common.NOTIFY_SCHEMA_MAP[protocols[0]].__init__)
+            N_MGR._schema_map[protocols[0]].__init__)
 
         function_args = \
             (set(parse_list(spec.varkw)) - set(['kwargs'])) \
@@ -1773,7 +1750,8 @@ def test_apprise_details_plugin_verification():
                     '{}.__init__() expects a {}=None entry according to '
                     'template configuration'
                     .format(
-                        common.NOTIFY_SCHEMA_MAP[protocols[0]].__name__, arg))
+                        N_MGR._schema_map
+                        [protocols[0]].__name__, arg))
 
         # Iterate over all of the function arguments and make sure that
         # it maps back to a key
@@ -1783,8 +1761,7 @@ def test_apprise_details_plugin_verification():
                 raise AssertionError(
                     '{}.__init__({}) found but not defined in the '
                     'template configuration'
-                    .format(
-                        common.NOTIFY_SCHEMA_MAP[protocols[0]].__name__, arg))
+                    .format(N_MGR._schema_map[protocols[0]].__name__, arg))
 
         # Iterate over our map_to_aliases and make sure they were defined in
         # either the as a token or arg
@@ -1987,4 +1964,4 @@ class NotifyBugger(NotifyBase):
         # always parseable
         return ConfigBase.parse_url(url, verify_host=False)""")
 
-    __load_matrix(path=str(base), name=module_name)
+    N_MGR.load_modules(path=str(base), name=module_name)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -703,6 +703,11 @@ def test_apprise_schemas(tmpdir):
 
         secure_protocol = 'markdowns'
 
+    schemas = URLBase.schemas(TextNotification)
+    assert isinstance(schemas, set) is True
+    # We didn't define a protocol or secure protocol
+    assert len(schemas) == 0
+
     # Store our notifications into our schema map
     N_MGR['text'] = TextNotification
     N_MGR['html'] = HtmlNotification
@@ -710,8 +715,10 @@ def test_apprise_schemas(tmpdir):
 
     schemas = URLBase.schemas(TextNotification)
     assert isinstance(schemas, set) is True
-    # We didn't define a protocol or secure protocol
-    assert len(schemas) == 0
+    # We didn't define a protocol or secure protocol one
+    # but one got assigned in he above N_MGR call
+    assert len(schemas) == 1
+    assert 'text' in schemas
 
     schemas = URLBase.schemas(HtmlNotification)
     assert isinstance(schemas, set) is True

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -32,6 +32,7 @@ import re
 import sys
 import pytest
 import requests
+from inspect import cleandoc
 from unittest import mock
 
 from os.path import dirname
@@ -1923,56 +1924,61 @@ def test_notify_matrix_dynamic_importing(tmpdir):
     base.join("__init__.py").write('')
 
     # Test no app_id
-    base.join('NotifyBadFile1.py').write(
+    base.join('NotifyBadFile1.py').write(cleandoc(
         """
-class NotifyBadFile1:
-    pass""")
+        class NotifyBadFile1:
+            pass
+        """))
 
     # No class of the same name
-    base.join('NotifyBadFile2.py').write(
+    base.join('NotifyBadFile2.py').write(cleandoc(
         """
-class BadClassName:
-    pass""")
+        class BadClassName:
+            pass
+        """))
 
     # Exception thrown
     base.join('NotifyBadFile3.py').write("""raise ImportError()""")
 
     # Utilizes a schema:// already occupied (as string)
-    base.join('NotifyGoober.py').write(
+    base.join('NotifyGoober.py').write(cleandoc(
         """
-from apprise import NotifyBase
-class NotifyGoober(NotifyBase):
-    # This class tests the fact we have a new class name, but we're
-    # trying to over-ride items previously used
+        from apprise import NotifyBase
+        class NotifyGoober(NotifyBase):
+            # This class tests the fact we have a new class name, but we're
+            # trying to over-ride items previously used
 
-    # The default simple (insecure) protocol (used by NotifyMail)
-    protocol = ('mailto', 'goober')
+            # The default simple (insecure) protocol (used by NotifyMail)
+            protocol = ('mailto', 'goober')
 
-    # The default secure protocol (used by NotifyMail)
-    secure_protocol = 'mailtos'
+            # The default secure protocol (used by NotifyMail)
+            secure_protocol = 'mailtos'
 
-    @staticmethod
-    def parse_url(url, *args, **kwargs):
-        # always parseable
-        return ConfigBase.parse_url(url, verify_host=False)""")
+            @staticmethod
+            def parse_url(url, *args, **kwargs):
+                # always parseable
+                return ConfigBase.parse_url(url, verify_host=False)
+        """))
 
     # Utilizes a schema:// already occupied (as tuple)
-    base.join('NotifyBugger.py').write("""
-from apprise import NotifyBase
-class NotifyBugger(NotifyBase):
-    # This class tests the fact we have a new class name, but we're
-    # trying to over-ride items previously used
+    base.join('NotifyBugger.py').write(cleandoc(
+        """
+        from apprise import NotifyBase
+        class NotifyBugger(NotifyBase):
+            # This class tests the fact we have a new class name, but we're
+            # trying to over-ride items previously used
 
-    # The default simple (insecure) protocol (used by NotifyMail), the other
-    # isn't
-    protocol = ('mailto', 'bugger-test' )
+            # The default simple (insecure) protocol (used by NotifyMail), the
+            # other isn't
+            protocol = ('mailto', 'bugger-test' )
 
-    # The default secure protocol (used by NotifyMail), the other isn't
-    secure_protocol = ('mailtos', ['garbage'])
+            # The default secure protocol (used by NotifyMail), the other isn't
+            secure_protocol = ('mailtos', ['garbage'])
 
-    @staticmethod
-    def parse_url(url, *args, **kwargs):
-        # always parseable
-        return ConfigBase.parse_url(url, verify_host=False)""")
+            @staticmethod
+            def parse_url(url, *args, **kwargs):
+                # always parseable
+                return ConfigBase.parse_url(url, verify_host=False)
+            """))
 
     N_MGR.load_modules(path=str(base), name=module_name)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -364,7 +364,11 @@ def apprise_test(do_notify):
             # Support URL
             return ''
 
+    N_MGR.unload_modules()
     N_MGR['throw'] = ThrowInstantiateNotification
+
+    # Store our good notification in our schema map
+    N_MGR['good'] = GoodNotification
 
     # Reset our object
     a.clear()

--- a/test/test_apprise_cli.py
+++ b/test/test_apprise_cli.py
@@ -970,6 +970,14 @@ def test_apprise_cli_plugin_loading(mock_post, tmpdir):
         print("{}: {} - {}".format(notify_type, title, body))
 
         # No return (so a return of None) get's translated to True
+
+    # Define another in the same file
+    @notify(on="clihookA")
+    def mywrapper(body, title, notify_type, *args, **kwargs):
+        # A simple test - print to screen
+        print("!! {}: {} - {}".format(notify_type, title, body))
+
+        # No return (so a return of None) get's translated to True
     """))
 
     result = runner.invoke(cli.main, [
@@ -999,8 +1007,11 @@ def test_apprise_cli_plugin_loading(mock_post, tmpdir):
     # Capture our key for reference
     key = [k for k in N_MGR._custom_module_map.keys()][0]
 
-    assert len(N_MGR._custom_module_map[key]['notify']) == 1
+    # We loaded 2 entries from the same file
+    assert len(N_MGR._custom_module_map[key]['notify']) == 2
     assert 'clihook' in N_MGR._custom_module_map[key]['notify']
+    # Converted to lower case
+    assert 'clihooka' in N_MGR._custom_module_map[key]['notify']
 
     # Our function name
     assert N_MGR._custom_module_map[key]['notify']['clihook']['fn_name'] \
@@ -1015,7 +1026,7 @@ def test_apprise_cli_plugin_loading(mock_post, tmpdir):
     # Our Base Notification object when initialized:
     assert len(
         N_MGR._module_map[N_MGR._custom_module_map[key]['name']]['plugin']) \
-        == 1
+        == 2
     for plugin in \
             N_MGR._module_map[N_MGR._custom_module_map[key]['name']]['plugin']:
         assert isinstance(plugin(), NotifyBase)

--- a/test/test_apprise_config.py
+++ b/test/test_apprise_config.py
@@ -37,15 +37,18 @@ from apprise import AppriseConfig
 from apprise import AppriseAsset
 from apprise.config.ConfigBase import ConfigBase
 from apprise.plugins.NotifyBase import NotifyBase
+from apprise.NotificationManager import NotificationManager
 
 from apprise.common import CONFIG_SCHEMA_MAP
-from apprise.common import NOTIFY_SCHEMA_MAP
 from apprise.config import __load_matrix
 from apprise.config.ConfigFile import ConfigFile
 
 # Disable logging for a cleaner testing output
 import logging
 logging.disable(logging.CRITICAL)
+
+# Grant access to our Notification Manager Singleton
+N_MGR = NotificationManager()
 
 
 def test_apprise_config(tmpdir):
@@ -248,7 +251,7 @@ def test_apprise_multi_config_entries(tmpdir):
             return ''
 
     # Store our good notification in our schema map
-    NOTIFY_SCHEMA_MAP['good'] = GoodNotification
+    N_MGR._schema_map['good'] = GoodNotification
 
     # Create ourselves a config object
     ac = AppriseConfig()
@@ -566,7 +569,7 @@ def test_apprise_config_with_apprise_obj(tmpdir):
             return ''
 
     # Store our good notification in our schema map
-    NOTIFY_SCHEMA_MAP['good'] = GoodNotification
+    N_MGR._schema_map['good'] = GoodNotification
 
     # Create ourselves a config object
     ac = AppriseConfig(cache=False)

--- a/test/test_apprise_config.py
+++ b/test/test_apprise_config.py
@@ -38,9 +38,8 @@ from apprise import AppriseAsset
 from apprise.config.ConfigBase import ConfigBase
 from apprise.plugins.NotifyBase import NotifyBase
 from apprise.NotificationManager import NotificationManager
+from apprise.ConfigurationManager import ConfigurationManager
 
-from apprise.common import CONFIG_SCHEMA_MAP
-from apprise.config import __load_matrix
 from apprise.config.ConfigFile import ConfigFile
 
 # Disable logging for a cleaner testing output
@@ -49,6 +48,9 @@ logging.disable(logging.CRITICAL)
 
 # Grant access to our Notification Manager Singleton
 N_MGR = NotificationManager()
+
+# Grant access to our Configuration Manager Singleton
+C_MGR = ConfigurationManager()
 
 
 def test_apprise_config(tmpdir):
@@ -471,7 +473,7 @@ def test_apprise_config_instantiate():
             return ConfigBase.parse_url(url, verify_host=False)
 
     # Store our bad configuration in our schema map
-    CONFIG_SCHEMA_MAP['bad'] = BadConfig
+    C_MGR['bad'] = BadConfig
 
     with pytest.raises(TypeError):
         AppriseConfig.instantiate(
@@ -504,7 +506,7 @@ def test_invalid_apprise_config(tmpdir):
             return ConfigBase.parse_url(url, verify_host=False)
 
     # Store our bad configuration in our schema map
-    CONFIG_SCHEMA_MAP['bad'] = BadConfig
+    C_MGR['bad'] = BadConfig
 
     # temporary file to work with
     t = tmpdir.mkdir("apprise-bad-obj").join("invalid")
@@ -768,9 +770,9 @@ def test_recursive_config_inclusion(tmpdir):
         allow_cross_includes = ContentIncludeMode.NEVER
 
     # store our entries
-    CONFIG_SCHEMA_MAP['never'] = ConfigCrossPostNever
-    CONFIG_SCHEMA_MAP['strict'] = ConfigCrossPostStrict
-    CONFIG_SCHEMA_MAP['always'] = ConfigCrossPostAlways
+    C_MGR['never'] = ConfigCrossPostNever
+    C_MGR['strict'] = ConfigCrossPostStrict
+    C_MGR['always'] = ConfigCrossPostAlways
 
     # Make our new path valid
     suite = tmpdir.mkdir("apprise_config_recursion")
@@ -977,11 +979,6 @@ def test_apprise_config_matrix_load():
     apprise.config.ConfigDummy3 = ConfigDummy3
     apprise.config.ConfigDummy4 = ConfigDummy4
 
-    __load_matrix()
-
-    # Call it again so we detect our entries already loaded
-    __load_matrix()
-
 
 def test_configmatrix_dynamic_importing(tmpdir):
     """
@@ -1054,8 +1051,6 @@ class ConfigBugger(ConfigBase):
     def parse_url(url, *args, **kwargs):
         # always parseable
         return ConfigBase.parse_url(url, verify_host=False)""")
-
-    __load_matrix(path=str(base), name=module_name)
 
 
 @mock.patch('os.path.getsize')

--- a/test/test_asyncio.py
+++ b/test/test_asyncio.py
@@ -31,12 +31,14 @@ import pytest
 from apprise import Apprise
 from apprise import NotifyBase
 from apprise import NotifyFormat
-
-from apprise.common import NOTIFY_SCHEMA_MAP
+from apprise.NotificationManager import NotificationManager
 
 # Disable logging for a cleaner testing output
 import logging
 logging.disable(logging.CRITICAL)
+
+# Grant access to our Notification Manager Singleton
+N_MGR = NotificationManager()
 
 
 @pytest.mark.skipif(sys.version_info >= (3, 7),
@@ -65,7 +67,7 @@ def test_apprise_asyncio_runtime_error():
             return NotifyBase.parse_url(url, verify_host=False)
 
     # Store our good notification in our schema map
-    NOTIFY_SCHEMA_MAP['good'] = GoodNotification
+    N_MGR['good'] = GoodNotification
 
     # Create ourselves an Apprise object
     a = Apprise()

--- a/test/test_attach_http.py
+++ b/test/test_attach_http.py
@@ -36,8 +36,8 @@ from os.path import dirname
 from os.path import getsize
 from apprise.attachment.AttachHTTP import AttachHTTP
 from apprise import AppriseAttachment
+from apprise.NotificationManager import NotificationManager
 from apprise.plugins.NotifyBase import NotifyBase
-from apprise.common import NOTIFY_SCHEMA_MAP
 from apprise.common import ContentLocation
 
 # Disable logging for a cleaner testing output
@@ -45,6 +45,9 @@ import logging
 logging.disable(logging.CRITICAL)
 
 TEST_VAR_DIR = join(dirname(__file__), 'var')
+
+# Grant access to our Notification Manager Singleton
+N_MGR = NotificationManager()
 
 # Some exception handling we'll use
 REQUEST_EXCEPTIONS = (
@@ -131,7 +134,7 @@ def test_attach_http(mock_get):
             return ''
 
     # Store our good notification in our schema map
-    NOTIFY_SCHEMA_MAP['good'] = GoodNotification
+    N_MGR['good'] = GoodNotification
 
     # Temporary path
     path = join(TEST_VAR_DIR, 'apprise-test.gif')

--- a/test/test_config_http.py
+++ b/test/test_config_http.py
@@ -34,12 +34,14 @@ import requests
 from apprise.common import ConfigFormat
 from apprise.config.ConfigHTTP import ConfigHTTP
 from apprise.plugins.NotifyBase import NotifyBase
-from apprise.common import NOTIFY_SCHEMA_MAP
+from apprise.NotificationManager import NotificationManager
 
 # Disable logging for a cleaner testing output
 import logging
 logging.disable(logging.CRITICAL)
 
+# Grant access to our Notification Manager Singleton
+N_MGR = NotificationManager()
 
 # Some exception handling we'll use
 REQUEST_EXCEPTIONS = (
@@ -77,7 +79,7 @@ def test_config_http(mock_post):
             return ''
 
     # Store our good notification in our schema map
-    NOTIFY_SCHEMA_MAP['good'] = GoodNotification
+    N_MGR['good'] = GoodNotification
 
     # Our default content
     default_content = """taga,tagb=good://server01"""

--- a/test/test_decorator_notify.py
+++ b/test/test_decorator_notify.py
@@ -34,10 +34,14 @@ from apprise import AppriseConfig
 from apprise import AppriseAsset
 from apprise import AppriseAttachment
 from apprise import common
+from apprise.NotificationManager import NotificationManager
 
 # Disable logging for a cleaner testing output
 import logging
 logging.disable(logging.CRITICAL)
+
+# Grant access to our Notification Manager Singleton
+N_MGR = NotificationManager()
 
 TEST_VAR_DIR = join(dirname(__file__), 'var')
 
@@ -48,7 +52,7 @@ def test_notify_simple_decoration():
 
     # Verify our schema we're about to declare doesn't already exist
     # in our schema map:
-    assert 'utiltest' not in common.NOTIFY_SCHEMA_MAP
+    assert 'utiltest' not in N_MGR
 
     verify_obj = {}
 
@@ -68,7 +72,7 @@ def test_notify_simple_decoration():
         })
 
     # Now after our hook being inline... it's been loaded
-    assert 'utiltest' in common.NOTIFY_SCHEMA_MAP
+    assert 'utiltest' in N_MGR
 
     # Create ourselves an apprise object
     aobj = Apprise()
@@ -146,7 +150,7 @@ def test_notify_simple_decoration():
     assert verify_obj['kwargs']['meta']['schema'] == 'utiltest'
     assert verify_obj['kwargs']['meta']['url'] == 'utiltest://'
 
-    assert 'notexc' not in common.NOTIFY_SCHEMA_MAP
+    assert 'notexc' not in N_MGR
 
     # Define a function here on the spot
     @notify(on="notexc", name="Apprise @notify Exception Handling")
@@ -154,7 +158,7 @@ def test_notify_simple_decoration():
             body, title, notify_type, attach, *args, **kwargs):
         raise ValueError("An exception was thrown!")
 
-    assert 'notexc' in common.NOTIFY_SCHEMA_MAP
+    assert 'notexc' in N_MGR
 
     # Create ourselves an apprise object
     aobj = Apprise()
@@ -165,8 +169,7 @@ def test_notify_simple_decoration():
     assert aobj.notify("Exceptions will be thrown!") is False
 
     # Tidy
-    del common.NOTIFY_SCHEMA_MAP['utiltest']
-    del common.NOTIFY_SCHEMA_MAP['notexc']
+    N_MGR.remove('utiltest', 'notexc')
 
 
 def test_notify_complex_decoration():
@@ -175,7 +178,7 @@ def test_notify_complex_decoration():
 
     # Verify our schema we're about to declare doesn't already exist
     # in our schema map:
-    assert 'utiltest' not in common.NOTIFY_SCHEMA_MAP
+    assert 'utiltest' not in N_MGR
 
     verify_obj = {}
 
@@ -196,7 +199,7 @@ def test_notify_complex_decoration():
         })
 
     # Now after our hook being inline... it's been loaded
-    assert 'utiltest' in common.NOTIFY_SCHEMA_MAP
+    assert 'utiltest' in N_MGR
 
     # Create ourselves an apprise object
     aobj = Apprise()
@@ -312,7 +315,7 @@ def test_notify_complex_decoration():
     assert 'key2=another' in verify_obj['kwargs']['meta']['url']
 
     # Tidy
-    del common.NOTIFY_SCHEMA_MAP['utiltest']
+    N_MGR.remove('utiltest')
 
 
 def test_notify_multi_instance_decoration(tmpdir):
@@ -321,7 +324,7 @@ def test_notify_multi_instance_decoration(tmpdir):
 
     # Verify our schema we're about to declare doesn't already exist
     # in our schema map:
-    assert 'multi' not in common.NOTIFY_SCHEMA_MAP
+    assert 'multi' not in N_MGR
 
     verify_obj = []
 
@@ -342,7 +345,7 @@ def test_notify_multi_instance_decoration(tmpdir):
         })
 
     # Now after our hook being inline... it's been loaded
-    assert 'multi' in common.NOTIFY_SCHEMA_MAP
+    assert 'multi' in N_MGR
 
     # Prepare our config
     t = tmpdir.mkdir("multi-test").join("apprise.yml")
@@ -449,4 +452,4 @@ def test_notify_multi_instance_decoration(tmpdir):
     assert meta['url'] == 'multi://user2:pass2@hostname'
 
     # Tidy
-    del common.NOTIFY_SCHEMA_MAP['multi']
+    N_MGR.remove('multi')

--- a/test/test_notification_manager.py
+++ b/test/test_notification_manager.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2023, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import re
+import pytest
+import types
+
+from apprise.NotificationManager import NotificationManager
+from apprise.plugins.NotifyBase import NotifyBase
+
+# Disable logging for a cleaner testing output
+import logging
+logging.disable(logging.CRITICAL)
+
+# Grant access to our Notification Manager Singleton
+N_MGR = NotificationManager()
+
+
+def test_notification_manager():
+    """
+    N_MGR: Notification Manager General testing
+
+    """
+    # Clear our set so we can test init calls
+    N_MGR.unload_modules()
+    assert isinstance(N_MGR.schemas(), list)
+    assert len(N_MGR.schemas()) > 0
+    N_MGR.unload_modules(disable_native=True)
+    assert isinstance(N_MGR.schemas(), list)
+    assert len(N_MGR.schemas()) == 0
+
+    N_MGR.unload_modules()
+    assert len(N_MGR) > 0
+
+    N_MGR.unload_modules()
+    assert bool(N_MGR) is False
+    assert len([x for x in iter(N_MGR)]) > 0
+    assert bool(N_MGR) is True
+
+    N_MGR.unload_modules()
+    assert isinstance(N_MGR.plugins(), types.GeneratorType)
+    assert len([x for x in N_MGR.plugins()]) > 0
+    N_MGR.unload_modules(disable_native=True)
+    assert isinstance(N_MGR.plugins(), types.GeneratorType)
+    assert len([x for x in N_MGR.plugins()]) == 0
+    N_MGR.unload_modules()
+    assert isinstance(N_MGR['json'](host='localhost'), NotifyBase)
+    N_MGR.unload_modules()
+    assert 'json' in N_MGR
+
+    # Define our good:// url
+    class DisabledNotification(NotifyBase):
+        # Always disabled
+        enabled = False
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+        def notify(self, *args, **kwargs):
+            # Pretend everything is okay
+            return True
+
+        def url(self, **kwargs):
+            # Support url() function
+            return ''
+
+    # Define our good:// url
+    class GoodNotification(NotifyBase):
+
+        secure_protocol = ('good', 'goods')
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+        def notify(self, *args, **kwargs):
+            # Pretend everything is okay
+            return True
+
+        def url(self, **kwargs):
+            # Support url() function
+            return ''
+
+    N_MGR.unload_modules()
+    with pytest.raises(KeyError):
+        del N_MGR['good']
+    N_MGR['good'] = GoodNotification
+    del N_MGR['good']
+
+    N_MGR.unload_modules()
+    N_MGR['good'] = GoodNotification
+    assert N_MGR['good'].enabled is True
+    N_MGR.enable_only('json', 'xml')
+    assert N_MGR['good'].enabled is False
+    assert N_MGR['json'].enabled is True
+    assert N_MGR['jsons'].enabled is True
+    assert N_MGR['xml'].enabled is True
+    assert N_MGR['xmls'].enabled is True
+    N_MGR.enable_only('good')
+    assert N_MGR['good'].enabled is True
+    assert N_MGR['json'].enabled is False
+    assert N_MGR['jsons'].enabled is False
+    assert N_MGR['xml'].enabled is False
+    assert N_MGR['xmls'].enabled is False
+
+    N_MGR.unload_modules()
+    N_MGR['disabled'] = DisabledNotification
+    assert N_MGR['disabled'].enabled is False
+    N_MGR.enable_only('disabled')
+    # Can't enable items that aren't supposed to be:
+    assert N_MGR['disabled'].enabled is False
+
+    N_MGR['good'] = GoodNotification
+    assert N_MGR['good'].enabled is True
+
+    N_MGR.unload_modules()
+    N_MGR.enable_only('form', 'xml')
+    for schema in N_MGR.schemas(include_disabled=False):
+        assert re.match(r'^(form|xml)s?$', schema, re.IGNORECASE) is not None
+
+    N_MGR.unload_modules()
+    assert N_MGR['form'].enabled is True
+    assert N_MGR['xml'].enabled is True
+    assert N_MGR['json'].enabled is True
+    N_MGR.enable_only('form', 'xml')
+    assert N_MGR['form'].enabled is True
+    assert N_MGR['xml'].enabled is True
+    assert N_MGR['json'].enabled is False
+
+    N_MGR.disable('invalid', 'xml')
+    assert N_MGR['form'].enabled is True
+    assert N_MGR['xml'].enabled is False
+    assert N_MGR['json'].enabled is False
+
+    # Detect that our json object is enabled
+    with pytest.raises(KeyError):
+        # The below can not be indexed
+        N_MGR['invalid']
+
+    N_MGR.unload_modules()
+    assert N_MGR['json'].enabled is True
+
+    # Work with an empty module tree
+    N_MGR.unload_modules(disable_native=True)
+    with pytest.raises(KeyError):
+        # The below can not be indexed
+        N_MGR['good']
+
+    N_MGR.unload_modules()
+    N_MGR['good'] = GoodNotification
+
+    N_MGR.unload_modules()
+    N_MGR.remove('good', 'invalid')
+    assert 'good' not in N_MGR
+    assert 'goods' not in N_MGR

--- a/test/test_plugin_glib.py
+++ b/test/test_plugin_glib.py
@@ -114,7 +114,6 @@ def setup_glib_environment():
 
     # When patching something which has a side effect on the module-level code
     # of a plugin, make sure to reload it.
-    current_module = sys.modules[__name__]
     reload_plugin('NotifyDBus')
 
 
@@ -416,7 +415,6 @@ def test_plugin_dbus_gi_missing(dbus_glib_environment):
 
     # When patching something which has a side effect on the module-level code
     # of a plugin, make sure to reload it.
-    current_module = sys.modules[__name__]
     reload_plugin('NotifyDBus')
 
     # Create the instance.
@@ -444,7 +442,6 @@ def test_plugin_dbus_gi_require_version_error(dbus_glib_environment):
 
     # When patching something which has a side effect on the module-level code
     # of a plugin, make sure to reload it.
-    current_module = sys.modules[__name__]
     reload_plugin('NotifyDBus')
 
     # Create instance.
@@ -472,7 +469,6 @@ def test_plugin_dbus_module_croaks(mocker, dbus_glib_environment):
 
     # When patching something which has a side effect on the module-level code
     # of a plugin, make sure to reload it.
-    current_module = sys.modules[__name__]
     reload_plugin('NotifyDBus')
 
     # Verify plugin is not available.

--- a/test/test_plugin_glib.py
+++ b/test/test_plugin_glib.py
@@ -115,7 +115,7 @@ def setup_glib_environment():
     # When patching something which has a side effect on the module-level code
     # of a plugin, make sure to reload it.
     current_module = sys.modules[__name__]
-    reload_plugin('NotifyDBus', replace_in=current_module)
+    reload_plugin('NotifyDBus')
 
 
 @pytest.fixture
@@ -417,7 +417,7 @@ def test_plugin_dbus_gi_missing(dbus_glib_environment):
     # When patching something which has a side effect on the module-level code
     # of a plugin, make sure to reload it.
     current_module = sys.modules[__name__]
-    reload_plugin('NotifyDBus', replace_in=current_module)
+    reload_plugin('NotifyDBus')
 
     # Create the instance.
     obj = apprise.Apprise.instantiate('glib://', suppress_exceptions=False)
@@ -445,7 +445,7 @@ def test_plugin_dbus_gi_require_version_error(dbus_glib_environment):
     # When patching something which has a side effect on the module-level code
     # of a plugin, make sure to reload it.
     current_module = sys.modules[__name__]
-    reload_plugin('NotifyDBus', replace_in=current_module)
+    reload_plugin('NotifyDBus')
 
     # Create instance.
     obj = apprise.Apprise.instantiate('glib://', suppress_exceptions=False)
@@ -473,7 +473,7 @@ def test_plugin_dbus_module_croaks(mocker, dbus_glib_environment):
     # When patching something which has a side effect on the module-level code
     # of a plugin, make sure to reload it.
     current_module = sys.modules[__name__]
-    reload_plugin('NotifyDBus', replace_in=current_module)
+    reload_plugin('NotifyDBus')
 
     # Verify plugin is not available.
     obj = apprise.Apprise.instantiate('glib://', suppress_exceptions=False)

--- a/test/test_plugin_gnome.py
+++ b/test/test_plugin_gnome.py
@@ -97,8 +97,7 @@ def setup_glib_environment():
 
     # When patching something which has a side effect on the module-level code
     # of a plugin, make sure to reload it.
-    current_module = sys.modules[__name__]
-    reload_plugin('NotifyGnome', replace_in=current_module)
+    reload_plugin('NotifyGnome')
 
 
 @pytest.fixture
@@ -345,8 +344,7 @@ def test_plugin_gnome_gi_croaks():
 
     # When patching something which has a side effect on the module-level code
     # of a plugin, make sure to reload it.
-    current_module = sys.modules[__name__]
-    reload_plugin('NotifyGnome', replace_in=current_module)
+    reload_plugin('NotifyGnome')
 
     # Create instance.
     obj = apprise.Apprise.instantiate('gnome://', suppress_exceptions=False)

--- a/test/test_plugin_macosx.py
+++ b/test/test_plugin_macosx.py
@@ -43,7 +43,7 @@ logging.disable(logging.CRITICAL)
 
 
 if sys.platform not in ["darwin", "linux"]:
-    pytest.skip("Only makes sense on macOS, but also works on Linux",
+    pytest.skip("Only makes sense on macOS, but testable in Linux",
                 allow_module_level=True)
 
 
@@ -56,8 +56,7 @@ def pretend_macos(mocker):
     mocker.patch("platform.mac_ver", return_value=('10.8', ('', '', ''), ''))
 
     # Reload plugin module, in order to re-run module-level code.
-    current_module = sys.modules[__name__]
-    reload_plugin("NotifyMacOSX", replace_in=current_module)
+    reload_plugin("NotifyMacOSX")
 
 
 @pytest.fixture
@@ -93,6 +92,7 @@ def test_plugin_macosx_general_success(macos_notify_environment):
     NotifyMacOSX() general checks
     """
 
+    # Toggle Enable Flag
     obj = apprise.Apprise.instantiate(
         'macosx://_/?image=True', suppress_exceptions=False)
     assert isinstance(obj, NotifyMacOSX) is True


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** n/a

This is a massive re-factor of how notifications are loaded into memory.  It also refactors the way the Emoji engine is loaded (saving on memory when it's not needed).

After this PR, notifications are no longer loaded on the `import apprise` command.  Instead leveraging a new library, they are only imported on demand.

- Improved startup logging and information on load times (both Native Notifications and Custom ones loaded thereafter)
- Testing re-factored to better handle the dynamic reloading of modules to test how they handle.

## Breaking Changes
- This will require the Apprise API to be refactored to work correctly once this is merged.  It will also break anyone who learned of the 'under-the-hood' Apprise environment and was manipulating the old SCHEMA -> Module mapping.

Those using the library as it was intended will not see any breakage at all.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] 100% test coverage

