### PR TITLE
Fixed mattermost channel handling

### DIFF
--- a/apprise/plugins/mattermost.py
+++ b/apprise/plugins/mattermost.py
@@ -132,6 +132,9 @@ class NotifyMattermost(NotifyBase):
             'name': _('Channels'),
             'type': 'list:string',
         },
+        'channel': {
+            'alias_of': 'channels',
+        },
         'image': {
             'name': _('Include Image'),
             'type': 'bool',
@@ -357,16 +360,21 @@ class NotifyMattermost(NotifyBase):
         # Support both 'to' (for yaml configuration) and channel=
         if 'to' in results['qsd'] and len(results['qsd']['to']):
             # Allow the user to specify the channel to post to
-            results['channels'].append(
+            results['channels'].extend(
                 NotifyMattermost.parse_list(results['qsd']['to']))
 
         if 'channel' in results['qsd'] and len(results['qsd']['channel']):
             # Allow the user to specify the channel to post to
-            results['channels'].append(
+            results['channels'].extend(
                 NotifyMattermost.parse_list(results['qsd']['channel']))
 
+        if 'channels' in results['qsd'] and len(results['qsd']['channels']):
+            # Allow the user to specify the channel to post to
+            results['channels'].extend(
+                NotifyMattermost.parse_list(results['qsd']['channels']))
+
         # Image manipulation
-        results['include_image'] = \
-            parse_bool(results['qsd'].get('image', False))
+        results['include_image'] = parse_bool(results['qsd'].get(
+            'image', NotifyMattermost.template_args['image']['default']))
 
         return results

--- a/test/test_plugin_mattermost.py
+++ b/test/test_plugin_mattermost.py
@@ -27,8 +27,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import pytest
+import json
 import requests
-
+from apprise import Apprise
 from apprise.plugins.mattermost import NotifyMattermost
 from helpers import AppriseURLTester
 
@@ -55,6 +56,9 @@ apprise_url_tests = (
         'instance': NotifyMattermost,
     }),
     ('mmost://user@localhost/3ccdd113474722377935511fc85d3dd4?channel=test', {
+        'instance': NotifyMattermost,
+    }),
+    ('mmost://user@localhost/3ccdd113474722377935511fc85d3dd4?channels=test', {
         'instance': NotifyMattermost,
     }),
     ('mmost://user@localhost/3ccdd113474722377935511fc85d3dd4?to=test', {
@@ -117,6 +121,17 @@ apprise_url_tests = (
 )
 
 
+@pytest.fixture
+def request_mock(mocker):
+    """
+    Prepare requests mock.
+    """
+    mock_post = mocker.patch("requests.post")
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+    return mock_post
+
+
 def test_plugin_mattermost_urls():
     """
     NotifyMattermost() Apprise URLs
@@ -138,3 +153,44 @@ def test_plugin_mattermost_edge_cases():
         NotifyMattermost(None)
     with pytest.raises(TypeError):
         NotifyMattermost("     ")
+
+
+def test_plugin_mattermost_channels(request_mock):
+    """
+    NotifyMattermost() Channel Testing
+    """
+
+    # Test channels with/without hashtag (#)
+    user = 'user1'
+    token = 'token'
+    channels = ['#one', 'two']
+
+    # Instantiate our URL
+    obj = Apprise.instantiate(
+        'mmost://{user}@localhost:8065/{token}?channels={channels}'.format(
+            user=user,
+            token=token,
+            channels=','.join(channels)))
+
+    assert isinstance(obj, NotifyMattermost)
+    assert obj.notify(body="body", title='title') is True
+
+    assert request_mock.called is True
+    assert request_mock.call_count == 2
+    assert request_mock.call_args_list[0][0][0].startswith(
+        'http://localhost:8065/hooks/token')
+
+    # Our Posted JSON Object
+    posted_json = json.loads(request_mock.call_args_list[0][1]['data'])
+    assert 'username' in posted_json
+    assert 'channel' in posted_json
+    assert 'text' in posted_json
+    assert posted_json['username'] == 'user1'
+    assert posted_json['channel'] == 'one'
+    assert posted_json['text'] == 'title\r\nbody'
+
+    # Our second Posted JSON Object
+    posted_json = json.loads(request_mock.call_args_list[1][1]['data'])
+    assert posted_json['username'] == 'user1'
+    assert posted_json['channel'] == 'two'
+    assert posted_json['text'] == 'title\r\nbody'


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1019 

Channels are not properly handled when parsed from the Apprise URL (as documented)

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1019-mattermost-channels

# Test out the changes with the following command (as an example):
apprise -t "Test Title" -b "Test Message" \
 "mmost://localhost/token/?channels=general

```

