### PR TITLE
fix(pushover): Do not escape HTML in the message

### DIFF
--- a/apprise/plugins/pushover.py
+++ b/apprise/plugins/pushover.py
@@ -380,6 +380,9 @@ class NotifyPushover(NotifyBase):
             payload['url_title'] = self.supplemental_url_title
 
         if self.notify_format == NotifyFormat.HTML:
+            # Do not escape HTML in the message as Pushover
+            # expects the text of the message to be unescaped.
+            self.notify_format = NotifyFormat.TEXT
             # https://pushover.net/api#html
             payload['html'] = 1
 

--- a/apprise/plugins/pushover.py
+++ b/apprise/plugins/pushover.py
@@ -382,7 +382,8 @@ class NotifyPushover(NotifyBase):
         if self.notify_format == NotifyFormat.HTML:
             # Do not escape HTML in the message as Pushover
             # expects the text of the message to be unescaped.
-            self.notify_format = NotifyFormat.TEXT
+            payload['message'] = convert_between(
+                NotifyFormat.HTML, NotifyFormat.TEXT, body)
             # https://pushover.net/api#html
             payload['html'] = 1
 


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #<!--apprise issue number goes here-->

https://github.com/caronc/apprise/issues/1315

<!-- Have anything else to describe? Define it here -->

Not sure the best way to handle this but I would like it fixed so here is one solution.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@<this.branch-name>

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  <apprise url related to ticket>

```

