### PR TITLE
freemobile:// msg moved from GET parameters and into payload

### DIFF
--- a/apprise/plugins/NotifyFreeMobile.py
+++ b/apprise/plugins/NotifyFreeMobile.py
@@ -30,7 +30,7 @@
 #   1. Visit https://mobile.free.fr/
 
 # the URL will look something like this:
-#      https://smsapi.free-mobile.fr/sendmsg?msg=content
+#      https://smsapi.free-mobile.fr/sendmsg
 #
 
 import requests
@@ -132,10 +132,6 @@ class NotifyFreeMobile(NotifyBase):
         payload = {
             'user': self.user,
             'pass': self.password,
-        }
-
-        # Our Message
-        params = {
             'msg': body
         }
 
@@ -150,7 +146,6 @@ class NotifyFreeMobile(NotifyBase):
             r = requests.post(
                 self.notify_url,
                 data=dumps(payload).encode('utf-8'),
-                params=params,
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1090

Bugfix to move `msg` into payload (and out of kwarg GET parameters)

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1090-mobile-free-bugfix

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  freemobile://user@password

```

