### PR TITLE
Added Free-Mobile Support

### DIFF
--- a/KEYWORDS
+++ b/KEYWORDS
@@ -21,6 +21,7 @@ Faast
 FCM
 Flock
 Form
+Free Mobile
 Gnome
 Google Chat
 Gotify

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ The table below identifies the services this tool supports and some example serv
 | [DAPNET](https://github.com/caronc/apprise/wiki/Notify_dapnet) | dapnet://  | (TCP) 80   | dapnet://user:pass@callsign<br/>dapnet://user:pass@callsign1/callsign2/callsignN
 | [D7 Networks](https://github.com/caronc/apprise/wiki/Notify_d7networks) | d7sms://  | (TCP) 443   | d7sms://token@PhoneNo<br/>d7sms://token@ToPhoneNo1/ToPhoneNo2/ToPhoneNoN
 | [DingTalk](https://github.com/caronc/apprise/wiki/Notify_dingtalk)  | dingtalk://   | (TCP) 443   | dingtalk://token/<br />dingtalk://token/ToPhoneNo<br />dingtalk://token/ToPhoneNo1/ToPhoneNo2/ToPhoneNo1/
+| [Free-Mobile](https://github.com/caronc/apprise/wiki/Notify_freemobile)  | freemobile://   | (TCP) 443   | freemobile://user@password/
  [httpSMS](https://github.com/caronc/apprise/wiki/Notify_httpsms) | httpsms://  | (TCP) 443   | httpsms://ApiKey@FromPhoneNo<br/>httpsms://ApiKey@FromPhoneNo/ToPhoneNo<br/>httpsms://ApiKey@FromPhoneNo/ToPhoneNo1/ToPhoneNo2/ToPhoneNoN/
 | [Kavenegar](https://github.com/caronc/apprise/wiki/Notify_kavenegar) | kavenegar://  | (TCP) 443   | kavenegar://ApiKey/ToPhoneNo<br/>kavenegar://FromPhoneNo@ApiKey/ToPhoneNo<br/>kavenegar://ApiKey/ToPhoneNo1/ToPhoneNo2/ToPhoneNoN
 | [MessageBird](https://github.com/caronc/apprise/wiki/Notify_messagebird) | msgbird://  | (TCP) 443   | msgbird://ApiKey/FromPhoneNo<br/>msgbird://ApiKey/FromPhoneNo/ToPhoneNo<br/>msgbird://ApiKey/FromPhoneNo/ToPhoneNo1/ToPhoneNo2/ToPhoneNoN/

--- a/apprise/plugins/NotifyFreeMobile.py
+++ b/apprise/plugins/NotifyFreeMobile.py
@@ -1,0 +1,207 @@
+# -*- coding: utf-8 -*-
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2024, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Free Mobile
+#   1. Visit https://mobile.free.fr/
+
+# the URL will look something like this:
+#      https://smsapi.free-mobile.fr/sendmsg?msg=content
+#
+
+import requests
+from json import dumps
+
+from .NotifyBase import NotifyBase
+from ..common import NotifyType
+from ..AppriseLocale import gettext_lazy as _
+
+
+class NotifyFreeMobile(NotifyBase):
+    """
+    A wrapper for Free-Mobile Notifications
+    """
+
+    # The default descriptive name associated with the Notification
+    service_name = _('Free-Mobile')
+
+    # The services URL
+    service_url = 'https://mobile.free.fr/'
+
+    # The default secure protocol
+    secure_protocol = 'freemobile'
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = 'https://github.com/caronc/apprise/wiki/Notify_freemobile'
+
+    # Plain Text Notification URL
+    notify_url = 'https://smsapi.free-mobile.fr/sendmsg'
+
+    # Define object templates
+    templates = (
+        '{schema}://{user}@{password}',
+    )
+
+    # The title is not used
+    title_maxlen = 0
+
+    # SMS Messages are restricted in size
+    body_maxlen = 160
+
+    # Define our tokens; these are the minimum tokens required required to
+    # be passed into this function (as arguments). The syntax appends any
+    # previously defined in the base package and builds onto them
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'user': {
+            'name': _('Username'),
+            'type': 'string',
+        },
+        'password': {
+            'name': _('Password'),
+            'type': 'string',
+            'private': True,
+        },
+    })
+
+    def __init__(self, **kwargs):
+        """
+        Initialize Free Mobile Object
+        """
+        super().__init__(**kwargs)
+
+        if not (self.user and self.password):
+            msg = 'A FreeMobile user and password ' \
+                  'combination was not provided.'
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        return
+
+    def url(self, privacy=False, *args, **kwargs):
+        """
+        Returns the URL built dynamically based on specified arguments.
+        """
+
+        # Prepare our parameters
+        params = self.url_parameters(privacy=privacy, *args, **kwargs)
+
+        return '{schema}://{user}@{password}/?{params}'.format(
+            schema=self.secure_protocol,
+            user=self.user,
+            password=self.pprint(self.password, privacy, safe=''),
+            params=NotifyFreeMobile.urlencode(params),
+        )
+
+    def send(self, body, title='', notify_type=NotifyType.INFO, **kwargs):
+        """
+        Send our notification
+        """
+
+        # prepare our headers
+        headers = {
+            'User-Agent': self.app_id,
+        }
+
+        # Prepare our payload
+        payload = {
+            'user': self.user,
+            'pass': self.password,
+        }
+
+        # Our Message
+        params = {
+            'msg': body
+        }
+
+        self.logger.debug('Free Mobile GET URL: %s (cert_verify=%r)' % (
+            self.notify_url, self.verify_certificate))
+        self.logger.debug('Free Mobile Payload: %s' % str(payload))
+
+        # Always call throttle before any remote server i/o is made
+        self.throttle()
+
+        try:
+            r = requests.post(
+                self.notify_url,
+                data=dumps(payload).encode('utf-8'),
+                params=params,
+                headers=headers,
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+            )
+            if r.status_code != requests.codes.ok:
+                # We had a problem
+                status_str = \
+                    NotifyFreeMobile.http_response_code_lookup(r.status_code)
+
+                self.logger.warning(
+                    'Failed to send Free Mobile notification: '
+                    '{}{}error={}.'.format(
+                        status_str,
+                        ', ' if status_str else '',
+                        r.status_code))
+
+                self.logger.debug('Response Details:\r\n{}'.format(r.content))
+
+                # Return; we're done
+                return False
+
+            else:
+                self.logger.info('Sent Free Mobile notification.')
+
+        except requests.RequestException as e:
+            self.logger.warning(
+                'A Connection error occurred sending Free Mobile '
+                'notification.')
+            self.logger.debug('Socket Exception: %s' % str(e))
+
+            # Return; we're done
+            return False
+
+        return True
+
+    @staticmethod
+    def parse_url(url):
+        """
+        Parses the URL and returns enough arguments that can allow
+        us to re-instantiate this object.
+
+        """
+
+        # parse_url already handles getting the `user` and `password` fields
+        # populated.
+        results = NotifyBase.parse_url(url, verify_host=False)
+        if not results:
+            # We're done early as we couldn't load the results
+            return results
+
+        # The hostname can act as the password if specified and a password
+        # was otherwise not (specified):
+        if not results.get('password'):
+            results['password'] = NotifyFreeMobile.unquote(results['host'])
+
+        return results

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -41,17 +41,17 @@ it easy to access:
 
 Apprise API, APRS, AWS SES, AWS SNS, Bark, Boxcar, Burst SMS, BulkSMS, BulkVS,
 ClickSend, DAPNET, DingTalk, Discord, E-Mail, Emby, Faast, FCM, Flock,
-Google Chat, Gotify, Growl, Guilded, Home Assistant, httpSMS, IFTTT, Join,
-Kavenegar, KODI, Kumulos, LaMetric, Line, LunaSea, MacOSX, Mailgun, Mastodon,
-Mattermost,Matrix, MessageBird, Microsoft Windows, Microsoft Teams, Misskey,
-MQTT, MSG91, MyAndroid, Nexmo, Nextcloud, NextcloudTalk, Notica, Notifiarr,
-Notifico, ntfy, Office365, OneSignal, Opsgenie, PagerDuty, PagerTree,
-ParsePlatform, PopcornNotify, Prowl, Pushalot, PushBullet, Pushjet, PushMe,
-Pushover, PushSafer, Pushy, PushDeer, Revolt, Reddit, Rocket.Chat, RSyslog,
-SendGrid, ServerChan, Signal, SimplePush, Sinch, Slack, SMSEagle, SMS Manager,
-SMTP2Go, SparkPost, Super Toasty, Streamlabs, Stride, Synology Chat, Syslog,
-Techulus Push, Telegram, Threema Gateway, Twilio, Twitter, Twist, XBMC,
-Voipms, Vonage, WeCom Bot, WhatsApp, Webex Teams}
+Free Mobile, Google Chat, Gotify, Growl, Guilded, Home Assistant, httpSMS,
+IFTTT, Join, Kavenegar, KODI, Kumulos, LaMetric, Line, LunaSea, MacOSX,
+Mailgun, Mastodon, Mattermost,Matrix, MessageBird, Microsoft Windows,
+Microsoft Teams, Misskey, MQTT, MSG91, MyAndroid, Nexmo, Nextcloud,
+NextcloudTalk, Notica, Notifiarr, Notifico, ntfy, Office365, OneSignal,
+Opsgenie, PagerDuty, PagerTree, ParsePlatform, PopcornNotify, Prowl, Pushalot,
+PushBullet, Pushjet, PushMe, Pushover, PushSafer, Pushy, PushDeer, Revolt,
+Reddit, Rocket.Chat, RSyslog, SendGrid, ServerChan, Signal, SimplePush, Sinch,
+Slack, SMSEagle, SMS Manager, SMTP2Go, SparkPost, Super Toasty, Streamlabs,
+Stride, Synology Chat, Syslog, Techulus Push, Telegram, Threema Gateway, Twilio,
+Twitter, Twist, XBMC, Voipms, Vonage, WeCom Bot, WhatsApp, Webex Teams}
 
 Name:           python-%{pypi_name}
 Version:        1.7.4

--- a/test/test_plugin_freemobile.py
+++ b/test/test_plugin_freemobile.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2024, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import requests
+
+from apprise.plugins.NotifyFreeMobile import NotifyFreeMobile
+from helpers import AppriseURLTester
+
+# Disable logging for a cleaner testing output
+import logging
+logging.disable(logging.CRITICAL)
+
+# Our Testing URLs
+apprise_url_tests = (
+    ('freemobile://', {
+        'instance': TypeError,
+    }),
+    ('freemobile://:@/', {
+        'instance': TypeError,
+    }),
+    ('freemobile://user@password', {
+        # Minimum requirements met
+        'instance': NotifyFreeMobile,
+    }),
+    ('freemobile://?user=user&pass=password', {
+        # Test ?user= and pass=
+        'instance': NotifyFreeMobile,
+    }),
+    ('freemobile://user@password', {
+        'instance': NotifyFreeMobile,
+        # force a failure
+        'response': False,
+        'requests_response_code': requests.codes.internal_server_error,
+    }),
+    ('freemobile://user@password', {
+        'instance': NotifyFreeMobile,
+        # throw a bizzare code forcing us to fail to look it up
+        'response': False,
+        'requests_response_code': 999,
+    }),
+    ('freemobile://user@password', {
+        'instance': NotifyFreeMobile,
+        # Throws a series of connection and transfer exceptions when this flag
+        # is set and tests that we gracfully handle them
+        'test_requests_exceptions': True,
+    }),
+)
+
+
+def test_plugin_freemobile_urls():
+    """
+    NotifyFreeMobile() Apprise URLs
+
+    """
+
+    # Run our general tests
+    AppriseURLTester(tests=apprise_url_tests).run_all()


### PR DESCRIPTION
## Description
Free Mobile Apprise Support Added
* **Source**: https://mobile.free.fr/
* **Icon Support**: No
* **Message Format**: Text
* **Message Limit**: 160 Characters per message

### Account Setup
Sign up with Free Mobile ([link](https://mobile.free.fr/)) and use your credentials (user and pass) to send a notification.

### Syntax
Valid syntax is as follows:
* `freemobile://{user}@{password}`

## New Service Completion Status
<!-- This section is only applicable if you're adding a new service -->
* [x] apprise/plugins/NotifyFreeMobile.py
* [x] KEYWORDS
    - add new service into this file (alphabetically).
* [x] README.md
    - add entry for new service to table (as a quick reference)
* [x] packaging/redhat/python-apprise.spec
    - add new service into the `%global common_description`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@free-mobile-support

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  freemobile://user@pass

```

