### PR TITLE
discord:// supports ping= feature now

### DIFF
--- a/tests/test_plugin_discord.py
+++ b/tests/test_plugin_discord.py
@@ -88,7 +88,7 @@ apprise_url_tests = (
     ),
     # test image= field
     (
-        "discord://{}/{}?format=markdown&footer=Yes&image=Yes".format(
+        "discord://{}/{}?format=markdown&footer=Yes&image=Yes&ping=Joe".format(
             "i" * 24, "t" * 64
         ),
         {
@@ -403,6 +403,55 @@ def test_plugin_discord_notifications(mock_post):
     assert len(payload["allow_mentions"]["parse"]) == 2
     assert "everyone" in payload["allow_mentions"]["parse"]
     assert "admin" in payload["allow_mentions"]["parse"]
+
+    # Reset our object
+    mock_post.reset_mock()
+
+    # Test our header parsing when not lead with a header
+    body = """ """
+
+    results = NotifyDiscord.parse_url(
+        # & -> %26 for role otherwise & separates our URL from further parsing
+        f"discord://{webhook_id}/{webhook_token}/?ping=@joe,<@321>,<@%26654>"
+    )
+
+    assert isinstance(results, dict)
+    assert results["user"] is None
+    assert results["webhook_id"] == webhook_id
+    assert results["webhook_token"] == webhook_token
+    assert results["password"] is None
+    assert results["port"] is None
+    assert results["host"] == webhook_id
+    assert results["fullpath"] == f"/{webhook_token}/"
+    assert results["path"] == f"/{webhook_token}/"
+    assert results["query"] is None
+    assert results["schema"] == "discord"
+    assert results["url"] == f"discord://{webhook_id}/{webhook_token}/"
+    instance = NotifyDiscord(**results)
+    assert isinstance(instance, NotifyDiscord)
+
+    response = instance.send(body=body)
+    assert response is True
+    assert mock_post.call_count == 1
+
+    details = mock_post.call_args_list[0]
+    assert (
+        details[0][0]
+        == f"https://discord.com/api/webhooks/{webhook_id}/{webhook_token}"
+    )
+
+    payload = loads(details[1]["data"])
+
+    assert "allow_mentions" in payload
+    assert len(payload["allow_mentions"]["users"]) == 1
+    assert "321" in payload["allow_mentions"]["users"]
+    assert "<@321>" in payload["content"]
+    assert len(payload["allow_mentions"]["roles"]) == 1
+    assert "654" in payload["allow_mentions"]["roles"]
+    assert "<@&654>" in payload["content"]
+    assert len(payload["allow_mentions"]["parse"]) == 1
+    assert "joe" in payload["allow_mentions"]["parse"]
+    assert "@joe" in payload["content"]
 
 
 @mock.patch("requests.post")


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1327

This pull request adds optional **ping support** to the Discord plugin via a new
`ping=` URL query parameter. This allows Apprise to send *ping-only* or
*ping-augmented* notifications that explicitly mention one or more Discord
users or roles by ID.

The goal is to:

- Allow callers to trigger real Discord mentions, not just visually formatted
  `@name` text.
- Keep the feature fully backwards compatible for existing Discord URLs.
- Make the behaviour explicit and predictable through the URL configuration.

**Note:** One caveate is that a role is the format `@&1234` (or `<@&1234>`).  But the problem with this is `&` is reserved in a URL string to read the next parameter.  It is important that if you want to specify a Role in the URL that you URL escape it. (`%26`)

## URL Parameter: `ping=`

The new `ping` query parameter accepts a **comma-separated list** of tokens.
These tokens can be any mix of:

- User IDs: `123456789012345678`
- Role IDs: `&987654321098765432` (or `<@&987654321098765432>`)
- Special keywords: `@everyone`, `@here`

Examples:

```text
# Ping a single user by ID
discord://WEBHOOK_ID/WEBHOOK_TOKEN/?ping=@123456789012345678

# Ping multiple users
discord://WEBHOOK_ID/WEBHOOK_TOKEN/?ping=@123456789012345678,@234567890123456789

# Ping a role by ID (note the leading & is escaped to %26)
discord://WEBHOOK_ID/WEBHOOK_TOKEN/?ping=@%26&987654321098765432

# Ping a mix of users and roles  (note the leading & in the role is escaped to %26)
discord://WEBHOOK_ID/WEBHOOK_TOKEN/?ping=@123456789012345678,@%26987654321098765432

# Ping @everyone (uses allowed_mentions.parse)
discord://WEBHOOK_ID/WEBHOOK_TOKEN/?ping=@everyone
```

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `tox -e lint` and even `tox -e format` to autofix what it can)
* [x] Test coverage added (use `tox -e minimal`)

## Testing
<!-- If this your code is testable by other users of the program
     it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1327-discord-ping-feature

# Test out the changes with the following command:
apprise -t "Test Title" -b "Test Message" \
         "discord://credentials/?ping=<targets>"

# If you have cloned the branch and have tox available to you
# the following can also allow you to test:
tox -e apprise -- -t "Test Title" -b "Test Message" \
          "discord://credentials/?ping=<targets>"
```
