### PR TITLE
fixes parse_url() -> url() -> parse_url() inconsistency

### DIFF
--- a/apprise/utils/parse.py
+++ b/apprise/utils/parse.py
@@ -1011,8 +1011,18 @@ def urlencode(query, doseq=False, safe="", encoding=None, errors=None):
     """
     # Tidy query by eliminating any records set to None
     query_ = {k: v for (k, v) in query.items() if v is not None}
+    # Use quote (not quote_plus) so spaces become %20 rather than +.
+    # Apprise's parse_qsd intentionally leaves + raw (it is a reserved
+    # character in tokens/passwords), so values encoded with + can never
+    # round-trip cleanly.  %20 is decoded correctly by unquote() and is
+    # safe across all Apprise plugin URL round-trips.
     return _urlencode(
-        query_, doseq=doseq, safe=safe, encoding=encoding, errors=errors
+        query_,
+        doseq=doseq,
+        safe=safe,
+        encoding=encoding,
+        errors=errors,
+        quote_via=quote,
     )
 
 

--- a/tests/test_apprise_utils.py
+++ b/tests/test_apprise_utils.py
@@ -1300,7 +1300,7 @@ def test_url_assembly():
             **utils.parse.parse_url(url, verify_host=False)
         )
         == "schema://hostname:10/a%20space/file.php?"
-        "arg=a%2Bspace&arg2=a+space&arg3=a+space"
+        "arg=a%2Bspace&arg2=a%20space&arg3=a%20space"
     )
 
     # encode=True should only be used if you're passing in un-assembled
@@ -1310,7 +1310,7 @@ def test_url_assembly():
             **utils.parse.parse_url(url, verify_host=False), encode=True
         )
         == "schema://hostname:10/a%2520space/file.php?"
-        "arg=a%2Bspace&arg2=a+space&arg3=a+space"
+        "arg=a%2Bspace&arg2=a%20space&arg3=a%20space"
     )
 
     # But the following utilizes the encode=True and produces the
@@ -1328,7 +1328,7 @@ def test_url_assembly():
     assert (
         utils.parse.url_assembly(**content, encode=True)
         == "schema://hostname/a%20space/file.php?"
-        "arg=a%2Bspace&arg2=a+space&arg3=a+space"
+        "arg=a%2Bspace&arg2=a%20space&arg3=a%20space"
     )
 
 

--- a/tests/test_decorator_notify.py
+++ b/tests/test_decorator_notify.py
@@ -515,7 +515,8 @@ def test_notify_decorator_urls_with_space():
 
     assert meta.get("schema") == "posts"
     assert (
-        meta.get("url") == "posts://example.com/my%20endpoint?-token=ab+cdefg"
+        meta.get("url")
+        == "posts://example.com/my%20endpoint?-token=ab%20cdefg"
     )
     assert meta.get("qsd") == {"-token": "ab cdefg"}
     assert meta.get("host") == "example.com"

--- a/tests/test_plugin_email.py
+++ b/tests/test_plugin_email.py
@@ -1201,7 +1201,7 @@ def test_plugin_email_url_variations():
     assert obj.from_addr[0] == "Charles"
     assert obj.from_addr[1] == "from@example.jp"
     assert (
-        re.match(r".*from=Charles\+%3Cfrom%40example.jp%3E.*", obj.url())
+        re.match(r".*from=Charles%20%3Cfrom%40example.jp%3E.*", obj.url())
         is not None
     )
 
@@ -1702,7 +1702,7 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
     assert obj.secure_mode == "starttls"
     assert obj.url().startswith("mailtos://user:pass@example.com")
     # Test that our template over-ride worked
-    assert "reply=Chris+%3Cnoreply%40example.ca%3E" in obj.url()
+    assert "reply=Chris%20%3Cnoreply%40example.ca%3E" in obj.url()
 
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0


### PR DESCRIPTION
## Description
**Related issue (if applicable):**: n/a

Fixes the case where the URL gets partially mangled surrounding whitespace when `plugin.url()` is passed back into `plugin.parse_url()`

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [ ] Documentation ticket created (if applicable): n/a
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@url-encoded-whitespace-fix

# If you have cloned the branch and have tox available to you:
tox -e qa
```
