### PR TITLE
Improved variable parsing in YAML files

### DIFF
--- a/apprise/config/ConfigBase.py
+++ b/apprise/config/ConfigBase.py
@@ -1184,6 +1184,9 @@ class ConfigBase(URLBase):
                 # Prepare our Asset Object
                 _results['asset'] = asset
 
+                # Handle post processing of result set
+                _results = URLBase.post_process_parse_url_results(_results)
+
                 # Store our preloaded entries
                 preloaded.append({
                     'results': _results,

--- a/apprise/decorators/CustomNotifyPlugin.py
+++ b/apprise/decorators/CustomNotifyPlugin.py
@@ -147,6 +147,10 @@ class CustomNotifyPlugin(NotifyBase):
 
                 self._default_args = {}
 
+                # Some variables do not need to be set
+                if 'secure' in kwargs:
+                    del kwargs['secure']
+
                 # Apply our updates based on what was parsed
                 dict_full_update(self._default_args, self._base_args)
                 dict_full_update(self._default_args, kwargs)

--- a/test/test_decorator_notify.py
+++ b/test/test_decorator_notify.py
@@ -29,6 +29,7 @@
 from os.path import dirname
 from os.path import join
 from apprise.decorators import notify
+from apprise.decorators.CustomNotifyPlugin import CustomNotifyPlugin
 from apprise import Apprise
 from apprise import AppriseConfig
 from apprise import AppriseAsset
@@ -351,7 +352,7 @@ def test_notify_multi_instance_decoration(tmpdir):
     t = tmpdir.mkdir("multi-test").join("apprise.yml")
     t.write("""urls:
     - multi://user1:pass@hostname
-    - multi://user2:pass2@hostname
+    - multi://user2:pass2@hostname?verify=no
     """)
 
     # Create ourselves a config object
@@ -404,11 +405,12 @@ def test_notify_multi_instance_decoration(tmpdir):
     assert 'tag' in meta
     assert isinstance(meta['tag'], set)
 
-    assert len(meta) == 7
+    assert len(meta) == 8
     # We carry all of our default arguments from the @notify's initialization
     assert meta['schema'] == 'multi'
     assert meta['host'] == 'hostname'
     assert meta['user'] == 'user1'
+    assert meta['verify'] is True
     assert meta['password'] == 'pass'
 
     # Verify our URL is correct
@@ -441,15 +443,24 @@ def test_notify_multi_instance_decoration(tmpdir):
     assert 'tag' in meta
     assert isinstance(meta['tag'], set)
 
-    assert len(meta) == 7
+    assert len(meta) == 9
     # We carry all of our default arguments from the @notify's initialization
     assert meta['schema'] == 'multi'
     assert meta['host'] == 'hostname'
     assert meta['user'] == 'user2'
     assert meta['password'] == 'pass2'
+    assert meta['verify'] is False
+    assert meta['qsd']['verify'] == 'no'
 
     # Verify our URL is correct
-    assert meta['url'] == 'multi://user2:pass2@hostname'
+    assert meta['url'] == 'multi://user2:pass2@hostname?verify=no'
 
     # Tidy
     N_MGR.remove('multi')
+
+
+def test_custom_notify_plugin_decoration():
+    """decorators: CustomNotifyPlugin testing
+    """
+
+    CustomNotifyPlugin()


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1087

Better parsing of YAML files that contain globals parsed by Apprise itself (such as `user`, `pass`, `verify`, etc)

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1087-notify-email-variables

# Prepare a config file:
cat _EOF > test.yaml
 urls:
      - mailtos://alt.lan/:
         - user: testuser@alt.lan
           pass: xxxxXXXxxx
           smtp: smtp.alt.lan
           to: alteriks@alt.lan
_EOF

# Test out the changes with the following command:
apprise -vvvv  -t "Test Title" -b "Test Message" -c test.yaml

# Verify the debug logs correctly parse the pass variable 
```

