### PR TITLE
Default locale logical compatibility with Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,6 +63,8 @@ jobs:
             python-version: "3.10"
           - os: "ubuntu-latest"
             python-version: "3.11"
+          - os: "ubuntu-latest"
+            python-version: "3.12"
 
     defaults:
       run:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,6 +119,7 @@ jobs:
     # and run project-specific tasks.
     - name: Setup project
       run: |
+        python -m pip install --upgrade pip setuptools wheel
         pip install --editable=.
         python setup.py compile_catalog
 

--- a/apprise/AppriseLocale.py
+++ b/apprise/AppriseLocale.py
@@ -219,6 +219,9 @@ class AppriseLocale:
             try:
                 # Acquire our locale
                 lang = locale.getlocale()[0]
+                # Compatibility for Python >= 3.12
+                if lang == 'C':
+                    lang = 'en_US'
 
             except (ValueError, TypeError) as e:
                 # This occurs when an invalid locale was parsed from the

--- a/apprise/AppriseLocale.py
+++ b/apprise/AppriseLocale.py
@@ -221,7 +221,7 @@ class AppriseLocale:
                 lang = locale.getlocale()[0]
                 # Compatibility for Python >= 3.12
                 if lang == 'C':
-                    lang = 'en_US'
+                    lang = AppriseLocale._default_language
 
             except (ValueError, TypeError) as e:
                 # This occurs when an invalid locale was parsed from the


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** N/A

This pull request fixes the behavioural differences on Python 3.12, where if the default locale is unspecified, the new Python defaults to `C.UTF-8` instead of `en_US.UTF-8` on Unix systems.

## Checklist
* [X] The code change is tested and works locally.
* [X] There is no commented out code in this PR.
* [X] No lint errors (use `flake8`)
* [X] 100% test coverage

## Testing
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@<this.branch-name>

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  <apprise url related to ticket>

```

