### PR TITLE
Added test case to strengthen YAML configuration validation

### DIFF
--- a/test/test_config_base.py
+++ b/test/test_config_base.py
@@ -220,6 +220,31 @@ urls:
     assert isinstance(result, list)
     assert len(result) == 1
 
+def test_config_base_discord_bug_report_01():
+    """
+    API: ConfigBase.config_parse user feedback
+
+    A Discord report that a tag was not correctly assigned to a URL when
+    presented in the following format
+       urls:
+         - json://myhost:
+           - tag: test
+             userid: test
+    """
+    result, config = ConfigBase.config_parse("""
+    urls:
+      - json://myhost:
+        - tag: test
+          userid: test
+    """, asset=AppriseAsset())
+
+    # We expect to parse 4 entries from the above
+    assert isinstance(result, list)
+    assert isinstance(config, list)
+    assert len(result) == 1
+    assert len(result[0].tags) == 1
+    assert 'test' in result[0].tags
+
 
 def test_config_base_config_parse_text():
     """

--- a/test/test_config_base.py
+++ b/test/test_config_base.py
@@ -220,6 +220,7 @@ urls:
     assert isinstance(result, list)
     assert len(result) == 1
 
+
 def test_config_base_discord_bug_report_01():
     """
     API: ConfigBase.config_parse user feedback


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** n/a

It was reported that an Apprise URL could not load a single instance in a YAML configuration tied to a tag.

This was just a test case added to re-produce the scenario

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

