### PR TITLE
Pin paho-mqtt version < 2.0.0

### DIFF
--- a/all-plugin-requirements.txt
+++ b/all-plugin-requirements.txt
@@ -9,4 +9,5 @@ cryptography
 gntp
 
 # Provides mqtt:// support
-paho-mqtt
+# use v1.x due to https://github.com/eclipse/paho.mqtt.python/issues/814
+paho-mqtt < 2.0.0


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** n/a

MQTT v2 appears to be unstable and is causing the following error to appear in a lot of new services that require it.
```
Traceback (most recent call last):
File "/usr/local/lib/python3.8/site-packages/paho/mqtt/client.py", line 874, in del
self._reset_sockets()
File "/usr/local/lib/python3.8/site-packages/paho/mqtt/client.py", line 1133, in _reset_sockets
self._sock_close()
File "/usr/local/lib/python3.8/site-packages/paho/mqtt/client.py", line 1119, in _sock_close
if not self._sock:
AttributeError: 'Client' object has no attribute '_sock'
```

Apprise has been reported to be impacted [here](https://github.com/mcguirepr89/BirdNET-Pi/issues/1132) .  Best work-around would be to make sure systems do not leverage the new paho-mqtt version; the official bug report is here: [eclipse/paho-mqtt/814](https://github.com/eclipse/paho.mqtt.python/issues/814)

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@mqtt-avoid-v2-for-now

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "mqtt://credentials"

```

