### PR TITLE
URLs that can not be loaded are more verbose

### DIFF
--- a/apprise/apprise_config.py
+++ b/apprise/apprise_config.py
@@ -35,6 +35,7 @@ from .config.base import ConfigBase
 from .logger import logger
 from .manager_config import ConfigurationManager
 from .url import URLBase
+from .utils.cwe312 import cwe312_url
 from .utils.logic import is_exclusive_match
 from .utils.parse import GET_SCHEMA_RE, parse_list
 
@@ -388,7 +389,7 @@ class AppriseConfig:
 
             # Some basic validation
             if schema not in C_MGR:
-                logger.warning(f"Unsupported schema {schema}.")
+                logger.error(f"Unsupported schema {schema}.")
                 return None
 
         # Parse our url details of the server object as dictionary containing
@@ -397,7 +398,14 @@ class AppriseConfig:
 
         if not results:
             # Failed to parse the server URL
-            logger.warning(f"Unparseable URL {url}.")
+            # CWE-312 (Secure Logging) Handling
+            secure_logging = (
+                asset.secure_logging
+                if isinstance(asset, AppriseAsset)
+                else True
+            )
+            loggable_url = url if not secure_logging else cwe312_url(url)
+            logger.error(f"Unparseable URL {loggable_url}.")
             return None
 
         # Build a list of tags to associate with the newly added notifications
@@ -426,7 +434,13 @@ class AppriseConfig:
 
             except Exception:
                 # the arguments are invalid or can not be used.
-                logger.warning(f"Could not load URL: {url}")
+                # CWE-312 (Secure Logging) Handling
+                loggable_url = (
+                    url
+                    if not results["asset"].secure_logging
+                    else cwe312_url(url)
+                )
+                logger.error(f"Could not load URL: {loggable_url}")
                 return None
 
         else:

--- a/apprise/config/base.py
+++ b/apprise/config/base.py
@@ -247,7 +247,7 @@ class ConfigBase(URLBase):
 
                     # Some basic validation
                     if schema not in C_MGR:
-                        ConfigBase.logger.warning(
+                        ConfigBase.logger.error(
                             f"Unsupported include schema {schema}."
                         )
                         continue
@@ -262,7 +262,7 @@ class ConfigBase(URLBase):
                 results = C_MGR[schema].parse_url(url)
                 if not results:
                     # Failed to parse the server URL
-                    self.logger.warning(
+                    self.logger.error(
                         f"Unparseable include URL {loggable_url}"
                     )
                     continue
@@ -305,7 +305,7 @@ class ConfigBase(URLBase):
 
                 except Exception as e:
                     # the arguments are invalid or can not be used.
-                    self.logger.warning(
+                    self.logger.error(
                         f"Could not load include URL: {loggable_url}"
                     )
                     self.logger.debug(f"Loading Exception: {e!s}")
@@ -760,8 +760,9 @@ class ConfigBase(URLBase):
                 url, secure_logging=asset.secure_logging
             )
             if results is None:
-                # Failed to parse the server URL
-                ConfigBase.logger.warning(
+                # url_to_dict() already logged an error with the URL;
+                # repeat at debug level with line number for context.
+                ConfigBase.logger.debug(
                     f"Unparseable URL {loggable_url} on line {line}."
                 )
                 continue
@@ -819,7 +820,7 @@ class ConfigBase(URLBase):
 
             except Exception as e:
                 # the arguments are invalid or can not be used.
-                ConfigBase.logger.warning(
+                ConfigBase.logger.error(
                     "Could not load URL {} on line {}.".format(
                         entry["loggable_url"], entry["line"]
                     )
@@ -1088,7 +1089,9 @@ class ConfigBase(URLBase):
                     url, secure_logging=asset.secure_logging
                 )
                 if results_ is None:
-                    ConfigBase.logger.warning(
+                    # url_to_dict() already logged an error with the URL;
+                    # repeat at debug level with entry number for context.
+                    ConfigBase.logger.debug(
                         f"Unparseable URL {loggable_url}, entry #{no + 1}"
                     )
                     continue
@@ -1336,7 +1339,7 @@ class ConfigBase(URLBase):
 
             except Exception as e:
                 # the arguments are invalid or can not be used.
-                ConfigBase.logger.warning(
+                ConfigBase.logger.error(
                     "Could not load Apprise YAML configuration "
                     "entry #{}, item #{}".format(entry["entry"], entry["item"])
                 )


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #469

Improved awareness of Apprise URLs that can not be loaded leveraging the logger `ERROR`.  The idea is to just bring more awareness to the user of Apprise when/if the URL they provided was not valid.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [ ] Documentation ticket created (if applicable): n/a
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@469-url-load-fails-more-verbose

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    garbage://
```
