### PR TITLE
ntfy:// markdown support added

### DIFF
--- a/apprise/plugins/NotifyNtfy.py
+++ b/apprise/plugins/NotifyNtfy.py
@@ -42,6 +42,7 @@ from json import dumps
 from os.path import basename
 
 from .NotifyBase import NotifyBase
+from ..common import NotifyFormat
 from ..common import NotifyType
 from ..common import NotifyImageSize
 from ..AppriseLocale import gettext_lazy as _
@@ -514,6 +515,10 @@ class NotifyNtfy(NotifyBase):
 
         if body:
             virt_payload['message'] = body
+
+        if self.notify_format == NotifyFormat.MARKDOWN:
+            # Support Markdown
+            headers['X-Markdown'] = 'yes'
 
         if self.priority != NtfyPriority.NORMAL:
             headers['X-Priority'] = self.priority

--- a/test/test_plugin_ntfy.py
+++ b/test/test_plugin_ntfy.py
@@ -487,6 +487,22 @@ def test_plugin_custom_ntfy_edge_cases(mock_post):
     assert response['attach'] == 'http://example.com/file.jpg'
     assert response['filename'] == 'smoke.jpg'
 
+    # Reset our mock object
+    mock_post.reset_mock()
+
+    # Markdown Support
+    results = NotifyNtfy.parse_url('ntfys://topic/?format=markdown')
+    assert isinstance(results, dict)
+    instance = NotifyNtfy(**results)
+
+    assert instance.notify(
+        body='body', title='title',
+        notify_type=apprise.NotifyType.INFO) is True
+
+    assert mock_post.call_count == 1
+    assert mock_post.call_args_list[0][0][0] == 'https://ntfy.sh'
+    assert 'X-Markdown' in mock_post.call_args_list[0][1]['headers']
+
 
 @mock.patch('requests.post')
 @mock.patch('requests.get')


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1053

Simply add support for `?format=markdown` that can be applied to the Apprise `ntfy://` URL.  Default is still to pass as is (`text`) to avoid breaking existing system setup.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1053-ntfy-markdown-support

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "ntfy://mytopic/?format=markdown"

```

