### PR TITLE
Signal API support for "text_mode=styled"

### DIFF
--- a/apprise/plugins/signal_api.py
+++ b/apprise/plugins/signal_api.py
@@ -39,7 +39,7 @@ from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import is_phone_no, parse_bool, parse_phone_no
 from ..utils.sanitize import sanitize_payload
-from .base import NotifyBase
+from .base import NotifyBase, NotifyFormat
 
 GROUP_REGEX = re.compile(
     r"^\s*((\@|\%40)?(group\.)|\@|\%40)(?P<group>[a-z0-9_=-]+)", re.I
@@ -276,6 +276,12 @@ class NotifySignalAPI(NotifyBase):
             "Content-Type": "application/json",
         }
 
+        # Support Styled (Markdown formatting)
+        text_mode = (
+            "styled" if self.notify_format == NotifyFormat.MARKDOWN
+            else "normal"
+        )
+
         # Format defined here:
         #   https://bbernhard.github.io/signal-cli-rest-api\
         #       /#/Messages/post_v2_send
@@ -303,6 +309,7 @@ class NotifySignalAPI(NotifyBase):
                 ).rstrip()
             ),
             "number": self.source,
+            "text_mode": text_mode,
             "recipients": [],
         }
 


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1476

This change adds explicit support for Signal CLI REST API `styled` messages when
Markdown formatting is requested.

When a Signal notification is configured with `format=markdown` (via URL or
plugin instantiation), the outgoing payload now includes `text_mode=styled`,
allowing the Signal service to correctly render Markdown content such as bold,
italic, and other supported styles.

This behavior aligns with the Signal CLI REST API specification and preserves
the existing default behavior (`text_mode=normal`) for non-Markdown messages.

## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `tox -e lint` and even `tox -e format` to autofix what it can)
* [x] Test coverage added (use `tox -e minimal`)

## Testing
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1476-signal-api-styled-support

# Send a styled (Markdown) Signal message:
apprise -t "Title" -b "**Bold** _Italic_" \
  "signals://localhost/+15551234567/+15557654321?format=markdown"

# Send a styled (Markdown) Signal message:
tox -e apprise -t "Title" -b "**Bold** _Italic_" \
  s"ignals://localhost/+15551234567/+15557654321?format=markdown"
```
