### PR TITLE
Bugzilla 2424601 resolved - no NotifyType enum leaking

### DIFF
--- a/apprise/plugins/custom_form.py
+++ b/apprise/plugins/custom_form.py
@@ -347,7 +347,7 @@ class NotifyForm(NotifyBase):
             (FORMPayloadField.VERSION, self.form_version),
             (FORMPayloadField.TITLE, title),
             (FORMPayloadField.MESSAGE, body),
-            (FORMPayloadField.MESSAGETYPE, notify_type),
+            (FORMPayloadField.MESSAGETYPE, notify_type.value),
         ):
 
             if not self.payload_map[key]:

--- a/apprise/plugins/custom_json.py
+++ b/apprise/plugins/custom_json.py
@@ -253,7 +253,7 @@ class NotifyJSON(NotifyBase):
             JSONPayloadField.TITLE: title,
             JSONPayloadField.MESSAGE: body,
             JSONPayloadField.ATTACHMENTS: attachments,
-            JSONPayloadField.MESSAGETYPE: notify_type,
+            JSONPayloadField.MESSAGETYPE: notify_type.value,
         }
 
         for key, value in self.payload_extras.items():

--- a/apprise/plugins/custom_xml.py
+++ b/apprise/plugins/custom_xml.py
@@ -278,7 +278,7 @@ class NotifyXML(NotifyBase):
             ),
             (
                 XMLPayloadField.MESSAGETYPE,
-                NotifyXML.escape_html(notify_type, whitespace=False),
+                NotifyXML.escape_html(notify_type.value, whitespace=False),
             ),
         ):
 

--- a/apprise/plugins/ifttt.py
+++ b/apprise/plugins/ifttt.py
@@ -199,7 +199,7 @@ class NotifyIFTTT(NotifyBase):
         payload = {
             self.ifttt_default_title_key: title,
             self.ifttt_default_body_key: body,
-            self.ifttt_default_type_key: notify_type,
+            self.ifttt_default_type_key: notify_type.value,
         }
 
         # Add any new tokens expected (this can also potentially override

--- a/apprise/plugins/msg91.py
+++ b/apprise/plugins/msg91.py
@@ -231,7 +231,7 @@ class NotifyMSG91(NotifyBase):
             "mobiles": None,
             # Keyword Tokens
             MSG91PayloadField.BODY: body,
-            MSG91PayloadField.MESSAGETYPE: notify_type,
+            MSG91PayloadField.MESSAGETYPE: notify_type.value,
         }
 
         # Prepare Recipient Payload Object

--- a/apprise/plugins/notifiarr.py
+++ b/apprise/plugins/notifiarr.py
@@ -288,7 +288,7 @@ class NotifyNotifiarr(NotifyBase):
             # prepare Notifiarr Object
             payload = {
                 "source": self.source if self.source else self.app_id,
-                "type": notify_type,
+                "type": notify_type.value,
                 "notification": {
                     "update": bool(self.event),
                     "name": self.app_id,

--- a/apprise/plugins/pagerduty.py
+++ b/apprise/plugins/pagerduty.py
@@ -374,7 +374,7 @@ class NotifyPagerDuty(NotifyBase):
         if image_url:
             payload["images"] = [{
                 "src": image_url,
-                "alt": notify_type,
+                "alt": notify_type.value,
             }]
 
         if self.details:

--- a/apprise/plugins/whatsapp.py
+++ b/apprise/plugins/whatsapp.py
@@ -381,7 +381,7 @@ class NotifyWhatsApp(NotifyBase):
                         "text": (
                             body
                             if self.components[key] == "body"
-                            else notify_type
+                            else notify_type.value
                         ),
                     })
 

--- a/apprise/plugins/workflows.py
+++ b/apprise/plugins/workflows.py
@@ -308,7 +308,7 @@ class NotifyWorkflows(NotifyBase):
                 "type": "Image",
                 "url": image_url,
                 "height": "32px",
-                "altText": notify_type,
+                "altText": notify_type.value,
             })
 
         if title:

--- a/tests/test_plugin_custom_form.py
+++ b/tests/test_plugin_custom_form.py
@@ -480,6 +480,8 @@ def test_plugin_custom_form_edge_cases(mock_get, mock_post):
     # `message`
     assert "msg" in details[1]["data"]
     assert details[1]["data"]["msg"] == "body"
+    assert details[1]["data"]["type"] == NotifyType.INFO.value
+    assert "NotifyType." not in str(details[1]["data"])
 
     assert instance.url(privacy=False).startswith(
         "form://localhost:8080/command?"

--- a/tests/test_plugin_custom_xml.py
+++ b/tests/test_plugin_custom_xml.py
@@ -375,6 +375,7 @@ def test_plugin_custom_xml_edge_cases(mock_get, mock_post):
     assert mock_get.call_count == 1
 
     details = mock_get.call_args_list[0]
+    assert "NotifyType." not in details[1]["data"]
     assert details[0][0] == "http://localhost:8080/command"
     assert instance.url(privacy=False).startswith(
         "xml://localhost:8080/command?"
@@ -441,6 +442,7 @@ def test_plugin_custom_xml_edge_cases(mock_get, mock_post):
     assert mock_get.call_count == 0
 
     details = mock_post.call_args_list[0]
+    assert "NotifyType." not in details[1]["data"]
     assert details[0][0] == "http://localhost:8081/command"
     assert instance.url(privacy=False).startswith(
         "xml://localhost:8081/command?"
@@ -464,7 +466,8 @@ def test_plugin_custom_xml_edge_cases(mock_get, mock_post):
 
     # Test our data set for our key/value pair
     assert re.search(r"<Version>[1-9]+\.[0-9]+</Version>", details[1]["data"])
-    assert re.search(r"<MessageType>info</MessageType>", details[1]["data"])
+    assert re.search(r"<MessageType>{}</MessageType>".format(
+        NotifyType.INFO.value), details[1]["data"])
     assert re.search(r"<Subject>title</Subject>", details[1]["data"])
     # No over-ride
     assert re.search(r"<Message>body</Message>", details[1]["data"])
@@ -503,6 +506,7 @@ def test_plugin_custom_xml_edge_cases(mock_get, mock_post):
     assert mock_get.call_count == 0
 
     details = mock_post.call_args_list[0]
+    assert "NotifyType." not in details[1]["data"]
     assert details[0][0] == "https://localhost"
     assert instance.url(privacy=False).startswith("xmls://localhost")
 
@@ -516,7 +520,8 @@ def test_plugin_custom_xml_edge_cases(mock_get, mock_post):
     )
 
     # Test our data set for our key/value pair
-    assert re.search(r"<MessageType>info</MessageType>", details[1]["data"])
+    assert re.search(r"<MessageType>{}</MessageType>".format(
+        NotifyType.INFO.value), details[1]["data"])
 
     # Subject is swapped for Title
     assert re.search(r"<Subject>title</Subject>", details[1]["data"]) is None

--- a/tests/test_plugin_ifttt.py
+++ b/tests/test_plugin_ifttt.py
@@ -189,6 +189,17 @@ def test_plugin_ifttt_edge_cases(mock_post, mock_get):
         is True
     )
 
+    # Validate outbound payload does not leak NotifyType Enum
+    assert mock_post.call_count >= 1
+    call = mock_post.call_args_list[-1]
+    payload = call[1].get("json") or call[1].get("data") or ""
+    payload_text = payload if isinstance(payload, str) else str(payload)
+
+    assert "NotifyType." not in payload_text
+    # If JSON dict is used:
+    if isinstance(payload, dict):
+        assert NotifyType.INFO.value in payload_text
+
     # Test the addition of tokens
     obj = NotifyIFTTT(
         webhook_id=webhook_id,

--- a/tests/test_plugin_msg91.py
+++ b/tests/test_plugin_msg91.py
@@ -35,7 +35,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
-from apprise import Apprise
+from apprise import Apprise, NotifyType
 from apprise.plugins.msg91 import NotifyMSG91
 
 logging.disable(logging.CRITICAL)
@@ -210,7 +210,7 @@ def test_plugin_msg91_keywords(mock_post):
 
     # Our base tokens
     assert response["recipients"][0]["body"] == message_contents
-    assert response["recipients"][0]["type"] == "info"
+    assert response["recipients"][0]["type"] == NotifyType.INFO.value
     assert response["recipients"][0]["key"] == "value"
 
     mock_post.reset_mock()
@@ -228,6 +228,7 @@ def test_plugin_msg91_keywords(mock_post):
     # Validate expected call parameters
     assert mock_post.call_count == 1
     first_call = mock_post.call_args_list[0]
+    assert "NotifyType." not in first_call[1]["data"]
 
     # URL and message parameters are the same for both calls
     assert first_call[0][0] == "https://control.msg91.com/api/v5/flow/"

--- a/tests/test_plugin_notifiarr.py
+++ b/tests/test_plugin_notifiarr.py
@@ -35,6 +35,7 @@ from unittest import mock
 from helpers import AppriseURLTester
 import requests
 
+from apprise import NotifyType
 from apprise.plugins.notifiarr import NotifyNotifiarr
 
 logging.disable(logging.CRITICAL)
@@ -264,6 +265,7 @@ def test_plugin_notifiarr_notifications(mock_post):
     assert mock_post.call_count == 1
 
     details = mock_post.call_args_list[0]
+    assert "NotifyType." not in details[1]["data"]
     assert details[0][0] == "https://notifiarr.com/api/v1/notification/apprise"
 
     payload = loads(details[1]["data"])
@@ -271,7 +273,7 @@ def test_plugin_notifiarr_notifications(mock_post):
     # First role and first user stored
     assert payload == {
         "source": "Apprise",
-        "type": "info",
+        "type": NotifyType.INFO.value,
         "notification": {"update": False, "name": "Apprise", "event": ""},
         "discord": {
             "color": "#3AA3E3",

--- a/tests/test_plugin_workflows.py
+++ b/tests/test_plugin_workflows.py
@@ -283,6 +283,7 @@ def test_plugin_workflows_simple_test(
         "https://host:443/workflows/workflow/triggers/manual/paths/invoke"
     )
     payload = json.loads(request_mock.call_args_list[0][1]["data"])
+    assert "NotifyType." not in request_mock.call_args_list[0][1]["data"]
     assert payload == {
         "type": "message",
         "attachments": [
@@ -301,7 +302,7 @@ def test_plugin_workflows_simple_test(
                             "master/apprise/assets/themes/default/"
                             "apprise-info-32x32.png",
                             "height": "32px",
-                            "altText": "info",
+                            "altText": NotifyType.INFO.value,
                         }, {
                             "type": "TextBlock",
                             # Verify our Title is set
@@ -343,6 +344,8 @@ def test_plugin_workflows_simple_test(
         "workflows/workflow/triggers/manual/paths/invoke"
     )
     payload = json.loads(request_mock.call_args_list[0][1]["data"])
+    assert "NotifyType." not in request_mock.call_args_list[0][1]["data"]
+
     assert payload == {
         "type": "message",
         "attachments": [
@@ -435,6 +438,7 @@ def test_plugin_workflows_templating_basic_success(
 
     # Our Posted JSON Object
     posted_json = json.loads(request_mock.call_args_list[0][1]["data"])
+    assert "NotifyType." not in request_mock.call_args_list[0][1]["data"]
     assert "summary" in posted_json
     assert posted_json["summary"] == "Apprise"
     assert posted_json["themeColor"] == "#3AA3E3"
@@ -553,6 +557,7 @@ def test_plugin_workflows_templating_target_success(
 
     # Our Posted JSON Object
     posted_json = json.loads(request_mock.call_args_list[0][1]["data"])
+    assert "NotifyType." not in request_mock.call_args_list[0][1]["data"]
     assert "summary" in posted_json
     assert posted_json["summary"] == "Apprise Notifications"
     assert posted_json["themeColor"] == "#3AA3E3"


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** https://bugzilla.redhat.com/show_bug.cgi?id=2424601


## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `tox -e lint` and even `tox -e format` to autofix what it can)
* [x] Test coverage added (use `tox -e minimal`)

## Testing
Covered in unit tests
