### PR TITLE
Resolved chanify:// naming confusion

### DIFF
--- a/KEYWORDS
+++ b/KEYWORDS
@@ -6,7 +6,7 @@ AWS
 BulkSMS
 BulkVS
 Burst SMS
-Chantify
+Chanify
 Chat
 CLI
 ClickSend

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The table below identifies the services this tool supports and some example serv
 | [Apprise API](https://github.com/caronc/apprise/wiki/Notify_apprise_api)  | apprise:// or apprises:// | (TCP) 80 or 443 | apprise://hostname/Token
 | [AWS SES](https://github.com/caronc/apprise/wiki/Notify_ses)  | ses://   | (TCP) 443   | ses://user@domain/AccessKeyID/AccessSecretKey/RegionName<br/>ses://user@domain/AccessKeyID/AccessSecretKey/RegionName/email1/email2/emailN
 | [Bark](https://github.com/caronc/apprise/wiki/Notify_bark)  | bark://   | (TCP) 80 or 443   | bark://hostname<br />bark://hostname/device_key<br />bark://hostname/device_key1/device_key2/device_keyN<br/>barks://hostname<br />barks://hostname/device_key<br />barks://hostname/device_key1/device_key2/device_keyN
-| [Chantify](https://github.com/caronc/apprise/wiki/Notify_chantify) | chantify://    | (TCP) 443    | chantify://token
+| [Chanify](https://github.com/caronc/apprise/wiki/Notify_chanify) | chantify://    | (TCP) 443    | chantify://token
 | [Discord](https://github.com/caronc/apprise/wiki/Notify_discord)  | discord://   | (TCP) 443   | discord://webhook_id/webhook_token<br />discord://avatar@webhook_id/webhook_token
 | [Emby](https://github.com/caronc/apprise/wiki/Notify_emby)  | emby:// or embys:// | (TCP) 8096 | emby://user@hostname/<br />emby://user:password@hostname
 | [Enigma2](https://github.com/caronc/apprise/wiki/Notify_enigma2)  | enigma2:// or enigma2s:// | (TCP) 80 or 443 | enigma2://hostname

--- a/apprise/plugins/chanify.py
+++ b/apprise/plugins/chanify.py
@@ -26,7 +26,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# Chantify
+# Chanify
 #   1. Visit https://chanify.net/
 
 # The API URL will look something like this:
@@ -41,22 +41,22 @@ from ..utils.parse import validate_regex
 from ..locale import gettext_lazy as _
 
 
-class NotifyChantify(NotifyBase):
+class NotifyChanify(NotifyBase):
     """
-    A wrapper for Chantify Notifications
+    A wrapper for Chanify Notifications
     """
 
     # The default descriptive name associated with the Notification
-    service_name = _('Chantify')
+    service_name = _('Chanify')
 
     # The services URL
     service_url = 'https://chanify.net/'
 
     # The default secure protocol
-    secure_protocol = 'chantify'
+    secure_protocol = 'chanify'
 
     # A URL that takes you to the setup/help of the specific protocol
-    setup_url = 'https://github.com/caronc/apprise/wiki/Notify_chantify'
+    setup_url = 'https://github.com/caronc/apprise/wiki/Notify_chanify'
 
     # Notification URL
     notify_url = 'https://api.chanify.net/v1/sender/{token}/'
@@ -91,14 +91,14 @@ class NotifyChantify(NotifyBase):
 
     def __init__(self, token, **kwargs):
         """
-        Initialize Chantify Object
+        Initialize Chanify Object
         """
         super().__init__(**kwargs)
 
         self.token = validate_regex(
             token, *self.template_tokens['token']['regex'])
         if not self.token:
-            msg = 'The Chantify token specified ({}) is invalid.'\
+            msg = 'The Chanify token specified ({}) is invalid.'\
                 .format(token)
             self.logger.warning(msg)
             raise TypeError(msg)
@@ -121,9 +121,9 @@ class NotifyChantify(NotifyBase):
             'text': body
         }
 
-        self.logger.debug('Chantify GET URL: %s (cert_verify=%r)' % (
+        self.logger.debug('Chanify GET URL: %s (cert_verify=%r)' % (
             self.notify_url, self.verify_certificate))
-        self.logger.debug('Chantify Payload: %s' % str(payload))
+        self.logger.debug('Chanify Payload: %s' % str(payload))
 
         # Always call throttle before any remote server i/o is made
         self.throttle()
@@ -139,10 +139,10 @@ class NotifyChantify(NotifyBase):
             if r.status_code != requests.codes.ok:
                 # We had a problem
                 status_str = \
-                    NotifyChantify.http_response_code_lookup(r.status_code)
+                    NotifyChanify.http_response_code_lookup(r.status_code)
 
                 self.logger.warning(
-                    'Failed to send Chantify notification: '
+                    'Failed to send Chanify notification: '
                     '{}{}error={}.'.format(
                         status_str,
                         ', ' if status_str else '',
@@ -154,11 +154,11 @@ class NotifyChantify(NotifyBase):
                 return False
 
             else:
-                self.logger.info('Sent Chantify notification.')
+                self.logger.info('Sent Chanify notification.')
 
         except requests.RequestException as e:
             self.logger.warning(
-                'A Connection error occurred sending Chantify '
+                'A Connection error occurred sending Chanify '
                 'notification.')
             self.logger.debug('Socket Exception: %s' % str(e))
 
@@ -178,7 +178,7 @@ class NotifyChantify(NotifyBase):
         return '{schema}://{token}/?{params}'.format(
             schema=self.secure_protocol,
             token=self.pprint(self.token, privacy, safe=''),
-            params=NotifyChantify.urlencode(params),
+            params=NotifyChanify.urlencode(params),
         )
 
     @property
@@ -207,9 +207,9 @@ class NotifyChantify(NotifyBase):
 
         # Allow over-ride
         if 'token' in results['qsd'] and len(results['qsd']['token']):
-            results['token'] = NotifyChantify.unquote(results['qsd']['token'])
+            results['token'] = NotifyChanify.unquote(results['qsd']['token'])
 
         else:
-            results['token'] = NotifyChantify.unquote(results['host'])
+            results['token'] = NotifyChanify.unquote(results['host'])
 
         return results

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -40,7 +40,7 @@ notification services that are out there. Apprise opens the door and makes
 it easy to access:
 
 Africas Talking, Apprise API, APRS, AWS SES, AWS SNS, Bark, Burst SMS,
-BulkSMS, BulkVS, Chantify, ClickSend, DAPNET, DingTalk, Discord, E-Mail, Emby,
+BulkSMS, BulkVS, Chanify, ClickSend, DAPNET, DingTalk, Discord, E-Mail, Emby,
 FCM, Feishu, Flock, Free Mobile, Google Chat, Gotify, Growl, Guilded, Home
 Assistant, httpSMS, IFTTT, Join, Kavenegar, KODI, Kumulos, LaMetric, Line,
 LunaSea, MacOSX, Mailgun, Mastodon, Mattermost,Matrix, MessageBird, Microsoft

--- a/test/test_plugin_chanify.py
+++ b/test/test_plugin_chanify.py
@@ -28,7 +28,7 @@
 
 import requests
 
-from apprise.plugins.chantify import NotifyChantify
+from apprise.plugins.chanify import NotifyChanify
 from helpers import AppriseURLTester
 
 # Disable logging for a cleaner testing output
@@ -37,37 +37,37 @@ logging.disable(logging.CRITICAL)
 
 # Our Testing URLs
 apprise_url_tests = (
-    ('chantify://', {
+    ('chanify://', {
         'instance': TypeError,
     }),
-    ('chantify://:@/', {
+    ('chanify://:@/', {
         'instance': TypeError,
     }),
-    ('chantify://%badtoken%', {
+    ('chanify://%badtoken%', {
         'instance': TypeError,
     }),
-    ('chantify://abc123', {
+    ('chanify://abc123', {
         # Test token
-        'instance': NotifyChantify,
+        'instance': NotifyChanify,
     }),
-    ('chantify://?token=abc123', {
+    ('chanify://?token=abc123', {
         # Test token
-        'instance': NotifyChantify,
+        'instance': NotifyChanify,
     }),
-    ('chantify://token', {
-        'instance': NotifyChantify,
+    ('chanify://token', {
+        'instance': NotifyChanify,
         # force a failure
         'response': False,
         'requests_response_code': requests.codes.internal_server_error,
     }),
-    ('chantify://token', {
-        'instance': NotifyChantify,
+    ('chanify://token', {
+        'instance': NotifyChanify,
         # throw a bizzare code forcing us to fail to look it up
         'response': False,
         'requests_response_code': 999,
     }),
-    ('chantify://token', {
-        'instance': NotifyChantify,
+    ('chanify://token', {
+        'instance': NotifyChanify,
         # Throws a series of connection and transfer exceptions when this flag
         # is set and tests that we gracfully handle them
         'test_requests_exceptions': True,
@@ -75,9 +75,9 @@ apprise_url_tests = (
 )
 
 
-def test_plugin_chantify_urls():
+def test_plugin_chanify_urls():
     """
-    NotifyChantify() Apprise URLs
+    NotifyChanify() Apprise URLs
 
     """
 


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1259 

the `chanify://` plugin had `chantify://` and `Chantify` references everywhere.  This was overlooked during it's original comit to the code base and corrected in this PR.

See https://chaify.net/ for details on this plugin. [Apprise Wiki Page also updated to reflect this inconistency](https://github.com/caronc/apprise/wiki/Notify_chanify)

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1265-chanify-plugin-cleanup

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "chanify://token"

```

