### PR TITLE
Dropped Python v3.7 GH Action Test Support (deprecated)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,8 +50,6 @@ jobs:
 
           # Test more available versions of CPython on Linux.
           - os: "ubuntu-latest"
-            python-version: "3.7"
-          - os: "ubuntu-latest"
             python-version: "3.8"
           - os: "ubuntu-latest"
             python-version: "3.9"


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** n/a

It appears GitHub Actions has dropped support for test cases ran in Python v3.7.  As a result, all the tests were failing here.   this PR just removes the python v3.7 reference to restore order.