### PR TITLE
Resolved 'file can not be opened for read' AttachMemory issue

### DIFF
--- a/apprise/attachment/memory.py
+++ b/apprise/attachment/memory.py
@@ -162,7 +162,8 @@ class AttachMemory(AttachBase):
 
     def invalidate(self):
         """Removes data."""
-        self._data.truncate(0)
+        if not self._data.closed:
+            self._data.truncate(0)
         return
 
     def exists(self):

--- a/apprise/plugins/discord.py
+++ b/apprise/plugins/discord.py
@@ -530,8 +530,9 @@ class NotifyDiscord(NotifyBase):
                     "file": (
                         attach.name,
                         # file handle is safely closed in `finally`; inline
-                        # open is intentional
-                        open(attach.path, "rb"),  # noqa: SIM115
+                        # open is intentional; attach.open() dispatches to
+                        # BytesIO for memory attachments
+                        attach.open(),
                     )
                 }
             else:

--- a/apprise/plugins/fluxer.py
+++ b/apprise/plugins/fluxer.py
@@ -634,8 +634,9 @@ class NotifyFluxer(NotifyBase):
                     "files[0]": (
                         attach.name,
                         # file handle is safely closed in `finally`; inline
-                        # open is intentional
-                        open(attach.path, "rb"),  # noqa: SIM115
+                        # open is intentional; attach.open() dispatches to
+                        # BytesIO for memory attachments
+                        attach.open(),
                         # Explicitly declare the file type so the server
                         # doesn't hang
                         attach.mimetype,

--- a/apprise/plugins/pushover.py
+++ b/apprise/plugins/pushover.py
@@ -510,8 +510,9 @@ class NotifyPushover(NotifyBase):
                     "attachment": (
                         attach.name,
                         # file handle is safely closed in `finally`; inline
-                        # open is intentional
-                        open(attach.path, "rb"),  # noqa: SIM115
+                        # open is intentional; attach.open() dispatches to
+                        # BytesIO for memory attachments
+                        attach.open(),
                     )}
 
             r = requests.post(

--- a/apprise/plugins/slack.py
+++ b/apprise/plugins/slack.py
@@ -1020,8 +1020,9 @@ class NotifySlack(NotifyBase):
                     "file": (
                         attach.name,
                         # file handle is safely closed in `finally`; inline
-                        # open is intentional
-                        open(attach.path, "rb"),  # noqa: SIM115
+                        # open is intentional; attach.open() dispatches to
+                        # BytesIO for memory attachments
+                        attach.open(),
                         ),
                     }
 

--- a/apprise/plugins/telegram.py
+++ b/apprise/plugins/telegram.py
@@ -603,7 +603,8 @@ class NotifyTelegram(NotifyBase):
             payload["message_thread_id"] = topic
 
         try:
-            with open(path, "rb") as f:
+            with (attach if isinstance(attach, AttachBase)
+                  else open(path, "rb")) as f:
                 # Configure file payload (for upload)
                 files = {key: (file_name, f)}
 

--- a/tests/test_plugin_discord.py
+++ b/tests/test_plugin_discord.py
@@ -1195,3 +1195,30 @@ def test_plugin_discord_markdown_single_field_posts_once(mock_post):
     )
     assert obj.send(body=body) is True
     assert mock_post.call_count == 1
+
+
+@mock.patch("requests.post")
+def test_plugin_discord_attach_memory(mock_post):
+    """Regression: AttachMemory must be sendable without OSError."""
+    from apprise.attachment.memory import AttachMemory
+
+    webhook_id = "C" * 24
+    webhook_token = "D" * 64
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = b""
+    mock_post.return_value = response
+
+    obj = Apprise.instantiate(
+        f"discord://{webhook_id}/{webhook_token}/"
+    )
+
+    mem = AttachMemory(
+        content=b"<html><body><h1>Test</h1></body></html>",
+        name="report.html",
+        mimetype="text/html",
+    )
+
+    assert obj.notify(body="Test", attach=mem) is True
+    assert mock_post.call_count >= 1

--- a/tests/test_plugin_fluxer.py
+++ b/tests/test_plugin_fluxer.py
@@ -1331,3 +1331,29 @@ def test_plugin_fluxer_429_attachment_closes_edge_cases(
 
     assert obj.send(body="test", attach=attach) is True
     assert good.closed is True
+
+
+@mock.patch("requests.post")
+def test_plugin_fluxer_attach_memory(mock_post: mock.MagicMock) -> None:
+    """Regression: AttachMemory must be sendable without OSError."""
+    from apprise.attachment.memory import AttachMemory
+
+    webhook_id, webhook_token = _tokens()
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = b""
+    mock_post.return_value = response
+
+    obj = Apprise.instantiate(
+        f"fluxer://{webhook_id}/{webhook_token}/"
+    )
+
+    mem = AttachMemory(
+        content=b"<html><body><h1>Test</h1></body></html>",
+        name="report.html",
+        mimetype="text/html",
+    )
+
+    assert obj.notify(body="Test", attach=mem) is True
+    assert mock_post.call_count >= 1

--- a/tests/test_plugin_pushover.py
+++ b/tests/test_plugin_pushover.py
@@ -538,3 +538,31 @@ def test_plugin_pushover_config_files(mock_post):
 
     # Notify everything loaded
     assert aobj.notify(title="title", body="body") is True
+
+
+@mock.patch("requests.post")
+def test_plugin_pushover_attach_memory(mock_post):
+    """Regression: AttachMemory must be sendable without OSError."""
+    from apprise.attachment.memory import AttachMemory
+
+    user_key = "u" * 30
+    api_token = "a" * 30
+
+    response = mock.Mock()
+    response.content = dumps(
+        {"status": 1, "request": "647d2300-702c-4b38-8b2f-d56326ae460b"}
+    )
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    obj = apprise.Apprise.instantiate(f"pover://{user_key}@{api_token}/")
+    assert isinstance(obj, NotifyPushover)
+
+    mem = AttachMemory(
+        content=b"<html><body><h1>Test</h1></body></html>",
+        name="report.html",
+        mimetype="text/html",
+    )
+
+    assert obj.notify(body="Test", attach=mem) is True
+    assert mock_post.call_count == 1

--- a/tests/test_plugin_slack.py
+++ b/tests/test_plugin_slack.py
@@ -1243,3 +1243,48 @@ def test_plugin_slack_file_upload_fails_missing_files(mock_request):
     )
 
     assert result is False
+
+
+@mock.patch("requests.request")
+def test_plugin_slack_attach_memory(mock_request):
+    """Regression: AttachMemory must be sendable without OSError."""
+    from apprise.attachment.memory import AttachMemory
+
+    token = "xoxb-1234-1234-abc124"
+
+    mock_request.side_effect = [
+        mock.Mock(**{
+            "content": dumps({"ok": True, "channel": "C123456"}),
+            "status_code": requests.codes.ok,
+        }),
+        mock.Mock(**{
+            "content": dumps({
+                "ok": True,
+                "upload_url": "https://files.slack.com/upload/v1/ABC123",
+                "file_id": "F123ABC456",
+            }),
+            "status_code": requests.codes.ok,
+        }),
+        mock.Mock(**{
+            "content": b"OK - 100",
+            "status_code": requests.codes.ok,
+        }),
+        mock.Mock(**{
+            "content": dumps({
+                "ok": True,
+                "files": [{"id": "F123ABC456", "title": "report"}],
+            }),
+            "status_code": requests.codes.ok,
+        }),
+    ]
+
+    obj = NotifySlack(access_token=token, targets=["#general"])
+
+    mem = AttachMemory(
+        content=b"<html><body><h1>Test</h1></body></html>",
+        name="report.html",
+        mimetype="text/html",
+    )
+
+    assert obj.notify(body="Test", attach=mem) is True
+    assert mock_request.call_count >= 1

--- a/tests/test_plugin_telegram.py
+++ b/tests/test_plugin_telegram.py
@@ -1617,3 +1617,27 @@ def test_plugin_telegram_markdown_v2(mock_post):
         )
 
         mock_post.reset_mock()
+
+
+@mock.patch("requests.post")
+def test_plugin_telegram_attach_memory(mock_post):
+    """Regression: AttachMemory must be sendable without OSError."""
+    from apprise.attachment.memory import AttachMemory
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = dumps({"ok": True, "result": True})
+    mock_post.return_value = response
+
+    obj = NotifyTelegram(
+        bot_token="123456789:abcdefg_hijklmnop", targets="12345"
+    )
+
+    mem = AttachMemory(
+        content=b"<html><body><h1>Test</h1></body></html>",
+        name="test.html",
+        mimetype="text/html",
+    )
+
+    assert obj.notify(body="Test", attach=mem) is True
+    assert mock_post.call_count >= 1


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1539

Resolved issue where `AttachMemory()` would not work for the Telegram plugin; but as it turns out this same issue was found in some other modules that use attachments.   It was additionally updated here.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable):** [apprise-docs/21](https://github.com/caronc/apprise-docs/pull/21)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e minimal`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1539-attachmemory-exception-fix

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    <apprise url related to this change>
```
