### PR TITLE
Updated reference to BSDv2 clause in RPM

### DIFF
--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -58,7 +58,7 @@ Name:           python-%{pypi_name}
 Version:        1.9.1
 Release:        1%{?dist}
 Summary:        A simple wrapper to many popular notification services used today
-License:        BSD
+License:        BSD-2-Clause
 URL:            https://github.com/caronc/%{pypi_name}
 Source0:        %{url}/archive/v%{version}/%{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** n/a

A maintainer of EPEL/Fedora reached out to me pointing out i was using the wrong BSD reference in the RPM SPEC File. 

Corrected in this PR

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
not required; only code review

