### PR TITLE
Add email related content support (RFC2387).

### DIFF
--- a/apprise/plugins/email/base.py
+++ b/apprise/plugins/email/base.py
@@ -927,7 +927,7 @@ class NotifyEmail(NotifyBase):
                 base = MIMEText(body, 'plain', 'utf-8')
 
             if attach:
-                mixed = MIMEMultipart("mixed")
+                mixed = MIMEMultipart("related")
                 mixed.attach(base)
                 # Now store our attachments
                 for no, attachment in enumerate(attach, start=1):
@@ -959,6 +959,10 @@ class NotifyEmail(NotifyBase):
                                 Header(filename, 'utf-8')),
                         )
                         mixed.attach(app)
+                        app.add_header(
+                            'Content-ID',
+                             '<{}>'.format(Header(filename, 'utf-8')),
+                        )
                 base = mixed
 
             if pgp:


### PR DESCRIPTION
MIME multipart contents can access other email parts when using "multipart/related" Content-Type.
This allows, for example, the HTML body to embed attached image files accepted by email clients and email web clients following RFC 2387. 

Additionally it is necessary to add the Content-ID header to the attachment part so the html body can link it.

This commit inserts the Content-ID to each attachment with filename as the tag value, allowing the HTML body to reference it using: 
```
<img src="cid:FILE_NAME.EXT">
```

Tested with:
- Outlook
- Thunderbird - Windows and Linux
- IOS Native email app
- GMAIL - Web Interface
- GMAIL - Android and IOS APP

## Description:
**Related issue (if applicable):** #<!--apprise issue number goes here-->

<!-- Have anything else to describe? Define it here -->

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@<this.branch-name>

# Test out the changes with the following command:
bin/test.sh email

```

