### PR TITLE
Resend plugin improvements adding improved support for name=, cc=, reply=, and to=

### DIFF
--- a/apprise/utils/parse.py
+++ b/apprise/utils/parse.py
@@ -414,7 +414,7 @@ def is_email(address):
             "name": (
                 ""
                 if match.group("name") is None
-                else match.group("name").strip()
+                else match.group("name").rstrip(" \t\r\n\x0b\x0c+")
             ),
             # The email address
             "email": match.group("email"),
@@ -424,7 +424,7 @@ def is_email(address):
             "label": (
                 ""
                 if match.group("label") is None
-                else match.group("label").strip()
+                else match.group("label").strip(" \t\r\n\x0b\x0c+")
             ),
             # The user (which does not include the label) from the email
             # parsed.

--- a/tests/helpers/rest.py
+++ b/tests/helpers/rest.py
@@ -261,14 +261,13 @@ class AppriseURLTester:
                     f" expected '{privacy_url}'"
                 )
 
-            if url_matches:
-                # Assess that our URL matches a set regex
-                if not re.search(url_matches, obj.url()):
-                    raise AssertionError(
-                        f"URL: {url} generated an reloadable "
-                        f"url() of {obj.url()} that does not match "
-                        f"'{url_matches}'"
-                    )
+            # Assess that our URL matches a set regex
+            if url_matches and not re.search(url_matches, obj.url()):
+                raise AssertionError(
+                    f"URL: {url} generated an reloadable "
+                    f"url() of {obj.url()} that does not match "
+                    f"'{url_matches}'"
+                )
 
             # Instantiate the exact same object again using the URL
             # from the one that was already created properly

--- a/tests/test_plugin_resend.py
+++ b/tests/test_plugin_resend.py
@@ -89,25 +89,25 @@ apprise_url_tests = (
         },
     ),
     (
-        "resend://abcd:user@example.com/newuser@example.com",
+        "resend://abcd:user@example.com/newuser1@example.com",
         {
             # A good email
             "instance": NotifyResend,
         },
     ),
     (
-        "resend://abcd:user@example.com/newuser@example.com?name=Jessica",
+        "resend://abcd:user@example.com/newuser2@example.com?name=Jessica",
         {
             # A good email
             "instance": NotifyResend,
             "privacy_url": \
-                "resend://a...d:user@example.com/newuser@example.com",
+                "resend://a...d:user@example.com/newuser2@example.com",
             "url_matches": r"name=Jessica",
         },
     ),
     (
         (
-            "resend://abcd@newuser%40example.com?name=Ralph"
+            "resend://abcd@newuser4%40example.com?name=Ralph"
             "&from=user2@example.ca"
         ),
         {
@@ -121,19 +121,42 @@ apprise_url_tests = (
     (
         (
             "resend://?apikey=abcd&from=Joe<user@example.com>"
-            "&to=newuser@example.com"
+            "&to=newuser5@example.com"
          ),
         {
             # A good email
             "instance": NotifyResend,
             "privacy_url": \
-                "resend://a...d:user@example.com/newuser@example.com",
+                "resend://a...d:user@example.com/newuser5@example.com",
             "url_matches": r"name=Joe",
         },
     ),
     (
         (
-            "resend://abcd:user@example.com/newuser@example.com"
+            "resend://?apikey=abcd&from=Joe<user@example.com>"
+            "&reply=John<newuser6@example.com>"
+         ),
+        {
+            # A good email
+            "instance": NotifyResend,
+            "privacy_url": \
+                "resend://a...d:user@example.com",
+            "url_matches": r"reply=John",
+        },
+    ),
+    (
+        (
+            "resend://?apikey=abcd&from=Joe<user@example.com>"
+            "&reply=garbage%"
+         ),
+        {
+            # A good email but has a garbage reply-to value
+            "instance": NotifyResend,
+        },
+    ),
+    (
+        (
+            "resend://abcd:user@example.com/newuser7@example.com"
             "?bcc=l2g@nuxref.com"
         ),
         {
@@ -142,21 +165,32 @@ apprise_url_tests = (
         },
     ),
     (
-        "resend://abcd:user@example.com/newuser@example.com?cc=l2g@nuxref.com",
+        "resend://abcd:user@example.com/newuser8@example.com?cc=l2g@nuxref.com",
         {
             # A good email with Carbon Copy
             "instance": NotifyResend,
         },
     ),
     (
-        "resend://abcd:user@example.com/newuser@example.com?to=l2g@nuxref.com",
+        (
+            "resend://abcd:user@example.com/newuser8@example.com?"
+            "cc=Chris<l2g@nuxref.com>"
+        ),
+        {
+            # A good email with Carbon Copy + Name
+            "instance": NotifyResend,
+        },
+    ),
+
+    (
+        "resend://abcd:user@example.com/newuser9@example.com?to=l2g@nuxref.com",
         {
             # A good email with Carbon Copy
             "instance": NotifyResend,
         },
     ),
     (
-        "resend://abcd:user@example.ca/newuser@example.ca",
+        "resend://abcd:user@example.ca/newuser0@example.ca",
         {
             "instance": NotifyResend,
             # force a failure
@@ -165,7 +199,7 @@ apprise_url_tests = (
         },
     ),
     (
-        "resend://abcd:user@example.uk/newuser@example.uk",
+        "resend://abcd:user@example.uk/newuser01@example.uk",
         {
             "instance": NotifyResend,
             # throw a bizarre code forcing us to fail to look it up
@@ -174,7 +208,7 @@ apprise_url_tests = (
         },
     ),
     (
-        "resend://abcd:user@example.au/newuser@example.au",
+        "resend://abcd:user@example.au/newuser02@example.au",
         {
             "instance": NotifyResend,
             # Throws a series of i/o exceptions with this flag


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1404

The core request was to just support `name=`.  But upon reviewing what is accepted in the Resend payload, more function was added in addition to this.

### Parameter Breakdown

The list below only includes the additions added to this `resend://` plugin:

| Variable  | Required |  Description   |
|-----------|----------|----------------|
| name   | No       | With respect to {from_email}, this allows you to provide a name with your *Reply-To* address. <br/>**Note:** This field has become redundant and become synonymous to `from=`. It still behaves as it did in previous versions, but you can also follow the `A User<user@email.com>` syntax as well. To eliminate ambiguity; the values parsed from the `from=` will always trump the `name=`.
| reply   | No     |  Provide a Reply-To email (or set of). More than one can be separated with a space and/or comma.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `tox -e lint` and even `tox -e format` to autofix what it can)
* [x] Test coverage added (use `tox -e minimal`)

## Testing
<!-- If this your code is testable by other users of the program
     it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1404-resend-sender-name

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
   resend://credentials

# If you have cloned the branch and have tox available to you
# the following can also allow you to test:
tox -e apprise -- -t "Test Title" -b "Test Message" \
        resend://credentials
```
