### PR TITLE
pyobject availability does not impact glib testing (attempt 2)

### DIFF
--- a/tests/test_plugin_glib.py
+++ b/tests/test_plugin_glib.py
@@ -176,7 +176,7 @@ def test_plugin_glib_send_raises_generic(mocker, enabled_glib_environment):
     # handling is already tested via `GLib.Error` branches or during actual
     # usage of `NotifyGLib.send()`. This test supplements that by simulating
     # the rare fallback case of a non-GLib-related exception during Notify().
-    import gi
+    gi = pytest.importorskip("gi", reason="pygobject not installed")
     if hasattr(gi, "repository"):
         pytest.skip(
             "pygobject introspection active, test won't behave as expected")
@@ -276,8 +276,7 @@ def test_plugin_glib_require_version_valueerror(monkeypatch):
     """Simulate gi.require_version() raising ValueError without reload
     crash."""
 
-    import gi
-
+    gi = pytest.importorskip("gi", reason="pygobject not installed")
     import apprise.plugins.glib as plugin_glib
 
     # Patch require_version after import


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1383 & #1384

this is a second attempt to make the glib tests be less intrusive and fail when not applicable to the environment. I'll get it right eventually :slightly_smiling_face: 

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `tox -e lint` and even `tox -e format` to autofix what it can)
* [ ] Test coverage added (use `tox -e minimal`)
