### PR TITLE
Threema E2E Support

### DIFF
--- a/all-plugin-requirements.txt
+++ b/all-plugin-requirements.txt
@@ -24,3 +24,6 @@ smpplib
 
 # For xmpp:// support
 slixmpp >= 1.10.0
+
+# Provides Threema Gateway E2E encryption support
+PyNaCl

--- a/apprise/plugins/threema.py
+++ b/apprise/plugins/threema.py
@@ -410,7 +410,7 @@ class NotifyThreema(NotifyBase):
 
             # Some Debug Logging
             self.logger.debug(
-                "Threema Gateway GET URL:"
+                "Threema Gateway POST URL:"
                 f" {self.notify_url}"
                 f" (cert_verify={self.verify_certificate})"
             )
@@ -726,7 +726,13 @@ class NotifyThreema(NotifyBase):
         if self.mode == ThreemaMode.E2E:
             params["mode"] = ThreemaMode.E2E
             params["privkey"] = (
-                self.pprint(self._privkey, "key", safe="")
+                self.pprint(
+                    self._privkey,
+                    privacy=privacy,
+                    # Parmameters are quoted anyway; avoid double quote
+                    quote=False,
+                    safe="*",
+                )
                 if privacy
                 else f"private:{self._privkey}"
             )

--- a/apprise/plugins/threema.py
+++ b/apprise/plugins/threema.py
@@ -257,9 +257,16 @@ class NotifyThreema(NotifyBase):
             self.logger.warning(msg)
             raise TypeError(msg)
 
-        # Verify our Gateway ID
+        # Normalize Gateway ID: prepend * if the user omitted it
+        if not self.user.startswith("*"):
+            self.user = "*" + self.user
+
+        # Verify our Gateway ID (must be * + 7 characters = 8 total)
         if len(self.user) != 8:
-            msg = "Threema Gateway ID must be 8 characters in length"
+            msg = (
+                "Threema Gateway ID must be 7 characters "
+                "(e.g. MYGWYID or *MYGWYID)"
+            )
             self.logger.warning(msg)
             raise TypeError(msg)
 
@@ -740,7 +747,7 @@ class NotifyThreema(NotifyBase):
         schemaStr = "{schema}://{gatewayid}@{secret}/{targets}?{params}"
         return schemaStr.format(
             schema=self.secure_protocol,
-            gatewayid=NotifyThreema.quote(self.user),
+            gatewayid=NotifyThreema.quote(self.user, safe="*"),
             secret=self.pprint(
                 self.secret, privacy, mode=PrivacyMode.Secret, safe=""
             ),

--- a/apprise/plugins/threema.py
+++ b/apprise/plugins/threema.py
@@ -26,20 +26,97 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 # Create an account https://gateway.threema.ch/en/ if you don't already have
-# one
+# one.
 #
-# Read more about Threema Gateway API here:
-#   - https://gateway.threema.ch/en/developer/api
+# Two messaging modes are supported:
+#
+#  Basic Mode (default):
+#    Messages are encrypted server-side by Threema. Requires a "Basic"
+#    Gateway ID. Supports Threema ID, phone number, and email targets.
+#    Read more: https://gateway.threema.ch/en/developer/api
+#
+#  End-to-End (E2E) Mode (?mode=e2e):
+#    Messages are encrypted on your machine before transmission using
+#    NaCl (Curve25519 + XSalsa20-Poly1305). Requires an "E2E" Gateway
+#    ID and your Curve25519 private key. Only Threema ID targets are
+#    supported in this mode. Requires: pip install PyNaCl
+#    Read more: https://gateway.threema.ch/en/developer/api
+#
+# Syntax:
+#   Basic:  threema://{gateway_id}@{secret}/{targets}
+#   E2E:    threema://{gateway_id}@{secret}/{targets}?mode=e2e
+#             &privkey={your_private_key}
+#
+# Where:
+#   gateway_id   - Your 8-character Gateway ID (e.g., *MYGWYID)
+#   secret       - The API secret associated with your Gateway ID
+#   targets      - Threema ID, phone number(s), or email address(es)
+#   privkey      - Your Curve25519 private key (E2E mode only).
+#                  Accepts either the raw 64-character hex string shown
+#                  in the Threema Gateway portal, OR the full SDK format
+#                  with the "private:" prefix (both work):
+#                    ?privkey=aabbcc...  (raw hex, 64 chars)
+#                    ?privkey=private:aabbcc...  (SDK format)
 
 from itertools import chain
+import os
 
 import requests
 
-from ..common import NotifyType
+try:
+    from nacl.public import (
+        Box as _NaclBox,
+        PrivateKey as _NaclPrivateKey,
+        PublicKey as _NaclPublicKey,
+    )
+    from nacl.utils import random as _nacl_random
+
+    _NACL_NONCE_SIZE = _NaclBox.NONCE_SIZE
+    NACL_SUPPORT = True
+
+except ImportError:
+    _NaclBox = None
+    _NaclPrivateKey = None
+    _NaclPublicKey = None
+    _nacl_random = None
+    _NACL_NONCE_SIZE = 24
+    NACL_SUPPORT = False
+
+from ..common import NotifyType, PersistentStoreMode
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import is_email, is_phone_no, parse_list, validate_regex
 from .base import NotifyBase
+
+
+class ThreemaMode:
+    """Tracks the mode of operation for the Threema plugin."""
+
+    # Basic mode: server-side encryption, no private key required
+    BASIC = "basic"
+
+    # End-to-end mode: client-side NaCl encryption, private key required
+    E2E = "e2e"
+
+
+THREEMA_MODES = (
+    ThreemaMode.BASIC,
+    ThreemaMode.E2E,
+)
+
+# E2E encrypted-message endpoint
+THREEMA_E2E_URL = "https://msgapi.threema.ch/send_e2e"
+
+# Public key lookup endpoint; format with the recipient Threema ID
+THREEMA_PUBKEY_URL = "https://msgapi.threema.ch/pubkeys/{}"
+
+# Threema-specific HTTP status messages
+THREEMA_HTTP_ERROR_MAP = {
+    402: "Insufficient credits.",
+    404: "Recipient not found.",
+    413: "Message too large.",
+    429: "Rate limited; try again later.",
+}
 
 
 class ThreemaRecipientTypes:
@@ -53,6 +130,20 @@ class ThreemaRecipientTypes:
 class NotifyThreema(NotifyBase):
     """A wrapper for Threema Gateway Notifications."""
 
+    requirements = {
+        # PyNaCl is only needed for E2E encrypted mode; basic mode
+        # works without it.
+        "packages_recommended": "PyNaCl",
+    }
+
+    # Enable persistent storage so that fetched public keys survive
+    # across plugin instances and process restarts
+    storage_mode = PersistentStoreMode.AUTO
+
+    # Cache fetched public keys for 30 days; Threema keys are stable
+    # but may be rotated, so an expiry prevents stale key use.
+    pubkey_cache_expiry_sec = 60 * 60 * 24 * 30
+
     # The default descriptive name associated with the Notification
     service_name = "Threema Gateway"
 
@@ -65,7 +156,7 @@ class NotifyThreema(NotifyBase):
     # A URL that takes you to the setup/help of the specific protocol
     setup_url = "https://appriseit.com/services/threema/"
 
-    # Threema Gateway uses the http protocol with JSON requests
+    # Basic (send_simple) endpoint
     notify_url = "https://msgapi.threema.ch/send_simple"
 
     # The maximum length of the body
@@ -135,10 +226,27 @@ class NotifyThreema(NotifyBase):
             "to": {
                 "alias_of": "targets",
             },
+            "mode": {
+                "name": _("Mode"),
+                "type": "choice:string",
+                "values": THREEMA_MODES,
+            },
+            "privkey": {
+                "name": _("Private Key"),
+                "type": "string",
+                "private": True,
+            },
         },
     )
 
-    def __init__(self, secret=None, targets=None, **kwargs):
+    def __init__(
+        self,
+        secret=None,
+        targets=None,
+        mode=None,
+        privkey=None,
+        **kwargs,
+    ):
         """Initialize Threema Gateway Object."""
         super().__init__(**kwargs)
 
@@ -162,6 +270,37 @@ class NotifyThreema(NotifyBase):
             self.logger.warning(msg)
             raise TypeError(msg)
 
+        # Resolve operating mode
+        if mode:
+            self.mode = next(
+                (m for m in THREEMA_MODES if m.startswith(mode.lower())),
+                None,
+            )
+            if self.mode not in THREEMA_MODES:
+                msg = f"The Threema mode specified ({mode}) is invalid."
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
+        elif privkey:
+            # Auto-detect E2E when a private key is supplied
+            self.mode = ThreemaMode.E2E
+
+        else:
+            self.mode = ThreemaMode.BASIC
+
+        # E2E-specific validation
+        self._privkey = None
+        if self.mode == ThreemaMode.E2E:
+            self._privkey = self._parse_privkey(privkey)
+            if not self._privkey:
+                msg = (
+                    "Threema E2E mode requires a valid"
+                    " 32-byte Curve25519 private key"
+                    f" ({privkey!r})"
+                )
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
         # Parse our targets
         self.targets = []
 
@@ -179,7 +318,10 @@ class NotifyThreema(NotifyBase):
             if result:
                 # Store our user
                 self.targets.append(
-                    (ThreemaRecipientTypes.EMAIL, result["full_email"])
+                    (
+                        ThreemaRecipientTypes.EMAIL,
+                        result["full_email"],
+                    )
                 )
                 continue
 
@@ -199,10 +341,35 @@ class NotifyThreema(NotifyBase):
 
         return
 
+    @staticmethod
+    def _parse_privkey(key):
+        """Parse and validate a Curve25519 private key string.
+
+        Accepts 'private:64hexchars' (Threema SDK format) or a raw
+        64-character hex string. Returns the hex string (lower-cased)
+        on success, or None on failure.
+        """
+        if not isinstance(key, str):
+            return None
+        if key.startswith("private:"):
+            key = key[8:]
+        if len(key) != 64:
+            return None
+        try:
+            bytes.fromhex(key)
+        except ValueError:
+            return None
+        return key.lower()
+
     def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
         """Perform Threema Gateway Notification."""
+        if self.mode == ThreemaMode.E2E:
+            return self._send_e2e(body)
+        return self._send_basic(body)
 
-        if len(self.targets) == 0:
+    def _send_basic(self, body):
+        """Send via the basic (send_simple) endpoint."""
+        if not self.targets:
             # There were no services to notify
             self.logger.warning(
                 "There were no Threema Gateway targets to notify"
@@ -215,7 +382,9 @@ class NotifyThreema(NotifyBase):
         # Prepare our headers
         headers = {
             "User-Agent": self.app_id,
-            "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+            "Content-Type": (
+                "application/x-www-form-urlencoded; charset=utf-8"
+            ),
             "Accept": "*/*",
         }
 
@@ -229,7 +398,7 @@ class NotifyThreema(NotifyBase):
         # Create a copy of the targets list
         targets = list(self.targets)
 
-        while len(targets):
+        while targets:
             # Get our target to notify
             key, target = targets.pop(0)
 
@@ -242,7 +411,8 @@ class NotifyThreema(NotifyBase):
             # Some Debug Logging
             self.logger.debug(
                 "Threema Gateway GET URL:"
-                f" {self.notify_url} (cert_verify={self.verify_certificate})"
+                f" {self.notify_url}"
+                f" (cert_verify={self.verify_certificate})"
             )
             self.logger.debug(f"Threema Gateway Payload: {payload}")
 
@@ -283,7 +453,7 @@ class NotifyThreema(NotifyBase):
                     has_error = True
                     continue
 
-                # We wee successful
+                # We were successful
                 self.logger.info(
                     f"Sent Threema Gateway notification to {target}"
                 )
@@ -301,6 +471,243 @@ class NotifyThreema(NotifyBase):
 
         return not has_error
 
+    def _send_e2e(self, body):
+        """Send end-to-end encrypted messages via /send_e2e.
+
+        Only Threema ID targets are supported in E2E mode.
+        Phone and email targets are skipped with a warning.
+        """
+        if not NACL_SUPPORT:
+            self.logger.warning(
+                "Threema E2E mode requires PyNaCl;"
+                " install with: pip install PyNaCl"
+            )
+            return False
+
+        e2e_targets = [
+            (k, v)
+            for k, v in self.targets
+            if k == ThreemaRecipientTypes.THREEMA_ID
+        ]
+
+        skipped = len(self.targets) - len(e2e_targets)
+        if skipped:
+            self.logger.warning(
+                "Threema E2E mode only supports Threema ID"
+                " targets; skipping %d phone/email target(s)",
+                skipped,
+            )
+
+        if not e2e_targets:
+            self.logger.warning("No Threema ID targets for E2E mode; aborting")
+            return False
+
+        # error tracking (used for function return)
+        has_error = False
+
+        # Prepare our headers
+        headers = {
+            "User-Agent": self.app_id,
+            "Content-Type": (
+                "application/x-www-form-urlencoded; charset=utf-8"
+            ),
+            "Accept": "*/*",
+        }
+
+        private_key = _NaclPrivateKey(bytes.fromhex(self._privkey))
+
+        for _rtype, threema_id in e2e_targets:
+            pubkey_bytes = self._fetch_pubkey(threema_id, headers)
+            if pubkey_bytes is None:
+                has_error = True
+                continue
+
+            try:
+                nonce, ciphertext = self._encrypt_message(
+                    body, private_key, pubkey_bytes
+                )
+            except Exception as exc:
+                self.logger.warning(
+                    f"Failed to encrypt Threema E2E message for {threema_id}"
+                )
+                self.logger.debug(f"Encryption error: {exc!s}")
+                has_error = True
+                continue
+
+            payload = {
+                "secret": self.secret,
+                "from": self.user,
+                "to": threema_id,
+                "nonce": nonce.hex(),
+                "box": ciphertext.hex(),
+            }
+
+            self.logger.debug(
+                "Threema E2E POST URL:"
+                f" {THREEMA_E2E_URL}"
+                f" (cert_verify={self.verify_certificate})"
+            )
+            self.logger.debug(
+                "Threema E2E from=%s to=%s nonce=%s",
+                payload["from"],
+                threema_id,
+                payload["nonce"],
+            )
+
+            # Always call throttle before any remote server i/o is made
+            self.throttle()
+
+            try:
+                r = requests.post(
+                    THREEMA_E2E_URL,
+                    params=payload,
+                    headers=headers,
+                    verify=self.verify_certificate,
+                    timeout=self.request_timeout,
+                )
+
+                if r.status_code != requests.codes.ok:
+                    # We had a problem
+                    status_str = NotifyThreema.http_response_code_lookup(
+                        r.status_code,
+                        THREEMA_HTTP_ERROR_MAP,
+                    )
+
+                    self.logger.warning(
+                        "Failed to send Threema E2E notification"
+                        " to {}: {}{}error={}".format(
+                            threema_id,
+                            status_str,
+                            ", " if status_str else "",
+                            r.status_code,
+                        )
+                    )
+
+                    self.logger.debug(
+                        "Response Details:\r\n%r",
+                        (r.content or b"")[:2000],
+                    )
+
+                    # Mark our failure
+                    has_error = True
+                    continue
+
+                # We were successful
+                self.logger.info(
+                    f"Sent Threema E2E notification to {threema_id}"
+                )
+
+            except requests.RequestException as e:
+                self.logger.warning(
+                    "A Connection error occurred sending"
+                    f" Threema E2E:{threema_id} notification"
+                )
+                self.logger.debug(f"Socket Exception: {e!s}")
+
+                # Mark our failure
+                has_error = True
+                continue
+
+        return not has_error
+
+    def _fetch_pubkey(self, threema_id, headers):
+        """Fetch and cache the public key for a Threema ID.
+
+        Returns the raw 32-byte public key on success, or None on
+        failure. Keys are cached in persistent storage to avoid
+        repeated API calls across sends and restarts.
+        """
+        store_key = f"pubkey_{threema_id}"
+        cached = self.store.get(store_key)
+        if cached is not None:
+            return cached
+
+        url = THREEMA_PUBKEY_URL.format(threema_id)
+        params = {"secret": self.secret, "from": self.user}
+
+        self.logger.debug("Fetching Threema public key for %s", threema_id)
+
+        # Always call throttle before any remote server i/o is made
+        self.throttle()
+
+        try:
+            r = requests.get(
+                url,
+                params=params,
+                headers=headers,
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+            )
+
+        except requests.RequestException as exc:
+            self.logger.warning(
+                "Connection error fetching public key for Threema ID %s",
+                threema_id,
+            )
+            self.logger.debug(f"Socket Exception: {exc!s}")
+            return None
+
+        if r.status_code != requests.codes.ok:
+            self.logger.warning(
+                "Failed to fetch public key for Threema ID %s: error=%d",
+                threema_id,
+                r.status_code,
+            )
+            return None
+
+        pubkey_hex = r.text.strip()
+        if len(pubkey_hex) != 64:
+            self.logger.warning(
+                "Invalid public key length for Threema"
+                " ID %s (got %d hex chars, expected 64)",
+                threema_id,
+                len(pubkey_hex),
+            )
+            return None
+
+        try:
+            pubkey_bytes = bytes.fromhex(pubkey_hex)
+        except ValueError:
+            self.logger.warning(
+                "Non-hex public key received for Threema ID %s",
+                threema_id,
+            )
+            return None
+
+        self.store.set(
+            store_key,
+            pubkey_bytes,
+            expires=self.pubkey_cache_expiry_sec,
+        )
+        return pubkey_bytes
+
+    def _encrypt_message(self, text, private_key, pubkey_bytes):
+        """Encrypt a text message using a NaCl Box.
+
+        Builds the Threema message container (type byte 0x01 + UTF-8
+        text + PKCS#7 padding) then encrypts it using Curve25519 +
+        XSalsa20-Poly1305 (NaCl crypto_box).
+
+        Returns (nonce_bytes, ciphertext_bytes).
+        """
+        public_key = _NaclPublicKey(pubkey_bytes)
+        box = _NaclBox(private_key, public_key)
+
+        # Message container: type byte (0x01 = text message) + UTF-8 body
+        plaintext = b"\x01" + text.encode("utf-8")
+
+        # PKCS#7 padding: minimum 1 byte, minimum total 32 bytes
+        min_pad = max(1, 32 - len(plaintext))
+        max_extra = 255 - min_pad
+        extra = int.from_bytes(os.urandom(1), "big") % (max_extra + 1)
+        pad_len = min_pad + extra
+        plaintext += bytes([pad_len] * pad_len)
+
+        nonce = _nacl_random(_NACL_NONCE_SIZE)
+        encrypted = box.encrypt(plaintext, nonce)
+
+        return encrypted.nonce, encrypted.ciphertext
+
     @property
     def url_identifier(self):
         """Returns all of the identifiers that make this URL unique from
@@ -315,6 +722,14 @@ class NotifyThreema(NotifyBase):
 
         # Define any URL parameters
         params = self.url_parameters(privacy=privacy, *args, **kwargs)
+
+        if self.mode == ThreemaMode.E2E:
+            params["mode"] = ThreemaMode.E2E
+            params["privkey"] = (
+                self.pprint(self._privkey, "key", safe="")
+                if privacy
+                else f"private:{self._privkey}"
+            )
 
         schemaStr = "{schema}://{gatewayid}@{secret}/{targets}?{params}"
         return schemaStr.format(
@@ -374,4 +789,19 @@ class NotifyThreema(NotifyBase):
                 results["qsd"]["to"], allow_whitespace=False
             )
 
+        if "mode" in results["qsd"] and results["qsd"]["mode"]:
+            results["mode"] = NotifyThreema.unquote(results["qsd"]["mode"])
+
+        if "privkey" in results["qsd"] and results["qsd"]["privkey"]:
+            results["privkey"] = NotifyThreema.unquote(
+                results["qsd"]["privkey"]
+            )
+
         return results
+
+    @staticmethod
+    def runtime_deps():
+        """Return a tuple of top-level Python package names that this
+        plugin imported as optional runtime dependencies.
+        """
+        return ("nacl",)

--- a/bin/build-rpm.sh
+++ b/bin/build-rpm.sh
@@ -72,6 +72,10 @@ mkdir -p "$SOURCES_DIR"
 cp "$TARBALL" "$SOURCES_DIR/"
 find $APPRISE_DIR/packaging/redhat/ -iname '*.patch' -exec cp {} "$SOURCES_DIR" \;
 
+echo "==> Resolving dynamic dependencies from spec"
+sudo dnf builddep -y \
+   "$APPRISE_DIR/packaging/redhat/python-apprise.spec"
+
 echo "==> Building RPM (source and binary)"
 mkdir -p "$DIST_DIR"
 rpmbuild --define "_topdir $APPRISE_DIR" \

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -130,7 +130,6 @@ BuildRequires: python3dist(markdown)
 BuildRequires: python3dist(pyyaml)
 BuildRequires: python3dist(babel)
 BuildRequires: python3dist(cryptography)
-BuildRequires: python3dist(pynacl)
 BuildRequires: python3dist(certifi)
 BuildRequires: python3dist(tox)
 

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -130,6 +130,7 @@ BuildRequires: python3dist(markdown)
 BuildRequires: python3dist(pyyaml)
 BuildRequires: python3dist(babel)
 BuildRequires: python3dist(cryptography)
+BuildRequires: python3dist(pynacl)
 BuildRequires: python3dist(certifi)
 BuildRequires: python3dist(tox)
 
@@ -148,6 +149,7 @@ Requires: python3dist(pyyaml)
 Recommends: python3dist(hidapi)
 Recommends: python3dist(paho-mqtt) >= 2.1.0
 Recommends: python3dist(slixmpp)
+Recommends: python3dist(pynacl)
 
 %if 0%{?legacy_python_build} == 0
 # Logic for non-RHEL ≤ 9 systems

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,6 +242,9 @@ all-plugins = [
 
     # For xmpp:// support
     "slixmpp >= 1.10.0",
+
+    # Provides Threema Gateway E2E encryption support
+    "PyNaCl",
 ]
 windows = [
     "pywin32",

--- a/tests/docker/Dockerfile.el10
+++ b/tests/docker/Dockerfile.el10
@@ -51,8 +51,9 @@ RUN \
 
 # Place our build file into the path
 COPY packaging/redhat/python-apprise.spec /
-RUN rpmspec -q --buildrequires /python-apprise.spec | cut -f1 -d' ' | \
-    xargs dnf install -y && dnf clean all
+
+# Use builddep to resolve and install all spec dependencies correctly
+RUN dnf builddep -y /python-apprise.spec && dnf clean all
 
 # RPM build structure setup
 ENV FLAVOR=rpmbuild OS=centos DIST=el10

--- a/tests/docker/Dockerfile.el9
+++ b/tests/docker/Dockerfile.el9
@@ -49,8 +49,9 @@ RUN \
 
 # Place our build file into the path
 COPY packaging/redhat/python-apprise.spec /
-RUN rpmspec -q --buildrequires /python-apprise.spec | cut -f1 -d' ' | \
-    xargs dnf install -y && dnf clean all
+
+# Use builddep to resolve and install all spec dependencies correctly
+RUN dnf builddep -y /python-apprise.spec && dnf clean all
 
 # RPM Build Structure Setup
 ENV FLAVOR=rpmbuild OS=centos DIST=el9

--- a/tests/test_plugin_threema.py
+++ b/tests/test_plugin_threema.py
@@ -351,6 +351,32 @@ def test_plugin_threema_e2e_url():
 
 
 @pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+def test_plugin_threema_e2e_privkey_privacy_masking():
+    """url(privacy=True) masks the private key."""
+
+    obj = NotifyThreema(
+        user=GW_ID,
+        secret=SECRET,
+        targets=[RECIPIENT_ID],
+        privkey=VALID_PRIVKEY,
+    )
+
+    priv_url = obj.url(privacy=True)
+
+    # Full 64-char hex must not appear in the privacy URL
+    assert VALID_PRIVKEY_HEX not in priv_url
+    # The SDK-format "private:<hex>" form must not appear either
+    assert VALID_PRIVKEY not in priv_url
+
+    # pprint Outer mode yields "{first_char}...{last_char}" -- verify
+    # the masked token appears verbatim in the URL.
+    expected_mask = obj.pprint(
+        VALID_PRIVKEY_HEX, privacy=True, quote=False, safe="*"
+    )
+    assert expected_mask in priv_url
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
 @mock.patch("requests.get")
 @mock.patch("requests.post")
 def test_plugin_threema_e2e_send(mock_post, mock_get):

--- a/tests/test_plugin_threema.py
+++ b/tests/test_plugin_threema.py
@@ -33,9 +33,30 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
-from apprise.plugins.threema import NotifyThreema
+from apprise.plugins.threema import (
+    NACL_SUPPORT,
+    THREEMA_E2E_URL,
+    THREEMA_PUBKEY_URL,
+    NotifyThreema,
+    ThreemaMode,
+    ThreemaRecipientTypes,
+)
 
 logging.disable(logging.CRITICAL)
+
+# A valid 64-character hex private key (all-zeros for testing)
+VALID_PRIVKEY_HEX = "a" * 64
+VALID_PRIVKEY = f"private:{VALID_PRIVKEY_HEX}"
+
+# A valid 64-character hex public key (all-ones for testing)
+VALID_PUBKEY_HEX = "b" * 64
+
+# A valid 8-character Gateway ID
+GW_ID = "*THEGWID"
+SECRET = "mysecret"
+
+# A valid 8-character Threema recipient ID
+RECIPIENT_ID = "ABCD1234"
 
 # Our Testing URLs
 apprise_url_tests = (
@@ -204,3 +225,522 @@ def test_plugin_threema_edge_cases(mock_post):
     assert details[1]["params"]["from"] == gwid
     assert details[1]["params"]["phone"] == "15551239876"
     assert details[1]["params"]["text"] == "body 😊".encode()
+
+
+def test_plugin_threema_modes():
+    """NotifyThreema() mode detection and validation."""
+
+    # Default mode is basic
+    obj = NotifyThreema(user=GW_ID, secret=SECRET, targets=[RECIPIENT_ID])
+    assert obj.mode == ThreemaMode.BASIC
+
+    # Explicit basic mode
+    obj = NotifyThreema(
+        user=GW_ID, secret=SECRET, targets=[RECIPIENT_ID], mode="basic"
+    )
+    assert obj.mode == ThreemaMode.BASIC
+
+    # Invalid mode raises
+    with pytest.raises(TypeError):
+        NotifyThreema(
+            user=GW_ID, secret=SECRET, targets=[RECIPIENT_ID], mode="bad"
+        )
+
+
+def test_plugin_threema_parse_privkey():
+    """NotifyThreema._parse_privkey() handles all input forms."""
+
+    # Valid raw hex
+    assert NotifyThreema._parse_privkey(VALID_PRIVKEY_HEX) == VALID_PRIVKEY_HEX
+
+    # Valid with 'private:' prefix
+    assert (
+        NotifyThreema._parse_privkey(f"private:{VALID_PRIVKEY_HEX}")
+        == VALID_PRIVKEY_HEX
+    )
+
+    # Upper-case hex is normalised to lower-case
+    upper = VALID_PRIVKEY_HEX.upper()
+    assert NotifyThreema._parse_privkey(upper) == VALID_PRIVKEY_HEX
+
+    # Wrong length
+    assert NotifyThreema._parse_privkey("aa" * 31) is None
+    assert NotifyThreema._parse_privkey("aa" * 33) is None
+
+    # Non-hex characters
+    assert NotifyThreema._parse_privkey("g" * 64) is None
+
+    # Not a string
+    assert NotifyThreema._parse_privkey(None) is None
+    assert NotifyThreema._parse_privkey(123) is None
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+def test_plugin_threema_e2e_init():
+    """NotifyThreema() E2E mode initialisation."""
+
+    # Auto-detect E2E when privkey supplied
+    obj = NotifyThreema(
+        user=GW_ID,
+        secret=SECRET,
+        targets=[RECIPIENT_ID],
+        privkey=VALID_PRIVKEY,
+    )
+    assert obj.mode == ThreemaMode.E2E
+    assert obj._privkey == VALID_PRIVKEY_HEX
+
+    # Explicit e2e mode
+    obj = NotifyThreema(
+        user=GW_ID,
+        secret=SECRET,
+        targets=[RECIPIENT_ID],
+        mode="e2e",
+        privkey=VALID_PRIVKEY,
+    )
+    assert obj.mode == ThreemaMode.E2E
+
+    # E2E mode without a private key raises
+    with pytest.raises(TypeError):
+        NotifyThreema(
+            user=GW_ID,
+            secret=SECRET,
+            targets=[RECIPIENT_ID],
+            mode="e2e",
+        )
+
+    # E2E mode with an invalid private key raises
+    with pytest.raises(TypeError):
+        NotifyThreema(
+            user=GW_ID,
+            secret=SECRET,
+            targets=[RECIPIENT_ID],
+            privkey="not-a-valid-key",
+        )
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+def test_plugin_threema_e2e_url():
+    """NotifyThreema() URL round-trip for E2E mode."""
+
+    obj = NotifyThreema(
+        user=GW_ID,
+        secret=SECRET,
+        targets=[RECIPIENT_ID],
+        privkey=VALID_PRIVKEY,
+    )
+
+    # url() encodes mode and privkey
+    url = obj.url()
+    assert "mode=e2e" in url
+    assert VALID_PRIVKEY_HEX in url
+
+    # Privacy URL masks the private key
+    priv_url = obj.url(privacy=True)
+    assert VALID_PRIVKEY_HEX not in priv_url
+    assert "key" in priv_url
+
+    # parse_url round-trip
+    results = NotifyThreema.parse_url(url)
+    assert results is not None
+    assert results["mode"] == "e2e"
+    assert VALID_PRIVKEY_HEX in results["privkey"]
+
+    obj2 = NotifyThreema(**results)
+    assert obj2.mode == ThreemaMode.E2E
+    assert obj2._privkey == VALID_PRIVKEY_HEX
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_threema_e2e_send(mock_post, mock_get):
+    """NotifyThreema() E2E send — success path."""
+
+    # Public-key lookup response
+    pubkey_resp = mock.MagicMock()
+    pubkey_resp.status_code = requests.codes.ok
+    pubkey_resp.text = VALID_PUBKEY_HEX
+    mock_get.return_value = pubkey_resp
+
+    # Send response
+    send_resp = mock.MagicMock()
+    send_resp.status_code = requests.codes.ok
+    mock_post.return_value = send_resp
+
+    obj = NotifyThreema(
+        user=GW_ID,
+        secret=SECRET,
+        targets=[RECIPIENT_ID],
+        privkey=VALID_PRIVKEY,
+    )
+
+    assert obj.send(body="Hello E2E") is True
+
+    # One GET (pubkey lookup) + one POST (send_e2e)
+    assert mock_get.call_count == 1
+    assert mock_post.call_count == 1
+
+    get_url = mock_get.call_args[0][0]
+    assert RECIPIENT_ID in get_url
+    assert "pubkeys" in get_url
+
+    post_url = mock_post.call_args[0][0]
+    assert post_url == THREEMA_E2E_URL
+
+    payload = mock_post.call_args[1]["params"]
+    assert payload["from"] == GW_ID
+    assert payload["to"] == RECIPIENT_ID
+    assert payload["secret"] == SECRET
+    # nonce: 48 hex chars (24 bytes)
+    assert len(payload["nonce"]) == 48
+    # box: non-empty hex
+    assert len(payload["box"]) > 0
+    assert all(c in "0123456789abcdef" for c in payload["box"])
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_threema_e2e_pubkey_cached(mock_post, mock_get):
+    """NotifyThreema() E2E public key is fetched once and cached."""
+
+    pubkey_resp = mock.MagicMock()
+    pubkey_resp.status_code = requests.codes.ok
+    pubkey_resp.text = VALID_PUBKEY_HEX
+    mock_get.return_value = pubkey_resp
+
+    send_resp = mock.MagicMock()
+    send_resp.status_code = requests.codes.ok
+    mock_post.return_value = send_resp
+
+    obj = NotifyThreema(
+        user=GW_ID,
+        secret=SECRET,
+        targets=[RECIPIENT_ID, "XXXXXXXX"],
+        privkey=VALID_PRIVKEY,
+    )
+
+    # Pre-populate the persistent store for RECIPIENT_ID so its pubkey
+    # lookup is skipped — only XXXXXXXX needs a live GET.
+    obj.store.set(
+        f"pubkey_{RECIPIENT_ID}",
+        bytes.fromhex(VALID_PUBKEY_HEX),
+    )
+
+    assert obj.send(body="Cached") is True
+    # Only one GET (for XXXXXXXX); RECIPIENT_ID served from cache
+    assert mock_get.call_count == 1
+    assert mock_post.call_count == 2
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+@mock.patch("requests.get")
+def test_plugin_threema_e2e_encrypt_failure(mock_get):
+    """NotifyThreema() E2E handles exceptions from _encrypt_message."""
+
+    pubkey_resp = mock.MagicMock()
+    pubkey_resp.status_code = requests.codes.ok
+    pubkey_resp.text = VALID_PUBKEY_HEX
+    mock_get.return_value = pubkey_resp
+
+    obj = NotifyThreema(
+        user=GW_ID,
+        secret=SECRET,
+        targets=[RECIPIENT_ID],
+        privkey=VALID_PRIVKEY,
+    )
+
+    with mock.patch.object(
+        obj, "_encrypt_message", side_effect=Exception("boom")
+    ):
+        assert obj.send(body="test") is False
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+@mock.patch("requests.get")
+def test_plugin_threema_e2e_pubkey_fetch_error(mock_get):
+    """NotifyThreema() E2E aborts gracefully when pubkey fetch fails."""
+
+    obj = NotifyThreema(
+        user=GW_ID,
+        secret=SECRET,
+        targets=[RECIPIENT_ID],
+        privkey=VALID_PRIVKEY,
+    )
+
+    # HTTP error from pubkey endpoint
+    err_resp = mock.MagicMock()
+    err_resp.status_code = requests.codes.not_found
+    mock_get.return_value = err_resp
+    assert obj.send(body="test") is False
+
+    # Connection error from pubkey endpoint
+    mock_get.side_effect = requests.RequestException("conn error")
+    assert obj.send(body="test") is False
+
+    # Invalid pubkey length
+    mock_get.side_effect = None
+    bad_len_resp = mock.MagicMock()
+    bad_len_resp.status_code = requests.codes.ok
+    bad_len_resp.text = "abcd"  # too short
+    mock_get.return_value = bad_len_resp
+    assert obj.send(body="test") is False
+
+    # Non-hex pubkey
+    bad_hex_resp = mock.MagicMock()
+    bad_hex_resp.status_code = requests.codes.ok
+    bad_hex_resp.text = "z" * 64  # valid length, non-hex
+    mock_get.return_value = bad_hex_resp
+    assert obj.send(body="test") is False
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_threema_e2e_send_http_error(mock_post, mock_get):
+    """NotifyThreema() E2E handles HTTP errors from /send_e2e."""
+
+    pubkey_resp = mock.MagicMock()
+    pubkey_resp.status_code = requests.codes.ok
+    pubkey_resp.text = VALID_PUBKEY_HEX
+    mock_get.return_value = pubkey_resp
+
+    obj = NotifyThreema(
+        user=GW_ID,
+        secret=SECRET,
+        targets=[RECIPIENT_ID],
+        privkey=VALID_PRIVKEY,
+    )
+
+    # HTTP 500
+    err_resp = mock.MagicMock()
+    err_resp.status_code = requests.codes.internal_server_error
+    err_resp.content = b""
+    mock_post.return_value = err_resp
+    assert obj.send(body="test") is False
+
+    # HTTP 999 — pubkey already in store; no new GET needed
+    err_resp.status_code = 999
+    assert obj.send(body="test") is False
+
+    # RequestException from /send_e2e — pubkey already in store
+    mock_post.side_effect = requests.RequestException("conn")
+    assert obj.send(body="test") is False
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_threema_e2e_partial_failure(mock_post, mock_get):
+    """NotifyThreema() E2E returns False when any target fails."""
+
+    pubkey_resp = mock.MagicMock()
+    pubkey_resp.status_code = requests.codes.ok
+    pubkey_resp.text = VALID_PUBKEY_HEX
+    mock_get.return_value = pubkey_resp
+
+    ok_resp = mock.MagicMock()
+    ok_resp.status_code = requests.codes.ok
+    err_resp = mock.MagicMock()
+    err_resp.status_code = requests.codes.internal_server_error
+    err_resp.content = b""
+
+    # First target succeeds, second fails
+    mock_post.side_effect = [ok_resp, err_resp]
+
+    obj = NotifyThreema(
+        user=GW_ID,
+        secret=SECRET,
+        targets=[RECIPIENT_ID, "XXXXXXXX"],
+        privkey=VALID_PRIVKEY,
+    )
+
+    assert obj.send(body="test") is False
+    assert mock_post.call_count == 2
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+@mock.patch("requests.get")
+def test_plugin_threema_e2e_skip_non_id_targets(mock_get):
+    """NotifyThreema() E2E skips phone/email targets with a warning."""
+
+    obj = NotifyThreema(
+        user=GW_ID,
+        secret=SECRET,
+        targets=["16134442222"],  # phone number
+        privkey=VALID_PRIVKEY,
+    )
+    # All targets are phones — nothing to send
+    assert obj.send(body="test") is False
+    # No pubkey lookups attempted
+    assert mock_get.call_count == 0
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_threema_e2e_mixed_targets(mock_post, mock_get):
+    """NotifyThreema() E2E sends to ID targets and skips phone/email."""
+
+    pubkey_resp = mock.MagicMock()
+    pubkey_resp.status_code = requests.codes.ok
+    pubkey_resp.text = VALID_PUBKEY_HEX
+    mock_get.return_value = pubkey_resp
+
+    send_resp = mock.MagicMock()
+    send_resp.status_code = requests.codes.ok
+    mock_post.return_value = send_resp
+
+    obj = NotifyThreema(
+        user=GW_ID,
+        secret=SECRET,
+        targets=["16134442222", RECIPIENT_ID],  # phone + ID
+        privkey=VALID_PRIVKEY,
+    )
+
+    assert obj.send(body="test") is True
+    # Only the Threema ID target should be sent
+    assert mock_post.call_count == 1
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+def test_plugin_threema_e2e_no_targets():
+    """NotifyThreema() E2E returns False when there are no ID targets."""
+
+    obj = NotifyThreema(
+        user=GW_ID,
+        secret=SECRET,
+        targets=[],  # no targets at all
+        privkey=VALID_PRIVKEY,
+    )
+    assert obj.send(body="test") is False
+
+
+@pytest.mark.skipif(NACL_SUPPORT, reason="PyNaCl IS installed")
+def test_plugin_threema_e2e_no_nacl():
+    """NotifyThreema() loads but send() returns False without PyNaCl."""
+
+    # Plugin should load without error even when PyNaCl is missing
+    obj = NotifyThreema(
+        user=GW_ID,
+        secret=SECRET,
+        targets=[RECIPIENT_ID],
+        privkey=VALID_PRIVKEY,
+    )
+    assert obj.mode == ThreemaMode.E2E
+
+    # send() must fail gracefully with a warning, not raise
+    assert obj.send(body="test") is False
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+def test_plugin_threema_e2e_encrypt_message():
+    """NotifyThreema._encrypt_message() returns valid nonce+ciphertext."""
+    from nacl.public import PrivateKey
+
+    obj = NotifyThreema(
+        user=GW_ID,
+        secret=SECRET,
+        targets=[RECIPIENT_ID],
+        privkey=VALID_PRIVKEY,
+    )
+
+    recipient_key = PrivateKey.generate()
+    pubkey_bytes = bytes(recipient_key.public_key)
+
+    sender_key = PrivateKey(bytes.fromhex(VALID_PRIVKEY_HEX))
+
+    nonce, ciphertext = obj._encrypt_message("hello", sender_key, pubkey_bytes)
+
+    assert len(nonce) == 24
+    assert len(ciphertext) > 0
+
+    # Verify ciphertext can be decrypted by the recipient
+    from nacl.public import Box
+
+    box = Box(recipient_key, sender_key.public_key)
+    plaintext = box.decrypt(ciphertext, nonce)
+    # First byte is the type byte (0x01)
+    assert plaintext[0:1] == b"\x01"
+    # Remaining bytes (before padding) contain the message
+    assert b"hello" in plaintext
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+def test_plugin_threema_url_identifier():
+    """NotifyThreema.url_identifier uniquely identifies the plugin instance."""
+
+    obj = NotifyThreema(
+        user=GW_ID,
+        secret=SECRET,
+        targets=[RECIPIENT_ID],
+    )
+    ident = obj.url_identifier
+    assert ident == ("threema", GW_ID, SECRET)
+
+    obj_e2e = NotifyThreema(
+        user=GW_ID,
+        secret=SECRET,
+        targets=[RECIPIENT_ID],
+        privkey=VALID_PRIVKEY,
+    )
+    # url_identifier is the same regardless of mode
+    assert obj_e2e.url_identifier == ident
+
+
+def test_plugin_threema_parse_url_e2e():
+    """NotifyThreema.parse_url() round-trips E2E parameters."""
+
+    url = (
+        f"threema://{GW_ID}@{SECRET}/{RECIPIENT_ID}"
+        f"?mode=e2e&privkey=private:{VALID_PRIVKEY_HEX}"
+    )
+    results = NotifyThreema.parse_url(url)
+    assert results is not None
+    assert results["mode"] == "e2e"
+    assert VALID_PRIVKEY_HEX in results["privkey"]
+    assert RECIPIENT_ID in results["targets"]
+
+
+def test_plugin_threema_parse_url_no_privkey():
+    """NotifyThreema.parse_url() without privkey returns no privkey key."""
+
+    url = f"threema://{GW_ID}@{SECRET}/{RECIPIENT_ID}"
+    results = NotifyThreema.parse_url(url)
+    assert results is not None
+    assert "privkey" not in results or not results.get("privkey")
+
+
+def test_plugin_threema_len():
+    """NotifyThreema.__len__() returns at least 1."""
+
+    obj = NotifyThreema(user=GW_ID, secret=SECRET, targets=[])
+    assert len(obj) == 1
+
+    obj2 = NotifyThreema(
+        user=GW_ID, secret=SECRET, targets=["16134442222", "16134443333"]
+    )
+    assert len(obj2) == 2
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+def test_plugin_threema_pubkey_url_format():
+    """THREEMA_PUBKEY_URL contains the expected base URL."""
+    url = THREEMA_PUBKEY_URL.format(RECIPIENT_ID)
+    assert "msgapi.threema.ch" in url
+    assert "pubkeys" in url
+    assert RECIPIENT_ID in url
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+def test_plugin_threema_e2e_url_constant():
+    """THREEMA_E2E_URL points at the correct endpoint."""
+    assert "msgapi.threema.ch" in THREEMA_E2E_URL
+    assert "send_e2e" in THREEMA_E2E_URL
+
+
+def test_plugin_threema_recipient_types():
+    """ThreemaRecipientTypes constants have expected values."""
+    assert ThreemaRecipientTypes.THREEMA_ID == "to"
+    assert ThreemaRecipientTypes.PHONE == "phone"
+    assert ThreemaRecipientTypes.EMAIL == "email"

--- a/tests/test_plugin_threema.py
+++ b/tests/test_plugin_threema.py
@@ -82,6 +82,16 @@ apprise_url_tests = (
         },
     ),
     (
+        "threema://THEGWID@secret/{targets}/".format(
+            targets="/".join(["16134442222"])
+        ),
+        {
+            # Valid - asterisk prepended automatically when omitted
+            "instance": NotifyThreema,
+            "privacy_url": "threema://*THEGWID@****/16134442222",
+        },
+    ),
+    (
         "threema://*THEGWID@secret/{targets}/".format(
             targets="/".join(["2222"])
         ),
@@ -89,7 +99,7 @@ apprise_url_tests = (
             # Invalid target phone number
             "instance": NotifyThreema,
             "notify_response": False,
-            "privacy_url": "threema://%2ATHEGWID@****/2222",
+            "privacy_url": "threema://*THEGWID@****/2222",
         },
     ),
     (
@@ -99,7 +109,7 @@ apprise_url_tests = (
         {
             # Valid
             "instance": NotifyThreema,
-            "privacy_url": "threema://%2ATHEGWID@****/16134442222",
+            "privacy_url": "threema://*THEGWID@****/16134442222",
         },
     ),
     (
@@ -109,7 +119,7 @@ apprise_url_tests = (
         {
             # Valid multiple targets
             "instance": NotifyThreema,
-            "privacy_url": "threema://%2ATHEGWID@****/16134442222/16134443333",
+            "privacy_url": "threema://*THEGWID@****/16134442222/16134443333",
         },
     ),
     (


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #986

Add end-to-end encrypted messaging support to the Threema Gateway plugin
(`threema://`).

**How it works:**
- Basic mode (default) — unchanged; no new dependency required. If you do not provide a mode, but provide a prvkey= then it is presumed you wanted the mode to be e2e.
- E2E mode (`?mode=e2e`) — encrypts messages client-side. 
  - Only Threema ID targets are supported in E2E mode.
- The private key is accepted as `private:{64hexchars}` (Threema SDK format) or a raw 64-char hex string.
- PyNaCl is added as an optional dependency; if not installed, E2E mode will not work, however you're free to leverage the basic mode.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/30(https://github.com/caronc/apprise-docs/pull/30)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install "git+https://github.com/caronc/apprise.git@986-threema-e2e-support"

# Basic mode (no PyNaCl needed):
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "threema://*MYGWYID@mysecret/FRIENDID"

# E2E mode (requires PyNaCl + an E2E Gateway ID + private key):
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "threema://*MYGWYID@mysecret/FRIENDID?mode=e2e&privkey=private:<64hexchars>"
```
