### PR TITLE
Set default port for Mattermost notifications

### DIFF
--- a/apprise/plugins/mattermost.py
+++ b/apprise/plugins/mattermost.py
@@ -205,6 +205,10 @@ class NotifyMattermost(NotifyBase):
         # Set our user
         payload['username'] = self.user if self.user else self.app_id
 
+        port = ''
+        if self.port is not None:
+            port = ':{}'.format(self.port)
+
         # For error tracking
         has_error = False
 
@@ -215,8 +219,8 @@ class NotifyMattermost(NotifyBase):
             if channel:
                 payload['channel'] = channel
 
-            url = '{}://{}:{}{}/hooks/{}'.format(
-                self.schema, self.host, self.port,
+            url = '{}://{}{}{}/hooks/{}'.format(
+                self.schema, self.host, port,
                 self.fullpath.rstrip('/'), self.token)
 
             self.logger.debug('Mattermost POST URL: %s (cert_verify=%r)' % (

--- a/test/test_plugin_mattermost.py
+++ b/test/test_plugin_mattermost.py
@@ -199,3 +199,27 @@ def test_plugin_mattermost_channels(request_mock):
     assert posted_json['username'] == 'user1'
     assert posted_json['channel'] == 'two'
     assert posted_json['text'] == 'title\r\nbody'
+
+def test_mattermost_post_default_port(request_mock):
+    # Test token
+    token = 'token'
+
+    # Instantiate our URL
+    obj = Apprise.instantiate(
+        'mmosts://mattermost.example.com/{token}'.format(
+            token=token)
+    )
+
+    assert isinstance(obj, NotifyMattermost)
+    assert obj.notify(body="body", title='title') is True
+
+    # Make sure we don't use port if not provided
+    assert request_mock.called is True
+    assert request_mock.call_count == 1
+    assert request_mock.call_args_list[0][0][0].startswith(
+        'https://mattermost.example.com/hooks/token')
+
+    # Our Posted JSON Object
+    posted_json = json.loads(request_mock.call_args_list[0][1]['data'])
+    assert 'text' in posted_json
+    assert posted_json['text'] == 'title\r\nbody'

--- a/test/test_plugin_mattermost.py
+++ b/test/test_plugin_mattermost.py
@@ -200,6 +200,7 @@ def test_plugin_mattermost_channels(request_mock):
     assert posted_json['channel'] == 'two'
     assert posted_json['text'] == 'title\r\nbody'
 
+
 def test_mattermost_post_default_port(request_mock):
     # Test token
     token = 'token'


### PR DESCRIPTION
-------

## Description:

When we generate a MM notification URL with:
```
>>> NotifyMattermost(token="secret", host="chat.example.com", port=443, secure=True).url()
'mmosts://chat.example.com/secret/?image=no&format=text&overflow=upstream'
```

We need to be able to also parse it out with same defaults. However:
```
>>> from apprise import Apprise
>>> ac=Apprise()
>>> ac.add(NotifyMattermost(token="secret", host="chat.example.com", port=443, secure=True).u
rl())
>>> ac.urls()
['mmosts://chat.example.com:None/secret/?image=no&format=text&overflow=upstream']
```

This causes failure of notifications due to Port being set to None instead of parsing default port 443or 80 (depending whether secure is True). This PR sets the default port if not provided

## New Service Completion Status
<!-- This section is only applicable if you're adding a new service -->
* [x] apprise/plugins/<!--new plugin name -->.py
* [x] KEYWORDS
    - add new service into this file (alphabetically).
* [x] README.md
    - add entry for new service to table (as a quick reference)
* [x] packaging/redhat/python-apprise.spec
    - add new service into the `%global common_description`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/sochotnicky/apprise.git@fix-mm-port-parsing

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
   'mmosts://chat.example.com/secret/?image=no&format=text&overflow=upstream'
```