### PR TITLE
Slack supports <@userid> in message body

### DIFF
--- a/test/test_plugin_slack.py
+++ b/test/test_plugin_slack.py
@@ -731,6 +731,10 @@ def test_plugin_slack_markdown(mock_get, mock_request):
     Channel Testing
     <!channelA>
     <!channelA|Description>
+
+    User ID Testing
+    <@U1ZQL9N3Y>
+    <@U1ZQL9N3Y|heheh>
     """)
 
     # Send our notification
@@ -752,7 +756,8 @@ def test_plugin_slack_markdown(mock_get, mock_request):
         "\n   <https://slack.com?arg=val&arg2=val2|Slack Link>.\n"\
         "We also want to be able to support <https://slack.com> "\
         "links without the\ndescription."\
-        "\n\nChannel Testing\n<!channelA>\n<!channelA|Description>"
+        "\n\nChannel Testing\n<!channelA>\n<!channelA|Description>\n\n"\
+        "User ID Testing\n<@U1ZQL9N3Y>\n<@U1ZQL9N3Y|heheh>"
 
 
 @mock.patch('requests.request')


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #849 

Added support for `<@userid>` and `<@userid|desc>` to slack payload

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@849-slack-userid-in-body

# Test out the changes with the following command:
apprise -t "Test Title" -b "Hi <@U1ZQL9N3Y>!" \
  "slack://credentials/"

```

