### PR TITLE
Removed python-xdist development dependency due to it not being used

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,5 +3,4 @@ flake8
 pytest
 pytest-cov
 pytest-mock
-pytest-xdist
 babel

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -105,7 +105,6 @@ BuildRequires: python%{python3_pkgversion}-pytest
 BuildRequires: python%{python3_pkgversion}-pytest-mock
 BuildRequires: python%{python3_pkgversion}-pytest-runner
 BuildRequires: python%{python3_pkgversion}-pytest-cov
-BuildRequires: python%{python3_pkgversion}-pytest-xdist
 %endif
 
 %description -n python%{python3_pkgversion}-%{pypi_name} %{common_description}


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** [NixOS/34721](https://github.com/NixOS/nixpkgs/pull/347214#event-14565986751)

Thanks to the amazing team over on NixOS, they pointed out that while Apprise references the `python-xdist` package, it does not actually use it.  There is confusion as those who choose to use it do not get the desired/expected test results.

Removing it from the Apprise library for consistency.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage


