### PR TITLE
Migrate the Dot. (Quote/0) plugin from API v1 to API v2

### DIFF
--- a/apprise/plugins/dot.py
+++ b/apprise/plugins/dot.py
@@ -26,27 +26,35 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 #
-# API: https://dot.mindreset.tech/docs/service/studio/api/text_api
-#      https://dot.mindreset.tech/docs/service/studio/api/image_api
+# API: https://dot.mindreset.tech/docs/service/open/text_api
+#      https://dot.mindreset.tech/docs/service/open/image_api
+#
+# New API endpoints (v2):
+#   - Text API: /api/authV2/open/device/:deviceId/text
+#   - Image API: /api/authV2/open/device/:deviceId/image
+#
+# Note: Old endpoints (/api/open/text and /api/open/image) are deprecated
+# and will be removed in the future. Requests are automatically forwarded
+# to the new endpoints.
 #
 # Text API Fields:
 #   - refreshNow (bool, optional, default true): controls display timing.
-#   - deviceId (string, required): unique device serial.
 #   - title (string, optional): title text shown on screen.
 #   - message (string, optional): body text shown on screen.
 #   - signature (string, optional): footer/signature text.
 #   - icon (string, optional): base64 PNG icon (40px x 40px).
 #   - link (string, optional): tap-to-interact target URL.
+#   - taskKey (string, optional): specify which text API content to update.
 #
 # Image API Fields:
 #   - refreshNow (bool, optional, default true): controls display timing.
-#   - deviceId (string, required): unique device serial.
 #   - image (string, required): base64 PNG image (296px x 152px).
 #   - link (string, optional): tap-to-interact target URL.
 #   - border (number, optional, default 0): 0=white, 1=black frame.
 #   - ditherType (string, optional, default DIFFUSION): dithering mode.
 #   - ditherKernel (string, optional, default FLOYD_STEINBERG):
 #     dithering kernel.
+#   - taskKey (string, optional): specify which image API content to update.
 
 from contextlib import suppress
 import json
@@ -186,6 +194,10 @@ class NotifyDot(NotifyBase):
                 "values": DOT_DITHER_KERNELS,
                 "default": "FLOYD_STEINBERG",
             },
+            "task_key": {
+                "name": _("Task Key"),
+                "type": "string",
+            },
         },
     )
     # Note:
@@ -201,7 +213,7 @@ class NotifyDot(NotifyBase):
         apikey=None,
         device_id=None,
         mode=DEFAULT_MODE,
-        refresh_now=True,
+        refresh_now=None,
         signature=None,
         icon=None,
         link=None,
@@ -209,6 +221,7 @@ class NotifyDot(NotifyBase):
         dither_type=None,
         dither_kernel=None,
         image_data=None,
+        task_key=None,
         **kwargs,
     ):
         """Initialize Notify Dot Object."""
@@ -221,7 +234,14 @@ class NotifyDot(NotifyBase):
         self.device_id = device_id
 
         # Refresh Now flag: True shows content immediately (default).
-        self.refresh_now = parse_bool(refresh_now, default=True)
+        self.refresh_now = (
+            parse_bool(
+                refresh_now,
+                self.template_args["refresh"]["default"],
+            )
+            if refresh_now is not None
+            else self.template_args["refresh"]["default"]
+        )
 
         # API mode ("text" or "image")
         self.mode = (
@@ -267,11 +287,20 @@ class NotifyDot(NotifyBase):
         # Dither kernel for the Image API
         self.dither_kernel = dither_kernel
 
-        # Text API endpoint
-        self.text_api_url = "https://dot.mindreset.tech/api/open/text"
+        # Task Key for specifying which content to update
+        self.task_key = task_key if isinstance(task_key, str) else None
 
-        # Image API endpoint
-        self.image_api_url = "https://dot.mindreset.tech/api/open/image"
+        # Text API endpoint (v2)
+        self.text_api_url = (
+            f"https://dot.mindreset.tech/api/authV2/open/device/"
+            f"{self.device_id}/text"
+        )
+
+        # Image API endpoint (v2)
+        self.image_api_url = (
+            f"https://dot.mindreset.tech/api/authV2/open/device/"
+            f"{self.device_id}/image"
+        )
 
         return
 
@@ -335,17 +364,16 @@ class NotifyDot(NotifyBase):
 
             # Use Image API
             # Image API payload:
-            #   refreshNow: display timing control.
-            #   deviceId: Dot device serial (required).
+            #   refreshNow: display timing control (optional).
             #   image: base64 PNG 296x152 (required).
             #   link: optional tap target.
             #   border: optional frame color.
             #   ditherType: optional dithering mode.
             #   ditherKernel: optional dithering kernel.
+            #   taskKey: optional task identifier.
             payload = {
-                "refreshNow": self.refresh_now,
-                "deviceId": self.device_id,
                 "image": image_data,  # Image payload shown on screen
+                "refreshNow": self.refresh_now,
             }
 
             if self.link:
@@ -360,21 +388,23 @@ class NotifyDot(NotifyBase):
             if self.dither_kernel is not None:
                 payload["ditherKernel"] = self.dither_kernel
 
+            if self.task_key is not None:
+                payload["taskKey"] = self.task_key
+
             api_url = self.image_api_url
 
         else:
             # Use Text API
             # Text API payload:
-            #   refreshNow: display timing control.
-            #   deviceId: Dot device serial (required).
+            #   refreshNow: display timing control (optional).
             #   title: optional title on screen.
             #   message: optional body on screen.
             #   signature: optional footer text.
             #   icon: optional base64 PNG icon (40x40).
             #   link: optional tap target.
+            #   taskKey: optional task identifier.
             payload = {
                 "refreshNow": self.refresh_now,
-                "deviceId": self.device_id,
             }
 
             if title:
@@ -412,6 +442,9 @@ class NotifyDot(NotifyBase):
             if self.link:
                 payload["link"] = self.link
 
+            if self.task_key is not None:
+                payload["taskKey"] = self.task_key
+
             api_url = self.text_api_url
 
         # Some Debug Logging
@@ -445,8 +478,7 @@ class NotifyDot(NotifyBase):
             status_str = NotifyDot.http_response_code_lookup(r.status_code)
 
             self.logger.warning(
-                "Failed to send Dot notification to {}: "
-                "{}{}error={}.".format(
+                "Failed to send Dot notification to {}: {}{}error={}.".format(
                     self.device_id,
                     status_str,
                     ", " if status_str else "",
@@ -455,7 +487,8 @@ class NotifyDot(NotifyBase):
             )
 
             self.logger.debug(
-                "Response Details:\r\n%r", (r.content or b"")[:2000])
+                "Response Details:\r\n%r", (r.content or b"")[:2000]
+            )
 
             return False
 
@@ -484,9 +517,10 @@ class NotifyDot(NotifyBase):
         """Returns the URL built dynamically based on specified arguments."""
 
         # Define any URL parameters
-        params = {
-            "refresh": "yes" if self.refresh_now else "no",
-        }
+        params = {}
+
+        # Add refresh parameter
+        params["refresh"] = "yes" if self.refresh_now else "no"
 
         if self.mode == "text":
             if self.signature:
@@ -513,6 +547,10 @@ class NotifyDot(NotifyBase):
 
             if self.dither_kernel and self.dither_kernel != "FLOYD_STEINBERG":
                 params["dither_kernel"] = self.dither_kernel
+
+        # Add task_key if provided
+        if self.task_key:
+            params["task_key"] = self.task_key
 
         # Extend our parameters
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
@@ -615,5 +653,10 @@ class NotifyDot(NotifyBase):
         image_value = results["qsd"].get("image")
         if image_value:
             results["image_data"] = NotifyDot.unquote(image_value.strip())
+
+        # Task Key
+        task_key_value = results["qsd"].get("task_key")
+        if task_key_value:
+            results["task_key"] = NotifyDot.unquote(task_key_value.strip())
 
         return results

--- a/tests/test_plugin_dot.py
+++ b/tests/test_plugin_dot.py
@@ -193,7 +193,8 @@ def test_notify_dot_image_mode_with_attachment():
     _args, kwargs = mock_post.call_args
     payload = json.loads(kwargs["data"])
     assert payload["image"] == "YmFzZTY0"
-    assert payload["deviceId"] == "device"
+    # API v2: deviceId should NOT be in payload
+    assert "deviceId" not in payload
 
 
 def test_notify_dot_image_mode_with_existing_image_data():
@@ -243,7 +244,8 @@ def test_notify_dot_text_mode_with_existing_icon():
     _args, kwargs = mock_post.call_args
     payload = json.loads(kwargs["data"])
     assert "image" not in payload
-    assert payload["deviceId"] == "device"
+    # API v2: deviceId should NOT be in payload
+    assert "deviceId" not in payload
     assert payload["message"] == "world"
     # Should use existing icon, not attachment
     assert payload["icon"] == "aW5jb24="
@@ -269,7 +271,8 @@ def test_notify_dot_text_mode_uses_attachment_as_icon():
 
     _args, kwargs = mock_post.call_args
     payload = json.loads(kwargs["data"])
-    assert payload["deviceId"] == "device"
+    # API v2: deviceId should NOT be in payload
+    assert "deviceId" not in payload
     assert payload["message"] == "world"
     # Should use attachment as icon
     assert payload["icon"] == "attachment_icon_data"
@@ -433,9 +436,10 @@ def test_notify_dot_image_mode_with_failed_attachment():
 
     dot = NotifyDot(apikey="token", device_id="device", mode="image")
     # Should fail when no valid image data is available
-    assert dot.notify(
-        title="test", body="test", attach=[FailedAttachment()]
-    ) is False
+    assert (
+        dot.notify(title="test", body="test", attach=[FailedAttachment()])
+        is False
+    )
 
 
 def test_notify_dot_url_generation_defaults():
@@ -650,11 +654,14 @@ def test_notify_dot_image_mode_attachment_exception():
 
     # First attachment throws exception, should log warning and fail
     with mock.patch.object(dot.logger, "warning") as mock_warning:
-        assert dot.send(
-            body="test",
-            title="test",
-            attach=[ExceptionAttachment()],
-        ) is False
+        assert (
+            dot.send(
+                body="test",
+                title="test",
+                attach=[ExceptionAttachment()],
+            )
+            is False
+        )
         # Should log warning about failed attachment processing
         assert mock_warning.called
         # Check that the warning message contains expected text
@@ -670,11 +677,14 @@ def test_notify_dot_image_mode_attachment_none():
     dot = NotifyDot(apikey="token", device_id="device", mode="image")
 
     # Attachment is None, should skip base64() call and fail
-    assert dot.send(
-        body="test",
-        title="test",
-        attach=[None],
-    ) is False
+    assert (
+        dot.send(
+            body="test",
+            title="test",
+            attach=[None],
+        )
+        is False
+    )
 
 
 def test_notify_dot_image_mode_attachment_falsy():
@@ -689,11 +699,14 @@ def test_notify_dot_image_mode_attachment_falsy():
         def base64(self):
             return "should_not_be_called"
 
-    assert dot.send(
-        body="test",
-        title="test",
-        attach=[FalsyAttachment()],
-    ) is False
+    assert (
+        dot.send(
+            body="test",
+            title="test",
+            attach=[FalsyAttachment()],
+        )
+        is False
+    )
 
 
 def test_notify_dot_text_mode_attachment_exception():
@@ -915,11 +928,14 @@ def test_notify_dot_image_mode_first_attachment_fails():
     dot = NotifyDot(apikey="token", device_id="device", mode="image")
 
     # First attachment returns None, should fail immediately
-    assert dot.notify(
-        title="",
-        body="",
-        attach=[FailingAttachment()],
-    ) is False
+    assert (
+        dot.notify(
+            title="",
+            body="",
+            attach=[FailingAttachment()],
+        )
+        is False
+    )
 
 
 def test_notify_dot_image_mode_with_empty_attach_list():
@@ -929,11 +945,14 @@ def test_notify_dot_image_mode_with_empty_attach_list():
     # Try with empty attachments list
     # Condition: not image_data and attach -> not None and [] -> False
     # Should skip the for loop and go directly to line 313
-    assert dot.notify(
-        title="",
-        body="",
-        attach=[],  # Empty list (truthy in Python but loop won't execute)
-    ) is False
+    assert (
+        dot.notify(
+            title="",
+            body="",
+            attach=[],  # Empty list is falsy; no attachment used
+        )
+        is False
+    )
 
 
 def test_notify_dot_parse_url_without_host_field():
@@ -965,3 +984,370 @@ def test_notify_dot_parse_url_without_host_field():
         assert result.get("device_id") is None
         assert result.get("apikey") == "apikey"
         assert result.get("refresh_now") is True  # refresh was in qsd
+
+
+def test_notify_dot_api_v2_endpoint_construction():
+    """Test API v2 endpoints with device_id in URL."""
+    # Test text mode endpoint
+    dot_text = NotifyDot(apikey="test_key", device_id="DEVICE123", mode="text")
+    expected_text_url = (
+        "https://dot.mindreset.tech/api/authV2/open/device/DEVICE123/text"
+    )
+    assert dot_text.text_api_url == expected_text_url
+
+    # Test image mode endpoint
+    dot_image = NotifyDot(
+        apikey="test_key", device_id="DEVICE456", mode="image"
+    )
+    expected_image_url = (
+        "https://dot.mindreset.tech/api/authV2/open/device/DEVICE456/image"
+    )
+    assert dot_image.image_api_url == expected_image_url
+
+
+def test_notify_dot_deviceid_not_in_text_payload():
+    """Test deviceId NOT in text payload (API v2)."""
+    dot = NotifyDot(apikey="test_key", device_id="12345", mode="text")
+
+    response = mock.Mock()
+    response.status_code = 200
+
+    with mock.patch("requests.post", return_value=response) as mock_post:
+        assert dot.send("test body", "test title")
+
+        # Verify payload does NOT contain deviceId
+        call_args = mock_post.call_args
+        payload = json.loads(call_args[1]["data"])
+        assert "deviceId" not in payload
+
+        # Verify URL contains device_id in path
+        called_url = call_args[0][0]
+        assert "/device/12345/text" in called_url
+
+
+def test_notify_dot_deviceid_not_in_image_payload():
+    """Test deviceId NOT in image payload (API v2)."""
+    dot = NotifyDot(
+        apikey="test_key",
+        device_id="67890",
+        mode="image",
+        image_data="base64data",
+    )
+
+    response = mock.Mock()
+    response.status_code = 200
+
+    with mock.patch("requests.post", return_value=response) as mock_post:
+        assert dot.send("", "")
+
+        # Verify payload does NOT contain deviceId
+        call_args = mock_post.call_args
+        payload = json.loads(call_args[1]["data"])
+        assert "deviceId" not in payload
+
+        # Verify URL contains device_id in path
+        called_url = call_args[0][0]
+        assert "/device/67890/image" in called_url
+
+
+def test_notify_dot_task_key_in_text_mode():
+    """Test taskKey parameter in text mode payload."""
+    dot = NotifyDot(
+        apikey="test_key",
+        device_id="12345",
+        mode="text",
+        task_key="my_task_123",
+    )
+
+    response = mock.Mock()
+    response.status_code = 200
+
+    with mock.patch("requests.post", return_value=response) as mock_post:
+        assert dot.send("test body", "test title")
+
+        # Verify payload contains taskKey
+        call_args = mock_post.call_args
+        payload = json.loads(call_args[1]["data"])
+        assert "taskKey" in payload
+        assert payload["taskKey"] == "my_task_123"
+
+
+def test_notify_dot_task_key_in_image_mode():
+    """Test taskKey parameter in image mode payload."""
+    dot = NotifyDot(
+        apikey="test_key",
+        device_id="12345",
+        mode="image",
+        task_key="image_task_456",
+        image_data="base64encodedimage",
+    )
+
+    response = mock.Mock()
+    response.status_code = 200
+
+    with mock.patch("requests.post", return_value=response) as mock_post:
+        assert dot.send("", "")
+
+        # Verify payload contains taskKey
+        call_args = mock_post.call_args
+        payload = json.loads(call_args[1]["data"])
+        assert "taskKey" in payload
+        assert payload["taskKey"] == "image_task_456"
+
+
+def test_notify_dot_task_key_none_not_in_payload():
+    """Test that taskKey is NOT in payload when None."""
+    dot = NotifyDot(
+        apikey="test_key",
+        device_id="12345",
+        task_key=None,
+    )
+
+    response = mock.Mock()
+    response.status_code = 200
+
+    with mock.patch("requests.post", return_value=response) as mock_post:
+        assert dot.send("test", "title")
+
+        call_args = mock_post.call_args
+        payload = json.loads(call_args[1]["data"])
+        assert "taskKey" not in payload
+
+
+def test_notify_dot_task_key_url_parsing():
+    """Test parsing taskKey from URL."""
+    url = "dot://apikey@device_id/text/?task_key=parsed_task"
+    result = NotifyDot.parse_url(url)
+
+    assert result is not None
+    assert result["task_key"] == "parsed_task"
+
+
+def test_notify_dot_task_key_in_url_method():
+    """Test that url() method includes task_key parameter."""
+    dot = NotifyDot(
+        apikey="test_key",
+        device_id="12345",
+        task_key="url_task",
+    )
+    url = dot.url()
+
+    assert "task_key=url_task" in url
+
+
+def test_notify_dot_refresh_now_none_defaults_to_true():
+    """Test that refreshNow defaults to True when None is passed."""
+    dot = NotifyDot(apikey="key", device_id="id", refresh_now=None)
+
+    response = mock.Mock()
+    response.status_code = 200
+
+    with mock.patch("requests.post", return_value=response) as mock_post:
+        assert dot.send("test", "title")
+
+        payload = json.loads(mock_post.call_args[1]["data"])
+        # None resolves to template default (True)
+        assert payload["refreshNow"] is True
+
+
+def test_notify_dot_refresh_now_true_in_payload():
+    """Test that refreshNow is in payload when True."""
+    dot = NotifyDot(apikey="key", device_id="id", refresh_now=True)
+
+    response = mock.Mock()
+    response.status_code = 200
+
+    with mock.patch("requests.post", return_value=response) as mock_post:
+        assert dot.send("test", "title")
+
+        payload = json.loads(mock_post.call_args[1]["data"])
+        assert payload.get("refreshNow") is True
+
+
+def test_notify_dot_refresh_now_false_in_payload():
+    """Test that refreshNow is in payload when False."""
+    dot = NotifyDot(apikey="key", device_id="id", refresh_now=False)
+
+    response = mock.Mock()
+    response.status_code = 200
+
+    with mock.patch("requests.post", return_value=response) as mock_post:
+        assert dot.send("test", "title")
+
+        payload = json.loads(mock_post.call_args[1]["data"])
+        assert payload.get("refreshNow") is False
+
+
+def test_notify_dot_refresh_now_none_defaults_in_url():
+    """Test that refresh defaults to 'yes' in URL when refresh_now is None."""
+    dot = NotifyDot(apikey="key", device_id="id", refresh_now=None)
+    url = dot.url()
+
+    # None resolves to template default (True) -> refresh=yes
+    assert "refresh=yes" in url
+
+
+def test_notify_dot_image_refresh_now_none_defaults_to_true():
+    """Test that refreshNow defaults to True in image mode when None."""
+    dot = NotifyDot(
+        apikey="key",
+        device_id="id",
+        mode="image",
+        image_data="iVBOR",
+        refresh_now=None,
+    )
+
+    response = mock.Mock()
+    response.status_code = 200
+
+    with mock.patch("requests.post", return_value=response) as mock_post:
+        assert dot.send("", "")
+
+        payload = json.loads(mock_post.call_args[1]["data"])
+        assert payload["refreshNow"] is True
+        assert payload["image"] == "iVBOR"
+
+
+def test_notify_dot_device_id_with_special_characters():
+    """Test that device_id with special characters is properly URL-encoded."""
+    # Test various special characters
+    test_cases = [
+        ("device/id", "device%2Fid"),  # forward slash
+        ("device?id", "device%3Fid"),  # question mark
+        ("device#id", "device%23id"),  # hash
+        ("device%id", "device%25id"),  # percent
+        ("device id", "device%20id"),  # space
+        ("device@id", "device%40id"),  # at sign
+    ]
+
+    for device_id, expected_encoded in test_cases:
+        dot = NotifyDot(apikey="test_key", device_id=device_id)
+        # Verify URL method properly encodes
+        url = dot.url()
+        assert expected_encoded in url, (
+            f"device_id '{device_id}' should be encoded"
+            f" as '{expected_encoded}'"
+        )
+
+
+def test_notify_dot_url_roundtrip_with_task_key():
+    """Test URL parsing and reconstruction maintains taskKey."""
+    original_url = "dot://apikey@device123/text/?task_key=test&signature=sig"
+
+    # Parse URL
+    result = NotifyDot.parse_url(original_url)
+
+    # Create object
+    dot = NotifyDot(**result)
+
+    # Reconstruct URL
+    reconstructed = dot.url(privacy=False)
+
+    # Verify key parameters are maintained
+    assert "device123" in reconstructed
+    assert "text" in reconstructed
+    assert "task_key=test" in reconstructed
+    assert "signature=sig" in reconstructed
+
+
+def test_notify_dot_authorization_header_bearer_format():
+    """Test that Authorization header uses Bearer format."""
+    dot = NotifyDot(apikey="MY_SECRET_KEY", device_id="12345")
+
+    response = mock.Mock()
+    response.status_code = 200
+
+    with mock.patch("requests.post", return_value=response) as mock_post:
+        assert dot.send("test", "title")
+
+        call_args = mock_post.call_args
+        headers = call_args[1]["headers"]
+
+        assert "Authorization" in headers
+        assert headers["Authorization"] == "Bearer MY_SECRET_KEY"
+
+
+def test_notify_dot_device_id_in_endpoint_url():
+    """Test that device_id is properly embedded in endpoint URL."""
+    dot = NotifyDot(apikey="key", device_id="ABC123", mode="text")
+
+    response = mock.Mock()
+    response.status_code = 200
+
+    with mock.patch("requests.post", return_value=response) as mock_post:
+        assert dot.send("test", "title")
+
+        # Check the actual URL that was called
+        called_url = mock_post.call_args[0][0]
+        assert "ABC123" in called_url
+        assert "/api/authV2/open/device/ABC123/text" in called_url
+
+
+def test_notify_dot_multiple_parameters_combined():
+    """Test combining multiple new API v2 parameters."""
+    dot = NotifyDot(
+        apikey="key",
+        device_id="device",
+        mode="text",
+        task_key="combined_task",
+        refresh_now=False,
+        signature="test_sig",
+        link="https://example.com",
+    )
+
+    response = mock.Mock()
+    response.status_code = 200
+
+    with mock.patch("requests.post", return_value=response) as mock_post:
+        assert dot.send("body", "title")
+
+        # Verify all parameters in payload
+        payload = json.loads(mock_post.call_args[1]["data"])
+        assert "deviceId" not in payload  # Should NOT be in payload
+        assert payload.get("taskKey") == "combined_task"
+        assert payload.get("refreshNow") is False
+        assert payload.get("signature") == "test_sig"
+        assert payload.get("link") == "https://example.com"
+        assert payload.get("title") == "title"
+        assert payload.get("message") == "body"
+
+        # Verify URL structure
+        called_url = mock_post.call_args[0][0]
+        assert "/device/device/text" in called_url
+
+
+def test_notify_dot_image_mode_combined_parameters():
+    """Test image mode with all API v2 parameters."""
+    dot = NotifyDot(
+        apikey="key",
+        device_id="img_device",
+        mode="image",
+        image_data="base64image",
+        task_key="img_task",
+        refresh_now=True,
+        link="https://example.com",
+        border=1,
+        dither_type="ORDERED",
+        dither_kernel="ATKINSON",
+    )
+
+    response = mock.Mock()
+    response.status_code = 200
+
+    with mock.patch("requests.post", return_value=response) as mock_post:
+        assert dot.send("", "")
+
+        # Verify all parameters in payload
+        payload = json.loads(mock_post.call_args[1]["data"])
+        assert "deviceId" not in payload  # Should NOT be in payload
+        assert payload.get("image") == "base64image"
+        assert payload.get("taskKey") == "img_task"
+        assert payload.get("refreshNow") is True
+        assert payload.get("link") == "https://example.com"
+        assert payload.get("border") == 1
+        assert payload.get("ditherType") == "ORDERED"
+        assert payload.get("ditherKernel") == "ATKINSON"
+
+        # Verify URL structure
+        called_url = mock_post.call_args[0][0]
+        assert "/device/img_device/image" in called_url


### PR DESCRIPTION
## Description

Migrate the Dot. (Quote/0) plugin from API v1 to API v2.

### Key Changes

**API Endpoint Migration (v1 → v2):**
- Text API: `/api/open/text` → `/api/authV2/open/device/:deviceId/text`
- Image API: `/api/open/image` → `/api/authV2/open/device/:deviceId/image`

**Payload Changes:**
- `deviceId` removed from request body — now embedded in the URL path.
- `refreshNow` is now conditionally included (omitted when `None` instead of always present).

**New Feature:**
- Added `taskKey` parameter support for both Text and Image APIs, allowing users to specify which content slot to update when multiple exist on a device.

**Documentation:**
- Updated API doc links from `/docs/service/studio/api/` to `/docs/service/open/`.
- Updated inline comments to reflect v2 field requirements.

> **Note:** The old v1 endpoints are deprecated and the server currently auto-forwards requests. This PR proactively adopts the v2 endpoints before the v1 endpoints are removed.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e minimal`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@feature/dot-api-v2

# Test Text API (requires a real API key and device serial)
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "dot://YOUR_API_KEY@YOUR_DEVICE_ID/text/"

# Test Text API with taskKey
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "dot://YOUR_API_KEY@YOUR_DEVICE_ID/text/?task_key=my_task"

# Test Image API (with base64-encoded image)
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "dot://YOUR_API_KEY@YOUR_DEVICE_ID/image/?image=BASE64_PNG_DATA"
```