### PR TITLE
Fix Telegram Thread/Topic handling

### DIFF
--- a/apprise/plugins/telegram.py
+++ b/apprise/plugins/telegram.py
@@ -361,6 +361,9 @@ class NotifyTelegram(NotifyBase):
             'name': _('Topic Thread ID'),
             'type': 'int',
         },
+        'thread': {
+            'alias_of': 'topic',
+        },
         'mdv': {
             'name': _('Markdown Version'),
             'type': 'choice:string',
@@ -460,14 +463,22 @@ class NotifyTelegram(NotifyBase):
                 self.detect_owner = False
                 continue
 
-            try:
-                topic = int(
-                    results.group('topic')
-                    if results.group('topic') else self.topic)
+            if results.group('topic'):
+                try:
+                    topic = int(
+                        results.group('topic')
+                        if results.group('topic') else self.topic)
 
-            except TypeError:
-                # No worries
-                topic = None
+                except TypeError:
+                    self.logger.warning(
+                        'Dropped invalid Telegram chat/group '
+                        '({}) specified; topic is invalid.'
+                        .format(target),
+                    )
+                    continue
+            else:
+                # Default (if one set)
+                topic = self.topic
 
             if results.group('name') is not None:
                 # Name
@@ -730,7 +741,7 @@ class NotifyTelegram(NotifyBase):
             _id = self.detect_bot_owner()
             if _id:
                 # Permanently store our id in our target list for next time
-                self.targets.append((str(_id), None))
+                self.targets.append((str(_id), self.topic))
                 self.logger.info(
                     'Update your Telegram Apprise URL to read: '
                     '{}'.format(self.url(privacy=True)))
@@ -1042,6 +1053,9 @@ class NotifyTelegram(NotifyBase):
         # Support Thread Topic
         if 'topic' in results['qsd'] and len(results['qsd']['topic']):
             results['topic'] = results['qsd']['topic']
+
+        elif 'thread' in results['qsd'] and len(results['qsd']['thread']):
+            results['topic'] = results['qsd']['thread']
 
         # Silent (Sends the message Silently); users will receive
         # notification with no sound.

--- a/apprise/plugins/telegram.py
+++ b/apprise/plugins/telegram.py
@@ -464,18 +464,9 @@ class NotifyTelegram(NotifyBase):
                 continue
 
             if results.group('topic'):
-                try:
-                    topic = int(
-                        results.group('topic')
-                        if results.group('topic') else self.topic)
-
-                except TypeError:
-                    self.logger.warning(
-                        'Dropped invalid Telegram chat/group '
-                        '({}) specified; topic is invalid.'
-                        .format(target),
-                    )
-                    continue
+                topic = int(
+                    results.group('topic')
+                    if results.group('topic') else self.topic)
             else:
                 # Default (if one set)
                 topic = self.topic

--- a/test/test_plugin_telegram.py
+++ b/test/test_plugin_telegram.py
@@ -98,6 +98,10 @@ apprise_url_tests = (
     ('tgram://bottest@123456789:abcdefg_hijklmnop/id1/?topic=12345', {
         'instance': NotifyTelegram,
     }),
+    # Thread is just an alias of topic
+    ('tgram://bottest@123456789:abcdefg_hijklmnop/id1/?thread=12345', {
+        'instance': NotifyTelegram,
+    }),
     # Threads must be numeric
     ('tgram://bottest@123456789:abcdefg_hijklmnop/id1/?topic=invalid', {
         'instance': TypeError,
@@ -907,12 +911,9 @@ def test_plugin_telegram_html_formatting(mock_post):
     NotifyTelegram() HTML Formatting
 
     """
-    # on't send anything other than <b>, <i>, <a>,<code> and <pre>
-
     # Prepare Mock
     mock_post.return_value = requests.Request()
     mock_post.return_value.status_code = requests.codes.ok
-    mock_post.return_value.content = '{}'
 
     # Simple success response
     mock_post.return_value.content = dumps({
@@ -942,7 +943,6 @@ def test_plugin_telegram_html_formatting(mock_post):
             }},
         ],
     })
-    mock_post.return_value.status_code = requests.codes.ok
 
     aobj = Apprise()
     aobj.add('tgram://123456789:abcdefg_hijklmnop/')
@@ -1005,3 +1005,111 @@ def test_plugin_telegram_html_formatting(mock_post):
         '<b>Heading 3</b>\r\n<b>Heading 4</b>\r\n<b>Heading 5</b>\r\n' \
         '<b>Heading 6</b>\r\nA set of text\r\n' \
         'Another line after the set of text\r\nMore text\r\nlabel'
+
+
+@mock.patch('requests.post')
+def test_plugin_telegram_threads(mock_post):
+    """
+    NotifyTelegram() Threads/Topics
+
+    """
+    # Prepare Mock
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    # Simple success response
+    mock_post.return_value.content = dumps({
+        "ok": True,
+        "result": [{
+            "update_id": 645421321,
+            "message": {
+                "message_id": 2,
+                "from": {
+                    "id": 532389719,
+                    "is_bot": False,
+                    "first_name": "Chris",
+                    "language_code": "en-US"
+                },
+                "chat": {
+                    "id": 532389719,
+                    "first_name": "Chris",
+                    "type": "private"
+                },
+                "date": 1519694394,
+                "text": "/start",
+                "entities": [{
+                    "offset": 0,
+                    "length": 6,
+                    "type": "bot_command",
+                }],
+            }},
+        ],
+    })
+
+    aobj = Apprise()
+    aobj.add('tgram://123456789:abcdefg_hijklmnop/?thread=1234')
+
+    assert len(aobj) == 1
+
+    assert isinstance(aobj[0], NotifyTelegram)
+
+    body = 'my message'
+
+    assert aobj.notify(body=body)
+
+    # 1 call to look up bot owner, and second for notification
+    assert mock_post.call_count == 2
+
+    payload = loads(mock_post.call_args_list[1][1]['data'])
+
+    assert 'message_thread_id' in payload
+    assert payload['message_thread_id'] == 1234
+
+    mock_post.reset_mock()
+
+    aobj = Apprise()
+    aobj.add('tgram://123456789:abcdefg_hijklmnop/?topic=1234')
+
+    assert len(aobj) == 1
+
+    assert isinstance(aobj[0], NotifyTelegram)
+
+    body = 'my message'
+
+    assert aobj.notify(body=body)
+
+    # 1 call to look up bot owner, and second for notification
+    assert mock_post.call_count == 2
+
+    payload = loads(mock_post.call_args_list[1][1]['data'])
+
+    assert 'message_thread_id' in payload
+    assert payload['message_thread_id'] == 1234
+
+    mock_post.reset_mock()
+
+    aobj = Apprise()
+    aobj.add('tgram://123456789:abcdefg_hijklmnop/9876:1234/9876:1111')
+
+    assert len(aobj) == 1
+
+    assert isinstance(aobj[0], NotifyTelegram)
+
+    body = 'my message'
+
+    assert aobj.notify(body=body)
+
+    # 1 call to look up bot owner, and second for notification
+    assert mock_post.call_count == 2
+
+    payload = loads(mock_post.call_args_list[0][1]['data'])
+
+    assert 'message_thread_id' in payload
+    assert payload['message_thread_id'] == 1111
+
+    payload = loads(mock_post.call_args_list[1][1]['data'])
+
+    assert 'message_thread_id' in payload
+    assert payload['message_thread_id'] == 1234
+
+    mock_post.reset_mock()

--- a/test/test_plugin_telegram.py
+++ b/test/test_plugin_telegram.py
@@ -110,6 +110,11 @@ apprise_url_tests = (
     ('tgram://bottest@123456789:abcdefg_hijklmnop/id1/?content=invalid', {
         'instance': TypeError,
     }),
+    ('tgram://bottest@123456789:abcdefg_hijklmnop/id1:invalid/?thread=12345', {
+        'instance': NotifyTelegram,
+        # Notify will fail (bad target)
+        'response': False,
+    }),
     # Testing image
     ('tgram://123456789:abcdefg_hijklmnop/lead2gold/?image=Yes', {
         'instance': NotifyTelegram,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1143

This turned out to be a documented feature that simply did not work until this PR.  Provided Thread/Topic iD's on the Apprise URL were just ignored.

This PR fixes 2 key issues and adds `?thread=` to the telegram support too.

* You can provide threads by specifying `?topic=<id>` or `?thread=<id>` on the URL.   This sets up a default thrad for all detected targets thereaftr (if defined at all).
* You can also provide the topic/threads by adding them to each target (as originally documented) `<target>:<topic>` to just apply a topic to the specific target. 

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1143-discord-topic-defect

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  tgram://credentials?topic=valiue

```

