### PR TITLE
dot:// setup_url to align with other apprise ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The table below identifies the services this tool supports and some example serv
 | [BlueSky](https://github.com/caronc/apprise/wiki/Notify_bluesky) | bluesky://  | (TCP) 443   | bluesky://Handle:AppPw<br />bluesky://Handle:AppPw/TargetHandle<br />bluesky://Handle:AppPw/TargetHandle1/TargetHandle2/TargetHandleN
 | [Chanify](https://github.com/caronc/apprise/wiki/Notify_chanify) | chantify://    | (TCP) 443    | chantify://token
 | [Discord](https://github.com/caronc/apprise/wiki/Notify_discord)  | discord://   | (TCP) 443   | discord://webhook_id/webhook_token<br />discord://avatar@webhook_id/webhook_token
-| [Dot.](https://dot.mindreset.tech/docs/service/studio/api/text_api)  | dot:// | (TCP) 443 | dot://apikey@device_id/text/<br />dot://apikey@device_id/image/<br />**Note**: `device_id` is the Quote/0 hardware serial
+| [Dot.](https://github.com/caronc/apprise/wiki/Notify_dot)  | dot:// | (TCP) 443 | dot://apikey@device_id/text/<br />dot://apikey@device_id/image/<br />**Note**: `device_id` is the Quote/0 hardware serial
 | [Emby](https://github.com/caronc/apprise/wiki/Notify_emby)  | emby:// or embys:// | (TCP) 8096 | emby://user@hostname/<br />emby://user:password@hostname
 | [Enigma2](https://github.com/caronc/apprise/wiki/Notify_enigma2)  | enigma2:// or enigma2s:// | (TCP) 80 or 443 | enigma2://hostname
 | [FCM](https://github.com/caronc/apprise/wiki/Notify_fcm) | fcm://    | (TCP) 443    | fcm://project@apikey/DEVICE_ID<br />fcm://project@apikey/#TOPIC<br/>fcm://project@apikey/DEVICE_ID1/#topic1/#topic2/DEVICE_ID2/

--- a/apprise/plugins/dot.py
+++ b/apprise/plugins/dot.py
@@ -95,7 +95,7 @@ class NotifyDot(NotifyBase):
     secure_protocol = "dot"
 
     # A URL that takes you to the setup/help of the specific protocol
-    setup_url = "https://dot.mindreset.tech/docs/service/studio/api/text_api"
+    setup_url = "https://github.com/caronc/apprise/wiki/Notify_dot"
 
     # Allows the user to specify the NotifyImageSize object
     image_size = NotifyImageSize.XY_128
@@ -105,6 +105,7 @@ class NotifyDot(NotifyBase):
 
     # Supported API modes
     SUPPORTED_MODES = ("text", "image")
+
     DEFAULT_MODE = "text"
 
     # Define object templates


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1445 

Dot. introduced in related PR is a fantastic community contribution; alignment with `setup_url` entries fixed to align with others.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `tox -e lint` and even `tox -e format` to autofix what it can)
* [x] Test coverage added (use `tox -e minimal`)

## Testing
n/a - code review is fine