### PR TITLE
Eliminated non-essential warning log in mailto:// parsing

### DIFF
--- a/apprise/plugins/email.py
+++ b/apprise/plugins/email.py
@@ -1440,14 +1440,9 @@ class NotifyEmail(NotifyBase):
             from_addr = NotifyEmail.unquote(results['qsd']['from'])
 
             if 'name' in results['qsd'] and len(results['qsd']['name']):
-                # Depricate use of both `from=` and `name=` in the same url as
-                # they will be synomomus of one another in the future.
                 from_addr = formataddr(
                     (NotifyEmail.unquote(results['qsd']['name']), from_addr),
                     charset='utf-8')
-                logger.warning(
-                    'Email name= and from= are synonymous; '
-                    'use one or the other.')
 
         elif 'name' in results['qsd'] and len(results['qsd']['name']):
             # Extract from name to associate with from address

--- a/apprise/plugins/email.py
+++ b/apprise/plugins/email.py
@@ -52,7 +52,6 @@ from ..common import NotifyFormat, NotifyType, PersistentStoreMode
 from ..conversion import convert_between
 from ..utils import is_ipaddr, is_email, parse_emails, is_hostname, parse_bool
 from ..locale import gettext_lazy as _
-from ..logger import logger
 
 try:
     import pgpy


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1207

Eliminated non-essential warning in the mailto:// parsing

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1207-mailto-warnings?

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "mailto://credentials/"

```

