### PR TITLE
Slack Templates (Raw & Blocks API JSON)

### DIFF
--- a/apprise/plugins/slack.py
+++ b/apprise/plugins/slack.py
@@ -617,14 +617,14 @@ class NotifySlack(NotifyBase):
                 # Support <url|desc>, <url> entries
                 for match in self._re_url_support.findall(body):
                     # Swap back any ampersands previously updaated
-                    url = match[1].replace('&amp;', '&')
+                    url_ = match[1].replace('&amp;', '&')
                     desc = match[2].strip()
 
                     # Update our string
                     body = re.sub(
                         re.escape(match[0]),
-                        '<{url}|{desc}>'.format(url=url, desc=desc)
-                        if desc else '<{url}>'.format(url=url),
+                        '<{url}|{desc}>'.format(url=url_, desc=desc)
+                        if desc else '<{url}>'.format(url=url_),
                         body,
                         re.IGNORECASE)
 


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #641 

This PR adds the following functionality to the Slack plugin
(Similar to MSTeams implementation)
* `template` key to all Slack URLs accepts a file (or any attachment) which is used to generate the sent message
* Tokens prepended with `:` are dynamically added to the template (e.g: `...&template=file.txt&:token=value`)

* Full Support of the [Block Kit API](https://app.slack.com/block-kit-builder/)
The templates can utilize the full power of the Blocks Kit API. If the AppRise URL contains `blocks=yes`, then the template file is parsed as JSON, and it is passed as-is. An example follows:
`template-blocks.json`
```json
{
  "blocks": [
    {
      "type": "section",
      "text": {
        "type": "mrkdwn",
        "text": "Hey there 👋: {{ app_desc }}."
      }
    },
    {
      "type": "section",
      "text": {
        "type": "mrkdwn",
        "text": "{{ app_body }}"
      }
    },
    {
      "type": "actions",
      "elements": [
        {
          "type": "button",
          "text": {
            "type": "plain_text",
            "emoji": true,
            "text": "{{ app_id }}"
          },
          "style": "primary",
          "value": "click_me_123"
        }
      ]
    }
  ]
}
```
```python
apprise_url = 'slack://x/x/x?blocks=true&template=template-blocks.json'
apprise_obj = apprise.Apprise()
apprise_obj.add(apprise_url)

apprise_obj.notify(body="body of the message", title="TITLE")
```
![image](https://github.com/user-attachments/assets/dee632c1-934b-4a30-a57e-4bf0f70f221b)
##### NOTE: As you can see the `title` is not rendered, as it was not used in the template. *With great power comes great responsibility*.
##### NOTE: `footer` and params that traditionally modify the message are ignored when `template` is used with `blocks`.

* If the URL does not contain `blocks` param, then the template is free text, only sent as `body` of the notification. The `title` is processed as usually.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [ ] 100% test coverage

## Testing
**This PR's feature is testable by everyone!**

### We can use a Github Gist containing a template!
The Gist below contains the Blocks template used above:
https://gist.github.com/operatorequals/16864f51c215a0a9628f934b0740095a
We can use it by filling its Raw URL to the AppRise template, getting an AppRise URL as below:
```
slack://x/x/x?blocks=true&template=https://gist.githubusercontent.com/operatorequals/16864f51c215a0a9628f934b0740095a/raw/fd582669e3e35f9a9705946568989f41a3fe8166/slack-blocks-apprise-template.json
```
##### NOTE: fill the `x` to your Slack Incoming Webhook values

<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@<this.branch-name>

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  <apprise url related to ticket>

```

