### PR TITLE
discord:// now supports the kwarg of 'botname'

### DIFF
--- a/apprise/plugins/discord.py
+++ b/apprise/plugins/discord.py
@@ -596,15 +596,21 @@ class NotifyDiscord(NotifyBase):
         if self.thread_id:
             params['thread'] = self.thread_id
 
+        # Ensure our botname is set
+        botname = f'{self.user}@' if self.user else ''
+
         # Extend our parameters
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
 
-        return '{schema}://{webhook_id}/{webhook_token}/?{params}'.format(
-            schema=self.secure_protocol,
-            webhook_id=self.pprint(self.webhook_id, privacy, safe=''),
-            webhook_token=self.pprint(self.webhook_token, privacy, safe=''),
-            params=NotifyDiscord.urlencode(params),
-        )
+        return '{schema}://{botname}{webhook_id}/{webhook_token}/?{params}' \
+            .format(
+                schema=self.secure_protocol,
+                botname=botname,
+                webhook_id=self.pprint(self.webhook_id, privacy, safe=''),
+                webhook_token=self.pprint(
+                    self.webhook_token, privacy, safe=''),
+                params=NotifyDiscord.urlencode(params),
+            )
 
     @property
     def url_identifier(self):
@@ -667,6 +673,11 @@ class NotifyDiscord(NotifyBase):
         # Boolean to include an image or not
         results['include_image'] = parse_bool(results['qsd'].get(
             'image', NotifyDiscord.template_args['image']['default']))
+
+        if 'botname' in results['qsd']:
+            # Alias to User
+            results['user'] = \
+                NotifyDiscord.unquote(results['qsd']['botname'])
 
         # Extract avatar url if it was specified
         if 'avatar_url' in results['qsd']:

--- a/test/test_plugin_discord.py
+++ b/test/test_plugin_discord.py
@@ -89,10 +89,11 @@ apprise_url_tests = (
             'instance': NotifyDiscord,
             'requests_response_code': requests.codes.no_content,
     }),
-    ('discord://%s/%s?format=markdown&footer=Yes&image=Yes' % (
+    ('discord://jack@%s/%s?format=markdown&footer=Yes&image=Yes' % (
         'i' * 24, 't' * 64), {
             'instance': NotifyDiscord,
             'requests_response_code': requests.codes.no_content,
+            'privacy_url': 'discord://jack@i...i/t...t/',
     }),
     ('https://discord.com/api/webhooks/{}/{}'.format(
         '0' * 10, 'B' * 40), {
@@ -113,6 +114,14 @@ apprise_url_tests = (
             # Native URL Support with arguments
             'instance': NotifyDiscord,
             'requests_response_code': requests.codes.no_content,
+            'privacy_url': 'discord://0...0/B...B/',
+    }),
+    ('https://discordapp.com/api/webhooks/{}/{}?footer=yes&botname=joe'.format(
+        '0' * 10, 'B' * 40), {
+            # Native URL Support with arguments
+            'instance': NotifyDiscord,
+            'requests_response_code': requests.codes.no_content,
+            'privacy_url': 'discord://joe@0...0/B...B/',
     }),
     ('discord://%s/%s?format=markdown&avatar=No&footer=No' % (
         'i' * 24, 't' * 64), {


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** _discord report_
![image](https://github.com/user-attachments/assets/f34fc6e4-a0a1-4094-9162-7a35a2060c2f)

It was reported that the following URL would not work for the user:
- `https://discord.com/api/webhooks/xxxx?avatar_url=https://i.imgur.com/FsEpmwg.jpeg&botname=TEST`

The expected results is the `botname` would have been set to `TEST` and it wasn't.  Until this PR, the `botname` keyword wasn't supported.


## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@discord-parameter-alignment

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
 "https://discord.com/api/webhooks/xxxx?avatar_url=https://i.imgur.com/FsEpmwg.jpeg&botname=TEST"

```

