### PR TITLE
apprise.urls() bulletproofing/bugfix

### DIFF
--- a/apprise/apprise.py
+++ b/apprise/apprise.py
@@ -759,7 +759,14 @@ class Apprise:
         """
         Returns all of the loaded URLs defined in this apprise object.
         """
-        return [x.url(privacy=privacy) for x in self.servers]
+        urls = []
+        for s in self.servers:
+            if isinstance(s, (ConfigBase, AppriseConfig)):
+                for _s in s.servers():
+                    urls.append(_s.url(privacy=privacy))
+            else:
+                urls.append(s.url(privacy=privacy))
+        return urls
 
     def pop(self, index):
         """

--- a/test/test_apprise_config.py
+++ b/test/test_apprise_config.py
@@ -895,6 +895,28 @@ include strict://{}""".format(str(cfg04), str(cfg04), str(cfg04)))
     assert len(ac.servers()) == 3
 
 
+def test_apprise_config_file_loading(tmpdir):
+    """
+    API: AppriseConfig() URL Testing
+
+    """
+
+    config_path = tmpdir / "apprise.yml"
+
+    # Create a temporary config file
+    config_path.write("urls:\n      - json://localhost")
+
+    # Flow from README.md
+    ap = Apprise()
+    ap.add('xml://localhost')
+    config = AppriseConfig()
+    config.add(str(config_path))
+    ap.add(config)
+
+    # Using urls()
+    assert len(ap.urls()) == 2
+
+
 def test_apprise_config_matrix_load():
     """
     API: AppriseConfig() matrix initialization


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1297

Bugfix to prevent `apprise.urls()` from working when a `AppriseConfig()` has been defined within it.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1297-config-url-bugfix
```

