### PR TITLE
Add support .yaml files via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,28 +235,37 @@ No one wants to put their credentials out for everyone to see on the command lin
 #  ~/.apprise.yml
 #  ~/.config/apprise
 #  ~/.config/apprise.yml
+#  ~/.config/apprise.yaml
 #  /etc/apprise
 #  /etc/apprise.yml
+#  /etc/apprise.yaml
 
 # Also a subdirectory handling allows you to leverage plugins
 #  ~/.apprise/apprise
 #  ~/.apprise/apprise.yml
 #  ~/.config/apprise/apprise
 #  ~/.config/apprise/apprise.yml
+#  ~/.config/apprise/apprise.yaml
 #  /etc/apprise/apprise
 #  /etc/apprise/apprise.yml
+#  /etc/apprise/apprise.yaml
 
 # Windows users can store their default configuration files here:
 #  %APPDATA%/Apprise/apprise
 #  %APPDATA%/Apprise/apprise.yml
+#  %APPDATA%/Apprise/apprise.yaml
 #  %LOCALAPPDATA%/Apprise/apprise
 #  %LOCALAPPDATA%/Apprise/apprise.yml
+#  %LOCALAPPDATA%/Apprise/apprise.yaml
 #  %ALLUSERSPROFILE%\Apprise\apprise
 #  %ALLUSERSPROFILE%\Apprise\apprise.yml
+#  %ALLUSERSPROFILE%\Apprise\apprise.yaml
 #  %PROGRAMFILES%\Apprise\apprise
 #  %PROGRAMFILES%\Apprise\apprise.yml
+#  %PROGRAMFILES%\Apprise\apprise.yaml
 #  %COMMONPROGRAMFILES%\Apprise\apprise
 #  %COMMONPROGRAMFILES%\Apprise\apprise.yml
+#  %COMMONPROGRAMFILES%\Apprise\apprise.yaml
 
 # If you loaded one of those files, your command line gets really easy:
 apprise -vv -t 'my title' -b 'my notification body'

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ No one wants to put their credentials out for everyone to see on the command lin
 # configuration files (if present) from:
 #  ~/.apprise
 #  ~/.apprise.yml
+#  ~/.apprise.yaml
 #  ~/.config/apprise
 #  ~/.config/apprise.yml
 #  ~/.config/apprise.yaml
@@ -243,6 +244,7 @@ No one wants to put their credentials out for everyone to see on the command lin
 # Also a subdirectory handling allows you to leverage plugins
 #  ~/.apprise/apprise
 #  ~/.apprise/apprise.yml
+#  ~/.apprise/apprise.yaml
 #  ~/.config/apprise/apprise
 #  ~/.config/apprise/apprise.yml
 #  ~/.config/apprise/apprise.yaml

--- a/apprise/cli.py
+++ b/apprise/cli.py
@@ -68,20 +68,26 @@ DEFAULT_CONFIG_PATHS = (
     # Legacy Path Support
     '~/.apprise',
     '~/.apprise.yml',
+    '~/.apprise.yaml',
     '~/.config/apprise',
     '~/.config/apprise.yml',
+    '~/.config/apprise.yaml',
 
     # Plugin Support Extended Directory Search Paths
     '~/.apprise/apprise',
     '~/.apprise/apprise.yml',
+    '~/.apprise/apprise.yaml',
     '~/.config/apprise/apprise',
     '~/.config/apprise/apprise.yml',
+    '~/.config/apprise/apprise.yaml',
 
     # Global Configuration Support
     '/etc/apprise',
     '/etc/apprise.yml',
+    '/etc/apprise.yaml',
     '/etc/apprise/apprise',
     '/etc/apprise/apprise.yml',
+    '/etc/apprise/apprise.yaml',
 )
 
 # Define our paths to search for plugins
@@ -99,8 +105,10 @@ if platform.system() == 'Windows':
     DEFAULT_CONFIG_PATHS = (
         expandvars('%APPDATA%\\Apprise\\apprise'),
         expandvars('%APPDATA%\\Apprise\\apprise.yml'),
+        expandvars('%APPDATA%\\Apprise\\apprise.yaml'),
         expandvars('%LOCALAPPDATA%\\Apprise\\apprise'),
         expandvars('%LOCALAPPDATA%\\Apprise\\apprise.yml'),
+        expandvars('%LOCALAPPDATA%\\Apprise\\apprise.yaml'),
 
         #
         # Global Support
@@ -109,14 +117,17 @@ if platform.system() == 'Windows':
         # C:\ProgramData\Apprise\
         expandvars('%ALLUSERSPROFILE%\\Apprise\\apprise'),
         expandvars('%ALLUSERSPROFILE%\\Apprise\\apprise.yml'),
+        expandvars('%ALLUSERSPROFILE%\\Apprise\\apprise.yaml'),
 
         # C:\Program Files\Apprise
         expandvars('%PROGRAMFILES%\\Apprise\\apprise'),
         expandvars('%PROGRAMFILES%\\Apprise\\apprise.yml'),
+        expandvars('%PROGRAMFILES%\\Apprise\\apprise.yaml'),
 
         # C:\Program Files\Common Files
         expandvars('%COMMONPROGRAMFILES%\\Apprise\\apprise'),
         expandvars('%COMMONPROGRAMFILES%\\Apprise\\apprise.yml'),
+        expandvars('%COMMONPROGRAMFILES%\\Apprise\\apprise.yaml'),
     )
 
     # Default Plugin Search Path for Windows Users

--- a/packaging/man/apprise.md
+++ b/packaging/man/apprise.md
@@ -190,18 +190,24 @@ in the following local locations for configuration files and loads them:
 
     ~/.apprise
     ~/.apprise.yml
+    ~/.apprise.yaml
     ~/.config/apprise
     ~/.config/apprise.yml
+    ~/.config/apprise.yaml
 
     ~/.apprise/apprise
     ~/.apprise/apprise.yml
+    ~/.apprise/apprise.yaml
     ~/.config/apprise/apprise
     ~/.config/apprise/apprise.yml
+    ~/.config/apprise/apprise.yaml
 
     /etc/apprise
     /etc/apprise.yml
+    /etc/apprise.yaml
     /etc/apprise/apprise
     /etc/apprise/apprise.yml
+    /etc/apprise/apprise.yaml
 
 If a default configuration file is referenced in any way by the **apprise**
 tool, you no longer need to provide it a Service URL.  Usage of the **apprise**


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1069 

Allow Apprise to support `.yaml` files in addition to `.yml`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@support-yaml-files

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  <apprise url related to ticket>

```

