### PR TITLE
Fix flaky test in translation tests

### DIFF
--- a/test/test_apprise_translations.py
+++ b/test/test_apprise_translations.py
@@ -297,6 +297,9 @@ def test_apprise_trans_windows_users_nux(mock_getlocale):
     # 4105 = en_CA
     windll.kernel32.GetUserDefaultUILanguage.return_value = 4105
 
+    # Store default value to not break other tests
+    default_language = locale.AppriseLocale._default_language
+
     with environ('LANGUAGE', 'LC_ALL', 'LC_CTYPE', 'LANG'):
         # Our default language
         locale.AppriseLocale._default_language = 'zz'
@@ -324,6 +327,9 @@ def test_apprise_trans_windows_users_nux(mock_getlocale):
         assert locale.AppriseLocale.detect_language() == 'fr'
 
     delattr(ctypes, 'windll')
+
+    # Restore default value
+    locale.AppriseLocale._default_language = default_language
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Unique Nux test cases")


### PR DESCRIPTION
## Description:

<!-- Have anything else to describe? Define it here -->
For a university course, I tested this project for flaky tests, which are tests that can both pass or fail without changes to their code.
I noticed that when test_apprise_trans_windows_users_nux is executed before test_apprise_trans_add, the first assertion in test_apprise_trans_add fails because the fallback value was changed in test_apprise_trans_windows_users_nux. My changes restore the default value as done [here](https://github.com/caronc/apprise/blob/9bf45e415ddb7c08decb78029153478ed6bca4a4/test/test_apprise_translations.py#L197), which fixes the test. I assume the same should be done in the windows test but I'm unable to test on Windows.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/dg98/apprise.git@master

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  <apprise url related to ticket>

```

