### PR TITLE
fix: conversion html_to_text hr tags rstrip non string object

### DIFF
--- a/apprise/conversion.py
+++ b/apprise/conversion.py
@@ -180,7 +180,7 @@ class HTMLConverter(HTMLParser, object):
             self._result.append('\n')
 
         elif tag == 'hr':
-            if self._result and isinstance(self._result[-1],str):
+            if self._result and isinstance(self._result[-1], str):
                 self._result[-1] = self._result[-1].rstrip(' ')
             else:
                 pass

--- a/apprise/conversion.py
+++ b/apprise/conversion.py
@@ -180,8 +180,10 @@ class HTMLConverter(HTMLParser, object):
             self._result.append('\n')
 
         elif tag == 'hr':
-            if self._result:
+            if self._result and isinstance(self._result[-1],str):
                 self._result[-1] = self._result[-1].rstrip(' ')
+            else:
+                pass
 
             self._result.append('\n---\n')
 

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -137,7 +137,8 @@ def test_conversion_html_to_text():
     <p>
        Hi!<br/>
        How are you?<br/>
-       <font color="#FF0000">red font</font> <a href="http://www.python.org">link</a> you wanted.
+       <font color="#FF0000">red font</font>
+       <a href="http://www.python.org">link</a> you wanted.
     </p>
 </p>
 <br/>

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -127,6 +127,25 @@ def test_conversion_html_to_text():
     # If you give nothing, you get nothing in return
     assert to_html("") == ""
 
+    assert to_html(
+        """
+<html>
+<head></head>
+<body>
+<p>
+   <hr/><b>TEST</b>
+    <p>
+       Hi!<br/>
+       How are you?<br/>
+       <font color="#FF0000">red font</font> <a href="http://www.python.org">link</a> you wanted.
+    </p>
+</p>
+<br/>
+</body>
+</html>
+     """
+    ) == "TEST Hi! How are you? red font link you wanted."
+
     with pytest.raises(TypeError):
         # Invalid input
         assert to_html(None)

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -145,7 +145,7 @@ def test_conversion_html_to_text():
 </body>
 </html>
      """
-    ) == "TEST Hi! How are you? red font link you wanted."
+    ) == "---\nTEST\n  Hi!\n  How are you?\n  red font link you wanted."
 
     with pytest.raises(TypeError):
         # Invalid input

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -145,7 +145,7 @@ def test_conversion_html_to_text():
 </body>
 </html>
      """
-    ) == "---\nTEST\n  Hi!\n  How are you?\n  red font link you wanted."
+    ) == "TEST\n  Hi!\n  How are you?\n  red font link you wanted.\n---"
 
     with pytest.raises(TypeError):
         # Invalid input

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -158,7 +158,7 @@ red font link you wanted."
         """) == "FROM: apprise-test@mydomain.yyy\n---\nHi!\n \
 How are you?\n red font link you wanted."
 
-    # Special case on HR if text is sorrunded by HR tags 
+    # Special case on HR if text is sorrunded by HR tags
     # its created a dict element
     assert to_html("""
         <html>

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -127,25 +127,44 @@ def test_conversion_html_to_text():
     # If you give nothing, you get nothing in return
     assert to_html("") == ""
 
+    # Special case on HR tag
     assert to_html(
-        """
-<html>
+"""<html>
+    <head></head>
+    <body>
+        <p><b>FROM: </b>apprise-test@mydomain.yyy<apprise-test@mydomain.yyy></p>
+        Hi!<br/>
+        How are you?<br/>
+        <font color=3D"#FF0000">red font</font> <a href=3D"http://www.python.org">link</a> you wanted.<br/>
+    </body>
+</html>"""
+    ) == "FROM: apprise-test@mydomain.yyy\nHi!\n How are you?\n red font link you wanted."
+
+    assert to_html(
+"""<html>
+    <head></head>
+    <body>
+        <p><hr><b>FROM: </b>apprise-test@mydomain.yyy<apprise-test@mydomain.yyy><hr></p>
+        Hi!<br/>
+        How are you?<br/>
+        <font color=3D"#FF0000">red font</font> <a href=3D"http://www.python.org">link</a> you wanted.<br/>
+    </body>
+</html>"""
+    ) == "---\nFROM: apprise-test@mydomain.yyy\n---\nHi!\n How are you?\n red font link you wanted."
+
+    assert to_html(
+"""<html>
 <head></head>
 <body>
-<p>
-   <hr/><b>TEST</b>
     <p>
-       Hi!<br/>
-       How are you?<br/>
-       <font color="#FF0000">red font</font>
-       <a href="http://www.python.org">link</a> you wanted.
+        <hr><b>TEST</b><hr>
     </p>
-</p>
-<br/>
+    Hi!<br/>
+    How are you?<br/>
+    <font color=3D"#FF0000">red font</font> <a href=3D"http://www.python.org">link</a> you wanted.<br/>
 </body>
-</html>
-     """
-    ) == "TEST\n  Hi!\n  How are you?\n  red font link you wanted.\n---"
+</html>"""
+    ) == "---\nTEST\n---\nHi!\n How are you?\n red font link you wanted."
 
     with pytest.raises(TypeError):
         # Invalid input

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -128,43 +128,51 @@ def test_conversion_html_to_text():
     assert to_html("") == ""
 
     # Special case on HR tag
-    assert to_html(
-"""<html>
-    <head></head>
-    <body>
-        <p><b>FROM: </b>apprise-test@mydomain.yyy<apprise-test@mydomain.yyy></p>
-        Hi!<br/>
-        How are you?<br/>
-        <font color=3D"#FF0000">red font</font> <a href=3D"http://www.python.org">link</a> you wanted.<br/>
-    </body>
-</html>"""
-    ) == "FROM: apprise-test@mydomain.yyy\nHi!\n How are you?\n red font link you wanted."
+    assert to_html("""
+        <html>
+            <head></head>
+            <body>
+                <p><b>FROM: </b>apprise-test@mydomain.yyy
+                <apprise-test@mydomain.yyy></p>
+                Hi!<br/>
+                How are you?<br/>
+<font color=3D"#FF0000">red font</font>
+<a href=3D"http://www.python.org">link</a> you wanted.<br/>
+            </body>
+        </html>
+        """) == "FROM: apprise-test@mydomain.yyy\nHi!\n How are you?\n \
+red font link you wanted."
 
-    assert to_html(
-"""<html>
-    <head></head>
-    <body>
-        <p><hr><b>FROM: </b>apprise-test@mydomain.yyy<apprise-test@mydomain.yyy><hr></p>
-        Hi!<br/>
-        How are you?<br/>
-        <font color=3D"#FF0000">red font</font> <a href=3D"http://www.python.org">link</a> you wanted.<br/>
-    </body>
-</html>"""
-    ) == "---\nFROM: apprise-test@mydomain.yyy\n---\nHi!\n How are you?\n red font link you wanted."
+    assert to_html("""
+        <html>
+            <head></head>
+            <body>
+                <p><hr><b>FROM: </b>apprise-test@mydomain.yyy
+                    <apprise-test@mydomain.yyy><hr></p>
+                Hi!<br/>
+                How are you?<br/>
+<font color=3D"#FF0000">red font</font>
+<a href=3D"http://www.python.org">link</a> you wanted.<br/>
+            </body>
+        </html>
+        """) == "---\nFROM: apprise-test@mydomain.yyy\n---\nHi!\n \
+How are you?\n red font link you wanted."
 
-    assert to_html(
-"""<html>
-<head></head>
-<body>
-    <p>
-        <hr><b>TEST</b><hr>
-    </p>
-    Hi!<br/>
-    How are you?<br/>
-    <font color=3D"#FF0000">red font</font> <a href=3D"http://www.python.org">link</a> you wanted.<br/>
-</body>
-</html>"""
-    ) == "---\nTEST\n---\nHi!\n How are you?\n red font link you wanted."
+    assert to_html("""
+        <html>
+            <head></head>
+            <body>
+                <p>
+                    <hr><b>TEST</b><hr>
+                </p>
+                Hi!<br/>
+                How are you?<br/>
+<font color=3D"#FF0000">red font</font>
+<a href=3D"http://www.python.org">link</a> you wanted.<br/>
+            </body>
+            </html>
+        """) == "---\nTEST\n---\nHi!\n How are you?\n red font link you \
+wanted."
 
     with pytest.raises(TypeError):
         # Invalid input

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -147,6 +147,23 @@ red font link you wanted."
         <html>
             <head></head>
             <body>
+                <p><b>FROM: </b>apprise-test@mydomain.yyy
+                    <apprise-test@mydomain.yyy><hr></p>
+                Hi!<br/>
+                How are you?<br/>
+<font color=3D"#FF0000">red font</font>
+<a href=3D"http://www.python.org">link</a> you wanted.<br/>
+            </body>
+        </html>
+        """) == "FROM: apprise-test@mydomain.yyy\n---\nHi!\n \
+How are you?\n red font link you wanted."
+
+    # Special case on HR if text is sorrunded by HR tags 
+    # its created a dict element
+    assert to_html("""
+        <html>
+            <head></head>
+            <body>
                 <p><hr><b>FROM: </b>apprise-test@mydomain.yyy
                     <apprise-test@mydomain.yyy><hr></p>
                 Hi!<br/>


### PR DESCRIPTION
## Description:
During the conversion from HTML to TEXT ( method `html_to_text` file: `apprise/conversion.py` on ´hr´ tag ) if the `_result` list have a dictionary object inside the method use `rstrip` on it so raise an Exception:
```
self._result[-1] = self._result[-1].rstrip(' ')
AttributeError: 'dict' object has no attribute 'rstrip'
```

## Example
```
self._result = [' ', ' ', {}, 'Hi!', '\n', ' How are you?', '\n', ' ', 'red font', ' ', 'link', ' you wanted. ', {}, ' ', {}]
```

## Checklist
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [] 100% test coverage