### PR TITLE
Support Slack Replies by allowing use of thread_timestamp

### DIFF
--- a/apprise/plugins/NotifySlack.py
+++ b/apprise/plugins/NotifySlack.py
@@ -96,8 +96,6 @@ SLACK_HTTP_ERROR_MAP = {
 # Used to break path apart into list of channels
 CHANNEL_LIST_DELIM = re.compile(r'[ \t\r\n,#\\/]+')
 
-# Regex for reply Detection
-
 
 class SlackMode:
     """
@@ -562,10 +560,11 @@ class NotifySlack(NotifyBase):
                     continue
 
                 # Add timestamp to payload if present
-                if timestamp_match := re.compile(
-                        r':(.*)',
-                        re.IGNORECASE).search(channel):
+                timestamp_match = re.compile(r':(.*)',
+                                             re.IGNORECASE).search(channel)
+                if timestamp_match:
                     payload['thread_ts'] = timestamp_match.group(1)
+                    # reset channel name to remove the timestamp that is given
                     channel = channel[:timestamp_match.start()]
 
                 if channel[0] == '+':
@@ -802,7 +801,6 @@ class NotifySlack(NotifyBase):
         """
         Wrapper to the requests (post) object
         """
-        print(payload)
         self.logger.debug('Slack POST URL: %s (cert_verify=%r)' % (
             url, self.verify_certificate,
         ))

--- a/apprise/plugins/NotifySlack.py
+++ b/apprise/plugins/NotifySlack.py
@@ -98,7 +98,7 @@ CHANNEL_LIST_DELIM = re.compile(r'[ \t\r\n,#\\/]+')
 
 # Channel Regular Expression Parsing
 CHANNEL_RE = re.compile(
-    r'^(?P<channel>[+#@]?[A-Z0-9_]{1,32})(:(?P<thread_ts>[0-9]+))?$', re.I)
+    r'^(?P<channel>[+#@]?[A-Z0-9_-]{1,32})(:(?P<thread_ts>[0-9.]+))?$', re.I)
 
 
 class SlackMode:

--- a/apprise/plugins/NotifySlack.py
+++ b/apprise/plugins/NotifySlack.py
@@ -96,6 +96,10 @@ SLACK_HTTP_ERROR_MAP = {
 # Used to break path apart into list of channels
 CHANNEL_LIST_DELIM = re.compile(r'[ \t\r\n,#\\/]+')
 
+# Channel Regular Expression Parsing
+CHANNEL_RE = re.compile(
+    r'^(?P<channel>[+#@]?[A-Z0-9_]{1,32})(:(?P<thread_ts>[0-9]+))?$', re.I)
+
 
 class SlackMode:
     """
@@ -548,44 +552,51 @@ class NotifySlack(NotifyBase):
         while len(channels):
             channel = channels.pop(0)
             if channel is not None:
-                channel = validate_regex(channel, r'[+#@]?[A-Z0-9_]{1,32}')
-                if not channel:
-                    # Channel over-ride was specified
-                    self.logger.warning(
-                        "The specified target {} is invalid;"
-                        "skipping.".format(channel))
+                # We'll perform a user lookup if we detect an email
+                email = is_email(channel)
+                if email:
+                    payload['channel'] = \
+                        self.lookup_userid(email['full_email'])
 
-                    # Mark our failure
-                    has_error = True
-                    continue
+                    if not payload['channel']:
+                        # Move along; any notifications/logging would have
+                        # come from lookup_userid()
+                        has_error = True
+                        continue
 
-                # Add timestamp to payload if present
-                timestamp_match = re.compile(r':(.*)',
-                                             re.IGNORECASE).search(channel)
-                if timestamp_match:
-                    payload['thread_ts'] = timestamp_match.group(1)
-                    # reset channel name to remove the timestamp that is given
-                    channel = channel[:timestamp_match.start()]
+                else:  # Channel
+                    result = CHANNEL_RE.match(channel)
 
-                if channel[0] == '+':
-                    # Treat as encoded id if prefixed with a +
-                    payload['channel'] = channel[1:]
+                    if not result:
+                        # Channel over-ride was specified
+                        self.logger.warning(
+                            "The specified Slack target {} is invalid;"
+                            "skipping.".format(channel))
 
-                elif channel[0] == '@':
-                    # Treat @ value 'as is'
-                    payload['channel'] = channel
-                else:
-                    # We'll perform a user lookup if we detect an email
-                    email = is_email(channel)
-                    if email:
-                        payload['channel'] = \
-                            self.lookup_userid(email['full_email'])
+                        # Mark our failure
+                        has_error = True
+                        continue
 
-                        if not payload['channel']:
-                            # Move along; any notifications/logging would have
-                            # come from lookup_userid()
-                            has_error = True
-                            continue
+                    # Store oure content
+                    channel, thread_ts = \
+                        result.group('channel'), result.group('thread_ts')
+                    if thread_ts:
+                        payload['thread_ts'] = thread_ts
+
+                    elif 'thread_ts' in payload:
+                        # Handle situations where one channel has a thread_id
+                        # specified, and the next does not.  We do not want to
+                        # cary forward the last value specified
+                        del payload['thread_ts']
+
+                    if channel[0] == '+':
+                        # Treat as encoded id if prefixed with a +
+                        payload['channel'] = channel[1:]
+
+                    elif channel[0] == '@':
+                        # Treat @ value 'as is'
+                        payload['channel'] = channel
+
                     else:
                         # Prefix with channel hash tag (if not already)
                         payload['channel'] = \

--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -1589,20 +1589,3 @@ def dict_full_update(dict1, dict2):
 
     _merge(dict1, dict2)
     return
-
-
-def remove_from_targets_and_return_on_prefix(prefix, targets):
-    """
-    Removes a value from list target based on prefix values.
-
-    Args:
-        prefix (string): prefix string query on.
-        targets (list): list of all targets in given url
-
-    Returns:
-        int: value of prefix, False if not found
-    """
-    for index, value in enumerate(targets):
-        if value.startswith(prefix):
-            return index
-    return False

--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -1589,3 +1589,20 @@ def dict_full_update(dict1, dict2):
 
     _merge(dict1, dict2)
     return
+
+
+def remove_from_targets_and_return_on_prefix(prefix, targets):
+    """
+    Removes a value from list target based on prefix values.
+
+    Args:
+        prefix (string): prefix string query on.
+        targets (list): list of all targets in given url
+
+    Returns:
+        int: value of prefix, False if not found
+    """
+    for index, value in enumerate(targets):
+        if value.startswith(prefix):
+            return index
+    return False

--- a/test/test_plugin_slack.py
+++ b/test/test_plugin_slack.py
@@ -702,3 +702,45 @@ def test_plugin_slack_markdown(mock_get, mock_post):
         "We also want to be able to support <https://slack.com> "\
         "links without the\ndescription."\
         "\n\nChannel Testing\n<!channelA>\n<!channelA|Description>"
+
+
+@mock.patch('requests.post')
+def test_plugin_slack_thread_reply(mock_post):
+    """
+    NotifySlack() Send Notification as a Reply
+
+    """
+
+    # Generate a (valid) bot token
+    token = 'xoxb-1234-1234-abc124'
+    timestamp = 100.23
+
+    request = mock.Mock()
+    request.content = dumps({
+        'ok': True,
+        'message': '',
+        'user': {
+            'id': 'ABCD1234'
+        }
+    })
+    request.status_code = requests.codes.ok
+
+    # Prepare Mock
+    mock_post.return_value = request
+
+    # Variation Initializations
+    obj = NotifySlack(access_token=token, targets=[f'ts={timestamp}'])
+    assert isinstance(obj, NotifySlack) is True
+    assert isinstance(obj.url(), str) is True
+
+    # No calls made yet
+    assert mock_post.call_count == 0
+
+    # Send our notification
+    assert obj.notify(
+        body='body', title='title', notify_type=NotifyType.INFO) is True
+
+    # Post was made
+    assert mock_post.call_count == 1
+    assert mock_post.call_args_list[0][0][0] == \
+        'https://slack.com/api/chat.postMessage'

--- a/test/test_plugin_slack.py
+++ b/test/test_plugin_slack.py
@@ -729,7 +729,7 @@ def test_plugin_slack_thread_reply(mock_post):
     mock_post.return_value = request
 
     # Variation Initializations
-    obj = NotifySlack(access_token=token, targets=[f'ts={timestamp}'])
+    obj = NotifySlack(access_token=token)
     assert isinstance(obj, NotifySlack) is True
     assert isinstance(obj.url(), str) is True
 

--- a/test/test_plugin_slack.py
+++ b/test/test_plugin_slack.py
@@ -255,8 +255,26 @@ apprise_url_tests = (
     }),
     ('slack://notify@T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/#b:100', {
         'instance': NotifySlack,
-        'test_requests_exceptions': 200,
         'requests_response_text': 'ok',
+    }),
+    ('slack://notify@T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/+124:100', {
+        'instance': NotifySlack,
+        'requests_response_text': 'ok',
+    }),
+    # test a case where we have a channel defined alone (without a thread_ts)
+    # that exists after a definition where a thread_ts does exist.  this
+    # tests the branch of code that ensures we do not pass the same thread_ts
+    # twice
+    ('slack://notify@T1JJ3T3L2/A1BRTD4JD/'
+     'TIiajkdnlazkcOXrIdevi7FQ/+124:100/@chan', {
+         'instance': NotifySlack,
+         'requests_response_text': 'ok',
+     }),
+    ('slack://notify@T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/#b:bad', {
+        'instance': NotifySlack,
+        'requests_response_text': 'ok',
+        # we'll fail because our thread_ts is bad
+        'response': False,
     }),
 )
 


### PR DESCRIPTION
## Description:
This enhancement allows Slack notification plugin to accept timestamps of messages that it should reply too.

This allows Apprise to reply into multiple channel's messages, creating a chat thread for relevant notifications.

### Syntax
Thread Timestamp (defined as `{thread_ts}` below can be added to defined elements using a colon `:` delimiter like so:
* `slack://{tokenA}/{tokenB}/{tokenC}/#{channel}:{thread_ts}`
* `slack://{tokenA}/{tokenB}/{tokenC}/#{channel1}:{thread_ts}/#{channel2}:{thread_ts}/#{channelN}:{thread_ts}`
* `slack://{botname}@{tokenA}/{tokenB}/{tokenC}/+{encoded_id}:{thread_ts}`
* `slack://{botname}@{tokenA}/{tokenB}/{tokenC}/+{encoded_id1}:{thread_ts}/+{encoded_id2}:{thread_ts}/+{encoded_id3}:{thread_ts}`
* `slack://{botname}@{tokenA}/{tokenB}/{tokenC}/@{user_id}:{thread_ts}`
* `slack://{botname}@{tokenA}/{tokenB}/{tokenC}/@{user_id1}:{thread_ts}/@{user_id2}:{thread_ts}/@{user_id3}:{thread_ts}`

## New Service Completion Status
Not Applicable

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@<this.branch-name>

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  slack://slack_bot_oauth/#channel1:timestamp1/channel2:timestamp2

```

