### PR TITLE
bark:// ?format=markdown support for Markdown rendering

### DIFF
--- a/apprise/plugins/bark.py
+++ b/apprise/plugins/bark.py
@@ -32,7 +32,7 @@ import json
 
 import requests
 
-from ..common import NotifyImageSize, NotifyType
+from ..common import NotifyFormat, NotifyImageSize, NotifyType
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import parse_bool, parse_list
@@ -218,11 +218,6 @@ class NotifyBark(NotifyBase):
                 "type": "bool",
                 "default": False,
             },
-            "markdown": {
-                "name": _("Markdown"),
-                "type": "bool",
-                "default": False,
-            },
         },
     )
 
@@ -239,7 +234,6 @@ class NotifyBark(NotifyBase):
         volume=None,
         icon=None,
         call=None,
-        markdown=None,
         **kwargs,
     ):
         """Initialize Notify Bark Object."""
@@ -321,9 +315,6 @@ class NotifyBark(NotifyBase):
         # Call
         self.call = parse_bool(call)
 
-        # Markdown mode
-        self.markdown = parse_bool(markdown)
-
         # Icon URL
         self.icon = icon if isinstance(icon, str) else None
 
@@ -377,7 +368,7 @@ class NotifyBark(NotifyBase):
             "title": title if title else self.app_desc,
         }
 
-        if self.markdown:
+        if self.notify_format == NotifyFormat.MARKDOWN:
             payload["markdown"] = body
         else:
             payload["body"] = body
@@ -535,9 +526,6 @@ class NotifyBark(NotifyBase):
         if self.call:
             params["call"] = "yes"
 
-        if self.markdown:
-            params["markdown"] = "yes"
-
         # Extend our parameters
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
 
@@ -647,11 +635,6 @@ class NotifyBark(NotifyBase):
         # Call
         results["call"] = parse_bool(
             results["qsd"].get("call", False)
-        )
-
-        # Markdown
-        results["markdown"] = parse_bool(
-            results["qsd"].get("markdown", False)
         )
 
         return results

--- a/tests/test_plugin_bark.py
+++ b/tests/test_plugin_bark.py
@@ -269,16 +269,16 @@ apprise_url_tests = (
         },
     ),
     (
-        "bark://192.168.0.6:8081/device_key/?markdown=yes",
+        "bark://192.168.0.6:8081/device_key/?format=markdown",
         {
-            # enable markdown mode
+            # enable markdown mode via global format parameter
             "instance": NotifyBark,
         },
     ),
     (
-        "bark://192.168.0.6:8081/device_key/?markdown=no",
+        "bark://192.168.0.6:8081/device_key/?format=text",
         {
-            # explicitly disable markdown (default behavior)
+            # explicitly set text format (default behavior)
             "instance": NotifyBark,
         },
     ),


### PR DESCRIPTION
## Description
**Related issue (if applicable):** N/A

Add Markdown rendering support to the Bark notification plugin by leveraging Apprise's existing `?format=markdown` global parameter. Bark Server API V2 supports a `markdown` field that renders push content in Markdown format on iOS. When `?format=markdown` is set, the plugin sends the notification body via the `markdown` field instead of the `body` field, allowing users to send formatted content (headings, bold, lists, etc.) to their iOS devices.

This follows the same pattern used by the Email and Telegram plugins, which already adapt their behavior based on `self.notify_format`.

> **Note:** This feature is documented on the [Bark official site](https://bark.day.app/#/tutorial?id=%e8%af%b7%e6%b1%82%e5%8f%82%e6%95%b0) and has been verified working in testing, although the [GitHub API V2 documentation](https://github.com/Finb/bark-server/blob/master/docs/API_V2.md) has not yet been updated to reflect it.

## Changes

- In `NotifyBark.send()`, check `self.notify_format == NotifyFormat.MARKDOWN` to decide whether to use the `markdown` or `body` payload field
- Add `NotifyFormat` to imports
- Add test cases for `?format=markdown` and `?format=text`
- No new custom parameters introduced — uses Apprise's built-in `?format=` mechanism

## Examples

Send a Markdown-formatted notification:
```bash
apprise -vv -t "Title" -b "**Bold** and *italic* text" \
    bark://myserver.example.com/device_key/?format=markdown
```

## Checklist
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e minimal`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@feature/bark-markdown-support

# Test with markdown enabled
apprise -vv -t "Test Title" -b "**Bold** and *italic*" \
    bark://your-bark-server/your-device-key/?format=markdown

# Test without markdown (default behavior unchanged)
apprise -vv -t "Test Title" -b "Plain text message" \
    bark://your-bark-server/your-device-key/
```
