### PR TITLE
Remove unnecessary pytest rpm dependencies

### DIFF
--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -133,8 +133,6 @@ BuildRequires: python3dist(tox)
 %if %{with tests}
 BuildRequires: python3dist(pytest)
 BuildRequires: python3dist(pytest-mock)
-BuildRequires: python3dist(pytest-runner)
-BuildRequires: python3dist(pytest-cov)
 %endif
 
 Requires: python3dist(requests)
@@ -238,6 +236,9 @@ LANG=C.UTF-8 PYTHONPATH=%{buildroot}%{python3_sitelib}:%{_builddir}/%{name}-%{ve
 %changelog
 * Tue Jan 20 2026 Chris Caron <lead2gold@gmail.com> - 1.9.7-1
 - Updated to v1.9.7
+
+* Sun Jan 18 2026 Benjamin A. Beasley <code@musicinmybrain.net> - 1.9.6-2
+- Remove unnecessary pytest-runner, pytest-cov dependencies
 
 * Sat Jan 17 2026 Fedora Release Engineering <releng@fedoraproject.org> - 1.9.6-2
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_44_Mass_Rebuild


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1500

Content fell out of sync with https://src.fedoraproject.org/rpms/python-apprise

Specifically this entry:
<img width="1578" height="1470" alt="image" src="https://github.com/user-attachments/assets/755957f5-03fa-44d1-92e8-1641df5d8aba" />


This has been fixed here allowing the closing of https://bugzilla.redhat.com/show_bug.cgi?id=2433120

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [ ] Documentation ticket created (if applicable):** n/a
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e minimal`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1500-BZ2433120-fedora-spec-fix

# Test that RPMs still build
tox -e  build-el9-rpm
tox -e  build-el10-rpm
```
