### PR TITLE
decorator to reamin backwards compatible even after rework in #1368

### DIFF
--- a/apprise/decorators/base.py
+++ b/apprise/decorators/base.py
@@ -175,7 +175,7 @@ class CustomNotifyPlugin(NotifyBase):
                     result = self.__send(
                         body,
                         title,
-                        notify_type,
+                        notify_type.value,
                         *args,
                         meta=self._default_args,
                         **kwargs,

--- a/tests/test_apprise_cli.py
+++ b/tests/test_apprise_cli.py
@@ -2008,7 +2008,7 @@ def test_apprise_cli_plugin_loading(mock_post, tmpdir):
     @notify(on="clihook")
     def mywrapper(body, title, notify_type, *args, **kwargs):
         # A simple test - print to screen
-        print("{}: {} - {}".format(notify_type.value, title, body))
+        print("{}: {} - {}".format(notify_type, title, body))
 
         # No return (so a return of None) get's translated to True
 
@@ -2016,7 +2016,7 @@ def test_apprise_cli_plugin_loading(mock_post, tmpdir):
     @notify(on="clihookA")
     def mywrapper(body, title, notify_type, *args, **kwargs):
         # A simple test - print to screen
-        print("!! {}: {} - {}".format(notify_type.value, title, body))
+        print("!! {}: {} - {}".format(notify_type, title, body))
 
         # No return (so a return of None) get's translated to True
     """))


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1381

Based on discussion [here](https://github.com/caronc/apprise/discussions/1380) and the PR #1368, to avoid issues after the next Apprise release, this PR just keeps code base compatible.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `tox -e lint` and even `tox -e format` to autofix what it can)
* [x] Test coverage added (use `tox -e minimal`)
