### PR TITLE
matrix:// homeserver not requred by default

### DIFF
--- a/apprise/plugins/matrix.py
+++ b/apprise/plugins/matrix.py
@@ -283,7 +283,7 @@ class NotifyMatrix(NotifyBase):
             "hsreq": {
                 "name": _("Force Home Server on Room IDs"),
                 "type": "bool",
-                "default": False,
+                "default": True,
             },
             "mode": {
                 "name": _("Webhook Mode"),


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1508

## Parameter Breakdown

| Variable  | Required |  Description   |
|-----------|----------|----------------|
| hsreq               | No       | Enforces homeserver inclusion on room identifiers. Default is **yes**.                         |

## Examples

Sends a simple example:
```bash
# Force legacy homeserver enforcement:
apprise -vv -t "Test Message Title" -b "Test Message Body" \
   "matrixs://nuxref:abc123@matrix.example.com/!abc123?hsreq=yes"
```

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): https://github.com/caronc/apprise-docs/pull/10
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e minimal`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1508-home-server-handling

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
   "matrix://credentials/!channel"
```
