### PR TITLE
Twilio WhatsApp support added

### DIFF
--- a/apprise/url.py
+++ b/apprise/url.py
@@ -577,7 +577,7 @@ class URLBase:
         return content
 
     @staticmethod
-    def parse_phone_no(content, unquote=True):
+    def parse_phone_no(content, unquote=True, prefix=False):
         """A wrapper to utils.parse_phone_no() with unquoting support
 
         Parses a specified set of data and breaks it into a list.
@@ -600,7 +600,7 @@ class URLBase:
                 # Nothing further to do
                 return []
 
-        content = parse_phone_no(content)
+        content = parse_phone_no(content, prefix=prefix)
 
         return content
 

--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -174,6 +174,11 @@ IS_PHONE_NO = re.compile(r'^\+?(?P<phone>[0-9\s)(+-]+)\s*$')
 PHONE_NO_DETECTION_RE = re.compile(
     r'\s*([+(\s]*[0-9][0-9()\s-]+[0-9])(?=$|[\s,+(]+[0-9])', re.I)
 
+# Support for prefix: (string followed by colon) infront of phone no
+PHONE_NO_WPREFIX_DETECTION_RE = re.compile(
+    r'\s*((?:[a-z]+:)?[+(\s]*[0-9][0-9()\s-]+[0-9])'
+    r'(?=$|(?:[a-z]+:)?[\s,+(]+[0-9])', re.I)
+
 # A simple verification check to make sure the content specified
 # rougly conforms to a ham radio call sign before we parse it further
 IS_CALL_SIGN = re.compile(
@@ -939,7 +944,7 @@ def parse_bool(arg, default=False):
     return bool(arg)
 
 
-def parse_phone_no(*args, store_unparseable=True, **kwargs):
+def parse_phone_no(*args, store_unparseable=True, prefix=False, **kwargs):
     """
     Takes a string containing phone numbers separated by comma's and/or spaces
     and returns a list.
@@ -948,7 +953,8 @@ def parse_phone_no(*args, store_unparseable=True, **kwargs):
     result = []
     for arg in args:
         if isinstance(arg, str) and arg:
-            _result = PHONE_NO_DETECTION_RE.findall(arg)
+            _result = (PHONE_NO_DETECTION_RE if not prefix
+                       else PHONE_NO_WPREFIX_DETECTION_RE).findall(arg)
             if _result:
                 result += _result
 
@@ -966,7 +972,7 @@ def parse_phone_no(*args, store_unparseable=True, **kwargs):
         elif isinstance(arg, (set, list, tuple)):
             # Use recursion to handle the list of phone numbers
             result += parse_phone_no(
-                *arg, store_unparseable=store_unparseable)
+                *arg, store_unparseable=store_unparseable, prefix=prefix)
 
     return result
 

--- a/test/test_plugin_twilio.py
+++ b/test/test_plugin_twilio.py
@@ -69,8 +69,8 @@ apprise_url_tests = (
         # sid and token provided and from but invalid from no
         'instance': TypeError,
     }),
-    ('twilio://AC{}:{}@{}/123/{}/abcd/'.format(
-        'a' * 32, 'b' * 32, '3' * 11, '9' * 15), {
+    ('twilio://AC{}:{}@{}/123/{}/abcd/w:{}'.format(
+        'a' * 32, 'b' * 32, '3' * 11, '9' * 15, 8 * 11), {
         # valid everything but target numbers
         'instance': NotifyTwilio,
     }),
@@ -80,6 +80,20 @@ apprise_url_tests = (
 
         # Our expected url(privacy=True) startswith() response:
         'privacy_url': 'twilio://...aaaa:b...b@12345',
+    }),
+    ('twilio://AC{}:{}@98765/{}/w:{}/'.format(
+        'a' * 32, 'b' * 32, '4' * 11, '5' * 11), {
+            # using short-code (5 characters) and 1 twillio address ignored
+            # because source phone number can not be a short code
+            'instance': NotifyTwilio,
+
+            # Our expected url(privacy=True) startswith() response:
+            'privacy_url': 'twilio://...aaaa:b...b@98765',
+    }),
+    ('twilio://AC{}:{}@w:12345/{}/{}'.format(
+        'a' * 32, 'b' * 32, '4' * 11, '5' * 11), {
+            # Invalid short-code
+            'instance': TypeError,
     }),
     ('twilio://AC{}:{}@123456/{}'.format('a' * 32, 'b' * 32, '4' * 11), {
         # using short-code (6 characters)
@@ -93,6 +107,11 @@ apprise_url_tests = (
     ('twilio://_?sid=AC{}&token={}&from={}'.format(
         'a' * 32, 'b' * 32, '5' * 11), {
         # use get args to acomplish the same thing
+        'instance': NotifyTwilio,
+    }),
+    ('twilio://_?sid=AC{}&token={}&from={}&to=w:{}'.format(
+        'a' * 32, 'b' * 32, '5' * 11, '6' * 11), {
+        # Support whatsapp (w: before number)
         'instance': NotifyTwilio,
     }),
     ('twilio://_?sid=AC{}&token={}&source={}'.format(
@@ -227,6 +246,11 @@ def test_plugin_twilio_edge_cases(mock_post):
     with pytest.raises(TypeError):
         NotifyTwilio(
             account_sid=account_sid, auth_token=None, source=source)
+
+    # Source is bad
+    with pytest.raises(TypeError):
+        NotifyTwilio(
+            account_sid=account_sid, auth_token=auth_token, source='')
 
     # a error response
     response.status_code = 400


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** Discord Request

This Pull Request allows you to add `whatsapp:phoneno` as target phone numbers in twillio.  this will only work if you're hooked up with Twillio through them.

For example:
- `twilio://credentials/whatsapp:555-555-5555` would send the message though Whatsapp instead of the regular Twillio Infrastructure.

You can also shorten the code to just be `w:` (no need to spell out `whatsapp:`).  Long naming is preserved so it aligns with Twilio documentation.

You can chain more phone numbers if you wish to as well:
- `twilio://credentials/w:555-555-5555/w:555-555-1234/ `

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@twilio-whatsapp-support

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "twilio://credentials/target-no"
```

