### PR TITLE
setup.py deprecation workaround with --use-pep517

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
         sudo apt-get install libdbus-1-dev
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
@@ -98,25 +98,25 @@ jobs:
 
     - name: Install project dependencies (Baseline)
       run: |
-        pip install wheel
-        pip install -r requirements.txt -r dev-requirements.txt
+        pip install --use-pep517 wheel
+        pip install --use-pep517 -r requirements.txt -r dev-requirements.txt
 
     - name: Install project dependencies (All plugins)
       if: matrix.bare != true
       run: |
-        pip install -r all-plugin-requirements.txt
+        pip install --use-pep517 -r all-plugin-requirements.txt
         
     - name: Install project dependencies (Windows)
       if: runner.os == 'Windows'
       run: |
-        pip install -r win-requirements.txt || true
+        pip install --use-pep517 -r win-requirements.txt || true
 
     # Install package in editable mode,
     # and run project-specific tasks.
     - name: Setup project
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install --editable=.
+        pip install --use-pep517 --editable=.
         python setup.py compile_catalog
 
     # For saving resources, code style checking is


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1167 

Getting the following errors with the GitHub runners now:
![image](https://github.com/user-attachments/assets/5c425941-3041-4793-bb92-73c9ece4cf16)
...
![image](https://github.com/user-attachments/assets/fb666a1f-0e2c-4d33-987a-fbe744cf648a)

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

