### PR TITLE
matrix: Set default notifiction format to HTML

### DIFF
--- a/apprise/plugins/NotifyMatrix.py
+++ b/apprise/plugins/NotifyMatrix.py
@@ -145,6 +145,8 @@ class NotifyMatrix(NotifyBase):
     # Support Attachments
     attachment_support = True
 
+    notify_format = NotifyFormat.HTML
+
     # A URL that takes you to the setup/help of the specific protocol
     setup_url = 'https://github.com/caronc/apprise/wiki/Notify_matrix'
 


### PR DESCRIPTION
This ensures the org.matrix.custom.html is added which is usually what we want as otherwise no formatting is applied.

## Description:

Set default notifiction format to HTML
    
This ensures the `org.matrix.custom.html` element is added which is usually what we want as otherwise no formatting is applied.

I assume there's a reason for not doing so by default but looking around I couldn't spot any as other plugins set this too.

## Checklist
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@<this.branch-name>

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  <apprise url related to ticket>

```
