### PR TITLE
Matrix: Allow token only client API authorization with token parameter

### DIFF
--- a/apprise/plugins/matrix.py
+++ b/apprise/plugins/matrix.py
@@ -1478,7 +1478,7 @@ class NotifyMatrix(NotifyBase):
 
         auth = ''
         if self.mode != MatrixWebhookMode.T2BOT:
-            if self.version == "token":
+            if self.version == MatrixVersion.TOKEN:
                 self.access_token = self.user
 
             # Determine Authentication

--- a/apprise/plugins/matrix.py
+++ b/apprise/plugins/matrix.py
@@ -1581,7 +1581,7 @@ class NotifyMatrix(NotifyBase):
 
         elif 'v' in results['qsd'] and len(results['qsd']['v']):
             results['version'] = NotifyMatrix.unquote(results['qsd']['v'])
-            if results['version'] == "token":
+            if results['version'] == MatrixVersion.TOKEN:
                 results['mode'] = MatrixWebhookMode.DISABLED
 
         return results

--- a/apprise/plugins/matrix.py
+++ b/apprise/plugins/matrix.py
@@ -616,7 +616,7 @@ class NotifyMatrix(NotifyBase):
 
         if self.access_token is None and self.password and not self.user:
             self.access_token = self.password
-            
+
         if self.access_token is None:
             # We need to register
             if not self._login():

--- a/apprise/plugins/matrix.py
+++ b/apprise/plugins/matrix.py
@@ -103,15 +103,11 @@ class MatrixVersion:
     # Version 3
     V3 = "3"
 
-    # Token
-    TOKEN = "token"
-
 
 # webhook modes are placed into this list for validation purposes
 MATRIX_VERSIONS = (
     MatrixVersion.V2,
     MatrixVersion.V3,
-    MatrixVersion.TOKEN
 )
 
 
@@ -205,9 +201,11 @@ class NotifyMatrix(NotifyBase):
         '{schema}://{token}',
         '{schema}://{user}@{token}',
 
-        # Disabled webhook
+        # Matrix Server
         '{schema}://{user}:{password}@{host}/{targets}',
         '{schema}://{user}:{password}@{host}:{port}/{targets}',
+        '{schema}://{token}@{host}/{targets}',
+        '{schema}://{token}@{host}:{port}/{targets}',
 
         # Webhook mode
         '{schema}://{user}:{token}@{host}/{targets}',
@@ -616,6 +614,9 @@ class NotifyMatrix(NotifyBase):
         Perform Direct Matrix Server Notification (no webhook)
         """
 
+        if self.access_token is None and self.password and not self.user:
+            self.access_token = self.password
+            
         if self.access_token is None:
             # We need to register
             if not self._login():
@@ -894,31 +895,32 @@ class NotifyMatrix(NotifyBase):
             # Login not required; silently skip-over
             return True
 
-        if not (self.user and self.password):
+        if (self.user and self.password):
+            # Prepare our Authentication Payload
+            if self.version == MatrixVersion.V3:
+                payload = {
+                    'type': 'm.login.password',
+                    'identifier': {
+                        'type': 'm.id.user',
+                        'user': self.user,
+                    },
+                    'password': self.password,
+                }
+
+            else:
+                payload = {
+                    'type': 'm.login.password',
+                    'user': self.user,
+                    'password': self.password,
+                }
+
+        else:
             # It's not possible to register since we need these 2 values to
             # make the action possible.
             self.logger.warning(
                 'Failed to login to Matrix server: '
-                'user/pass combo is missing.')
+                'token or user/pass combo is missing.')
             return False
-
-        # Prepare our Authentication Payload
-        if self.version == MatrixVersion.V3:
-            payload = {
-                'type': 'm.login.password',
-                'identifier': {
-                    'type': 'm.id.user',
-                    'user': self.user,
-                },
-                'password': self.password,
-            }
-
-        else:
-            payload = {
-                'type': 'm.login.password',
-                'user': self.user,
-                'password': self.password,
-            }
 
         # Build our URL
         postokay, response = self._fetch('/login', payload=payload)
@@ -1478,9 +1480,6 @@ class NotifyMatrix(NotifyBase):
 
         auth = ''
         if self.mode != MatrixWebhookMode.T2BOT:
-            if self.version == MatrixVersion.TOKEN:
-                self.access_token = self.user
-
             # Determine Authentication
             if self.user and self.password:
                 auth = '{user}:{password}@'.format(
@@ -1490,9 +1489,10 @@ class NotifyMatrix(NotifyBase):
                         safe=''),
                 )
 
-            elif self.user:
-                auth = '{user}@'.format(
-                    user=NotifyMatrix.quote(self.user, safe=''),
+            elif self.user or self.password:
+                auth = '{value}@'.format(
+                    value=NotifyMatrix.quote(
+                        self.user if self.user else self.password, safe=''),
                 )
 
         default_port = 443 if self.secure else 80
@@ -1574,6 +1574,11 @@ class NotifyMatrix(NotifyBase):
         if 'token' in results['qsd'] and len(results['qsd']['token']):
             results['password'] = NotifyMatrix.unquote(results['qsd']['token'])
 
+        elif not results['password'] and results['user']:
+            # swap
+            results['password'] = results['user']
+            results['user'] = None
+
         # Support the use of the version= or v= keyword
         if 'version' in results['qsd'] and len(results['qsd']['version']):
             results['version'] = \
@@ -1581,8 +1586,6 @@ class NotifyMatrix(NotifyBase):
 
         elif 'v' in results['qsd'] and len(results['qsd']['v']):
             results['version'] = NotifyMatrix.unquote(results['qsd']['v'])
-            if results['version'] == MatrixVersion.TOKEN:
-                results['mode'] = MatrixWebhookMode.DISABLED
 
         return results
 

--- a/apprise/plugins/matrix.py
+++ b/apprise/plugins/matrix.py
@@ -103,11 +103,15 @@ class MatrixVersion:
     # Version 3
     V3 = "3"
 
+    # Token
+    TOKEN = "token"
+
 
 # webhook modes are placed into this list for validation purposes
 MATRIX_VERSIONS = (
     MatrixVersion.V2,
     MatrixVersion.V3,
+    MatrixVersion.TOKEN
 )
 
 
@@ -1474,6 +1478,9 @@ class NotifyMatrix(NotifyBase):
 
         auth = ''
         if self.mode != MatrixWebhookMode.T2BOT:
+            if self.version == "token":
+                self.access_token = self.user
+
             # Determine Authentication
             if self.user and self.password:
                 auth = '{user}:{password}@'.format(
@@ -1574,6 +1581,8 @@ class NotifyMatrix(NotifyBase):
 
         elif 'v' in results['qsd'] and len(results['qsd']['v']):
             results['version'] = NotifyMatrix.unquote(results['qsd']['v'])
+            if results['version'] == "token":
+                results['mode'] = MatrixWebhookMode.DISABLED
 
         return results
 


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #<!--apprise issue number goes here-->
N/A

<!-- Have anything else to describe? Define it here -->

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Description
When a token is passed and the url version is `token` we force it out of T2/Webhook mode and just pass the token as authentication instead.

# Test out the changes with the following command:
```
#encrypted
apprise -t "Test Title" -b "Test Message" \
  matrixs://mct_xxxxxxxxxxxxxxxx@matrix.yourdomain.com?v=token

#unencrypted
apprise -t "Test Title" -b "Test Message" \
  matrix://mct_xxxxxxxxxxxxxxxx@matrix.yourdomain.com?v=token

where `mct_xxxxxxxxxxxxxxxx` is your header authorization bearer token for matrix.
```