### PR TITLE
Revert "ntfy:// tags added into payload"

### DIFF
--- a/apprise/plugins/ntfy.py
+++ b/apprise/plugins/ntfy.py
@@ -604,8 +604,6 @@ class NotifyNtfy(NotifyBase):
 
         if self.__tags:
             headers["X-Tags"] = ",".join(self.__tags)
-            # 2026-02-18: X-Tags is not honored; use JSON payload
-            virt_payload["tags"] = self.__tags
 
         if self.__actions:
             headers["X-Actions"] = self.__actions


### PR DESCRIPTION
Reverts caronc/apprise#1524

Upon discussion in https://github.com/binwiederhier/ntfy/issues/1617; this is not the solution to the problem raised in ticket #1520;  tags work with and without the PR;  reverting for consistentcy.