### PR TITLE
Webex wxteams:// Bot API Support

### DIFF
--- a/apprise/plugins/webexteams.py
+++ b/apprise/plugins/webexteams.py
@@ -28,33 +28,56 @@
 # At the time I created this plugin, their website had lots of issues with the
 # Firefox Browser.  I fell back to Chrome and had no problems.
 
-# To use this plugin, you need to first access https://teams.webex.com and
-# make yourself an account if you don't already have one. You'll want to
-# create at least one 'space' before getting the 'incoming webhook'.
+# There are 2 ways to use this plugin...
 #
-# Next you'll need to install the 'Incoming webhook' plugin found under
-# the 'other' category here: https://apphub.webex.com/integrations/
-
-# These links may not always work as time goes by and websites always
-# change, but at the time of creating this plugin this was a direct link
-# to it: https://apphub.webex.com/integrations/incoming-webhooks-cisco-systems
-
-# If you're logged in, you'll be able to click on the 'Connect' button. From
-# there you'll need to accept the permissions it will ask of you. Give the
-# webhook a name such as 'apprise'.
-# When you're complete, you will recieve a URL that looks something like this:
-# https://api.ciscospark.com/v1/webhooks/incoming/\
-#       Y3lzY29zcGkyazovL3VzL1dFQkhPT0sajkkzYWU4fTMtMGE4Yy00
+# Method 1: Via Webhook (default mode):
+#   Visit https://teams.webex.com and make yourself an account if you don't
+#   already have one.  You'll want to create at least one 'space' before
+#   getting the 'incoming webhook'.
 #
-# The last part of the URL is all you need to be interested in. Think of this
-# url as:
-#   https://api.ciscospark.com/v1/webhooks/incoming/{token}
+#   Next you'll need to install the 'Incoming webhook' plugin found under
+#   the 'other' category here: https://apphub.webex.com/integrations/
 #
-# You will need to assemble all of your URLs for this plugin to work as:
-#   wxteams://{token}
+#   These links may not always work as time goes by and websites always
+#   change, but at the time of creating this plugin this was a direct link
+#   to it:
+#     https://apphub.webex.com/integrations/incoming-webhooks-cisco-systems
+#
+#   If you're logged in, you'll be able to click on the 'Connect' button.
+#   From there you'll need to accept the permissions it will ask of you.
+#   Give the webhook a name such as 'apprise'.
+#   When you're complete, you will recieve a URL that looks something like:
+#     https://api.ciscospark.com/v1/webhooks/incoming/\
+#           Y3lzY29zcGkyazovL3VzL1dFQkhPT0sajkkzYWU4fTMtMGE4Yy00
+#
+#   The last part of the URL is all you need to be interested in. Think of
+#   this url as:
+#     https://api.ciscospark.com/v1/webhooks/incoming/{token}
+#
+#   You will need to assemble all of your URLs for this plugin to work as:
+#     wxteams://{token}
+#
+#
+# Method 2: Via Bot/API (supports file attachments):
+#   Visit https://developer.webex.com/my-apps and create a new Bot.
+#   After creating the bot, you'll receive a Bot Access Token.
+#
+#   You will also need to know the Room ID(s) you want to post to.
+#   Room IDs can be retrieved from the Webex API:
+#     https://developer.webex.com/docs/api/v1/rooms/list-rooms
+#
+#   Assemble your Apprise URL as:
+#     wxteams://{access_token}/{room_id}
+#     wxteams://{access_token}/{room_id1}/{room_id2}
+#
+#   The plugin auto-detects the mode:
+#     - If the token is 80-160 lowercase alphanumeric chars -> Webhook mode
+#     - Otherwise -> Bot mode (requires at least one room ID)
+#   You may also force the mode with ?mode=webhook or ?mode=bot.
 #
 # Resources
 # - https://developer.webex.com/docs/api/basics - markdown/post syntax
+# - https://developer.webex.com/docs/api/v1/messages/create-a-message
 # - https://developer.cisco.com/ecosystem/webex/apps/\
 #       incoming-webhooks-cisco-systems/ - Simple webhook example
 
@@ -65,7 +88,7 @@ import requests
 
 from ..common import NotifyFormat, NotifyType
 from ..locale import gettext_lazy as _
-from ..utils.parse import validate_regex
+from ..utils.parse import parse_list, validate_regex
 from .base import NotifyBase
 
 # Extend HTTP Error Messages
@@ -76,6 +99,25 @@ WEBEX_HTTP_ERROR_MAP = {
     429: "To many consecutive requests were made.",
     503: "Service is overloaded, try again later",
 }
+
+
+class WebexTeamsMode:
+    """Tracks the mode of which we're using Webex Teams."""
+
+    # We're dealing with an incoming webhook
+    # Token is 80-160 lowercase alphanumeric chars
+    WEBHOOK = "webhook"
+
+    # We're dealing with a Bot/API access token (supports attachments)
+    # Token is a Bearer access token from the Webex developer portal
+    BOT = "bot"
+
+
+# Define our Webex Teams Modes
+WEBEX_TEAMS_MODES = (
+    WebexTeamsMode.WEBHOOK,
+    WebexTeamsMode.BOT,
+)
 
 
 class NotifyWebexTeams(NotifyBase):
@@ -93,11 +135,19 @@ class NotifyWebexTeams(NotifyBase):
     # A URL that takes you to the setup/help of the specific protocol
     setup_url = "https://appriseit.com/services/wxteams/"
 
-    # Webex Teams uses the http protocol with JSON requests
+    # Webex Teams Webhook URL
     notify_url = "https://api.ciscospark.com/v1/webhooks/incoming/"
 
-    # The maximum allowable characters allowed in the body per message
-    body_maxlen = 1000
+    # Webex Teams Bot API URL (used in Bot mode)
+    api_url = "https://webexapis.com/v1/messages"
+
+    # Bot mode supports attachments
+    attachment_support = True
+
+    # Do not set body_maxlen as it is set in a property value below
+    # since the length varies depending on whether we are using a
+    # webhook (1000 chars) or the bot API (7439 chars)
+    # body_maxlen = see below @property defined
 
     # We don't support titles for Webex notifications
     title_maxlen = 0
@@ -105,19 +155,34 @@ class NotifyWebexTeams(NotifyBase):
     # Default to markdown; fall back to text
     notify_format = NotifyFormat.MARKDOWN
 
-    # Define object templates
-    templates = ("{schema}://{token}",)
+    # Define object URL templates
+    templates = (
+        # Webhook mode (existing)
+        "{schema}://{token}",
+        # Bot mode (access_token in host, one or more room IDs in path)
+        "{schema}://{access_token}/{targets}",
+    )
 
     # Define our template tokens
     template_tokens = dict(
         NotifyBase.template_tokens,
         **{
             "token": {
-                "name": _("Token"),
+                "name": _("Webhook Token"),
                 "type": "string",
                 "private": True,
                 "required": True,
                 "regex": (r"^[a-z0-9]{80,160}$", "i"),
+            },
+            "access_token": {
+                "name": _("Bot Access Token"),
+                "type": "string",
+                "private": True,
+                "required": True,
+            },
+            "targets": {
+                "name": _("Room IDs"),
+                "type": "list:string",
             },
         },
     )
@@ -128,32 +193,118 @@ class NotifyWebexTeams(NotifyBase):
             "token": {
                 "alias_of": "token",
             },
+            "mode": {
+                "name": _("Mode"),
+                "type": "choice:string",
+                "values": WEBEX_TEAMS_MODES,
+                # mode is auto-detected if not specified
+            },
+            "to": {
+                "alias_of": "targets",
+            },
         },
     )
 
-    def __init__(self, token, **kwargs):
+    def __init__(
+        self,
+        token=None,
+        access_token=None,
+        targets=None,
+        mode=None,
+        **kwargs,
+    ):
         """Initialize Webex Teams Object."""
         super().__init__(**kwargs)
 
-        # The token associated with the account
-        self.token = validate_regex(
-            token, *self.template_tokens["token"]["regex"]
-        )
-        if not self.token:
-            msg = f"The Webex Teams token specified ({token}) is invalid."
-            self.logger.warning(msg)
-            raise TypeError(msg)
+        # Resolve mode: explicit override wins, otherwise auto-detect
+        if mode and isinstance(mode, str):
+            self.mode = next(
+                (m for m in WEBEX_TEAMS_MODES if m.startswith(mode)), None
+            )
+            if self.mode not in WEBEX_TEAMS_MODES:
+                msg = (
+                    "The Webex Teams mode specified"
+                    f" ({mode}) is invalid."
+                )
+                self.logger.warning(msg)
+                raise TypeError(msg)
 
-    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+        else:
+            # Auto-detect: webhook tokens are 80-160 lowercase alphanumeric
+            _candidate = access_token or token
+            if token and validate_regex(
+                token, *self.template_tokens["token"]["regex"]
+            ):
+                self.mode = WebexTeamsMode.WEBHOOK
+
+            elif _candidate:
+                # Non-webhook token length/format -> assume BOT
+                self.mode = WebexTeamsMode.BOT
+
+            else:
+                # No usable token at all; will fail below
+                self.mode = WebexTeamsMode.WEBHOOK
+
+        if self.mode == WebexTeamsMode.WEBHOOK:
+            self.access_token = None
+            self.targets = []
+
+            # Webhook token: prefer 'token', fall back to 'access_token'
+            _tok = token or access_token
+            self.token = validate_regex(
+                _tok, *self.template_tokens["token"]["regex"]
+            )
+            if not self.token:
+                msg = (
+                    "The Webex Teams webhook token"
+                    f" specified ({_tok}) is invalid."
+                )
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
+        else:  # WebexTeamsMode.BOT
+            self.token = None
+
+            # Bot access token: prefer 'access_token', fall back to 'token'
+            _at = access_token or token
+            if not _at:
+                msg = (
+                    "A Webex Teams bot access token must be specified."
+                )
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
+            self.access_token = _at
+
+            self.targets = parse_list(targets)
+
+    def send(
+        self,
+        body,
+        title="",
+        notify_type=NotifyType.INFO,
+        attach=None,
+        **kwargs,
+    ):
         """Perform Webex Teams Notification."""
+        if self.mode == WebexTeamsMode.WEBHOOK:
+            if attach and self.attachment_support:
+                self.logger.warning(
+                    "Webex Teams Webhooks do not support"
+                    " attachments; use bot mode."
+                )
+            return self._send_webhook(body)
 
-        # Setup our headers
+        return self._send_bot(body, attach=attach)
+
+    def _send_webhook(self, body):
+        """Post via incoming webhook (no attachment support)."""
+
         headers = {
             "User-Agent": self.app_id,
             "Content-Type": "application/json",
         }
 
-        # Prepare our URL
         url = f"{self.notify_url}/{self.token}"
 
         payload = {
@@ -165,7 +316,7 @@ class NotifyWebexTeams(NotifyBase):
         }
 
         self.logger.debug(
-            "Webex Teams POST URL:"
+            "Webex Teams Webhook POST URL:"
             f" {url} (cert_verify={self.verify_certificate!r})"
         )
         self.logger.debug(f"Webex Teams Payload: {payload!s}")
@@ -184,36 +335,246 @@ class NotifyWebexTeams(NotifyBase):
                 requests.codes.ok,
                 requests.codes.no_content,
             ):
-                # We had a problem
                 status_str = NotifyWebexTeams.http_response_code_lookup(
-                    r.status_code
+                    r.status_code, WEBEX_HTTP_ERROR_MAP
                 )
 
                 self.logger.warning(
                     "Failed to send Webex Teams notification: "
                     "{}{}error={}.".format(
-                        status_str, ", " if status_str else "", r.status_code
+                        status_str,
+                        ", " if status_str else "",
+                        r.status_code,
                     )
                 )
 
                 self.logger.debug(
-                    "Response Details:\r\n%r", (r.content or b"")[:2000]
+                    "Response Details:\r\n%r",
+                    (r.content or b"")[:2000],
                 )
 
                 return False
 
-            else:
-                self.logger.info("Sent Webex Teams notification.")
+            self.logger.info("Sent Webex Teams notification.")
 
         except requests.RequestException as e:
             self.logger.warning(
-                "A Connection error occurred sending Webex Teams notification."
+                "A Connection error occurred sending"
+                " Webex Teams notification."
             )
             self.logger.debug(f"Socket Exception: {e!s}")
-
             return False
 
         return True
+
+    def _send_bot(self, body, attach=None):
+        """Post via Bot/API to one or more rooms (supports attachments)."""
+
+        if not self.targets:
+            self.logger.warning(
+                "Webex Teams Bot mode has no room IDs to notify, "
+                "aborting."
+            )
+            return False
+
+        has_error = False
+        for room_id in self.targets:
+            if not self._post_to_room(body, room_id, attach=attach):
+                has_error = True
+
+        return not has_error
+
+    def _post_to_room(self, body, room_id, attach=None):
+        """Send a single message (and optional attachments) to a room."""
+
+        headers = {
+            "User-Agent": self.app_id,
+            "Authorization": f"Bearer {self.access_token}",
+        }
+
+        text_key = (
+            "markdown"
+            if self.notify_format == NotifyFormat.MARKDOWN
+            else "text"
+        )
+
+        has_attachment = (
+            attach
+            and self.attachment_support
+            and len(attach) > 0
+        )
+
+        if not has_attachment:
+            # --- Text-only message sent as JSON ---
+            headers["Content-Type"] = "application/json"
+            payload = {
+                "roomId": room_id,
+                text_key: body,
+            }
+
+            self.logger.debug(
+                "Webex Teams Bot POST URL:"
+                f" {self.api_url}"
+                f" (cert_verify={self.verify_certificate!r})"
+            )
+            self.logger.debug(f"Webex Teams Bot Payload: {payload!s}")
+
+            self.throttle()
+            try:
+                r = requests.post(
+                    self.api_url,
+                    data=dumps(payload),
+                    headers=headers,
+                    verify=self.verify_certificate,
+                    timeout=self.request_timeout,
+                )
+                if r.status_code != requests.codes.ok:
+                    status_str = (
+                        NotifyWebexTeams.http_response_code_lookup(
+                            r.status_code, WEBEX_HTTP_ERROR_MAP
+                        )
+                    )
+                    self.logger.warning(
+                        "Failed to send Webex Teams Bot"
+                        " notification:"
+                        " {}{}error={}.".format(
+                            status_str,
+                            ", " if status_str else "",
+                            r.status_code,
+                        )
+                    )
+                    self.logger.debug(
+                        "Response Details:\r\n%r",
+                        (r.content or b"")[:2000],
+                    )
+                    return False
+
+                self.logger.info(
+                    "Sent Webex Teams Bot notification"
+                    f" to room {room_id}."
+                )
+
+            except requests.RequestException as e:
+                self.logger.warning(
+                    "A Connection error occurred sending"
+                    " Webex Teams Bot notification."
+                )
+                self.logger.debug(f"Socket Exception: {e!s}")
+                return False
+
+            return True
+
+        # --- Multipart attachment(s) ---
+        for no, attachment in enumerate(attach, start=1):
+            if not attachment:
+                self.logger.error(
+                    "Could not access Webex Teams attachment"
+                    f" {attachment.url(privacy=True)}."
+                )
+                return False
+
+            self.logger.debug(
+                "Posting Webex Teams attachment"
+                f" {attachment.url(privacy=True)}"
+            )
+
+            files = None
+            try:
+                files = {
+                    "files": (
+                        (
+                            attachment.name
+                            if attachment.name
+                            else f"file{no:03}.dat"
+                        ),
+                        # open() returns a BytesIO for memory attachments
+                        attachment.open(),
+                        attachment.mimetype,
+                    ),
+                }
+
+                data = {"roomId": room_id}
+                # Include message body only with the first attachment
+                if no == 1:
+                    data[text_key] = body
+
+                self.logger.debug(
+                    "Webex Teams Bot attachment POST URL:"
+                    f" {self.api_url}"
+                    f" (cert_verify={self.verify_certificate!r})"
+                )
+
+                self.throttle()
+                r = requests.post(
+                    self.api_url,
+                    data=data,
+                    headers=headers,
+                    files=files,
+                    verify=self.verify_certificate,
+                    timeout=self.request_timeout,
+                )
+
+                if r.status_code != requests.codes.ok:
+                    status_str = (
+                        NotifyWebexTeams.http_response_code_lookup(
+                            r.status_code, WEBEX_HTTP_ERROR_MAP
+                        )
+                    )
+                    self.logger.warning(
+                        "Failed to send Webex Teams attachment"
+                        " {}: {}{}error={}.".format(
+                            attachment.name,
+                            status_str,
+                            ", " if status_str else "",
+                            r.status_code,
+                        )
+                    )
+                    self.logger.debug(
+                        "Response Details:\r\n%r",
+                        (r.content or b"")[:2000],
+                    )
+                    return False
+
+                self.logger.info(
+                    "Sent Webex Teams attachment"
+                    f" {attachment.name} to room {room_id}."
+                )
+
+            except requests.RequestException as e:
+                self.logger.warning(
+                    "A Connection error occurred posting"
+                    " Webex Teams attachment."
+                )
+                self.logger.debug(f"Socket Exception: {e!s}")
+                return False
+
+            except OSError as e:
+                self.logger.warning(
+                    "An I/O error occurred while reading {}.".format(
+                        attachment.name
+                        if attachment.name
+                        else "attachment"
+                    )
+                )
+                self.logger.debug(f"I/O Exception: {e!s}")
+                return False
+
+            finally:
+                # Ensure the file handle is always closed
+                if files:
+                    files["files"][1].close()
+
+        return True
+
+    @property
+    def body_maxlen(self):
+        """The maximum allowable characters allowed in the body per message.
+        Webhook mode is limited to 1000 chars; the Bot API allows 7439."""
+        return (
+            1000
+            if self.mode == WebexTeamsMode.WEBHOOK
+            else 7439
+        )
 
     @property
     def url_identifier(self):
@@ -222,45 +583,89 @@ class NotifyWebexTeams(NotifyBase):
 
         Targets or end points should never be identified here.
         """
-        return (self.secure_protocol[0], self.token)
+        if self.mode == WebexTeamsMode.WEBHOOK:
+            return (self.secure_protocol[0], self.token)
+
+        # BOT mode
+        return (self.secure_protocol[0], self.access_token)
 
     def url(self, privacy=False, *args, **kwargs):
         """Returns the URL built dynamically based on specified arguments."""
 
-        # Our URL parameters
-        params = self.url_parameters(privacy=privacy, *args, **kwargs)
+        params = {"mode": self.mode}
+        params.update(
+            self.url_parameters(privacy=privacy, *args, **kwargs)
+        )
 
-        return "{schema}://{token}/?{params}".format(
+        if self.mode == WebexTeamsMode.WEBHOOK:
+            return "{schema}://{token}/?{params}".format(
+                schema=self.secure_protocol[0],
+                token=self.pprint(self.token, privacy, safe=""),
+                params=NotifyWebexTeams.urlencode(params),
+            )
+
+        # BOT mode
+        return "{schema}://{token}/{targets}/?{params}".format(
             schema=self.secure_protocol[0],
-            token=self.pprint(self.token, privacy, safe=""),
+            token=self.pprint(self.access_token, privacy, safe=""),
+            targets="/".join(
+                [
+                    NotifyWebexTeams.quote(r, safe="")
+                    for r in self.targets
+                ]
+            ),
             params=NotifyWebexTeams.urlencode(params),
         )
 
     @staticmethod
     def parse_url(url):
-        """Parses the URL and returns enough arguments that can allow us to re-
-        instantiate this object."""
+        """Parses the URL and returns enough arguments that can allow us
+        to re-instantiate this object."""
         results = NotifyBase.parse_url(url, verify_host=False)
         if not results:
-            # We're done early as we couldn't load the results
             return results
 
-        # Set our token if found as an argument
-        if "token" in results["qsd"] and len(results["qsd"]["token"]):
-            results["token"] = NotifyWebexTeams.unquote(
-                results["qsd"]["token"]
+        # Explicit mode parameter wins
+        if "mode" in results["qsd"] and results["qsd"]["mode"]:
+            results["mode"] = NotifyWebexTeams.unquote(
+                results["qsd"]["mode"]
             )
 
+        # Pull additional room-ID path entries (bot mode)
+        entries = NotifyWebexTeams.split_path(results["fullpath"])
+
+        # Support ?to= for room IDs
+        if "to" in results["qsd"] and results["qsd"]["to"]:
+            entries += NotifyWebexTeams.split_path(
+                NotifyWebexTeams.unquote(results["qsd"]["to"])
+            )
+
+        # Support ?token= for the primary token/access_token
+        if "token" in results["qsd"] and results["qsd"]["token"]:
+            host = NotifyWebexTeams.unquote(results["qsd"]["token"])
         else:
-            # The first token is stored in the hostname
-            results["token"] = NotifyWebexTeams.unquote(results["host"])
+            host = NotifyWebexTeams.unquote(results["host"])
+
+        # Determine whether this is webhook or bot mode.
+        # Path entries mean bot mode (room IDs present).
+        # Explicit mode= has already been stored above.
+        explicit_mode = results.get("mode", "")
+        if explicit_mode == WebexTeamsMode.BOT or (
+            entries and explicit_mode != WebexTeamsMode.WEBHOOK
+        ):
+            results["access_token"] = host
+            results["targets"] = entries
+        else:
+            results["token"] = host
 
         return results
 
     @staticmethod
     def parse_native_url(url):
         """
-        Support https://api.ciscospark.com/v1/webhooks/incoming/WEBHOOK_TOKEN
+        Support:
+          https://api.ciscospark.com/v1/webhooks/incoming/WEBHOOK_TOKEN
+          https://webexapis.com/v1/webhooks/incoming/WEBHOOK_TOKEN
         """
 
         result = re.match(

--- a/apprise/plugins/webexteams.py
+++ b/apprise/plugins/webexteams.py
@@ -222,10 +222,7 @@ class NotifyWebexTeams(NotifyBase):
                 (m for m in WEBEX_TEAMS_MODES if m.startswith(mode)), None
             )
             if self.mode not in WEBEX_TEAMS_MODES:
-                msg = (
-                    "The Webex Teams mode specified"
-                    f" ({mode}) is invalid."
-                )
+                msg = f"The Webex Teams mode specified ({mode}) is invalid."
                 self.logger.warning(msg)
                 raise TypeError(msg)
 
@@ -268,9 +265,7 @@ class NotifyWebexTeams(NotifyBase):
             # Bot access token: prefer 'access_token', fall back to 'token'
             _at = access_token or token
             if not _at:
-                msg = (
-                    "A Webex Teams bot access token must be specified."
-                )
+                msg = "A Webex Teams bot access token must be specified."
                 self.logger.warning(msg)
                 raise TypeError(msg)
 
@@ -359,8 +354,7 @@ class NotifyWebexTeams(NotifyBase):
 
         except requests.RequestException as e:
             self.logger.warning(
-                "A Connection error occurred sending"
-                " Webex Teams notification."
+                "A Connection error occurred sending Webex Teams notification."
             )
             self.logger.debug(f"Socket Exception: {e!s}")
             return False
@@ -372,8 +366,7 @@ class NotifyWebexTeams(NotifyBase):
 
         if not self.targets:
             self.logger.warning(
-                "Webex Teams Bot mode has no room IDs to notify, "
-                "aborting."
+                "Webex Teams Bot mode has no room IDs to notify, aborting."
             )
             return False
 
@@ -398,11 +391,7 @@ class NotifyWebexTeams(NotifyBase):
             else "text"
         )
 
-        has_attachment = (
-            attach
-            and self.attachment_support
-            and len(attach) > 0
-        )
+        has_attachment = attach and self.attachment_support and len(attach) > 0
 
         if not has_attachment:
             # --- Text-only message sent as JSON ---
@@ -429,10 +418,8 @@ class NotifyWebexTeams(NotifyBase):
                     timeout=self.request_timeout,
                 )
                 if r.status_code != requests.codes.ok:
-                    status_str = (
-                        NotifyWebexTeams.http_response_code_lookup(
-                            r.status_code, WEBEX_HTTP_ERROR_MAP
-                        )
+                    status_str = NotifyWebexTeams.http_response_code_lookup(
+                        r.status_code, WEBEX_HTTP_ERROR_MAP
                     )
                     self.logger.warning(
                         "Failed to send Webex Teams Bot"
@@ -450,8 +437,7 @@ class NotifyWebexTeams(NotifyBase):
                     return False
 
                 self.logger.info(
-                    "Sent Webex Teams Bot notification"
-                    f" to room {room_id}."
+                    f"Sent Webex Teams Bot notification to room {room_id}."
                 )
 
             except requests.RequestException as e:
@@ -515,10 +501,8 @@ class NotifyWebexTeams(NotifyBase):
                 )
 
                 if r.status_code != requests.codes.ok:
-                    status_str = (
-                        NotifyWebexTeams.http_response_code_lookup(
-                            r.status_code, WEBEX_HTTP_ERROR_MAP
-                        )
+                    status_str = NotifyWebexTeams.http_response_code_lookup(
+                        r.status_code, WEBEX_HTTP_ERROR_MAP
                     )
                     self.logger.warning(
                         "Failed to send Webex Teams attachment"
@@ -551,9 +535,7 @@ class NotifyWebexTeams(NotifyBase):
             except OSError as e:
                 self.logger.warning(
                     "An I/O error occurred while reading {}.".format(
-                        attachment.name
-                        if attachment.name
-                        else "attachment"
+                        attachment.name if attachment.name else "attachment"
                     )
                 )
                 self.logger.debug(f"I/O Exception: {e!s}")
@@ -570,11 +552,7 @@ class NotifyWebexTeams(NotifyBase):
     def body_maxlen(self):
         """The maximum allowable characters allowed in the body per message.
         Webhook mode is limited to 1000 chars; the Bot API allows 7439."""
-        return (
-            1000
-            if self.mode == WebexTeamsMode.WEBHOOK
-            else 7439
-        )
+        return 1000 if self.mode == WebexTeamsMode.WEBHOOK else 7439
 
     @property
     def url_identifier(self):
@@ -593,9 +571,7 @@ class NotifyWebexTeams(NotifyBase):
         """Returns the URL built dynamically based on specified arguments."""
 
         params = {"mode": self.mode}
-        params.update(
-            self.url_parameters(privacy=privacy, *args, **kwargs)
-        )
+        params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
 
         if self.mode == WebexTeamsMode.WEBHOOK:
             return "{schema}://{token}/?{params}".format(
@@ -609,10 +585,7 @@ class NotifyWebexTeams(NotifyBase):
             schema=self.secure_protocol[0],
             token=self.pprint(self.access_token, privacy, safe=""),
             targets="/".join(
-                [
-                    NotifyWebexTeams.quote(r, safe="")
-                    for r in self.targets
-                ]
+                [NotifyWebexTeams.quote(r, safe="") for r in self.targets]
             ),
             params=NotifyWebexTeams.urlencode(params),
         )
@@ -627,9 +600,7 @@ class NotifyWebexTeams(NotifyBase):
 
         # Explicit mode parameter wins
         if "mode" in results["qsd"] and results["qsd"]["mode"]:
-            results["mode"] = NotifyWebexTeams.unquote(
-                results["qsd"]["mode"]
-            )
+            results["mode"] = NotifyWebexTeams.unquote(results["qsd"]["mode"])
 
         # Pull additional room-ID path entries (bot mode)
         entries = NotifyWebexTeams.split_path(results["fullpath"])

--- a/apprise/plugins/webexteams.py
+++ b/apprise/plugins/webexteams.py
@@ -464,41 +464,42 @@ class NotifyWebexTeams(NotifyBase):
                 f" {attachment.url(privacy=True)}"
             )
 
-            files = None
             try:
-                files = {
-                    "files": (
-                        (
-                            attachment.name
-                            if attachment.name
-                            else f"file{no:03}.dat"
+                # open() returns a BytesIO for memory attachments; the
+                # context manager guarantees the handle is closed on exit
+                with attachment.open() as fp:
+                    files = {
+                        "files": (
+                            (
+                                attachment.name
+                                if attachment.name
+                                else f"file{no:03}.dat"
+                            ),
+                            fp,
+                            attachment.mimetype,
                         ),
-                        # open() returns a BytesIO for memory attachments
-                        attachment.open(),
-                        attachment.mimetype,
-                    ),
-                }
+                    }
 
-                data = {"roomId": room_id}
-                # Include message body only with the first attachment
-                if no == 1:
-                    data[text_key] = body
+                    data = {"roomId": room_id}
+                    # Include message body only with the first attachment
+                    if no == 1:
+                        data[text_key] = body
 
-                self.logger.debug(
-                    "Webex Teams Bot attachment POST URL:"
-                    f" {self.api_url}"
-                    f" (cert_verify={self.verify_certificate!r})"
-                )
+                    self.logger.debug(
+                        "Webex Teams Bot attachment POST URL:"
+                        f" {self.api_url}"
+                        f" (cert_verify={self.verify_certificate!r})"
+                    )
 
-                self.throttle()
-                r = requests.post(
-                    self.api_url,
-                    data=data,
-                    headers=headers,
-                    files=files,
-                    verify=self.verify_certificate,
-                    timeout=self.request_timeout,
-                )
+                    self.throttle()
+                    r = requests.post(
+                        self.api_url,
+                        data=data,
+                        headers=headers,
+                        files=files,
+                        verify=self.verify_certificate,
+                        timeout=self.request_timeout,
+                    )
 
                 if r.status_code != requests.codes.ok:
                     status_str = NotifyWebexTeams.http_response_code_lookup(
@@ -540,11 +541,6 @@ class NotifyWebexTeams(NotifyBase):
                 )
                 self.logger.debug(f"I/O Exception: {e!s}")
                 return False
-
-            finally:
-                # Ensure the file handle is always closed
-                if files:
-                    files["files"][1].close()
 
         return True
 

--- a/tests/test_plugin_webex_teams.py
+++ b/tests/test_plugin_webex_teams.py
@@ -656,8 +656,7 @@ def test_plugin_webex_teams_bot_attachments(mock_post):
 
     mock_post.return_value = response
 
-    # OSError raised by attachment.open() before 'files' dict is assigned
-    # exercises the finally: if files: False branch
+    # OSError raised by attachment.open() (before the file handle is used)
     mock_post.reset_mock()
     mock_post.side_effect = None
     with mock.patch(

--- a/tests/test_plugin_webex_teams.py
+++ b/tests/test_plugin_webex_teams.py
@@ -105,9 +105,7 @@ apprise_url_tests = (
     ),
     # Support Native Webhook URLs
     (
-        "https://api.ciscospark.com/v1/webhooks/incoming/{}".format(
-            "a" * 80
-        ),
+        "https://api.ciscospark.com/v1/webhooks/incoming/{}".format("a" * 80),
         {
             # token provided - we're good
             "instance": NotifyWebexTeams,
@@ -115,9 +113,7 @@ apprise_url_tests = (
     ),
     # Support New Native Webhook URLs
     (
-        "https://webexapis.com/v1/webhooks/incoming/{}".format(
-            "a" * 100
-        ),
+        "https://webexapis.com/v1/webhooks/incoming/{}".format("a" * 100),
         {
             # token provided - we're good
             "instance": NotifyWebexTeams,
@@ -170,9 +166,7 @@ apprise_url_tests = (
         {
             "instance": NotifyWebexTeams,
             "response": False,
-            "requests_response_code": (
-                requests.codes.internal_server_error
-            ),
+            "requests_response_code": (requests.codes.internal_server_error),
         },
     ),
     # Webhook mode: unusual HTTP response code
@@ -201,9 +195,7 @@ apprise_url_tests = (
         {
             "instance": NotifyWebexTeams,
             "response": False,
-            "requests_response_code": (
-                requests.codes.internal_server_error
-            ),
+            "requests_response_code": (requests.codes.internal_server_error),
         },
     ),
     # Bot mode: unusual HTTP response code
@@ -298,9 +290,7 @@ def test_plugin_webex_teams_webhook_mode():
 def test_plugin_webex_teams_bot_mode():
     """NotifyWebexTeams() Bot mode direct tests."""
 
-    obj = NotifyWebexTeams(
-        access_token=BOT_TOKEN, targets=[ROOM_ID]
-    )
+    obj = NotifyWebexTeams(access_token=BOT_TOKEN, targets=[ROOM_ID])
     assert isinstance(obj, NotifyWebexTeams)
     assert obj.mode == WebexTeamsMode.BOT
     assert obj.access_token == BOT_TOKEN
@@ -335,9 +325,7 @@ def test_plugin_webex_teams_bot_mode():
     assert len(obj3.targets) == 2
 
     # No room IDs -> loads fine, but send() returns False
-    obj_no_rooms = NotifyWebexTeams(
-        access_token=BOT_TOKEN, targets=[]
-    )
+    obj_no_rooms = NotifyWebexTeams(access_token=BOT_TOKEN, targets=[])
     assert isinstance(obj_no_rooms, NotifyWebexTeams)
     assert obj_no_rooms.send(body="test") is False
 
@@ -350,9 +338,7 @@ def test_plugin_webex_teams_bot_mode():
         NotifyWebexTeams(mode="bot", targets=[ROOM_ID])
 
     # Explicit mode=bot on a short (webhook-style) token
-    obj4 = NotifyWebexTeams(
-        token="a" * 80, mode="bot", targets=[ROOM_ID]
-    )
+    obj4 = NotifyWebexTeams(token="a" * 80, mode="bot", targets=[ROOM_ID])
     assert obj4.mode == WebexTeamsMode.BOT
     # The 'token' argument is used as access_token in bot mode
     assert obj4.access_token == "a" * 80
@@ -374,9 +360,7 @@ def test_plugin_webex_teams_body_maxlen():
     assert obj.body_maxlen == 1000
 
     # Bot mode: 7439 chars
-    obj = NotifyWebexTeams(
-        access_token=BOT_TOKEN, targets=[ROOM_ID]
-    )
+    obj = NotifyWebexTeams(access_token=BOT_TOKEN, targets=[ROOM_ID])
     assert obj.body_maxlen == 7439
 
 
@@ -393,15 +377,11 @@ def test_plugin_webex_teams_mode_detection():
     assert obj.mode == WebexTeamsMode.WEBHOOK
 
     # Token longer than 160 chars -> fails webhook regex -> BOT
-    obj = NotifyWebexTeams(
-        token="a" * 200, targets=[ROOM_ID]
-    )
+    obj = NotifyWebexTeams(token="a" * 200, targets=[ROOM_ID])
     assert obj.mode == WebexTeamsMode.BOT
 
     # Token with hyphens (non-alphanumeric) -> fails webhook regex -> BOT
-    obj = NotifyWebexTeams(
-        access_token=BOT_TOKEN, targets=[ROOM_ID]
-    )
+    obj = NotifyWebexTeams(access_token=BOT_TOKEN, targets=[ROOM_ID])
     assert obj.mode == WebexTeamsMode.BOT
 
 
@@ -409,9 +389,7 @@ def test_plugin_webex_teams_url_parsing():
     """NotifyWebexTeams() URL parsing edge cases."""
 
     # Webhook via ?token= param
-    result = NotifyWebexTeams.parse_url(
-        "wxteams://?token={}".format("a" * 80)
-    )
+    result = NotifyWebexTeams.parse_url("wxteams://?token={}".format("a" * 80))
     assert result is not None
     obj = NotifyWebexTeams(**result)
     assert obj.mode == WebexTeamsMode.WEBHOOK
@@ -446,9 +424,7 @@ def test_plugin_webex_teams_url_parsing():
 
     # Native webhook URL
     result = NotifyWebexTeams.parse_native_url(
-        "https://api.ciscospark.com/v1/webhooks/incoming/{}".format(
-            "a" * 80
-        )
+        "https://api.ciscospark.com/v1/webhooks/incoming/{}".format("a" * 80)
     )
     assert result is not None
     obj = NotifyWebexTeams(**result)
@@ -456,18 +432,19 @@ def test_plugin_webex_teams_url_parsing():
 
     # New native webhook URL
     result = NotifyWebexTeams.parse_native_url(
-        "https://webexapis.com/v1/webhooks/incoming/{}".format(
-            "a" * 100
-        )
+        "https://webexapis.com/v1/webhooks/incoming/{}".format("a" * 100)
     )
     assert result is not None
     obj = NotifyWebexTeams(**result)
     assert obj.mode == WebexTeamsMode.WEBHOOK
 
     # parse_native_url returns None for non-matching URLs
-    assert NotifyWebexTeams.parse_native_url(
-        "https://example.com/not/a/webex/url"
-    ) is None
+    assert (
+        NotifyWebexTeams.parse_native_url(
+            "https://example.com/not/a/webex/url"
+        )
+        is None
+    )
 
     # Webhook mode forced with ?mode=webhook even with path entries
     result = NotifyWebexTeams.parse_url(
@@ -547,9 +524,7 @@ def test_plugin_webex_teams_bot_send(mock_post):
     response.content = b""
     mock_post.return_value = response
 
-    obj = NotifyWebexTeams(
-        access_token=BOT_TOKEN, targets=[ROOM_ID]
-    )
+    obj = NotifyWebexTeams(access_token=BOT_TOKEN, targets=[ROOM_ID])
 
     # Successful text send
     assert obj.send(body="hello from bot") is True
@@ -614,9 +589,7 @@ def test_plugin_webex_teams_bot_attachments(mock_post):
     response.content = b""
     mock_post.return_value = response
 
-    obj = NotifyWebexTeams(
-        access_token=BOT_TOKEN, targets=[ROOM_ID]
-    )
+    obj = NotifyWebexTeams(access_token=BOT_TOKEN, targets=[ROOM_ID])
 
     path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     attach = AppriseAttachment(path)
@@ -697,9 +670,7 @@ def test_plugin_webex_teams_bot_attachments(mock_post):
 
     # Invalid/inaccessible attachment
     mock_post.reset_mock()
-    invalid_path = os.path.join(
-        TEST_VAR_DIR, "/invalid/path/to/file.jpg"
-    )
+    invalid_path = os.path.join(TEST_VAR_DIR, "/invalid/path/to/file.jpg")
     bad_attach = AppriseAttachment(invalid_path)
     assert (
         obj.notify(
@@ -731,7 +702,5 @@ def test_plugin_webex_teams_apprise_integration(mock_post):
 
     # Bot mode via Apprise
     app2 = Apprise()
-    assert app2.add(
-        "wxteams://{}/{}".format(BOT_TOKEN, ROOM_ID)
-    )
+    assert app2.add("wxteams://{}/{}".format(BOT_TOKEN, ROOM_ID))
     assert app2.notify(body="bot test") is True

--- a/tests/test_plugin_webex_teams.py
+++ b/tests/test_plugin_webex_teams.py
@@ -27,28 +27,51 @@
 
 # Disable logging for a cleaner testing output
 import logging
+import os
+from unittest import mock
 
 from helpers import AppriseURLTester
+import pytest
 import requests
 
-from apprise.plugins.webexteams import NotifyWebexTeams
+from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise.plugins.webexteams import (
+    NotifyWebexTeams,
+    WebexTeamsMode,
+)
 
 logging.disable(logging.CRITICAL)
+
+# Attachment Directory
+TEST_VAR_DIR = os.path.join(os.path.dirname(__file__), "var")
+
+# A valid webhook token (80 lowercase alphanumeric chars)
+WEBHOOK_TOKEN = "a" * 80
+
+# A valid bot access token (longer than 160 chars, contains hyphen)
+# Must be > 160 chars or contain non-alphanumeric chars to bypass
+# the webhook-token regex (which only allows [a-z0-9], 80-160 chars).
+# Using 200 chars ending in '0' so the privacy URL ends in '0'.
+BOT_TOKEN = "Bc10" * 50  # 200 chars, ends in '0'
+
+# A valid Webex room ID (base64url-like, 50 chars)
+ROOM_ID = "Y2lzY29zcGFyazovL3VzL1JPTU9NLzEyMzQ1Njc4OTAxMjM0"
+ROOM_ID2 = "Y2lzY29zcGFyazovL3VzL1JPTU9NL2FiY2RlZjEyMzQ1Njc4"
 
 # Our Testing URLs
 apprise_url_tests = (
     (
         "wxteams://",
         {
-            # Teams Token missing
+            # Token missing
             "instance": TypeError,
         },
     ),
     (
         "wxteams://:@/",
         {
-            # We don't have strict host checking on for wxteams, so this URL
-            # actually becomes parseable and :@ becomes a hostname.
+            # We don't have strict host checking on for wxteams, so this
+            # URL actually becomes parseable and :@ becomes a hostname.
             # The below errors because a second token wasn't found
             "instance": TypeError,
         },
@@ -56,7 +79,7 @@ apprise_url_tests = (
     (
         "wxteams://{}".format("a" * 80),
         {
-            # token provided - we're good
+            # webhook token provided - we're good
             "instance": NotifyWebexTeams,
             # Our expected url(privacy=True) startswith() response:
             "privacy_url": "wxteams://a...a/",
@@ -65,7 +88,7 @@ apprise_url_tests = (
     (
         "wxteams://?token={}".format("a" * 80),
         {
-            # token provided - we're good
+            # token as query param - we're good
             "instance": NotifyWebexTeams,
             # Our expected url(privacy=True) startswith() response:
             "privacy_url": "wxteams://a...a/",
@@ -74,31 +97,15 @@ apprise_url_tests = (
     (
         "webex://{}".format("a" * 140),
         {
-            # token provided - we're good
+            # token provided via 'webex' schema - we're good
             "instance": NotifyWebexTeams,
             # Our expected url(privacy=True) startswith() response:
             "privacy_url": "wxteams://a...a/",
         },
     ),
-    # Support Native URLs
+    # Support Native Webhook URLs
     (
-        "https://api.ciscospark.com/v1/webhooks/incoming/{}".format("a" * 80),
-        {
-            # token provided - we're good
-            "instance": NotifyWebexTeams,
-        },
-    ),
-    # Support New Native URLs
-    (
-        "https://webexapis.com/v1/webhooks/incoming/{}".format("a" * 100),
-        {
-            # token provided - we're good
-            "instance": NotifyWebexTeams,
-        },
-    ),
-    # Support Native URLs with arguments
-    (
-        "https://api.ciscospark.com/v1/webhooks/incoming/{}?format=text".format(
+        "https://api.ciscospark.com/v1/webhooks/incoming/{}".format(
             "a" * 80
         ),
         {
@@ -106,15 +113,69 @@ apprise_url_tests = (
             "instance": NotifyWebexTeams,
         },
     ),
+    # Support New Native Webhook URLs
+    (
+        "https://webexapis.com/v1/webhooks/incoming/{}".format(
+            "a" * 100
+        ),
+        {
+            # token provided - we're good
+            "instance": NotifyWebexTeams,
+        },
+    ),
+    # Support Native Webhook URLs with arguments
+    (
+        "https://api.ciscospark.com/v1/webhooks/incoming/{}"
+        "?format=text".format("a" * 80),
+        {
+            # token provided - we're good
+            "instance": NotifyWebexTeams,
+        },
+    ),
+    # Bot mode: access_token + room ID
+    (
+        "wxteams://{}/{}".format(BOT_TOKEN, ROOM_ID),
+        {
+            "instance": NotifyWebexTeams,
+            "privacy_url": "wxteams://B...0/",
+        },
+    ),
+    # Bot mode: explicit mode=bot with no room IDs - loads but fails to send
+    (
+        "wxteams://{}?mode=bot".format("a" * 80),
+        {
+            "instance": NotifyWebexTeams,
+            # notify() returns False with no targets (no HTTP call needed)
+            "notify_response": False,
+        },
+    ),
+    # Explicit mode=webhook with a valid webhook token
+    (
+        "wxteams://{}?mode=webhook".format("a" * 80),
+        {
+            "instance": NotifyWebexTeams,
+            "privacy_url": "wxteams://a...a/",
+        },
+    ),
+    # Invalid mode
+    (
+        "wxteams://{}?mode=invalid".format("a" * 80),
+        {
+            "instance": TypeError,
+        },
+    ),
+    # Webhook mode: HTTP 500 response
     (
         "wxteams://{}".format("a" * 80),
         {
             "instance": NotifyWebexTeams,
-            # force a failure
             "response": False,
-            "requests_response_code": requests.codes.internal_server_error,
+            "requests_response_code": (
+                requests.codes.internal_server_error
+            ),
         },
     ),
+    # Webhook mode: unusual HTTP response code
     (
         "wxteams://{}".format("a" * 80),
         {
@@ -124,12 +185,41 @@ apprise_url_tests = (
             "requests_response_code": 999,
         },
     ),
+    # Webhook mode: request exception
     (
         "wxteams://{}".format("a" * 80),
         {
             "instance": NotifyWebexTeams,
-            # Throws a series of i/o exceptions with this flag
-            # is set and tests that we gracefully handle them
+            # Throws a series of i/o exceptions with this flag set and
+            # tests that we gracefully handle them
+            "test_requests_exceptions": True,
+        },
+    ),
+    # Bot mode: HTTP 500 response
+    (
+        "wxteams://{}/{}".format(BOT_TOKEN, ROOM_ID),
+        {
+            "instance": NotifyWebexTeams,
+            "response": False,
+            "requests_response_code": (
+                requests.codes.internal_server_error
+            ),
+        },
+    ),
+    # Bot mode: unusual HTTP response code
+    (
+        "wxteams://{}/{}".format(BOT_TOKEN, ROOM_ID),
+        {
+            "instance": NotifyWebexTeams,
+            "response": False,
+            "requests_response_code": 999,
+        },
+    ),
+    # Bot mode: request exception
+    (
+        "wxteams://{}/{}".format(BOT_TOKEN, ROOM_ID),
+        {
+            "instance": NotifyWebexTeams,
             "test_requests_exceptions": True,
         },
     ),
@@ -141,3 +231,507 @@ def test_plugin_webex_teams_urls():
 
     # Run our general tests
     AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+def test_plugin_webex_teams_webhook_mode():
+    """NotifyWebexTeams() Webhook mode direct tests."""
+
+    # Valid webhook token
+    token = "b" * 80
+
+    obj = NotifyWebexTeams(token=token)
+    assert isinstance(obj, NotifyWebexTeams)
+    assert obj.mode == WebexTeamsMode.WEBHOOK
+
+    # url() round-trip
+    url = obj.url()
+    assert "wxteams://" in url
+    assert "mode=webhook" in url
+
+    # parse_url round-trip
+    result = NotifyWebexTeams.parse_url(url)
+    assert result is not None
+    obj2 = NotifyWebexTeams(**result)
+    assert obj2.mode == WebexTeamsMode.WEBHOOK
+    assert obj2.token == token
+
+    # privacy URL
+    priv = obj.url(privacy=True)
+    assert obj.token not in priv
+
+    # url_identifier
+    assert obj.url_identifier == (
+        NotifyWebexTeams.secure_protocol[0],
+        token,
+    )
+
+    # 80-char token (minimum)
+    assert NotifyWebexTeams(token="c" * 80)
+    # 160-char token (maximum)
+    assert NotifyWebexTeams(token="c" * 160)
+
+    # Too short for webhook -> falls to bot mode (no targets), loads but
+    # send() returns False
+    obj_short = NotifyWebexTeams(token="c" * 79)
+    assert obj_short.mode == WebexTeamsMode.BOT
+    assert obj_short.send(body="test") is False
+
+    # Too long for webhook -> bot mode, same behaviour
+    obj_long = NotifyWebexTeams(token="c" * 161)
+    assert obj_long.mode == WebexTeamsMode.BOT
+    assert obj_long.send(body="test") is False
+
+    # No token -> TypeError (no candidate at all)
+    with pytest.raises(TypeError):
+        NotifyWebexTeams(token=None)
+
+    # Empty token -> TypeError
+    with pytest.raises(TypeError):
+        NotifyWebexTeams(token="")
+
+    # Non-alphanumeric chars -> falls to bot mode (no targets)
+    obj_hyph = NotifyWebexTeams(token="a-b-" * 20)
+    assert obj_hyph.mode == WebexTeamsMode.BOT
+    assert obj_hyph.send(body="test") is False
+
+
+def test_plugin_webex_teams_bot_mode():
+    """NotifyWebexTeams() Bot mode direct tests."""
+
+    obj = NotifyWebexTeams(
+        access_token=BOT_TOKEN, targets=[ROOM_ID]
+    )
+    assert isinstance(obj, NotifyWebexTeams)
+    assert obj.mode == WebexTeamsMode.BOT
+    assert obj.access_token == BOT_TOKEN
+    assert ROOM_ID in obj.targets
+
+    # url() round-trip
+    url = obj.url()
+    assert "wxteams://" in url
+    assert "mode=bot" in url
+
+    result = NotifyWebexTeams.parse_url(url)
+    assert result is not None
+    obj2 = NotifyWebexTeams(**result)
+    assert obj2.mode == WebexTeamsMode.BOT
+    assert obj2.access_token == BOT_TOKEN
+    assert ROOM_ID in obj2.targets
+
+    # privacy URL masks the token
+    priv = obj.url(privacy=True)
+    assert BOT_TOKEN not in priv
+
+    # url_identifier
+    assert obj.url_identifier == (
+        NotifyWebexTeams.secure_protocol[0],
+        BOT_TOKEN,
+    )
+
+    # Multiple rooms
+    obj3 = NotifyWebexTeams(
+        access_token=BOT_TOKEN, targets=[ROOM_ID, ROOM_ID2]
+    )
+    assert len(obj3.targets) == 2
+
+    # No room IDs -> loads fine, but send() returns False
+    obj_no_rooms = NotifyWebexTeams(
+        access_token=BOT_TOKEN, targets=[]
+    )
+    assert isinstance(obj_no_rooms, NotifyWebexTeams)
+    assert obj_no_rooms.send(body="test") is False
+
+    # No access_token -> TypeError
+    with pytest.raises(TypeError):
+        NotifyWebexTeams(access_token=None, targets=[ROOM_ID])
+
+    # Explicit bot mode with neither token nor access_token -> TypeError
+    with pytest.raises(TypeError):
+        NotifyWebexTeams(mode="bot", targets=[ROOM_ID])
+
+    # Explicit mode=bot on a short (webhook-style) token
+    obj4 = NotifyWebexTeams(
+        token="a" * 80, mode="bot", targets=[ROOM_ID]
+    )
+    assert obj4.mode == WebexTeamsMode.BOT
+    # The 'token' argument is used as access_token in bot mode
+    assert obj4.access_token == "a" * 80
+
+    # Invalid mode
+    with pytest.raises(TypeError):
+        NotifyWebexTeams(
+            access_token=BOT_TOKEN,
+            targets=[ROOM_ID],
+            mode="invalid",
+        )
+
+
+def test_plugin_webex_teams_body_maxlen():
+    """NotifyWebexTeams() body_maxlen varies by mode."""
+
+    # Webhook mode: 1000 chars
+    obj = NotifyWebexTeams(token=WEBHOOK_TOKEN)
+    assert obj.body_maxlen == 1000
+
+    # Bot mode: 7439 chars
+    obj = NotifyWebexTeams(
+        access_token=BOT_TOKEN, targets=[ROOM_ID]
+    )
+    assert obj.body_maxlen == 7439
+
+
+def test_plugin_webex_teams_mode_detection():
+    """NotifyWebexTeams() auto-detects mode from token format."""
+
+    # 80-char lowercase alphanumeric -> WEBHOOK
+    obj = NotifyWebexTeams(token="a" * 80)
+    assert obj.mode == WebexTeamsMode.WEBHOOK
+
+    # 80-char uppercase alphanumeric also matches webhook regex
+    # (regex uses 'i' flag); no targets means webhook mode
+    obj = NotifyWebexTeams(token="A" * 80)
+    assert obj.mode == WebexTeamsMode.WEBHOOK
+
+    # Token longer than 160 chars -> fails webhook regex -> BOT
+    obj = NotifyWebexTeams(
+        token="a" * 200, targets=[ROOM_ID]
+    )
+    assert obj.mode == WebexTeamsMode.BOT
+
+    # Token with hyphens (non-alphanumeric) -> fails webhook regex -> BOT
+    obj = NotifyWebexTeams(
+        access_token=BOT_TOKEN, targets=[ROOM_ID]
+    )
+    assert obj.mode == WebexTeamsMode.BOT
+
+
+def test_plugin_webex_teams_url_parsing():
+    """NotifyWebexTeams() URL parsing edge cases."""
+
+    # Webhook via ?token= param
+    result = NotifyWebexTeams.parse_url(
+        "wxteams://?token={}".format("a" * 80)
+    )
+    assert result is not None
+    obj = NotifyWebexTeams(**result)
+    assert obj.mode == WebexTeamsMode.WEBHOOK
+    assert obj.token == "a" * 80
+
+    # Bot mode: access_token in host, room ID in path
+    result = NotifyWebexTeams.parse_url(
+        "wxteams://{}/{}".format(BOT_TOKEN, ROOM_ID)
+    )
+    assert result is not None
+    obj = NotifyWebexTeams(**result)
+    assert obj.mode == WebexTeamsMode.BOT
+    assert ROOM_ID in obj.targets
+
+    # Bot mode: multiple room IDs in path
+    result = NotifyWebexTeams.parse_url(
+        "wxteams://{}/{}/{}".format(BOT_TOKEN, ROOM_ID, ROOM_ID2)
+    )
+    assert result is not None
+    obj = NotifyWebexTeams(**result)
+    assert obj.mode == WebexTeamsMode.BOT
+    assert len(obj.targets) == 2
+
+    # Bot mode: room IDs via ?to= param
+    result = NotifyWebexTeams.parse_url(
+        "wxteams://{}?to={}&mode=bot".format(BOT_TOKEN, ROOM_ID)
+    )
+    assert result is not None
+    obj = NotifyWebexTeams(**result)
+    assert obj.mode == WebexTeamsMode.BOT
+    assert ROOM_ID in obj.targets
+
+    # Native webhook URL
+    result = NotifyWebexTeams.parse_native_url(
+        "https://api.ciscospark.com/v1/webhooks/incoming/{}".format(
+            "a" * 80
+        )
+    )
+    assert result is not None
+    obj = NotifyWebexTeams(**result)
+    assert obj.mode == WebexTeamsMode.WEBHOOK
+
+    # New native webhook URL
+    result = NotifyWebexTeams.parse_native_url(
+        "https://webexapis.com/v1/webhooks/incoming/{}".format(
+            "a" * 100
+        )
+    )
+    assert result is not None
+    obj = NotifyWebexTeams(**result)
+    assert obj.mode == WebexTeamsMode.WEBHOOK
+
+    # parse_native_url returns None for non-matching URLs
+    assert NotifyWebexTeams.parse_native_url(
+        "https://example.com/not/a/webex/url"
+    ) is None
+
+    # Webhook mode forced with ?mode=webhook even with path entries
+    result = NotifyWebexTeams.parse_url(
+        "wxteams://{}?mode=webhook".format("a" * 80)
+    )
+    assert result is not None
+    obj = NotifyWebexTeams(**result)
+    assert obj.mode == WebexTeamsMode.WEBHOOK
+
+
+@mock.patch("requests.post")
+def test_plugin_webex_teams_webhook_send(mock_post):
+    """NotifyWebexTeams() Webhook send() coverage."""
+
+    # Prepare a good response
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = b""
+    mock_post.return_value = response
+
+    obj = NotifyWebexTeams(token=WEBHOOK_TOKEN)
+
+    # Successful send
+    assert obj.send(body="test message") is True
+    assert mock_post.call_count == 1
+    call_url = mock_post.call_args[0][0]
+    assert "webhooks/incoming" in call_url
+    assert WEBHOOK_TOKEN in call_url
+
+    # Verify correct Content-Type header
+    headers = mock_post.call_args[1]["headers"]
+    assert headers["Content-Type"] == "application/json"
+
+    mock_post.reset_mock()
+
+    # 204 No Content is also acceptable
+    response.status_code = requests.codes.no_content
+    assert obj.send(body="test") is True
+
+    mock_post.reset_mock()
+
+    # HTTP error
+    response.status_code = requests.codes.internal_server_error
+    assert obj.send(body="test") is False
+
+    mock_post.reset_mock()
+
+    # Unknown HTTP error code
+    response.status_code = 999
+    assert obj.send(body="test") is False
+
+    mock_post.reset_mock()
+
+    # Connection error
+    mock_post.side_effect = requests.RequestException()
+    assert obj.send(body="test") is False
+
+    mock_post.side_effect = None
+    mock_post.return_value = response
+    response.status_code = requests.codes.ok
+
+    # Webhook warns about attachments (but still proceeds)
+    mock_post.reset_mock()
+    path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
+    attach = AppriseAttachment(path)
+    assert obj.send(body="test", attach=attach) is True
+    # Only one POST call: text-only webhook
+    assert mock_post.call_count == 1
+
+
+@mock.patch("requests.post")
+def test_plugin_webex_teams_bot_send(mock_post):
+    """NotifyWebexTeams() Bot send() text-only coverage."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = b""
+    mock_post.return_value = response
+
+    obj = NotifyWebexTeams(
+        access_token=BOT_TOKEN, targets=[ROOM_ID]
+    )
+
+    # Successful text send
+    assert obj.send(body="hello from bot") is True
+    assert mock_post.call_count == 1
+    call_url = mock_post.call_args[0][0]
+    assert call_url == "https://webexapis.com/v1/messages"
+
+    # Verify Bearer authorization
+    headers = mock_post.call_args[1]["headers"]
+    assert headers["Authorization"] == f"Bearer {BOT_TOKEN}"
+    assert headers["Content-Type"] == "application/json"
+
+    mock_post.reset_mock()
+
+    # Two rooms -> two calls
+    obj2 = NotifyWebexTeams(
+        access_token=BOT_TOKEN, targets=[ROOM_ID, ROOM_ID2]
+    )
+    assert obj2.send(body="broadcast") is True
+    assert mock_post.call_count == 2
+
+    mock_post.reset_mock()
+
+    # HTTP error for bot mode
+    response.status_code = requests.codes.internal_server_error
+    assert obj.send(body="test") is False
+
+    mock_post.reset_mock()
+
+    response.status_code = 999
+    assert obj.send(body="test") is False
+
+    mock_post.reset_mock()
+
+    # Connection error for bot mode
+    mock_post.side_effect = requests.RequestException()
+    assert obj.send(body="test") is False
+
+    mock_post.side_effect = None
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    # Two rooms: second fails -> overall failure reported
+    mock_post.reset_mock()
+    fail_response = mock.Mock()
+    fail_response.status_code = requests.codes.internal_server_error
+    fail_response.content = b""
+
+    mock_post.side_effect = [response, fail_response]
+    obj2 = NotifyWebexTeams(
+        access_token=BOT_TOKEN, targets=[ROOM_ID, ROOM_ID2]
+    )
+    assert obj2.send(body="test") is False
+
+
+@mock.patch("requests.post")
+def test_plugin_webex_teams_bot_attachments(mock_post):
+    """NotifyWebexTeams() Bot mode attachment coverage."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = b""
+    mock_post.return_value = response
+
+    obj = NotifyWebexTeams(
+        access_token=BOT_TOKEN, targets=[ROOM_ID]
+    )
+
+    path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
+    attach = AppriseAttachment(path)
+
+    # Successful single attachment
+    mock_post.reset_mock()
+    assert (
+        obj.notify(
+            body="see attached",
+            title="",
+            notify_type=NotifyType.INFO,
+            attach=attach,
+        )
+        is True
+    )
+    # One POST call for the single attachment
+    assert mock_post.call_count == 1
+    call_url = mock_post.call_args[0][0]
+    assert call_url == "https://webexapis.com/v1/messages"
+    # No Content-Type header set (multipart sets its own)
+    headers = mock_post.call_args[1]["headers"]
+    assert "Content-Type" not in headers
+    # files kwarg was provided
+    assert mock_post.call_args[1].get("files") is not None
+
+    # Multiple attachments -> one POST per attachment
+    mock_post.reset_mock()
+    path2 = os.path.join(TEST_VAR_DIR, "apprise-test.png")
+    attach2 = AppriseAttachment([path, path2])
+    assert obj.send(body="two files", attach=attach2) is True
+    assert mock_post.call_count == 2
+
+    # Two rooms, one attachment -> 2 POST calls
+    mock_post.reset_mock()
+    obj2 = NotifyWebexTeams(
+        access_token=BOT_TOKEN, targets=[ROOM_ID, ROOM_ID2]
+    )
+    assert obj2.send(body="room broadcast", attach=attach) is True
+    assert mock_post.call_count == 2
+
+    # Connection error on attachment POST
+    mock_post.reset_mock()
+    mock_post.side_effect = requests.RequestException()
+    assert obj.send(body="test", attach=attach) is False
+
+    mock_post.side_effect = None
+    mock_post.return_value = response
+
+    # OSError reading attachment
+    mock_post.reset_mock()
+    mock_post.side_effect = OSError()
+    assert obj.send(body="test", attach=attach) is False
+
+    mock_post.side_effect = None
+    mock_post.return_value = response
+
+    # HTTP error on attachment upload
+    mock_post.reset_mock()
+    bad_response = mock.Mock()
+    bad_response.status_code = requests.codes.internal_server_error
+    bad_response.content = b""
+    mock_post.return_value = bad_response
+    assert obj.send(body="test", attach=attach) is False
+
+    mock_post.return_value = response
+
+    # OSError raised by attachment.open() before 'files' dict is assigned
+    # exercises the finally: if files: False branch
+    mock_post.reset_mock()
+    mock_post.side_effect = None
+    with mock.patch(
+        "apprise.attachment.file.AttachFile.open",
+        side_effect=OSError("open failed"),
+    ):
+        assert obj.send(body="test", attach=attach) is False
+    mock_post.side_effect = None
+    mock_post.return_value = response
+
+    # Invalid/inaccessible attachment
+    mock_post.reset_mock()
+    invalid_path = os.path.join(
+        TEST_VAR_DIR, "/invalid/path/to/file.jpg"
+    )
+    bad_attach = AppriseAttachment(invalid_path)
+    assert (
+        obj.notify(
+            body="test",
+            notify_type=NotifyType.INFO,
+            attach=bad_attach,
+        )
+        is False
+    )
+    # No POST should have been made
+    assert mock_post.call_count == 0
+
+
+@mock.patch("requests.post")
+def test_plugin_webex_teams_apprise_integration(mock_post):
+    """NotifyWebexTeams() Apprise.notify() integration."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = b""
+    mock_post.return_value = response
+
+    # Webhook mode via Apprise
+    app = Apprise()
+    assert app.add("wxteams://{}".format(WEBHOOK_TOKEN))
+    assert app.notify(body="webhook test") is True
+
+    mock_post.reset_mock()
+
+    # Bot mode via Apprise
+    app2 = Apprise()
+    assert app2.add(
+        "wxteams://{}/{}".format(BOT_TOKEN, ROOM_ID)
+    )
+    assert app2.notify(body="bot test") is True


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1256 

Added Webex Bot API support.

This also allows the use of attachments.

The new supported format is:
- `wxteams://{bot_token}/{room_id}/`

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/28](https://github.com/caronc/apprise-docs/pull/28)
* [ ] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1256-webex-api-support

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
     "wxteams://{bot_token}/{room_id}/"
```
