### PR TITLE
Extend options for plugin Seven

### DIFF
--- a/apprise/plugins/seven.py
+++ b/apprise/plugins/seven.py
@@ -37,6 +37,7 @@ from ..common import NotifyType
 from ..utils.parse import is_phone_no, parse_phone_no, parse_bool
 from ..locale import gettext_lazy as _
 
+
 class NotifySeven(NotifyBase):
     """
     A wrapper for seven Notifications
@@ -114,7 +115,8 @@ class NotifySeven(NotifyBase):
         },
     })
 
-    def __init__(self, apikey, targets=None, source=None, flash=None, **kwargs):
+    def __init__(self, apikey, targets=None, source=None, flash=None,
+                 **kwargs):
         """
         Initialize Seven Object
         """

--- a/test/test_plugin_seven.py
+++ b/test/test_plugin_seven.py
@@ -85,6 +85,14 @@ apprise_url_tests = (
         # valid number, utilizing the optional source= variable (same as from)
         'instance': NotifySeven,
     }),
+    ('seven://{}/15551232000?from=apprise&flash=true'.format('3' * 14), {
+        # valid number, utilizing the optional from= variable
+        'instance': NotifySeven,
+    }),
+    ('seven://{}/15551232000?source=apprise&flash=true'.format('3' * 14), {
+        # valid number, utilizing the optional source= variable (same as from)
+        'instance': NotifySeven,
+    }),
 )
 
 

--- a/test/test_plugin_seven.py
+++ b/test/test_plugin_seven.py
@@ -77,6 +77,14 @@ apprise_url_tests = (
         # Our call to notify() under the hood will fail
         'notify_response': False,
     }),
+    ('seven://{}/15551232000?from=apprise'.format('3' * 14), {
+        # valid number, utilizing the optional from= variable
+        'instance': NotifySeven,
+    }),
+    ('seven://{}/15551232000?source=apprise'.format('3' * 14), {
+        # valid number, utilizing the optional source= variable (same as from)
+        'instance': NotifySeven,
+    }),
 )
 
 


### PR DESCRIPTION
## Description:
I added some common options to the plugin Seven:
- from
- flash
**Related issue (if applicable):** #<!--apprise issue number goes here-->

<!-- Have anything else to describe? Define it here -->


## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@<this.branch-name>

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
   "seven://<SEVEN_API_KEY>/<RECIPIENT>?from=apprise&flash=true"
```

