### PR TITLE
Added QQ Push Support

### DIFF
--- a/KEYWORDS
+++ b/KEYWORDS
@@ -79,6 +79,7 @@ Pushplus
 PushSafer
 Pushy
 PushDeer
+QQ Push
 Reddit
 Resend
 Revolt

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The table below identifies the services this tool supports and some example serv
 | [PushSafer](https://github.com/caronc/apprise/wiki/Notify_pushsafer)  | psafer:// or psafers://  | (TCP) 80 or 443  | psafer://privatekey<br />psafers://privatekey/DEVICE<br />psafer://privatekey/DEVICE1/DEVICE2/DEVICEN
 | [Pushy](https://github.com/caronc/apprise/wiki/Notify_pushy)  | pushy://  | (TCP) 443  | pushy://apikey/DEVICE<br />pushy://apikey/DEVICE1/DEVICE2/DEVICEN<br />pushy://apikey/TOPIC<br />pushy://apikey/TOPIC1/TOPIC2/TOPICN
 | [PushDeer](https://github.com/caronc/apprise/wiki/Notify_pushdeer) | pushdeer:// or pushdeers:// | (TCP) 80 or 443 | pushdeer://pushKey<br />pushdeer://hostname/pushKey<br />pushdeer://hostname:port/pushKey
+| [QQ Push](https://github.com/caronc/apprise/wiki/Notify_qq) | qq://  | (TCP) 443   | qq://Token
 | [Reddit](https://github.com/caronc/apprise/wiki/Notify_reddit) | reddit:// | (TCP) 443   | reddit://user:password@app_id/app_secret/subreddit<br />reddit://user:password@app_id/app_secret/sub1/sub2/subN
 | [Resend](https://github.com/caronc/apprise/wiki/Notify_resend) | resend://  | (TCP) 443   | resend://APIToken:FromEmail/<br />resend://APIToken:FromEmail/ToEmail<br />resend://APIToken:FromEmail/ToEmail1/ToEmail2/ToEmailN/
 | [Revolt](https://github.com/caronc/apprise/wiki/Notify_Revolt) | revolt:// | (TCP) 443   |  revolt://bottoken/ChannelID<br />revolt://bottoken/ChannelID1/ChannelID2/ChannelIDN |

--- a/apprise/plugins/qq.py
+++ b/apprise/plugins/qq.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+#
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2025, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Assumes QQ Push API provided by third-party bridge like message-pusher
+
+import re
+import requests
+
+from ..utils.parse import validate_regex
+from ..url import PrivacyMode
+from .base import NotifyBase
+from ..locale import gettext_lazy as _
+from ..common import NotifyType
+
+
+class NotifyQQ(NotifyBase):
+    """
+    A wrapper for QQ Push Notifications
+    """
+
+    # The default descriptive name associated with the Notification
+    service_name = _('QQ Push')
+
+    # The services URL
+    service_url = 'https://github.com/songquanpeng/message-pusher'
+
+    # The default secure protocol
+    secure_protocol = 'qq'
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = 'https://github.com/caronc/apprise/wiki/Notify_qq'
+
+    # URL used to send notifications with
+    notify_url = 'https://qmsg.zendee.cn/send/'
+
+    templates = (
+        '{schema}://{token}',
+    )
+
+    template_tokens = dict(NotifyBase.template_tokens, **{
+        'token': {
+            'name': _('User Token'),
+            'type': 'string',
+            'private': True,
+            'required': True,
+            'regex': (r'^[a-z0-9]{24,64}$', 'i'),
+        },
+    })
+
+    def __init__(self, token, **kwargs):
+        """
+        Initialize QQ Push Object
+
+        Args:
+            token (str): User push token from QQ Push provider (e.g., Qmsg)
+        """
+        super().__init__(**kwargs)
+
+        self.token = validate_regex(
+            token, *self.template_tokens['token']['regex']
+        )
+        if not self.token:
+            msg = 'The QQ Push token ({}) is invalid.'.format(token)
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        self.webhook_url = f'{self.notify_url}{self.token}'
+
+    def url(self, privacy=False, *args, **kwargs):
+        """
+        Returns the URL built dynamically based on specified arguments.
+        """
+        params = self.url_parameters(privacy=privacy, *args, **kwargs)
+        return '{schema}://{token}/?{params}'.format(
+            schema=self.secure_protocol,
+            token=self.pprint(self.token, privacy, mode=PrivacyMode.Secret),
+            params=self.urlencode(params),
+        )
+
+    @property
+    def url_identifier(self):
+        """
+        Returns a unique identifier for this plugin instance
+        """
+        return (self.secure_protocol, self.token)
+
+    def send(self, body, title='', notify_type=NotifyType.INFO, **kwargs):
+        """
+        Send a QQ Push Notification
+        """
+        payload = {
+            'msg': f'{title}\n{body}' if title else body
+        }
+
+        headers = {
+            'User-Agent': self.app_id,
+            'Content-Type': 'application/x-www-form-urlencoded',
+        }
+
+        self.throttle()
+        try:
+            response = requests.post(
+                self.webhook_url,
+                headers=headers,
+                data=payload,
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+            )
+
+            if response.status_code != requests.codes.ok:
+                self.logger.warning(
+                    'QQ Push notification failed: %d - %s',
+                    response.status_code, response.text)
+                return False
+
+        except requests.RequestException as e:
+            self.logger.warning(f'QQ Push Exception: {e}')
+            return False
+
+        self.logger.info('QQ Push notification sent successfully.')
+        return True
+
+    @staticmethod
+    def parse_url(url):
+        """
+        Parses the URL and returns arguments to re-instantiate the object
+        """
+        results = NotifyBase.parse_url(url, verify_host=False)
+        if not results:
+            return results
+
+        if 'token' in results['qsd'] and results['qsd']['token']:
+            results['token'] = NotifyQQ.unquote(results['qsd']['token'])
+        else:
+            results['token'] = NotifyQQ.unquote(results['host'])
+
+        return results
+
+    @staticmethod
+    def parse_native_url(url):
+        """
+        Parse native QQ push-style URL into Apprise format
+        """
+        match = re.match(
+            r'^https://qmsg\.zendee\.cn/send/([a-z0-9]+)$', url, re.I)
+        if not match:
+            return None
+
+        return NotifyQQ.parse_url(
+            '{schema}://{token}'.format(
+                schema=NotifyQQ.secure_protocol,
+                token=match.group(1)))

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -48,12 +48,12 @@ Windows, Microsoft Teams, Misskey, MQTT, MSG91, MyAndroid, Nexmo, Nextcloud,
 NextcloudTalk, Notica, Notifiarr, Notifico, ntfy, Office365, OneSignal,
 Opsgenie, PagerDuty, PagerTree, ParsePlatform, Plivo, PopcornNotify, Prowl,
 Pushalot, PushBullet, Pushjet, PushMe, Pushover, Pushplus, PushSafer, Pushy,
-PushDeer, Revolt, Reddit, Resend, Rocket.Chat, RSyslog, SendGrid, ServerChan,
-Seven, SFR, Signal, SimplePush, Sinch, Slack, SMPP, SMSEagle, SMS Manager,
-SMTP2Go, SparkPost, Splunk, Spike, Spug Push, Super Toasty, Streamlabs, Stride,
-Synology Chat, Syslog, Techulus Push, Telegram, Threema Gateway, Twilio,
-Twitter, Twist, Vapid, VictorOps, Voipms, Vonage, WebPush, WeCom Bot, WhatsApp,
-Webex Teams, Workflows, WxPusher, XBMC}
+PushDeer, QQ Push, Revolt, Reddit, Resend, Rocket.Chat, RSyslog, SendGrid,
+ServerChan, Seven, SFR, Signal, SimplePush, Sinch, Slack, SMPP, SMSEagle,
+SMS Manager, SMTP2Go, SparkPost, Splunk, Spike, Spug Push, Super Toasty,
+Streamlabs, Stride, Synology Chat, Syslog, Techulus Push, Telegram, Threema
+Gateway, Twilio, Twitter, Twist, Vapid, VictorOps, Voipms, Vonage, WebPush,
+WeCom Bot, WhatsApp, Webex Teams, Workflows, WxPusher, XBMC}
 
 Name:           python-%{pypi_name}
 Version:        1.9.3

--- a/test/test_plugin_qq.py
+++ b/test/test_plugin_qq.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2025, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import requests
+from apprise.plugins.qq import NotifyQQ
+from helpers import AppriseURLTester
+
+import logging
+logging.disable(logging.CRITICAL)
+
+apprise_url_tests = (
+    ('qq://', {
+        'instance': TypeError,
+    }),
+    ('qq://invalid!', {
+        'instance': TypeError,
+    }),
+    ('qq://abc123def456ghi789jkl012mno345pq', {
+        'instance': NotifyQQ,
+        'privacy_url': 'qq://****/',
+    }),
+    ('qq://?token=abc123def456ghi789jkl012mno345pq', {
+        'instance': NotifyQQ,
+        'privacy_url': 'qq://****/',
+    }),
+    ('https://qmsg.zendee.cn/send/abc123def456ghi789jkl012mno345pq', {
+        'instance': NotifyQQ,
+    }),
+    ('qq://abc123def456ghi789jkl012mno345pq', {
+        'instance': NotifyQQ,
+        'response': False,
+        'requests_response_code': requests.codes.internal_server_error,
+    }),
+    ('qq://abc123def456ghi789jkl012mno345pq', {
+        'instance': NotifyQQ,
+        'response': False,
+        'requests_response_code': 999,
+    }),
+    ('qq://ffffffffffffffffffffffffffffffff', {
+        'instance': NotifyQQ,
+        'test_requests_exceptions': True,
+    }),
+)
+
+
+def test_plugin_qq_urls():
+
+    AppriseURLTester(tests=apprise_url_tests).run_all()


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** n/a

## QQ Push Notifications
* **Source**: https://github.com/songquanpeng/message-pusher
* **Icon Support**: No
* **Message Format**: Plain Text
* **Message Limit**: ~10,000 Characters

QQ Push is a third-party gateway for sending notifications to QQ users via services like [qmsg.zendee.cn](https://qmsg.zendee.cn/).

To use it with Apprise, you'll need to register and obtain a personal **Token**.

---

### 🛠️ Setup Instructions

1. Visit [qmsg.zendee.cn](https://qmsg.zendee.cn/) and sign in using your QQ account.
2. Once logged in, generate and copy your **token**.
3. You’ll receive a webhook URL like this:

```
https://qmsg.zendee.cn/send/abc123def456ghi789jkl012mno345pq
```

---

### ✅ Apprise Support

You can use the full native webhook or a simplified Apprise URL.

### Syntax

Valid syntax is as follows:
- `https://qmsg.zendee.cn/send/{token}`
- `qq://{token}`
- `qq://?token={token}`

---

### 🔐 Parameter Breakdown

| Variable | Required | Description |
|----------|----------|-------------|
| token    | Yes      | Your personal QQ Push token from qmsg.zendee.cn |

---

### 📦 Examples

#### 1. Using the simplified Apprise URL
```bash
apprise -vv -t "QQ Title" -b "Message content" \
    qq://abc123def456ghi789jkl012mno345pq
```

#### 2. Using the query parameter form
```bash
apprise -vv -t "QQ Title" -b "Message content" \
    qq://?token=abc123def456ghi789jkl012mno345pq
```

#### 3. Using the native webhook URL
```bash
apprise -vv -t "QQ Title" -b "Message content" \
    https://qmsg.zendee.cn/send/abc123def456ghi789jkl012mno345pq
```

All formats above are accepted and deliver the same result.

---

## New Service Completion Status
<!-- This section is only applicable if you're adding a new service -->
* [x] apprise/plugins/qq.py
* [x] KEYWORDS
    - add new service into this file (alphabetically).
* [x] README.md
    - add entry for new service to table (as a quick reference)
* [x] packaging/redhat/python-apprise.spec
    - add new service into the `%global common_description`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@<this.branch-name>qq-support

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  qq://token

```

