### PR TITLE
Matrix API v4 Support Added

### DIFF
--- a/apprise/plugins/matrix.py
+++ b/apprise/plugins/matrix.py
@@ -72,17 +72,18 @@ MATRIX_HTTP_ERROR_MAP = {
 
 # Matrix Room Syntax
 IS_ROOM_ALIAS = re.compile(
-    r"^\s*(#|%23)?(?P<room>[a-z0-9-]+)((:|%3A)"
-    r"(?P<home_server>[a-z0-9.-]+))?\s*$",
+    r"^\s*(#|%23)?(?P<room>[A-Za-z0-9._=-]+)((:|%3A)"
+    r"(?P<home_server>[A-Za-z0-9.-]+))?\s*$",
     re.I,
 )
 
 # Room ID MUST start with an exclamation to avoid ambiguity
 IS_ROOM_ID = re.compile(
-    r"^\s*(!|&#33;|%21)(?P<room>[a-z0-9-]+)((:|%3A)"
-    r"(?P<home_server>[a-z0-9.-]+))?\s*$",
+    r"^\s*(!|&#33;|%21)(?P<room>[A-Za-z0-9._=-]+)((:|%3A)"
+    r"(?P<home_server>[A-Za-z0-9.-]+))?\s*$",
     re.I,
 )
+
 
 # Matrix is_image check
 IS_IMAGE = re.compile(r"^image/.*", re.I)
@@ -261,7 +262,7 @@ class NotifyMatrix(NotifyBase):
             "target_room_alias": {
                 "name": _("Target Room Alias"),
                 "type": "string",
-                "prefix": "!",
+                "prefix": "#",
                 "map_to": "targets",
             },
             "targets": {

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -218,7 +218,9 @@ apprise_url_tests = (
         },
     ),
     (
-        "matrixs://user:token@localhost?mode=slack&format=markdown&image=False",
+        (
+            "matrixs://user:token@localhost"
+            "?mode=slack&format=markdown&image=False"),
         {
             # user and token specified; image set to True
             "instance": NotifyMatrix,
@@ -921,6 +923,22 @@ def test_plugin_matrix_url_parsing():
     assert "#room1" in result["targets"]
     assert "#room2" in result["targets"]
     assert "#room3" in result["targets"]
+
+    # Mixed-case alias with underscore should parse
+    result = NotifyMatrix.parse_url(
+        "matrix://user:token@localhost?to=#Dev_Room:localhost"
+    )
+    assert isinstance(result, dict) is True
+    assert len(result["targets"]) == 1
+    assert "#Dev_Room:localhost" in result["targets"]
+
+    # Mixed-case room id with underscore should be accepted by _room_join
+    from apprise.plugins.matrix import IS_ROOM_ID  # local alias
+    nm = NotifyMatrix(host="localhost")
+    nm.access_token = "abc"   # simulate logged-in
+    nm.home_server = "localhost"
+    # this should NOT be rejected by the regex
+    assert IS_ROOM_ID.match("!Jm_LvU1nas_8KJPBmN9n:nginx.eu")
 
 
 @mock.patch("requests.put")


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1349 

This came as a request through Discord to add support for the Matrix API v4.0.

There does not appear to be a lot of changes between v3 and v4 that impact Apprise beyond just using the `/v4/` URL paths.  Still to investigate, but as of now; this PR should cover support. - To be confirmed

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [ ] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `tox -e lint` and even `tox -e format` to autofix what it can)
* [x] Test coverage added (use `tox -e minimal`)

## Testing
<!-- If this your code is testable by other users of the program
     it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# If you have cloned the branch and have tox available to you
# the following can also allow you to test:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "matrix://credentials/?v=4"
```
