### PR TITLE
Escape unsupported Telegram MarkdownV2 characters

### DIFF
--- a/apprise/plugins/telegram.py
+++ b/apprise/plugins/telegram.py
@@ -368,7 +368,7 @@ class NotifyTelegram(NotifyBase):
             'name': _('Markdown Version'),
             'type': 'choice:string',
             'values': ('v1', 'v2'),
-            'default': 'v2',
+            'default': 'v1',
         },
         'to': {
             'alias_of': 'targets',

--- a/apprise/plugins/telegram.py
+++ b/apprise/plugins/telegram.py
@@ -765,6 +765,14 @@ class NotifyTelegram(NotifyBase):
         # Prepare Message Body
         if self.notify_format == NotifyFormat.MARKDOWN:
             _payload['parse_mode'] = self.markdown_ver
+
+            if self.markdown_ver == TelegramMarkdownVersion.TWO:
+                # Telegram Markdown v2 is not very accomodating to some
+                # characters such as the hashtag (#) which is fine in v1.
+                # To try and be accomodating we escape them in advance
+                # See: https://stackoverflow.com/a/69892704/355584
+                body = re.sub(r'(?<!\\)([_*[\]()~`>#+=|{}.!-])', r'\\\1', body)
+
             _payload['text'] = body
 
         else:  # HTML

--- a/apprise/plugins/telegram.py
+++ b/apprise/plugins/telegram.py
@@ -764,15 +764,17 @@ class NotifyTelegram(NotifyBase):
 
         # Prepare Message Body
         if self.notify_format == NotifyFormat.MARKDOWN:
-            _payload['parse_mode'] = self.markdown_ver
 
-            if self.markdown_ver == TelegramMarkdownVersion.TWO:
+            if body_format not in (None, NotifyFormat.MARKDOWN) \
+                    and self.markdown_ver == TelegramMarkdownVersion.TWO:
                 # Telegram Markdown v2 is not very accomodating to some
                 # characters such as the hashtag (#) which is fine in v1.
                 # To try and be accomodating we escape them in advance
                 # See: https://stackoverflow.com/a/69892704/355584
+                # Also: https://core.telegram.org/bots/api#markdownv2-style
                 body = re.sub(r'(?<!\\)([_*[\]()~`>#+=|{}.!-])', r'\\\1', body)
 
+            _payload['parse_mode'] = self.markdown_ver
             _payload['text'] = body
 
         else:  # HTML

--- a/test/test_plugin_telegram.py
+++ b/test/test_plugin_telegram.py
@@ -695,7 +695,38 @@ def test_plugin_telegram_formatting(mock_post):
            ' had [a change](http://127.0.0.1)'
 
     aobj = Apprise()
-    aobj.add('tgram://123456789:abcdefg_hijklmnop/?format=markdown')
+    aobj.add('tgram://123456789:abcdefg_hijklmnop/?format=markdown&mdv=2')
+    assert len(aobj) == 1
+
+    assert aobj.notify(
+        title=title, body=body, body_format=NotifyFormat.MARKDOWN)
+
+    # Test our calls
+    assert mock_post.call_count == 2
+
+    assert mock_post.call_args_list[0][0][0] == \
+        'https://api.telegram.org/bot123456789:abcdefg_hijklmnop/getUpdates'
+    assert mock_post.call_args_list[1][0][0] == \
+        'https://api.telegram.org/bot123456789:abcdefg_hijklmnop/sendMessage'
+
+    payload = loads(mock_post.call_args_list[1][1]['data'])
+
+    # Test that everything is escaped properly in a HTML mode
+    assert payload['text'] == \
+        '\\# 🚨 Change detected for \\_Apprise Test Title\\_\r\n' \
+        '\\_\\[Apprise Body Title\\]\\(http://localhost\\)\\_ had ' \
+        '\\[a change\\]\\(http://127\\.0\\.0\\.1\\)'
+
+    # Reset our values
+    mock_post.reset_mock()
+
+    # Now test our MARKDOWN Handling
+    title = '# 🚨 Change detected for _Apprise Test Title_'
+    body = '_[Apprise Body Title](http://localhost)_' \
+           ' had [a change](http://127.0.0.1)'
+
+    aobj = Apprise()
+    aobj.add('tgram://123456789:abcdefg_hijklmnop/?format=markdown&mdv=1')
     assert len(aobj) == 1
 
     assert aobj.notify(


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1178 

Telegram characters that are otherwise unsupported by `MarkdownV2` are now automatically escapped in Apprise.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1178-telegram-md2-friendly

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" "tgram://credentials?format=markdown&mdv=2"

```

