### PR TITLE
Added disclaimer for AES-CBC-128 weakness with simplepush://

### DIFF
--- a/apprise/plugins/simplepush.py
+++ b/apprise/plugins/simplepush.py
@@ -177,7 +177,25 @@ class NotifySimplePush(NotifyBase):
 
         padder = padding.PKCS7(algorithms.AES.block_size).padder()
         content = padder.update(content.encode()) + padder.finalize()
+        #
+        # Encryption Notice
+        #
 
+        # CBC mode doesn't provide integrity guarantees. Unless the message
+        # authentication for IV and the ciphertext are applied, it will be
+        # vulnerable to a padding oracle attack
+
+        # It is important to identify that both the Apprise package and team
+        # recognizes this AES-CBC-128 weakness but requires that it exists due
+        # to it being the SimplePush Requirement as documented on their
+        # website here https://simplepush.io/features.
+
+        # In the event the website link above does not exist/work, a screen
+        # capture of the reference to the requirement for this encryption
+        # can also be found on the Apprise SimplePush Wiki:
+        #   https://github.com/caronc/apprise/wiki/Notify_simplepush\
+        #       #lock-aes-cbc-128-encryption-weakness
+        #
         encryptor = Cipher(
             algorithms.AES(self._key),
             modes.CBC(self._iv),


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** n/a

Updated SendPush Wiki as well [here](https://github.com/caronc/apprise/wiki/Notify_simplepush) with the following content:

### :lock: AES-CBC-128 Encryption Weakness
The Apprise team recognizes that the encryption used by this plugin is AES-CBC-128 which has been identified to have weaknesses including being vulnerable to the padding oracle attack ([Reference](https://soatok.blog/2020/07/12/comparison-of-symmetric-encryption-methods/#aes-gcm-vs-aes-cbc)).

If the level of encryption is not satisfactory to you, your options are:
1. Reach out to SimplePush and ask for them to improve their security (to which Apprise will gladly accomodate) ...or
1. Choose not to use Simple Push and select one of the [many other options available](https://github.com/caronc/apprise/wiki#notification-services).

What is important to identify is this weak encryption used by Apprise to access SimplePush is in place for compliance only. This will never have any cascading effect or impact any other secure notification service also supported by Apprise.

Below is a screenshot from https://simplepush.io/features explaining why the encryption is required (for compliance)<br/>![Screenshot from 2024-10-03 21-52-46](https://github.com/user-attachments/assets/d6764e5f-6f90-46be-9994-4cffc881477a)

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@simple-push-encryption-weak-id
```

