### PR TITLE
resolves reoccuring warning for GdkPixbuf

### DIFF
--- a/apprise/plugins/gnome.py
+++ b/apprise/plugins/gnome.py
@@ -39,6 +39,7 @@ try:
 
     # require_version() call is required otherwise we generate a warning
     gi.require_version("Notify", "0.7")
+    gi.require_version("GdkPixbuf", "2.0")
 
     # We can import the actual libraries we care about now:
     from gi.repository import GdkPixbuf, Notify


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** #1475

Resolves warning message:
```text
plugins/gnome.py:44: PyGIWarning: GdkPixbuf was imported without specifying a version first. Use gi.require_version('GdkPixbuf', '2.0') before import to ensure that the right version gets loaded.
from gi.repository import GdkPixbuf, Notify
```
## Checklist
<!-- The following must be completed or your PR can't be merged -->
* [x] The code change is tested and works locally.
* [x] There is no commented out code in this PR.
* [x] No lint errors (use `tox -e lint` and even `tox -e format` to autofix what it can)
* [ ] Test coverage added (use `tox -e minimal`)

## Testing
<!-- If this your code is testable by other users of the program
     it would be really helpful to define this here -->
Anyone can help test this source code as follows:
```bash
# Create a virtual environment to work in as follows:
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1475-gdkpixbuf-warning-fix

# Test out the changes with the following command:
apprise --dry-run
```
