### PR TITLE
Fix mailto://ip.addr support

### DIFF
--- a/apprise/plugins/NotifyEmail.py
+++ b/apprise/plugins/NotifyEmail.py
@@ -45,7 +45,7 @@ from .NotifyBase import NotifyBase
 from ..URLBase import PrivacyMode
 from ..common import NotifyFormat, NotifyType
 from ..conversion import convert_between
-from ..utils import is_email, parse_emails, is_hostname
+from ..utils import is_ipaddr, is_email, parse_emails, is_hostname
 from ..AppriseLocale import gettext_lazy as _
 from ..logger import logger
 
@@ -1053,8 +1053,12 @@ class NotifyEmail(NotifyBase):
         # Prepare our target lists
         results['targets'] = []
 
-        if not is_hostname(results['host'], ipv4=False, ipv6=False,
-                           underscore=False):
+        if is_ipaddr(results['host']):
+            # Silently move on and do not disrupt any configuration
+            pass
+
+        elif not is_hostname(results['host'], ipv4=False, ipv6=False,
+                             underscore=False):
 
             if is_email(NotifyEmail.unquote(results['host'])):
                 # Don't lose defined email addresses


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1113

This was broken in #1095 where the mailto:// syntax got a bit smarter and made mailto:// syntax shorter for most cases.  However it broke the `mailto://ip.address` references ( :eyes: )

This PR resolves this issue.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1113-mailto-ipaddr-fix

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "mailto://1.2.3.4"

```

