### PR TITLE
Fix Reply-To header variable consistency

### DIFF
--- a/apprise/plugins/email/base.py
+++ b/apprise/plugins/email/base.py
@@ -1042,11 +1042,11 @@ class NotifyEmail(NotifyBase):
                 for addr in _bcc
             ]
 
-            if reply_to:
+            if _reply_to:
                 # Format our reply-to addresses to support the Name field
                 reply_to = [
                     formataddr((names.get(addr, False), addr), charset="utf-8")
-                    for addr in reply_to
+                    for addr in _reply_to
                 ]
 
             logger.debug(
@@ -1175,8 +1175,8 @@ class NotifyEmail(NotifyBase):
             if cc:
                 base["Cc"] = ",".join(_cc)
 
-            if reply_to:
-                base["Reply-To"] = ",".join(_reply_to)
+            if _reply_to:
+                base["Reply-To"] = ",".join(reply_to)
 
             yield EmailMessage(
                 recipient=to_addr,


### PR DESCRIPTION
Reply-To header was empty if reply_to was used.

Fixed by using `_reply_to` for checks and `reply_to` for the formatted header value.

## Before (broken):
```
From: "domain.com" <test@domain.com>
To: XXX@gmail.com
Reply-To:                          ← Empty string
```

## After (fixed):
```
From: "domain.com" <test@domain.com>
To: XXX@gmail.com
Reply-To: hello@domain.com         ← Works
```

Tested with real SMTP server, delivered to Gmail successfully.

```python
# cat test-fix.py 
#!/usr/bin/env python3
"""Test the Reply-To fix"""
from apprise.plugins.email import NotifyEmail
from apprise import NotifyFormat

DOMAIN = "domain.com"
MAIL_HOST = ""

to_email = "xxx@gmail.com"
subject = "Testing Reply-To Fix"
body = "This email should have proper Reply-To header from the fixed Apprise"
from_addr = "Test <test@domain.com>"
reply_to = "XXX <XXX@gmail.com>"

auth_email = f"test@{DOMAIN}"
auth_password = ""

# Test with native reply_to parameter (should work now)
email_plugin = NotifyEmail(
    smtp_host=MAIL_HOST,
    user=auth_email,
    password=auth_password,
    from_addr=from_addr,
    targets=[to_email],
    reply_to=[reply_to],
    secure_mode='starttls',
    port=587
)

print("Email plugin created with native reply_to parameter")
print(f"  from_addr: {email_plugin.from_addr}")
print(f"  targets: {email_plugin.targets}")
print(f"  reply_to: {email_plugin.reply_to}")
print(f"  names: {email_plugin.names}")
print("")

# Generate the email messages to inspect them
for message in NotifyEmail.prepare_emails(
    subject=subject,
    body=body,
    from_addr=email_plugin.from_addr,
    to=email_plugin.targets,
    reply_to=email_plugin.reply_to,
    smtp_host=MAIL_HOST,
    notify_format=NotifyFormat.TEXT,
    names=email_plugin.names
):
    print("Generated email message headers:")
    print(f"  Recipient: {message.recipient}")
    print(f"  To addrs: {message.to_addrs}")
    print("")

    # Parse the body to extract headers
    lines = message.body.split('\n')
    for line in lines[:25]:
        print(line)
        if line.strip() == '' and 'Reply-To' in message.body[:500]:
            break

print("")
print("Sending email...")
email_plugin.notify(title=subject, body=body)
print("✓ Email sent")
```