### PR TITLE
Support for Slack rotation OAuth Bot Support

### DIFF
--- a/apprise/plugins/slack.py
+++ b/apprise/plugins/slack.py
@@ -195,7 +195,7 @@ class NotifySlack(NotifyBase):
                 "type": "string",
                 "private": True,
                 "required": True,
-                "regex": (r"^xox[abp]-[A-Z0-9-]+$", "i"),
+                "regex": (r"^(?:xoxe\.)?xox[abp]-[A-Z0-9-]+$", "i"),
             },
             # Token required as part of the Webhook request
             #  /AAAAAAAAA/........./........................

--- a/tests/test_plugin_slack.py
+++ b/tests/test_plugin_slack.py
@@ -109,6 +109,47 @@ apprise_url_tests = (
         },
     ),
     (
+        (
+            "slack://username@xoxe.xoxb-1234-1234-abc124/#nuxref?footer=no"
+            "&timestamp=yes"
+        ),
+        {
+            "instance": NotifySlack,
+            "requests_response_text": {
+                "ok": True,
+                "message": "",
+            },
+        },
+    ),
+    (
+        (
+            "slack://username@xoxe.xoxp-1234-1234-abc124/#nuxref?footer=yes"
+            "&timestamp=no"
+        ),
+        {
+            "instance": NotifySlack,
+            "requests_response_text": {
+                "ok": True,
+                "message": "",
+            },
+        },
+    ),
+    # Test using a rotating bot-token as argument
+    (
+        (
+            "slack://?token=xoxe.xoxb-1234-1234-abc124&to=#nuxref&footer=no"
+            "&user=test"
+        ),
+        {
+            "instance": NotifySlack,
+            "requests_response_text": {
+                "ok": True,
+                "message": "",
+            },
+            "privacy_url": "slack://test@x...4/nuxref/",
+        },
+    ),
+    (
         "slack://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/+id/@id/",
         {
             # + encoded id,
@@ -491,6 +532,9 @@ def test_plugin_slack_oauth_access_token(mock_request):
     # Generate a (valid) bot token
     token = "xoxb-1234-1234-abc124"
 
+    # Generate a (valid) rotating bot token
+    rotating_token = "xoxe.xoxb-1234-1234-abc124"
+
     # Prepare Mock
     mock_request.return_value = request
     # Variation Initializations
@@ -500,6 +544,16 @@ def test_plugin_slack_oauth_access_token(mock_request):
 
     # apprise room was found
     assert obj.send(body="test") is True
+
+    # Validate rotating token is accepted too
+    obj = NotifySlack(access_token=rotating_token, targets="#apprise")
+    assert isinstance(obj, NotifySlack) is True
+    assert isinstance(obj.url(), str) is True
+    assert obj.send(body="test") is True
+
+    # A poorly formatted xoxe prefix should still be rejected
+    with pytest.raises(TypeError):
+        NotifySlack(access_token="xoxe.xo-invalid", targets="#apprise")
 
     # Test Valid Attachment
     mock_request.reset_mock()


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1532

Support OAuth rotation Tokens.

**Note**: It wouldn't be ideal to use these as it will also require you to update your Apprise URL every time the token rotates. Honoring issue requested.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [ ] Documentation ticket created (if applicable): n/a
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e minimal`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1532-slack-rotation-token-support

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "slack://credentials"
```
