### PR TITLE
Slack files upload deprecation

### DIFF
--- a/apprise/plugins/slack.py
+++ b/apprise/plugins/slack.py
@@ -923,8 +923,8 @@ class NotifySlack(NotifyBase):
                     # Responses for file uploads look like this
                     # 'OK - <file length>'
                     (
-                        r.content and 
-                        isinstance(r.content, bytes) and 
+                        r.content and
+                        isinstance(r.content, bytes) and
                         b'OK' in r.content
                     )
                 )

--- a/apprise/plugins/slack.py
+++ b/apprise/plugins/slack.py
@@ -930,7 +930,11 @@ class NotifySlack(NotifyBase):
                     (response and response.get('ok', False)) or
                     # Responses for file uploads look like this
                     # 'OK - <file length>'
-                    (r.content and isinstance(r.content, bytes) and b'OK' in r.content)
+                    (
+                        r.content and 
+                        isinstance(r.content, bytes) and 
+                        b'OK' in r.content
+                    )
                 )
             elif r.content == b'ok':
                 # The text 'ok' is returned if this is a Webhook request

--- a/apprise/plugins/slack.py
+++ b/apprise/plugins/slack.py
@@ -619,10 +619,8 @@ class NotifySlack(NotifyBase):
                     ' to {}'.format(channel)
                     if channel is not None else ''))
 
-        if (
-            attach and self.attachment_support and
-            self.mode is SlackMode.BOT and attach_channel_list
-        ):
+        if attach and self.attachment_support and \
+                self.mode is SlackMode.BOT and attach_channel_list:
             # Send our attachments (can only be done in bot mode)
             for attachment in attach:
 
@@ -848,15 +846,8 @@ class NotifySlack(NotifyBase):
 
         return user_id
 
-    def _send(
-            self,
-            url,
-            payload,
-            attach=None,
-            http_method='post',
-            params=None,
-            **kwargs
-    ):
+    def _send(self, url, payload, attach=None, http_method='post', params=None,
+              **kwargs):
         """
         Wrapper to the requests (post) object
         """
@@ -940,9 +931,9 @@ class NotifySlack(NotifyBase):
                         r.status_code, SLACK_HTTP_ERROR_MAP)
 
                 self.logger.warning(
-                    'Failed to send {} to Slack: '
+                    'Failed to send{} to Slack: '
                     '{}{}error={}.'.format(
-                        attach.name if attach else '',
+                        (' ' + attach.name) if attach else '',
                         status_str,
                         ', ' if status_str else '',
                         r.status_code))

--- a/apprise/plugins/slack.py
+++ b/apprise/plugins/slack.py
@@ -609,8 +609,8 @@ class NotifySlack(NotifyBase):
                 has_error = True
                 continue
 
-            # Store the valid and massaged payload that is recognizable by
-            # slack. This list is used for sending attachments later.
+            # Store the valid channel or chat ID (for DMs) that will
+            # be accepted by Slack's attachment method later.
             if response.get('channel'):
                 attach_channel_list.append(response.get('channel'))
 
@@ -618,10 +618,6 @@ class NotifySlack(NotifyBase):
                 'Sent Slack notification{}.'.format(
                     ' to {}'.format(channel)
                     if channel is not None else ''))
-            self.logger.info(
-                'Channel return {}.'
-                .format(response.get('channel'))
-            )
 
         if (
             attach and self.attachment_support and

--- a/apprise/plugins/slack.py
+++ b/apprise/plugins/slack.py
@@ -661,10 +661,6 @@ class NotifySlack(NotifyBase):
 
                 # Upload file
                 response = self._send(upload_url, {}, attach=attachment)
-                if not response:
-                    self.logger.error('Failed to upload file.')
-                    # We failed to upload the file, take an early exit
-                    return False
 
                 # Send file to channels
                 # https://api.slack.com/methods/files.completeUploadExternal
@@ -1009,7 +1005,7 @@ class NotifySlack(NotifyBase):
                 files['file'][1].close()
 
         # Return the response for processing
-        return response or r.content
+        return response
 
     def url(self, privacy=False, *args, **kwargs):
         """

--- a/test/helpers/rest.py
+++ b/test/helpers/rest.py
@@ -115,7 +115,8 @@ class AppriseURLTester:
 
     @mock.patch('requests.get')
     @mock.patch('requests.post')
-    def run(self, url, meta, mock_post, mock_get):
+    @mock.patch('requests.request')
+    def run(self, url, meta, mock_request, mock_post, mock_get):
         """
         Run a specific test
         """
@@ -150,6 +151,7 @@ class AppriseURLTester:
         robj.content = u''
         mock_get.return_value = robj
         mock_post.return_value = robj
+        mock_request.return_value = robj
 
         try:
             # We can now instantiate our object:
@@ -276,7 +278,8 @@ class AppriseURLTester:
     @mock.patch('requests.put')
     @mock.patch('requests.delete')
     @mock.patch('requests.patch')
-    def __notify(self, url, obj, meta, asset, mock_patch, mock_del, mock_put,
+    @mock.patch('requests.request')
+    def __notify(self, url, obj, meta, asset, mock_request, mock_patch, mock_del, mock_put,
                  mock_head, mock_post, mock_get):
         """
         Perform notification testing against object specified
@@ -342,6 +345,7 @@ class AppriseURLTester:
         mock_patch.return_value = robj
         mock_del.return_value = robj
         mock_put.return_value = robj
+        mock_request.return_value = robj
 
         if test_requests_exceptions is False:
             # Handle our default response
@@ -351,6 +355,7 @@ class AppriseURLTester:
             mock_post.return_value.status_code = requests_response_code
             mock_get.return_value.status_code = requests_response_code
             mock_patch.return_value.status_code = requests_response_code
+            mock_request.return_value.status_code = requests_response_code
 
             # Handle our default text response
             mock_get.return_value.content = requests_response_content
@@ -359,6 +364,7 @@ class AppriseURLTester:
             mock_put.return_value.content = requests_response_content
             mock_head.return_value.content = requests_response_content
             mock_patch.return_value.content = requests_response_content
+            mock_request.return_value.content = requests_response_content
 
             mock_get.return_value.text = requests_response_text
             mock_post.return_value.text = requests_response_text
@@ -366,6 +372,7 @@ class AppriseURLTester:
             mock_del.return_value.text = requests_response_text
             mock_head.return_value.text = requests_response_text
             mock_patch.return_value.text = requests_response_text
+            mock_request.return_value.text = requests_response_text
 
             # Ensure there is no side effect set
             mock_post.side_effect = None
@@ -374,6 +381,7 @@ class AppriseURLTester:
             mock_head.side_effect = None
             mock_get.side_effect = None
             mock_patch.side_effect = None
+            mock_request.side_effect = None
 
         else:
             # Handle exception testing; first we turn the boolean flag
@@ -532,6 +540,7 @@ class AppriseURLTester:
                     mock_put.side_effect = _exception
                     mock_get.side_effect = _exception
                     mock_patch.side_effect = _exception
+                    mock_request.side_effect = _exception
 
                     try:
                         assert obj.notify(
@@ -577,6 +586,7 @@ class AppriseURLTester:
                     mock_head.side_effect = _exception
                     mock_get.side_effect = _exception
                     mock_patch.side_effect = _exception
+                    mock_request.side_effect = _exception
 
                     try:
                         assert obj.notify(

--- a/test/helpers/rest.py
+++ b/test/helpers/rest.py
@@ -279,8 +279,20 @@ class AppriseURLTester:
     @mock.patch('requests.delete')
     @mock.patch('requests.patch')
     @mock.patch('requests.request')
-    def __notify(self, url, obj, meta, asset, mock_request, mock_patch, mock_del, mock_put,
-                 mock_head, mock_post, mock_get):
+    def __notify(
+        self,
+        url,
+        obj,
+        meta,
+        asset,
+        mock_request,
+        mock_patch,
+        mock_del,
+        mock_put,
+        mock_head,
+        mock_post,
+        mock_get
+    ):
         """
         Perform notification testing against object specified
         """

--- a/test/test_plugin_slack.py
+++ b/test/test_plugin_slack.py
@@ -451,18 +451,18 @@ def test_plugin_slack_oauth_access_token(mock_request):
     # Test Email Lookup
 
 
-@mock.patch('requests.post')
-def test_plugin_slack_webhook_mode(mock_post):
+@mock.patch('requests.request')
+def test_plugin_slack_webhook_mode(mock_request):
     """
     NotifySlack() Webhook Mode Tests
 
     """
 
     # Prepare Mock
-    mock_post.return_value = requests.Request()
-    mock_post.return_value.status_code = requests.codes.ok
-    mock_post.return_value.content = b'ok'
-    mock_post.return_value.text = 'ok'
+    mock_request.return_value = requests.Request()
+    mock_request.return_value.status_code = requests.codes.ok
+    mock_request.return_value.content = b'ok'
+    mock_request.return_value.text = 'ok'
 
     # Initialize some generic (but valid) tokens
     token_a = 'A' * 9
@@ -496,9 +496,9 @@ def test_plugin_slack_webhook_mode(mock_post):
         body='body', title='title', notify_type=NotifyType.INFO) is True
 
 
-@mock.patch('requests.post')
+@mock.patch('requests.request')
 @mock.patch('requests.get')
-def test_plugin_slack_send_by_email(mock_get, mock_post):
+def test_plugin_slack_send_by_email(mock_get, mock_request):
     """
     NotifySlack() Send by Email Tests
 
@@ -518,7 +518,7 @@ def test_plugin_slack_send_by_email(mock_get, mock_post):
     request.status_code = requests.codes.ok
 
     # Prepare Mock
-    mock_post.return_value = request
+    mock_request.return_value = request
     mock_get.return_value = request
 
     # Variation Initializations
@@ -527,7 +527,7 @@ def test_plugin_slack_send_by_email(mock_get, mock_post):
     assert isinstance(obj.url(), str) is True
 
     # No calls made yet
-    assert mock_post.call_count == 0
+    assert mock_request.call_count == 0
     assert mock_get.call_count == 0
 
     # Send our notification
@@ -537,18 +537,18 @@ def test_plugin_slack_send_by_email(mock_get, mock_post):
     # 2 calls were made, one to perform an email lookup, the second
     # was the notification itself
     assert mock_get.call_count == 1
-    assert mock_post.call_count == 1
+    assert mock_request.call_count == 1
     assert mock_get.call_args_list[0][0][0] == \
         'https://slack.com/api/users.lookupByEmail'
-    assert mock_post.call_args_list[0][0][0] == \
+    assert mock_request.call_args_list[0][0][1] == \
         'https://slack.com/api/chat.postMessage'
 
     # Reset our mock object
-    mock_post.reset_mock()
+    mock_request.reset_mock()
     mock_get.reset_mock()
 
     # Prepare Mock
-    mock_post.return_value = request
+    mock_request.return_value = request
     mock_get.return_value = request
 
     # Send our notification again (cached copy of user id associated with
@@ -557,8 +557,8 @@ def test_plugin_slack_send_by_email(mock_get, mock_post):
         body='body', title='title', notify_type=NotifyType.INFO) is True
 
     assert mock_get.call_count == 0
-    assert mock_post.call_count == 1
-    assert mock_post.call_args_list[0][0][0] == \
+    assert mock_request.call_count == 1
+    assert mock_request.call_args_list[0][0][1] == \
         'https://slack.com/api/chat.postMessage'
 
     #
@@ -570,11 +570,11 @@ def test_plugin_slack_send_by_email(mock_get, mock_post):
     })
 
     # Reset our mock object
-    mock_post.reset_mock()
+    mock_request.reset_mock()
     mock_get.reset_mock()
 
     # Prepare Mock
-    mock_post.return_value = request
+    mock_request.return_value = request
     mock_get.return_value = request
 
     # Variation Initializations
@@ -583,7 +583,7 @@ def test_plugin_slack_send_by_email(mock_get, mock_post):
     assert isinstance(obj.url(), str) is True
 
     # No calls made yet
-    assert mock_post.call_count == 0
+    assert mock_request.call_count == 0
     assert mock_get.call_count == 0
 
     # Send our notification; it will fail because we failed to look up
@@ -594,7 +594,7 @@ def test_plugin_slack_send_by_email(mock_get, mock_post):
     # We would have failed to look up the email, therefore we wouldn't have
     # even bothered to attempt to send the notification
     assert mock_get.call_count == 1
-    assert mock_post.call_count == 0
+    assert mock_request.call_count == 0
     assert mock_get.call_args_list[0][0][0] == \
         'https://slack.com/api/users.lookupByEmail'
 
@@ -604,11 +604,11 @@ def test_plugin_slack_send_by_email(mock_get, mock_post):
     request.content = '}'
 
     # Reset our mock object
-    mock_post.reset_mock()
+    mock_request.reset_mock()
     mock_get.reset_mock()
 
     # Prepare Mock
-    mock_post.return_value = request
+    mock_request.return_value = request
     mock_get.return_value = request
 
     # Variation Initializations
@@ -617,7 +617,7 @@ def test_plugin_slack_send_by_email(mock_get, mock_post):
     assert isinstance(obj.url(), str) is True
 
     # No calls made yet
-    assert mock_post.call_count == 0
+    assert mock_request.call_count == 0
     assert mock_get.call_count == 0
 
     # Send our notification; it will fail because we failed to look up
@@ -628,7 +628,7 @@ def test_plugin_slack_send_by_email(mock_get, mock_post):
     # We would have failed to look up the email, therefore we wouldn't have
     # even bothered to attempt to send the notification
     assert mock_get.call_count == 1
-    assert mock_post.call_count == 0
+    assert mock_request.call_count == 0
     assert mock_get.call_args_list[0][0][0] == \
         'https://slack.com/api/users.lookupByEmail'
 
@@ -638,11 +638,11 @@ def test_plugin_slack_send_by_email(mock_get, mock_post):
     request.content = '}'
 
     # Reset our mock object
-    mock_post.reset_mock()
+    mock_request.reset_mock()
     mock_get.reset_mock()
 
     # Prepare Mock
-    mock_post.return_value = request
+    mock_request.return_value = request
     mock_get.return_value = request
 
     # Variation Initializations
@@ -651,7 +651,7 @@ def test_plugin_slack_send_by_email(mock_get, mock_post):
     assert isinstance(obj.url(), str) is True
 
     # No calls made yet
-    assert mock_post.call_count == 0
+    assert mock_request.call_count == 0
     assert mock_get.call_count == 0
 
     # Send our notification; it will fail because we failed to look up
@@ -662,7 +662,7 @@ def test_plugin_slack_send_by_email(mock_get, mock_post):
     # We would have failed to look up the email, therefore we wouldn't have
     # even bothered to attempt to send the notification
     assert mock_get.call_count == 1
-    assert mock_post.call_count == 0
+    assert mock_request.call_count == 0
     assert mock_get.call_args_list[0][0][0] == \
         'https://slack.com/api/users.lookupByEmail'
 
@@ -681,11 +681,11 @@ def test_plugin_slack_send_by_email(mock_get, mock_post):
     request.status_code = requests.codes.ok
 
     # Reset our mock object
-    mock_post.reset_mock()
+    mock_request.reset_mock()
     mock_get.reset_mock()
 
     # Prepare Mock
-    mock_post.return_value = request
+    mock_request.return_value = request
     mock_get.side_effect = requests.ConnectionError(
         0, 'requests.ConnectionError() not handled')
 
@@ -695,7 +695,7 @@ def test_plugin_slack_send_by_email(mock_get, mock_post):
     assert isinstance(obj.url(), str) is True
 
     # No calls made yet
-    assert mock_post.call_count == 0
+    assert mock_request.call_count == 0
     assert mock_get.call_count == 0
 
     # Send our notification; it will fail because we failed to look up
@@ -706,14 +706,14 @@ def test_plugin_slack_send_by_email(mock_get, mock_post):
     # We would have failed to look up the email, therefore we wouldn't have
     # even bothered to attempt to send the notification
     assert mock_get.call_count == 1
-    assert mock_post.call_count == 0
+    assert mock_request.call_count == 0
     assert mock_get.call_args_list[0][0][0] == \
         'https://slack.com/api/users.lookupByEmail'
 
 
-@mock.patch('requests.post')
+@mock.patch('requests.request')
 @mock.patch('requests.get')
-def test_plugin_slack_markdown(mock_get, mock_post):
+def test_plugin_slack_markdown(mock_get, mock_request):
     """
     NotifySlack() Markdown tests
 
@@ -724,7 +724,7 @@ def test_plugin_slack_markdown(mock_get, mock_post):
     request.status_code = requests.codes.ok
 
     # Prepare Mock
-    mock_post.return_value = request
+    mock_request.return_value = request
     mock_get.return_value = request
 
     # Variation Initializations
@@ -753,12 +753,12 @@ def test_plugin_slack_markdown(mock_get, mock_post):
     # We would have failed to look up the email, therefore we wouldn't have
     # even bothered to attempt to send the notification
     assert mock_get.call_count == 0
-    assert mock_post.call_count == 1
-    assert mock_post.call_args_list[0][0][0] == \
+    assert mock_request.call_count == 1
+    assert mock_request.call_args_list[0][0][1] == \
         'https://hooks.slack.com/services/T1JJ3T3L2/A1BRTD4JD/' \
         'TIiajkdnlazkcOXrIdevi7FQ'
 
-    data = loads(mock_post.call_args_list[0][1]['data'])
+    data = loads(mock_request.call_args_list[0][1]['data'])
     assert data['attachments'][0]['text'] == \
         "Here is a <https://slack.com|Slack Link> we want to support as part "\
         "of it's\nmarkdown.\n\nThis one has arguments we want to preserve:"\
@@ -768,8 +768,8 @@ def test_plugin_slack_markdown(mock_get, mock_post):
         "\n\nChannel Testing\n<!channelA>\n<!channelA|Description>"
 
 
-@mock.patch('requests.post')
-def test_plugin_slack_single_thread_reply(mock_post):
+@mock.patch('requests.request')
+def test_plugin_slack_single_thread_reply(mock_request):
     """
     NotifySlack() Send Notification as a Reply
 
@@ -789,7 +789,7 @@ def test_plugin_slack_single_thread_reply(mock_post):
     request.status_code = requests.codes.ok
 
     # Prepare Mock
-    mock_post.return_value = request
+    mock_request.return_value = request
 
     # Variation Initializations
     obj = NotifySlack(access_token=token, targets=[f'#general:{thread_id}'])
@@ -797,22 +797,22 @@ def test_plugin_slack_single_thread_reply(mock_post):
     assert isinstance(obj.url(), str) is True
 
     # No calls made yet
-    assert mock_post.call_count == 0
+    assert mock_request.call_count == 0
 
     # Send our notification
     assert obj.notify(
         body='body', title='title', notify_type=NotifyType.INFO) is True
 
     # Post was made
-    assert mock_post.call_count == 1
-    assert mock_post.call_args_list[0][0][0] == \
+    assert mock_request.call_count == 1
+    assert mock_request.call_args_list[0][0][1] == \
         'https://slack.com/api/chat.postMessage'
-    assert loads(mock_post.call_args_list[0][1]['data']).get("thread_ts") \
+    assert loads(mock_request.call_args_list[0][1]['data']).get("thread_ts") \
         == str(thread_id)
 
 
-@mock.patch('requests.post')
-def test_plugin_slack_multiple_thread_reply(mock_post):
+@mock.patch('requests.request')
+def test_plugin_slack_multiple_thread_reply(mock_request):
     """
     NotifySlack() Send Notification to multiple channels as Reply
 
@@ -832,7 +832,7 @@ def test_plugin_slack_multiple_thread_reply(mock_post):
     request.status_code = requests.codes.ok
 
     # Prepare Mock
-    mock_post.return_value = request
+    mock_request.return_value = request
 
     # Variation Initializations
     obj = NotifySlack(access_token=token,
@@ -843,17 +843,17 @@ def test_plugin_slack_multiple_thread_reply(mock_post):
     assert isinstance(obj.url(), str) is True
 
     # No calls made yet
-    assert mock_post.call_count == 0
+    assert mock_request.call_count == 0
 
     # Send our notification
     assert obj.notify(
         body='body', title='title', notify_type=NotifyType.INFO) is True
 
     # Post was made
-    assert mock_post.call_count == 2
-    assert mock_post.call_args_list[0][0][0] == \
+    assert mock_request.call_count == 2
+    assert mock_request.call_args_list[0][0][1] == \
         'https://slack.com/api/chat.postMessage'
-    assert loads(mock_post.call_args_list[0][1]['data']).get("thread_ts") \
+    assert loads(mock_request.call_args_list[0][1]['data']).get("thread_ts") \
         == str(thread_id_1)
-    assert loads(mock_post.call_args_list[1][1]['data']).get("thread_ts") \
+    assert loads(mock_request.call_args_list[1][1]['data']).get("thread_ts") \
         == str(thread_id_2)

--- a/test/test_plugin_slack.py
+++ b/test/test_plugin_slack.py
@@ -131,10 +131,6 @@ apprise_url_tests = (
         'requests_response_text': {
             'ok': True,
             'message': '',
-            # support attachments
-            'file': {
-                'url_private': 'http://localhost/',
-            },
         },
     }),
     # Test blocks mode
@@ -170,10 +166,6 @@ apprise_url_tests = (
         'requests_response_text': {
             'ok': True,
             'message': '',
-            # support attachments
-            'file': {
-                'url_private': 'http://localhost/',
-            },
         },
         # Our expected url(privacy=True) startswith() response:
         'privacy_url': 'slack://test@x...4/nuxref/',
@@ -184,10 +176,6 @@ apprise_url_tests = (
         'requests_response_text': {
             'ok': True,
             'message': '',
-            # support attachments
-            'file': {
-                'url_private': 'http://localhost/',
-            },
         },
         # We fail because of the empty channel #$ and #-
         'notify_response': False,

--- a/test/test_plugin_slack.py
+++ b/test/test_plugin_slack.py
@@ -299,13 +299,13 @@ def test_plugin_slack_oauth_access_token(mock_request):
     # Generate an invalid bot token
     token = 'xo-invalid'
 
-    response = mock.Mock()
-    response.content = dumps({
+    request = mock.Mock()
+    request.content = dumps({
         'ok': True,
         'message': '',
         'channel': 'C123456',
     })
-    response.status_code = requests.codes.ok
+    request.status_code = requests.codes.ok
 
     # We'll fail to validate the access_token
     with pytest.raises(TypeError):
@@ -315,7 +315,7 @@ def test_plugin_slack_oauth_access_token(mock_request):
     token = 'xoxb-1234-1234-abc124'
 
     # Prepare Mock
-    mock_request.return_value = response
+    mock_request.return_value = request
     # Variation Initializations
     obj = NotifySlack(access_token=token, targets='#apprise')
     assert isinstance(obj, NotifySlack) is True
@@ -327,7 +327,7 @@ def test_plugin_slack_oauth_access_token(mock_request):
     # Test Valid Attachment
     mock_request.reset_mock()
     mock_request.side_effect = [
-        response,
+        request,
         mock.Mock(**{
             'content': dumps({
                 "ok": True,
@@ -380,7 +380,7 @@ def test_plugin_slack_oauth_access_token(mock_request):
 
     # Test a valid attachment that throws an Connection Error
     mock_request.return_value = None
-    mock_request.side_effect = (response, requests.ConnectionError(
+    mock_request.side_effect = (request, requests.ConnectionError(
         0, 'requests.ConnectionError() not handled'))
     assert obj.notify(
         body='body', title='title', notify_type=NotifyType.INFO,
@@ -388,13 +388,13 @@ def test_plugin_slack_oauth_access_token(mock_request):
 
     # Test a valid attachment that throws an OSError
     mock_request.return_value = None
-    mock_request.side_effect = (response, OSError(0, 'OSError'))
+    mock_request.side_effect = (request, OSError(0, 'OSError'))
     assert obj.notify(
         body='body', title='title', notify_type=NotifyType.INFO,
         attach=attach) is False
 
     # Reset our mock object back to how it was
-    mock_request.return_value = response
+    mock_request.return_value = request
     mock_request.side_effect = None
 
     # Test invalid attachment
@@ -406,7 +406,7 @@ def test_plugin_slack_oauth_access_token(mock_request):
     # Test case where expected return attachment payload is invalid
     mock_request.reset_mock()
     mock_request.side_effect = [
-        response,
+        request,
         mock.Mock(**{
             'content': dumps({
                 "ok": False,
@@ -423,15 +423,15 @@ def test_plugin_slack_oauth_access_token(mock_request):
 
     # Slack requests pay close attention to the response to determine
     # if things go well... this is not a good JSON response:
-    response.content = '{'
+    request.content = '{'
     mock_request.reset_mock()
-    mock_request.return_value = response
+    mock_request.return_value = request
     mock_request.side_effect = None
 
     # As a result, we'll fail to send our notification
     assert obj.send(body="test", attach=attach) is False
 
-    response.content = dumps({
+    request.content = dumps({
         'ok': False,
         'message': 'We failed',
     })

--- a/test/test_plugin_slack.py
+++ b/test/test_plugin_slack.py
@@ -49,14 +49,6 @@ TEST_VAR_DIR = os.path.join(os.path.dirname(__file__), 'var')
 
 # Our Testing URLs
 apprise_url_tests = (
-    ('slack://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/#channel', {
-        # No username specified; this is still okay as we sub in
-        # default; The one invalid channel is skipped when sending a message
-        'instance': NotifySlack,
-        # don't include an image by default
-        'include_image': False,
-        'requests_response_text': 'ok'
-    }),
     ('slack://', {
         'instance': TypeError,
     }),
@@ -82,6 +74,14 @@ apprise_url_tests = (
             'ok': False,
             'message': 'Bad Channel',
         },
+    }),
+    ('slack://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/#channel', {
+        # No username specified; this is still okay as we sub in
+        # default; The one invalid channel is skipped when sending a message
+        'instance': NotifySlack,
+        # don't include an image by default
+        'include_image': False,
+        'requests_response_text': 'ok'
     }),
     ('slack://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/+id/@id/', {
         # + encoded id,

--- a/test/test_plugin_slack.py
+++ b/test/test_plugin_slack.py
@@ -354,7 +354,6 @@ def test_plugin_slack_oauth_access_token(mock_request):
         }),
     ]
 
-
     path = os.path.join(TEST_VAR_DIR, 'apprise-test.gif')
     attach = AppriseAttachment(path)
     assert obj.notify(


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** #1126

The Slack `files.upload` method is [deprecated](https://api.slack.com/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay). Instead, you now [need](https://api.slack.com/messaging/files#uploading_files) to use the [`files.getUploadURLExternal`](https://api.slack.com/methods/files.getUploadURLExternal) and [`files.completeUploadExternal`](https://api.slack.com/methods/files.completeUploadExternal) methods to upload files to Slack.

<!-- Have anything else to describe? Define it here -->

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage.

Local test result:

<img width="655" alt="Screenshot 2024-05-24 at 11 39 24" src="https://github.com/caronc/apprise/assets/4767109/43d039d7-37f4-4e36-b0ca-6c552211fc7a">


## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/delenamalan/apprise.git@slack-files-upload-deprecation

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  --attach /path/to/image.png \
  "slack://xoxb-your-slack-key/#your-channel"
```

