### PR TITLE
Added JSON Content-Type header to freemobile://

### DIFF
--- a/apprise/plugins/NotifyFreeMobile.py
+++ b/apprise/plugins/NotifyFreeMobile.py
@@ -126,6 +126,7 @@ class NotifyFreeMobile(NotifyBase):
         # prepare our headers
         headers = {
             'User-Agent': self.app_id,
+            'Content-Type': 'application/json',
         }
 
         # Prepare our payload


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1090

Added `Content-Type` of  `application/json` to service submission.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1090-free-mobile-update-2

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  freemobile://credentials

```

