### PR TITLE
ntfy:// tags added into payload

### DIFF
--- a/apprise/plugins/ntfy.py
+++ b/apprise/plugins/ntfy.py
@@ -604,6 +604,8 @@ class NotifyNtfy(NotifyBase):
 
         if self.__tags:
             headers["X-Tags"] = ",".join(self.__tags)
+            # 2026-02-18: X-Tags is not honored; use JSON payload
+            virt_payload["tags"] = self.__tags
 
         if self.__actions:
             headers["X-Actions"] = self.__actions


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1520 

Based on some investigation; it appears that Ntfy:// may not be honoring the Header `X-Tags`.  However it documents that it also supports setting tags through the payload object itself.  This PR doubles down on this.

The result of this PR:
<img width="1003" height="308" alt="Screenshot_20260219-074253" src="https://github.com/user-attachments/assets/8ab13a1e-b47a-4c7d-adc3-8bc827a66648" />
The above was produced with:
```bash
apprise -b test "ntfy://credentials?tags=warning"
```

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/12](https://github.com/caronc/apprise-docs/pull/13)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e minimal`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1520-ntfy-tag-support

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "ntfy://credentials/?tags=warning"
```
