### PR TITLE
Unpin paho-mqtt version

### DIFF
--- a/all-plugin-requirements.txt
+++ b/all-plugin-requirements.txt
@@ -9,8 +9,8 @@ cryptography
 gntp
 
 # Provides mqtt:// support
-# use v1.x due to https://github.com/eclipse/paho.mqtt.python/issues/814
-paho-mqtt < 2.0.0
+# use any version other than 2.0.x due to https://github.com/eclipse/paho.mqtt.python/issues/814
+paho-mqtt != 2.0.*
 
 # Pretty Good Privacy (PGP) Provides mailto:// and deltachat:// support
 PGPy

--- a/apprise/plugins/mqtt.py
+++ b/apprise/plugins/mqtt.py
@@ -89,7 +89,7 @@ class NotifyMQTT(NotifyBase):
 
     requirements = {
         # Define our required packaging in order to work
-        'packages_required': 'paho-mqtt < 2.0.0'
+        'packages_required': 'paho-mqtt != 2.0.*'
     }
 
     # The default descriptive name associated with the Notification


### PR DESCRIPTION
The new update to paho-mqtt, version 2.1.0, fixed the backward incompatible callback signature problem by defaulting the callback type to paho-mqtt V1 style callbacks. This means that packages can upgrade to paho-mqtt 2.1.0 or leave it at <2.0.0 without any software changes.

## Description:
**Related issue (if applicable):** #1065 (original issue where they pinned)
<!-- Have anything else to describe? Define it here -->

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Modify dockerfile to include paho-mqtt
perl -pi -e 's,^(RUN pip.*requirements.txt$),COPY all-plugin-requirements.txt /\n\1 -r /all-plugin-requirements.txt,g' test/docker/Dockerfile.py311

# Build the container
docker compose build test.py311

# Run MQTT tests
docker compose run --rm test.py311 bin/test.sh mqtt
```

