### PR TITLE
comcast.net email template added

### DIFF
--- a/apprise/plugins/NotifyEmail.py
+++ b/apprise/plugins/NotifyEmail.py
@@ -295,6 +295,21 @@ EMAIL_TEMPLATES = (
         },
     ),
 
+    # Comcast.net
+    (
+        'Comcast.net',
+        re.compile(
+            r'^((?P<label>[^+]+)\+)?(?P<id>[^@]+)@'
+            r'(?P<domain>(comcast)\.net)$', re.I),
+        {
+            'port': 465,
+            'smtp_host': 'smtp.comcast.net',
+            'secure': True,
+            'secure_mode': SecureMailMode.SSL,
+            'login_type': (WebBaseLogin.EMAIL, )
+        },
+    ),
+
     # Catch All
     (
         'Custom',

--- a/test/test_plugin_email.py
+++ b/test/test_plugin_email.py
@@ -1144,6 +1144,34 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
     response.reset_mock()
 
     results = NotifyEmail.parse_url(
+        'mailto://user:pass@comcast.net')
+    obj = Apprise.instantiate(results, suppress_exceptions=False)
+    assert isinstance(obj, NotifyEmail) is True
+    assert obj.smtp_host == 'smtp.comcast.net'
+    assert obj.user == 'user@comcast.net'
+    assert obj.password == 'pass'
+    assert obj.secure_mode == 'ssl'
+    assert obj.port == 465
+
+    assert mock_smtp.call_count == 0
+    assert mock_smtp_ssl.call_count == 0
+    assert response.starttls.call_count == 0
+    assert obj.notify("test") is True
+    assert mock_smtp.call_count == 0
+    assert mock_smtp_ssl.call_count == 1
+    assert response.starttls.call_count == 0
+    assert response.login.call_count == 1
+    assert response.sendmail.call_count == 1
+
+    user, pw = response.login.call_args[0]
+    assert pw == 'pass'
+    assert user == 'user@comcast.net'
+
+    mock_smtp.reset_mock()
+    mock_smtp_ssl.reset_mock()
+    response.reset_mock()
+
+    results = NotifyEmail.parse_url(
         'mailtos://user:pass123@live.com')
     obj = Apprise.instantiate(results, suppress_exceptions=False)
     assert isinstance(obj, NotifyEmail) is True


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1058

`comcast.net` email template added.  Users of comcast can format their email using apprise as:
- `mailto://user:pass@comcast.net`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1058-comcast-email-template

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "mailto://user:pass@comcast.net"

```

