### PR TITLE
Update apprise_api token length 

### DIFF
--- a/apprise/plugins/apprise_api.py
+++ b/apprise/plugins/apprise_api.py
@@ -123,7 +123,7 @@ class NotifyAppriseAPI(NotifyBase):
             'type': 'string',
             'required': True,
             'private': True,
-            'regex': (r'^[A-Z0-9_-]{1,32}$', 'i'),
+            'regex': (r'^[A-Z0-9_-]{1,128}$', 'i'),
         },
     })
 

--- a/test/test_plugin_apprise_api.py
+++ b/test/test_plugin_apprise_api.py
@@ -70,6 +70,12 @@ apprise_url_tests = (
         # Our expected url(privacy=True) startswith() response:
         'privacy_url': 'apprise://localhost/a...a/',
     }),
+    # A valid URL with long Token
+    ('apprise://localhost/%s' % ('a' * 128), {
+        'instance': NotifyAppriseAPI,
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'apprise://localhost/a...a/',
+    }),
     # A valid URL with Token (using port)
     ('apprise://localhost:8080/%s' % ('b' * 32), {
         'instance': NotifyAppriseAPI,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** caronc/apprise-api#187

<!-- Have anything else to describe? Define it here -->
It looks like the [apprise-api README](https://github.com/caronc/apprise-api?tab=readme-ov-file#api-notes) suggests a key length of up to 128 chars, so updating the apprise_api plugin token check seemed appropriate. 

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/isometimescode/apprise.git@apprise-api-token-length

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  apprise://example.com/asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdf

```

