### PR TITLE
[fix] allow body or title to be non str (int or float)

### DIFF
--- a/apprise/plugins/base.py
+++ b/apprise/plugins/base.py
@@ -548,8 +548,8 @@ class NotifyBase(URLBase):
         response = list()
 
         # tidy
-        title = '' if not title else title.strip()
-        body = '' if not body else body.rstrip()
+        title = '' if not title else str(title).strip()
+        body = '' if not body else str(body).rstrip()
 
         if overflow is None:
             # default


### PR DESCRIPTION
When body and/or title are (int, float), prevent something like below by converting them to str:

```python
.local/lib/python3.10/site-packages/apprise/plugins/base.py", line 522, in _apply_overflow
    body = '' if not body else body.rstrip()
AttributeError: 'float' object has no attribute 'rstrip'
```

## Description:
**Related issue (if applicable):** #<!--apprise issue number goes here-->

<!-- Have anything else to describe? Define it here -->

## New Service Completion Status
<!-- This section is only applicable if you're adding a new service -->
* [ ] apprise/plugins/<!--new plugin name -->.py
* [ ] KEYWORDS
    - add new service into this file (alphabetically).
* [ ] README.md
    - add entry for new service to table (as a quick reference)
* [ ] packaging/redhat/python-apprise.spec
    - add new service into the `%global common_description`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

Tested locally but no tests added. Feel free to edit or close this pr if not desired.

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@<this.branch-name>

# Test out the changes with the following commands:
apprise -t "Test Title" -b "Test Message" \
  <apprise url related to ticket>
```
To reproduce use something like this:
```python
apb = apprise.Apprise()
config = apprise.AppriseConfig()

config_path = f"/home/{current_user}/.config/apprise"
if path.exists(config_path):
    config.add(config_path)
    apb.add(config)

apb.notify(body=3, title="description...")
