### PR TITLE
RocketChat Token Support

### DIFF
--- a/test/test_plugin_rocket_chat.py
+++ b/test/test_plugin_rocket_chat.py
@@ -107,6 +107,16 @@ apprise_url_tests = (
         },
         'privacy_url': 'rockets://user:****@localhost',
     }),
+    # A channel using token based
+    ('rockets://user:token@localhost/#channel?mode=token', {
+        'instance': NotifyRocketChat,
+        'privacy_url': 'rockets://user:****@localhost',
+    }),
+    # Token is detected based o it's length
+    ('rockets://user:{}@localhost/#channel'.format('t' * 40), {
+        'instance': NotifyRocketChat,
+        'privacy_url': 'rockets://user:****@localhost',
+    }),
     # Several channels
     ('rocket://user:pass@localhost/#channel1/#channel2/?avatar=Yes', {
         'instance': NotifyRocketChat,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #210

Added `token` support to the `?mode=` list. The syntax is:
- `{schema}://{user}:{token}@{host}:{port}/{targets}`
- `{schema}://{user}:{token}@{host}/{targets}`

Note: `{schema}` is either `rocket` or `rockets`

this is similar to `{schema}://{user}:{password}@{host}:{port}/{targets}`.  Apprise tries to detect if it was a `{password}` or `{token}` based on it's length. If the value specified is >32 characters, then it assumes `?mode=token`, otherwise it will use `?mode=basic`.

You can always specific the `mode=<val>` to enforce what you meant.

If you specify a `{user}/{token}`, then authentication HTTP requests are skipped and the  `X-User-Id` and `X-Auth-Token` are pre-populated in the headers in advance.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@210-rocket-token-support

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "rocket://user:token@rocket.server?mode=token"

```

