### PR TITLE
.conf configuration file support added to CLI + doc ambiguity cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,8 +258,8 @@ No one wants to put their credentials out for everyone to see on the command lin
 #  %COMMONPROGRAMFILES%\Apprise\apprise.conf
 #  %COMMONPROGRAMFILES%\Apprise\apprise.yaml
 
-# Note: .yml extensions are also scanned (above) and files without .conf
-#      extension for backwards compatibility with previous versions of apprise
+# The configuration files specified above can also be identified with a `.yml`
+# extension or even just entirely removing the `.conf` extension altogether.
 
 # If you loaded one of those files, your command line gets really easy:
 apprise -vv -t 'my title' -b 'my notification body'

--- a/README.md
+++ b/README.md
@@ -232,42 +232,34 @@ No one wants to put their credentials out for everyone to see on the command lin
 # By default if no url or configuration is specified apprise will attempt to load
 # configuration files (if present) from:
 #  ~/.apprise
-#  ~/.apprise.yml
 #  ~/.apprise.yaml
-#  ~/.config/apprise
-#  ~/.config/apprise.yml
+#  ~/.config/apprise.conf
 #  ~/.config/apprise.yaml
-#  /etc/apprise
-#  /etc/apprise.yml
+#  /etc/apprise.conf
 #  /etc/apprise.yaml
 
 # Also a subdirectory handling allows you to leverage plugins
 #  ~/.apprise/apprise
-#  ~/.apprise/apprise.yml
 #  ~/.apprise/apprise.yaml
-#  ~/.config/apprise/apprise
-#  ~/.config/apprise/apprise.yml
+#  ~/.config/apprise/apprise.conf
 #  ~/.config/apprise/apprise.yaml
-#  /etc/apprise/apprise
-#  /etc/apprise/apprise.yml
 #  /etc/apprise/apprise.yaml
+#  /etc/apprise/apprise.conf
 
 # Windows users can store their default configuration files here:
-#  %APPDATA%/Apprise/apprise
-#  %APPDATA%/Apprise/apprise.yml
+#  %APPDATA%/Apprise/apprise.conf
 #  %APPDATA%/Apprise/apprise.yaml
-#  %LOCALAPPDATA%/Apprise/apprise
-#  %LOCALAPPDATA%/Apprise/apprise.yml
+#  %LOCALAPPDATA%/Apprise/apprise.conf
 #  %LOCALAPPDATA%/Apprise/apprise.yaml
-#  %ALLUSERSPROFILE%\Apprise\apprise
-#  %ALLUSERSPROFILE%\Apprise\apprise.yml
+#  %ALLUSERSPROFILE%\Apprise\apprise.conf
 #  %ALLUSERSPROFILE%\Apprise\apprise.yaml
-#  %PROGRAMFILES%\Apprise\apprise
-#  %PROGRAMFILES%\Apprise\apprise.yml
+#  %PROGRAMFILES%\Apprise\apprise.conf
 #  %PROGRAMFILES%\Apprise\apprise.yaml
-#  %COMMONPROGRAMFILES%\Apprise\apprise
-#  %COMMONPROGRAMFILES%\Apprise\apprise.yml
+#  %COMMONPROGRAMFILES%\Apprise\apprise.conf
 #  %COMMONPROGRAMFILES%\Apprise\apprise.yaml
+
+# Note: .yml extensions are also scanned (above) and files without .conf
+#      extension for backwards compatibility with previous versions of apprise
 
 # If you loaded one of those files, your command line gets really easy:
 apprise -vv -t 'my title' -b 'my notification body'

--- a/apprise/cli.py
+++ b/apprise/cli.py
@@ -67,25 +67,30 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 DEFAULT_CONFIG_PATHS = (
     # Legacy Path Support
     '~/.apprise',
+    '~/.apprise.conf',
     '~/.apprise.yml',
     '~/.apprise.yaml',
     '~/.config/apprise',
+    '~/.config/apprise.conf',
     '~/.config/apprise.yml',
     '~/.config/apprise.yaml',
 
     # Plugin Support Extended Directory Search Paths
     '~/.apprise/apprise',
+    '~/.apprise/apprise.conf',
     '~/.apprise/apprise.yml',
     '~/.apprise/apprise.yaml',
     '~/.config/apprise/apprise',
+    '~/.config/apprise/apprise.conf',
     '~/.config/apprise/apprise.yml',
     '~/.config/apprise/apprise.yaml',
 
-    # Global Configuration Support
+    # Global Configuration File Support
     '/etc/apprise',
     '/etc/apprise.yml',
     '/etc/apprise.yaml',
     '/etc/apprise/apprise',
+    '/etc/apprise/apprise.conf',
     '/etc/apprise/apprise.yml',
     '/etc/apprise/apprise.yaml',
 )
@@ -104,9 +109,11 @@ if platform.system() == 'Windows':
     # Default Config Search Path for Windows Users
     DEFAULT_CONFIG_PATHS = (
         expandvars('%APPDATA%\\Apprise\\apprise'),
+        expandvars('%APPDATA%\\Apprise\\apprise.conf'),
         expandvars('%APPDATA%\\Apprise\\apprise.yml'),
         expandvars('%APPDATA%\\Apprise\\apprise.yaml'),
         expandvars('%LOCALAPPDATA%\\Apprise\\apprise'),
+        expandvars('%LOCALAPPDATA%\\Apprise\\apprise.conf'),
         expandvars('%LOCALAPPDATA%\\Apprise\\apprise.yml'),
         expandvars('%LOCALAPPDATA%\\Apprise\\apprise.yaml'),
 
@@ -116,16 +123,19 @@ if platform.system() == 'Windows':
 
         # C:\ProgramData\Apprise\
         expandvars('%ALLUSERSPROFILE%\\Apprise\\apprise'),
+        expandvars('%ALLUSERSPROFILE%\\Apprise\\apprise.conf'),
         expandvars('%ALLUSERSPROFILE%\\Apprise\\apprise.yml'),
         expandvars('%ALLUSERSPROFILE%\\Apprise\\apprise.yaml'),
 
         # C:\Program Files\Apprise
         expandvars('%PROGRAMFILES%\\Apprise\\apprise'),
+        expandvars('%PROGRAMFILES%\\Apprise\\apprise.conf'),
         expandvars('%PROGRAMFILES%\\Apprise\\apprise.yml'),
         expandvars('%PROGRAMFILES%\\Apprise\\apprise.yaml'),
 
         # C:\Program Files\Common Files
         expandvars('%COMMONPROGRAMFILES%\\Apprise\\apprise'),
+        expandvars('%COMMONPROGRAMFILES%\\Apprise\\apprise.conf'),
         expandvars('%COMMONPROGRAMFILES%\\Apprise\\apprise.yml'),
         expandvars('%COMMONPROGRAMFILES%\\Apprise\\apprise.yaml'),
     )

--- a/packaging/man/apprise.md
+++ b/packaging/man/apprise.md
@@ -188,26 +188,23 @@ command line and all of them will be loaded.  You can also point your configurat
 a cloud location (by referencing `http://` or `https://`. By default **apprise** looks
 in the following local locations for configuration files and loads them:
 
-    ~/.apprise
-    ~/.apprise.yml
+    ~/.apprise.conf
     ~/.apprise.yaml
-    ~/.config/apprise
-    ~/.config/apprise.yml
+    ~/.config/apprise.conf
     ~/.config/apprise.yaml
 
-    ~/.apprise/apprise
-    ~/.apprise/apprise.yml
+    ~/.apprise/apprise.conf
     ~/.apprise/apprise.yaml
-    ~/.config/apprise/apprise
-    ~/.config/apprise/apprise.yml
+    ~/.config/apprise/apprise.conf
     ~/.config/apprise/apprise.yaml
 
-    /etc/apprise
-    /etc/apprise.yml
+    /etc/apprise.conf
     /etc/apprise.yaml
-    /etc/apprise/apprise
-    /etc/apprise/apprise.yml
+    /etc/apprise/apprise.conf
     /etc/apprise/apprise.yaml
+
+The **configuration files** specified above can also be identified with a `.yml`
+extension or even just entirely removing the `.conf` extension altogether.
 
 If a default configuration file is referenced in any way by the **apprise**
 tool, you no longer need to provide it a Service URL.  Usage of the **apprise**


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1076

Eliminate confusion of the configuration file `/etc/apprise` by removing this entirely from the documentation (but not from the source code - keeping it backwards compatible).

Adding `.conf` extension support and improving the documentation to focus around this.  Hopefully this will make it a bit more clear for those using the software.  Apprise very much lacks good documentation.   This issue is a segway into trying to fulfill #869 someday.


## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1076-cli-conf-support

# Now Additionally Supports:
#  ~/.apprise.conf
#  ~/.config/apprise.conf
#  /etc/apprise.conf

# also
#  ~/.apprise/apprise/apprise.conf
#  ~/.config/apprise/apprise.conf
#  /etc/apprise/apprise.conf

apprise -t "Test Title" -b "Test Message" \
  <apprise url related to ticket>

```

