### PR TITLE
Resolved ConfigMemory AttributeError Exception

### DIFF
--- a/apprise/AppriseConfig.py
+++ b/apprise/AppriseConfig.py
@@ -26,7 +26,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from . import config
 from . import ConfigBase
 from . import CONFIG_FORMATS
 from .ConfigurationManager import ConfigurationManager

--- a/apprise/AppriseConfig.py
+++ b/apprise/AppriseConfig.py
@@ -255,7 +255,7 @@ class AppriseConfig:
         logger.debug("Loading raw configuration: {}".format(content))
 
         # Create ourselves a ConfigMemory Object to store our configuration
-        instance = config.ConfigMemory.ConfigMemory(
+        instance = C_MGR['memory'](
             content=content, format=format, asset=asset, tag=tag,
             recursion=recursion, insecure_includes=insecure_includes)
 
@@ -330,7 +330,7 @@ class AppriseConfig:
         schema = GET_SCHEMA_RE.match(url)
         if schema is None:
             # Plan B is to assume we're dealing with a file
-            schema = config.ConfigFile.ConfigFile.protocol
+            schema = 'file'
             url = '{}://{}'.format(schema, URLBase.quote(url))
 
         else:


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** n/a

When trying to adapt Apprise v1.7.0 with the Apprise API, the following exception was thrown (relating back to this package):
```
2023-12-28 12:54:05,342 [ERROR] django.request: Internal Server Error: /json/urls/apprise/
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.10/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.10/site-packages/django/views/generic/base.py", line 104, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/django/utils/decorators.py", line 46, in _wrapper
    return bound_method(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/django/utils/decorators.py", line 134, in _wrapper_view
    response = view_func(request, *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/django/views/decorators/cache.py", line 62, in _wrapper_view_func
    response = view_func(request, *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/django/views/generic/base.py", line 143, in dispatch
    return handler(request, *args, **kwargs)
  File "/apprise-api/apprise_api/api/views.py", line 1199, in get
    ac_obj.add_config(config, format=format)
  File "/apprise-api/.local/lib/python3.10/site-packages/apprise/AppriseConfig.py", line 258, in add_config
    instance = config.ConfigMemory.ConfigMemory(
AttributeError: module 'apprise.config' has no attribute 'ConfigMemory'
```

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@attribute-error-configmemory

```

