### PR TITLE
Fixed deprication warnings for Markdown extensions

### DIFF
--- a/apprise/conversion.py
+++ b/apprise/conversion.py
@@ -58,7 +58,8 @@ def markdown_to_html(content):
     """
     Converts specified content from markdown to HTML.
     """
-    return markdown(content, extensions=['nl2br', 'tables'])
+    return markdown(content, extensions=[
+        'markdown.extensions.nl2br', 'markdown.extensions.tables'])
 
 
 def text_to_html(content):


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** n/a

Remove deprecation warnings surrounding Markdown extensions.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

