### PR TITLE
Fix configuration file name in documentation

### DIFF
--- a/packaging/man/apprise.1.html
+++ b/packaging/man/apprise.1.html
@@ -282,9 +282,9 @@ in the following local locations for configuration files and loads them:</p>
 ~/.config/apprise.yml
 
 ~/.apprise/apprise
-~/.apprise/apprise.yaml
+~/.apprise/apprise.yml
 ~/.config/apprise/apprise
-~/.config/apprise/apprise.yaml
+~/.config/apprise/apprise.yml
 
 /etc/apprise
 /etc/apprise.yml

--- a/packaging/man/apprise.md
+++ b/packaging/man/apprise.md
@@ -194,9 +194,9 @@ in the following local locations for configuration files and loads them:
     ~/.config/apprise.yml
 
     ~/.apprise/apprise
-    ~/.apprise/apprise.yaml
+    ~/.apprise/apprise.yml
     ~/.config/apprise/apprise
-    ~/.config/apprise/apprise.yaml
+    ~/.config/apprise/apprise.yml
 
     /etc/apprise
     /etc/apprise.yml


### PR DESCRIPTION
-------

## Description:

Two instances of `config.yaml` (instead of `config.yml`) were present in the documentation, each time twice.

## Checklist

* [X] The code change is tested and works locally.
* [X] There is no commented out code in this PR.
* [X] No lint errors (use `flake8`)
* [X] 100% test coverage

(no code change)

## Testing

N/A