### PR TITLE
Fix throttling in matrix plugin

### DIFF
--- a/apprise/plugins/matrix.py
+++ b/apprise/plugins/matrix.py
@@ -1279,6 +1279,9 @@ class NotifyMatrix(NotifyBase):
         fn = requests.post if method == 'POST' else (
             requests.put if method == 'PUT' else requests.get)
 
+        # Always call throttle before any remote server i/o is made
+        self.throttle()
+
         # Define how many attempts we'll make if we get caught in a throttle
         # event
         retries = self.default_retries if self.default_retries > 0 else 1

--- a/apprise/plugins/matrix.py
+++ b/apprise/plugins/matrix.py
@@ -177,7 +177,7 @@ class NotifyMatrix(NotifyBase):
     default_retries = 2
 
     # The number of micro seconds to wait if we get a 429 error code and
-    # the server doesn't remind us how long we shoul wait for
+    # the server doesn't remind us how long we should wait for
     default_wait_ms = 1000
 
     # Our default is to no not use persistent storage beyond in-memory
@@ -1319,25 +1319,24 @@ class NotifyMatrix(NotifyBase):
                 response = loads(r.content)
 
                 if r.status_code == requests.codes.too_many_requests:
-                    wait = self.default_wait_ms / 1000
+                    wait_ms = self.default_wait_ms
                     try:
-                        wait = response['retry_after_ms'] / 1000
+                        wait_ms = response['retry_after_ms']
 
                     except KeyError:
                         try:
                             errordata = response['error']
-                            wait = errordata['retry_after_ms'] / 1000
+                            wait_ms = errordata['retry_after_ms']
                         except KeyError:
                             pass
 
                     self.logger.warning(
-                        'Matrix server requested we throttle back {}ms; '
-                        'retries left {}.'.format(wait, retries))
-                    self.logger.debug(
-                        'Response Details:\r\n{}'.format(r.content))
+                        f'Matrix server requested we throttle back '
+                        f'{wait_ms}ms; retries left {retries}.')
+                    self.logger.debug(f'Response Details:\r\n{r.content}')
 
                     # Throttle for specified wait
-                    self.throttle(wait=wait)
+                    self.throttle(wait=wait_ms / 1000)
 
                     # Try again
                     continue


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** -

I noticed that in our project the automatic throttling after hitting the Matrix login rate limit did not work. This is an issue for us as long as the Apprise Persistent Storage is not working for the `apache-airflow-providers-apprise` package (see https://github.com/apache/airflow/issues/51102).

There is also - in a separate commit - a small fix for a warning log message which confused me.

Sorry, I do not have time to look into test coverage...

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [X] The code change is tested and works locally.
* [X] There is no commented out code in this PR.
* [X] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@fix-throttling-in-matrix-plugin

# Test out the changes with deactivated Persistent Storage, by calling the following command multiple times in a row until you hit the login rate limit.
apprise  --storage-mode=memory -vvv -t "Test Title" -b "Test Message" \
  <apprise URL of a Matrix server with login rate limit>
```
With this PR, throttling works as expected:
```
...
2025-06-16 15:25:12,182 - DEBUG - Matrix POST URL: https://<your server>/_matrix/client/v3/login (cert_verify=True)
2025-06-16 15:25:12,182 - DEBUG - Matrix Payload: <...>
2025-06-16 15:25:12,940 - DEBUG - Matrix Response: code=429, b'{"errcode":"M_LIMIT_EXCEEDED","error":"Too Many Requests","retry_after_ms":301339}'
2025-06-16 15:25:12,940 - WARNING - Matrix server requested we throttle back 301339ms; retries left 1.
2025-06-16 15:25:12,940 - DEBUG - Response Details:
b'{"errcode":"M_LIMIT_EXCEEDED","error":"Too Many Requests","retry_after_ms":301339}'
2025-06-16 15:25:12,940 - DEBUG - Throttling forced for 301.339s...
2025-06-16 15:30:14,279 - DEBUG - Matrix POST URL: https://<your server>/_matrix/client/v3/login (cert_verify=True)
2025-06-16 15:30:14,279 - DEBUG - Matrix Payload: <...>
2025-06-16 15:30:14,702 - DEBUG - Matrix Response: code=200, <...>
2025-06-16 15:30:14,702 - DEBUG - Authenticated successfully with Matrix server.
...
```
Throttling works: We can log in with the first retry.

Without this PR:
```
...
2025-06-16 15:38:25,679 - DEBUG - Matrix POST URL: https://<your server>/_matrix/client/v3/login (cert_verify=True)
2025-06-16 15:38:25,679 - DEBUG - Matrix Payload: <...>
2025-06-16 15:38:26,195 - DEBUG - Matrix Response: code=429, <...>
2025-06-16 15:38:26,195 - WARNING - Matrix server requested we throttle back 174.511ms; retries left 1.
2025-06-16 15:38:26,196 - DEBUG - Response Details:
b'{"errcode":"M_LIMIT_EXCEEDED","error":"Too Many Requests","retry_after_ms":174511}'
2025-06-16 15:38:26,196 - DEBUG - Matrix POST URL: https://<your server>/_matrix/client/v3/login (cert_verify=True)
2025-06-16 15:38:26,196 - DEBUG - Matrix Payload: <...>
2025-06-16 15:38:26,713 - DEBUG - Matrix Response: code=429, b'{"errcode":"M_LIMIT_EXCEEDED","error":"Too Many Requests","retry_after_ms":173992}'
2025-06-16 15:38:26,713 - WARNING - Matrix server requested we throttle back 173.992ms; retries left 0.
2025-06-16 15:38:26,713 - DEBUG - Response Details:
b'{"errcode":"M_LIMIT_EXCEEDED","error":"Too Many Requests","retry_after_ms":173992}'
2025-06-16 15:38:26,713 - DEBUG - Throttling forced for 173.992s...
2025-06-16 15:41:20,706 - DEBUG - Matrix POST URL: https://<your server>/_matrix/client/v3/register (cert_verify=True)
2025-06-16 15:41:20,706 - DEBUG - Matrix Payload: <...>
2025-06-16 15:41:20,725 - DEBUG - Matrix Response: code=403, b'{"errcode":"M_FORBIDDEN","error":"Registration has been disabled"}'
2025-06-16 15:41:20,725 - WARNING - Failed to handshake with Matrix server: Unauthorized - Invalid Token., error=403.
2025-06-16 15:41:20,725 - DEBUG - Response Details:
b'{"errcode":"M_FORBIDDEN","error":"Registration has been disabled"}'
```
Note, how the first throttling does not work: We are asked to throttle for 174 seconds but immediately POST another login request, without waiting.