### PR TITLE
Ntfy.sh Internationalized URL support added for click=

### DIFF
--- a/apprise/plugins/ntfy.py
+++ b/apprise/plugins/ntfy.py
@@ -40,7 +40,7 @@ import requests
 from json import loads
 from json import dumps
 from os.path import basename
-
+from urllib.parse import quote
 from .base import NotifyBase
 from ..common import NotifyFormat
 from ..common import NotifyType
@@ -347,7 +347,10 @@ class NotifyNtfy(NotifyBase):
         self.filename = filename
 
         # A clickthrough option for notifications
-        self.click = click
+        # Support Internationalized URLs
+        self.click = None if not isinstance(click, str) else (
+            click if not any(ord(char) > 127 for char in click)
+            else quote(click, safe=':/?&=[]'))
 
         # Time delay for notifications (various string formats)
         self.delay = delay
@@ -539,7 +542,7 @@ class NotifyNtfy(NotifyBase):
             headers['X-Delay'] = self.delay
 
         if self.click is not None:
-            headers['X-Click'] = self.click
+            headers['X-Click'] = quote(self.click, safe=':/?@&=#')
 
         if self.email is not None:
             headers['X-Email'] = self.email


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1308

Support ntfy.sh internationalized URLs

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1308-escape-ntfy-click

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
   "ntfys://ntfy.sh/topic/?click=https://通知の例"

```

