### PR TITLE
fixes for zulip plugin

### DIFF
--- a/apprise/plugins/zulip.py
+++ b/apprise/plugins/zulip.py
@@ -252,7 +252,7 @@ class NotifyZulip(NotifyBase):
 
         # prepare JSON Object
         payload = {
-            'subject': title,
+            'topic': title,
             'content': body,
         }
 

--- a/apprise/plugins/zulip.py
+++ b/apprise/plugins/zulip.py
@@ -284,7 +284,7 @@ class NotifyZulip(NotifyBase):
             self.logger.debug('Zulip POST URL: %s (cert_verify=%r)' % (
                 url, self.verify_certificate,
             ))
-            self.logger.debug('Zulip Payload: %s' % str(payload))
+            self.logger.warning('Zulip Payload: %s' % str(payload))
 
             # Always call throttle before any remote server i/o is made
             self.throttle()
@@ -311,8 +311,8 @@ class NotifyZulip(NotifyBase):
                             ', ' if status_str else '',
                             r.status_code))
 
-                    self.logger.debug(
-                        'Response Details:\r\n{}'.format(r.content))
+                    self.logger.warning('Response Details:\r\n{}'.format(
+                        r.content))
 
                     # Mark our failure
                     has_error = True


### PR DESCRIPTION
## Description:

Without looking into it much, I found that talking to zulip (self-hosted, zulip/docker-zulip:9.4-0) fails without a 'topic' key and succeeds with one.

Failure looks like this. Notice how the response body is critical for debugging, so I promoted it to `warning`:

```
[main] 2025-05-10 21:30:30,245 [WARNING] apprise: Zulip Payload: {'title': 'topic1', 'content': 'line1', 'type': 'stream', 'to': 'alerts'}
[main] 2025-05-10 21:30:30,292 [WARNING] apprise: Failed to send Zulip notification to alerts: Bad Request - Unsupported Parameters., error=400.
[main] 2025-05-10 21:30:30,292 [WARNING] apprise: Response Details:
[main] b'{"result":"error","msg":"Missing topic","code":"BAD_REQUEST"}\n'
```

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [ ] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
bin/test.sh didn't work for me, but `grep topic test/test_plugin_zulip.py` returns nothing :) so CI will probably pass.
