### PR TITLE
Improved markdown to html conversions

### DIFF
--- a/apprise/conversion.py
+++ b/apprise/conversion.py
@@ -58,8 +58,7 @@ def markdown_to_html(content):
     """
     Converts specified content from markdown to HTML.
     """
-
-    return markdown(content)
+    return markdown(content, extensions=['nl2br', 'tables'])
 
 
 def text_to_html(content):


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1084

Better `MARKDOWN` to `HTML` Conversion

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1084-email-markdown-formatting

cat << _EOF > test_markdown
## Some Heading

With Data:

- Foo
- Bar

## Table Support Added Too

First Header  | Second Header
------------- | -------------
Content Cell  | Content Cell
Content Cell  | Content Cell
_EOF

# Test out the changes with the following command:
apprise -vvv -t "Test Title" -b "$(<test_markdown)" \
    -i markdown \
    "mailtos://credentials"
```

