### PR TITLE
Bark - add critical level alert plus ?volume= argument

### DIFF
--- a/apprise/plugins/bark.py
+++ b/apprise/plugins/bark.py
@@ -184,7 +184,7 @@ class NotifyBark(NotifyBase):
         'volume': {
             'name': _('Volume'),
             'type': 'int',
-            'min': 1,
+            'min': 0,
             'max': 10,
         },
         'click': {
@@ -272,14 +272,14 @@ class NotifyBark(NotifyBase):
         # Volume
         try:
             self.volume = int(volume) if volume is not None else None
-            if self.volume is not None and not (1 <= self.volume <= 10):
+            if self.volume is not None and not (0 <= self.volume <= 10):
                 raise ValueError()
         except (TypeError, ValueError):
             self.volume = None
             if volume is not None:
                 self.logger.warning(
                     'The specified Bark volume ({}) is not valid. '
-                    'Must be between 1 and 10', volume)
+                    'Must be between 0 and 10', volume)
 
         # Level
         self.level = None if not level else next(

--- a/apprise/plugins/bark.py
+++ b/apprise/plugins/bark.py
@@ -270,13 +270,14 @@ class NotifyBark(NotifyBase):
                 'The specified Bark sound ({}) was not found ', sound)
 
         # Volume
-        try:
-            self.volume = int(volume) if volume is not None else None
-            if self.volume is not None and not (0 <= self.volume <= 10):
-                raise ValueError()
-        except (TypeError, ValueError):
-            self.volume = None
-            if volume is not None:
+        self.volume = None
+        if volume is not None:
+            try:
+                self.volume = int(volume) if volume is not None else None
+                if self.volume is not None and not (0 <= self.volume <= 10):
+                    raise ValueError()
+
+            except (TypeError, ValueError):
                 self.logger.warning(
                     'The specified Bark volume ({}) is not valid. '
                     'Must be between 0 and 10', volume)

--- a/apprise/plugins/bark.py
+++ b/apprise/plugins/bark.py
@@ -89,11 +89,14 @@ class NotifyBarkLevel:
 
     PASSIVE = 'passive'
 
+    CRITICAL = 'critical'
+
 
 BARK_LEVELS = (
     NotifyBarkLevel.ACTIVE,
     NotifyBarkLevel.TIME_SENSITIVE,
     NotifyBarkLevel.PASSIVE,
+    NotifyBarkLevel.CRITICAL,
 )
 
 
@@ -178,6 +181,12 @@ class NotifyBark(NotifyBase):
             'type': 'choice:string',
             'values': BARK_LEVELS,
         },
+        'volume': {
+            'name': _('Volume'),
+            'type': 'int',
+            'min': 1,
+            'max': 10,
+        },
         'click': {
             'name': _('Click'),
             'type': 'string',
@@ -205,7 +214,7 @@ class NotifyBark(NotifyBase):
 
     def __init__(self, targets=None, include_image=True, sound=None,
                  category=None, group=None, level=None, click=None,
-                 badge=None, **kwargs):
+                 badge=None, volume=None, **kwargs):
         """
         Initialize Notify Bark Object
         """
@@ -259,6 +268,18 @@ class NotifyBark(NotifyBase):
         if sound and not self.sound:
             self.logger.warning(
                 'The specified Bark sound ({}) was not found ', sound)
+
+        # Volume
+        try:
+            self.volume = int(volume) if volume is not None else None
+            if self.volume is not None and not (1 <= self.volume <= 10):
+                raise ValueError()
+        except (TypeError, ValueError):
+            self.volume = None
+            if volume is not None:
+                self.logger.warning(
+                    'The specified Bark volume ({}) is not valid. '
+                    'Must be between 1 and 10', volume)
 
         # Level
         self.level = None if not level else next(
@@ -329,6 +350,9 @@ class NotifyBark(NotifyBase):
 
         if self.group:
             payload['group'] = self.group
+
+        if self.volume:
+            payload['volume'] = self.volume
 
         auth = None
         if self.user:
@@ -429,6 +453,9 @@ class NotifyBark(NotifyBase):
         if self.level:
             params['level'] = self.level
 
+        if self.volume:
+            params['volume'] = str(self.volume)
+
         if self.category:
             params['category'] = self.category
 
@@ -501,6 +528,11 @@ class NotifyBark(NotifyBase):
         if 'badge' in results['qsd'] and results['qsd']['badge']:
             results['badge'] = NotifyBark.unquote(
                 results['qsd']['badge'].strip())
+
+        # Volume
+        if 'volume' in results['qsd'] and results['qsd']['volume']:
+            results['volume'] = NotifyBark.unquote(
+                results['qsd']['volume'].strip())
 
         # Level
         if 'level' in results['qsd'] and results['qsd']['level']:

--- a/test/test_plugin_bark.py
+++ b/test/test_plugin_bark.py
@@ -133,8 +133,8 @@ apprise_url_tests = (
         # volume > 10
         'instance': NotifyBark,
     }),
-    ('bark://192.168.0.6:8081/device_key/?level=critical&volume=0', {
-        # volume < 1
+    ('bark://192.168.0.6:8081/device_key/?level=critical&volume=-1', {
+        # volume < 0
         'instance': NotifyBark,
     }),
     ('bark://192.168.0.6:8081/device_key/?level=critical&volume=', {
@@ -174,4 +174,3 @@ def test_plugin_bark_urls():
 
     # Run our general tests
     AppriseURLTester(tests=apprise_url_tests).run_all()
-

--- a/test/test_plugin_bark.py
+++ b/test/test_plugin_bark.py
@@ -117,6 +117,30 @@ apprise_url_tests = (
         # active level
         'instance': NotifyBark,
     }),
+    ('bark://192.168.0.6:8081/device_key/?level=critical', {
+        # critical level
+        'instance': NotifyBark,
+    }),
+    ('bark://192.168.0.6:8081/device_key/?level=critical&volume=10', {
+        # critical level with volume 10
+        'instance': NotifyBark,
+    }),
+    ('bark://192.168.0.6:8081/device_key/?level=critical&volume=invalid', {
+        # critical level with invalid volume
+        'instance': NotifyBark,
+    }),
+    ('bark://192.168.0.6:8081/device_key/?level=critical&volume=11', {
+        # volume > 10
+        'instance': NotifyBark,
+    }),
+    ('bark://192.168.0.6:8081/device_key/?level=critical&volume=0', {
+        # volume < 1
+        'instance': NotifyBark,
+    }),
+    ('bark://192.168.0.6:8081/device_key/?level=critical&volume=', {
+        # volume None
+        'instance': NotifyBark,
+    }),
     ('bark://user:pass@192.168.0.5:8086/device_key/device_key2/', {
         # Everything is okay
         'instance': NotifyBark,
@@ -150,3 +174,4 @@ def test_plugin_bark_urls():
 
     # Run our general tests
     AppriseURLTester(tests=apprise_url_tests).run_all()
+


### PR DESCRIPTION
## Description:

Critical Alert will ignore silent and Do Not Disturb modes.
Volume range: 0-10.

https://github.com/Finb/Bark/commit/f059fde0c2fbed2a61e7b77002a123ba68c8570c

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/pb8DvwQkfRR/apprise.git@bark-critical

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  bark://api.day.app/<device_key>/?level=critical&volume=1

```

