### PR TITLE
increase of Pushover attachment size to 5MB

### DIFF
--- a/apprise/plugins/pushover.py
+++ b/apprise/plugins/pushover.py
@@ -166,9 +166,9 @@ class NotifyPushover(NotifyBase):
     # Default Pushover sound
     default_pushover_sound = PushoverSound.PUSHOVER
 
-    # 2.5MB is the maximum supported image filesize as per documentation
-    # here: https://pushover.net/api#attachments (Dec 26th, 2019)
-    attach_max_size_bytes = 2621440
+    # 5MB is the maximum supported image filesize as per documentation
+    # here: https://pushover.net/api#limits (Oct 5th, 2025)
+    attach_max_size_bytes = 5242880
 
     # The regular expression of the current attachment supported mime types
     # At this time it is only images


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1425

Pushover attachment size documented to be 5MB ([new source](https://pushover.net/api#limits)).

<img width="786" height="32" alt="Image" src="https://github.com/user-attachments/assets/45cd8e45-a089-4995-a662-8c3fe95511de" />

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [ ] There is no commented out code in this PR.
* [ ] No lint errors (use `tox -e lint` and even `tox -e format` to autofix what it can)
* [ ] Test coverage added (use `tox -e minimal`)

## Testing
<!-- If this your code is testable by other users of the program
     it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1425-pushover-attach-size-increase

# If you have cloned the branch and have tox available to you
# the following can also allow you to test:
tox -e apprise -- -t "Test Title" -b "Test Message" \
          --attach /path/to/image.file.less.than.5MB.in.size.png \
         pover://credentials
```
