### PR TITLE
Fix large throttling time issues in unit tests that use freezegun.freeze_time

### DIFF
--- a/apprise/URLBase.py
+++ b/apprise/URLBase.py
@@ -294,7 +294,7 @@ class URLBase:
         # the defined request_rate_per_sec then we need to throttle for the
         # remaining balance of this time.
 
-        elapsed = (reference - self._last_io_datetime).total_seconds()
+        elapsed = abs(reference - self._last_io_datetime).total_seconds()
 
         if wait is not None:
             self.logger.debug('Throttling forced for {}s...'.format(wait))

--- a/apprise/plugins/NotifyPushover.py
+++ b/apprise/plugins/NotifyPushover.py
@@ -161,6 +161,9 @@ class NotifyPushover(NotifyBase):
     # Pushover uses the http protocol with JSON requests
     notify_url = 'https://api.pushover.net/1/messages.json'
 
+    # NotifyBase throttles but Pushover does not require throttling, so disable it
+    request_rate_per_sec = 0.0
+
     # Support attachments
     attachment_support = True
 


### PR DESCRIPTION
## Description:
Two fixes here:
* Pushover service does not require throttling, so set throttling to 0
* When using freeze_time for unit testing client code in "frozen time", this could lead to very large sleep times, which is a bummer in a unit test. Making the throttling elapsed time positive fixes that. 