### PR TITLE
miskey:// visibility flags updated

### DIFF
--- a/apprise/plugins/misskey.py
+++ b/apprise/plugins/misskey.py
@@ -64,8 +64,6 @@ class MisskeyVisibility:
 
     FOLLOWERS = 'followers'
 
-    PRIVATE = 'private'
-
     SPECIFIED = 'specified'
 
 
@@ -74,7 +72,6 @@ MISSKEY_VISIBILITIES = (
     MisskeyVisibility.PUBLIC,
     MisskeyVisibility.HOME,
     MisskeyVisibility.FOLLOWERS,
-    MisskeyVisibility.PRIVATE,
     MisskeyVisibility.SPECIFIED,
 )
 

--- a/test/test_plugin_misskey.py
+++ b/test/test_plugin_misskey.py
@@ -78,7 +78,7 @@ apprise_url_tests = (
         # An invalid visibility
         'instance': TypeError,
     }),
-    ('misskeys://access_token@hostname?visibility=private', {
+    ('misskeys://access_token@hostname?visibility=specified', {
         # Specified a different visiblity
         'instance': NotifyMisskey,
     }),


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1251

Misskey appears to have changed it's supported flags around.  Using 2 sources, there are conflicts even with those.

__Source 1__:  https://misskey-hub.net/en/docs/for-users/features/note/
![image](https://github.com/user-attachments/assets/f3732217-56ac-420d-be79-88ce12dc0a49)

__Source 2__: https://docs.rs/misskey-api/latest/misskey_api/model/note/enum.Visibility.html
![image](https://github.com/user-attachments/assets/e5e820c7-2a91-4127-964c-b602d5b34e2b)


Source 2 provides actual Enum values, so will adapt on this for this PR.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1251-misskey-visibility

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "misskey://credentials"

```

