### PR TITLE
Added additional test coverage for Apprise configuration parsing

### DIFF
--- a/apprise/apprise_config.py
+++ b/apprise/apprise_config.py
@@ -299,7 +299,7 @@ class AppriseConfig:
         if not (instance.config_format and \
                 instance.config_format.value in common.CONFIG_FORMATS):
             logger.warning(
-                "The format of the configuration could not be deteced."
+                "The format of the configuration could not be detected."
             )
             return False
 


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** # [Apprise-API/271](https://github.com/caronc/apprise-api/pull/271)

Added test coverage that was used to help debug an issue with the API.  There is no sense not comitting the extra test used to solve the issue itself :slightly_smiling_face: 

Comitting to codebase in small PR.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `tox -e lint` and even `tox -e format` to autofix what it can)
* [x] Test coverage added (use `tox -e minimal`)
