### PR TITLE
Added support for slack-gov.com to slack://

### DIFF
--- a/tests/test_plugin_slack.py
+++ b/tests/test_plugin_slack.py
@@ -74,6 +74,13 @@ apprise_url_tests = (
         },
     ),
     (
+        "slack://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/?mode=invalid",
+        {
+            # invalid Mode provided
+            "instance": TypeError,
+        },
+    ),
+    (
         "slack://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/#hmm/#-invalid-",
         {
             # No username specified; this is still okay as we sub in
@@ -217,6 +224,22 @@ apprise_url_tests = (
             },
         },
     ),
+    # Testing modes
+    (
+        (
+            "slack://?token=T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/"
+            "&to=#chan&mode=hook"
+        ),
+        {"instance": NotifySlack, "requests_response_text": "ok"},
+    ),
+    # Forced mode on a url that does not have enough details to accomodate
+    (
+        (
+            "slack://?token=T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/"
+            "&to=#chan&mode=bot"
+        ),
+        {"instance": TypeError},
+    ),
     # Test blocks mode with timestamp variation
     (
         (
@@ -325,6 +348,17 @@ apprise_url_tests = (
         {
             "instance": NotifySlack,
             "requests_response_text": "ok",
+            "url_matches": "mode=hook",
+        },
+    ),
+    (
+        "https://hooks.slack-gov.com/services/{}/{}/{}".format(
+            "A" * 9, "B" * 9, "c" * 24
+        ),
+        {
+            "instance": NotifySlack,
+            "requests_response_text": "ok",
+            "url_matches": "mode=gov-hook",
         },
     ),
     # Native URL Support with arguments


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** [prefect/19564](https://github.com/prefecthq/prefect/issues/19564)

I Google every now and again since most bug reports against Apprise are filed against the projects that adapted it instead. Here is exactly a case of this.  The request involves supporting slack-gov.com with `slack://` webhook requests.

`mode=` added to parameters, but is still detected by default (so no breaking change).  Those who wish to use the `slack-gov` bot webhook can now provide it.  If they already have a slack://url prepared, they can just add `?mode=gov-hook` to their parameter listing

### 🔐 Parameter Breakdown

| Variable  | Required |  Description   |
|-----------|----------|----------------|
| mode | No      | Optionally enforce the mode the Slack plugin should operate in. This is detected by default, but possible options are `hook` (webhook mode) `gov-hook` (government webhook mode), and `bot` to have the service interact through the slack bot api|

---

### 📦 Examples

Leverage the government webhook mode:
```bash
# Pass the government hook directly:
apprise -vv -t "Title" -b "Message content" \
    "https://hooks.slack-gov.com/services/TABCD1234/BABCD1234/TABCD1234567890abcd12345"

# Or use the Apprise URL format:
apprise -vv -t "Title" -b "Message content" \
    "slack://TABCD1234/BABCD1234/TABCD1234567890abcd12345?mode=gov-hook"
```


## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `tox -e lint` and even `tox -e format` to autofix what it can)
* [x] Test coverage added (use `tox -e minimal`)

## Testing
<!-- If this your code is testable by other users of the program
     it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@slack-gov-webhook-support

# Test out the changes with the following command:
apprise -vv -t "Title" -b "Message content" \
    "https://hooks.slack-gov.com/services/TABCD1234/BABCD1234/TABCD1234567890abcd12345"

# Or use the Apprise URL format:
apprise -vv -t "Title" -b "Message content" \
    "slack://TABCD1234/BABCD1234/TABCD1234567890abcd12345?mode=gov-hook"

# If you have cloned the branch and have tox available to you
# the following can also allow you to test:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "https://hooks.slack-gov.com/services/TABCD1234/BABCD1234/TABCD1234567890abcd12345"
```
