### PR TITLE
Improved async/threading attachment support

### DIFF
--- a/apprise/attachment/AttachBase.py
+++ b/apprise/attachment/AttachBase.py
@@ -253,7 +253,7 @@ class AttachBase(URLBase):
         return self.detected_mimetype \
             if self.detected_mimetype else self.unknown_mimetype
 
-    def exists(self):
+    def exists(self, retrieve_if_missing=True):
         """
         Simply returns true if the object has downloaded and stored the
         attachment AND the attachment has not expired.
@@ -282,7 +282,7 @@ class AttachBase(URLBase):
                 # The file is not present
                 pass
 
-        return self.download()
+        return False if not retrieve_if_missing else self.download()
 
     def invalidate(self):
         """

--- a/apprise/attachment/AttachHTTP.py
+++ b/apprise/attachment/AttachHTTP.py
@@ -186,8 +186,9 @@ class AttachHTTP(AttachBase):
                         self.detected_name = result.group('name').strip()
 
                     # Create a temporary file to work with; delete must be set
-                    # to False or it isn't compatible with Microsoft Windows instances.
-                    # in lieu of this, __del__ will clean up the file for us.
+                    # to False or it isn't compatible with Microsoft Windows
+                    # instances. In lieu of this, __del__ will clean up the
+                    # file for us.
                     self._temp_file = NamedTemporaryFile(delete=False)
 
                     # Get our chunk size


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** [BirdNET-Pi/1171](https://github.com/mcguirepr89/BirdNET-Pi/issues/1171)

Issue was detected in another system.  Situation is a racing condition where multiple services want to share the same retrieved attachment.   The problem is the asynchronous process starts all fetching at the same time.  The ideal approach is to fetch the image once, and the remaining services share from the single fetch.

This PR Resolves this issue.


## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@/improved-attachment-support

# Test out the changes by just sending a web based attachment to 2 or more endpoints:
apprise -t "Test Title" -b "Test Message" \
  discord://credentials \
  pover://credentials \
 --attach=http://website/remote/image.jpg
  

```

