### PR TITLE
EL9 RPM build made public; workflow fixed to accommodate

### DIFF
--- a/.github/workflows/pkgbuild.yml
+++ b/.github/workflows/pkgbuild.yml
@@ -19,9 +19,6 @@ jobs:
     container:
       image: ghcr.io/caronc/apprise-rpmbuild:el9
       options: --user root
-      credentials:
-        username: caronc
-        password: ${{ secrets.CR_PAT }}
 
     steps:
       - name: Checkout source
@@ -54,9 +51,6 @@ jobs:
     container:
       image: ghcr.io/caronc/apprise-rpmbuild:el9
       options: --user root
-      credentials:
-        username: caronc
-        password: ${{ secrets.CR_PAT }}
 
     steps:
       - name: Download built RPMs


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1373 

Noticed that contributors are not able to pass workflow due to it's configuration; the `apprise-rpmbuild` repository has been made public should now work for all.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `tox -e lint`)
* [x] 100% test coverage (use `tox -e minimal`)

