### PR TITLE
Fix print statement in test run function.

### DIFF
--- a/test/helpers/rest.py
+++ b/test/helpers/rest.py
@@ -219,7 +219,7 @@ class AppriseURLTester:
 
         if not isinstance(obj, instance):
             print('%s instantiated %s (but expected %s)' % (
-                url, type(instance), type(obj)))
+                url, type(obj), instance))
             assert False
 
         if isinstance(obj, NotifyBase):


### PR DESCRIPTION
## Description:
In [nixpkgs](https://github.com/NixOS/nixpkgs), we've encountered a [test failure](https://hydra.nixos.org/build/274162033/nixlog/1) on x86-64-linux. While starting to investigate this, I noticed that the error message printed didn't have the expected context.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@<this.branch-name>

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  <apprise url related to ticket>

```

