### PR TITLE
Update notify_paths for Macports binary support

### DIFF
--- a/apprise/plugins/NotifyMacOSX.py
+++ b/apprise/plugins/NotifyMacOSX.py
@@ -98,6 +98,7 @@ class NotifyMacOSX(NotifyBase):
         '/usr/local/bin/terminal-notifier',
         '/usr/bin/terminal-notifier',
         '/bin/terminal-notifier',
+        '/opt/local/bin/terminal-notifier',
     )
 
     # Define object templates


### PR DESCRIPTION
- added path `/opt/local/bin` in order to support installations via Macports

## Description:
**Related issue (if applicable):** n/a

This minor change adds Macports' [default](https://guide.macports.org/chunked/installing.macports.html) [path](https://guide.macports.org/chunked/installing.shell.html) to the plugin's list of paths where the `terminal-notifier` gets located.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

