### PR TITLE
Added SendPulse Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The table below identifies the services this tool supports and some example serv
 | [RSyslog](https://github.com/caronc/apprise/wiki/Notify_rsyslog) | rsyslog://  | (UDP) 514 | rsyslog://hostname<br />rsyslog://hostname/Facility
 | [Ryver](https://github.com/caronc/apprise/wiki/Notify_ryver) | ryver://  | (TCP) 443   | ryver://Organization/Token<br />ryver://botname@Organization/Token
 | [SendGrid](https://github.com/caronc/apprise/wiki/Notify_sendgrid) | sendgrid://  | (TCP) 443   | sendgrid://APIToken:FromEmail/<br />sendgrid://APIToken:FromEmail/ToEmail<br />sendgrid://APIToken:FromEmail/ToEmail1/ToEmail2/ToEmailN/
+| [SendPulse](https://github.com/caronc/apprise/wiki/Notify_sendpulse) | sendpulse://  | (TCP) 443   | sendpulse://user@host/ClientId/ClientSecret<br />sendpulse://user@host/ClientId/clientSecret/ToEmail<br />sendpulse://user@host/ClientId/ClientSecret/ToEmail1/ToEmail2/ToEmailN/
 | [ServerChan](https://github.com/caronc/apprise/wiki/Notify_serverchan) | schan://   | (TCP) 443    | schan://sendkey/
 | [Signal API](https://github.com/caronc/apprise/wiki/Notify_signal) | signal://  or signals:// | (TCP) 80 or 443  | signal://hostname:port/FromPhoneNo<br/>signal://hostname:port/FromPhoneNo/ToPhoneNo<br/>signal://hostname:port/FromPhoneNo/ToPhoneNo1/ToPhoneNo2/ToPhoneNoN/
 | [SIGNL4](https://github.com/caronc/apprise/wiki/Notify_signl4) | signl4://  | (TCP) 80 or 443  | signl4://hostname

--- a/apprise/plugins/sendpulse.py
+++ b/apprise/plugins/sendpulse.py
@@ -1,0 +1,627 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2024, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Simple API Reference:
+#  - https://sendpulse.com/integrations/api/smtp
+
+import base64
+from email.utils import formataddr
+from json import dumps
+
+import requests
+
+from .. import exception
+from ..common import NotifyFormat, NotifyType
+from ..conversion import convert_between
+from ..locale import gettext_lazy as _
+from ..utils.parse import is_email, parse_emails, parse_list, validate_regex
+from .base import NotifyBase
+
+
+class NotifySendPulse(NotifyBase):
+    """
+    A wrapper for Notify SendPulse Notifications
+    """
+
+    # The default descriptive name associated with the Notification
+    service_name = "SendPulse"
+
+    # The services URL
+    service_url = "https://sendpulse.com"
+
+    # The default secure protocol
+    secure_protocol = "sendpulse"
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = "https://github.com/caronc/apprise/wiki/Notify_sendpulse"
+
+    # Default to markdown
+    notify_format = NotifyFormat.HTML
+
+    # The default Email API URL to use
+    notify_email_url = "https://api.sendpulse.com/smtp/emails"
+
+    # Support attachments
+    attachment_support = True
+
+    # Allow 300 requests per minute.
+    # 60/300 = 0.2
+    request_rate_per_sec = 0.2
+
+    # Support attachments
+    attachment_support = True
+
+    # The default subject to use if one isn't specified.
+    default_empty_subject = "<no subject>"
+
+    # Define object templates
+    templates = (
+        "{schema}://{from_email}/{client_id}/{client_secret}/",
+        "{schema}://{from_email}/{client_id}/{client_secret}/{targets}",
+    )
+
+    # Define our template arguments
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        "from_email": {
+            "name": _("Source Email"),
+            "type": "string",
+            "required": True,
+        },
+        "client_id": {
+            "name": _("Client ID"),
+            "type": "string",
+            "required": True,
+            "private": True,
+            "regex": (r"^[A-Z0-9._-]+$", "i"),
+        },
+        "client_secret": {
+            "name": _("Client Secret"),
+            "type": "string",
+            "required": True,
+            "private": True,
+            "regex": (r"^[A-Z0-9._-]+$", "i"),
+        },
+        "target_email": {
+            "name": _("Target Email"),
+            "type": "string",
+            "map_to": "targets",
+        },
+        "targets": {
+            "name": _("Targets"),
+            "type": "list:string",
+        },
+    })
+
+    # Define our template arguments
+    template_args = dict(NotifyBase.template_args, **{
+        "to": {
+            "alias_of": "targets",
+        },
+        "from": {
+            "name": _("From Email"),
+            "type": "string",
+            "map_to": "from_email",
+        },
+        "cc": {
+            "name": _("Carbon Copy"),
+            "type": "list:string",
+        },
+        "bcc": {
+            "name": _("Blind Carbon Copy"),
+            "type": "list:string",
+        },
+        "template": {
+            # The template ID is an integer
+            "name": _("Template ID"),
+            "type": "int",
+        },
+        "id": {
+            "alias_of": "client_id",
+        },
+        "secret": {
+            "alias_of": "client_secret",
+        }
+    })
+
+    # Support Template Dynamic Variables (Substitutions)
+    template_kwargs = {
+        "template_data": {
+            "name": _("Template Data"),
+            "prefix": "+",
+        },
+    }
+
+    def __init__(self, from_email, client_id, client_secret, targets=None,
+                 cc=None, bcc=None, template=None,
+                 template_data=None, **kwargs):
+        """
+        Initialize Notify SendPulse Object
+        """
+        super().__init__(**kwargs)
+
+        # Client ID
+        self.client_id = validate_regex(
+            client_id, *self.template_tokens["client_id"]["regex"])
+        if not self.client_id:
+            msg = "An invalid SendPulse Client ID " \
+                  "({}) was specified.".format(client_id)
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # Client Secret
+        self.client_secret = validate_regex(
+            client_secret, *self.template_tokens["client_secret"]["regex"])
+        if not self.client_secret:
+            msg = "An invalid SendPulse Client Secret " \
+                  "({}) was specified.".format(client_secret)
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        result = is_email(from_email)
+        if not result:
+            msg = "Invalid ~From~ email specified: {}".format(from_email)
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # Tracks emails to name lookups (if they exist)
+        self.__email_map = {}
+
+        # Store from email address
+        self.from_email = result["full_email"]
+        self.__email_map[self.from_email] = result["name"] \
+            if result["name"] else self.app_id
+
+        # Acquire Targets (To Emails)
+        self.targets = []
+
+        # Acquire Carbon Copies
+        self.cc = set()
+
+        # Acquire Blind Carbon Copies
+        self.bcc = set()
+
+        if template:
+            try:
+                # Store our template
+                self.template = int(template)
+
+            except (TypeError, ValueError):
+                # Not a valid integer; ignore entry
+                err = "The SendPulse Template ID specified ({}) is invalid."\
+                    .format(template)
+                self.logger.warning(err)
+                raise TypeError(err) from None
+
+        # Now our dynamic template data (if defined)
+        self.template_data = template_data \
+            if isinstance(template_data, dict) else {}
+
+        if targets:
+            # Validate recipients (to:) and drop bad ones:
+            for recipient in parse_emails(targets):
+                result = is_email(recipient)
+                if result:
+                    self.targets.append(
+                        (result["name"] if result["name"] else False,
+                            result["full_email"]))
+                    continue
+
+                self.logger.warning(
+                    "Dropped invalid To email "
+                    "({}) specified.".format(recipient),
+                )
+
+        else:
+            # If our target email list is empty we want to add ourselves to it
+            self.targets.append(self.from_email)
+
+        # Validate recipients (cc:) and drop bad ones:
+        for recipient in parse_list(cc):
+
+            result = is_email(recipient)
+            if result:
+                self.cc.add(result["full_email"])
+                if result["name"]:
+                    self.__email_lookup[result["full_email"]] = result["name"]
+                continue
+
+            self.logger.warning(
+                "Dropped invalid Carbon Copy email "
+                "({}) specified.".format(recipient),
+            )
+
+        # Validate recipients (bcc:) and drop bad ones:
+        for recipient in parse_list(bcc):
+
+            result = is_email(recipient)
+            if result:
+                self.bcc.add(result["full_email"])
+                if result["name"]:
+                    self.__email_lookup[result["full_email"]] = result["name"]
+                continue
+
+            self.logger.warning(
+                "Dropped invalid Blind Carbon Copy email "
+                "({}) specified.".format(recipient),
+            )
+
+        if len(self.targets) == 0:
+            # Notify ourselves
+            self.targets.append(self.from_email)
+
+        return
+
+    @property
+    def url_identifier(self):
+        """
+        Returns all of the identifiers that make this URL unique from
+        another simliar one. Targets or end points should never be identified
+        here.
+        """
+        return (self.secure_protocol, self.client_id, self.client_secret)
+
+    def url(self, privacy=False, *args, **kwargs):
+        """
+        Returns the URL built dynamically based on specified arguments.
+        """
+
+        # Our URL parameters
+        params = self.url_parameters(privacy=privacy, *args, **kwargs)
+
+        if len(self.cc) > 0:
+            # Handle our Carbon Copy Addresses
+            params["cc"] = ",".join([
+                formataddr(
+                    (self.__email_lookup.get(e, False), e),
+                    # Swap comma for it's escaped url code (if detected) since
+                    # we're using that as a delimiter
+                    charset="utf-8").replace(",", "%2C")
+                for e in self.cc])
+
+        if len(self.bcc) > 0:
+            # Handle our Blind Carbon Copy Addresses
+            params["bcc"] = ",".join([
+                formataddr(
+                    (self.__email_lookup.get(e, False), e),
+                    # Swap comma for it's escaped url code (if detected) since
+                    # we're using that as a delimiter
+                    charset="utf-8").replace(",", "%2C")
+                for e in self.bcc])
+
+        if self.template:
+            # Handle our Template ID if if was specified
+            params["template"] = self.template
+
+        # Append our template_data into our parameter list
+        params.update(
+            {"+{}".format(k): v for k, v in self.template_data.items()})
+
+        # a simple boolean check as to whether we display our target emails
+        # or not
+        has_targets = \
+            not (len(self.targets) == 1 and self.targets[0] == self.from_email)
+
+        return "{schema}://{source}/{cid}/{secret}/{targets}?{params}".format(
+            schema=self.secure_protocol,
+            source=self.from_email,
+            cid=self.pprint(self.client_id, privacy, safe=""),
+            secret=self.pprint(self.client_secret, privacy, safe=""),
+            targets="" if not has_targets else "/".join(
+                [NotifySendPulse.quote(x, safe="") for x in self.targets]),
+            params=NotifySendPulse.urlencode(params),
+        )
+
+    def __len__(self):
+        """
+        Returns the number of targets associated with this notification
+        """
+        return len(self.targets)
+
+    def send(self, body, title="", notify_type=NotifyType.INFO, attach=None,
+             **kwargs):
+        """
+        Perform SendPulse Notification
+        """
+
+        headers = {
+            "User-Agent": self.app_id,
+            "Content-Type": "application/json",
+            "Authorization": "Bearer {}".format(self.apikey),
+        }
+
+        # error tracking (used for function return)
+        has_error = False
+
+        # A Simple Email Payload Template
+        _payload = {
+            "email": {
+                "from": {
+                    "name": self.from_email[0],
+                    "email": self.from_email[1],
+                },
+                # To is populated further on
+                "to": [],
+                # A subject is a requirement, so if none is specified we must
+                # set a default with at least 1 character or SendPulse will
+                # deny our request
+                "subject": title if title else self.default_empty_subject,
+            }
+        }
+
+        # Prepare Email Message
+        if self.notify_format == NotifyFormat.HTML:
+            # HTML
+            _payload["email"].update({
+                "text": convert_between(
+                    NotifyFormat.HTML, NotifyFormat.TEXT, body),
+                "html": base64.b64encode(body.encode("utf-8")).decode("ascii"),
+            })
+
+        else:  # Text
+            _payload["email"]["text"] = body
+
+        if attach and self.attachment_support:
+            attachments = {}
+
+            # Send our attachments
+            for no, attachment in enumerate(attach, start=1):
+                # Perform some simple error checking
+                if not attachment:
+                    # We could not access the attachment
+                    self.logger.error(
+                        "Could not access SendPulse attachment {}.".format(
+                            attachment.url(privacy=True)))
+                    return False
+
+                try:
+                    attachments[
+                        attachment.name if attachment.name
+                        else f"file{no:03}.dat"] = attachment.base64()
+
+                except exception.AppriseException:
+                    # We could not access the attachment
+                    self.logger.error(
+                        "Could not access SendPulse attachment {}.".format(
+                            attachment.url(privacy=True)))
+                    return False
+
+                self.logger.debug(
+                    "Appending SendPulse attachment {}".format(
+                        attachment.url(privacy=True)))
+
+            # Append our attachments to the payload
+            _payload["email"].update({
+                "attachments_binary": attachments,
+            })
+
+        if self.template:
+            _payload["email"].update({
+                "template": {
+                    "id": self.template,
+                    "variables": self.template_data,
+                }})
+
+        targets = list(self.targets)
+        while len(targets) > 0:
+            target = targets.pop(0)
+
+            # Create a copy of our template
+            payload = _payload.copy()
+
+            # the cc, bcc, to field must be unique or SendMail will fail, the
+            # below code prepares this by ensuring the target isn't in the cc
+            # list or bcc list. It also makes sure the cc list does not contain
+            # any of the bcc entries
+            cc = (self.cc - self.bcc - {target})
+            bcc = (self.bcc - {target})
+
+            #
+            # prepare our 'to'
+            #
+            to = {
+                "email": target
+            }
+            if target in self.__email_lookup:
+                to["name"] = self.__email_lookup[target]
+
+            # Set our target
+            payload["email"]["to"] = [to]
+
+            if len(cc):
+                payload["email"]["cc"] = []
+                for email in cc:
+                    item = {
+                        "email": email,
+                    }
+                if email in self.__email_lookup:
+                    item["name"] = self.__email_lookup[email]
+
+                payload["email"]["cc"].append(item)
+
+            if len(bcc):
+                payload["email"]["bcc"] = []
+                for email in bcc:
+                    item = {
+                        "email": email,
+                    }
+                if email in self.__email_lookup:
+                    item["name"] = self.__email_lookup[email]
+
+                payload["email"]["bcc"].append(item)
+
+            self.logger.debug("SendPulse POST URL: %s (cert_verify=%r)",
+                self.notify_email_url, self.verify_certificate,
+            )
+            self.logger.debug("SendPulse Payload: %s",  str(payload))
+
+            # Always call throttle before any remote server i/o is made
+            self.throttle()
+            try:
+                r = requests.post(
+                    self.notify_email_url,
+                    data=dumps(payload),
+                    headers=headers,
+                    verify=self.verify_certificate,
+                    timeout=self.request_timeout,
+                )
+                if r.status_code not in (
+                        requests.codes.ok, requests.codes.accepted):
+                    # We had a problem
+                    status_str = \
+                        NotifySendPulse.http_response_code_lookup(
+                            r.status_code)
+
+                    self.logger.warning(
+                        "Failed to send SendPulse notification to {}: "
+                        "{}{}error={}.".format(
+                            target,
+                            status_str,
+                            ", " if status_str else "",
+                            r.status_code))
+
+                    self.logger.debug(
+                        "Response Details:\r\n{}".format(r.content))
+
+                    # Mark our failure
+                    has_error = True
+                    continue
+
+                else:
+                    self.logger.info(
+                        "Sent SendPulse notification to {}.".format(target))
+
+            except requests.RequestException as e:
+                self.logger.warning(
+                    "A Connection error occurred sending SendPulse "
+                    "notification to {}.".format(target))
+                self.logger.debug("Socket Exception: %s", str(e))
+
+                # Mark our failure
+                has_error = True
+                continue
+
+        return not has_error
+
+    @staticmethod
+    def parse_url(url):
+        """
+        Parses the URL and returns enough arguments that can allow
+        us to re-instantiate this object.
+
+        """
+
+        results = NotifyBase.parse_url(url)
+        if not results:
+            # We're done early as we couldn't load the results
+            return results
+
+        # Our URL looks like this:
+        #    {schema}://{from_email}:{client_id}/{client_secret}/{targets}
+        #
+        # which actually equates to:
+        #    {schema}://{user}@{host}/{client_id}/{client_secret}
+        #                                  /{email1}/{email2}/etc..
+        #                 ^       ^
+        #                 |       |
+        #                -from addr-
+
+        # Get our potential email targets
+        # First 2 elements are the client_id and client_secret
+        results["targets"] = NotifySendPulse.split_path(results["fullpath"])
+        # check for our client id
+        if "id" in results["qsd"] and len(results["qsd"]["id"]):
+            # Store our Client ID
+            results["client_id"] = \
+                NotifySendPulse.unquote(results["qsd"]["id"])
+
+        elif results["targets"]:
+            # Store our Client ID
+            results["client_id"] = results["targets"].pop(0)
+
+        else:  # Not defined
+            results["client_id"] = None
+
+        if "secret" in results["qsd"] and len(results["qsd"]["secret"]):
+            # Store our Client Secret
+            results["client_secret"] = \
+                NotifySendPulse.unquote(results["qsd"]["secret"])
+
+        elif results["targets"]:
+            # Store our Client Secret
+            results["client_secret"] = results["targets"].pop(0)
+
+        else:  # Not defined
+            results["client_secret"] = None
+
+        if "from" in results["qsd"] and len(results["qsd"]["from"]):
+            results["from_email"] = \
+                NotifySendPulse.unquote(results["qsd"]["from_email"])
+
+            # This means any user@host is the To Address if defined
+            if results.get("user") and results.get("host"):
+                results["targets"] += "{}@{}".format(
+                    NotifySendPulse.unquote(
+                        results["password"]
+                        if results["password"] else results["user"]),
+                    NotifySendPulse.unquote(results["host"]),
+                )
+
+        elif results.get("user") and results.get("host"):
+            results["from_email"] = "{}@{}".format(
+                NotifySendPulse.unquote(
+                    results["password"]
+                    if results["password"] else results["user"]),
+                NotifySendPulse.unquote(results["host"]),
+            )
+
+        else:  # Not defined
+            results["from_email"] = None
+
+        # The 'to' makes it easier to use yaml configuration
+        if "to" in results["qsd"] and len(results["qsd"]["to"]):
+            results["targets"] += \
+                NotifySendPulse.parse_list(results["qsd"]["to"])
+
+        # Handle Carbon Copy Addresses
+        if "cc" in results["qsd"] and len(results["qsd"]["cc"]):
+            results["cc"] = \
+                NotifySendPulse.parse_list(results["qsd"]["cc"])
+
+        # Handle Blind Carbon Copy Addresses
+        if "bcc" in results["qsd"] and len(results["qsd"]["bcc"]):
+            results["bcc"] = \
+                NotifySendPulse.parse_list(results["qsd"]["bcc"])
+
+        # Handle Blind Carbon Copy Addresses
+        if "template" in results["qsd"] and len(results["qsd"]["template"]):
+            results["template"] = \
+                NotifySendPulse.unquote(results["qsd"]["template"])
+
+        # Add any template substitutions
+        results["template_data"] = results["qsd+"]
+
+        return results

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -69,8 +69,8 @@ notification services. It supports sending alerts to platforms such as: \
 `ParsePlatform`, `Plivo`, `PopcornNotify`, `Prowl`, `Pushalot`, \
 `PushBullet`, `Pushjet`, `PushMe`, `Pushover`, `Pushplus`, `PushSafer`, \
 `Pushy`, `PushDeer`, `QQ Push`, `Revolt`, `Reddit`, `Resend`, `Rocket.Chat`, \
-`RSyslog`, `SendGrid`, `ServerChan`, `Seven`, `SFR`, `Signal`, `SIGNL4`, \
-`SimplePush`, `Sinch`, `Slack`, `SMPP`, `SMSEagle`, `SMS Manager`, \
+`RSyslog`, `SendGrid`, `SendPulse`, `ServerChan`, `Seven`, `SFR`, `Signal`, \
+`SIGNL4`, `SimplePush`, `Sinch`, `Slack`, `SMPP`, `SMSEagle`, `SMS Manager`, \
 `SMTP2Go`, `SparkPost`, `Splunk`, `Spike`, `Spug Push`, `Super Toasty`, \
 `Streamlabs`, `Stride`, `Synology Chat`, `Syslog`, `Techulus Push`, \
 `Telegram`, `Threema Gateway`, `Twilio`, `Twitter`, `Twist`, `Vapid`, \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ keywords = [
     "RSyslog",
     "Ryver",
     "SendGrid",
+    "SendPulse",
     "ServerChan",
     "SES",
     "Seven",

--- a/tests/test_apprise_utils.py
+++ b/tests/test_apprise_utils.py
@@ -2028,6 +2028,9 @@ def test_parse_emails():
     assert len(results) == len(emails)
     for email in emails:
         assert email in results
+        is_email = utils.parse.is_email(email)
+        assert is_email
+        assert is_email.get('name')
 
     # pass the entries in as a list
     results = utils.parse.parse_emails(emails)
@@ -2115,7 +2118,8 @@ def test_parse_urls():
     # Commas and spaces found inside URLs are ignored
     urls = [
         (
-            "mailgun://noreply@sandbox.mailgun.org/apikey/?to=test@example.com,test2@example.com,,"
+            "mailgun://noreply@sandbox.mailgun.org/apikey/"
+            "?to=test@example.com,test2@example.com,,"
             " abcd@example.com"
         ),
         (
@@ -3029,7 +3033,8 @@ def test_cwe312_url():
 
     assert (
         utils.cwe312.cwe312_url(
-            "slack://mybot@xoxb-43598234231-3248932482278-BZK5Wj15B9mPh1RkShJoCZ44"
+            "slack://mybot@xoxb-43598234231-3248932482278"
+            "-BZK5Wj15B9mPh1RkShJoCZ44"
             "/lead2gold@gmail.com"
         )
         == "slack://mybot@x...4/l...m"

--- a/tests/test_apprise_utils.py
+++ b/tests/test_apprise_utils.py
@@ -2030,7 +2030,7 @@ def test_parse_emails():
         assert email in results
         is_email = utils.parse.is_email(email)
         assert is_email
-        assert is_email.get('name')
+        assert is_email.get("name")
 
     # pass the entries in as a list
     results = utils.parse.parse_emails(emails)

--- a/tests/test_plugin_sendpulse.py
+++ b/tests/test_plugin_sendpulse.py
@@ -1,7 +1,7 @@
 # BSD 2-Clause License
 #
 # Apprise - Push Notification Library.
-# Copyright (c) 2024, Chris Caron <lead2gold@gmail.com>
+# Copyright (c) 2025, Chris Caron <lead2gold@gmail.com>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -25,6 +25,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from json import dumps, loads
+
 # Disable logging for a cleaner testing output
 import logging
 import os
@@ -39,73 +41,215 @@ from apprise.plugins.sendpulse import NotifySendPulse
 
 logging.disable(logging.CRITICAL)
 
+SENDPULSE_GOOD_RESPONSE = dumps({
+    "access_token": "abc123",
+    "expires_in": 3600,
+})
+
+SENDPULSE_BAD_RESPONSE = "{"
+
 # Attachment Directory
 TEST_VAR_DIR = os.path.join(os.path.dirname(__file__), "var")
 
 # Our Testing URLs
 apprise_url_tests = (
     ("sendpulse://", {
-        "instance": None,
+        "instance": TypeError,
     }),
     ("sendpulse://:@/", {
-        "instance": None,
+        "instance": TypeError,
     }),
     ("sendpulse://abcd", {
-        # Just an broken email (no email, client_id or secret)
-        "instance": None,
+        # invalid from email
+        "instance": TypeError,
     }),
-    ("sendpulse://abcd@host", {
+    ("sendpulse://abcd@host.com", {
         # Just an Email specified, no client_id or client_secret
-        "instance": None,
+        "instance": TypeError,
     }),
-    ("sendpulse://user@example.com/client_id/client_secret/", {
+    ("sendpulse://user@example.com/client_id/cs/?template=invalid", {
+        # Invalid template
+        "instance": TypeError,
+    }),
+    ("sendpulse://user@example.com/client_id/cs1/?template=123", {
         "instance": NotifySendPulse,
+        "requests_response_text": SENDPULSE_GOOD_RESPONSE,
     }),
-    ("sendpulse://user@example.com/client_id/client_secret/"
+    ("sendpulse://user@example.com/client_id/cs1/", {
+        "instance": NotifySendPulse,
+        "requests_response_text": SENDPULSE_GOOD_RESPONSE,
+    }),
+    ("sendpulse://user@example.com/client_id/cs1/?format=text", {
+        "instance": NotifySendPulse,
+        "requests_response_text": SENDPULSE_GOOD_RESPONSE,
+    }),
+    ("sendpulse://user@example.com/client_id/cs1/?format=html", {
+        "instance": NotifySendPulse,
+        "requests_response_text": SENDPULSE_GOOD_RESPONSE,
+    }),
+    ("sendpulse://chris@example.com/client_id/cs1/?from=Chris", {
+        # Set name only
+        "instance": NotifySendPulse,
+        "requests_response_text": SENDPULSE_GOOD_RESPONSE,
+    }),
+    ("sendpulse://?id=ci&secret=cs&user=chris@example.com", {
+        # Set login through user= only
+        "instance": NotifySendPulse,
+        "requests_response_text": SENDPULSE_GOOD_RESPONSE,
+    }),
+    ("sendpulse://?id=ci&secret=cs&user=Chris<chris@example.com>", {
+        # Set login through user= only
+        "instance": NotifySendPulse,
+        "requests_response_text": SENDPULSE_GOOD_RESPONSE,
+    }),
+    ("sendpulse://?id=ci&secret=cs&user=chris", {
+        # Set login through user= only - invaild email
+        "instance": TypeError,
+    }),
+    ("sendpulse://example.com/client_id/cs1/?user=chris", {
+        # Set user as a name only
+        "instance": NotifySendPulse,
+        "requests_response_text": SENDPULSE_GOOD_RESPONSE,
+    }),
+    ("sendpulse://client_id/cs1/?user=chris@example.ca", {
+        # Set user as email
+        "instance": NotifySendPulse,
+        "requests_response_text": SENDPULSE_GOOD_RESPONSE,
+    }),
+    ("sendpulse://client_id/cs1/?from=Chris<chris@example.com>", {
+        # set full email with name
+        "instance": NotifySendPulse,
+        "requests_response_text": SENDPULSE_GOOD_RESPONSE,
+    }),
+    ("sendpulse://?from=Chris<chris@example.com>&id=ci&secret=cs", {
+        # leverage all get params from URL
+        "instance": NotifySendPulse,
+        "requests_response_text": SENDPULSE_GOOD_RESPONSE,
+    }),
+    ("sendpulse://user@example.com/client_id/cs1a/", {
+        "instance": NotifySendPulse,
+        "requests_response_text": SENDPULSE_BAD_RESPONSE,
+        # Notify will fail because auth failed
+        "response": False,
+    }),
+    ("sendpulse://user@example.com/client_id/cs2/"
      "?bcc=l2g@nuxref.com", {
          # A good email with Blind Carbon Copy
          "instance": NotifySendPulse,
+         "requests_response_text": SENDPULSE_GOOD_RESPONSE,
      }),
-    ("sendpulse://user@example.com/client_id/client_secret/"
+    ("sendpulse://user@example.com/client_id/cs2/"
+     "?bcc=invalid", {
+         # A good email with Blind Carbon Copy
+         "instance": NotifySendPulse,
+         "requests_response_text": SENDPULSE_GOOD_RESPONSE,
+     }),
+    ("sendpulse://user@example.com/client_id/cs3/"
      "?cc=l2g@nuxref.com", {
          # A good email with Carbon Copy
          "instance": NotifySendPulse,
+         "requests_response_text": SENDPULSE_GOOD_RESPONSE,
      }),
-    ("sendpulse://user@example.com/client_id/client_secret/"
-     "?to=l2g@nuxref.com", {
+    ("sendpulse://user@example.com/client_id/cs4/"
+     "?cc=Chris<l2g@nuxref.com>", {
          # A good email with Carbon Copy
          "instance": NotifySendPulse,
+         "requests_response_text": SENDPULSE_GOOD_RESPONSE,
      }),
-    ("sendpulse://user@example.com/client_id/client_secret/"
-     "?template=1234", {
-         # A good email with a template + no substitutions
+    ("sendpulse://user@example.com/client_id/cs5/"
+     "?cc=invalid", {
+         # A good email with Carbon Copy
          "instance": NotifySendPulse,
+         "requests_response_text": SENDPULSE_GOOD_RESPONSE,
      }),
-    ("sendpulse://user@example.com/client_id/client_secret/"
+    ("sendpulse://user@example.com/client_id/cs6/"
+     "?to=invalid", {
+         # an invalid to email
+         "instance": NotifySendPulse,
+         "requests_response_text": SENDPULSE_GOOD_RESPONSE,
+     }),
+    ("sendpulse://user@example.com/client_id/cs7/chris@example.com", {
+        # An email with a designated to email
+        "instance": NotifySendPulse,
+        "requests_response_text": SENDPULSE_GOOD_RESPONSE,
+    }),
+    ("sendpulse://user@example.com/client_id/cs8/"
+     "?to=Chris<chris@example.com>", {
+         # An email with a full name in in To field
+         "instance": NotifySendPulse,
+         "requests_response_text": SENDPULSE_GOOD_RESPONSE,
+     }),
+    ("sendpulse://user@example.com/client_id/cs9/"
+     "chris@example.com/chris2@example.com/Test<test@test.com>", {
+         # Several emails to notify
+         "instance": NotifySendPulse,
+         "requests_response_text": SENDPULSE_GOOD_RESPONSE,
+     }),
+    ("sendpulse://user@example.com/client_id/cs10/"
+     "?cc=Chris<chris@example.com>", {
+         # An email with a full name in cc
+         "instance": NotifySendPulse,
+         "requests_response_text": SENDPULSE_GOOD_RESPONSE,
+     }),
+    ("sendpulse://user@example.com/client_id/cs11/"
+     "?cc=chris@example.com", {
+         # An email with a full name in cc
+         "instance": NotifySendPulse,
+         "requests_response_text": SENDPULSE_GOOD_RESPONSE,
+     }),
+    ("sendpulse://user@example.com/client_id/cs12/"
+     "?bcc=Chris<chris@example.com>", {
+         # An email with a full name in bcc
+         "instance": NotifySendPulse,
+         "requests_response_text": SENDPULSE_GOOD_RESPONSE,
+     }),
+    ("sendpulse://user@example.com/client_id/cs13/"
+     "?bcc=chris@example.com", {
+         # An email with a full name in bcc
+         "instance": NotifySendPulse,
+         "requests_response_text": SENDPULSE_GOOD_RESPONSE,
+     }),
+    ("sendpulse://user@example.com/client_id/cs14/"
+     "?to=Chris<chris@example.com>", {
+         # An email with a full name in bcc
+         "instance": NotifySendPulse,
+         "requests_response_text": SENDPULSE_GOOD_RESPONSE,
+     }),
+    ("sendpulse://user@example.com/client_id/cs15/"
+     "?to=chris@example.com", {
+         # An email with a full name in bcc
+         "instance": NotifySendPulse,
+         "requests_response_text": SENDPULSE_GOOD_RESPONSE,
+     }),
+    ("sendpulse://user@example.com/client_id/cs16/"
      "?template=1234&+sub=value&+sub2=value2", {
          # A good email with a template + substitutions
          "instance": NotifySendPulse,
+         "requests_response_text": SENDPULSE_GOOD_RESPONSE,
 
          # Our expected url(privacy=True) startswith() response:
-         "privacy_url": "sendpulse://a...d:user@example.com/",
+         "privacy_url": "sendpulse://user@example.com/c...d/c...6/",
      }),
-    ("sendpulse://user@example.com/client_id/client_secret/", {
+    ("sendpulse://user@example.com/client_id/cs17/", {
         "instance": NotifySendPulse,
         # force a failure
         "response": False,
         "requests_response_code": requests.codes.internal_server_error,
+        "requests_response_text": SENDPULSE_GOOD_RESPONSE,
     }),
-    ("sendpulse://user@example.com/client_id/client_secret/", {
+    ("sendpulse://user@example.com/client_id/cs18/", {
         "instance": NotifySendPulse,
         # throw a bizzare code forcing us to fail to look it up
         "response": False,
         "requests_response_code": 999,
+        "requests_response_text": SENDPULSE_GOOD_RESPONSE,
     }),
-    ("sendpulse://user@example.com/client_id/client_secret/", {
+    ("sendpulse://user@example.com/client_id/cs19/", {
         "instance": NotifySendPulse,
         # Throws a series of connection and transfer exceptions when this flag
         # is set and tests that we gracfully handle them
         "test_requests_exceptions": True,
+        "requests_response_text": SENDPULSE_GOOD_RESPONSE,
     }),
 )
 
@@ -120,11 +264,227 @@ def test_plugin_sendpulse_urls():
     AppriseURLTester(tests=apprise_url_tests).run_all()
 
 
-@mock.patch("requests.get")
 @mock.patch("requests.post")
-def test_plugin_sendpulse_edge_cases(mock_post, mock_get):
+def test_plugin_sendpulse_edge_cases(mock_post):
     """
     NotifySendPulse() Edge Cases
+    """
+    request = mock.Mock()
+    request.status_code = requests.codes.ok
+    request.content = SENDPULSE_GOOD_RESPONSE
+
+    # Prepare Mock
+    mock_post.return_value = request
+
+    obj = Apprise.instantiate(
+        "sendpulse://user@example.com/ci/cs/Test<test@example.com>")
+
+    assert obj.notify(
+        body="body", title="title", notify_type=NotifyType.INFO) is True
+
+    # Test our call count
+    assert mock_post.call_count == 2
+
+    # Authentication
+    assert mock_post.call_args_list[0][0][0] == \
+        "https://api.sendpulse.com/oauth/access_token"
+
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+    assert payload == {
+        "grant_type": "client_credentials",
+        "client_id": "ci",
+        "client_secret": "cs",
+    }
+
+    assert mock_post.call_args_list[1][0][0] == \
+        "https://api.sendpulse.com/smtp/emails"
+    payload = loads(mock_post.call_args_list[1][1]["data"])
+
+    assert payload == {
+        "email": {
+            "from": {
+                "email": "user@example.com", "name": "Apprise"
+            },
+            "to": [{"email": "test@example.com", "name": "Test"}],
+            "subject": "title", "text": "body", "html": "Ym9keQ=="}}
+
+    mock_post.reset_mock()
+
+    obj = Apprise.instantiate("sendpulse://user@example.com/ci/cs/?from=John")
+
+    assert obj.notify(
+        body="body", title="title", notify_type=NotifyType.INFO) is True
+
+    # Test our call count
+    assert mock_post.call_count == 2
+
+    # Authentication
+    assert mock_post.call_args_list[0][0][0] == \
+        "https://api.sendpulse.com/oauth/access_token"
+
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+    assert payload == {
+        "grant_type": "client_credentials",
+        "client_id": "ci",
+        "client_secret": "cs",
+    }
+
+    assert mock_post.call_args_list[1][0][0] == \
+        "https://api.sendpulse.com/smtp/emails"
+    payload = loads(mock_post.call_args_list[1][1]["data"])
+
+    assert payload == {
+        "email": {
+            "from": {
+                "email": "user@example.com", "name": "John"
+            },
+            "to": [{"email": "user@example.com", "name": "John"}],
+            "subject": "title", "text": "body", "html": "Ym9keQ=="}}
+
+    mock_post.reset_mock()
+
+    # Second call no longer needs to authenticate
+    assert obj.notify(
+        body="body", title="title", notify_type=NotifyType.INFO) is True
+
+    assert mock_post.call_count == 1
+
+    assert mock_post.call_args_list[0][0][0] == \
+        "https://api.sendpulse.com/smtp/emails"
+
+    # force an exception
+    mock_post.side_effect = requests.RequestException
+    assert obj.notify(
+        body="body", title="title", notify_type=NotifyType.INFO) is False
+
+    # Set an invalid return code
+    mock_post.side_effect = None
+    request.status_code = 403
+    assert obj.notify(
+        body="body", title="title", notify_type=NotifyType.INFO) is False
+
+    # Test re-authentication
+    mock_post.reset_mock()
+    request = mock.Mock()
+    obj = Apprise.instantiate("sendpulse://usr2@example.com/ci/cs/?from=Retry")
+
+    class sendpulse:
+        def __init__(self):
+            # 200 login okay
+            # 401 on retrival
+            # recursive re-attempt to login returns 200
+            # fetch after works
+            self._side_effect = iter([
+                requests.codes.ok, requests.codes.unauthorized,
+                requests.codes.ok, requests.codes.ok,
+            ])
+
+        @property
+        def status_code(self):
+            return next(self._side_effect)
+
+        @property
+        def content(self):
+            return SENDPULSE_GOOD_RESPONSE
+
+    mock_post.return_value = sendpulse()
+
+    assert obj.notify(
+        body="body", title="title", notify_type=NotifyType.INFO) is True
+
+    assert mock_post.call_count == 4
+    # Authentication
+    assert mock_post.call_args_list[0][0][0] == \
+        "https://api.sendpulse.com/oauth/access_token"
+    # 401 received
+    assert mock_post.call_args_list[1][0][0] == \
+        "https://api.sendpulse.com/smtp/emails"
+    # Re-authenticate
+    assert mock_post.call_args_list[2][0][0] == \
+        "https://api.sendpulse.com/oauth/access_token"
+    # Try again
+    assert mock_post.call_args_list[3][0][0] == \
+        "https://api.sendpulse.com/smtp/emails"
+
+    # Test re-authentication  (no recursive loops)
+    mock_post.reset_mock()
+    request = mock.Mock()
+    obj = Apprise.instantiate("sendpulse://usr2@example.com/ci/cs/?from=Retry")
+
+    class sendpulse:
+        def __init__(self):
+            # oauth always returns okay but notify returns 401
+            # recursive re-attempt only once
+            self._side_effect = iter([
+                requests.codes.ok, requests.codes.unauthorized,
+                requests.codes.ok, requests.codes.unauthorized,
+                requests.codes.ok, requests.codes.unauthorized,
+                requests.codes.ok, requests.codes.unauthorized,
+                requests.codes.ok, requests.codes.unauthorized,
+                requests.codes.ok, requests.codes.unauthorized,
+                requests.codes.ok, requests.codes.unauthorized,
+                requests.codes.ok, requests.codes.unauthorized,
+            ])
+
+        @property
+        def status_code(self):
+            return next(self._side_effect)
+
+        @property
+        def content(self):
+            return SENDPULSE_GOOD_RESPONSE
+
+    mock_post.return_value = sendpulse()
+
+    assert obj.notify(
+        body="body", title="title", notify_type=NotifyType.INFO) is False
+
+    assert mock_post.call_count == 4
+    # Authentication
+    assert mock_post.call_args_list[0][0][0] == \
+        "https://api.sendpulse.com/oauth/access_token"
+    # 401 received
+    assert mock_post.call_args_list[1][0][0] == \
+        "https://api.sendpulse.com/smtp/emails"
+    # Re-authenticate
+    assert mock_post.call_args_list[2][0][0] == \
+        "https://api.sendpulse.com/oauth/access_token"
+    # Last failed attempt
+    assert mock_post.call_args_list[3][0][0] == \
+        "https://api.sendpulse.com/smtp/emails"
+
+    mock_post.side_effect = None
+    request = mock.Mock()
+    request.status_code = requests.codes.ok
+    request.content = SENDPULSE_GOOD_RESPONSE
+    mock_post.return_value = request
+    for expires_in in (None, -1, "garbage", 3600, 300000):
+        request.content = dumps({
+            "access_token": "abc123",
+            "expires_in": expires_in,
+        })
+
+        # Instantiate our object
+        obj = Apprise.instantiate("sendpulse://user@example.com/ci/cs/")
+
+        # Test variations of responses
+        obj.notify(
+            body="body", title="title", notify_type=NotifyType.INFO)
+
+        # expires_in is missing
+        request.content = dumps({
+            "access_token": "abc123",
+        })
+
+        # Instantiate our object
+        obj = Apprise.instantiate("sendpulse://user@example.com/ci/cs/")
+        assert obj.notify(
+            body="body", title="title", notify_type=NotifyType.INFO) is True
+
+
+def test_plugin_sendpulse_fail_cases():
+    """
+    NotifySendPulse() Fail Cases
 
     """
 
@@ -132,39 +492,38 @@ def test_plugin_sendpulse_edge_cases(mock_post, mock_get):
     with pytest.raises(TypeError):
         NotifySendPulse(
             client_id="abcd", client_secret=None,
-            from_email="user@example.com")
+            from_addr="user@example.com")
 
     with pytest.raises(TypeError):
         NotifySendPulse(
-            client_id=None, client_secret="abcd",
-            from_email="user@example.com")
+            client_id=None, client_secret="abcd123",
+            from_addr="user@example.com")
 
     # invalid from email
     with pytest.raises(TypeError):
         NotifySendPulse(
-            client_id="abcd", client_secret="abcd", from_email="!invalid")
+            client_id="abcd", client_secret="abcd456", from_addr="!invalid")
 
     # no email
     with pytest.raises(TypeError):
         NotifySendPulse(
-            client_id="abcd", client_secret="abcd", from_email=None)
+            client_id="abcd", client_secret="abcd789", from_addr=None)
 
     # Invalid To email address
     NotifySendPulse(
-        client_id="abcd", client_secret="abcd",
-        from_email="user@example.com", targets="!invalid")
+        client_id="abcd", client_secret="abcd321",
+        from_addr="user@example.com", targets="!invalid")
 
     # Test invalid bcc/cc entries mixed with good ones
     assert isinstance(NotifySendPulse(
-        client_id="abcd", client_secret="abcd",
-        from_email="l2g@example.com",
+        client_id="abcd", client_secret="abcd654",
+        from_addr="l2g@example.com",
         bcc=("abc@def.com", "!invalid"),
         cc=("abc@test.org", "!invalid")), NotifySendPulse)
 
 
-@mock.patch("requests.get")
 @mock.patch("requests.post")
-def test_plugin_sendpulse_attachments(mock_post, mock_get):
+def test_plugin_sendpulse_attachments(mock_post):
     """
     NotifySendPulse() Attachments
 
@@ -172,21 +531,20 @@ def test_plugin_sendpulse_attachments(mock_post, mock_get):
 
     request = mock.Mock()
     request.status_code = requests.codes.ok
+    request.content = SENDPULSE_GOOD_RESPONSE
 
     # Prepare Mock
     mock_post.return_value = request
-    mock_get.return_value = request
 
     path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     attach = AppriseAttachment(path)
-    obj = Apprise.instantiate("sendpulse://user@example.com/abcd/abcd")
+    obj = Apprise.instantiate("sendpulse://user@example.com/aaaa/bbbb")
     assert isinstance(obj, NotifySendPulse)
     assert obj.notify(
         body="body", title="title", notify_type=NotifyType.INFO,
         attach=attach) is True
 
     mock_post.reset_mock()
-    mock_get.reset_mock()
 
     # Try again in a use case where we can't access the file
     with mock.patch("os.path.isfile", return_value=False):

--- a/tests/test_plugin_sendpulse.py
+++ b/tests/test_plugin_sendpulse.py
@@ -1,0 +1,201 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2024, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Disable logging for a cleaner testing output
+import logging
+import os
+from unittest import mock
+
+from helpers import AppriseURLTester
+import pytest
+import requests
+
+from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise.plugins.sendpulse import NotifySendPulse
+
+logging.disable(logging.CRITICAL)
+
+# Attachment Directory
+TEST_VAR_DIR = os.path.join(os.path.dirname(__file__), "var")
+
+# Our Testing URLs
+apprise_url_tests = (
+    ("sendpulse://", {
+        "instance": None,
+    }),
+    ("sendpulse://:@/", {
+        "instance": None,
+    }),
+    ("sendpulse://abcd", {
+        # Just an broken email (no email, client_id or secret)
+        "instance": None,
+    }),
+    ("sendpulse://abcd@host", {
+        # Just an Email specified, no client_id or client_secret
+        "instance": None,
+    }),
+    ("sendpulse://user@example.com/client_id/client_secret/", {
+        "instance": NotifySendPulse,
+    }),
+    ("sendpulse://user@example.com/client_id/client_secret/"
+     "?bcc=l2g@nuxref.com", {
+         # A good email with Blind Carbon Copy
+         "instance": NotifySendPulse,
+     }),
+    ("sendpulse://user@example.com/client_id/client_secret/"
+     "?cc=l2g@nuxref.com", {
+         # A good email with Carbon Copy
+         "instance": NotifySendPulse,
+     }),
+    ("sendpulse://user@example.com/client_id/client_secret/"
+     "?to=l2g@nuxref.com", {
+         # A good email with Carbon Copy
+         "instance": NotifySendPulse,
+     }),
+    ("sendpulse://user@example.com/client_id/client_secret/"
+     "?template=1234", {
+         # A good email with a template + no substitutions
+         "instance": NotifySendPulse,
+     }),
+    ("sendpulse://user@example.com/client_id/client_secret/"
+     "?template=1234&+sub=value&+sub2=value2", {
+         # A good email with a template + substitutions
+         "instance": NotifySendPulse,
+
+         # Our expected url(privacy=True) startswith() response:
+         "privacy_url": "sendpulse://a...d:user@example.com/",
+     }),
+    ("sendpulse://user@example.com/client_id/client_secret/", {
+        "instance": NotifySendPulse,
+        # force a failure
+        "response": False,
+        "requests_response_code": requests.codes.internal_server_error,
+    }),
+    ("sendpulse://user@example.com/client_id/client_secret/", {
+        "instance": NotifySendPulse,
+        # throw a bizzare code forcing us to fail to look it up
+        "response": False,
+        "requests_response_code": 999,
+    }),
+    ("sendpulse://user@example.com/client_id/client_secret/", {
+        "instance": NotifySendPulse,
+        # Throws a series of connection and transfer exceptions when this flag
+        # is set and tests that we gracfully handle them
+        "test_requests_exceptions": True,
+    }),
+)
+
+
+def test_plugin_sendpulse_urls():
+    """
+    NotifySendPulse() Apprise URLs
+
+    """
+
+    # Run our general tests
+    AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_sendpulse_edge_cases(mock_post, mock_get):
+    """
+    NotifySendPulse() Edge Cases
+
+    """
+
+    # no client_id
+    with pytest.raises(TypeError):
+        NotifySendPulse(
+            client_id="abcd", client_secret=None,
+            from_email="user@example.com")
+
+    with pytest.raises(TypeError):
+        NotifySendPulse(
+            client_id=None, client_secret="abcd",
+            from_email="user@example.com")
+
+    # invalid from email
+    with pytest.raises(TypeError):
+        NotifySendPulse(
+            client_id="abcd", client_secret="abcd", from_email="!invalid")
+
+    # no email
+    with pytest.raises(TypeError):
+        NotifySendPulse(
+            client_id="abcd", client_secret="abcd", from_email=None)
+
+    # Invalid To email address
+    NotifySendPulse(
+        client_id="abcd", client_secret="abcd",
+        from_email="user@example.com", targets="!invalid")
+
+    # Test invalid bcc/cc entries mixed with good ones
+    assert isinstance(NotifySendPulse(
+        client_id="abcd", client_secret="abcd",
+        from_email="l2g@example.com",
+        bcc=("abc@def.com", "!invalid"),
+        cc=("abc@test.org", "!invalid")), NotifySendPulse)
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_sendpulse_attachments(mock_post, mock_get):
+    """
+    NotifySendPulse() Attachments
+
+    """
+
+    request = mock.Mock()
+    request.status_code = requests.codes.ok
+
+    # Prepare Mock
+    mock_post.return_value = request
+    mock_get.return_value = request
+
+    path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
+    attach = AppriseAttachment(path)
+    obj = Apprise.instantiate("sendpulse://user@example.com/abcd/abcd")
+    assert isinstance(obj, NotifySendPulse)
+    assert obj.notify(
+        body="body", title="title", notify_type=NotifyType.INFO,
+        attach=attach) is True
+
+    mock_post.reset_mock()
+    mock_get.reset_mock()
+
+    # Try again in a use case where we can't access the file
+    with mock.patch("os.path.isfile", return_value=False):
+        assert obj.notify(
+            body="body", title="title", notify_type=NotifyType.INFO,
+            attach=attach) is False
+
+    # Try again in a use case where we can't access the file
+    with mock.patch("builtins.open", side_effect=OSError):
+        assert obj.notify(
+            body="body", title="title", notify_type=NotifyType.INFO,
+            attach=attach) is False


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1137 

## SendPulse Notifications
* **Source**: https://sendpulse.com/
* **Icon Support**: no
* **Attachment Support**: yes
* **Message Format**: Text
* **Message Limit**: 32768 Characters per message

### Account Setup
Once you have an account and access to [your dashboard](https://app.sendpulse.com/). You will need to ensure you acquire your Client ID and Client Secret in order to construct the Apprise URLs

### Syntax
Valid syntaxes are as follows:
* `{schema}://{user}@{host}/{client_id}/{client_secret}`
* `{schema}://{user}@{host}/{client_id}/{client_secret}/{to_email}`
* `{schema}://{user}@{host}/{client_id}/{client_secret}/{to_email1}/{to_email2}/{to_email3}`

Template support is also supported as well,  You just need to specify the integer assigned to it as part of the URL:
* `{schema}://{user}@{host}/{client_id}/{client_secret}/:{to_email}?template={temlate_int}`

If you want to take advantage of the `dynamic_template_data` variables, just create arguments prefixed with a plus (+); for example:
* `sendpulse://{user}@{host}/{client_id}/{client_secret}/{to_email}?template={template_int}&+{sub1}=value&+{sub2}=value2`

### Parameter Breakdown
| Variable    | Required | Description
| ----------- | -------- | -----------
| user      | Yes      | Combined with the `host`, it constructs the email address you have configured with your SendPulse account.
| host      | Yes      | Combined with the `user`, it constructs the email address you have configured with your SendPulse account.
| client_id      | Yes      | The Client ID associated with your SendPulse account.
| client_secret      | Yes      | The Client Secret associated with your SendPulse account.
| from | No      | You can optionally identify who the email is from if you wish.
| to_email    | No       | This is the email address will identify the email's destination (the _To_ address).  If one isn't specified then the *from_email* is used instead.
| template    | No       | You may optionally specify the integer of a previously generated SendPulse  template to base the email on.
| cc          | No       | The _Carbon Copy_ (CC:) portion of the email.  This is entirely optional.  
| bcc         | No       | The _Blind Carbon Copy_ (BCC:) portion of the email.

#### Dynamic Template Data
Apprise has template support for SendPulse.  Just define the `?template=` and the optional arguments you want to set. You can identify and set these variables using Apprise by simply sticking a plus (+) in front of any parameter you specify on your URL string.

Consider the following template: `1234`

An Apprise URL might look like:<br/>
`sendpulse://user@example.com?template=1234&+what=templates&+app=Apprise`

#### Example
Send a SendPulse notification:
```bash
# Assuming our {user} is user@example.com
# Assuming our {client_id} is client_id
# Assuming our {client_secret} is client_secret
# Assuming we want to send an email to target@example.com
# Assuming our {to_email} is someone@microsoft.com
apprise -vv -t "Test Message Title" -b "Test Message Body" \
   sendpulse:///user@example.com/client_id/client_secret/target@example.com
```


## New Service Completion Status
* [x] apprise/plugins/sendpulse.py
* [x] KEYWORDS
    - add new service into this file (alphabetically).
* [x] README.md
    - add entry for new service to table (as a quick reference)
* [x] packaging/redhat/python-apprise.spec
    - add new service into the `%global common_description`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1137-sendpulse-support

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "sendpulse://from@email/client_id/client_secret"

```

