### PR TITLE
Add Power Automate (Workflows/MS Teams) alternative url support

### DIFF
--- a/apprise/plugins/workflows.py
+++ b/apprise/plugins/workflows.py
@@ -29,10 +29,17 @@
 #  https://support.microsoft.com/en-us/office/browse-and-add-workflows-\
 #       in-microsoft-teams-4998095c-8b72-4b0e-984c-f2ad39e6ba9a
 
-# Your webhook will look somthing like this:
+# Your webhook will look somthing like this (legacy):
 # https://prod-161.westeurope.logic.azure.com:443/\
 #       workflows/643e69f83c8944438d68119179a10a64/triggers/manual/\
 #       paths/invoke?api-version=2016-06-01&sp=%2Ftriggers%2Fmanual%2Frun&\
+#       sv=1.0&sig=KODuebWbDGYFr0z0eu-6Rj8aUKz7108W3wrNJZxFE5A
+#
+# Or it may now look something like this:
+# https://prod-161.westeurope.logic.azure.com:443/\
+#       powerautomate/automations/direct/\
+#       workflows/643e69f83c8944438d68119179a10a64/triggers/manual/\
+#       paths/invoke?api-version=2022-03-01-preview&sp=%2Ftriggers%2Fmanual%2Frun&\
 #       sv=1.0&sig=KODuebWbDGYFr0z0eu-6Rj8aUKz7108W3wrNJZxFE5A
 #
 # Yes... The URL is that big... But it looks like this (greatly simplified):
@@ -149,6 +156,12 @@ class NotifyWorkflows(NotifyBase):
                 "default": True,
                 "map_to": "include_image",
             },
+            "power_automate": {
+                "name": _("Power Automate"),
+                "type": "bool",
+                "default": False,
+                "map_to": "power_automate",
+            },
             "wrap": {
                 "name": _("Wrap Text"),
                 "type": "bool",
@@ -169,6 +182,7 @@ class NotifyWorkflows(NotifyBase):
                 "name": _("API Version"),
                 "type": "string",
                 "default": "2016-06-01",
+                "pa_default": "2022-03-01-preview",
                 "map_to": "version",
             },
             "api-version": {"alias_of": "ver"},
@@ -188,6 +202,7 @@ class NotifyWorkflows(NotifyBase):
         workflow,
         signature,
         include_image=None,
+        power_automate=None,
         version=None,
         template=None,
         tokens=None,
@@ -220,6 +235,13 @@ class NotifyWorkflows(NotifyBase):
             else self.template_args["image"]["default"]
         )
 
+        # Power Automate status
+        self.power_automate = bool(
+            power_automate
+            if power_automate is not None
+            else self.template_args["power_automate"]["default"]
+        )
+
         # Wrap Text
         self.wrap = bool(
             wrap if wrap is not None else self.template_args["wrap"]["default"]
@@ -234,10 +256,17 @@ class NotifyWorkflows(NotifyBase):
             self.template[0].max_file_size = self.max_workflows_template_size
 
         # Prepare Version
+        # The default is taken from the template_args
+        default_api_version = self.template_args["ver"]["default"]
+
+        # If using power_automate, the API version required is different.
+        if self.power_automate:
+            default_api_version = self.template_args["ver"]["pa_default"]
+
         self.api_version = (
             version
             if version is not None
-            else self.template_args["ver"]["default"]
+            else default_api_version
         )
 
         # Template functionality
@@ -379,11 +408,20 @@ class NotifyWorkflows(NotifyBase):
             "sig": self.signature,
         }
 
+        # The URL changes depending on whether we're using power automate or
+        # not
+        path = (
+            "/powerautomate/automations/direct"
+            if self.power_automate
+            else ""
+        )
+
         notify_url = (
-            "https://{host}{port}/workflows/{workflow}/"
+            "https://{host}{port}{path}/workflows/{workflow}/"
             "triggers/manual/paths/invoke".format(
                 host=self.host,
                 port="" if not self.port else f":{self.port}",
+                path=path,
                 workflow=self.workflow,
             )
         )
@@ -471,6 +509,7 @@ class NotifyWorkflows(NotifyBase):
         params = {
             "image": "yes" if self.include_image else "no",
             "wrap": "yes" if self.wrap else "no",
+            "power_automate": "yes" if self.power_automate else "no",
         }
 
         if self.template:
@@ -480,7 +519,10 @@ class NotifyWorkflows(NotifyBase):
 
         # Store our version if it differs from default
         if self.api_version != self.template_args["ver"]["default"]:
-            params["ver"] = self.api_version
+            # But only do so if we're not using power automate with the
+            # default version for that.
+            if not self.power_automate or self.api_version != self.template_args["ver"]["pa_default"]:
+                params["ver"] = self.api_version
 
         # Extend our parameters
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
@@ -515,6 +557,13 @@ class NotifyWorkflows(NotifyBase):
         results["include_image"] = parse_bool(
             results["qsd"].get(
                 "image", NotifyWorkflows.template_args["image"]["default"]
+            )
+        )
+
+        # Support Power Automate?
+        results["power_automate"] = parse_bool(
+            results["qsd"].get(
+                "power_automate", NotifyWorkflows.template_args["power_automate"]["default"]
             )
         )
 
@@ -584,12 +633,16 @@ class NotifyWorkflows(NotifyBase):
         """
         Support parsing the webhook straight out of workflows
             https://HOST:443/workflows/WORKFLOWID/triggers/manual/paths/invoke
+            or
+            https://HOST:443/powerautomate/automations/direct/workflows/WORKFLOWID/triggers/manual/paths/invoke
         """
 
         # Match our workflows webhook URL and re-assemble
         result = re.match(
             r"^https?://(?P<host>[A-Z0-9_.-]+)"
             r"(?P<port>:[1-9][0-9]{0,5})?"
+            # The new URL structure includes /powerautomate/automations/direct
+            r"(?P<power_automate>/powerautomate/automations/direct)?"
             r"/workflows/"
             r"(?P<workflow>[A-Z0-9_-]+)"
             r"/triggers/manual/paths/invoke/?"
@@ -599,9 +652,17 @@ class NotifyWorkflows(NotifyBase):
         )
 
         if result:
+            # Determine if we're using power automate or not
+            power_automate = (
+                "&power_automate=yes"
+                if result.group("power_automate")
+                else ""
+            )
+
             # Construct our URL
             return NotifyWorkflows.parse_url(
-                "{schema}://{host}{port}/{workflow}/{params}".format(
+                "{schema}://{host}{port}/{workflow}/{params}{power_automate}"
+                .format(
                     schema=NotifyWorkflows.secure_protocol[0],
                     host=result.group("host"),
                     port=(
@@ -611,6 +672,7 @@ class NotifyWorkflows(NotifyBase):
                     ),
                     workflow=result.group("workflow"),
                     params=result.group("params"),
+                    power_automate=power_automate,
                 )
             )
         return None

--- a/tests/test_plugin_workflows.py
+++ b/tests/test_plugin_workflows.py
@@ -135,6 +135,15 @@ apprise_url_tests = (
             "privacy_url": "workflow://host:443/w...b/s...e/",
         },
     ),
+    (
+        "workflows://host:443/workflow1e/signature/?power_automate=yes",
+        {
+            # support power_automate flag
+            "instance": NotifyWorkflows,
+            # Our expected power_automate flag (defaults to False)
+            "self": {"power_automate": True},
+        },
+    ),
     # Support native URLs
     (
         (
@@ -148,6 +157,22 @@ apprise_url_tests = (
             "instance": NotifyWorkflows,
             # Our expected url(privacy=True) startswith() response
             "privacy_url": "workflow://server.azure.com:443/6...4/K...u/",
+        },
+    ),
+    (
+        (
+            "https://server.azure.com:443/"
+            "powerautomate/automations/direct/"
+            "workflows/643e69f83c8944/"
+            "triggers/manual/paths/invoke?"
+            "api-version=2022-03-01-preview&sp=%2Ftriggers%2Fmanual%2Frun&"
+            "sv=1.0&sig=KODuebWbDGYFr0z0eu"
+        ),
+        {
+            # Power-Automate alternative URL - All tokens provided - we're good
+            "instance": NotifyWorkflows,
+            # Our expected power_automate flag (defaults to False)
+            "self": {"power_automate": True},
         },
     ),
     (


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** [#1405](https://github.com/caronc/apprise/issues/1405)

Adds support for the (new?) power-automate webhook URL pattern:
`https://host:PORT/powerautomate/automations/direct/workflows/ABCD/triggers/manual/path/...sig=DEFG`

The native URL (as above) is supported, maintaining backward compatibility with the existing/legacy Workflows native URL.  A query parameter and internal flag were introduced to manage control of the URL pattern. e.g.:
`workflow://host:443/WFID/SIGNATURE/?power_automate=yes`

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `tox -e lint` and even `tox -e format` to autofix what it can)
* [x] Test coverage added (use `tox -e minimal`)

## Testing
<!-- If this your code is testable by other users of the program
     it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/LaFeev/apprise.git@powerautomate_url_pattern

# Test out the changes with the following command:
apprise -vvvv -t "Test Title" -b "Test Message" \
  workflow://<host>:443/<WFID>/<SIG>/?power_automate=yes
# replace with your host/workflow ID/signature from a power-automate webhook
```
