### PR TITLE
Add option label for plugin seven

### DIFF
--- a/apprise/plugins/seven.py
+++ b/apprise/plugins/seven.py
@@ -37,6 +37,7 @@ from ..common import NotifyType
 from ..utils.parse import is_phone_no, parse_phone_no, parse_bool
 from ..locale import gettext_lazy as _
 
+
 class NotifySeven(NotifyBase):
     """
     A wrapper for seven Notifications
@@ -114,7 +115,8 @@ class NotifySeven(NotifyBase):
         },
     })
 
-    def __init__(self, apikey, targets=None, source=None, flash=None, **kwargs):
+    def __init__(self, apikey, targets=None, source=None, flash=None,
+                 **kwargs):
         """
         Initialize Seven Object
         """

--- a/apprise/plugins/seven.py
+++ b/apprise/plugins/seven.py
@@ -113,10 +113,14 @@ class NotifySeven(NotifyBase):
             'type': 'bool',
             'default': False,
         },
+        'label': {
+            'name': _('Label'),
+            'type': 'string'
+        },
     })
 
     def __init__(self, apikey, targets=None, source=None, flash=None,
-                 **kwargs):
+                 label=None, **kwargs):
         """
         Initialize Seven Object
         """
@@ -133,6 +137,8 @@ class NotifySeven(NotifyBase):
             if not isinstance(source, str) else source.strip()
         self.flash = self.template_args['flash']['default'] \
             if flash is None else bool(flash)
+        self.label = None \
+            if not isinstance(label, str) else label.strip()
 
         # Parse our targets
         self.targets = list()
@@ -154,7 +160,7 @@ class NotifySeven(NotifyBase):
     def url_identifier(self):
         """
         Returns all of the identifiers that make this URL unique from
-        another simliar one. Targets or end points should never be identified
+        another similar one. Targets or end points should never be identified
         here.
         """
         return (self.secure_protocol, self.apikey)
@@ -189,6 +195,8 @@ class NotifySeven(NotifyBase):
             payload['from'] = self.source
         if self.flash:
             payload['flash'] = self.flash
+        if self.label:
+            payload['label'] = self.label
         # Create a copy of the targets list
         targets = list(self.targets)
         while len(targets):
@@ -278,6 +286,8 @@ class NotifySeven(NotifyBase):
         }
         if self.source:
             params['from'] = self.source
+        if self.label:
+            params['label'] = self.label
 
         # Our URL parameters
         params = self.url_parameters(privacy=privacy, *args, **kwargs)
@@ -332,5 +342,7 @@ class NotifySeven(NotifyBase):
 
         results['flash'] = \
             parse_bool(results['qsd'].get('flash', False))
+        results['label'] = \
+            results['qsd'].get('label', None)
 
         return results

--- a/test/test_plugin_seven.py
+++ b/test/test_plugin_seven.py
@@ -93,6 +93,10 @@ apprise_url_tests = (
         # valid number, utilizing the optional source= variable (same as from)
         'instance': NotifySeven,
     }),
+    ('seven://{}/15551232000?source=AR&flash=1&label=123'.format('3' * 14), {
+        # valid number, utilizing the optional source= variable (same as from)
+        'instance': NotifySeven,
+    }),
 )
 
 

--- a/test/test_plugin_seven.py
+++ b/test/test_plugin_seven.py
@@ -85,6 +85,14 @@ apprise_url_tests = (
         # valid number, utilizing the optional source= variable (same as from)
         'instance': NotifySeven,
     }),
+    ('seven://{}/15551232000?from=apprise&flash=true'.format('3' * 14), {
+        # valid number, utilizing the optional from= variable
+        'instance': NotifySeven,
+    }),
+    ('seven://{}/15551232000?source=apprise&flash=true'.format('3' * 14), {
+        # valid number, utilizing the optional source= variable (same as from)
+        'instance': NotifySeven,
+    }),
 )
 
 

--- a/test/test_plugin_seven.py
+++ b/test/test_plugin_seven.py
@@ -77,6 +77,14 @@ apprise_url_tests = (
         # Our call to notify() under the hood will fail
         'notify_response': False,
     }),
+    ('seven://{}/15551232000?from=apprise'.format('3' * 14), {
+        # valid number, utilizing the optional from= variable
+        'instance': NotifySeven,
+    }),
+    ('seven://{}/15551232000?source=apprise'.format('3' * 14), {
+        # valid number, utilizing the optional source= variable (same as from)
+        'instance': NotifySeven,
+    }),
 )
 
 


### PR DESCRIPTION
Hi,
a customer of ours requested this option. Hope all is good!

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@<this.branch-name>

# Test out the changes with the following command:
apprise % bin/apprise -t "Test Title" -b "Test Message" \
  "seven://<SEVEN_API_KEY>/491716992343?from=AR&label=label123"
```

