### PR TITLE
mqtt:// support for publishing retain flag

### DIFF
--- a/test/test_plugin_mqtt.py
+++ b/test/test_plugin_mqtt.py
@@ -320,6 +320,24 @@ def test_plugin_mqtt_session_client_id_success(mqtt_client_mock):
     assert re.search(r'my/topic', obj.url())
     assert re.search(r'client_id=apprise', obj.url())
     assert re.search(r'session=yes', obj.url())
+    assert re.search(r'retain=no', obj.url())
+    assert obj.notify(body="test=test") is True
+
+
+def test_plugin_mqtt_retain(mqtt_client_mock):
+    """
+    Verify handling of Retain Message Flag
+    """
+
+    obj = apprise.Apprise.instantiate(
+        'mqtt://user@localhost/my/topic?retain=yes',
+        suppress_exceptions=False)
+
+    assert isinstance(obj, NotifyMQTT)
+    assert obj.url().startswith('mqtt://user@localhost')
+    assert re.search(r'my/topic', obj.url())
+    assert re.search(r'session=no', obj.url())
+    assert re.search(r'retain=yes', obj.url())
     assert obj.notify(body="test=test") is True
 
 


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #799

`mqtt://` URL now supports `retain=yes` as a kwarg parameter supported.  It defaults to no to avoid obstructing previous behavior

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@799-mqtt-retain-flag

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" "mqtt://host/topic/?retain=yes"

```

