### PR TITLE
Display SMTP host in debug mode

### DIFF
--- a/apprise/plugins/email/base.py
+++ b/apprise/plugins/email/base.py
@@ -498,7 +498,7 @@ class NotifyEmail(NotifyBase):
 
             self.logger.trace('Login ID: {}'.format(self.user))
             if self.user and self.password:
-                # Apply Login credetials
+                # Apply Login credentials
                 self.logger.debug('Applying user credentials...')
                 socket.login(self.user, self.password)
 
@@ -588,7 +588,7 @@ class NotifyEmail(NotifyBase):
             params['smtp'] = self.smtp_host
 
         if self.secure:
-            # Mode is only requried if we're dealing with a secure connection
+            # Mode is only required if we're dealing with a secure connection
             params['mode'] = self.secure_mode
 
         if self.from_addr[0] and self.from_addr[0] != self.app_id:
@@ -677,7 +677,7 @@ class NotifyEmail(NotifyBase):
     def url_identifier(self):
         """
         Returns all of the identifiers that make this URL unique from
-        another simliar one. Targets or end points should never be identified
+        another similar one. Targets or end points should never be identified
         here.
         """
         return (
@@ -867,7 +867,7 @@ class NotifyEmail(NotifyBase):
             # Generate a host identifier (used for Message-ID Creation)
             smtp_host = from_addr[1].split('@')[1]
 
-        logger.debug('SMTP Host: {smtp_host}')
+        logger.debug(f'SMTP Host: {smtp_host}')
 
         # Create a copy of the targets list
         emails = list(to)
@@ -980,7 +980,7 @@ class NotifyEmail(NotifyBase):
                     logger.warning(msg)
                     raise AppriseEmailException(msg)
 
-                # prepare our messsage
+                # prepare our message
                 base = MIMEMultipart(
                     "encrypted", protocol="application/pgp-encrypted")
 


### PR DESCRIPTION
## Description:
Small PR - displays SMTP host in debug mode. It also fixes a few typos along the way.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@<this.branch-name>

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  <apprise url related to ticket>

```

