### PR TITLE
tgram:// supports chat_id:topic arguments

### DIFF
--- a/test/test_plugin_telegram.py
+++ b/test/test_plugin_telegram.py
@@ -243,7 +243,7 @@ def test_plugin_telegram_general(mock_post):
     invalid_bot_token = 'abcd:123'
 
     # Chat ID
-    chat_ids = 'l2g, lead2gold'
+    chat_ids = 'l2g:1234, lead2gold'
 
     # Prepare Mock
     mock_post.return_value = requests.Request()
@@ -397,7 +397,7 @@ def test_plugin_telegram_general(mock_post):
 
     obj = NotifyTelegram(bot_token=bot_token, targets='12345')
     assert len(obj.targets) == 1
-    assert obj.targets[0] == '12345'
+    assert obj.targets[0] == (12345, None)
 
     # Test the escaping of characters since Telegram escapes stuff for us to
     # which we need to consider
@@ -440,7 +440,7 @@ def test_plugin_telegram_general(mock_post):
 
     assert obj.notify(title='hello', body='world') is True
     assert len(obj.targets) == 1
-    assert obj.targets[0] == '532389719'
+    assert obj.targets[0] == ('532389719', None)
 
     # Do the test again, but without the expected (parsed response)
     mock_post.return_value.content = dumps({
@@ -550,7 +550,7 @@ def test_plugin_telegram_general(mock_post):
         'tgram://123456789:ABCdefghijkl123456789opqyz/-123456789525')
     assert isinstance(obj, NotifyTelegram)
     assert len(obj.targets) == 1
-    assert '-123456789525' in obj.targets
+    assert (-123456789525, None) in obj.targets
 
 
 @mock.patch('requests.post')


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1021

Telegram plugin supports: `tgram://{chat_id}:{topic}` now (using a colon (`:`) as a delimiter.  Hence the following is valid too: ` tgram://{chat_id}:{topic}/{chat_id2}:{topic2}/...` 

Topics are purely optional

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1021-telegram-chatid-to-topics

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
     "tgram://credentials/chat_id:topic"
```

