### PR TITLE
Notifico Standalone Support Added

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The table below identifies the services this tool supports and some example serv
 | [Notica](https://appriseit.com/services/notica/) | notica://  | (TCP) 443   | notica://Token/
 | [NotificationAPI](https://appriseit.com/services/notificationapi/) | napi://  | (TCP) 443   | napi://ClientID/ClientSecret/Target<br />napi://ClientID/ClientSecret/Target1/Target2/TargetN<br />napi://MessageType@ClientID/ClientSecret/Target
 | [Notifiarr](https://appriseit.com/services/notifiarr/) | notifiarr:// | (TCP) 443 | notifiarr://apikey/#channel<br />notifiarr://apikey/#channel1/#channel2/#channeln
-| [Notifico](https://appriseit.com/services/notifico/) | notifico://  | (TCP) 443   | notifico://ProjectID/MessageHook/
+| [Notifico](https://appriseit.com/services/notifico/) | notifico:// or notificos://  | (TCP) 80 or 443   | notifico://ProjectID/MessageHook/<br />notifico://host/ProjectID/MessageHook/<br />notificos://host/ProjectID/MessageHook/
 | [ntfy](https://appriseit.com/services/ntfy/) | ntfy://  | (TCP) 80 or 443   | ntfy://topic/<br/>ntfys://topic/
 | [Octopush](https://appriseit.com/services/octopush/) | octopush:// | (TCP) 443 | octopush://APILogin/APIKey/TargetPhoneNo<br />octopush://Sender:APILogin/APIKey/TargetPhoneNo<br />octopush://Sender:APILogin/APIKey/TargetPhoneNo1/TargetPhoneNo2/TargetPhoneNoN
 | [Office 365](https://appriseit.com/services/office365/) | o365://  | (TCP) 443   | o365://TenantID:AccountEmail/ClientID/ClientSecret<br />o365://TenantID:AccountEmail/ClientID/ClientSecret/TargetEmail<br />o365://TenantID:AccountEmail/ClientID/ClientSecret/TargetEmail1/TargetEmail2/TargetEmailN

--- a/apprise/plugins/notifico.py
+++ b/apprise/plugins/notifico.py
@@ -27,18 +27,32 @@
 
 # Notifico allows you to relay notifications into IRC channels.
 #
-# 1. visit https://n.tkte.ch and sign up for an account
-# 2. create a project; either manually or sync with github
-# 3. from within the project, you can create a message hook
+# The original hosted service (https://n.tkte.ch) has gone offline.
+# The project is open source and can be self-hosted:
+#   https://notifico.tech/
 #
-# the URL will look something like this:
+# Official/hosted-instance usage (project_id takes the host position):
+#   1. Visit https://n.tkte.ch and sign up for an account.
+#   2. Create a project; either manually or sync with GitHub.
+#   3. From within the project, create a Plain Text Message Hook.
+#
+# The hook URL will look something like:
 #       https://n.tkte.ch/h/2144/uJmKaBW9WFk42miB146ci3Kj
 #                            ^                ^
 #                            |                |
 #                         project id       message hook
 #
-# This plugin also supports taking the URL (as identified above) directly
-# as well.
+# To use the official endpoint with Apprise, the two path parts above
+# become the arguments:
+#   notifico://{ProjectID}/{MessageHook}
+#
+# To point Apprise at a self-hosted instance instead:
+#   notifico://{host}/{ProjectID}/{MessageHook}      (HTTP)
+#   notificos://{host}/{ProjectID}/{MessageHook}     (HTTPS)
+#   notifico://{host}:{port}/{ProjectID}/{MessageHook}
+#   notifico://{user}:{pass}@{host}/{ProjectID}/{MessageHook}
+#
+# This plugin also supports taking the n.tkte.ch URL directly as input.
 
 import re
 
@@ -46,8 +60,26 @@ import requests
 
 from ..common import NotifyType
 from ..locale import gettext_lazy as _
+from ..url import PrivacyMode
 from ..utils.parse import parse_bool, validate_regex
 from .base import NotifyBase
+
+
+class NotificoMode:
+    # Tracks the mode of operation for the Notifico plugin.
+
+    # Notifications delivered via the official n.tkte.ch endpoint
+    OFFICIAL = "official"
+
+    # Notifications delivered via a self-hosted Notifico instance
+    SELFHOSTED = "selfhosted"
+
+
+# Define our Notifico Modes
+NOTIFICO_MODES = (
+    NotificoMode.OFFICIAL,
+    NotificoMode.SELFHOSTED,
+)
 
 
 class NotificoFormat:
@@ -91,18 +123,19 @@ class NotifyNotifico(NotifyBase):
     service_name = "Notifico"
 
     # The services URL
-    service_url = "https://n.tkte.ch"
+    service_url = "https://notifico.tech/"
 
-    # The default protocol
+    # The default protocol (HTTP -- used for self-hosted instances and
+    # also as the schema for official-mode URLs)
     protocol = "notifico"
 
-    # The default secure protocol
-    secure_protocol = "notifico"
+    # The default secure protocol (HTTPS -- self-hosted instances only)
+    secure_protocol = "notificos"
 
     # A URL that takes you to the setup/help of the specific protocol
     setup_url = "https://appriseit.com/services/notifico/"
 
-    # Plain Text Notification URL
+    # Official Notifico webhook endpoint
     notify_url = "https://n.tkte.ch/h/{proj}/{hook}"
 
     # The title is not used
@@ -112,12 +145,42 @@ class NotifyNotifico(NotifyBase):
     body_maxlen = 512
 
     # Define object templates
-    templates = ("{schema}://{project_id}/{msghook}",)
+    templates = (
+        # Official endpoint: project_id takes the host position
+        "{schema}://{project_id}/{msghook}",
+        # Self-hosted variants (HTTP or HTTPS)
+        "{schema}://{host}/{project_id}/{msghook}",
+        "{schema}://{host}:{port}/{project_id}/{msghook}",
+        "{schema}://{user}@{host}/{project_id}/{msghook}",
+        "{schema}://{user}@{host}:{port}/{project_id}/{msghook}",
+        "{schema}://{user}:{password}@{host}/{project_id}/{msghook}",
+        "{schema}://{user}:{password}@{host}:{port}/{project_id}/{msghook}",
+    )
 
-    # Define our template arguments
+    # Define our template tokens
     template_tokens = dict(
         NotifyBase.template_tokens,
         **{
+            # Self-hosted connection fields
+            "host": {
+                "name": _("Hostname"),
+                "type": "string",
+            },
+            "port": {
+                "name": _("Port"),
+                "type": "int",
+                "min": 1,
+                "max": 65535,
+            },
+            "user": {
+                "name": _("Username"),
+                "type": "string",
+            },
+            "password": {
+                "name": _("Password"),
+                "type": "string",
+                "private": True,
+            },
             # The Project ID is found as the first part of the URL
             #  /1234/........................
             "project_id": {
@@ -143,28 +206,43 @@ class NotifyNotifico(NotifyBase):
     template_args = dict(
         NotifyBase.template_args,
         **{
-            # You can optionally pass IRC colors into
+            # You can optionally pass IRC colors into the notification
             "color": {
                 "name": _("IRC Colors"),
                 "type": "bool",
                 "default": True,
             },
-            # You can optionally pass IRC color into
+            # You can optionally include a notification-type prefix
             "prefix": {
                 "name": _("Prefix"),
                 "type": "bool",
                 "default": True,
             },
+            # Backward-compatible query-string aliases
+            "token": {
+                "alias_of": "msghook",
+            },
+            "project": {
+                "alias_of": "project_id",
+            },
         },
     )
 
-    def __init__(self, project_id, msghook, color=True, prefix=True, **kwargs):
+    def __init__(
+        self,
+        project_id,
+        msghook,
+        color=True,
+        prefix=True,
+        **kwargs,
+    ):
         """Initialize Notifico Object."""
         super().__init__(**kwargs)
 
-        # Assign our message hook
+        # Assign our project id
         self.project_id = validate_regex(
-            project_id, *self.template_tokens["project_id"]["regex"]
+            project_id,
+            *self.template_tokens["project_id"]["regex"],
         )
         if not self.project_id:
             msg = (
@@ -175,7 +253,8 @@ class NotifyNotifico(NotifyBase):
 
         # Assign our message hook
         self.msghook = validate_regex(
-            msghook, *self.template_tokens["msghook"]["regex"]
+            msghook,
+            *self.template_tokens["msghook"]["regex"],
         )
         if not self.msghook:
             msg = (
@@ -184,18 +263,18 @@ class NotifyNotifico(NotifyBase):
             self.logger.warning(msg)
             raise TypeError(msg)
 
+        # Detect operating mode: self-hosted when a hostname is present
+        self.mode = (
+            NotificoMode.SELFHOSTED if self.host else NotificoMode.OFFICIAL
+        )
+
         # Prefix messages with a [?] where ? identifies the message type
         # such as if it's an error, warning, info, or success
         self.prefix = prefix
 
-        # Send colors
+        # Send IRC colors
         self.color = color
 
-        # Prepare our notification URL now:
-        self.api_url = self.notify_url.format(
-            proj=self.project_id,
-            hook=self.msghook,
-        )
         return
 
     @property
@@ -205,7 +284,16 @@ class NotifyNotifico(NotifyBase):
 
         Targets or end points should never be identified here.
         """
-        return (self.secure_protocol, self.project_id, self.msghook)
+        return (
+            self.secure_protocol if self.secure else self.protocol,
+            self.mode,
+            # host and port distinguish self-hosted instances;
+            # both are None for the official endpoint
+            self.host,
+            self.port,
+            self.project_id,
+            self.msghook,
+        )
 
     def url(self, privacy=False, *args, **kwargs):
         """Returns the URL built dynamically based on specified arguments."""
@@ -219,23 +307,62 @@ class NotifyNotifico(NotifyBase):
         # Extend our parameters
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
 
-        return "{schema}://{proj}/{hook}/?{params}".format(
-            schema=self.secure_protocol,
+        if self.mode == NotificoMode.OFFICIAL:
+            # Official mode: project_id lives in the host position
+            return "{schema}://{proj}/{hook}/?{params}".format(
+                schema=self.protocol,
+                proj=self.pprint(self.project_id, privacy, safe=""),
+                hook=self.pprint(self.msghook, privacy, safe=""),
+                params=NotifyNotifico.urlencode(params),
+            )
+
+        # Self-hosted mode: include hostname, optional port and credentials
+        auth = ""
+
+        # Determine Authentication
+        if self.user and self.password:
+            auth = "{user}:{password}@".format(
+                user=NotifyNotifico.quote(self.user, safe=""),
+                password=self.pprint(
+                    self.password,
+                    privacy,
+                    mode=PrivacyMode.Secret,
+                    safe="",
+                ),
+            )
+        elif self.user:
+            auth = "{user}@".format(
+                user=NotifyNotifico.quote(self.user, safe=""),
+            )
+
+        default_port = 443 if self.secure else 80
+
+        return "{schema}://{auth}{host}{port}/{proj}/{hook}/?{params}".format(
+            schema=(self.secure_protocol if self.secure else self.protocol),
+            auth=auth,
+            host=self.host,
+            port=(
+                ""
+                if self.port is None or self.port == default_port
+                else f":{self.port}"
+            ),
             proj=self.pprint(self.project_id, privacy, safe=""),
             hook=self.pprint(self.msghook, privacy, safe=""),
             params=NotifyNotifico.urlencode(params),
         )
 
     def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
-        """Wrapper to _send since we can alert more then one channel."""
+        """Perform Notifico Notification."""
 
-        # prepare our headers
+        # Prepare our headers
         headers = {
             "User-Agent": self.app_id,
-            "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+            "Content-Type": (
+                "application/x-www-form-urlencoded; charset=utf-8"
+            ),
         }
 
-        # Prepare our IRC Prefix
+        # Prepare our IRC color and type prefix token
         color = ""
         token = ""
         if notify_type == NotifyType.INFO:
@@ -255,14 +382,12 @@ class NotifyNotifico(NotifyBase):
             token = "✗"
 
         if self.color:
-            # Colors were specified, make sure we capture and correctly
-            # allow them to exist inline in the message
+            # Colors were specified; allow IRC color codes to pass through
             # \g<1> is less ambiguous than \1
             body = re.sub(r"\\x03(\d{0,2})", r"\\x03\g<1>", body)
 
         else:
-            # no colors specified, make sure we strip out any colors found
-            # to make the string read-able
+            # No colors; strip any IRC color codes to keep the text readable
             body = re.sub(r"\\x03(\d{1,2}(,[0-9]{1,2})?)?", r"", body)
 
         # Prepare our payload
@@ -279,7 +404,7 @@ class NotifyNotifico(NotifyBase):
                     NotificoFormat.Bold if self.color else "",
                     self.app_id,
                     NotificoFormat.Reset if self.color else "",
-                    # Message Body
+                    # Message body
                     body,
                     # Reset
                     NotificoFormat.Reset if self.color else "",
@@ -287,9 +412,27 @@ class NotifyNotifico(NotifyBase):
             ),
         }
 
+        # Build the notify URL
+        if self.mode == NotificoMode.OFFICIAL:
+            # Always use the official HTTPS endpoint
+            notify_url = self.notify_url.format(
+                proj=self.project_id,
+                hook=self.msghook,
+            )
+            auth = None
+
+        else:
+            # Self-hosted: construct URL from host/port
+            schema = "https" if self.secure else "http"
+            notify_url = f"{schema}://{self.host}"
+            if isinstance(self.port, int):
+                notify_url += f":{self.port}"
+            notify_url += f"/h/{self.project_id}/{self.msghook}"
+            auth = (self.user, self.password or "") if self.user else None
+
         self.logger.debug(
-            "Notifico GET URL:"
-            f" {self.api_url} (cert_verify={self.verify_certificate!r})"
+            f"Notifico GET URL: {notify_url} "
+            f"(cert_verify={self.verify_certificate!r})"
         )
         self.logger.debug(f"Notifico Payload: {payload!s}")
 
@@ -298,7 +441,8 @@ class NotifyNotifico(NotifyBase):
 
         try:
             r = requests.get(
-                self.api_url,
+                notify_url,
+                auth=auth,
                 params=payload,
                 headers=headers,
                 verify=self.verify_certificate,
@@ -314,7 +458,9 @@ class NotifyNotifico(NotifyBase):
                 self.logger.warning(
                     "Failed to send Notifico notification: "
                     "{}{}error={}.".format(
-                        status_str, ", " if status_str else "", r.status_code
+                        status_str,
+                        ", " if status_str else "",
+                        r.status_code,
                     )
                 )
 
@@ -341,30 +487,53 @@ class NotifyNotifico(NotifyBase):
 
     @staticmethod
     def parse_url(url):
-        """Parses the URL and returns enough arguments that can allow us to re-
-        instantiate this object."""
+        """Parses the URL and returns enough arguments that can allow us to
+        re-instantiate this object."""
 
         results = NotifyBase.parse_url(url, verify_host=False)
         if not results:
             # We're done early as we couldn't load the results
             return results
 
-        # The first token is stored in the hostname
-        results["project_id"] = NotifyNotifico.unquote(results["host"])
+        # Retrieve path entries for project_id / msghook extraction
+        entries = NotifyNotifico.split_path(results["fullpath"])
 
-        # Get Message Hook
-        try:
-            results["msghook"] = NotifyNotifico.split_path(
-                results["fullpath"]
-            )[0]
+        # Unquote the host field
+        host = NotifyNotifico.unquote(results.get("host", "") or "")
 
-        except IndexError:
-            results["msghook"] = None
+        if re.match(r"^[0-9]+$", host):
+            # Official mode: numeric host value is the project_id
+            results["project_id"] = host
+            # Clear all connection fields -- official mode always routes
+            # to the hardcoded n.tkte.ch endpoint
+            results["host"] = None
+            results["port"] = None
+            results["user"] = None
+            results["password"] = None
+            # First path segment is the message hook
+            results["msghook"] = entries[0] if entries else None
 
-        # Include Color
+        else:
+            # Self-hosted mode: host is the server; path carries the IDs
+            results["project_id"] = entries[0] if entries else None
+            results["msghook"] = entries[1] if len(entries) > 1 else None
+
+        # Support ?token= as an alias for msghook
+        if "token" in results["qsd"] and results["qsd"]["token"]:
+            results["msghook"] = NotifyNotifico.unquote(
+                results["qsd"]["token"]
+            )
+
+        # Support ?project= as an alias for project_id
+        if "project" in results["qsd"] and results["qsd"]["project"]:
+            results["project_id"] = NotifyNotifico.unquote(
+                results["qsd"]["project"]
+            )
+
+        # Include Color option
         results["color"] = parse_bool(results["qsd"].get("color", True))
 
-        # Include Prefix
+        # Include Prefix option
         results["prefix"] = parse_bool(results["qsd"].get("prefix", True))
 
         return results
@@ -387,7 +556,7 @@ class NotifyNotifico(NotifyBase):
         if result:
             return NotifyNotifico.parse_url(
                 "{schema}://{proj}/{hook}/{params}".format(
-                    schema=NotifyNotifico.secure_protocol,
+                    schema=NotifyNotifico.protocol,
                     proj=result.group("proj"),
                     hook=result.group("hook"),
                     params=(

--- a/tests/test_plugin_notifico.py
+++ b/tests/test_plugin_notifico.py
@@ -27,11 +27,15 @@
 
 # Disable logging for a cleaner testing output
 import logging
+from unittest import mock
+from urllib.parse import urlparse
 
 from helpers import AppriseURLTester
+import pytest
 import requests
 
-from apprise.plugins.notifico import NotifyNotifico
+from apprise.common import NotifyType
+from apprise.plugins.notifico import NotificoMode, NotifyNotifico
 
 logging.disable(logging.CRITICAL)
 
@@ -59,14 +63,14 @@ apprise_url_tests = (
     (
         "notifico://abcd/ckhrjW8w672m6HG",
         {
-            # an invalid project id provided
+            # an invalid project id provided (not all digits)
             "instance": TypeError,
         },
     ),
     (
         "notifico://1234/ckhrjW8w672m6HG",
         {
-            # A project id and message hook provided
+            # A project id and message hook provided (official mode)
             "instance": NotifyNotifico,
         },
     ),
@@ -121,11 +125,60 @@ apprise_url_tests = (
             "privacy_url": "notifico://1...4/c...G",
         },
     ),
-    # Support Native URLs
+    # Native URL (official endpoint)
     (
         "https://n.tkte.ch/h/2144/uJmKaBW9WFk42miB146ci3Kj",
         {
             "instance": NotifyNotifico,
+        },
+    ),
+    # Self-hosted HTTP
+    (
+        "notifico://example.com/1234/ckhrjW8w672m6HG",
+        {
+            "instance": NotifyNotifico,
+        },
+    ),
+    # Self-hosted HTTPS
+    (
+        "notificos://example.com/1234/ckhrjW8w672m6HG",
+        {
+            "instance": NotifyNotifico,
+            "privacy_url": "notificos://example.com/1...4/c...G",
+        },
+    ),
+    # Self-hosted with port and color
+    (
+        "notifico://user@example.com:20/1234/ckhrjW8w672m6HG?color=yes",
+        {
+            "instance": NotifyNotifico,
+            "notify_type": "info",
+        },
+    ),
+    # Self-hosted HTTPS with auth
+    (
+        "notificos://user:pass@example.com/1234/ckhrjW8w672m6HG?color=yes",
+        {
+            "instance": NotifyNotifico,
+            "notify_type": "success",
+            "privacy_url": "notificos://user:****@example.com/1...4/c...G",
+        },
+    ),
+    # Self-hosted: project and token supplied as query params
+    (
+        "notificos://user:pass@example.com/"
+        "?project=1234&token=ckhrjW8w672m6HG&color=yes",
+        {
+            "instance": NotifyNotifico,
+            "notify_type": "success",
+            "privacy_url": "notificos://user:****@example.com/1...4/c...G",
+        },
+    ),
+    # Self-hosted: invalid project_id in path
+    (
+        "notifico://example.com/abcd/ckhrjW8w672m6HG",
+        {
+            "instance": TypeError,
         },
     ),
     (
@@ -136,6 +189,7 @@ apprise_url_tests = (
             "include_image": False,
         },
     ),
+    # Official: HTTP error responses
     (
         "notifico://1234/ckhrjW8w672m6HG",
         {
@@ -158,8 +212,32 @@ apprise_url_tests = (
         "notifico://1234/ckhrjW8w672m6HG",
         {
             "instance": NotifyNotifico,
-            # Throws a series of i/o exceptions with this flag
-            # is set and tests that we gracefully handle them
+            # Throws a series of i/o exceptions with this flag set
+            # and tests that we gracefully handle them
+            "test_requests_exceptions": True,
+        },
+    ),
+    # Self-hosted: HTTP error responses
+    (
+        "notifico://example.com/1234/ckhrjW8w672m6HG",
+        {
+            "instance": NotifyNotifico,
+            "response": False,
+            "requests_response_code": requests.codes.internal_server_error,
+        },
+    ),
+    (
+        "notifico://example.com/1234/ckhrjW8w672m6HG",
+        {
+            "instance": NotifyNotifico,
+            "response": False,
+            "requests_response_code": 999,
+        },
+    ),
+    (
+        "notifico://example.com/1234/ckhrjW8w672m6HG",
+        {
+            "instance": NotifyNotifico,
             "test_requests_exceptions": True,
         },
     ),
@@ -171,3 +249,304 @@ def test_plugin_notifico_urls():
 
     # Run our general tests
     AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+@mock.patch("requests.get")
+def test_plugin_notifico_official_mode(mock_get):
+    """NotifyNotifico() official-mode init and round-trip."""
+
+    # Prepare a successful response
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    mock_get.return_value = response
+
+    # Valid official-mode instance
+    obj = NotifyNotifico(
+        project_id="2144",
+        msghook="uJmKaBW9WFk42miB146ci3Kj",
+    )
+    assert obj.mode == NotificoMode.OFFICIAL
+    assert not obj.host
+
+    # url() round-trip preserves identity
+    url = obj.url()
+    assert "2144" in url
+    assert "uJmKaBW9WFk42miB146ci3Kj" in url
+
+    result = NotifyNotifico.parse_url(url)
+    assert result is not None
+    obj2 = NotifyNotifico(**result)
+    assert obj2.url_identifier == obj.url_identifier
+
+    # send() succeeds and hits the official n.tkte.ch endpoint
+    assert obj.send(body="test") is True
+    assert mock_get.call_count == 1
+    call_url = mock_get.call_args[0][0]
+    assert "n.tkte.ch" in call_url
+    assert "2144" in call_url
+    assert "uJmKaBW9WFk42miB146ci3Kj" in call_url
+
+
+@mock.patch("requests.get")
+def test_plugin_notifico_selfhosted_http(mock_get):
+    """NotifyNotifico() self-hosted HTTP mode."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    mock_get.return_value = response
+
+    obj = NotifyNotifico(
+        project_id="1234",
+        msghook="ckhrjW8w672m6HG",
+        host="myhost.local",
+    )
+    assert obj.mode == NotificoMode.SELFHOSTED
+    assert obj.host == "myhost.local"
+    assert obj.secure is False
+
+    # url() encodes the hostname
+    url = obj.url()
+    assert url.startswith("notifico://myhost.local/1234/ckhrjW8w672m6HG")
+
+    # Round-trip preserves identity
+    result = NotifyNotifico.parse_url(url)
+    assert result is not None
+    obj2 = NotifyNotifico(**result)
+    assert obj2.url_identifier == obj.url_identifier
+
+    # send() uses HTTP against the self-hosted host
+    assert obj.send(body="test") is True
+    call_url = mock_get.call_args[0][0]
+    parsed = urlparse(call_url)
+    assert parsed.scheme == "http"
+    assert parsed.hostname == "myhost.local"
+    assert "1234" in call_url
+    assert "ckhrjW8w672m6HG" in call_url
+
+
+@mock.patch("requests.get")
+def test_plugin_notifico_selfhosted_https(mock_get):
+    """NotifyNotifico() self-hosted HTTPS mode with auth and port."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    mock_get.return_value = response
+
+    # Parse a notificos:// URL with credentials and non-default port
+    result = NotifyNotifico.parse_url(
+        "notificos://user:secret@myhost.local:8443/9999/AbCdEfGh"
+    )
+    assert result is not None
+    obj = NotifyNotifico(**result)
+
+    assert obj.mode == NotificoMode.SELFHOSTED
+    assert obj.secure is True
+    assert obj.host == "myhost.local"
+    assert obj.port == 8443
+    assert obj.user == "user"
+
+    # url() emits notificos:// with the non-default port
+    url = obj.url()
+    assert url.startswith("notificos://user:")
+    assert "myhost.local:8443" in url
+    assert "9999" in url
+
+    # Privacy URL hides the password
+    privacy = obj.url(privacy=True)
+    assert "****" in privacy
+
+    # send() uses HTTPS against the self-hosted host
+    assert obj.send(body="test") is True
+    call_url = mock_get.call_args[0][0]
+    parsed = urlparse(call_url)
+    assert parsed.scheme == "https"
+    assert parsed.hostname == "myhost.local"
+    assert parsed.port == 8443
+    assert "9999" in call_url
+    assert "AbCdEfGh" in call_url
+
+
+@mock.patch("requests.get")
+def test_plugin_notifico_invalid_params(mock_get):
+    """NotifyNotifico() invalid init parameters raise TypeError."""
+
+    # Invalid project_id (not all digits)
+    with pytest.raises(TypeError):
+        NotifyNotifico(project_id="abc", msghook="validhook")
+
+    # Invalid msghook (contains special characters)
+    with pytest.raises(TypeError):
+        NotifyNotifico(project_id="1234", msghook="bad hook!")
+
+    # None project_id
+    with pytest.raises(TypeError):
+        NotifyNotifico(project_id=None, msghook="validhook")
+
+    # None msghook
+    with pytest.raises(TypeError):
+        NotifyNotifico(project_id="1234", msghook=None)
+
+    # No HTTP calls should have been made
+    assert mock_get.call_count == 0
+
+
+@mock.patch("requests.get")
+def test_plugin_notifico_parse_url(mock_get):
+    """NotifyNotifico() parse_url edge cases."""
+
+    # Official mode: numeric host is the project_id
+    result = NotifyNotifico.parse_url("notifico://1234/hookABC")
+    assert result is not None
+    assert result["project_id"] == "1234"
+    assert result["msghook"] == "hookABC"
+    assert not result["host"]
+
+    # Official mode must clear port/user/password even when present
+    # in the URL (e.g. notifico://user:pass@1234:8080/hook);
+    # these fields have no meaning for the official n.tkte.ch endpoint
+    result = NotifyNotifico.parse_url("notifico://user:pass@1234:8080/hookABC")
+    assert result is not None
+    assert result["project_id"] == "1234"
+    assert result["msghook"] == "hookABC"
+    assert not result["host"]
+    assert result["port"] is None
+    assert result["user"] is None
+    assert result["password"] is None
+
+    # Self-hosted mode: hostname in host position
+    result = NotifyNotifico.parse_url("notifico://myhost.example/5678/hookXYZ")
+    assert result is not None
+    assert result["project_id"] == "5678"
+    assert result["msghook"] == "hookXYZ"
+    assert result["host"] == "myhost.example"
+
+    # Query-param aliases override path-based values
+    result = NotifyNotifico.parse_url(
+        "notificos://example.com/?project=9999&token=hookQQQ"
+    )
+    assert result is not None
+    assert result["project_id"] == "9999"
+    assert result["msghook"] == "hookQQQ"
+
+    # Color and prefix default to True
+    result = NotifyNotifico.parse_url("notifico://1234/hook")
+    assert result["color"] is True
+    assert result["prefix"] is True
+
+    # Explicit color=no and prefix=no
+    result = NotifyNotifico.parse_url(
+        "notifico://1234/hook?color=no&prefix=no"
+    )
+    assert result["color"] is False
+    assert result["prefix"] is False
+
+    # parse_url returns None only when parse_url itself cannot parse the URL
+    assert NotifyNotifico.parse_url(None) is None
+
+    assert mock_get.call_count == 0
+
+
+@mock.patch("requests.get")
+def test_plugin_notifico_send_http_errors(mock_get):
+    """NotifyNotifico() handles HTTP error responses gracefully."""
+
+    obj = NotifyNotifico(project_id="1234", msghook="validHook")
+
+    # HTTP 500
+    response = mock.Mock()
+    response.status_code = requests.codes.internal_server_error
+    response.content = b""
+    mock_get.return_value = response
+    assert obj.send(body="test") is False
+
+    # Unrecognised HTTP status
+    response.status_code = 999
+    assert obj.send(body="test") is False
+
+    # Network exception
+    mock_get.side_effect = requests.RequestException("connection refused")
+    assert obj.send(body="test") is False
+
+
+@mock.patch("requests.get")
+def test_plugin_notifico_send_notify_types(mock_get):
+    """NotifyNotifico() sends all four notification types successfully."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    mock_get.return_value = response
+
+    obj = NotifyNotifico(
+        project_id="1234",
+        msghook="validHook",
+        color=True,
+        prefix=True,
+    )
+
+    for notify_type in (
+        NotifyType.INFO,
+        NotifyType.SUCCESS,
+        NotifyType.WARNING,
+        NotifyType.FAILURE,
+    ):
+        mock_get.reset_mock()
+        assert obj.send(body="msg", notify_type=notify_type) is True
+        assert mock_get.call_count == 1
+
+
+@mock.patch("requests.get")
+def test_plugin_notifico_color_prefix_flags(mock_get):
+    """NotifyNotifico() color=False strips IRC codes; prefix=False omits it."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    mock_get.return_value = response
+
+    # color=False, prefix=False -- payload should be the raw body
+    obj = NotifyNotifico(
+        project_id="1234",
+        msghook="validHook",
+        color=False,
+        prefix=False,
+    )
+    assert obj.send(body="plain text") is True
+    payload = mock_get.call_args[1]["params"]["payload"]
+    assert payload == "plain text"
+
+    # color=True, prefix=True -- payload contains the prefix bracket
+    mock_get.reset_mock()
+    obj2 = NotifyNotifico(
+        project_id="1234",
+        msghook="validHook",
+        color=True,
+        prefix=True,
+    )
+    assert obj2.send(body="colored text", notify_type=NotifyType.INFO) is True
+    payload2 = mock_get.call_args[1]["params"]["payload"]
+    assert "colored text" in payload2
+    assert "[" in payload2
+
+
+@mock.patch("requests.get")
+def test_plugin_notifico_native_url(mock_get):
+    """NotifyNotifico() parse_native_url() parses n.tkte.ch URLs."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    mock_get.return_value = response
+
+    # Standard native URL
+    result = NotifyNotifico.parse_native_url(
+        "https://n.tkte.ch/h/2144/uJmKaBW9WFk42miB146ci3Kj"
+    )
+    assert result is not None
+    obj = NotifyNotifico(**result)
+    assert obj.mode == NotificoMode.OFFICIAL
+    assert obj.project_id == "2144"
+    assert obj.msghook == "uJmKaBW9WFk42miB146ci3Kj"
+    assert obj.send(body="test") is True
+
+    # Non-matching URL returns None
+    assert (
+        NotifyNotifico.parse_native_url("https://other.host/h/1/abc") is None
+    )


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1254

## *Notifico* Notifications
* **Source**: https://notifico.tech/
* **Image Support**: No
* **Message Format**: Plain Text
* **Message Limit**: 512 characters

Notifico relays notifications to IRC channels. The original hosted service at `n.tkte.ch` has gone offline. This PR adds support for self-hosted Notifico instances while preserving full backward compatibility with the official `n.tkte.ch` endpoint (for users who still have it accessible or run a mirror).

## Account Setup
1. Deploy a self-hosted Notifico instance via https://notifico.tech/ or access a running instance.
2. Create a project and a **Plain Text Message Hook**.
3. Copy the Project ID (integer) and Message Hook token from the hook URL.

## Syntax

Valid syntax is as follows:

- `notifico://{ProjectID}/{MessageHook}` -- official/legacy endpoint
- `notifico://{host}/{ProjectID}/{MessageHook}` -- self-hosted HTTP
- `notificos://{host}/{ProjectID}/{MessageHook}` -- self-hosted HTTPS
- `notifico://{host}:{port}/{ProjectID}/{MessageHook}`
- `notifico://{user}:{password}@{host}/{ProjectID}/{MessageHook}`
- `notificos://{user}:{password}@{host}:{port}/{ProjectID}/{MessageHook}`

## Parameter Breakdown

| Variable    | Required | Description                                                      |
|-------------|----------|------------------------------------------------------------------|
| ProjectID   | Yes      | Integer project ID from the Notifico hook URL                    |
| MessageHook | Yes      | Token string from the end of the Notifico hook URL               |
| host        | No       | Hostname/IP of a self-hosted instance (omit for official n.tkte.ch) |
| port        | No       | Port of the self-hosted instance (default: 80 HTTP / 443 HTTPS)  |
| user        | No       | HTTP Basic Auth username for a self-hosted instance              |
| password    | No       | HTTP Basic Auth password for a self-hosted instance              |
| color       | No       | Send IRC color codes (default: yes)                              |
| prefix      | No       | Prepend a notification-type prefix to the message (default: yes) |

## Examples

Send to the official endpoint (legacy):
```bash
apprise -vv -t "Title" -b "Message" \
    notifico://2144/uJmKaBW9WFk42miB146ci3Kj
```

Send to a self-hosted instance over HTTP:
```bash
apprise -vv -t "Title" -b "Message" \
    notifico://myhost.example/2144/uJmKaBW9WFk42miB146ci3Kj
```

Send to a self-hosted instance over HTTPS with credentials:
```bash
apprise -vv -t "Title" -b "Message" \
    notificos://user:password@myhost.example:8443/2144/uJmKaBW9WFk42miB146ci3Kj
```

## New Service Completion Status
* [x] apprise/plugins/notifico.py
* [x] README.md -- updated notifico entry to show `notifico://` and `notificos://` with self-hosted forms

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/75](https://github.com/caronc/apprise-docs/pull/75)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`). -- 100% coverage on plugin

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1254-notifico-standalone-support

# Self-hosted HTTP
tox -e apprise -- -t "Test Title" -b "Test Message" \
    notifico://myhost.example/2144/uJmKaBW9WFk42miB146ci3Kj

# Self-hosted HTTPS
tox -e apprise -- -t "Test Title" -b "Test Message" \
    notificos://myhost.example/2144/uJmKaBW9WFk42miB146ci3Kj
```
