### PR TITLE
Improved hostname verification

### DIFF
--- a/apprise/utils.py
+++ b/apprise/utils.py
@@ -325,7 +325,7 @@ def is_hostname(hostname, ipv4=True, ipv6=True, underscore=True):
     labels = hostname.split(".")
 
     # ipv4 check
-    if len(labels) == 4 and re.match(r'[0-9.]+', hostname):
+    if len(labels) == 4 and re.match(r'^[0-9.]+$', hostname):
         return is_ipaddr(hostname, ipv4=ipv4, ipv6=False)
 
     # - RFC 1123 permits hostname labels to start with digits

--- a/test/test_apprise_utils.py
+++ b/test/test_apprise_utils.py
@@ -87,6 +87,22 @@ def test_parse_url_general():
     assert result['qsd+'] == {}
     assert result['qsd:'] == {}
 
+    # GitHub Ticket 1234 - Unparseable Hostname
+    result = utils.parse_url('http://5t4m59hl-34343.euw.devtunnels.ms')
+    assert result['schema'] == 'http'
+    assert result['host'] == '5t4m59hl-34343.euw.devtunnels.ms'
+    assert result['port'] is None
+    assert result['user'] is None
+    assert result['password'] is None
+    assert result['fullpath'] is None
+    assert result['path'] is None
+    assert result['query'] is None
+    assert result['url'] == 'http://5t4m59hl-34343.euw.devtunnels.ms'
+    assert result['qsd'] == {}
+    assert result['qsd-'] == {}
+    assert result['qsd+'] == {}
+    assert result['qsd:'] == {}
+
     result = utils.parse_url('http://hostname/')
     assert result['schema'] == 'http'
     assert result['host'] == 'hostname'


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1234

Improves the Apprise Hostname Validation

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1234-unparsable-json

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  " json://5t4m82hl-33333.euw.devtunnels.ms"

```

