### PR TITLE
clicksend:// authentication bugfix

### DIFF
--- a/apprise/plugins/clicksend.py
+++ b/apprise/plugins/clicksend.py
@@ -88,7 +88,7 @@ class NotifyClickSend(NotifyBase):
 
     # Define object templates
     templates = (
-        '{schema}://{user}:{password}@{targets}',
+        '{schema}://{user}:{apikey}@{targets}',
     )
 
     # Define our template tokens
@@ -98,11 +98,12 @@ class NotifyClickSend(NotifyBase):
             'type': 'string',
             'required': True,
         },
-        'password': {
-            'name': _('Password'),
+        'apikey': {
+            'name': _('API Key'),
             'type': 'string',
             'private': True,
             'required': True,
+            'map_to': 'password',
         },
         'target_phone': {
             'name': _('Target Phone No'),
@@ -122,6 +123,9 @@ class NotifyClickSend(NotifyBase):
     template_args = dict(NotifyBase.template_args, **{
         'to': {
             'alias_of': 'targets',
+        },
+        'key': {
+            'alias_of': 'apikey',
         },
         'batch': {
             'name': _('Batch Mode'),
@@ -318,6 +322,12 @@ class NotifyClickSend(NotifyBase):
         # Get Batch Mode Flag
         results['batch'] = \
             parse_bool(results['qsd'].get('batch', False))
+
+        # API Key
+        if 'key' in results['qsd'] and len(results['qsd']['key']):
+            # Extract the API Key from an argument
+            results['password'] = \
+                NotifyClickSend.unquote(results['qsd']['key'])
 
         # Support the 'to' variable so that we can support rooms this way too
         # The 'to' makes it easier to use yaml configuration

--- a/apprise/plugins/clicksend.py
+++ b/apprise/plugins/clicksend.py
@@ -41,7 +41,6 @@
 #
 import requests
 from json import dumps
-from base64 import b64encode
 
 from .base import NotifyBase
 from ..url import PrivacyMode
@@ -174,9 +173,6 @@ class NotifyClickSend(NotifyBase):
         headers = {
             'User-Agent': self.app_id,
             'Content-Type': 'application/json; charset=utf-8',
-            'Authorization': 'Basic {}'.format(
-                b64encode('{}:{}'.format(
-                    self.user, self.password).encode('utf-8'))),
         }
 
         # error tracking (used for function return)
@@ -208,6 +204,7 @@ class NotifyClickSend(NotifyBase):
                 r = requests.post(
                     self.notify_url,
                     data=dumps(payload),
+                    auth=(self.user, self.password),
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,

--- a/test/test_plugin_clicksend.py
+++ b/test/test_plugin_clicksend.py
@@ -62,6 +62,10 @@ apprise_url_tests = (
         # valid number - no batch
         'instance': NotifyClickSend,
     }),
+    ('clicksend://user@{}?batch=no&key=abc123'.format('3' * 14), {
+        # valid number - no batch
+        'instance': NotifyClickSend,
+    }),
     ('clicksend://user:pass@{}'.format('3' * 14), {
         'instance': NotifyClickSend,
         # throw a bizzare code forcing us to fail to look it up


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1103

Previous to this merge request, `clicksend://user:apikey` did not work correctly

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1103-clicksend-authfix

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "clicksend://user:apikey@..."

```

