### PR TITLE
Support mailto://localhost (default user is root)

### DIFF
--- a/apprise/plugins/email/base.py
+++ b/apprise/plugins/email/base.py
@@ -393,7 +393,7 @@ class NotifyEmail(NotifyBase):
         it was provided.
         """
 
-        if self.smtp_host or not self.user:
+        if self.smtp_host:
             # SMTP Server was explicitly specified, therefore it is assumed
             # the caller knows what he's doing and is intentionally
             # over-riding any smarts to be applied. We also can not apply
@@ -404,7 +404,7 @@ class NotifyEmail(NotifyBase):
         from_addr = '{}@{}'.format(
             re.split(r'[\s@]+', self.user)[0],
             self.host,
-        )
+        ) if self.user else self.host
 
         for i in range(len(templates.EMAIL_TEMPLATES)):  # pragma: no branch
             self.logger.trace('Scanning %s against %s' % (
@@ -457,6 +457,14 @@ class NotifyEmail(NotifyBase):
                         # user specified but login type
                         # not supported; switch it to email
                         self.user = '{}@{}'.format(self.user, self.host)
+
+                if 'from_user' in templates.EMAIL_TEMPLATES[i][2] \
+                        and not self.from_addr[1]:
+
+                    # Update our from address if defined
+                    self.from_addr[1] = '{}@{}'.format(
+                        templates.EMAIL_TEMPLATES[i][2]['from_user'],
+                        self.host)
 
                 break
 

--- a/apprise/plugins/email/templates.py
+++ b/apprise/plugins/email/templates.py
@@ -255,6 +255,19 @@ EMAIL_TEMPLATES = (
         },
     ),
 
+    # Localhost handling
+    (
+        'Local Mail Server',
+        re.compile(
+            r'^(((?P<label>[^+]+)\+)?(?P<id>[^@]+)@)?'
+            r'(?P<domain>localhost(\.localdomain)?)$', re.I),
+        {
+            # Provide a default user if one isn't provided
+            'from_user': 'root',
+            'smtp_host': None,
+        },
+    ),
+
     # Catch All
     (
         'Custom',


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1334

`mailto://localhost` now works in the simpliest URL form.  The default user is `root` and this is what who is notified if not otherwise specified.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@<this.branch-name>

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  "mailto://localhost"

```

