### PR TITLE
Fix matrix v3 attachments

### DIFF
--- a/apprise/plugins/matrix.py
+++ b/apprise/plugins/matrix.py
@@ -683,7 +683,7 @@ class NotifyMatrix(NotifyBase):
                 path = '/rooms/{}/send/m.room.message'.format(
                     NotifyMatrix.quote(room_id))
 
-            if image_url:
+            if image_url and self.version == MatrixVersion.V2:
                 # Define our payload
                 image_payload = {
                     'msgtype': 'm.image',

--- a/test/test_plugin_matrix.py
+++ b/test/test_plugin_matrix.py
@@ -967,15 +967,20 @@ def test_plugin_matrix_attachments_api_v3(mock_post, mock_get, mock_put):
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, 'apprise-test.gif'))
 
     # Test our call count
-    assert mock_put.call_count == 1
-    assert mock_post.call_count == 2
+    assert mock_put.call_count == 2
+    assert mock_post.call_count == 3
     assert mock_post.call_args_list[0][0][0] == \
         'http://localhost/_matrix/client/v3/login'
     assert mock_post.call_args_list[1][0][0] == \
+        'http://localhost/_matrix/media/v3/upload'
+    assert mock_post.call_args_list[2][0][0] == \
         'http://localhost/_matrix/client/v3/join/%23general%3Alocalhost'
     assert mock_put.call_args_list[0][0][0] == \
         'http://localhost/_matrix/client/v3/rooms/%21abc123%3Alocalhost/' \
         'send/m.room.message/0'
+    assert mock_put.call_args_list[1][0][0] == \
+        'http://localhost/_matrix/client/v3/rooms/%21abc123%3Alocalhost/' \
+        'send/m.room.message/1'
 
     # Attach an unsupported file type (it's just skipped)
     attach = AppriseAttachment(
@@ -999,8 +1004,7 @@ def test_plugin_matrix_attachments_api_v3(mock_post, mock_get, mock_put):
     for side_effect in (requests.RequestException(), OSError(), bad_response):
         mock_post.side_effect = [side_effect]
 
-        # We'll never fail because files are not attached
-        assert obj.send(body="test", attach=attach) is True
+        assert obj.send(body="test", attach=attach) is False
 
     # Throw an exception on the second call to requests.post()
     for side_effect in (requests.RequestException(), OSError(), bad_response):


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #<!--apprise issue number goes here-->

I noticed attachment was disabled and ignored on matrix v3 since it was broken in the upgrade to v3. I used the code commented with # FUTURE as a reference and tried to debug that. I noticed that the sending of mxc url was not upgraded to use PUT instead of POST. I also added the increment of the transaction ID after that part. Otherwise the rest of the message is ignored. I think I fixed the unit tests properly. I also did some local test with my tuwunel instance to send image and zip file without any problem with v3 enabled. 

## New Service Completion Status
<!-- This section is only applicable if you're adding a new service -->
* [ ] apprise/plugins/<!--new plugin name -->.py
* [ ] KEYWORDS
    - add new service into this file (alphabetically).
* [ ] README.md
    - add entry for new service to table (as a quick reference)
* [ ] packaging/redhat/python-apprise.spec
    - add new service into the `%global common_description`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `flake8`)
* [x] 100% test coverage

## Testing
<!-- If this your code is testable by other users of the program
      it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/privacyfr3ak/apprise.git@fix_matrix_v3_attachments

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
  -a path/to/image.jpg
  matrixs://user:pass@hostname/#room_alias?v=3

```

