### PR TITLE
Added support for discord:// flags=<int>

### DIFF
--- a/apprise/plugins/discord.py
+++ b/apprise/plugins/discord.py
@@ -275,7 +275,7 @@ class NotifyDiscord(NotifyBase):
                 msg = "An invalid Discord flags setting " \
                       "({}) was specified.".format(flags)
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise TypeError(msg) from None
         else:
             self.flags = None
 
@@ -307,7 +307,7 @@ class NotifyDiscord(NotifyBase):
 
         if self.flags:
             # Set our flag if defined:
-            payload['flags'] = self.flags
+            payload["flags"] = self.flags
 
         # Acquire image_url
         image_url = self.image_url(notify_type)

--- a/tests/test_plugin_discord.py
+++ b/tests/test_plugin_discord.py
@@ -165,6 +165,34 @@ apprise_url_tests = (
             "requests_response_code": requests.codes.no_content,
         },
     ),
+    (
+        "discord://{}/{}?flags=1".format(
+            "i" * 24, "t" * 64
+        ),
+        {
+            "instance": NotifyDiscord,
+            "requests_response_code": requests.codes.no_content,
+        },
+    ),
+    (
+        "discord://{}/{}?flags=-1".format(
+            "i" * 24, "t" * 64
+        ),
+        {
+            # invalid flags specified (variation 1)
+            "instance": TypeError,
+        },
+    ),
+    (
+        "discord://{}/{}?flags=invalid".format(
+            "i" * 24, "t" * 64
+        ),
+        {
+            # invalid flags specified (variation 2)
+            "instance": TypeError,
+        },
+    ),
+
     # different format support
     (
         "discord://{}/{}?format=markdown".format("i" * 24, "t" * 64),


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1406

Added support for `?flags=int` per documentation indentified here:
- https://discord.com/developers/docs/resources/webhook#execute-webhook-jsonform-params
- https://discord.com/developers/docs/resources/message#message-object-message-flags

### 🔐 Parameter Breakdown

| Variable  | Required |  Description   |
|-----------|----------|----------------|
| flags | No      | Set to an integer [value per documentation]( https://discord.com/developers/docs/resources/message#message-object-message-flags) |

---

### 📦 Examples

Sends a simple example
```bash
apprise -vv -t "Title" -b "Message content" \
    "discord://credentials?flags=32"
```

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `tox -e lint` and even `tox -e format` to autofix what it can)
* [ ] Test coverage added (use `tox -e minimal`)

## Testing
<!-- If this your code is testable by other users of the program
     it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@<this.branch-name>

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
      "discord://credentials?flags=32"

# If you have cloned the branch and have tox available to you
# the following can also allow you to test:
tox -e apprise -- -t "Test Title" -b "Test Message" \
             "discord://credentials?flags=32"
```
