### PR TITLE
Add Mattermost icon override support

### DIFF
--- a/apprise/plugins/mattermost.py
+++ b/apprise/plugins/mattermost.py
@@ -133,6 +133,10 @@ class NotifyMattermost(NotifyBase):
             "channel": {
                 "alias_of": "channels",
             },
+            "icon_url": {
+                "name": _("Icon URL"),
+                "type": "string",
+            },
             "image": {
                 "name": _("Include Image"),
                 "type": "bool",
@@ -151,6 +155,7 @@ class NotifyMattermost(NotifyBase):
         fullpath=None,
         channels=None,
         include_image=False,
+        icon_url=None,
         **kwargs,
     ):
         """Initialize Mattermost Object."""
@@ -183,6 +188,9 @@ class NotifyMattermost(NotifyBase):
         # Place a thumbnail image inline with the message body
         self.include_image = include_image
 
+        # Support a user-provided icon URL
+        self.icon_url = icon_url
+
         return
 
     def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
@@ -210,7 +218,13 @@ class NotifyMattermost(NotifyBase):
 
         # Acquire our image url if configured to do so
         image_url = (
-            None if not self.include_image else self.image_url(notify_type)
+            self.icon_url
+            if self.icon_url
+            else (
+                None
+                if not self.include_image
+                else self.image_url(notify_type)
+            )
         )
 
         if image_url:
@@ -329,6 +343,9 @@ class NotifyMattermost(NotifyBase):
             "image": "yes" if self.include_image else "no",
         }
 
+        if self.icon_url:
+            params["icon_url"] = self.icon_url
+
         # Extend our parameters
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
 
@@ -423,6 +440,11 @@ class NotifyMattermost(NotifyBase):
                 "image", NotifyMattermost.template_args["image"]["default"]
             )
         )
+
+        if "icon_url" in results["qsd"]:
+            results["icon_url"] = NotifyMattermost.unquote(
+                results["qsd"]["icon_url"]
+            )
 
         return results
 

--- a/tests/test_plugin_mattermost.py
+++ b/tests/test_plugin_mattermost.py
@@ -73,6 +73,15 @@ apprise_url_tests = (
         },
     ),
     (
+        (
+            "mmost://localhost/3ccdd113474722377935511fc85d3dd4"
+            "?icon_url=http://localhost/test.png"
+        ),
+        {
+            "instance": NotifyMattermost,
+        },
+    ),
+    (
         "mmost://user@localhost/3ccdd113474722377935511fc85d3dd4?channel=test",
         {
             "instance": NotifyMattermost,
@@ -281,3 +290,27 @@ def test_mattermost_post_default_port(request_mock):
     posted_json = json.loads(request_mock.call_args_list[0][1]["data"])
     assert "text" in posted_json
     assert posted_json["text"] == "title\r\nbody"
+
+
+def test_mattermost_icon_override(request_mock):
+    # Test token
+    token = "token"
+    icon_url = "http://localhost/test.png"
+
+    # Instantiate our URL with an icon override
+    obj = Apprise.instantiate(
+        "mmost://mattermost.example.com/{token}?icon_url={icon_url}".format(
+            token=token,
+            icon_url=icon_url,
+        )
+    )
+
+    assert isinstance(obj, NotifyMattermost)
+    assert obj.notify(body="body", title="title") is True
+
+    assert request_mock.called is True
+    assert request_mock.call_count == 1
+
+    # Our Posted JSON Object
+    posted_json = json.loads(request_mock.call_args_list[0][1]["data"])
+    assert posted_json["icon_url"] == icon_url


### PR DESCRIPTION
## Description

Mattermost allows you to override the icon in the message, which is really nice for re-using a webhook. This PR adds support for overriding the webhook icon via `icon_url`. 

This keeps the existing `image` flag behavior for default Apprise icons while allowing explicit overrides. I think it probably makes sense to merge/replace the current `image` parameter, but wanted to keep it around for backward compatibility.

## Checklist
* [x] Documentation ticket created: https://github.com/caronc/apprise-docs/pull/8
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e minimal`).

## Testing
```bash
tox -e apprise -- -t "This will have a custom username and icon (as long as they're allowed by the Mattermost admin)" \
    'mmosts://Firefox@MATTERMOST_HOST/MATTERMOST_TOKEN?icon_url=https%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Fcommons%2Fthumb%2Fa%2Fa0%2FFirefox_logo%252C_2019.svg%2F1280px-Firefox_logo%252C_2019.svg.png'
```
