### PR TITLE
Python 3.12 Support

### DIFF
--- a/Dockerfile.py312
+++ b/Dockerfile.py312
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2023, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Base
+FROM python:3.12-bookworm
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libdbus-1-dev libgirepository1.0-dev build-essential musl-dev bash dbus && \
+    rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache-dir dbus-python "PyGObject==3.44.2"
+
+# Apprise Setup
+VOLUME ["/apprise"]
+WORKDIR /apprise
+COPY requirements.txt /
+COPY dev-requirements.txt /
+ENV PYTHONPATH /apprise
+ENV PYTHONPYCACHEPREFIX /apprise/__pycache__/py312
+
+RUN pip install --no-cache-dir -r /requirements.txt -r /dev-requirements.txt
+
+RUN addgroup --gid ${USER_GID:-1000} apprise
+RUN adduser --system --uid ${USER_UID:-1000} --ingroup apprise --home /apprise --no-create-home --disabled-password apprise
+
+USER apprise

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,13 @@ services:
     volumes:
       - ./:/apprise
 
+  test.py312:
+    build:
+      context: .
+      dockerfile: Dockerfile.py312
+    volumes:
+      - ./:/apprise
+
   rpmbuild.el8:
     build:
       context: .


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1030 

This was created in lieu of the ticket opened that Apprise no longer worked under Python v3.12.

I added in the logic to test it here and everything appears okay.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing

```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1030-python-3-12-support

# Run entire test suite:
docker-compose run --rm test.py312 bin/checkdone.sh
```

