### PR TITLE
Feature revolt selfhosted

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@
 
 # Root certificate authority bundle
 certifi
+# DEBUG: MY SERVER HAS CA SSL.COM WHICH IS A PROBLEM FOR FIREFOX TRUST LIST RN
+certifi==2025.01.31
 
 # Application dependencies
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,6 @@
 
 # Root certificate authority bundle
 certifi
-# DEBUG: MY SERVER HAS CA SSL.COM WHICH IS A PROBLEM FOR FIREFOX TRUST LIST RN
-certifi==2025.01.31
 
 # Application dependencies
 requests


### PR DESCRIPTION


## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [X] The code change is tested and works locally.
* [X] There is no commented out code in this PR.
* [X] No lint errors (use `tox -e lint` and even `tox -e format` to autofix what it can)
* [ ] Test coverage added (use `tox -e minimal`)

## Changes
I added a schema `revolt://{server_api_url}/{bot_token}/{targets}` to support self hosted instances of Revolt.Chat, instead of only supporting the official instance. The differentiation of `revolt://{server_api_url}/{bot_token}/{targets}` and `revolt://{bot_token}/{targets}` works by detecting if domain ends with /, i.e. %2F. I did this to preserve possibility to use the current scheme so as to avoid breaking changes.

All tests and ruff linting tests seem to pass. I haven't added new tests as I am inexperienced in that regard and anticipate a lot of changes to this PR if it is to be accepted.

## Testing
Note: You need to be running a Revolt Chat server. If your api url contains forward slashes replace them with `%2F`:
`revolt.domain.tld/api/ -> revolt.domain.tld%2Fapi%2F`
<!-- If this your code is testable by other users of the program
     it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/i-vis/apprise.git@feature-revolt-selfhosted

# Test out the changes with the following commands:
# this corresponds to api link being {https://}revolt.domain.tld/api/
apprise -t "Test Title" -b "Test Message" \
  revolt://{revolt.domain.tld%2Fapi%2F}/{bot-token}/{channel-id}
  # this corresponds to official revolt chat server api
apprise -t "Test Title" -b "Test Message" \
  revolt://api.revolt.chat/{bot-token}/{channel-id}
# this corresponds to how plugin currently works (also official server api)
apprise -t "Test Title" -b "Test Message" \
  revolt://{bot-token}/{channel-id}
```
