### PR TITLE
Add missing % string in import failed trace message

### DIFF
--- a/apprise/manager.py
+++ b/apprise/manager.py
@@ -223,7 +223,7 @@ class PluginManager(metaclass=Singleton):
                     if not hasattr(plugin, 'app_id'):
                         # Filter out non-notification modules
                         logger.trace(
-                            "(%s) import failed; no app_id defined in %s",
+                            "%s(%s) import failed; no app_id defined in %s",
                             self.name, m_class, os.path.join(module_path, f))
                         continue
 

--- a/apprise/manager.py
+++ b/apprise/manager.py
@@ -223,7 +223,7 @@ class PluginManager(metaclass=Singleton):
                     if not hasattr(plugin, 'app_id'):
                         # Filter out non-notification modules
                         logger.trace(
-                            "%s(%s) import failed; no app_id defined in %s",
+                            "(%s.%s) import failed; no app_id defined in %s",
                             self.name, m_class, os.path.join(module_path, f))
                         continue
 


### PR DESCRIPTION
## Description:
The trace message in `manager.py` missed a % string which leads to `TypeError`:

```
Traceback (most recent call last):
  File "/Users/jbenecke/.pyenv/versions/3.12.4/lib/python3.12/logging/__init__.py", line 1160, in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "/Users/jbenecke/.pyenv/versions/3.12.4/lib/python3.12/logging/__init__.py", line 999, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "/Users/jbenecke/.pyenv/versions/3.12.4/lib/python3.12/logging/__init__.py", line 703, in format
    record.message = record.getMessage()
                     ^^^^^^^^^^^^^^^^^^^
  File "/Users/jbenecke/.pyenv/versions/3.12.4/lib/python3.12/logging/__init__.py", line 392, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting
Call stack:
  File "/Users/jbenecke/SourceCode/home-assistant-core/venv/bin/apprise", line 8, in <module>
    sys.exit(main())
  File "/Users/jbenecke/SourceCode/home-assistant-core/venv/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/Users/jbenecke/SourceCode/home-assistant-core/venv/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/Users/jbenecke/SourceCode/home-assistant-core/venv/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/jbenecke/SourceCode/home-assistant-core/venv/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/Users/jbenecke/SourceCode/home-assistant-core/venv/lib/python3.12/site-packages/apprise/cli.py", line 451, in main
    a.add(url)
  File "/Users/jbenecke/SourceCode/home-assistant-core/venv/lib/python3.12/site-packages/apprise/apprise.py", line 288, in add
    instance = Apprise.instantiate(_server, asset=asset, tag=tag)
  File "/Users/jbenecke/SourceCode/home-assistant-core/venv/lib/python3.12/site-packages/apprise/apprise.py", line 132, in instantiate
    results = plugins.url_to_dict(
  File "/Users/jbenecke/SourceCode/home-assistant-core/venv/lib/python3.12/site-packages/apprise/plugins/__init__.py", line 450, in url_to_dict
    if schema not in N_MGR:
  File "/Users/jbenecke/SourceCode/home-assistant-core/venv/lib/python3.12/site-packages/apprise/manager.py", line 634, in __contains__
    self.load_modules()
  File "/Users/jbenecke/SourceCode/home-assistant-core/venv/lib/python3.12/site-packages/apprise/manager.py", line 225, in load_modules
    logger.trace(
  File "/Users/jbenecke/SourceCode/home-assistant-core/venv/lib/python3.12/site-packages/apprise/logger.py", line 53, in trace
    self._log(logging.TRACE, message, args, **kwargs)
Message: '(%s) import failed; no app_id defined in %s'
```

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@<this.branch-name>

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  <apprise url related to ticket>

```

