### PR TITLE
Fixed series of pep8 fixes surfacinging in python 3.11 flake8 checks

### DIFF
--- a/apprise/cli.py
+++ b/apprise/cli.py
@@ -121,7 +121,7 @@ if platform.system() == 'Windows':
         # Global Support
         #
 
-        # C:\ProgramData\Apprise\
+        # C:\ProgramData\Apprise
         expandvars('%ALLUSERSPROFILE%\\Apprise\\apprise'),
         expandvars('%ALLUSERSPROFILE%\\Apprise\\apprise.conf'),
         expandvars('%ALLUSERSPROFILE%\\Apprise\\apprise.yml'),

--- a/apprise/plugins/bulksms.py
+++ b/apprise/plugins/bulksms.py
@@ -269,7 +269,7 @@ class NotifyBulkSMS(NotifyBase):
             'to': None,
             'body': body,
             'routingGroup': self.route,
-            'encoding': BulkSMSEncoding.UNICODE \
+            'encoding': BulkSMSEncoding.UNICODE
             if self.unicode else BulkSMSEncoding.TEXT,
             # Options are NONE, ALL and ERRORS
             'deliveryReports': "ERRORS"

--- a/apprise/plugins/lametric.py
+++ b/apprise/plugins/lametric.py
@@ -938,7 +938,7 @@ class NotifyLametric(NotifyBase):
                         LAMETRIC_IS_APP_TOKEN.match(results['password'])) and
 
                     # Scan for app_ flags
-                    next((f for f in results.keys() \
+                    next((f for f in results.keys()
                           if f.startswith('app_')), None) is None) \
                 else LametricMode.CLOUD
 

--- a/test/test_plugin_mattermost.py
+++ b/test/test_plugin_mattermost.py
@@ -66,10 +66,10 @@ apprise_url_tests = (
     ('mmost://localhost/3ccdd113474722377935511fc85d3dd4'
      '?to=test&image=True', {
          'instance': NotifyMattermost}),
-    ('mmost://localhost/3ccdd113474722377935511fc85d3dd4' \
+    ('mmost://localhost/3ccdd113474722377935511fc85d3dd4'
      '?to=test&image=False', {
          'instance': NotifyMattermost}),
-    ('mmost://localhost/3ccdd113474722377935511fc85d3dd4' \
+    ('mmost://localhost/3ccdd113474722377935511fc85d3dd4'
      '?to=test&image=True', {
          'instance': NotifyMattermost,
          # don't include an image by default

--- a/test/test_plugin_office365.py
+++ b/test/test_plugin_office365.py
@@ -96,7 +96,7 @@ apprise_url_tests = (
         },
 
         # Our expected url(privacy=True) startswith() response:
-        'privacy_url': 'o365://t...t:user@example.com/a...h/' \
+        'privacy_url': 'o365://t...t:user@example.com/a...h/'
                        '****/email1%40test.ca/'}),
     # test our arguments
     ('o365://_/?oauth_id={cid}&oauth_secret={secret}&tenant={tenant}'
@@ -117,7 +117,7 @@ apprise_url_tests = (
             },
 
             # Our expected url(privacy=True) startswith() response:
-            'privacy_url': 'o365://t...t:user@example.com/a...h/' \
+            'privacy_url': 'o365://t...t:user@example.com/a...h/'
                            '****/email1%40test.ca/'}),
     # Test invalid JSON (no tenant defaults to email domain)
     ('o365://{tenant}:{aid}/{cid}/{secret}/{targets}'.format(

--- a/test/test_plugin_sns.py
+++ b/test/test_plugin_sns.py
@@ -376,7 +376,7 @@ def test_plugin_sns_aws_topic_handling(mock_post):
         # Multi-Topic
         'sns://T1JJ3T3L2/A1BRTD4JD/TIiajkdnl/us-east-1/TopicA/TopicB/'
         # Topic-Mix
-        'sns://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkce/us-west-2/' \
+        'sns://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkce/us-west-2/'
         '12223334444/TopicA'])
 
     # CreateTopic fails

--- a/test/test_plugin_splunk.py
+++ b/test/test_plugin_splunk.py
@@ -66,13 +66,13 @@ apprise_url_tests = (
         'instance': NotifySplunk,
     }),
     # Support legacy URL
-    ('https://alert.victorops.com/integrations/generic/20131114/' \
+    ('https://alert.victorops.com/integrations/generic/20131114/'
      'alert/apikey/routing_key', {
          # We're good
          'instance': NotifySplunk,
      }),
     # Support legacy URL (with entity id provided)
-    ('https://alert.victorops.com/integrations/generic/20131114/' \
+    ('https://alert.victorops.com/integrations/generic/20131114/'
      'alert/apikey/routing_key/entity_id', {
          # We're good
          'instance': NotifySplunk,

--- a/test/test_plugin_threema.py
+++ b/test/test_plugin_threema.py
@@ -116,7 +116,7 @@ def test_plugin_threema():
     AppriseURLTester(tests=apprise_url_tests).run_all()
 
 
-@ mock.patch('requests.post')
+@mock.patch('requests.post')
 def test_plugin_threema_edge_cases(mock_post):
     """
     NotifyThreema() Edge Cases

--- a/test/test_plugin_voipms.py
+++ b/test/test_plugin_voipms.py
@@ -170,7 +170,7 @@ def test_plugin_voipms():
     AppriseURLTester(tests=apprise_url_tests).run_all()
 
 
-@ mock.patch('requests.get')
+@mock.patch('requests.get')
 def test_plugin_voipms_edge_cases(mock_get):
     """
     NotifyVoipms() Edge Cases


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1148 

Issues surfaced recently for some reason and became visible on the attached PR.

This corrects the `E502` PEP8 issues that have clearly existed long before.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
Unit tests pass is all that is tested here

