### PR TITLE
Office 365 posts include subject and body now

### DIFF
--- a/apprise/plugins/office365.py
+++ b/apprise/plugins/office365.py
@@ -366,15 +366,13 @@ class NotifyOffice365(NotifyBase):
 
         if self.from_email:
             # Apply from email if it is known
-            payload.update({
-                'message': {
-                    'from': {
-                        "emailAddress": {
-                            "address": self.from_email,
-                            "name": self.from_name or self.app_id,
-                        }
-                    },
-                }
+            payload['message'].update({
+                'from': {
+                    "emailAddress": {
+                        "address": self.from_email,
+                        "name": self.from_name or self.app_id,
+                    }
+                },
             })
 
         # Create a copy of the email list

--- a/test/test_plugin_office365.py
+++ b/test/test_plugin_office365.py
@@ -32,7 +32,7 @@ from unittest import mock
 import pytest
 import requests
 from datetime import datetime
-from json import dumps
+from json import dumps, loads
 from apprise import Apprise
 from apprise import NotifyType
 from apprise import AppriseAttachment
@@ -541,6 +541,18 @@ def test_plugin_office365_queries(mock_post, mock_get, mock_put):
         'https://login.microsoftonline.com/{}/oauth2/v2.0/token'.format(tenant)
     assert mock_post.call_args_list[1][0][0] == \
         'https://graph.microsoft.com/v1.0/users/abc-1234-object-id/sendMail'
+    payload = loads(mock_post.call_args_list[1][1]['data'])
+    assert payload == {
+        'message': {
+            'subject': 'title',
+            'body': {
+                'contentType': 'HTML',
+                'content': 'body',
+            },
+            'toRecipients': [
+                {'emailAddress': {'address': 'target@example.ca'}}]},
+        'saveToSentItems': 'true',
+    }
     mock_post.reset_mock()
 
     # Now test a case where we just couldn't get any email details from the


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1271 

Fixed bug causing `body` and `subject` to be cleared

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1271-office-365-payload?

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
 "o365://credentials"

```

