### PR TITLE
mmost:// supports legacy url webhooks (http://)

### DIFF
--- a/test/test_plugin_mattermost.py
+++ b/test/test_plugin_mattermost.py
@@ -93,6 +93,11 @@ apprise_url_tests = (
     ('mmosts://localhost/3ccdd113474722377935511fc85d3dd4', {
         'instance': NotifyMattermost,
     }),
+    ('https://mattermost.example.com/hooks/3ccdd113474722377935511fc85d3dd4', {
+        'instance': NotifyMattermost,
+        # Our expected url(privacy=True) startswith() response:
+        'privacy_url': 'mmosts://mattermost.example.com/3...4/',
+    }),
     # Test our paths
     ('mmosts://localhost/a/path/3ccdd113474722377935511fc85d3dd4', {
         'instance': NotifyMattermost,


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1245 

Mattermost supports parsing Native (http:// and https://) URLs as long as they conform to the following:
- `https://mattermost.HOSTNAME/hooks/TOKEN`
- `http://mattermost.HOSTNAME/hooks/TOKEN`

Rules for this to trigger:
- Must be part of `mattermost` subdomain

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1245-mattermost-native-url-support

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "https://mattermost.example.com/hooks/token-identifier-here"

```

