### PR TITLE
epel10 support requires removal of paho-mqtt requirement

### DIFF
--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -122,7 +122,6 @@ BuildRequires: python%{python3_pkgversion}-yaml
 BuildRequires: python%{python3_pkgversion}-babel
 BuildRequires: python%{python3_pkgversion}-cryptography
 BuildRequires: python%{python3_pkgversion}-certifi
-BuildRequires: python%{python3_pkgversion}-paho-mqtt
 BuildRequires: python%{python3_pkgversion}-tox
 Requires: python%{python3_pkgversion}-requests
 Requires: python%{python3_pkgversion}-requests-oauthlib


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1448

Apprise would not compile against RHEL10 due to `paho-mqtt`  `BuildRequires` reference.  This was dropped but `Recommends` entry still kept.  Apprise now successfully builds in a RHEL10 Environment; ref [koji/138939869](https://koji.fedoraproject.org/koji/taskinfo?taskID=138939869); screenshot provided below since links will eventually no longer work as older builds are removed.
<img width="850" height="718" alt="image" src="https://github.com/user-attachments/assets/f775fb8c-081d-49df-aac4-a7248c777440" />
