### PR TITLE
Improve split and truncate overflow methods

### DIFF
--- a/apprise/plugins/NotifyBase.py
+++ b/apprise/plugins/NotifyBase.py
@@ -494,9 +494,13 @@ class NotifyBase(URLBase):
             # Truncate our Title
             title = title[:self.title_maxlen]
 
-        # Combine title length into body if defined (2 for \r\n)
-        body_maxlen = self.body_maxlen \
-            if not title else self.body_maxlen - len(title) - 2
+        if self.body_maxlen > self.title_maxlen - 2:
+            # Combine title length into body if defined (2 for \r\n)
+            body_maxlen = self.body_maxlen \
+                if not title else self.body_maxlen - len(title) - 2
+        else:
+            # status quo
+            body_maxlen = self.body_maxlen
 
         if body_maxlen > 0 and len(body) <= body_maxlen:
             response.append({'body': body, 'title': title})

--- a/apprise/plugins/NotifyBase.py
+++ b/apprise/plugins/NotifyBase.py
@@ -494,14 +494,18 @@ class NotifyBase(URLBase):
             # Truncate our Title
             title = title[:self.title_maxlen]
 
-        if self.body_maxlen > 0 and len(body) <= self.body_maxlen:
+        # Combine title length into body if defined (2 for \r\n)
+        body_maxlen = self.body_maxlen \
+            if not title else self.body_maxlen - len(title) - 2
+
+        if body_maxlen > 0 and len(body) <= body_maxlen:
             response.append({'body': body, 'title': title})
             return response
 
         if overflow == OverflowMode.TRUNCATE:
             # Truncate our body and return
             response.append({
-                'body': body[:self.body_maxlen],
+                'body': body[:body_maxlen],
                 'title': title,
             })
             # For truncate mode, we're done now
@@ -511,8 +515,8 @@ class NotifyBase(URLBase):
         # For here, we want to split the message as many times as we have to
         # in order to fit it within the designated limits.
         response = [{
-            'body': body[i: i + self.body_maxlen],
-            'title': title} for i in range(0, len(body), self.body_maxlen)]
+            'body': body[i: i + body_maxlen],
+            'title': title} for i in range(0, len(body), body_maxlen)]
 
         return response
 

--- a/apprise/plugins/NotifyBase.py
+++ b/apprise/plugins/NotifyBase.py
@@ -515,12 +515,37 @@ class NotifyBase(URLBase):
             # For truncate mode, we're done now
             return response
 
+        # Display Count  [XX/XX]
+        #               ^^^^^^^^
+        #               \\\\\\\\
+        #               8 characters (space + count)
+        display_count_width = 8
+
+        # the min accepted length of a title to allow for a counter display
+        display_count_threshold = 130
+
+        show_counter = title and len(body) > body_maxlen \
+            and self.title_maxlen > \
+            (display_count_threshold + display_count_width)
+
+        count = 0
+        if show_counter:
+            count = int(len(body) / body_maxlen) \
+                + (1 if len(body) % body_maxlen else 0)
+
+            if len(title) > self.title_maxlen - display_count_width:
+                # Truncate our title further
+                title = title[:self.title_maxlen - display_count_width]
+
         # If we reach here, then we are in SPLIT mode.
         # For here, we want to split the message as many times as we have to
         # in order to fit it within the designated limits.
         response = [{
             'body': body[i: i + body_maxlen],
-            'title': title} for i in range(0, len(body), body_maxlen)]
+            'title': title + (
+                '' if not count else
+                ' [{:02}/{:02}]'.format(idx, count))} for idx, i in
+            enumerate(range(0, len(body), body_maxlen), start=1)]
 
         return response
 

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -338,6 +338,21 @@ def test_notify_overflow_split():
         assert body[offset: len(_body) + offset].rstrip() == _body
         offset += len(_body)
 
+    # Another edge case where the title just isn't that long leaving
+    # a lot of space for the [xx/xx] entries (no truncation needed)
+    chunks = obj._apply_overflow(body=body, title=title[:20])
+    offset = 0
+    assert len(chunks) == 4
+    for idx, chunk in enumerate(chunks, start=1):
+        # Our title has a counter added to it
+        assert title[:20] == chunk.get('title')[:-8]
+        assert chunk.get('title')[-8:] == \
+            ' [{:02}/{:02}]'.format(idx, len(chunks))
+        # Our body is only broken up; not lost
+        _body = chunk.get('body')
+        assert body[offset: len(_body) + offset].rstrip() == _body
+        offset += len(_body)
+
     #
     # Next Test: Append title to body + split body
     #

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -164,7 +164,7 @@ def test_notify_overflow_truncate():
     chunks = obj._apply_overflow(body=body, title=title)
     assert len(chunks) == 1
     # -2 because \r\n are factored into calculation (safe whitespace)
-    assert body[0:TestNotification.body_maxlen - 2] == chunks[0].get('body')
+    assert body[0:TestNotification.body_maxlen] == chunks[0].get('body')
     assert title == chunks[0].get('title')
 
     #

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -427,8 +427,6 @@ def test_notify_overflow_split():
         offset += len(_body)
 
 
-
-
 def test_notify_markdown_general():
     """
     API: Markdown General Testing

--- a/test/test_rest_plugins.py
+++ b/test/test_rest_plugins.py
@@ -163,7 +163,8 @@ def test_notify_overflow_truncate():
     # and that the body remains untouched
     chunks = obj._apply_overflow(body=body, title=title)
     assert len(chunks) == 1
-    assert body[0:TestNotification.body_maxlen] == chunks[0].get('body')
+    # -2 because \r\n are factored into calculation (safe whitespace)
+    assert body[0:TestNotification.body_maxlen - 2] == chunks[0].get('body')
     assert title == chunks[0].get('title')
 
     #


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #845

Improve `?overflow=split` and `?overflow=truncate` functionality to factor in the length of the title in it's calculations.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@845-bodylen-overflow-improvement

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  <apprise url related to ticket>

```

