### PR TITLE
Telegram messages leverage caption field when attachments

### DIFF
--- a/test/test_plugin_telegram.py
+++ b/test/test_plugin_telegram.py
@@ -445,12 +445,24 @@ def test_plugin_telegram_general(mock_post):
             body='body', title='title', notify_type=NotifyType.INFO,
             attach=attach) is True
 
+        # Test large messages
+        assert obj.notify(
+            body='a' * (obj.telegram_caption_maxlen + 1),
+            title='title', notify_type=NotifyType.INFO,
+            attach=attach) is True
+
         # An invalid attachment will cause a failure
         path = os.path.join(
             TEST_VAR_DIR, '/invalid/path/to/an/invalid/file.jpg')
         attach = AppriseAttachment(path)
         assert obj.notify(
             body='body', title='title', notify_type=NotifyType.INFO,
+            attach=path) is False
+
+        # Test large messages
+        assert obj.notify(
+            body='a' * (obj.telegram_caption_maxlen + 1),
+            title='title', notify_type=NotifyType.INFO,
             attach=path) is False
 
     obj = NotifyTelegram(bot_token=bot_token, targets=None)


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1279

Telegram leverages captions when there are file attachments

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1279-discord-image-caption

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  <apprise url related to ticket>

```

