### PR TITLE
Added py.typed back into repository and Manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,12 +2,15 @@ include LICENSE
 include README.md
 include CONTRIBUTING.md
 include ACKNOWLEDGEMENTS.md
+include SECURITY.md
 include pyproject.toml
 include tox.ini
+include babel.cfg
 include requirements.txt
 include win-requirements.txt
 include dev-requirements.txt
 include all-plugin-requirements.txt
+include apprise/py.typed
 recursive-include tests *
 recursive-include packaging *
 recursive-include apprise/i18n *.pot

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -199,7 +199,7 @@ LANG=C.UTF-8 PYTHONPATH=%{buildroot}%{python3_sitelib}:%{_builddir}/%{name}-%{ve
 
 %files -n python%{python3_pkgversion}-%{pypi_name}
 %license LICENSE
-%doc README.md ACKNOWLEDGEMENTS.md CONTRIBUTING.md
+%doc SECURITY.md README.md ACKNOWLEDGEMENTS.md CONTRIBUTING.md
 %{python3_sitelib}/%{pypi_name}/
 # Exclude i18n as it is handled below with the lang(spoken) tag below
 %exclude %{python3_sitelib}/%{pypi_name}/cli.*


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1424 

Removal of `py.typed` was accidental and part of the very large PR #1385 .  File is restored in this PR.

Also just added `SECURITY.md` and `bable.cfg` into Packaging/Manifest files while there.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `tox -e lint` and even `tox -e format` to autofix what it can)
* [x] Test coverage added (use `tox -e minimal`)

## Testing
<!-- If this your code is testable by other users of the program
     it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1424-mypy-fix

# Prepare our release files
tox -e release

# Verify py.typed is present:
tar tvfz dist/apprise-*.tar.gz | egrep py.typed

# Also other files snuck into this PR:
tar tvfz dist/apprise-*.tar.gz | egrep SECURITY.md
tar tvfz dist/apprise-*.tar.gz | egrep babel.cfg

# RPM Building confirmed to still work:
tox -e build-el9-rpm
tox -e build-f42-rpm
```
