### PR TITLE
Support Asynchronous Dynamic Module Loading

### DIFF
--- a/test/test_notification_manager.py
+++ b/test/test_notification_manager.py
@@ -420,6 +420,10 @@ def test_notification_manager_decorators(tmpdir):
     """))
     assert 'mytest' not in N_MGR
     N_MGR.load_modules(path=str(notify_base))
+
+    # It's still not loaded because the path has already been scanned
+    assert 'mytest' not in N_MGR
+    N_MGR.load_modules(path=str(notify_base), force=True)
     assert 'mytest' in N_MGR
 
     # Could not be loaded because the filename did not align with the class

--- a/test/test_notification_manager.py
+++ b/test/test_notification_manager.py
@@ -29,8 +29,10 @@
 import re
 import pytest
 import types
+import threading
 from inspect import cleandoc
 
+from apprise import Apprise
 from apprise.NotificationManager import NotificationManager
 from apprise.plugins.NotifyBase import NotifyBase
 
@@ -247,6 +249,48 @@ def test_notification_manager_module_loading(tmpdir):
     # memory then needed)
     N_MGR.load_modules()
     N_MGR.load_modules()
+
+    #
+    # Thread Testing
+    #
+
+    # This tests against a racing condition when the modules have not been
+    # loaded.  When multiple instances of Apprise are all instantiated,
+    # the loading of the modules will occur for each instance if detected
+    # having not been previously done, this tests that we can dynamically
+    # support the loading of modules once whe multiple instances to apprise
+    # are instantiated.
+    thread_count = 10
+
+    def thread_test(result, no):
+        """
+        Load our apprise object with valid URLs and store our result
+        """
+        apobj = Apprise()
+        result[no] = apobj.add('json://localhost') and \
+            apobj.add('form://localhost') and \
+            apobj.add('xml://localhost')
+
+    # Unload our modules
+    N_MGR.unload_modules()
+
+    # Prepare threads to load
+    results = [None] * thread_count
+    threads = [
+        threading.Thread(target=thread_test, args=(results, no))
+        for no in range(thread_count)
+    ]
+
+    # Verify we can safely load our modules in a thread safe environment
+    for t in threads:
+        t.start()
+
+    for t in threads:
+        t.join()
+
+    # Verify we loaded our urls in all threads successfully
+    for result in results:
+        assert result is True
 
 
 def test_notification_manager_decorators(tmpdir):

--- a/test/test_notification_manager.py
+++ b/test/test_notification_manager.py
@@ -435,3 +435,7 @@ def test_notification_manager_decorators(tmpdir):
     N_MGR.load_modules(path=str(notify_base))
     # Our item is still loaded as expected
     assert 'mytest' in N_MGR
+
+    # Simple test to make sure we can handle duplicate entries loaded
+    N_MGR.load_modules(path=str(notify_base), force=True)
+    N_MGR.load_modules(path=str(notify_base), force=True)


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1020

This is in efforts to address a racing condition that happens in [Home Assistant Core/110242](https://github.com/home-assistant/core/issues/110242)

Effectively what this patch does is adds a mutex around the (notification) plugin loading.   In addition to this, a flag is tracked when loading has been completed allowing threaded or asynchronous instances of Apprise to work correctly.

Previously (before this patch), the Apprise library would start loading it's (notification) plugins dynamically after first being instantiated.  However second instances would not recognize that the first instance hadn't completed loading all the libraries. The second instance would however detect that plugins were loaded (it really depends on how far the first instance got during it's startup) and assumed it was okay to start processing URLs it was fed.  If your notification URL referenced a plugin that simply hadn't loaded yet (it's a timing thing), it would flat out fail.


## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1020-async-module-loading-fix

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  <apprise url related to ticket>

```

