### PR TITLE
Fix test_time_zoneinfo edge case

### DIFF
--- a/tests/test_apprise_utils.py
+++ b/tests/test_apprise_utils.py
@@ -3253,18 +3253,20 @@ def test_time_zoneinfo():
     isinstance(tz, tzinfo)
     assert isinstance(utils.time.zoneinfo("Argentina/Cordoba"), tzinfo)
     assert utils.time.zoneinfo("Argentina/Cordoba").key == tz.key
-    # "America/Cordoba" has been obsoleted by IANA in facor of 
-    #  "America/Argentina/Cordoba", however the IANA database 
-    #  instance used is system-dependent, so these tests have 
+    # "America/Cordoba" has been obsoleted by IANA in facor of
+    #  "America/Argentina/Cordoba", however the IANA database
+    #  instance used is system-dependent, so these tests have
     #  different results depending on the system running them
-    if not isinstance(utils.time.zoneinfo("Cordoba"), None):
+    if utils.time.zoneinfo("Cordoba") is not None:
         # the system has the obsolete "America/Cordoba" entry
         assert isinstance(utils.time.zoneinfo("Cordoba"), tzinfo)
         assert utils.time.zoneinfo("Cordoba").key == "America/Cordoba"
     else:
-        assert isinstance(utils.time.zoneinfo("Cordoba"), None)
-        # the utils helper should still resolve this abbreviated (and lowercase) form
-        assert utils.time.zoneinfo("argentina/cordoba").key == "America/Argentina/Cordoba"
+        assert utils.time.zoneinfo("Cordoba") is None
+        # the utils helper should still resolve this abbreviated (and
+        #  lowercase) form
+        assert utils.time.zoneinfo("argentina/cordoba").key == \
+            "America/Argentina/Cordoba"
 
     # Too ambiguous
     assert utils.time.zoneinfo("Argentina") is None


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** [#1405](https://github.com/caronc/apprise/issues/1405)

As discussed [here](https://github.com/caronc/apprise/pull/1407#issuecomment-3267144526), a reliance on the system-dependent IANA timezone database results in the test_apprise_utils test failing (for me at least, on Windows).  I fixed the test to: 
- preserve the original test, which will operate on a tester's system that still has the obsolete "America/Cordoba" time zone
- test a slightly different, possibly redundant, scenario if the tester's system lacks the obsolete entry

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `tox -e lint` and even `tox -e format` to autofix what it can)
* [x] Test coverage added (use `tox -e minimal`)

## Testing
<!-- If this your code is testable by other users of the program
     it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/LaFeev/apprise.git@

# Test out the changes with the following command:
tox -e qa
```
