### PR TITLE
Apprise API payload bugfix

### DIFF
--- a/apprise/plugins/apprise_api.py
+++ b/apprise/plugins/apprise_api.py
@@ -328,8 +328,8 @@ class NotifyAppriseAPI(NotifyBase):
             # Apprise API Payload
             "title": title,
             "body": body,
-            "type": notify_type,
-            "format": self.notify_format,
+            "type": notify_type.value,
+            "format": self.notify_format.value,
         }
 
         if self.method == AppriseAPIMethod.JSON:


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1414 

This issue resolves an issue preventing the `apprise://` and `apprises://` from correctly passing along file attachments.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `tox -e lint` and even `tox -e format` to autofix what it can)
* [x] Test coverage added (use `tox -e minimal`)

## Testing
<!-- If this your code is testable by other users of the program
     it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1414-apprise-api-attach-fix

# If you have cloned the branch and have tox available to you
# the following can also allow you to test:
tox -e apprise -- -t "Test Title" -b "Test Message" \
        --attach=/path/to/a/file \
       apprise://credentials
```
