### PR TITLE
Matrix Token (m.login.token) support added

### DIFF
--- a/apprise/plugins/matrix.py
+++ b/apprise/plugins/matrix.py
@@ -201,9 +201,11 @@ class NotifyMatrix(NotifyBase):
         '{schema}://{token}',
         '{schema}://{user}@{token}',
 
-        # Disabled webhook
+        # Matrix Server
         '{schema}://{user}:{password}@{host}/{targets}',
         '{schema}://{user}:{password}@{host}:{port}/{targets}',
+        '{schema}://{token}@{host}/{targets}',
+        '{schema}://{token}@{host}:{port}/{targets}',
 
         # Webhook mode
         '{schema}://{user}:{token}@{host}/{targets}',
@@ -890,31 +892,39 @@ class NotifyMatrix(NotifyBase):
             # Login not required; silently skip-over
             return True
 
-        if not (self.user and self.password):
+        if (self.user and self.password):
+            # Prepare our Authentication Payload
+            if self.version == MatrixVersion.V3:
+                payload = {
+                    'type': 'm.login.password',
+                    'identifier': {
+                        'type': 'm.id.user',
+                        'user': self.user,
+                    },
+                    'password': self.password,
+                }
+
+            else:
+                payload = {
+                    'type': 'm.login.password',
+                    'user': self.user,
+                    'password': self.password,
+                }
+
+        elif self.password:
+            # token
+            payload = {
+                'type': 'm.login.token',
+                'token': self.password,
+            }
+
+        else:
             # It's not possible to register since we need these 2 values to
             # make the action possible.
             self.logger.warning(
                 'Failed to login to Matrix server: '
-                'user/pass combo is missing.')
+                'token or user/pass combo is missing.')
             return False
-
-        # Prepare our Authentication Payload
-        if self.version == MatrixVersion.V3:
-            payload = {
-                'type': 'm.login.password',
-                'identifier': {
-                    'type': 'm.id.user',
-                    'user': self.user,
-                },
-                'password': self.password,
-            }
-
-        else:
-            payload = {
-                'type': 'm.login.password',
-                'user': self.user,
-                'password': self.password,
-            }
 
         # Build our URL
         postokay, response = self._fetch('/login', payload=payload)
@@ -1483,9 +1493,10 @@ class NotifyMatrix(NotifyBase):
                         safe=''),
                 )
 
-            elif self.user:
-                auth = '{user}@'.format(
-                    user=NotifyMatrix.quote(self.user, safe=''),
+            elif self.user or self.password:
+                auth = '{value}@'.format(
+                    value=NotifyMatrix.quote(
+                        self.user if self.user else self.password, safe=''),
                 )
 
         default_port = 443 if self.secure else 80
@@ -1566,6 +1577,11 @@ class NotifyMatrix(NotifyBase):
         # Support the use of the token= keyword
         if 'token' in results['qsd'] and len(results['qsd']['token']):
             results['password'] = NotifyMatrix.unquote(results['qsd']['token'])
+
+        elif not results['password'] and results['user']:
+            # swap
+            results['password'] = results['user']
+            results['user'] = None
 
         # Support the use of the version= or v= keyword
         if 'version' in results['qsd'] and len(results['qsd']['version']):


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #895

The URLs now trigger reference to the Matrix Token based Authentication (`m.login.token`):

- `{schema}://{token}@{host}/{targets}`
- `{schema}://{token}@{host}:{port}/{targets}`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@895-matrix-token-support

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "matrixs://token@host/#general"

```

