### PR TITLE
xmpp send/disconnect race condition

### DIFF
--- a/apprise/plugins/xmpp/adapter.py
+++ b/apprise/plugins/xmpp/adapter.py
@@ -248,11 +248,7 @@ def _get_client_subclass(base_cls: type[Any]) -> type[Any]:
             """
             coro = self._session_start(*args, **kwargs)
 
-            # One-shot mode: let Slixmpp schedule the coroutine itself.
-            if self._oneshot:
-                return coro
-
-            # Keepalive mode: schedule on the assigned loop.
+            # Schedule on the event loop for both one-shot and keepalive.
             loop = getattr(self, "loop", None)
 
             # If the loop is missing or already closing, we MUST close the


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1541

The effort in resolving this issue is still very much researched.  This PR focuses on the potential of an undocumented feature of slixxmpp.process() returning None instead of it's documented True/False response handling.

The logs show:
```
2026-03-08 20:25:22,813 [DEBUG] slixmpp.xmlstream.xmlstream: Event triggered: connecting
2026-03-08 20:25:22,833 [DEBUG] slixmpp.xmlstream.xmlstream: Event triggered: connected
2026-03-08 20:25:22,834 [DEBUG] slixmpp.xmlstream.xmlstream: SEND: <stream:stream to='example.com' xmlns:stream='http://etherx.jabber.org/streams' xmlns='jabber:client' xml:lang='en' version='1.0'>
2026-03-08 20:25:22,834 [WARNING] apprise.xmpp: XMPP connect failed.
```

In all circumstances; it appears to be some kind of racing condition... The takeway (points of interest) are:
* A connection is being established, and a SEND call is made, but a disconnect was made on the exact same microsecond.
  * First theory: We're disconnecting before Slixmpp (underlining library) has even had a chance to send the message (perhaps it's queued).
  * Second theory:  We are possibly disconnecting from the server right after the call to `slixmpp.process()` is called due to it returning `None` intead of the expected `True/False` response. 
 
<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [ ] Documentation ticket created (if applicable): n/a
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1541-xmpp-early-disconnect

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
   "xmpps://credentials/jid"
```

## XMPP Prosody Server Setup

Below is the Prosody server setup I use which works both before and after this patch has been applied making it difficult for me to test this. 


```bash
docker run --rm -d \
  --name prosody-test \
  -p 5222:5222 \
  -e PROSODY_VIRTUAL_HOSTS=localhost \
  -e PROSODY_LOGLEVEL=debug \
  prosodyim/prosody:13.0
```

### Create Test Users

```bash
docker exec -it prosody-test prosodyctl register apprise localhost password123
docker exec -it prosody-test prosodyctl register receiver localhost password123

```

### Install the Client

Download and install [Gajim](https://gajim.org/)

```bash
sudo dnf install gajim
```

Log in as `receiver@localhost` and password `password123`

### Test Apprise

Send a notification

```bash
# starttls setup below:
tox -e apprise -- -vv -b 'test message' \
   'xmpps://apprise:password123@localhost/receiver?verify=no'
```