### PR TITLE
Matrix E2EE Support

### DIFF
--- a/apprise/plugins/matrix/__init__.py
+++ b/apprise/plugins/matrix/__init__.py
@@ -1,0 +1,36 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Matrix Notifications."""
+
+from .base import IS_ROOM_ID, MatrixDiscoveryException, NotifyMatrix
+
+__all__ = [
+    "IS_ROOM_ID",
+    "MatrixDiscoveryException",
+    "NotifyMatrix",
+]

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -65,6 +65,8 @@ from .e2ee import (
     MatrixMegOlmSession,
     MatrixOlmAccount,
     encrypt_attachment,
+    verify_device_keys,
+    verify_signed_otk,
 )
 
 # Define default path
@@ -750,6 +752,13 @@ class NotifyMatrix(NotifyBase):
             # We need to register
             return False
 
+        # When authenticating with a raw access token (no username) the
+        # login flow is skipped, so user_id and device_id are never returned
+        # by the server.  Resolve them via /account/whoami so that E2EE key
+        # upload and DM room lookup (m.direct) work correctly.
+        if not self.user and (not self.user_id or not self.device_id):
+            self._whoami()
+
         if len(self.rooms) == 0 and not self.users:
             # Attempt to retrieve a list of already joined channels
             self.rooms = self._joined_rooms()
@@ -764,6 +773,9 @@ class NotifyMatrix(NotifyBase):
         # Create a copy of our rooms to join and message
         rooms = list(self.rooms)
 
+        # Initialize our error tracking
+        has_error = False
+
         # Resolve DM user targets (@user) to room IDs
         for _user in self.users:
             dm_room_id = self._dm_room_find_or_create(_user)
@@ -775,9 +787,6 @@ class NotifyMatrix(NotifyBase):
                     _user,
                 )
                 has_error = True
-
-        # Initiaize our error tracking
-        has_error = False
 
         # E2EE setup (once per send call, not per room).
         # e2ee_capable means prerequisites are met; encryption is still
@@ -1182,6 +1191,51 @@ class NotifyMatrix(NotifyBase):
                 expires=self.default_cache_expiry_sec,
             )
 
+        return True
+
+    def _whoami(self):
+        """Resolve user_id, device_id, and home_server via GET /account/whoami.
+
+        Called when a raw access token is supplied (no login flow), so
+        the server never returned these identifiers directly.  Results
+        are cached in the persistent store for future calls.
+
+        Returns True on success, False otherwise.
+        """
+        ok, response, _ = self._fetch(
+            "/account/whoami", payload=None, method="GET"
+        )
+        if not (ok and isinstance(response, dict)):
+            return False
+
+        self.user_id = response.get("user_id") or self.user_id
+        self.device_id = response.get("device_id") or self.device_id
+
+        # Extract home_server from user_id (@localpart:homeserver) so that
+        # DM targets without an explicit homeserver resolve correctly.
+        if self.user_id and not self.home_server:
+            parts = self.user_id.split(":", 1)
+            if len(parts) == 2:
+                self.home_server = parts[1]
+
+        if self.user_id:
+            self.store.set(
+                "user_id",
+                self.user_id,
+                expires=self.default_cache_expiry_sec,
+            )
+        if self.device_id:
+            self.store.set(
+                "device_id",
+                self.device_id,
+                expires=self.default_cache_expiry_sec,
+            )
+        if self.home_server:
+            self.store.set(
+                "home_server",
+                self.home_server,
+                expires=self.default_cache_expiry_sec,
+            )
         return True
 
     def _logout(self):
@@ -1860,6 +1914,14 @@ class NotifyMatrix(NotifyBase):
         for uid, devices in resp.get("device_keys", {}).items():
             result[uid] = {}
             for dev_id, dev_info in devices.items():
+                if not verify_device_keys(dev_info, uid, dev_id):
+                    self.logger.debug(
+                        "Matrix E2EE: device key signature invalid "
+                        "for %s / %s; device skipped.",
+                        uid,
+                        dev_id,
+                    )
+                    continue
                 keys = dev_info.get("keys", {})
                 result[uid][dev_id] = {
                     "curve25519": keys.get("curve25519:{}".format(dev_id), ""),
@@ -1890,10 +1952,13 @@ class NotifyMatrix(NotifyBase):
         if not members:
             return True
 
-        # Build the claim request for all member devices
+        # Build the claim request for all member devices.
+        # "signed_curve25519" is the algorithm Matrix clients publish and
+        # servers are required to support; "curve25519" (unsigned) is
+        # deprecated and usually yields no keys on current servers.
         otk_request = {}
         for uid, devs in members.items():
-            otk_request[uid] = dict.fromkeys(devs, "curve25519")
+            otk_request[uid] = dict.fromkeys(devs, "signed_curve25519")
 
         postokay, otk_resp, _ = self._fetch(
             "/keys/claim",
@@ -1929,15 +1994,30 @@ class NotifyMatrix(NotifyBase):
                 if not their_ik:
                     continue
 
-                # Locate the OTK for this device
+                # Locate and verify the OTK for this device.
+                # Servers return signed_curve25519 keys (the algorithm we
+                # requested) as {"key": ..., "signatures": ...} dicts.
+                # The device Ed25519 key (already signature-verified above
+                # in _e2ee_room_members) is used to authenticate each OTK.
                 their_otk = None
                 otk_entry = otk_keys.get(uid, {}).get(dev_id, {})
                 if isinstance(otk_entry, dict):
                     for k, v in otk_entry.items():
-                        if not k.startswith("curve25519:"):
+                        if not k.startswith("signed_curve25519:"):
                             continue
                         if isinstance(v, dict):
-                            their_otk = v.get("key")
+                            ed25519_pub = dev_info.get("ed25519", "")
+                            if not ed25519_pub or not verify_signed_otk(
+                                v, uid, dev_id, ed25519_pub
+                            ):
+                                self.logger.debug(
+                                    "Matrix E2EE: OTK signature "
+                                    "invalid for %s / %s; skipped.",
+                                    uid,
+                                    dev_id,
+                                )
+                            else:
+                                their_otk = v.get("key")
                         elif isinstance(v, str):
                             their_otk = v
                         break
@@ -2000,7 +2080,7 @@ class NotifyMatrix(NotifyBase):
                 "Matrix E2EE: failed to deliver room key to devices in %s.",
                 room_id,
             )
-            # Not fatal -- the key may still have reached some devices
+            return False
 
         return True
 

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -2109,7 +2109,23 @@ class NotifyMatrix(NotifyBase):
             return False
 
         if not members:
+            self.logger.trace(
+                "Matrix E2EE: no room members found for %s; "
+                "skipping key share.",
+                room_id,
+            )
             return True
+
+        # Count total device slots being requested (for diagnostics)
+        total_devices = sum(len(devs) for devs in members.values())
+        self.logger.debug(
+            "Matrix E2EE: sharing session %s for room %s with "
+            "%d member(s) / %d device(s).",
+            session.session_id[:12],
+            room_id,
+            len(members),
+            total_devices,
+        )
 
         # Build the claim request for all member devices.
         # "signed_curve25519" is the algorithm Matrix clients publish and
@@ -2133,6 +2149,17 @@ class NotifyMatrix(NotifyBase):
             else {}
         )
 
+        # Log failures from the claim response
+        # spec: server populates failures{} with unreachable servers
+        failures = (
+            otk_resp.get("failures", {}) if isinstance(otk_resp, dict) else {}
+        )
+        if failures:
+            self.logger.debug(
+                "Matrix E2EE: /keys/claim reported failures for server(s): %s",
+                list(failures.keys()),
+            )
+
         # Build to-device message payload
         to_device_msgs = {}
         room_key_content = {
@@ -2141,72 +2168,152 @@ class NotifyMatrix(NotifyBase):
             "session_id": session.session_id,
             "session_key": session.session_key(),
         }
+        self.logger.trace(
+            "Matrix E2EE: room_key session_id=%s counter=%d",
+            session.session_id[:12],
+            session._counter,
+        )
+
+        skipped_own = 0
+        skipped_no_ik = 0
+        skipped_no_otk = 0
+        skipped_otk_invalid = 0
+        skipped_olm_fail = 0
+        built_count = 0
 
         for uid, devices in members.items():
             to_device_msgs[uid] = {}
             for dev_id, dev_info in devices.items():
                 # Skip our own device to avoid self-Olm-session setup
                 if uid == self.user_id and dev_id == self.device_id:
+                    skipped_own += 1
+                    self.logger.trace(
+                        "Matrix E2EE: skipping own device %s / %s.",
+                        uid,
+                        dev_id,
+                    )
                     continue
 
                 their_ik = dev_info.get("curve25519", "")
                 if not their_ik:
+                    skipped_no_ik += 1
+                    self.logger.trace(
+                        "Matrix E2EE: no curve25519 key for "
+                        "%s / %s; device skipped.",
+                        uid,
+                        dev_id,
+                    )
                     continue
 
                 # Locate and verify the OTK for this device.
                 # Servers return signed_curve25519 keys (the algorithm we
                 # requested) as {"key": ..., "signatures": ...} dicts.
-                # Locate and verify the OTK for this device.
                 # signed_curve25519 OTKs are always KeyObjects
                 # {"key": ..., "signatures": ...}; plain-string values
                 # are not valid for this algorithm and are rejected.
                 their_otk = None
                 otk_entry = otk_keys.get(uid, {}).get(dev_id, {})
+                self.logger.trace(
+                    "Matrix E2EE: OTK entry for %s / %s: keys=%s",
+                    uid,
+                    dev_id,
+                    list(otk_entry.keys())
+                    if isinstance(otk_entry, dict)
+                    else repr(type(otk_entry)),
+                )
                 if isinstance(otk_entry, dict):
                     for k, v in otk_entry.items():
                         if not k.startswith("signed_curve25519:"):
-                            continue
-                        if not isinstance(v, dict):
-                            self.logger.debug(
-                                "Matrix E2EE: OTK for %s / %s is "
-                                "not a KeyObject; skipped.",
+                            self.logger.trace(
+                                "Matrix E2EE: OTK key %r for %s / %s "
+                                "is not signed_curve25519; skipped.",
+                                k,
                                 uid,
                                 dev_id,
+                            )
+                            continue
+                        if not isinstance(v, dict):
+                            self.logger.trace(
+                                "Matrix E2EE: OTK for %s / %s is "
+                                "not a KeyObject (got %s); skipped.",
+                                uid,
+                                dev_id,
+                                type(v).__name__,
                             )
                             break
                         ed25519_pub = dev_info.get("ed25519", "")
                         if not ed25519_pub or not verify_signed_otk(
                             v, uid, dev_id, ed25519_pub
                         ):
+                            skipped_otk_invalid += 1
+                            # Keep at debug -- invalid signature is unexpected
+                            # and worth surfacing at -vv.
                             self.logger.debug(
                                 "Matrix E2EE: OTK signature "
-                                "invalid for %s / %s; skipped.",
+                                "invalid for %s / %s (ed25519_pub=%s); "
+                                "skipped.",
                                 uid,
                                 dev_id,
+                                ed25519_pub[:12] if ed25519_pub else "(empty)",
                             )
                         else:
                             their_otk = v.get("key")
+                            self.logger.trace(
+                                "Matrix E2EE: OTK accepted for "
+                                "%s / %s (key_id=%s).",
+                                uid,
+                                dev_id,
+                                k,
+                            )
                         break
+                else:
+                    self.logger.trace(
+                        "Matrix E2EE: no OTK dict for %s / %s "
+                        "(type=%s); device skipped.",
+                        uid,
+                        dev_id,
+                        type(otk_entry).__name__,
+                    )
 
                 if not their_otk:
+                    skipped_no_otk += 1
+                    self.logger.trace(
+                        "Matrix E2EE: no usable OTK for %s / %s; "
+                        "device skipped.",
+                        uid,
+                        dev_id,
+                    )
                     continue
 
                 try:
                     olm_session = self._e2ee_account.create_outbound_session(
                         their_ik, their_otk
                     )
-                except Exception:
+                except Exception as exc:
+                    skipped_olm_fail += 1
+                    # Keep at debug -- Olm session failure is unexpected.
                     self.logger.debug(
                         "Matrix E2EE: failed to build Olm session "
-                        "for %s / %s.",
+                        "for %s / %s: %s",
                         uid,
                         dev_id,
+                        exc,
                     )
                     continue
 
-                sender_device_keys = self._e2ee_account.device_keys_payload(
-                    self.user_id, self.device_id
-                )
+                # Build the m.room_key inner plaintext per Matrix spec:
+                #   https://spec.matrix.org/v1.11/client-server-api/#mroomkey
+                #
+                # Required fields only; non-standard extension fields
+                # (sender_device_keys, org.matrix.msc4147.device_keys) have
+                # been removed because they:
+                #   - Add ~930 bytes to an otherwise ~400-byte payload,
+                #     bloating the Olm ciphertext from ~400B to ~1640B.
+                #   - Are not part of the spec and may confuse strict
+                #     implementations (Element/matrix-sdk-crypto warns on
+                #     unknown fields in to-device events in some builds).
+                #   - Contain unsigned device-key material that recipients
+                #     should instead fetch via /keys/query for authenticity.
                 inner = dumps(
                     {
                         "type": "m.room_key",
@@ -2217,22 +2324,47 @@ class NotifyMatrix(NotifyBase):
                             "ed25519": dev_info.get("ed25519", "")
                         },
                         "keys": {"ed25519": self._e2ee_account.signing_key},
-                        "sender_device_keys": sender_device_keys,
-                        "org.matrix.msc4147.device_keys": sender_device_keys,
                     }
                 )
                 ciphertext = olm_session.encrypt(inner)
+                built_count += 1
+
+                self.logger.trace(
+                    "Matrix E2EE: Olm-encrypted room key for "
+                    "%s / %s (ciphertext type=%d, inner_len=%d).",
+                    uid,
+                    dev_id,
+                    ciphertext.get("type", -1),
+                    len(inner),
+                )
 
                 to_device_msgs[uid][dev_id] = {
                     "algorithm": "m.olm.v1.curve25519-aes-sha2",
                     "ciphertext": {their_ik: ciphertext},
-                    "recipient_key": their_ik,
                     "sender_key": self._e2ee_account.identity_key,
-                    "org.matrix.msgid": str(uuid.uuid4()),
                 }
+
+        self.logger.debug(
+            "Matrix E2EE: key-share summary for room %s: "
+            "built=%d skipped_own=%d skipped_no_ik=%d "
+            "skipped_no_otk=%d skipped_otk_invalid=%d "
+            "skipped_olm_fail=%d",
+            room_id,
+            built_count,
+            skipped_own,
+            skipped_no_ik,
+            skipped_no_otk,
+            skipped_otk_invalid,
+            skipped_olm_fail,
+        )
 
         # Only send if at least one device message was built
         if not any(v for v in to_device_msgs.values()):
+            self.logger.trace(
+                "Matrix E2EE: no to-device messages built for "
+                "room %s; nothing to send.",
+                room_id,
+            )
             return True
 
         self.transaction_id += 1
@@ -2254,6 +2386,13 @@ class NotifyMatrix(NotifyBase):
             )
             return False
 
+        self.logger.debug(
+            "Matrix E2EE: room key delivered to %d device(s) in %s "
+            "(txnId=%d).",
+            built_count,
+            room_id,
+            self.transaction_id,
+        )
         return True
 
     def _e2ee_send_to_room(self, room_id, body, title, notify_type):
@@ -2265,18 +2404,40 @@ class NotifyMatrix(NotifyBase):
         """
         session = self._e2ee_get_megolm(room_id)
 
+        self.logger.trace(
+            "Matrix E2EE: using MegOLM session %s counter=%d for %s.",
+            session.session_id[:12],
+            session._counter,
+            room_id,
+        )
+
         # Share the room key unless this exact MegOLM session was already
         # announced. Older stores may contain a legacy boolean flag; treat it
         # as stale so the next send re-shares the key and repairs recipients
         # that never received the original m.room_key.
         shared_flag = "e2ee_key_shared_{}".format(room_id)
-        if self.store.get(shared_flag) != session.session_id:
+        cached_shared = self.store.get(shared_flag)
+        if cached_shared != session.session_id:
+            self.logger.trace(
+                "Matrix E2EE: session key not yet shared "
+                "(cached=%r current=%r); sharing now.",
+                cached_shared[:12]
+                if isinstance(cached_shared, str)
+                else cached_shared,
+                session.session_id[:12],
+            )
             if not self._e2ee_share_room_key(room_id, session):
                 return False
             self.store.set(
                 shared_flag,
                 session.session_id,
                 expires=self.default_cache_expiry_sec,
+            )
+        else:
+            self.logger.trace(
+                "Matrix E2EE: session key already shared for "
+                "session %s; skipping key share.",
+                session.session_id[:12],
             )
 
         # Build the inner plaintext event
@@ -2328,6 +2489,15 @@ class NotifyMatrix(NotifyBase):
 
         ciphertext = session.encrypt(inner_event)
         self._e2ee_save_megolm(room_id, session)
+
+        self.logger.trace(
+            "Matrix E2EE: MegOLM ciphertext produced for room %s "
+            "(session_id=%s counter_before_encrypt=%d).",
+            room_id,
+            session.session_id[:12],
+            # _advance() already ran; counter is now N+1 after encrypt
+            session._counter - 1,
+        )
 
         path = "/rooms/{}/send/m.room.encrypted/{}".format(
             NotifyMatrix.quote(room_id), self.transaction_id

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -2304,7 +2304,7 @@ class NotifyMatrix(NotifyBase):
         # Update the m.direct account-data mapping so other clients
         # recognise this room as a DM conversation.
         if self.user_id:
-            mdirect[user_id] = mdirect.get(user_id, []) + [room_id]
+            mdirect[user_id] = [*mdirect.get(user_id, []), room_id]
             self._fetch(
                 "/user/{}/account_data/m.direct".format(
                     NotifyMatrix.quote(self.user_id)

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -2514,12 +2514,13 @@ class NotifyMatrix(NotifyBase):
             )
             return True
 
-        self.transaction_id += 1
-        self.store.set(
-            "transaction_id",
-            self.transaction_id,
-            expires=self.default_cache_expiry_sec,
-        )
+        if self.access_token != self.password:
+            self.transaction_id += 1
+            self.store.set(
+                "transaction_id",
+                self.transaction_id,
+                expires=self.default_cache_expiry_sec,
+            )
         path = "/sendToDevice/m.room.encrypted/{}".format(self.transaction_id)
         postokay, _, _ = self._fetch(
             path,
@@ -2535,7 +2536,7 @@ class NotifyMatrix(NotifyBase):
 
         self.logger.debug(
             "Matrix E2EE: room key delivered to %d device(s) in %s "
-            "(txnId=%d).",
+            "(txnId=%s).",
             built_count,
             room_id,
             self.transaction_id,

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -2471,7 +2471,9 @@ class NotifyMatrix(NotifyBase):
         ):
             return
 
-        self._logout()
+        # Best-effort cleanup only
+        with contextlib.suppress(Exception):
+            self._logout()
 
     @property
     def url_identifier(self):

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -2346,6 +2346,7 @@ class NotifyMatrix(NotifyBase):
         """
         return (
             self.secure_protocol if self.secure else self.protocol,
+            self.mode,
             (
                 self.host
                 if self.mode != MatrixWebhookMode.T2BOT
@@ -2355,6 +2356,14 @@ class NotifyMatrix(NotifyBase):
             self.user if self.mode != MatrixWebhookMode.T2BOT else None,
             self.password if self.mode != MatrixWebhookMode.T2BOT else None,
         )
+
+    @staticmethod
+    def runtime_deps():
+        """Return runtime dependency package names.
+
+        E2EE support requires the `cryptography` package.
+        """
+        return ("cryptography",)
 
     def url(self, privacy=False, *args, **kwargs):
         """Returns the URL built dynamically based on specified

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -99,6 +99,13 @@ IS_ROOM_ID = re.compile(
     re.I,
 )
 
+# Matrix User ID (for DM targets); must start with @
+IS_USER = re.compile(
+    r"^\s*(@|%40)(?P<user>[A-Za-z0-9._=+/-]+)((:|%3A)"
+    r"(?P<home_server>[A-Za-z0-9.-]+))?\s*$",
+    re.I,
+)
+
 
 # Matrix is_image check
 IS_IMAGE = re.compile(r"^image/.*", re.I)
@@ -353,8 +360,15 @@ class NotifyMatrix(NotifyBase):
         """Initialize Matrix Object."""
         super().__init__(**kwargs)
 
-        # Prepare a list of rooms to connect and notify
-        self.rooms = parse_list(targets)
+        # Prepare a list of rooms to connect and notify; separate
+        # @user DM targets from room identifiers.
+        self.rooms = []
+        self.users = []
+        for _target in parse_list(targets):
+            if IS_USER.match(_target):
+                self.users.append(_target)
+            else:
+                self.rooms.append(_target)
 
         # our home server gets populated after a login/registration
         self.home_server = None
@@ -736,7 +750,7 @@ class NotifyMatrix(NotifyBase):
             # We need to register
             return False
 
-        if len(self.rooms) == 0:
+        if len(self.rooms) == 0 and not self.users:
             # Attempt to retrieve a list of already joined channels
             self.rooms = self._joined_rooms()
 
@@ -749,6 +763,18 @@ class NotifyMatrix(NotifyBase):
 
         # Create a copy of our rooms to join and message
         rooms = list(self.rooms)
+
+        # Resolve DM user targets (@user) to room IDs
+        for _user in self.users:
+            dm_room_id = self._dm_room_find_or_create(_user)
+            if dm_room_id:
+                rooms.append(dm_room_id)
+            else:
+                self.logger.warning(
+                    "Could not find or create a DM room for Matrix user %s.",
+                    _user,
+                )
+                has_error = True
 
         # Initiaize our error tracking
         has_error = False
@@ -2196,6 +2222,99 @@ class NotifyMatrix(NotifyBase):
             )
         return postokay
 
+    def _dm_room_find_or_create(self, user):
+        """Resolve *user* (``@localpart`` or ``@localpart:homeserver``)
+        to a Matrix room ID suitable for direct messaging.
+
+        Lookup order:
+        1. Persistent-store cache.
+        2. ``GET /user/{selfId}/account_data/m.direct`` -- check whether
+           an existing DM room already exists for this user.
+        3. ``POST /createRoom`` with ``is_direct=true`` and an invite for
+           the target user.  The ``m.direct`` account-data entry is then
+           updated so other clients also recognise the room as a DM.
+
+        Returns the room ID string on success, or ``None`` on failure.
+        """
+        result = IS_USER.match(user)
+        if not result:
+            self.logger.warning("Matrix DM: invalid user identifier %r.", user)
+            return None
+
+        home_server = (
+            result.group("home_server")
+            if result.group("home_server")
+            else self.home_server
+        )
+        user_id = "@{}:{}".format(result.group("user"), home_server)
+
+        cache_key = "dm_room_{}".format(user_id)
+        cached = self.store.get(cache_key)
+        if cached:
+            return cached
+
+        # Fetch existing m.direct mapping from the server
+        if self.user_id:
+            ok, mdirect, _ = self._fetch(
+                "/user/{}/account_data/m.direct".format(
+                    NotifyMatrix.quote(self.user_id)
+                ),
+                method="GET",
+            )
+            if ok and isinstance(mdirect, dict):
+                rooms = mdirect.get(user_id, [])
+                if rooms:
+                    room_id = rooms[0]
+                    self.store.set(
+                        cache_key,
+                        room_id,
+                        expires=self.default_cache_expiry_sec,
+                    )
+                    return room_id
+            else:
+                mdirect = {}
+        else:
+            mdirect = {}
+
+        # No existing DM room -- create one
+        ok, response, _ = self._fetch(
+            "/createRoom",
+            payload={
+                "is_direct": True,
+                "preset": "trusted_private_chat",
+                "invite": [user_id],
+            },
+        )
+        if not ok or not isinstance(response, dict):
+            self.logger.warning(
+                "Matrix DM: failed to create room for %s.", user_id
+            )
+            return None
+
+        room_id = response.get("room_id")
+        if not room_id:
+            return None
+
+        self.store.set(
+            cache_key,
+            room_id,
+            expires=self.default_cache_expiry_sec,
+        )
+
+        # Update the m.direct account-data mapping so other clients
+        # recognise this room as a DM conversation.
+        if self.user_id:
+            mdirect[user_id] = mdirect.get(user_id, []) + [room_id]
+            self._fetch(
+                "/user/{}/account_data/m.direct".format(
+                    NotifyMatrix.quote(self.user_id)
+                ),
+                payload=mdirect,
+                method="PUT",
+            )
+
+        return room_id
+
     # ---------------------------------------------------------------
     # Destructor / URL / parse
     # ---------------------------------------------------------------
@@ -2289,14 +2408,14 @@ class NotifyMatrix(NotifyBase):
                 else self.pprint(self.access_token, privacy, safe="")
             ),
             port=("" if not self.port else f":{self.port}"),
-            rooms=NotifyMatrix.quote("/".join(self.rooms)),
+            rooms=NotifyMatrix.quote("/".join(self.rooms + self.users)),
             params=NotifyMatrix.urlencode(params),
         )
 
     def __len__(self):
         """Returns the number of targets associated with this
         notification."""
-        targets = len(self.rooms)
+        targets = len(self.rooms) + len(self.users)
         return targets if targets > 0 else 1
 
     @staticmethod

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -500,6 +500,14 @@ class NotifyMatrix(NotifyBase):
             # Device ID assigned by server
             self.device_id = self.store.get("device_id")
 
+            # Older cache entries may have user_id/access_token persisted
+            # without home_server. Recover it from @user:homeserver so room
+            # aliases do not degrade into '#room:None'.
+            if not self.home_server and self.user_id:
+                parts = self.user_id.split(":", 1)
+                if len(parts) == 2:
+                    self.home_server = parts[1]
+
         # This gets incremented for each request made against the v3 API
         self.transaction_id = (
             0 if not self.access_token else self.store.get("transaction_id", 0)
@@ -756,8 +764,15 @@ class NotifyMatrix(NotifyBase):
         # login flow is skipped, so user_id and device_id are never returned
         # by the server.  Resolve them via /account/whoami so that E2EE key
         # upload and DM room lookup (m.direct) work correctly.
-        if not self.user and (not self.user_id or not self.device_id):
+        if (not self.user and (not self.user_id or not self.device_id)) or (
+            self.access_token and not self.home_server
+        ):
             self._whoami()
+
+        # Last-resort fallback: if home_server is still unknown, assume
+        # it matches the Matrix host we are connecting to.
+        if not self.home_server:
+            self.home_server = self.host
 
         if len(self.rooms) == 0 and not self.users:
             # Attempt to retrieve a list of already joined channels
@@ -1074,6 +1089,13 @@ class NotifyMatrix(NotifyBase):
         if self.password:
             payload["password"] = self.password
 
+        # Reuse a previously assigned device ID when available so Matrix
+        # keeps this notifier on a stable device identity across runs.
+        if self.device_id:
+            payload["device_id"] = self.device_id
+        else:
+            payload["initial_device_display_name"] = self.app_id
+
         # Register
         postokay, response, _ = self._fetch(
             "/register", payload=payload, params=params
@@ -1084,20 +1106,30 @@ class NotifyMatrix(NotifyBase):
 
         # Pull the response details
         self.access_token = response.get("access_token")
-        self.home_server = response.get("home_server")
         self.user_id = response.get("user_id")
         self.device_id = response.get("device_id")
+
+        # home_server may be absent in modern Matrix responses; derive
+        # from user_id when the server does not include it explicitly.
+        hs_from_response = response.get("home_server")
+        if hs_from_response:
+            self.home_server = hs_from_response
+        elif self.user_id and not self.home_server:
+            parts = self.user_id.split(":", 1)
+            if len(parts) == 2:
+                self.home_server = parts[1]
 
         self.store.set(
             "access_token",
             self.access_token,
             expires=self.default_cache_expiry_sec,
         )
-        self.store.set(
-            "home_server",
-            self.home_server,
-            expires=self.default_cache_expiry_sec,
-        )
+        if self.home_server:
+            self.store.set(
+                "home_server",
+                self.home_server,
+                expires=self.default_cache_expiry_sec,
+            )
         self.store.set(
             "user_id", self.user_id, expires=self.default_cache_expiry_sec
         )
@@ -1144,6 +1176,13 @@ class NotifyMatrix(NotifyBase):
                     "password": self.password,
                 }
 
+            # Reuse our last-known device ID when possible to avoid
+            # creating a brand-new Matrix device on every login.
+            if self.device_id:
+                payload["device_id"] = self.device_id
+            else:
+                payload["initial_device_display_name"] = self.app_id
+
         else:
             # It's not possible to register since we need these 2 values
             # to make the action possible.
@@ -1161,9 +1200,19 @@ class NotifyMatrix(NotifyBase):
 
         # Pull the response details
         self.access_token = response.get("access_token")
-        self.home_server = response.get("home_server")
         self.user_id = response.get("user_id")
         self.device_id = response.get("device_id")
+
+        # home_server was dropped from login responses in recent Matrix
+        # spec versions.  Only update if the server still returns it;
+        # otherwise derive it from user_id so room-alias resolution works.
+        hs_from_response = response.get("home_server")
+        if hs_from_response:
+            self.home_server = hs_from_response
+        elif self.user_id and not self.home_server:
+            parts = self.user_id.split(":", 1)
+            if len(parts) == 2:
+                self.home_server = parts[1]
 
         if not self.access_token:
             return False
@@ -1176,11 +1225,12 @@ class NotifyMatrix(NotifyBase):
             self.access_token,
             expires=self.default_cache_expiry_sec,
         )
-        self.store.set(
-            "home_server",
-            self.home_server,
-            expires=self.default_cache_expiry_sec,
-        )
+        if self.home_server:
+            self.store.set(
+                "home_server",
+                self.home_server,
+                expires=self.default_cache_expiry_sec,
+            )
         self.store.set(
             "user_id", self.user_id, expires=self.default_cache_expiry_sec
         )
@@ -1379,6 +1429,16 @@ class NotifyMatrix(NotifyBase):
             if not result.group("home_server")
             else result.group("home_server")
         )
+        if not home_server and self.user_id:
+            parts = self.user_id.split(":", 1)
+            if len(parts) == 2:
+                home_server = parts[1]
+        if not home_server:
+            self.logger.warning(
+                "Could not resolve a homeserver for Matrix room alias %s.",
+                room,
+            )
+            return None
 
         # tidy our room (alias) identifier
         room = "#{}:{}".format(result.group("room"), home_server)
@@ -1453,6 +1513,12 @@ class NotifyMatrix(NotifyBase):
             if result.group("home_server")
             else self.home_server
         )
+        if not home_server and self.user_id:
+            parts = self.user_id.split(":", 1)
+            if len(parts) == 2:
+                home_server = parts[1]
+        if not home_server:
+            return None
 
         # update our room details
         room = "#{}:{}".format(result.group("room"), home_server)
@@ -1562,6 +1628,12 @@ class NotifyMatrix(NotifyBase):
             if result.group("home_server")
             else self.home_server
         )
+        if not home_server and self.user_id:
+            parts = self.user_id.split(":", 1)
+            if len(parts) == 2:
+                home_server = parts[1]
+        if not home_server:
+            return None
 
         # update our room details
         room = "#{}:{}".format(result.group("room"), home_server)
@@ -1586,6 +1658,7 @@ class NotifyMatrix(NotifyBase):
         attachment=None,
         method="POST",
         url_override=None,
+        ok_status=None,
     ):
         """Wrapper to request.post() to manage it's response better and
         make the send() function cleaner and easier to maintain.
@@ -1595,6 +1668,11 @@ class NotifyMatrix(NotifyBase):
 
         The response is a dict when JSON is parseable, otherwise an empty
         dict. The status_code defaults to 500 on local failures.
+
+        *ok_status* is an optional collection of additional HTTP status codes
+        to treat as success (no warning logged).  Use it for calls where a
+        non-200 response is expected and meaningful, e.g. 404 on a state-event
+        probe that returns "not found" = "feature not enabled".
         """
 
         # Define our headers
@@ -1727,6 +1805,12 @@ class NotifyMatrix(NotifyBase):
 
                 elif r.status_code != requests.codes.ok:
                     # We had a problem
+                    if ok_status and r.status_code in ok_status:
+                        # Caller declared this status code acceptable
+                        # (e.g. 404 on a state-event probe).  Return
+                        # failure tuple silently -- no warning logged.
+                        return (False, response, status_code)
+
                     status_str = NotifyMatrix.http_response_code_lookup(
                         r.status_code, MATRIX_HTTP_ERROR_MAP
                     )
@@ -1803,6 +1887,9 @@ class NotifyMatrix(NotifyBase):
                 NotifyMatrix.quote(room_id)
             ),
             method="GET",
+            # 404 = no encryption state event = room is not encrypted;
+            # suppress the warning that _fetch would otherwise log.
+            ok_status={requests.codes.not_found},
         )
         result = ok and bool(response)
         self.store.set(
@@ -1838,6 +1925,23 @@ class NotifyMatrix(NotifyBase):
                     expires=self.default_cache_expiry_sec,
                 )
 
+        # Keys uploaded status must match the current Matrix device identity
+        # and the account keys we are about to use. This lets us recover from
+        # cached state where the homeserver assigned a different device_id or
+        # where the local E2EE account changed.
+        current_binding = (
+            "{}|{}|{}|{}".format(
+                self.user_id or "",
+                self.device_id or "",
+                self._e2ee_account.identity_key,
+                self._e2ee_account.signing_key,
+            )
+            if self._e2ee_account is not None
+            else ""
+        )
+        if self.store.get("e2ee_device_binding") != current_binding:
+            self.store.clear("e2ee_keys_uploaded")
+
         if not self.store.get("e2ee_keys_uploaded"):
             return self._e2ee_upload_keys()
 
@@ -1855,16 +1959,42 @@ class NotifyMatrix(NotifyBase):
         payload = {
             "device_keys": self._e2ee_account.device_keys_payload(
                 self.user_id, self.device_id
-            )
+            ),
+            "one_time_keys": self._e2ee_account.one_time_keys_payload(
+                self.user_id, self.device_id
+            ),
+            "fallback_keys": self._e2ee_account.fallback_keys_payload(
+                self.user_id, self.device_id
+            ),
         }
         postokay, _, _ = self._fetch("/keys/upload", payload=payload)
         if not postokay:
             self.logger.warning("Matrix E2EE: device key upload failed.")
             return False
 
+        # Mirror stable python-olm account behaviour: once uploaded, the
+        # current one-time key batch is considered published and a future
+        # upload should generate a fresh set.
+        self._e2ee_account.mark_keys_as_published()
+        self.store.set(
+            "e2ee_account",
+            self._e2ee_account.to_dict(),
+            expires=self.default_cache_expiry_sec,
+        )
+
         self.store.set(
             "e2ee_keys_uploaded",
             True,
+            expires=self.default_cache_expiry_sec,
+        )
+        self.store.set(
+            "e2ee_device_binding",
+            "{}|{}|{}|{}".format(
+                self.user_id,
+                self.device_id,
+                self._e2ee_account.identity_key,
+                self._e2ee_account.signing_key,
+            ),
             expires=self.default_cache_expiry_sec,
         )
         self.logger.debug(
@@ -1885,9 +2015,14 @@ class NotifyMatrix(NotifyBase):
         session_data = self.store.get(store_key)
 
         if session_data:
-            session = MatrixMegOlmSession.from_dict(session_data)
-            if not session.should_rotate():
-                return session
+            try:
+                session = MatrixMegOlmSession.from_dict(session_data)
+                if not session.should_rotate():
+                    return session
+            except Exception:
+                # Cached session is unreadable or from an older incompatible
+                # format; force creation of a fresh one below.
+                pass
 
         # New or rotated session
         session = MatrixMegOlmSession()
@@ -2069,6 +2204,9 @@ class NotifyMatrix(NotifyBase):
                     )
                     continue
 
+                sender_device_keys = self._e2ee_account.device_keys_payload(
+                    self.user_id, self.device_id
+                )
                 inner = dumps(
                     {
                         "type": "m.room_key",
@@ -2079,7 +2217,8 @@ class NotifyMatrix(NotifyBase):
                             "ed25519": dev_info.get("ed25519", "")
                         },
                         "keys": {"ed25519": self._e2ee_account.signing_key},
-                        "sender_device": self.device_id,
+                        "sender_device_keys": sender_device_keys,
+                        "org.matrix.msc4147.device_keys": sender_device_keys,
                     }
                 )
                 ciphertext = olm_session.encrypt(inner)
@@ -2087,7 +2226,9 @@ class NotifyMatrix(NotifyBase):
                 to_device_msgs[uid][dev_id] = {
                     "algorithm": "m.olm.v1.curve25519-aes-sha2",
                     "ciphertext": {their_ik: ciphertext},
+                    "recipient_key": their_ik,
                     "sender_key": self._e2ee_account.identity_key,
+                    "org.matrix.msgid": str(uuid.uuid4()),
                 }
 
         # Only send if at least one device message was built
@@ -2124,14 +2265,17 @@ class NotifyMatrix(NotifyBase):
         """
         session = self._e2ee_get_megolm(room_id)
 
-        # Share room key if this session has not been announced yet
+        # Share the room key unless this exact MegOLM session was already
+        # announced. Older stores may contain a legacy boolean flag; treat it
+        # as stale so the next send re-shares the key and repairs recipients
+        # that never received the original m.room_key.
         shared_flag = "e2ee_key_shared_{}".format(room_id)
-        if not self.store.get(shared_flag):
+        if self.store.get(shared_flag) != session.session_id:
             if not self._e2ee_share_room_key(room_id, session):
                 return False
             self.store.set(
                 shared_flag,
-                True,
+                session.session_id,
                 expires=self.default_cache_expiry_sec,
             )
 

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -1997,29 +1997,36 @@ class NotifyMatrix(NotifyBase):
                 # Locate and verify the OTK for this device.
                 # Servers return signed_curve25519 keys (the algorithm we
                 # requested) as {"key": ..., "signatures": ...} dicts.
-                # The device Ed25519 key (already signature-verified above
-                # in _e2ee_room_members) is used to authenticate each OTK.
+                # Locate and verify the OTK for this device.
+                # signed_curve25519 OTKs are always KeyObjects
+                # {"key": ..., "signatures": ...}; plain-string values
+                # are not valid for this algorithm and are rejected.
                 their_otk = None
                 otk_entry = otk_keys.get(uid, {}).get(dev_id, {})
                 if isinstance(otk_entry, dict):
                     for k, v in otk_entry.items():
                         if not k.startswith("signed_curve25519:"):
                             continue
-                        if isinstance(v, dict):
-                            ed25519_pub = dev_info.get("ed25519", "")
-                            if not ed25519_pub or not verify_signed_otk(
-                                v, uid, dev_id, ed25519_pub
-                            ):
-                                self.logger.debug(
-                                    "Matrix E2EE: OTK signature "
-                                    "invalid for %s / %s; skipped.",
-                                    uid,
-                                    dev_id,
-                                )
-                            else:
-                                their_otk = v.get("key")
-                        elif isinstance(v, str):
-                            their_otk = v
+                        if not isinstance(v, dict):
+                            self.logger.debug(
+                                "Matrix E2EE: OTK for %s / %s is "
+                                "not a KeyObject; skipped.",
+                                uid,
+                                dev_id,
+                            )
+                            break
+                        ed25519_pub = dev_info.get("ed25519", "")
+                        if not ed25519_pub or not verify_signed_otk(
+                            v, uid, dev_id, ed25519_pub
+                        ):
+                            self.logger.debug(
+                                "Matrix E2EE: OTK signature "
+                                "invalid for %s / %s; skipped.",
+                                uid,
+                                dev_id,
+                            )
+                        else:
+                            their_otk = v.get("key")
                         break
 
                 if not their_otk:

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -2273,13 +2273,21 @@ class NotifyMatrix(NotifyBase):
 
         # Build the inner plaintext attachment event
         is_image = IS_IMAGE.match(attachment.mimetype)
+        content = {
+            "msgtype": "m.image" if is_image else "m.file",
+            "body": attachment.name or "file",
+            "file": file_info,
+            "info": {
+                "mimetype": attachment.mimetype,
+                "size": len(attachment),
+            },
+        }
+        if not is_image:
+            content["filename"] = attachment.name or "file"
+
         inner_event = {
             "type": "m.room.message",
-            "content": {
-                "msgtype": "m.image" if is_image else "m.file",
-                "body": attachment.name or "file",
-                "file": file_info,
-            },
+            "content": content,
             "room_id": room_id,
         }
 

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -760,13 +760,17 @@ class NotifyMatrix(NotifyBase):
             # We need to register
             return False
 
-        # When authenticating with a raw access token (no username) the
-        # login flow is skipped, so user_id and device_id are never returned
-        # by the server.  Resolve them via /account/whoami so that E2EE key
-        # upload and DM room lookup (m.direct) work correctly.
-        if (not self.user and (not self.user_id or not self.device_id)) or (
-            self.access_token and not self.home_server
-        ):
+        # Resolve user_id (and device_id / home_server as a side-effect) via
+        # /whoami whenever user_id is still absent after login/token setup.
+        # This covers all paths where the server does not return user_id:
+        #   - raw access-token auth (no /login flow at all)
+        #   - username + ?token= (password treated as token, not a login)
+        #   - servers that omit optional /login response fields
+        # Without user_id the m.direct lookup is skipped and
+        # each send creates a fresh orphan DM room instead of reusing the
+        # existing one.  home_server is recovered from user_id inside
+        # _whoami(); the fallback at handles any remaining gap.
+        if not self.user_id:
             self._whoami()
 
         # Last-resort fallback: if home_server is still unknown, assume

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -1468,6 +1468,19 @@ class NotifyMatrix(NotifyBase):
             "preset": "trusted_private_chat",
         }
 
+        # When E2EE is requested, enable encryption at room-creation time so
+        # that the room is encrypted from its very first message.  This only
+        # applies when Apprise is the one creating the room; pre-existing
+        # rooms keep whatever encryption state the server already has.
+        if self.e2ee and self.secure and MATRIX_E2EE_SUPPORT:
+            payload["initial_state"] = [
+                {
+                    "type": "m.room.encryption",
+                    "state_key": "",
+                    "content": {"algorithm": "m.megolm.v1.aes-sha2"},
+                }
+            ]
+
         postokay, response, _ = self._fetch("/createRoom", payload=payload)
         if not postokay:
             # Failed to create channel
@@ -1480,16 +1493,27 @@ class NotifyMatrix(NotifyBase):
                 return self._room_id(room)
             return None
 
+        room_id = response.get("room_id")
+
         # Cache our entry for fast access later
         self.store.set(
             response.get("room_alias"),
             {
-                "id": response.get("room_id"),
+                "id": room_id,
                 "home_server": home_server,
             },
         )
 
-        return response.get("room_id")
+        # Pre-seed the room encryption cache so _e2ee_room_encrypted() does
+        # not issue a redundant GET -- we just set the encryption state.
+        if room_id and self.e2ee and self.secure and MATRIX_E2EE_SUPPORT:
+            self.store.set(
+                "e2ee_room_enc_{}".format(room_id),
+                True,
+                expires=self.default_cache_expiry_sec,
+            )
+
+        return room_id
 
     def _joined_rooms(self):
         """Returns a list of the current rooms the logged in user is a
@@ -2370,14 +2394,23 @@ class NotifyMatrix(NotifyBase):
                     return room_id
 
         # No existing DM room -- create one
-        ok, response, _ = self._fetch(
-            "/createRoom",
-            payload={
-                "is_direct": True,
-                "preset": "trusted_private_chat",
-                "invite": [user_id],
-            },
-        )
+        dm_payload = {
+            "is_direct": True,
+            "preset": "trusted_private_chat",
+            "invite": [user_id],
+        }
+
+        # When E2EE is requested, enable encryption at room-creation time.
+        if self.e2ee and self.secure and MATRIX_E2EE_SUPPORT:
+            dm_payload["initial_state"] = [
+                {
+                    "type": "m.room.encryption",
+                    "state_key": "",
+                    "content": {"algorithm": "m.megolm.v1.aes-sha2"},
+                }
+            ]
+
+        ok, response, _ = self._fetch("/createRoom", payload=dm_payload)
         if not ok or not isinstance(response, dict):
             self.logger.warning(
                 "Matrix DM: failed to create room for %s.", user_id
@@ -2393,6 +2426,14 @@ class NotifyMatrix(NotifyBase):
             room_id,
             expires=self.default_cache_expiry_sec,
         )
+
+        # Pre-seed the room encryption cache.
+        if self.e2ee and self.secure and MATRIX_E2EE_SUPPORT:
+            self.store.set(
+                "e2ee_room_enc_{}".format(room_id),
+                True,
+                expires=self.default_cache_expiry_sec,
+            )
 
         # Update the m.direct account-data mapping so other clients
         # recognise this room as a DM conversation.

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -2575,6 +2575,16 @@ class NotifyMatrix(NotifyBase):
         )
         upload_url = base + media_path + "/upload"
 
+        self.logger.debug(
+            "Matrix E2EE: uploading encrypted attachment to %s "
+            "(name=%s size=%d iv=%s sha256=%s).",
+            upload_url,
+            attachment.name or "file",
+            len(ciphertext),
+            file_info.get("iv", "?"),
+            file_info.get("hashes", {}).get("sha256", "?"),
+        )
+
         self.throttle()
         try:
             r = requests.post(
@@ -2597,6 +2607,12 @@ class NotifyMatrix(NotifyBase):
         except Exception:
             upload_resp = {}
 
+        self.logger.debug(
+            "Matrix E2EE: upload response HTTP %d body=%r.",
+            r.status_code,
+            r.content[:200],
+        )
+
         if r.status_code != requests.codes.ok or not upload_resp.get(
             "content_uri"
         ):
@@ -2608,6 +2624,10 @@ class NotifyMatrix(NotifyBase):
             return False
 
         file_info["url"] = upload_resp["content_uri"]
+        self.logger.debug(
+            "Matrix E2EE: attachment content_uri=%s.",
+            upload_resp["content_uri"],
+        )
 
         # Build the inner plaintext attachment event
         is_image = IS_IMAGE.match(attachment.mimetype)

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -60,7 +60,12 @@ from ...utils.parse import (
     validate_regex,
 )
 from ..base import NotifyBase
-from .e2ee import MATRIX_E2EE_SUPPORT, MatrixMegOlmSession, MatrixOlmAccount
+from .e2ee import (
+    MATRIX_E2EE_SUPPORT,
+    MatrixMegOlmSession,
+    MatrixOlmAccount,
+    encrypt_attachment,
+)
 
 # Define default path
 MATRIX_V1_WEBHOOK_PATH = "/api/v1/matrix/hook"
@@ -760,15 +765,11 @@ class NotifyMatrix(NotifyBase):
                     "messages will be sent unencrypted."
                 )
 
-        # Prepare attachments once.  They are consumed by unencrypted rooms;
-        # E2EE rooms skip attachment delivery (media encryption is not yet
-        # supported) but other rooms in the same send call still receive them.
+        # Plaintext attachment payloads for unencrypted rooms.
+        # Lazy-initialized on the first unencrypted room so that purely
+        # E2EE setups never upload attachments in plaintext.
         attachments = None
-        if attach and self.attachment_support:
-            attachments = self._send_attachments(attach)
-            if attachments is False:
-                # take an early exit
-                return False
+        attachments_ready = False
 
         while len(rooms) > 0:
             # Get our room
@@ -785,20 +786,34 @@ class NotifyMatrix(NotifyBase):
                 continue
 
             if e2ee_capable and self._e2ee_room_encrypted(room_id):
-                # Room requires E2EE -- warn if attachments exist
-                if attach and self.attachment_support:
-                    self.logger.warning(
-                        "Matrix E2EE attachment encryption is not yet "
-                        "supported; attachments will be skipped."
-                    )
-                # E2EE path: encrypt and send as m.room.encrypted
+                # E2EE path: encrypt message and any attachments
                 if not self._e2ee_send_to_room(
                     room_id, body, title, notify_type
                 ):
                     has_error = True
+                    continue
+
+                if attach and self.attachment_support:
+                    session = self._e2ee_get_megolm(room_id)
+                    for attachment in attach:
+                        if not attachment:
+                            has_error = True
+                            break
+                        if not self._e2ee_send_attachment(
+                            attachment, room_id, session
+                        ):
+                            has_error = True
                 continue
 
             # --- Unencrypted path (existing behaviour) ---
+
+            # Upload attachments once; reuse content_uris for every
+            # subsequent unencrypted room in this send call.
+            if attach and self.attachment_support and not attachments_ready:
+                attachments = self._send_attachments(attach)
+                attachments_ready = True
+                if attachments is False:
+                    return False
 
             # Acquire our image url if we're configured to do so
             image_url = (
@@ -2056,6 +2071,129 @@ class NotifyMatrix(NotifyBase):
                 expires=self.default_cache_expiry_sec,
             )
 
+        return postokay
+
+    def _e2ee_send_attachment(self, attachment, room_id, session):
+        """Encrypt *attachment* and deliver it to *room_id* via MegOLM.
+
+        Steps:
+        1. Read the file into memory and encrypt with AES-256-CTR.
+        2. Upload the ciphertext to the media server (content_uri).
+        3. Build an ``m.room.message`` inner event whose ``file`` field
+           carries the EncryptedFile metadata (key + iv + sha256).
+        4. Encrypt the inner event with MegOLM and PUT to the room.
+
+        Returns ``True`` on success, ``False`` on any failure.
+        """
+        # Read file bytes
+        try:
+            with open(attachment.path, "rb") as fh:
+                file_data = fh.read()
+        except OSError as e:
+            self.logger.warning(
+                "Matrix E2EE: could not read attachment {}.".format(
+                    attachment.name or "file"
+                )
+            )
+            self.logger.debug(f"I/O Exception: {e!s}")
+            return False
+
+        # Encrypt locally with AES-256-CTR
+        ciphertext, file_info = encrypt_attachment(file_data)
+
+        # Upload the ciphertext to the media server.
+        # The encrypted bytes are posted directly rather than from a file
+        # path, so we call requests.post() directly instead of _fetch().
+        headers = {
+            "User-Agent": self.app_id,
+            "Content-Type": "application/octet-stream",
+            "Accept": "application/json",
+        }
+        if self.access_token:
+            headers["Authorization"] = f"Bearer {self.access_token}"
+
+        try:
+            base = self.base_url
+        except Exception:
+            return False
+
+        media_path = (
+            MATRIX_V3_MEDIA_PATH
+            if self.version == MatrixVersion.V3
+            else MATRIX_V2_MEDIA_PATH
+        )
+        upload_url = base + media_path + "/upload"
+
+        self.throttle()
+        try:
+            r = requests.post(
+                upload_url,
+                data=ciphertext,
+                params={"filename": attachment.name or "file"},
+                headers=headers,
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+            )
+        except requests.RequestException as e:
+            self.logger.warning(
+                "Matrix E2EE: connection error uploading encrypted attachment."
+            )
+            self.logger.debug(f"Socket Exception: {e!s}")
+            return False
+
+        try:
+            upload_resp = loads(r.content)
+        except Exception:
+            upload_resp = {}
+
+        if r.status_code != requests.codes.ok or not upload_resp.get(
+            "content_uri"
+        ):
+            self.logger.warning(
+                "Matrix E2EE: media upload failed (HTTP {}).".format(
+                    r.status_code
+                )
+            )
+            return False
+
+        file_info["url"] = upload_resp["content_uri"]
+
+        # Build the inner plaintext attachment event
+        is_image = IS_IMAGE.match(attachment.mimetype)
+        inner_event = {
+            "type": "m.room.message",
+            "content": {
+                "msgtype": "m.image" if is_image else "m.file",
+                "body": attachment.name or "file",
+                "file": file_info,
+            },
+            "room_id": room_id,
+        }
+
+        # Encrypt with MegOLM and send
+        ciphertext_event = session.encrypt(inner_event)
+        self._e2ee_save_megolm(room_id, session)
+
+        path = "/rooms/{}/send/m.room.encrypted/{}".format(
+            NotifyMatrix.quote(room_id), self.transaction_id
+        )
+        encrypted_payload = {
+            "algorithm": "m.megolm.v1.aes-sha2",
+            "ciphertext": ciphertext_event,
+            "sender_key": self._e2ee_account.identity_key,
+            "session_id": session.session_id,
+            "device_id": self.device_id or "",
+        }
+        postokay, _, _ = self._fetch(
+            path, payload=encrypted_payload, method="PUT"
+        )
+        if self.access_token != self.password:
+            self.transaction_id += 1
+            self.store.set(
+                "transaction_id",
+                self.transaction_id,
+                expires=self.default_cache_expiry_sec,
+            )
         return postokay
 
     # ---------------------------------------------------------------

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -29,6 +29,13 @@
 # - https://github.com/matrix-org/matrix-python-sdk
 # - https://github.com/matrix-org/synapse/blob/master/docs/reverse_proxy.rst
 #
+# End-to-End Encryption references:
+# - https://spec.matrix.org/v1.11/client-server-api/
+#   #end-to-end-encryption
+# - https://gitlab.matrix.org/matrix-org/olm/-/blob/master/docs/olm.md
+# - https://gitlab.matrix.org/matrix-org/olm/-/blob/master/docs/megolm.md
+#
+import contextlib
 from json import dumps, loads
 import re
 from time import time
@@ -37,17 +44,23 @@ import uuid
 from markdown import markdown
 import requests
 
-from ..common import (
+from ...common import (
     NotifyFormat,
     NotifyImageSize,
     NotifyType,
     PersistentStoreMode,
 )
-from ..exception import AppriseException
-from ..locale import gettext_lazy as _
-from ..url import PrivacyMode
-from ..utils.parse import is_hostname, parse_bool, parse_list, validate_regex
-from .base import NotifyBase
+from ...exception import AppriseException
+from ...locale import gettext_lazy as _
+from ...url import PrivacyMode
+from ...utils.parse import (
+    is_hostname,
+    parse_bool,
+    parse_list,
+    validate_regex,
+)
+from ..base import NotifyBase
+from .e2ee import MATRIX_E2EE_SUPPORT, MatrixMegOlmSession, MatrixOlmAccount
 
 # Define default path
 MATRIX_V1_WEBHOOK_PATH = "/api/v1/matrix/hook"
@@ -306,6 +319,11 @@ class NotifyMatrix(NotifyBase):
                 "values": MATRIX_MESSAGE_TYPES,
                 "default": MatrixMessageType.TEXT,
             },
+            "e2ee": {
+                "name": _("End-to-End Encryption"),
+                "type": "bool",
+                "default": True,
+            },
             "token": {
                 "alias_of": "token",
             },
@@ -324,6 +342,7 @@ class NotifyMatrix(NotifyBase):
         include_image=None,
         discovery=None,
         hsreq=None,
+        e2ee=None,
         **kwargs,
     ):
         """Initialize Matrix Object."""
@@ -341,8 +360,14 @@ class NotifyMatrix(NotifyBase):
         # This gets initialized after a login/registration
         self.access_token = None
 
+        # Our device ID assigned by the Matrix server during login
+        self.device_id = None
+
         # This gets incremented for each request made against the v3 API
         self.transaction_id = 0
+
+        # Lazy-initialized E2EE account (MatrixOlmAccount or None)
+        self._e2ee_account = None
 
         # Place an image inline with the message body
         self.include_image = (
@@ -363,6 +388,13 @@ class NotifyMatrix(NotifyBase):
         # with the authenticated homeserver.
         self.hsreq = (
             self.template_args["hsreq"]["default"] if hsreq is None else hsreq
+        )
+
+        # End-to-end encryption (server mode only; requires cryptography)
+        self.e2ee = (
+            self.template_args["e2ee"]["default"]
+            if e2ee is None
+            else parse_bool(e2ee)
         )
 
         # Setup our mode
@@ -444,10 +476,20 @@ class NotifyMatrix(NotifyBase):
             # This gets initialized after a login/registration
             self.access_token = self.store.get("access_token")
 
+            # Device ID assigned by server
+            self.device_id = self.store.get("device_id")
+
         # This gets incremented for each request made against the v3 API
         self.transaction_id = (
             0 if not self.access_token else self.store.get("transaction_id", 0)
         )
+
+        # Restore E2EE account from store if available
+        if self.e2ee and MATRIX_E2EE_SUPPORT:
+            acct_data = self.store.get("e2ee_account")
+            if acct_data:
+                with contextlib.suppress(Exception):
+                    self._e2ee_account = MatrixOlmAccount.from_dict(acct_data)
 
     def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
         """Perform Matrix Notification."""
@@ -504,7 +546,9 @@ class NotifyMatrix(NotifyBase):
         )
 
         self.logger.debug(
-            f"Matrix POST URL: {url} (cert_verify={self.verify_certificate!r})"
+            "Matrix POST URL: {} (cert_verify={!r})".format(
+                url, self.verify_certificate
+            )
         )
         self.logger.debug(f"Matrix Payload: {payload!s}")
 
@@ -527,12 +571,15 @@ class NotifyMatrix(NotifyBase):
 
                 self.logger.warning(
                     "Failed to send Matrix notification: {}{}error={}.".format(
-                        status_str, ", " if status_str else "", r.status_code
+                        status_str,
+                        ", " if status_str else "",
+                        r.status_code,
                     )
                 )
 
                 self.logger.debug(
-                    "Response Details:\r\n%r", (r.content or b"")[:2000]
+                    "Response Details:\r\n%r",
+                    (r.content or b"")[:2000],
                 )
 
                 # Return; we're done
@@ -701,6 +748,21 @@ class NotifyMatrix(NotifyBase):
         # Initiaize our error tracking
         has_error = False
 
+        # E2EE setup (once per send call, not per room).
+        # e2ee_capable means prerequisites are met; encryption is still
+        # decided per-room based on whether that room requires E2EE.
+        e2ee_capable = False
+        if self.e2ee and self.secure and MATRIX_E2EE_SUPPORT:
+            e2ee_capable = self._e2ee_setup()
+            if not e2ee_capable:
+                self.logger.warning(
+                    "Matrix E2EE setup failed; "
+                    "messages will be sent unencrypted."
+                )
+
+        # Prepare attachments once.  They are consumed by unencrypted rooms;
+        # E2EE rooms skip attachment delivery (media encryption is not yet
+        # supported) but other rooms in the same send call still receive them.
         attachments = None
         if attach and self.attachment_support:
             attachments = self._send_attachments(attach)
@@ -722,12 +784,29 @@ class NotifyMatrix(NotifyBase):
                 has_error = True
                 continue
 
+            if e2ee_capable and self._e2ee_room_encrypted(room_id):
+                # Room requires E2EE -- warn if attachments exist
+                if attach and self.attachment_support:
+                    self.logger.warning(
+                        "Matrix E2EE attachment encryption is not yet "
+                        "supported; attachments will be skipped."
+                    )
+                # E2EE path: encrypt and send as m.room.encrypted
+                if not self._e2ee_send_to_room(
+                    room_id, body, title, notify_type
+                ):
+                    has_error = True
+                continue
+
+            # --- Unencrypted path (existing behaviour) ---
+
             # Acquire our image url if we're configured to do so
             image_url = (
                 None if not self.include_image else self.image_url(notify_type)
             )
 
-            # Always use PUT with a transaction ID (spec-compliant since 2015)
+            # Always use PUT with a transaction ID
+            # (spec-compliant since 2015)
             path = "/rooms/{}/send/m.room.message/{}".format(
                 NotifyMatrix.quote(room_id), self.transaction_id
             )
@@ -794,7 +873,8 @@ class NotifyMatrix(NotifyBase):
             payload = {
                 "msgtype": f"m.{self.msgtype}",
                 "body": "{title}{body}".format(
-                    title="" if not title else f"# {title}\r\n", body=body
+                    title="" if not title else f"# {title}\r\n",
+                    body=body,
                 ),
             }
 
@@ -805,7 +885,7 @@ class NotifyMatrix(NotifyBase):
                     {
                         "format": "org.matrix.custom.html",
                         "formatted_body": "{title}{body}".format(
-                            title="" if not title else f"<h1>{title}</h1>",
+                            title=("" if not title else f"<h1>{title}</h1>"),
                             body=body,
                         ),
                     }
@@ -816,9 +896,10 @@ class NotifyMatrix(NotifyBase):
                     ""
                     if not title
                     else (
-                        "<h1>"
-                        f"{NotifyMatrix.escape_html(title, whitespace=False)}"
-                        "</h1>"
+                        "<h1>{}".format(
+                            NotifyMatrix.escape_html(title, whitespace=False)
+                        )
+                        + "</h1>"
                     )
                 )
 
@@ -922,8 +1003,8 @@ class NotifyMatrix(NotifyBase):
     def _register(self):
         """Register with the service if possible."""
 
-        # Prepare our Registration Payload. This will only work if registration
-        # is enabled for the public
+        # Prepare our Registration Payload. This will only work if
+        # registration is enabled for the public
         payload = {
             "kind": "user",
             "auth": {"type": "m.login.dummy"},
@@ -934,9 +1015,9 @@ class NotifyMatrix(NotifyBase):
             "kind": "user",
         }
 
-        # If a user is not specified, one will be randomly generated for you.
-        # If you do not specify a password, you will be unable to login to the
-        # account if you forget the access_token.
+        # If a user is not specified, one will be randomly generated for
+        # you. If you do not specify a password, you will be unable to
+        # login to the account if you forget the access_token.
         if self.user:
             payload["username"] = self.user
 
@@ -955,6 +1036,7 @@ class NotifyMatrix(NotifyBase):
         self.access_token = response.get("access_token")
         self.home_server = response.get("home_server")
         self.user_id = response.get("user_id")
+        self.device_id = response.get("device_id")
 
         self.store.set(
             "access_token",
@@ -969,6 +1051,12 @@ class NotifyMatrix(NotifyBase):
         self.store.set(
             "user_id", self.user_id, expires=self.default_cache_expiry_sec
         )
+        if self.device_id:
+            self.store.set(
+                "device_id",
+                self.device_id,
+                expires=self.default_cache_expiry_sec,
+            )
 
         if self.access_token is not None:
             # Store our token into our store
@@ -1007,8 +1095,8 @@ class NotifyMatrix(NotifyBase):
                 }
 
         else:
-            # It's not possible to register since we need these 2 values to
-            # make the action possible.
+            # It's not possible to register since we need these 2 values
+            # to make the action possible.
             self.logger.warning(
                 "Failed to login to Matrix server: "
                 "token or user/pass combo is missing."
@@ -1025,6 +1113,7 @@ class NotifyMatrix(NotifyBase):
         self.access_token = response.get("access_token")
         self.home_server = response.get("home_server")
         self.user_id = response.get("user_id")
+        self.device_id = response.get("device_id")
 
         if not self.access_token:
             return False
@@ -1045,6 +1134,12 @@ class NotifyMatrix(NotifyBase):
         self.store.set(
             "user_id", self.user_id, expires=self.default_cache_expiry_sec
         )
+        if self.device_id:
+            self.store.set(
+                "device_id",
+                self.device_id,
+                expires=self.default_cache_expiry_sec,
+            )
 
         return True
 
@@ -1079,10 +1174,18 @@ class NotifyMatrix(NotifyBase):
         self.access_token = None
         self.home_server = None
         self.user_id = None
+        self.device_id = None
+        self._e2ee_account = None
 
-        # clear our tokens
+        # clear our tokens (including E2EE upload flag so it re-uploads
+        # after a fresh login)
         self.store.clear(
-            "access_token", "home_server", "user_id", "transaction_id"
+            "access_token",
+            "home_server",
+            "user_id",
+            "transaction_id",
+            "device_id",
+            "e2ee_keys_uploaded",
         )
 
         self.logger.debug("Unauthenticated successfully with Matrix server.")
@@ -1092,8 +1195,9 @@ class NotifyMatrix(NotifyBase):
     def _room_join(self, room):
         """Joins a matrix room if we're not already in it.
 
-        Otherwise it attempts to create it if it doesn't exist and always
-        returns the room_id if it was successful, otherwise it returns None
+        Otherwise it attempts to create it if it doesn't exist and
+        always returns the room_id if it was successful, otherwise it
+        returns None
         """
 
         if not self.access_token:
@@ -1120,10 +1224,10 @@ class NotifyMatrix(NotifyBase):
                 else self.home_server
             )
 
-            # When hsreq is enabled (legacy behaviour), we always require a
-            # ':homeserver' segment on room IDs. Otherwise, we honour exactly
-            # what the caller provided and do not synthesise a homeserver when
-            # it was not specified.
+            # When hsreq is enabled (legacy behaviour), we always require
+            # a ':homeserver' segment on room IDs. Otherwise, we honour
+            # exactly what the caller provided and do not synthesise a
+            # homeserver when it was not specified.
             cache_key = f"!{room_token}:{home_server}"
             if explicit_home_server or self.hsreq:
                 room_id = cache_key
@@ -1213,9 +1317,9 @@ class NotifyMatrix(NotifyBase):
             return response.get("room_id")
 
         # Only attempt to create a room when the server clearly indicates
-        # the alias does not exist. A join can fail for many reasons, such as
-        # invite required, auth failure, or permissions, and in those cases
-        # auto-creating is both noisy and incorrect.
+        # the alias does not exist. A join can fail for many reasons, such
+        # as invite required, auth failure, or permissions, and in those
+        # cases auto-creating is both noisy and incorrect.
         if (
             status_code == requests.codes.not_found
             or response.get("errcode") == "M_NOT_FOUND"
@@ -1263,8 +1367,8 @@ class NotifyMatrix(NotifyBase):
             "room_alias_name": result.group("room"),
             # Set our channel name
             "name": "#{} - {}".format(result.group("room"), self.app_desc),
-            # hide the room by default; let the user open it up if they wish
-            # to others.
+            # hide the room by default; let the user open it up if they
+            # wish to others.
             "visibility": "private",
             "preset": "trusted_private_chat",
         }
@@ -1293,8 +1397,8 @@ class NotifyMatrix(NotifyBase):
         return response.get("room_id")
 
     def _joined_rooms(self):
-        """Returns a list of the current rooms the logged in user is a part
-        of."""
+        """Returns a list of the current rooms the logged in user is a
+        part of."""
 
         if not self.access_token:
             # No list is possible
@@ -1364,14 +1468,14 @@ class NotifyMatrix(NotifyBase):
         method="POST",
         url_override=None,
     ):
-        """Wrapper to request.post() to manage it's response better and make
-        the send() function cleaner and easier to maintain.
+        """Wrapper to request.post() to manage it's response better and
+        make the send() function cleaner and easier to maintain.
 
         This function always returns a 3-tuple:
             (success, response, status_code)
 
-        The response is a dict when JSON is parseable, otherwise an empty dict.
-        The status_code defaults to 500 on local failures.
+        The response is a dict when JSON is parseable, otherwise an empty
+        dict. The status_code defaults to 500 on local failures.
         """
 
         # Define our headers
@@ -1435,8 +1539,8 @@ class NotifyMatrix(NotifyBase):
         # Always call throttle before any remote server i/o is made
         self.throttle()
 
-        # Define how many attempts we'll make if we get caught in a throttle
-        # event
+        # Define how many attempts we'll make if we get caught in a
+        # throttle event
         retries = self.default_retries if self.default_retries > 0 else 1
         while retries > 0:
             # Decrement our throttle retry count
@@ -1472,7 +1576,9 @@ class NotifyMatrix(NotifyBase):
                 status_code = r.status_code
 
                 self.logger.debug(
-                    f"Matrix Response: code={r.status_code}, {r.content!s}"
+                    "Matrix Response: code={}, {}".format(
+                        r.status_code, r.content
+                    )
                 )
                 response = loads(r.content)
 
@@ -1490,7 +1596,7 @@ class NotifyMatrix(NotifyBase):
 
                     self.logger.warning(
                         "Matrix server requested we throttle back "
-                        f"{wait_ms}ms; retries left {retries}."
+                        "{}ms; retries left {}.".format(wait_ms, retries)
                     )
                     self.logger.debug(f"Response Details:\r\n{r.content}")
 
@@ -1532,10 +1638,13 @@ class NotifyMatrix(NotifyBase):
                 )
                 return (False, {}, status_code)
 
-            except (requests.TooManyRedirects, requests.RequestException) as e:
+            except (
+                requests.TooManyRedirects,
+                requests.RequestException,
+            ) as e:
                 self.logger.warning(
-                    "A Connection error occurred while registering with Matrix"
-                    " server."
+                    "A Connection error occurred while registering "
+                    "with Matrix server."
                 )
                 self.logger.debug("Socket Exception: %s", e)
                 # Return; we're done
@@ -1555,6 +1664,404 @@ class NotifyMatrix(NotifyBase):
         # If we get here, we ran out of retries
         return (False, {}, status_code)
 
+    # ---------------------------------------------------------------
+    # E2EE helpers
+    # ---------------------------------------------------------------
+
+    def _e2ee_room_encrypted(self, room_id):
+        """Return ``True`` if *room_id* has E2EE enabled on the server.
+
+        The result is cached in the persistent store so subsequent sends
+        to the same room do not issue additional network requests.
+        """
+        cache_key = "e2ee_room_enc_{}".format(room_id)
+        cached = self.store.get(cache_key)
+        if cached is not None:
+            return cached
+
+        ok, response, _ = self._fetch(
+            "/rooms/{}/state/m.room.encryption".format(
+                NotifyMatrix.quote(room_id)
+            ),
+            method="GET",
+        )
+        result = ok and bool(response)
+        self.store.set(
+            cache_key,
+            result,
+            expires=self.default_cache_expiry_sec,
+        )
+        return result
+
+    def _e2ee_setup(self):
+        """Ensure the E2EE device account exists and keys are uploaded.
+
+        Creates a new :class:`MatrixOlmAccount` if one does not yet
+        exist in the persistent store, then calls
+        :meth:`_e2ee_upload_keys` if the server has not yet received
+        our device keys for the current access token.
+
+        Returns ``True`` on success, ``False`` on failure.
+        """
+        if self._e2ee_account is None:
+            acct_data = self.store.get("e2ee_account")
+            if acct_data:
+                try:
+                    self._e2ee_account = MatrixOlmAccount.from_dict(acct_data)
+                except Exception:
+                    self._e2ee_account = None
+
+            if self._e2ee_account is None:
+                self._e2ee_account = MatrixOlmAccount()
+                self.store.set(
+                    "e2ee_account",
+                    self._e2ee_account.to_dict(),
+                    expires=self.default_cache_expiry_sec,
+                )
+
+        if not self.store.get("e2ee_keys_uploaded"):
+            return self._e2ee_upload_keys()
+
+        return True
+
+    def _e2ee_upload_keys(self):
+        """POST device keys to ``/_matrix/client/v3/keys/upload``."""
+        if not self.user_id or not self.device_id:
+            self.logger.warning(
+                "Matrix E2EE: cannot upload keys without user_id "
+                "and device_id; ensure login completes first."
+            )
+            return False
+
+        payload = {
+            "device_keys": self._e2ee_account.device_keys_payload(
+                self.user_id, self.device_id
+            )
+        }
+        postokay, _, _ = self._fetch("/keys/upload", payload=payload)
+        if not postokay:
+            self.logger.warning("Matrix E2EE: device key upload failed.")
+            return False
+
+        self.store.set(
+            "e2ee_keys_uploaded",
+            True,
+            expires=self.default_cache_expiry_sec,
+        )
+        self.logger.debug(
+            "Matrix E2EE: device keys uploaded for %s / %s.",
+            self.user_id,
+            self.device_id,
+        )
+        return True
+
+    def _e2ee_get_megolm(self, room_id):
+        """Return the current outbound MegOLM session for *room_id*.
+
+        Creates a new session when none exists or when the existing one
+        has reached the rotation threshold.  Also clears the
+        ``e2ee_key_shared_*`` flag so the new session key is re-shared.
+        """
+        store_key = "e2ee_megolm_{}".format(room_id)
+        session_data = self.store.get(store_key)
+
+        if session_data:
+            session = MatrixMegOlmSession.from_dict(session_data)
+            if not session.should_rotate():
+                return session
+
+        # New or rotated session
+        session = MatrixMegOlmSession()
+        self.store.set(
+            store_key,
+            session.to_dict(),
+            expires=self.default_cache_expiry_sec,
+        )
+        # Clear key-shared flag so we share the new session key
+        self.store.clear("e2ee_key_shared_{}".format(room_id))
+        return session
+
+    def _e2ee_save_megolm(self, room_id, session):
+        """Persist the updated MegOLM session state."""
+        self.store.set(
+            "e2ee_megolm_{}".format(room_id),
+            session.to_dict(),
+            expires=self.default_cache_expiry_sec,
+        )
+
+    def _e2ee_room_members(self, room_id):
+        """Query device keys for all joined members of *room_id*.
+
+        Returns a nested dict::
+
+            {user_id: {device_id: {"curve25519": ..., "ed25519": ...}}}
+
+        Returns ``None`` on HTTP failure, empty dict when the room has
+        no members (unlikely but tolerated).
+        """
+        path = "/rooms/{}/joined_members".format(NotifyMatrix.quote(room_id))
+        postokay, response, _ = self._fetch(path, payload=None, method="GET")
+        if not postokay or not isinstance(response, dict):
+            return None
+
+        member_ids = list(response.get("joined", {}).keys())
+        if not member_ids:
+            return {}
+
+        postokay, resp, _ = self._fetch(
+            "/keys/query",
+            payload={"device_keys": {uid: [] for uid in member_ids}},
+        )
+        if not postokay or not isinstance(resp, dict):
+            return None
+
+        result = {}
+        for uid, devices in resp.get("device_keys", {}).items():
+            result[uid] = {}
+            for dev_id, dev_info in devices.items():
+                keys = dev_info.get("keys", {})
+                result[uid][dev_id] = {
+                    "curve25519": keys.get("curve25519:{}".format(dev_id), ""),
+                    "ed25519": keys.get("ed25519:{}".format(dev_id), ""),
+                }
+        return result
+
+    def _e2ee_share_room_key(self, room_id, session):
+        """Send the MegOLM session key to all devices in *room_id*.
+
+        Flow:
+          1. Fetch joined-member device keys via /keys/query
+          2. Claim one-time keys via /keys/claim
+          3. Create outbound Olm sessions and encrypt the room-key event
+          4. Deliver via PUT /sendToDevice/m.room.encrypted/{txnId}
+
+        Returns ``True`` on success (partial device failures are
+        tolerated), ``False`` only when a critical step fails.
+        """
+        members = self._e2ee_room_members(room_id)
+        if members is None:
+            self.logger.warning(
+                "Matrix E2EE: failed to query room members for %s.",
+                room_id,
+            )
+            return False
+
+        if not members:
+            return True
+
+        # Build the claim request for all member devices
+        otk_request = {}
+        for uid, devs in members.items():
+            otk_request[uid] = dict.fromkeys(devs, "curve25519")
+
+        postokay, otk_resp, _ = self._fetch(
+            "/keys/claim",
+            payload={"one_time_keys": otk_request},
+        )
+        if not postokay:
+            self.logger.warning("Matrix E2EE: failed to claim one-time keys.")
+            return False
+
+        otk_keys = (
+            otk_resp.get("one_time_keys", {})
+            if isinstance(otk_resp, dict)
+            else {}
+        )
+
+        # Build to-device message payload
+        to_device_msgs = {}
+        room_key_content = {
+            "algorithm": "m.megolm.v1.aes-sha2",
+            "room_id": room_id,
+            "session_id": session.session_id,
+            "session_key": session.session_key(),
+        }
+
+        for uid, devices in members.items():
+            to_device_msgs[uid] = {}
+            for dev_id, dev_info in devices.items():
+                # Skip our own device to avoid self-Olm-session setup
+                if uid == self.user_id and dev_id == self.device_id:
+                    continue
+
+                their_ik = dev_info.get("curve25519", "")
+                if not their_ik:
+                    continue
+
+                # Locate the OTK for this device
+                their_otk = None
+                otk_entry = otk_keys.get(uid, {}).get(dev_id, {})
+                if isinstance(otk_entry, dict):
+                    for k, v in otk_entry.items():
+                        if not k.startswith("curve25519:"):
+                            continue
+                        if isinstance(v, dict):
+                            their_otk = v.get("key")
+                        elif isinstance(v, str):
+                            their_otk = v
+                        break
+
+                if not their_otk:
+                    continue
+
+                try:
+                    olm_session = self._e2ee_account.create_outbound_session(
+                        their_ik, their_otk
+                    )
+                except Exception:
+                    self.logger.debug(
+                        "Matrix E2EE: failed to build Olm session "
+                        "for %s / %s.",
+                        uid,
+                        dev_id,
+                    )
+                    continue
+
+                inner = dumps(
+                    {
+                        "type": "m.room_key",
+                        "content": room_key_content,
+                        "sender": self.user_id,
+                        "recipient": uid,
+                        "recipient_keys": {
+                            "ed25519": dev_info.get("ed25519", "")
+                        },
+                        "keys": {"ed25519": self._e2ee_account.signing_key},
+                        "sender_device": self.device_id,
+                    }
+                )
+                ciphertext = olm_session.encrypt(inner)
+
+                to_device_msgs[uid][dev_id] = {
+                    "algorithm": "m.olm.v1.curve25519-aes-sha2",
+                    "ciphertext": {their_ik: ciphertext},
+                    "sender_key": self._e2ee_account.identity_key,
+                }
+
+        # Only send if at least one device message was built
+        if not any(v for v in to_device_msgs.values()):
+            return True
+
+        self.transaction_id += 1
+        self.store.set(
+            "transaction_id",
+            self.transaction_id,
+            expires=self.default_cache_expiry_sec,
+        )
+        path = "/sendToDevice/m.room.encrypted/{}".format(self.transaction_id)
+        postokay, _, _ = self._fetch(
+            path,
+            payload={"messages": to_device_msgs},
+            method="PUT",
+        )
+        if not postokay:
+            self.logger.warning(
+                "Matrix E2EE: failed to deliver room key to devices in %s.",
+                room_id,
+            )
+            # Not fatal -- the key may still have reached some devices
+
+        return True
+
+    def _e2ee_send_to_room(self, room_id, body, title, notify_type):
+        """Encrypt and send one message to *room_id* via MegOLM.
+
+        Shares the MegOLM session key with room members when the
+        session is new or has just been rotated.
+        Returns ``True`` on success, ``False`` on failure.
+        """
+        session = self._e2ee_get_megolm(room_id)
+
+        # Share room key if this session has not been announced yet
+        shared_flag = "e2ee_key_shared_{}".format(room_id)
+        if not self.store.get(shared_flag):
+            if not self._e2ee_share_room_key(room_id, session):
+                return False
+            self.store.set(
+                shared_flag,
+                True,
+                expires=self.default_cache_expiry_sec,
+            )
+
+        # Build the inner plaintext event
+        msg_content = {
+            "msgtype": "m.{}".format(self.msgtype),
+            "body": "{title}{body}".format(
+                title="" if not title else "# {}\r\n".format(title),
+                body=body,
+            ),
+        }
+
+        if self.notify_format == NotifyFormat.HTML:
+            msg_content.update(
+                {
+                    "format": "org.matrix.custom.html",
+                    "formatted_body": "{title}{body}".format(
+                        title=(
+                            "" if not title else "<h1>{}</h1>".format(title)
+                        ),
+                        body=body,
+                    ),
+                }
+            )
+
+        elif self.notify_format == NotifyFormat.MARKDOWN:
+            msg_content.update(
+                {
+                    "format": "org.matrix.custom.html",
+                    "formatted_body": "{title}{body}".format(
+                        title=(
+                            ""
+                            if not title
+                            else "<h1>{}</h1>".format(
+                                NotifyMatrix.escape_html(
+                                    title, whitespace=False
+                                )
+                            )
+                        ),
+                        body=markdown(body),
+                    ),
+                }
+            )
+
+        inner_event = {
+            "type": "m.room.message",
+            "content": msg_content,
+            "room_id": room_id,
+        }
+
+        ciphertext = session.encrypt(inner_event)
+        self._e2ee_save_megolm(room_id, session)
+
+        path = "/rooms/{}/send/m.room.encrypted/{}".format(
+            NotifyMatrix.quote(room_id), self.transaction_id
+        )
+        encrypted_payload = {
+            "algorithm": "m.megolm.v1.aes-sha2",
+            "ciphertext": ciphertext,
+            "sender_key": self._e2ee_account.identity_key,
+            "session_id": session.session_id,
+            "device_id": self.device_id or "",
+        }
+
+        postokay, _, _ = self._fetch(
+            path, payload=encrypted_payload, method="PUT"
+        )
+
+        if self.access_token != self.password:
+            self.transaction_id += 1
+            self.store.set(
+                "transaction_id",
+                self.transaction_id,
+                expires=self.default_cache_expiry_sec,
+            )
+
+        return postokay
+
+    # ---------------------------------------------------------------
+    # Destructor / URL / parse
+    # ---------------------------------------------------------------
+
     def __del__(self):
         """Ensure we relinquish our token."""
         if self.mode == MatrixWebhookMode.T2BOT:
@@ -1562,8 +2069,8 @@ class NotifyMatrix(NotifyBase):
             return
 
         if self.store.mode != PersistentStoreMode.MEMORY:
-            # We no longer have to log out as we have persistant storage to
-            # re-use our credentials with
+            # We no longer have to log out as we have persistant storage
+            # to re-use our credentials with
             return
 
         if (
@@ -1595,7 +2102,8 @@ class NotifyMatrix(NotifyBase):
         )
 
     def url(self, privacy=False, *args, **kwargs):
-        """Returns the URL built dynamically based on specified arguments."""
+        """Returns the URL built dynamically based on specified
+        arguments."""
 
         # Define any URL parameters
         params = {
@@ -1606,6 +2114,9 @@ class NotifyMatrix(NotifyBase):
             "discovery": "yes" if self.discovery else "no",
             "hsreq": "yes" if self.hsreq else "no",
         }
+
+        if not self.e2ee:
+            params["e2ee"] = "no"
 
         # Extend our parameters
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
@@ -1632,7 +2143,7 @@ class NotifyMatrix(NotifyBase):
                 )
 
         return "{schema}://{auth}{hostname}{port}/{rooms}?{params}".format(
-            schema=self.secure_protocol if self.secure else self.protocol,
+            schema=(self.secure_protocol if self.secure else self.protocol),
             auth=auth,
             hostname=(
                 NotifyMatrix.quote(self.host, safe="")
@@ -1645,14 +2156,15 @@ class NotifyMatrix(NotifyBase):
         )
 
     def __len__(self):
-        """Returns the number of targets associated with this notification."""
+        """Returns the number of targets associated with this
+        notification."""
         targets = len(self.rooms)
         return targets if targets > 0 else 1
 
     @staticmethod
     def parse_url(url):
-        """Parses the URL and returns enough arguments that can allow us to re-
-        instantiate this object."""
+        """Parses the URL and returns enough arguments that can allow us
+        to re-instantiate this object."""
         results = NotifyBase.parse_url(url, verify_host=False)
         if not results:
             # We're done early as we couldn't load the results
@@ -1664,38 +2176,45 @@ class NotifyMatrix(NotifyBase):
         # Get our rooms
         results["targets"] = NotifyMatrix.split_path(results["fullpath"])
 
-        # Support the 'to' variable so that we can support rooms this way too
-        # The 'to' makes it easier to use yaml configuration
+        # Support the 'to' variable so that we can support rooms this
+        # way too.  The 'to' makes it easier to use yaml configuration
         if "to" in results["qsd"] and len(results["qsd"]["to"]):
             results["targets"] += NotifyMatrix.parse_list(results["qsd"]["to"])
 
         # Boolean to include an image or not
         results["include_image"] = parse_bool(
             results["qsd"].get(
-                "image", NotifyMatrix.template_args["image"]["default"]
+                "image",
+                NotifyMatrix.template_args["image"]["default"],
             )
         )
 
         # Boolean to perform a server discovery
         results["discovery"] = parse_bool(
             results["qsd"].get(
-                "discovery", NotifyMatrix.template_args["discovery"]["default"]
+                "discovery",
+                NotifyMatrix.template_args["discovery"]["default"],
             )
         )
 
         # Boolean to enforce ':homeserver' on room IDs when missing
         results["hsreq"] = parse_bool(
             results["qsd"].get(
-                "hsreq", NotifyMatrix.template_args["hsreq"]["default"]
+                "hsreq",
+                NotifyMatrix.template_args["hsreq"]["default"],
             )
         )
+
+        # E2EE flag
+        if "e2ee" in results["qsd"]:
+            results["e2ee"] = parse_bool(results["qsd"]["e2ee"])
 
         # Get our mode
         results["mode"] = results["qsd"].get("mode")
 
-        # t2bot detection... look for just a hostname, and/or just a user/host
-        # if we match this; we can go ahead and set the mode (but only if
-        # it was otherwise not set)
+        # t2bot detection... look for just a hostname, and/or just a
+        # user/host if we match this; we can go ahead and set the mode
+        # (but only if it was otherwise not set)
         if (
             results["mode"] is None
             and not results["password"]
@@ -1814,7 +2333,8 @@ class NotifyMatrix(NotifyBase):
         if status_code == requests.codes.not_found:
             # This is an acceptable response; we're done
             self.logger.debug(
-                "Matrix Well-Known Base URI not found at %s", verify_url
+                "Matrix Well-Known Base URI not found at %s",
+                verify_url,
             )
 
             # Set our keys out for fast recall later on
@@ -1883,8 +2403,8 @@ class NotifyMatrix(NotifyBase):
             raise MatrixDiscoveryException(msg)
 
         #
-        # Our .well-known extraction was successful; now we need to verify
-        # that the version information resolves.
+        # Our .well-known extraction was successful; now we need to
+        # verify that the version information resolves.
         #
         verify_url = f"{base_url}/_matrix/client/versions"
         # Post our content
@@ -1951,7 +2471,8 @@ class NotifyMatrix(NotifyBase):
             self.store.set(
                 self.discovery_identity_key,
                 identity_url,
-                # Add 2 seconds to prevent this key from expiring before base
+                # Add 2 seconds to prevent this key from expiring before
+                # base
                 expires=self.discovery_cache_length_sec + 2,
             )
         else:
@@ -1959,7 +2480,8 @@ class NotifyMatrix(NotifyBase):
             self.store.set(
                 self.discovery_identity_key,
                 "",
-                # Add 2 seconds to prevent this key from expiring before base
+                # Add 2 seconds to prevent this key from expiring before
+                # base
                 expires=self.discovery_cache_length_sec + 2,
             )
 
@@ -1987,8 +2509,8 @@ class NotifyMatrix(NotifyBase):
             )
             raise
 
-        # If we get hear, we need to build our URL dynamically based on what
-        # was provided to us during the plugins initialization
+        # If we get hear, we need to build our URL dynamically based on
+        # what was provided to us during the plugins initialization
         return "{schema}://{hostname}{port}".format(
             schema="https" if self.secure else "http",
             hostname=self.host,

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -2254,14 +2254,16 @@ class NotifyMatrix(NotifyBase):
             return cached
 
         # Fetch existing m.direct mapping from the server
+        mdirect = {}
         if self.user_id:
-            ok, mdirect, _ = self._fetch(
+            ok, resp, _ = self._fetch(
                 "/user/{}/account_data/m.direct".format(
                     NotifyMatrix.quote(self.user_id)
                 ),
                 method="GET",
             )
-            if ok and isinstance(mdirect, dict):
+            if ok and isinstance(resp, dict):
+                mdirect = resp
                 rooms = mdirect.get(user_id, [])
                 if rooms:
                     room_id = rooms[0]
@@ -2271,10 +2273,6 @@ class NotifyMatrix(NotifyBase):
                         expires=self.default_cache_expiry_sec,
                     )
                     return room_id
-            else:
-                mdirect = {}
-        else:
-            mdirect = {}
 
         # No existing DM room -- create one
         ok, response, _ = self._fetch(

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -217,6 +217,16 @@ class NotifyMatrix(NotifyBase):
     # Keep our cache for 20 days
     default_cache_expiry_sec = 60 * 60 * 24 * 20
 
+    # Number of signed_curve25519 one-time keys to generate and upload
+    # per batch (both on initial device registration and replenishment).
+    default_e2ee_otk_count = 10
+
+    # Replenish the server-side OTK pool when the estimated remaining
+    # count drops below this value.  /keys/claim consumes one OTK per
+    # device; without replenishment the pool runs dry and subsequent
+    # key-shares skip devices that have no OTK available.
+    default_e2ee_otk_replenish_threshold = 5
+
     # Used for server discovery
     discovery_base_key = "__discovery_base"
     discovery_identity_key = "__discovery_identity"
@@ -1965,13 +1975,15 @@ class NotifyMatrix(NotifyBase):
                 self.user_id, self.device_id
             ),
             "one_time_keys": self._e2ee_account.one_time_keys_payload(
-                self.user_id, self.device_id
+                self.user_id,
+                self.device_id,
+                count=self.default_e2ee_otk_count,
             ),
             "fallback_keys": self._e2ee_account.fallback_keys_payload(
                 self.user_id, self.device_id
             ),
         }
-        postokay, _, _ = self._fetch("/keys/upload", payload=payload)
+        postokay, response, _ = self._fetch("/keys/upload", payload=payload)
         if not postokay:
             self.logger.warning("Matrix E2EE: device key upload failed.")
             return False
@@ -2001,10 +2013,141 @@ class NotifyMatrix(NotifyBase):
             ),
             expires=self.default_cache_expiry_sec,
         )
+
+        # Track the server-side OTK count so _e2ee_replenish_otks can
+        # decide whether a top-up is needed after the next /keys/claim.
+        counts = (
+            response.get("one_time_key_counts", {})
+            if isinstance(response, dict)
+            else {}
+        )
+        self.store.set(
+            "e2ee_otk_server_count",
+            counts.get("signed_curve25519", 0),
+            expires=self.default_cache_expiry_sec,
+        )
+
         self.logger.debug(
-            "Matrix E2EE: device keys uploaded for %s / %s.",
+            "Matrix E2EE: device keys uploaded for %s / %s "
+            "(server OTK count: %d).",
             self.user_id,
             self.device_id,
+            counts.get("signed_curve25519", 0),
+        )
+        return True
+
+    def _e2ee_replenish_otks(self, claimed_count=0, skipped_no_otk=0):
+        """Top up the server-side OTK pool after a ``/keys/claim`` event.
+
+        Parameters:
+          claimed_count   -- number of OTKs successfully consumed by the
+                             preceding ``/keys/claim`` (= ``built_count``
+                             from :meth:`_e2ee_share_room_key`)
+          skipped_no_otk  -- devices that were skipped because the server
+                             returned no OTK for them (pool already dry)
+
+        A replenishment upload is issued when any of the following is true:
+
+        - ``skipped_no_otk > 0``: the pool was already depleted during
+          the current claim -- top up immediately so the next key share
+          can reach those devices.
+        - estimated remaining OTKs after claim <
+          ``default_e2ee_otk_replenish_threshold``: pool is running low.
+        - server count was never recorded (unknown state): replenish as a
+          precaution.
+
+        Only ``one_time_keys`` is uploaded so the server does not treat
+        this as a device re-registration.
+
+        Returns ``True`` on success (or when no top-up was needed),
+        ``False`` on network failure (non-fatal -- the preceding send
+        already succeeded).
+        """
+        if not self.user_id or not self.device_id:
+            return False
+
+        server_count = self.store.get("e2ee_otk_server_count")
+        unknown_count = server_count is None
+
+        if unknown_count:
+            remaining = 0
+        else:
+            remaining = max(0, server_count - claimed_count)
+
+        need_replenish = (
+            skipped_no_otk > 0
+            or unknown_count
+            or remaining < self.default_e2ee_otk_replenish_threshold
+        )
+
+        if not need_replenish:
+            self.logger.trace(
+                "Matrix E2EE: OTK pool sufficient "
+                "(~%d remaining after claim); skipping replenishment.",
+                remaining,
+            )
+            return True
+
+        if skipped_no_otk > 0:
+            self.logger.warning(
+                "Matrix E2EE: %d device(s) had no OTK available during "
+                "key share (server pool was depleted). Those device(s) "
+                "will not decrypt the current message. Replenishing OTK "
+                "pool now so the next session rotation can reach them.",
+                skipped_no_otk,
+            )
+        elif unknown_count:
+            self.logger.debug(
+                "Matrix E2EE: server OTK count unknown; "
+                "replenishing as a precaution.",
+            )
+        else:
+            self.logger.debug(
+                "Matrix E2EE: OTK pool low (~%d remaining after claim, "
+                "threshold=%d); replenishing.",
+                remaining,
+                self.default_e2ee_otk_replenish_threshold,
+            )
+
+        payload = {
+            "one_time_keys": self._e2ee_account.one_time_keys_payload(
+                self.user_id,
+                self.device_id,
+                count=self.default_e2ee_otk_count,
+            ),
+        }
+        postokay, response, _ = self._fetch("/keys/upload", payload=payload)
+        if not postokay:
+            self.logger.warning(
+                "Matrix E2EE: OTK replenishment upload failed "
+                "(estimated ~%d remaining); pool may be depleted "
+                "on the next key share.",
+                remaining,
+            )
+            return False
+
+        self._e2ee_account.mark_keys_as_published()
+        self.store.set(
+            "e2ee_account",
+            self._e2ee_account.to_dict(),
+            expires=self.default_cache_expiry_sec,
+        )
+
+        counts = (
+            response.get("one_time_key_counts", {})
+            if isinstance(response, dict)
+            else {}
+        )
+        new_count = counts.get("signed_curve25519", 0)
+        self.store.set(
+            "e2ee_otk_server_count",
+            new_count,
+            expires=self.default_cache_expiry_sec,
+        )
+        self.logger.debug(
+            "Matrix E2EE: OTK pool replenished; "
+            "server now reports %d signed_curve25519 key(s).",
+            new_count,
         )
         return True
 
@@ -2397,6 +2540,19 @@ class NotifyMatrix(NotifyBase):
             room_id,
             self.transaction_id,
         )
+
+        # Check whether the OTK pool needs topping up.  Pass the number of
+        # OTKs consumed (built_count) and any devices skipped because the
+        # server had no OTK for them so _e2ee_replenish_otks can log the
+        # right diagnostic and decide whether an upload is needed.
+        # We always reach here with built_count >= 1 (the any() guard above
+        # returns early when no messages were built), so the call is never
+        # redundant -- _e2ee_replenish_otks itself decides whether to upload.
+        self._e2ee_replenish_otks(
+            claimed_count=built_count,
+            skipped_no_otk=skipped_no_otk,
+        )
+
         return True
 
     def _e2ee_send_to_room(self, room_id, body, title, notify_type):

--- a/apprise/plugins/matrix/e2ee.py
+++ b/apprise/plugins/matrix/e2ee.py
@@ -174,6 +174,68 @@ def _canonical_json(obj):
     ).encode("utf-8")
 
 
+def encrypt_attachment(data):
+    """Encrypt *data* bytes for upload to a Matrix E2EE room.
+
+    Implements the Matrix attachment encryption spec (v2):
+      https://spec.matrix.org/v1.11/client-server-api/#sending-encrypted-attachments
+
+    Algorithm: AES-256-CTR.
+    IV: 8 random bytes followed by 8 zero bytes (avoids counter wrap).
+
+    Returns a ``(ciphertext, file_info)`` tuple where *file_info* is the
+    ``EncryptedFile`` object to embed in the ``m.room.message`` event:
+
+    .. code-block:: json
+
+        {
+            "v": "v2",
+            "key": { "kty": "oct", "alg": "A256CTR", "k": "<key>",
+                     "key_ops": ["encrypt", "decrypt"], "ext": true },
+            "iv": "<base64url-nopad 16-byte IV>",
+            "hashes": { "sha256": "<base64 SHA-256 of ciphertext>" }
+        }
+    """
+    key = os.urandom(32)
+    # IV: 8 random bytes + 8 zero bytes (spec requirement)
+    iv = os.urandom(8) + b"\x00" * 8
+
+    cipher = Cipher(
+        algorithms.AES(key),
+        modes.CTR(iv),
+        backend=default_backend(),
+    )
+    enc = cipher.encryptor()
+    ciphertext = enc.update(data) + enc.finalize()
+
+    # SHA-256 of the ciphertext (for integrity verification by recipients)
+    h = hashes.Hash(hashes.SHA256(), backend=default_backend())
+    h.update(ciphertext)
+    sha256_digest = h.finalize()
+
+    # JWK key: base64url no-padding
+    k_b64url = base64.urlsafe_b64encode(key).rstrip(b"=").decode()
+    # IV: base64url no-padding (spec uses unpadded base64)
+    iv_b64url = base64.urlsafe_b64encode(iv).rstrip(b"=").decode()
+    # SHA-256 hash: standard base64 no-padding
+    sha256_b64 = base64.b64encode(sha256_digest).rstrip(b"=").decode()
+
+    file_info = {
+        "v": "v2",
+        "key": {
+            "kty": "oct",
+            "key_ops": ["encrypt", "decrypt"],
+            "alg": "A256CTR",
+            "k": k_b64url,
+            "ext": True,
+        },
+        "iv": iv_b64url,
+        "hashes": {"sha256": sha256_b64},
+    }
+
+    return ciphertext, file_info
+
+
 # -----------------------------------------------------------------------
 # MatrixOlmAccount
 # -----------------------------------------------------------------------

--- a/apprise/plugins/matrix/e2ee.py
+++ b/apprise/plugins/matrix/e2ee.py
@@ -461,7 +461,6 @@ class MatrixOlmAccount:
         while len(self._otks) < count:
             key_id = uuid.uuid4().hex[:10]
             priv = X25519PrivateKey.generate()
-            priv.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
             self._otks[key_id] = _b64enc(
                 priv.private_bytes(
                     Encoding.Raw, PrivateFormat.Raw, NoEncryption()

--- a/apprise/plugins/matrix/e2ee.py
+++ b/apprise/plugins/matrix/e2ee.py
@@ -55,6 +55,7 @@ try:
     )
     from cryptography.hazmat.primitives.asymmetric.ed25519 import (
         Ed25519PrivateKey,
+        Ed25519PublicKey,
     )
     from cryptography.hazmat.primitives.asymmetric.x25519 import (
         X25519PrivateKey,
@@ -172,6 +173,69 @@ def _canonical_json(obj):
         ensure_ascii=False,
         separators=(",", ":"),
     ).encode("utf-8")
+
+
+def _verify_ed25519(public_key_b64, message_bytes, signature_b64):
+    """Verify an Ed25519 signature.
+
+    Returns ``True`` when *signature_b64* is a valid signature of
+    *message_bytes* under *public_key_b64*.  Returns ``False`` on any
+    error (wrong key, bad signature, decode failure, etc.).
+
+    Requires ``MATRIX_E2EE_SUPPORT`` (the ``cryptography`` package).
+    """
+    try:
+        pub = Ed25519PublicKey.from_public_bytes(_b64dec(public_key_b64))
+        pub.verify(_b64dec(signature_b64), message_bytes)
+        return True
+    except Exception:
+        return False
+
+
+def verify_device_keys(dev_info, user_id, device_id):
+    """Verify the Ed25519 self-signature on a /keys/query device object.
+
+    The device must have signed the device-keys object (excluding the
+    ``signatures`` and ``unsigned`` fields) with its own Ed25519 key.
+
+    Returns ``True`` only when the signature is present and valid.
+    """
+    sig_key = "ed25519:{}".format(device_id)
+    ed25519_pub = dev_info.get("keys", {}).get(sig_key, "")
+    if not ed25519_pub:
+        return False
+
+    sig = dev_info.get("signatures", {}).get(user_id, {}).get(sig_key, "")
+    if not sig:
+        return False
+
+    # Signed payload: all fields except 'signatures' and 'unsigned'
+    signed_obj = {
+        k: v
+        for k, v in dev_info.items()
+        if k not in ("signatures", "unsigned")
+    }
+    return _verify_ed25519(ed25519_pub, _canonical_json(signed_obj), sig)
+
+
+def verify_signed_otk(otk_obj, user_id, device_id, ed25519_pub_b64):
+    """Verify the Ed25519 signature on a ``signed_curve25519`` OTK.
+
+    The device signs the OTK object (excluding ``signatures``) with the
+    same Ed25519 key published in its device keys.
+
+    Returns ``True`` only when the signature is present and valid.
+    """
+    sig = (
+        otk_obj.get("signatures", {})
+        .get(user_id, {})
+        .get("ed25519:{}".format(device_id), "")
+    )
+    if not sig:
+        return False
+
+    signed_obj = {k: v for k, v in otk_obj.items() if k != "signatures"}
+    return _verify_ed25519(ed25519_pub_b64, _canonical_json(signed_obj), sig)
 
 
 def encrypt_attachment(data):
@@ -541,24 +605,25 @@ class MatrixMegOlmSession:
         """Advance the MegOLM ratchet by one step.
 
         Advancement rule (MegOLM spec):
-          - Every message: R[3] = HMAC-SHA256(R[2], b'\\x03')
-          - Every 256 messages: first advance R[2], then cascade to R[3]
+          After message n, if (n+1) is a multiple of the threshold:
+          - Every 256 messages: advance R[2], then cascade to R[3]
           - Every 65536 messages: advance R[1] then cascade down
           - Every 2^24 messages: advance R[0] then cascade all the way
+          - Otherwise: R[3] = HMAC-SHA256(R[2], b'\\x03')
         """
         r = self._ratchet
-        i = self._counter
+        n1 = self._counter + 1  # next counter value
 
-        if i > 0 and i % (1 << 24) == 0:
+        if n1 % (1 << 24) == 0:
             r[0] = _hmac_sha256(r[0], b"\x00")
             r[1] = _hmac_sha256(r[0], b"\x01")
             r[2] = _hmac_sha256(r[1], b"\x02")
             r[3] = _hmac_sha256(r[2], b"\x03")
-        elif i > 0 and i % (1 << 16) == 0:
+        elif n1 % (1 << 16) == 0:
             r[1] = _hmac_sha256(r[1], b"\x01")
             r[2] = _hmac_sha256(r[1], b"\x02")
             r[3] = _hmac_sha256(r[2], b"\x03")
-        elif i > 0 and i % (1 << 8) == 0:
+        elif n1 % (1 << 8) == 0:
             r[2] = _hmac_sha256(r[2], b"\x02")
             r[3] = _hmac_sha256(r[2], b"\x03")
         else:
@@ -588,17 +653,21 @@ class MatrixMegOlmSession:
     def encrypt(self, payload_dict):
         """Encrypt *payload_dict* and return base64 MegOLM ciphertext.
 
-        Wire format:
-          version (1 B = 0x03) | counter (4 B big-endian)
-          | AES-CBC ciphertext | HMAC-SHA-256 (8 B) | Ed25519 sig (64 B)
+        Wire format (MegOLM spec, Section 4):
+          version (1 B = 0x03)
+          | Protobuf body (field 8: message_index varint,
+          |                field 9: ciphertext bytes)
+          | HMAC-SHA-256 (8 B)
+          | Ed25519 sig (64 B)
 
         Reference: MegOLM spec, Section 4.
         """
         plaintext = dumps(payload_dict).encode("utf-8")
         aes_key, mac_key, iv = self._message_keys()
 
-        ciphertext = _aes_cbc_encrypt(aes_key, iv, plaintext)
-        body = b"\x03" + struct.pack(">I", self._counter) + ciphertext
+        ct_bytes = _aes_cbc_encrypt(aes_key, iv, plaintext)
+        pb_body = _pb_varint_field(8, self._counter) + _pb_bytes(9, ct_bytes)
+        body = b"\x03" + pb_body
         mac = _hmac_sha256(mac_key, body)[:8]
         sig = self._sk.sign(body + mac)
 

--- a/apprise/plugins/matrix/e2ee.py
+++ b/apprise/plugins/matrix/e2ee.py
@@ -45,6 +45,7 @@ from json import dumps
 import os
 import struct
 import time as _time
+import uuid
 
 try:
     from cryptography.hazmat.backends import default_backend
@@ -88,6 +89,11 @@ MEGOLM_ROTATION_MSGS = 100
 # Rotate the MegOLM session after this many seconds (7 days)
 MEGOLM_ROTATION_AGE = 60 * 60 * 24 * 7
 
+# Bump this whenever the custom outbound MegOLM/session serialization or
+# interoperability-critical behavior changes. Older cached sessions are then
+# treated as incompatible and rotated automatically.
+MATRIX_MEGOLM_STORE_VERSION = 1
+
 
 # -----------------------------------------------------------------------
 # Private helpers
@@ -95,8 +101,8 @@ MEGOLM_ROTATION_AGE = 60 * 60 * 24 * 7
 
 
 def _b64enc(data):
-    """Standard base64 of *data* as a padded ASCII string."""
-    return base64.b64encode(data).decode("utf-8")
+    """Matrix-style unpadded base64 of *data* as ASCII."""
+    return base64.b64encode(data).rstrip(b"=").decode("utf-8")
 
 
 def _b64dec(s):
@@ -328,7 +334,13 @@ class MatrixOlmAccount:
     Reference: Olm spec, Section 2 ("Keys").
     """
 
-    def __init__(self, ik_priv_b64=None, sk_priv_b64=None):
+    def __init__(
+        self,
+        ik_priv_b64=None,
+        sk_priv_b64=None,
+        otks=None,
+        fallback_otk=None,
+    ):
         """Initialise from saved keys or generate a fresh key pair.
 
         Parameters are the base64-encoded raw 32-byte private key bytes
@@ -353,6 +365,8 @@ class MatrixOlmAccount:
         self._sk_pub = self._sk.public_key().public_bytes(
             Encoding.Raw, PublicFormat.Raw
         )
+        self._otks = dict(otks or {})
+        self._fallback_otk = fallback_otk
 
     # --- Public-key properties -------------------------------------------
 
@@ -389,6 +403,8 @@ class MatrixOlmAccount:
                     Encoding.Raw, PrivateFormat.Raw, NoEncryption()
                 )
             ),
+            "otks": self._otks,
+            "fallback_otk": self._fallback_otk,
         }
 
     @staticmethod
@@ -397,6 +413,8 @@ class MatrixOlmAccount:
         return MatrixOlmAccount(
             ik_priv_b64=data["ik"],
             sk_priv_b64=data["sk"],
+            otks=data.get("otks"),
+            fallback_otk=data.get("fallback_otk"),
         )
 
     # --- Key-upload payload ----------------------------------------------
@@ -426,6 +444,78 @@ class MatrixOlmAccount:
         }
         return device_keys
 
+    def _signed_curve25519_key(self, user_id, device_id, key_b64):
+        """Wrap a Curve25519 key in a signed KeyObject."""
+        payload = {"key": key_b64}
+        payload["signatures"] = {
+            user_id: {
+                "ed25519:{}".format(device_id): self.sign(
+                    _canonical_json(payload)
+                )
+            }
+        }
+        return payload
+
+    def _ensure_otks(self, count=10):
+        """Ensure at least *count* signed_curve25519 one-time keys exist."""
+        while len(self._otks) < count:
+            key_id = uuid.uuid4().hex[:10]
+            priv = X25519PrivateKey.generate()
+            priv.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+            self._otks[key_id] = _b64enc(
+                priv.private_bytes(
+                    Encoding.Raw, PrivateFormat.Raw, NoEncryption()
+                )
+            )
+
+    def one_time_keys_payload(self, user_id, device_id, count=10):
+        """Build signed ``one_time_keys`` for ``POST /keys/upload``."""
+        self._ensure_otks(count=count)
+        payload = {}
+        for key_id, priv_b64 in self._otks.items():
+            priv = X25519PrivateKey.from_private_bytes(_b64dec(priv_b64))
+            pub = priv.public_key().public_bytes(
+                Encoding.Raw, PublicFormat.Raw
+            )
+            payload["signed_curve25519:{}".format(key_id)] = (
+                self._signed_curve25519_key(user_id, device_id, _b64enc(pub))
+            )
+        return payload
+
+    def fallback_keys_payload(self, user_id, device_id):
+        """Build signed ``fallback_keys`` for ``POST /keys/upload``."""
+        if not self._fallback_otk:
+            key_id = uuid.uuid4().hex[:10]
+            priv = X25519PrivateKey.generate()
+            self._fallback_otk = {
+                "id": key_id,
+                "sk": _b64enc(
+                    priv.private_bytes(
+                        Encoding.Raw, PrivateFormat.Raw, NoEncryption()
+                    )
+                ),
+            }
+
+        priv = X25519PrivateKey.from_private_bytes(
+            _b64dec(self._fallback_otk["sk"])
+        )
+        pub = priv.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+        key_id = self._fallback_otk["id"]
+        return {
+            "signed_curve25519:{}".format(key_id): self._signed_curve25519_key(
+                user_id, device_id, _b64enc(pub)
+            )
+        }
+
+    def mark_keys_as_published(self):
+        """Mark the current OTK batch as published.
+
+        This mirrors stable python-olm's ``Account.mark_keys_as_published()``:
+        the uploaded one-time keys are no longer treated as the next
+        unpublished batch, so a subsequent upload can generate a fresh set.
+        """
+        self._otks.clear()
+
     # --- Outbound session ------------------------------------------------
 
     def create_outbound_session(
@@ -449,24 +539,39 @@ class MatrixOlmAccount:
             _b64dec(their_one_time_key_b64)
         )
 
-        # Ephemeral key pair (EK_A) -- discarded after session creation
+        # E_A is Alice's ephemeral key.  It serves BOTH as the Base-Key
+        # (outer pre-key field 2) AND as the initial Ratchet-Key (inner
+        # field 1).  The Olm spec Section 5.1 is explicit:
+        #   "E_A^pub is also the ratchet key for the first message."
+        # libolm passes the same keypair to both the X3DH and the ratchet
+        # initialisation (ratchet.cpp: initialise_as_alice receives base_key
+        # and uses it as the initial sender ratchet key).  Using two
+        # different keys here breaks decryption.
         eph = X25519PrivateKey.generate()
         eph_pub = eph.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
 
         # Triple DH  (Olm spec, Section 4.1)
         #   DH1 = X25519(IK_A, OTK_B)
-        #   DH2 = X25519(EK_A, IK_B)
-        #   DH3 = X25519(EK_A, OTK_B)
+        #   DH2 = X25519(E_A, IK_B)
+        #   DH3 = X25519(E_A, OTK_B)
         dh1 = self._ik.exchange(their_otk)
         dh2 = eph.exchange(their_ik)
         dh3 = eph.exchange(their_otk)
 
-        # Root-key derivation
-        #   IKM  = 0xFF*32 || DH1 || DH2 || DH3
-        #   salt = 0x00*32
+        # Root-key derivation (libolm ratchet.cpp initialise_as_alice /
+        # vodozemac shared_secret.rs Shared3DHSecret::expand):
+        #   IKM  = DH1 || DH2 || DH3  (96 bytes — no zero prefix)
+        #   salt = nullptr / 0x00*32   (RFC 5869: missing salt = HashLen zeros)
         #   info = "OLM_ROOT"
-        ikm = b"\xff" * 32 + dh1 + dh2 + dh3
-        keys = _hkdf_sha256(ikm, 64, salt=b"\x00" * 32, info=b"OLM_ROOT")
+        #
+        # libolm passes the 96-byte secret directly
+        # (session.cpp: secret[3 * CURVE25519_SHARED_SECRET_LENGTH]).
+        # vodozemac does the same (Shared3DHSecret is Box<[u8; 96]>).
+        # Adding any prefix produces a different PRK and therefore
+        # different root/chain keys, causing the recipient to fail to
+        # decrypt the Olm pre-key message that carries the MegOLM room key.
+        ikm = dh1 + dh2 + dh3
+        keys = _hkdf_sha256(ikm, 64, salt=None, info=b"OLM_ROOT")
         root_key = keys[:32]
         chain_key = keys[32:]
 
@@ -504,6 +609,9 @@ class MatrixOlmSession:
         chain_key,
     ):
         self._our_ik_pub = our_ik_pub
+        # eph_pub is Alice's ephemeral key E_A.  Per Olm spec Section 5.1,
+        # E_A^pub is used in BOTH the outer pre-key Base-Key field AND the
+        # inner normal-message Ratchet-Key field.  They must be identical.
         self._eph_pub = eph_pub
         self._their_otk_pub = their_otk_pub
         self._their_ik_pub = their_ik_pub
@@ -549,6 +657,8 @@ class MatrixOlmSession:
         #   0x22 = field 4, wire-type 2 (bytes)  -> Cipher-Text
         # Note: there is no field 3 in the normal-message format; the
         # ciphertext is field 4 (tag 0x22), NOT field 3 (tag 0x1A).
+        # E_A^pub appears in BOTH the inner Ratchet-Key (field 1) and the
+        # outer Base-Key (field 2) -- same bytes, same key, per spec.
         inner = (
             b"\x03"
             + _pb_bytes(1, self._eph_pub)
@@ -560,9 +670,17 @@ class MatrixOlmSession:
         # -- Outer pre-key message  --------------------------------
         # Field numbers from the Olm spec wire format:
         #   0x0A = field 1 (bytes) -> One-Time-Key (Bob's OTK being consumed)
-        #   0x12 = field 2 (bytes) -> Base-Key (Alice's ephemeral key)
+        #   0x12 = field 2 (bytes) -> Base-Key (Alice's E_A; same key as the
+        #                              first Ratchet-Key)
         #   0x1A = field 3 (bytes) -> Identity-Key (Alice's identity key)
-        #   0x22 = field 4 (bytes) -> Message (inner message + MAC)
+        #   0x22 = field 4 (bytes) -> Message (inner message + inner MAC)
+        #
+        # The outer pre-key message has NO trailing MAC of its own.
+        # libolm session.cpp allocates exactly
+        # encode_one_time_key_message_length() bytes — no extra space for an
+        # outer MAC.  vodozemac decodes the outer payload with prost (strict
+        # protobuf) so extra bytes after the last field cause a DecodeError
+        # and the session fails to establish.
         outer = (
             b"\x03"
             + _pb_bytes(1, self._their_otk_pub)
@@ -570,10 +688,9 @@ class MatrixOlmSession:
             + _pb_bytes(3, self._our_ik_pub)
             + _pb_bytes(4, inner + inner_mac)
         )
-        outer_mac = _hmac_sha256(mac_key, outer)[:8]
 
         self._counter += 1
-        return {"type": 0, "body": _b64enc(outer + outer_mac)}
+        return {"type": 0, "body": _b64enc(outer)}
 
 
 # -----------------------------------------------------------------------
@@ -656,10 +773,16 @@ class MatrixMegOlmSession:
         self._counter += 1
 
     def _message_keys(self):
-        """Derive (aes_key, mac_key, iv) from the current ratchet state."""
-        # All four 32-byte ratchet components concatenated = 128 bytes
-        state = b"".join(self._ratchet)
-        keys = _hkdf_sha256(state, 80, salt=None, info=b"MEGOLM_KEYS")
+        """Derive (aes_key, mac_key, iv) from R[3] of the ratchet state.
+
+        Per the MegOLM spec and libolm (megolm.c ``compute_message_key``),
+        only the 4th ratchet component R[3] (32 bytes) is the HKDF IKM.
+        Using the full concatenated ratchet state produces keys that no
+        standard client can reproduce, causing undecryptable messages.
+        """
+        keys = _hkdf_sha256(
+            self._ratchet[3], 80, salt=None, info=b"MEGOLM_KEYS"
+        )
         return keys[:32], keys[32:64], keys[64:80]
 
     # --- Rotation --------------------------------------------------------
@@ -690,7 +813,10 @@ class MatrixMegOlmSession:
         aes_key, mac_key, iv = self._message_keys()
 
         ct_bytes = _aes_cbc_encrypt(aes_key, iv, plaintext)
-        pb_body = _pb_varint_field(8, self._counter) + _pb_bytes(9, ct_bytes)
+        # MegOLM spec wire format (libolm message.cpp):
+        #   GROUP_MESSAGE_INDEX_TAG = 0x08  (field 1, wire-type 0 varint)
+        #   GROUP_CIPHERTEXT_TAG    = 0x12  (field 2, wire-type 2 bytes)
+        pb_body = _pb_varint_field(1, self._counter) + _pb_bytes(2, ct_bytes)
         body = b"\x03" + pb_body
         mac = _hmac_sha256(mac_key, body)[:8]
         sig = self._sk.sign(body + mac)
@@ -703,25 +829,34 @@ class MatrixMegOlmSession:
     def session_key(self):
         """Base64 MegOLM session key for sharing in ``m.room_key`` events.
 
-        Wire format:
+        Wire format (libolm outbound_group_session.c,
+        ``olm_outbound_group_session_key``):
           version (1 B = 0x02) | counter (4 B big-endian)
           | R[0..3] (128 B) | Ed25519 signing pub key (32 B)
+          | Ed25519 signature (64 B) over all preceding 165 bytes
 
-        Reference: MegOLM spec, Section 2.
+        The signature lets the recipient verify the session key came from the
+        device that owns the Ed25519 signing key published in /keys/upload.
+        Without it, vodozemac and other clients reject the key.
+
+        Reference: MegOLM spec, Section 2; libolm
+        ``outbound_group_session.c``.
         """
-        data = (
+        payload = (
             b"\x02"
             + struct.pack(">I", self._counter)
             + b"".join(self._ratchet)
             + self._sk_pub
         )
-        return _b64enc(data)
+        sig = self._sk.sign(payload)
+        return _b64enc(payload + sig)
 
     # --- Serialisation ---------------------------------------------------
 
     def to_dict(self):
         """Export session state for persistent storage."""
         return {
+            "version": MATRIX_MEGOLM_STORE_VERSION,
             "ratchet": [_b64enc(r) for r in self._ratchet],
             "counter": self._counter,
             "sk": _b64enc(
@@ -736,6 +871,8 @@ class MatrixMegOlmSession:
     @staticmethod
     def from_dict(data):
         """Restore from a ``to_dict()`` snapshot."""
+        if data.get("version") != MATRIX_MEGOLM_STORE_VERSION:
+            raise ValueError("Incompatible MegOLM session cache format")
         return MatrixMegOlmSession(
             ratchet=[_b64dec(r) for r in data["ratchet"]],
             counter=data["counter"],

--- a/apprise/plugins/matrix/e2ee.py
+++ b/apprise/plugins/matrix/e2ee.py
@@ -745,43 +745,61 @@ class MatrixMegOlmSession:
     def _advance(self):
         """Advance the MegOLM ratchet by one step.
 
-        Advancement rule (MegOLM spec):
-          After message n, if (n+1) is a multiple of the threshold:
-          - Every 256 messages: advance R[2], then cascade to R[3]
-          - Every 65536 messages: advance R[1] then cascade down
-          - Every 2^24 messages: advance R[0] then cascade all the way
-          - Otherwise: R[3] = HMAC-SHA256(R[2], b'\\x03')
+        Mirrors libolm megolm.c ``megolm_advance`` and vodozemac ratchet.rs
+        ``Ratchet::advance``.
+
+        The ratchet has 4 parts R[0..3].  On each step, determine the
+        highest-index part h that stays constant:
+          - counter+1 is a multiple of 2^24  → h=0 (advance R[0..3] from R[0])
+          - counter+1 is a multiple of 2^16  → h=1 (advance R[1..3] from R[1])
+          - counter+1 is a multiple of 2^8   → h=2 (advance R[2..3] from R[2])
+          - otherwise                         → h=3 (advance R[3] from R[3])
+
+        All derived parts are computed from the ORIGINAL value of R[h]
+        (saved before any modification), then R[h] itself is updated last.
+        This matches libolm's loop which processes higher indices first
+        (i = 3 down to h), ensuring data[h] is still the original when it
+        is finally overwritten at i==h.
         """
         r = self._ratchet
         n1 = self._counter + 1  # next counter value
 
         if n1 % (1 << 24) == 0:
-            r[0] = _hmac_sha256(r[0], b"\x00")
-            r[1] = _hmac_sha256(r[0], b"\x01")
-            r[2] = _hmac_sha256(r[1], b"\x02")
-            r[3] = _hmac_sha256(r[2], b"\x03")
+            # h=0: all four parts derived from original R[0]
+            orig = r[0]
+            r[3] = _hmac_sha256(orig, b"\x03")
+            r[2] = _hmac_sha256(orig, b"\x02")
+            r[1] = _hmac_sha256(orig, b"\x01")
+            r[0] = _hmac_sha256(orig, b"\x00")
         elif n1 % (1 << 16) == 0:
-            r[1] = _hmac_sha256(r[1], b"\x01")
-            r[2] = _hmac_sha256(r[1], b"\x02")
-            r[3] = _hmac_sha256(r[2], b"\x03")
+            # h=1: R[1..3] derived from original R[1]
+            orig = r[1]
+            r[3] = _hmac_sha256(orig, b"\x03")
+            r[2] = _hmac_sha256(orig, b"\x02")
+            r[1] = _hmac_sha256(orig, b"\x01")
         elif n1 % (1 << 8) == 0:
-            r[2] = _hmac_sha256(r[2], b"\x02")
-            r[3] = _hmac_sha256(r[2], b"\x03")
+            # h=2: R[2..3] derived from original R[2]
+            orig = r[2]
+            r[3] = _hmac_sha256(orig, b"\x03")
+            r[2] = _hmac_sha256(orig, b"\x02")
         else:
-            r[3] = _hmac_sha256(r[2], b"\x03")
+            # h=3: R[3] re-seeded from itself
+            r[3] = _hmac_sha256(r[3], b"\x03")
 
         self._counter += 1
 
     def _message_keys(self):
-        """Derive (aes_key, mac_key, iv) from R[3] of the ratchet state.
+        """Derive (aes_key, mac_key, iv) from the full ratchet state R_i.
 
-        Per the MegOLM spec and libolm (megolm.c ``compute_message_key``),
-        only the 4th ratchet component R[3] (32 bytes) is the HKDF IKM.
-        Using the full concatenated ratchet state produces keys that no
-        standard client can reproduce, causing undecryptable messages.
+        Per the MegOLM spec Section 4.3 and vodozemac (cipher/key.rs
+        ``new_megolm``), the HKDF IKM is the complete 128-byte ratchet value
+        R_i = R[0]||R[1]||R[2]||R[3].  Using only R[3] (32 bytes) produces
+        different keys from what any standard client derives.
+
+        Spec:  AES_KEY||HMAC_KEY||AES_IV = HKDF(0, R_i, "MEGOLM_KEYS", 80)
         """
         keys = _hkdf_sha256(
-            self._ratchet[3], 80, salt=None, info=b"MEGOLM_KEYS"
+            b"".join(self._ratchet), 80, salt=None, info=b"MEGOLM_KEYS"
         )
         return keys[:32], keys[32:64], keys[64:80]
 

--- a/apprise/plugins/matrix/e2ee.py
+++ b/apprise/plugins/matrix/e2ee.py
@@ -195,11 +195,24 @@ def _verify_ed25519(public_key_b64, message_bytes, signature_b64):
 def verify_device_keys(dev_info, user_id, device_id):
     """Verify the Ed25519 self-signature on a /keys/query device object.
 
-    The device must have signed the device-keys object (excluding the
-    ``signatures`` and ``unsigned`` fields) with its own Ed25519 key.
+    Per the spec, the signed payload must carry ``user_id`` and
+    ``device_id`` fields whose values match the identity being
+    verified.  This prevents a malicious homeserver from substituting
+    keys from one device into the record of another.
 
-    Returns ``True`` only when the signature is present and valid.
+    Returns ``True`` only when all of the following hold:
+    - ``dev_info["user_id"] == user_id``
+    - ``dev_info["device_id"] == device_id``
+    - The Ed25519 self-signature over the canonical payload is valid.
     """
+    # Identity binding: payload fields must match who we think we're
+    # verifying.  Without this a server could swap key objects across
+    # users/devices and the signature would still verify.
+    if dev_info.get("user_id") != user_id:
+        return False
+    if dev_info.get("device_id") != device_id:
+        return False
+
     sig_key = "ed25519:{}".format(device_id)
     ed25519_pub = dev_info.get("keys", {}).get(sig_key, "")
     if not ed25519_pub:
@@ -530,15 +543,26 @@ class MatrixOlmSession:
         ciphertext = _aes_cbc_encrypt(aes_key, iv, plaintext)
 
         # -- Inner message  (version | fields | MAC) ---------------
+        # Field numbers from the Olm spec wire format:
+        #   0x0A = field 1, wire-type 2 (bytes)  -> Ratchet-Key
+        #   0x10 = field 2, wire-type 0 (varint) -> Chain-Index
+        #   0x22 = field 4, wire-type 2 (bytes)  -> Cipher-Text
+        # Note: there is no field 3 in the normal-message format; the
+        # ciphertext is field 4 (tag 0x22), NOT field 3 (tag 0x1A).
         inner = (
             b"\x03"
             + _pb_bytes(1, self._eph_pub)
             + _pb_varint_field(2, self._counter)
-            + _pb_bytes(3, ciphertext)
+            + _pb_bytes(4, ciphertext)
         )
         inner_mac = _hmac_sha256(mac_key, inner)[:8]
 
         # -- Outer pre-key message  --------------------------------
+        # Field numbers from the Olm spec wire format:
+        #   0x0A = field 1 (bytes) -> One-Time-Key (Bob's OTK being consumed)
+        #   0x12 = field 2 (bytes) -> Base-Key (Alice's ephemeral key)
+        #   0x1A = field 3 (bytes) -> Identity-Key (Alice's identity key)
+        #   0x22 = field 4 (bytes) -> Message (inner message + MAC)
         outer = (
             b"\x03"
             + _pb_bytes(1, self._their_otk_pub)

--- a/apprise/plugins/matrix/e2ee.py
+++ b/apprise/plugins/matrix/e2ee.py
@@ -526,12 +526,11 @@ class MatrixMegOlmSession:
                 _b64dec(sk_priv_b64)
             )
 
-        sk_pub = self._sk.public_key().public_bytes(
+        self._sk_pub = self._sk.public_key().public_bytes(
             Encoding.Raw, PublicFormat.Raw
         )
-        self._sk_pub = sk_pub
         # Session ID is the base64 of the Ed25519 signing public key
-        self.session_id = _b64enc(sk_pub)
+        self.session_id = _b64enc(self._sk_pub)
         self.created_at = (
             created_at if created_at is not None else _time.time()
         )

--- a/apprise/plugins/matrix/e2ee.py
+++ b/apprise/plugins/matrix/e2ee.py
@@ -1,0 +1,590 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Minimal Olm + MegOLM outbound implementation for Matrix E2EE.
+#
+# Only the *sending* path is implemented, which is all Apprise requires.
+# All cryptographic primitives come from the `cryptography` package that
+# is already an optional Apprise dependency (used by pem.py, VAPID, FCM).
+#
+# Protocol references:
+#  Olm spec:
+#   https://gitlab.matrix.org/matrix-org/olm/-/blob/master/docs/olm.md
+#  MegOLM spec:
+#   https://gitlab.matrix.org/matrix-org/olm/-/blob/master/docs/megolm.md
+#  Matrix E2EE client-server API:
+#   https://spec.matrix.org/v1.11/client-server-api/
+#   #end-to-end-encryption
+
+import base64
+from json import dumps
+import os
+import struct
+import time as _time
+
+try:
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import (
+        hashes,
+        hmac as _hmac_mod,
+        padding as _pad_mod,
+    )
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PrivateKey,
+    )
+    from cryptography.hazmat.primitives.asymmetric.x25519 import (
+        X25519PrivateKey,
+        X25519PublicKey,
+    )
+    from cryptography.hazmat.primitives.ciphers import (
+        Cipher,
+        algorithms,
+        modes,
+    )
+    from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+    from cryptography.hazmat.primitives.serialization import (
+        Encoding,
+        NoEncryption,
+        PrivateFormat,
+        PublicFormat,
+    )
+
+    # E2EE support is available
+    MATRIX_E2EE_SUPPORT = True
+
+except ImportError:
+    # E2EE support unavailable; `pip install cryptography` to enable
+    MATRIX_E2EE_SUPPORT = False
+
+
+# Rotate the MegOLM session after this many messages
+MEGOLM_ROTATION_MSGS = 100
+
+# Rotate the MegOLM session after this many seconds (7 days)
+MEGOLM_ROTATION_AGE = 60 * 60 * 24 * 7
+
+
+# -----------------------------------------------------------------------
+# Private helpers
+# -----------------------------------------------------------------------
+
+
+def _b64enc(data):
+    """Standard base64 of *data* as a padded ASCII string."""
+    return base64.b64encode(data).decode("utf-8")
+
+
+def _b64dec(s):
+    """Decode a base64 string; tolerates missing padding and URL-safe chars."""
+    s = s.replace("-", "+").replace("_", "/")
+    pad = len(s) % 4
+    if pad:
+        s += "=" * (4 - pad)
+    return base64.b64decode(s)
+
+
+def _hmac_sha256(key, data):
+    """32-byte HMAC-SHA-256 of *data* keyed by *key*."""
+    h = _hmac_mod.HMAC(key, hashes.SHA256(), backend=default_backend())
+    h.update(data)
+    return h.finalize()
+
+
+def _hkdf_sha256(ikm, length, salt, info):
+    """HKDF-SHA-256.  *salt* may be ``None`` or explicit ``bytes``."""
+    return HKDF(
+        algorithm=hashes.SHA256(),
+        length=length,
+        salt=salt,
+        info=info,
+        backend=default_backend(),
+    ).derive(ikm)
+
+
+def _aes_cbc_encrypt(key, iv, plaintext):
+    """AES-256-CBC-encrypt *plaintext* with PKCS#7 padding."""
+    padder = _pad_mod.PKCS7(128).padder()
+    padded = padder.update(plaintext) + padder.finalize()
+    cipher = Cipher(
+        algorithms.AES(key),
+        modes.CBC(iv),
+        backend=default_backend(),
+    )
+    enc = cipher.encryptor()
+    return enc.update(padded) + enc.finalize()
+
+
+def _varint(n):
+    """Encode *n* as a protobuf-style base-128 varint."""
+    if n == 0:
+        return b"\x00"
+    out = []
+    while n:
+        byte = n & 0x7F
+        n >>= 7
+        if n:
+            byte |= 0x80
+        out.append(byte)
+    return bytes(out)
+
+
+def _pb_bytes(field_num, data):
+    """Protobuf wire-type 2 (length-delimited bytes) field."""
+    tag = _varint((field_num << 3) | 2)
+    return tag + _varint(len(data)) + data
+
+
+def _pb_varint_field(field_num, value):
+    """Protobuf wire-type 0 (varint) field."""
+    tag = _varint((field_num << 3) | 0)
+    return tag + _varint(value)
+
+
+def _canonical_json(obj):
+    """UTF-8 canonical JSON (sorted keys, no spaces) for signing."""
+    return dumps(
+        obj,
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+# -----------------------------------------------------------------------
+# MatrixOlmAccount
+# -----------------------------------------------------------------------
+
+
+class MatrixOlmAccount:
+    """Device-level Curve25519 + Ed25519 key pair.
+
+    Generates a new key pair on first use and persists it via
+    ``to_dict()`` / ``from_dict()``.  Also creates outbound Olm sessions
+    used to distribute MegOLM room keys to other devices.
+
+    Reference: Olm spec, Section 2 ("Keys").
+    """
+
+    def __init__(self, ik_priv_b64=None, sk_priv_b64=None):
+        """Initialise from saved keys or generate a fresh key pair.
+
+        Parameters are the base64-encoded raw 32-byte private key bytes
+        for the Curve25519 identity key (*ik*) and Ed25519 signing key
+        (*sk*).  Supply both or neither.
+        """
+        if ik_priv_b64 and sk_priv_b64:
+            self._ik = X25519PrivateKey.from_private_bytes(
+                _b64dec(ik_priv_b64)
+            )
+            self._sk = Ed25519PrivateKey.from_private_bytes(
+                _b64dec(sk_priv_b64)
+            )
+        else:
+            self._ik = X25519PrivateKey.generate()
+            self._sk = Ed25519PrivateKey.generate()
+
+        # Cache public-key bytes for efficiency
+        self._ik_pub = self._ik.public_key().public_bytes(
+            Encoding.Raw, PublicFormat.Raw
+        )
+        self._sk_pub = self._sk.public_key().public_bytes(
+            Encoding.Raw, PublicFormat.Raw
+        )
+
+    # --- Public-key properties -------------------------------------------
+
+    @property
+    def identity_key(self):
+        """Base64-encoded Curve25519 public identity key."""
+        return _b64enc(self._ik_pub)
+
+    @property
+    def signing_key(self):
+        """Base64-encoded Ed25519 public signing key."""
+        return _b64enc(self._sk_pub)
+
+    # --- Signing ---------------------------------------------------------
+
+    def sign(self, data):
+        """Ed25519-sign *data* (bytes or str) and return base64."""
+        if isinstance(data, str):
+            data = data.encode("utf-8")
+        return _b64enc(self._sk.sign(data))
+
+    # --- Serialisation ---------------------------------------------------
+
+    def to_dict(self):
+        """Export private keys for persistent storage."""
+        return {
+            "ik": _b64enc(
+                self._ik.private_bytes(
+                    Encoding.Raw, PrivateFormat.Raw, NoEncryption()
+                )
+            ),
+            "sk": _b64enc(
+                self._sk.private_bytes(
+                    Encoding.Raw, PrivateFormat.Raw, NoEncryption()
+                )
+            ),
+        }
+
+    @staticmethod
+    def from_dict(data):
+        """Restore from a ``to_dict()`` snapshot."""
+        return MatrixOlmAccount(
+            ik_priv_b64=data["ik"],
+            sk_priv_b64=data["sk"],
+        )
+
+    # --- Key-upload payload ----------------------------------------------
+
+    def device_keys_payload(self, user_id, device_id):
+        """Build the signed ``device_keys`` object for ``POST /keys/upload``.
+
+        Reference:
+          https://spec.matrix.org/v1.11/client-server-api/
+          #post_matrixclientv3keysupload
+        """
+        device_keys = {
+            "algorithms": [
+                "m.olm.v1.curve25519-aes-sha2",
+                "m.megolm.v1.aes-sha2",
+            ],
+            "device_id": device_id,
+            "keys": {
+                "curve25519:{}".format(device_id): self.identity_key,
+                "ed25519:{}".format(device_id): self.signing_key,
+            },
+            "user_id": user_id,
+        }
+        sig = self.sign(_canonical_json(device_keys))
+        device_keys["signatures"] = {
+            user_id: {"ed25519:{}".format(device_id): sig}
+        }
+        return device_keys
+
+    # --- Outbound session ------------------------------------------------
+
+    def create_outbound_session(
+        self, their_identity_key_b64, their_one_time_key_b64
+    ):
+        """Create an outbound Olm session to a remote device.
+
+        Performs the X3DH triple-DH key exchange and returns a
+        :class:`MatrixOlmSession` ready to encrypt the first message.
+
+        Parameters:
+          their_identity_key_b64  - recipient's base64 Curve25519 pub key
+          their_one_time_key_b64  - recipient's base64 Curve25519 OTK
+
+        Reference: Olm spec, Section 4.1 ("Session establishment").
+        """
+        their_ik = X25519PublicKey.from_public_bytes(
+            _b64dec(their_identity_key_b64)
+        )
+        their_otk = X25519PublicKey.from_public_bytes(
+            _b64dec(their_one_time_key_b64)
+        )
+
+        # Ephemeral key pair (EK_A) -- discarded after session creation
+        eph = X25519PrivateKey.generate()
+        eph_pub = eph.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+
+        # Triple DH  (Olm spec, Section 4.1)
+        #   DH1 = X25519(IK_A, OTK_B)
+        #   DH2 = X25519(EK_A, IK_B)
+        #   DH3 = X25519(EK_A, OTK_B)
+        dh1 = self._ik.exchange(their_otk)
+        dh2 = eph.exchange(their_ik)
+        dh3 = eph.exchange(their_otk)
+
+        # Root-key derivation
+        #   IKM  = 0xFF*32 || DH1 || DH2 || DH3
+        #   salt = 0x00*32
+        #   info = "OLM_ROOT"
+        ikm = b"\xff" * 32 + dh1 + dh2 + dh3
+        keys = _hkdf_sha256(ikm, 64, salt=b"\x00" * 32, info=b"OLM_ROOT")
+        root_key = keys[:32]
+        chain_key = keys[32:]
+
+        return MatrixOlmSession(
+            our_ik_pub=self._ik_pub,
+            eph_pub=eph_pub,
+            their_otk_pub=_b64dec(their_one_time_key_b64),
+            their_ik_pub=_b64dec(their_identity_key_b64),
+            root_key=root_key,
+            chain_key=chain_key,
+        )
+
+
+# -----------------------------------------------------------------------
+# MatrixOlmSession
+# -----------------------------------------------------------------------
+
+
+class MatrixOlmSession:
+    """Single-use outbound Olm session (type-0 pre-key messages only).
+
+    Sufficient for delivering the MegOLM room-key to one recipient device.
+    Each call to :meth:`encrypt` advances the chain ratchet once.
+
+    Reference: Olm spec, Section 5 ("Message format").
+    """
+
+    def __init__(
+        self,
+        our_ik_pub,
+        eph_pub,
+        their_otk_pub,
+        their_ik_pub,
+        root_key,
+        chain_key,
+    ):
+        self._our_ik_pub = our_ik_pub
+        self._eph_pub = eph_pub
+        self._their_otk_pub = their_otk_pub
+        self._their_ik_pub = their_ik_pub
+        self._root_key = root_key
+        self._chain_key = chain_key
+        self._counter = 0
+
+    @property
+    def their_identity_key(self):
+        """Base64-encoded Curve25519 identity key of the remote device."""
+        return _b64enc(self._their_ik_pub)
+
+    def encrypt(self, plaintext):
+        """Encrypt *plaintext* (str) as an Olm pre-key (type-0) message.
+
+        Returns ``{"type": 0, "body": "<base64>"}`` suitable for
+        inclusion in the ``ciphertext`` object of an
+        ``m.olm.v1.curve25519-aes-sha2`` event.
+
+        Reference: Olm spec, Section 5.1.
+        """
+        if isinstance(plaintext, str):
+            plaintext = plaintext.encode("utf-8")
+
+        # -- Chain ratchet (Olm spec Section 6.1) -----------------
+        msg_key = _hmac_sha256(self._chain_key, b"\x01")
+        self._chain_key = _hmac_sha256(self._chain_key, b"\x02")
+
+        # -- Expand msg_key -> AES key / MAC key / IV  -----------
+        #    HKDF(msg_key, 80, salt=0x00*32, info="OLM_KEYS")
+        keys = _hkdf_sha256(msg_key, 80, salt=b"\x00" * 32, info=b"OLM_KEYS")
+        aes_key = keys[:32]
+        mac_key = keys[32:64]
+        iv = keys[64:80]
+
+        # -- AES-256-CBC ------------------------------------------
+        ciphertext = _aes_cbc_encrypt(aes_key, iv, plaintext)
+
+        # -- Inner message  (version | fields | MAC) ---------------
+        inner = (
+            b"\x03"
+            + _pb_bytes(1, self._eph_pub)
+            + _pb_varint_field(2, self._counter)
+            + _pb_bytes(3, ciphertext)
+        )
+        inner_mac = _hmac_sha256(mac_key, inner)[:8]
+
+        # -- Outer pre-key message  --------------------------------
+        outer = (
+            b"\x03"
+            + _pb_bytes(1, self._their_otk_pub)
+            + _pb_bytes(2, self._eph_pub)
+            + _pb_bytes(3, self._our_ik_pub)
+            + _pb_bytes(4, inner + inner_mac)
+        )
+        outer_mac = _hmac_sha256(mac_key, outer)[:8]
+
+        self._counter += 1
+        return {"type": 0, "body": _b64enc(outer + outer_mac)}
+
+
+# -----------------------------------------------------------------------
+# MatrixMegOlmSession
+# -----------------------------------------------------------------------
+
+
+class MatrixMegOlmSession:
+    """Outbound MegOLM session for room-message encryption.
+
+    State: a 4-component 256-bit ratchet R[0..3], a 32-bit counter,
+    and a per-session Ed25519 signing key.  The ratchet advances after
+    every encrypted message.  See :data:`MEGOLM_ROTATION_MSGS` and
+    :data:`MEGOLM_ROTATION_AGE` for rotation thresholds.
+
+    Reference: MegOLM spec.
+    """
+
+    def __init__(
+        self,
+        ratchet=None,
+        counter=0,
+        sk_priv_b64=None,
+        created_at=None,
+    ):
+        """New session (random state) or restore from ``to_dict()``."""
+        self._ratchet = (
+            [os.urandom(32) for _ in range(4)]
+            if ratchet is None
+            else [bytes(r) for r in ratchet]
+        )
+        self._counter = counter
+
+        if sk_priv_b64 is None:
+            self._sk = Ed25519PrivateKey.generate()
+        else:
+            self._sk = Ed25519PrivateKey.from_private_bytes(
+                _b64dec(sk_priv_b64)
+            )
+
+        sk_pub = self._sk.public_key().public_bytes(
+            Encoding.Raw, PublicFormat.Raw
+        )
+        self._sk_pub = sk_pub
+        # Session ID is the base64 of the Ed25519 signing public key
+        self.session_id = _b64enc(sk_pub)
+        self.created_at = (
+            created_at if created_at is not None else _time.time()
+        )
+
+    # --- Ratchet ----------------------------------------------------------
+
+    def _advance(self):
+        """Advance the MegOLM ratchet by one step.
+
+        Advancement rule (MegOLM spec):
+          - Every message: R[3] = HMAC-SHA256(R[2], b'\\x03')
+          - Every 256 messages: first advance R[2], then cascade to R[3]
+          - Every 65536 messages: advance R[1] then cascade down
+          - Every 2^24 messages: advance R[0] then cascade all the way
+        """
+        r = self._ratchet
+        i = self._counter
+
+        if i > 0 and i % (1 << 24) == 0:
+            r[0] = _hmac_sha256(r[0], b"\x00")
+            r[1] = _hmac_sha256(r[0], b"\x01")
+            r[2] = _hmac_sha256(r[1], b"\x02")
+            r[3] = _hmac_sha256(r[2], b"\x03")
+        elif i > 0 and i % (1 << 16) == 0:
+            r[1] = _hmac_sha256(r[1], b"\x01")
+            r[2] = _hmac_sha256(r[1], b"\x02")
+            r[3] = _hmac_sha256(r[2], b"\x03")
+        elif i > 0 and i % (1 << 8) == 0:
+            r[2] = _hmac_sha256(r[2], b"\x02")
+            r[3] = _hmac_sha256(r[2], b"\x03")
+        else:
+            r[3] = _hmac_sha256(r[2], b"\x03")
+
+        self._counter += 1
+
+    def _message_keys(self):
+        """Derive (aes_key, mac_key, iv) from the current ratchet state."""
+        # All four 32-byte ratchet components concatenated = 128 bytes
+        state = b"".join(self._ratchet)
+        keys = _hkdf_sha256(state, 80, salt=None, info=b"MEGOLM_KEYS")
+        return keys[:32], keys[32:64], keys[64:80]
+
+    # --- Rotation --------------------------------------------------------
+
+    def should_rotate(self, msg_count=None):
+        """Return ``True`` if this session has reached a rotation threshold."""
+        if msg_count is None:
+            msg_count = self._counter
+        if msg_count >= MEGOLM_ROTATION_MSGS:
+            return True
+        return (_time.time() - self.created_at) >= MEGOLM_ROTATION_AGE
+
+    # --- Encryption ------------------------------------------------------
+
+    def encrypt(self, payload_dict):
+        """Encrypt *payload_dict* and return base64 MegOLM ciphertext.
+
+        Wire format:
+          version (1 B = 0x03) | counter (4 B big-endian)
+          | AES-CBC ciphertext | HMAC-SHA-256 (8 B) | Ed25519 sig (64 B)
+
+        Reference: MegOLM spec, Section 4.
+        """
+        plaintext = dumps(payload_dict).encode("utf-8")
+        aes_key, mac_key, iv = self._message_keys()
+
+        ciphertext = _aes_cbc_encrypt(aes_key, iv, plaintext)
+        body = b"\x03" + struct.pack(">I", self._counter) + ciphertext
+        mac = _hmac_sha256(mac_key, body)[:8]
+        sig = self._sk.sign(body + mac)
+
+        self._advance()
+        return _b64enc(body + mac + sig)
+
+    # --- Session-key export  (shared via Olm to room members) ------------
+
+    def session_key(self):
+        """Base64 MegOLM session key for sharing in ``m.room_key`` events.
+
+        Wire format:
+          version (1 B = 0x02) | counter (4 B big-endian)
+          | R[0..3] (128 B) | Ed25519 signing pub key (32 B)
+
+        Reference: MegOLM spec, Section 2.
+        """
+        data = (
+            b"\x02"
+            + struct.pack(">I", self._counter)
+            + b"".join(self._ratchet)
+            + self._sk_pub
+        )
+        return _b64enc(data)
+
+    # --- Serialisation ---------------------------------------------------
+
+    def to_dict(self):
+        """Export session state for persistent storage."""
+        return {
+            "ratchet": [_b64enc(r) for r in self._ratchet],
+            "counter": self._counter,
+            "sk": _b64enc(
+                self._sk.private_bytes(
+                    Encoding.Raw, PrivateFormat.Raw, NoEncryption()
+                )
+            ),
+            "session_id": self.session_id,
+            "created_at": self.created_at,
+        }
+
+    @staticmethod
+    def from_dict(data):
+        """Restore from a ``to_dict()`` snapshot."""
+        return MatrixMegOlmSession(
+            ratchet=[_b64dec(r) for r in data["ratchet"]],
+            counter=data["counter"],
+            sk_priv_b64=data["sk"],
+            created_at=data.get("created_at"),
+        )

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -2952,13 +2952,23 @@ def test_plugin_matrix_e2ee_send(mock_post, mock_get, mock_put):
         r.content = dumps(d).encode()
         return r
 
-    # POST sequence: login, keys/upload, join, keys/query, keys/claim, logout
+    # POST sequence:
+    # login, keys/upload (with OTK count), join, keys/query, keys/claim,
+    # keys/upload (OTK replenishment), logout
     mock_post.side_effect = [
         _mk_resp(login_resp),
-        _mk_resp({}),  # keys/upload
+        _mk_resp({"one_time_key_counts": {"signed_curve25519": 1}}),
         _mk_resp({"room_id": "!room:localhost"}),  # join
         _mk_resp(query_resp),  # keys/query
         _mk_resp(claim_resp),  # keys/claim
+        # Replenishment: remaining = 1 - 1 (built_count) = 0 < threshold
+        _mk_resp(
+            {
+                "one_time_key_counts": {
+                    "signed_curve25519": NotifyMatrix.default_e2ee_otk_count,
+                }
+            }
+        ),
         _mk_resp({}),  # logout
     ]
     mock_get.return_value = _mk_resp(members_resp)
@@ -3225,7 +3235,11 @@ def test_plugin_matrix_e2ee_upload_keys_success_marks_published(
     resp = mock.Mock()
     resp.status_code = requests.codes.ok
     resp.content = dumps(
-        {"one_time_key_counts": {"signed_curve25519": 10}}
+        {
+            "one_time_key_counts": {
+                "signed_curve25519": NotifyMatrix.default_e2ee_otk_count,
+            }
+        }
     ).encode()
     mock_post.return_value = resp
 
@@ -3249,6 +3263,10 @@ def test_plugin_matrix_e2ee_upload_keys_success_marks_published(
     assert obj._e2ee_account._otks
     assert obj._e2ee_upload_keys() is True
     assert obj._e2ee_account._otks == {}
+    # Server OTK count from the response is persisted for threshold checks.
+    assert obj.store.get("e2ee_otk_server_count") == (
+        NotifyMatrix.default_e2ee_otk_count
+    )
 
 
 @mock.patch("requests.put")
@@ -3727,6 +3745,98 @@ def test_plugin_matrix_e2ee_share_room_key_branches(
         obj, "_e2ee_room_members", return_value=dict_members
     ):
         assert obj._e2ee_share_room_key("!r:h", session) is False
+
+
+@mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_e2ee_replenish_otks(mock_post):
+    """_e2ee_replenish_otks: threshold logic, diagnostics, and error paths."""
+    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
+
+    otk_count = NotifyMatrix.default_e2ee_otk_count
+    otk_threshold = NotifyMatrix.default_e2ee_otk_replenish_threshold
+
+    def _mk_resp(d, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(d).encode()
+        return r
+
+    def _make_obj():
+        obj = NotifyMatrix(
+            host="h", user="u", password="pass", targets=["#r"], e2ee=True
+        )
+        obj.user_id = "@u:h"
+        obj.device_id = "DEV"
+        obj._e2ee_account = MatrixOlmAccount()
+        return obj
+
+    # --- missing credentials: no network call, returns False ---
+    obj = _make_obj()
+    obj.user_id = None
+    assert obj._e2ee_replenish_otks() is False
+    assert mock_post.call_count == 0
+
+    obj = _make_obj()
+    obj.device_id = None
+    assert obj._e2ee_replenish_otks() is False
+    assert mock_post.call_count == 0
+
+    # --- pool sufficient: skip upload ---
+    # Store a count well above threshold; claimed_count=1 -> remaining is
+    # above default_e2ee_otk_replenish_threshold so no upload should happen.
+    obj = _make_obj()
+    obj.store.set("e2ee_otk_server_count", otk_threshold + otk_count)
+    result = obj._e2ee_replenish_otks(claimed_count=1, skipped_no_otk=0)
+    assert result is True
+    assert mock_post.call_count == 0
+
+    # --- pool low: remaining < threshold triggers upload ---
+    obj = _make_obj()
+    obj.store.set("e2ee_otk_server_count", otk_threshold - 1)
+    mock_post.return_value = _mk_resp(
+        {"one_time_key_counts": {"signed_curve25519": otk_count}}
+    )
+    assert obj._e2ee_replenish_otks(claimed_count=0, skipped_no_otk=0) is True
+    assert mock_post.call_count == 1
+    assert obj.store.get("e2ee_otk_server_count") == otk_count
+    assert obj.store.get("e2ee_account") is not None
+    mock_post.reset_mock()
+
+    # --- unknown server count (no store entry): replenish as precaution ---
+    obj = _make_obj()
+    # e2ee_otk_server_count not set -> unknown
+    mock_post.return_value = _mk_resp(
+        {"one_time_key_counts": {"signed_curve25519": otk_count}}
+    )
+    assert obj._e2ee_replenish_otks(claimed_count=0, skipped_no_otk=0) is True
+    assert mock_post.call_count == 1
+    mock_post.reset_mock()
+
+    # --- skipped_no_otk > 0: always replenishes regardless of count ---
+    obj = _make_obj()
+    obj.store.set("e2ee_otk_server_count", otk_threshold + otk_count)
+    mock_post.return_value = _mk_resp(
+        {"one_time_key_counts": {"signed_curve25519": otk_count}}
+    )
+    assert obj._e2ee_replenish_otks(claimed_count=0, skipped_no_otk=2) is True
+    assert mock_post.call_count == 1
+    mock_post.reset_mock()
+
+    # --- upload failure: returns False, logs warning ---
+    obj = _make_obj()
+    obj.store.set("e2ee_otk_server_count", 0)
+    mock_post.return_value = _mk_resp({}, code=500)
+    assert obj._e2ee_replenish_otks(claimed_count=0, skipped_no_otk=0) is False
+    mock_post.reset_mock()
+
+    # --- response missing one_time_key_counts: new count defaults to 0 ---
+    obj = _make_obj()
+    obj.store.set("e2ee_otk_server_count", 0)
+    mock_post.return_value = _mk_resp({})  # no one_time_key_counts key
+    assert obj._e2ee_replenish_otks(claimed_count=0, skipped_no_otk=0) is True
+    assert obj.store.get("e2ee_otk_server_count") == 0
+    mock_post.reset_mock()
 
 
 @mock.patch("requests.put")

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -1148,11 +1148,11 @@ def test_plugin_matrix_attachments_api_v3(mock_post, mock_put):
     )
     assert (
         mock_post.call_args_list[1][0][0]
-        == "http://localhost/_matrix/media/v3/upload"
+        == "http://localhost/_matrix/client/v3/join/%23general%3Alocalhost"
     )
     assert (
         mock_post.call_args_list[2][0][0]
-        == "http://localhost/_matrix/client/v3/join/%23general%3Alocalhost"
+        == "http://localhost/_matrix/media/v3/upload"
     )
     assert (
         mock_put.call_args_list[0][0][0]
@@ -1500,7 +1500,7 @@ def test_plugin_matrix_attachments_api_v2(mock_post, mock_get, mock_put):
         is True
     )
 
-    # Test our call count — login, upload, join use POST; sends use PUT
+    # Test our call count -- login, join, upload use POST; sends use PUT
     assert mock_post.call_count == 3
     assert (
         mock_post.call_args_list[0][0][0]
@@ -1508,12 +1508,12 @@ def test_plugin_matrix_attachments_api_v2(mock_post, mock_get, mock_put):
     )
     assert (
         mock_post.call_args_list[1][0][0]
-        == "https://matrix.example.com/_matrix/media/r0/upload"
+        == "https://matrix.example.com/_matrix/client/r0/"
+        "join/%23general%3Alocalhost"
     )
     assert (
         mock_post.call_args_list[2][0][0]
-        == "https://matrix.example.com/_matrix/client/r0/"
-        "join/%23general%3Alocalhost"
+        == "https://matrix.example.com/_matrix/media/r0/upload"
     )
     assert mock_put.call_count == 2
     assert (
@@ -3050,8 +3050,10 @@ def test_plugin_matrix_e2ee_setup_failure(mock_post, mock_get, mock_put):
 @mock.patch("requests.put")
 @mock.patch("requests.get")
 @mock.patch("requests.post")
-def test_plugin_matrix_e2ee_attachment_skip(mock_post, mock_get, mock_put):
-    """E2EE mode warns and skips attachments."""
+def test_plugin_matrix_e2ee_attachment_encrypted(
+    mock_post, mock_get, mock_put
+):
+    """E2EE mode encrypts and delivers attachments."""
     import tempfile
 
     login_resp = {
@@ -3060,6 +3062,7 @@ def test_plugin_matrix_e2ee_attachment_skip(mock_post, mock_get, mock_put):
         "home_server": "h",
         "device_id": "DEV",
     }
+    upload_resp = {"content_uri": "mxc://h/enc123"}
 
     def _mk_resp(d):
         r = mock.Mock()
@@ -3071,6 +3074,7 @@ def test_plugin_matrix_e2ee_attachment_skip(mock_post, mock_get, mock_put):
         _mk_resp(login_resp),
         _mk_resp({}),  # keys/upload
         _mk_resp({"room_id": "!r:h"}),  # join
+        _mk_resp(upload_resp),  # encrypted attachment upload
         _mk_resp({}),  # logout
     ]
     mock_get.return_value = _mk_resp({"joined": {}})
@@ -3093,16 +3097,259 @@ def test_plugin_matrix_e2ee_attachment_skip(mock_post, mock_get, mock_put):
             secure=True,
             discovery=False,
         )
-        # Pre-seed room encryption state, session, and shared flag so
-        # E2EE is active without any key-share or room-enc GET round-trips.
         from apprise.plugins.matrix.e2ee import MatrixMegOlmSession
 
         _s = MatrixMegOlmSession()
         obj.store.set("e2ee_room_enc_!r:h", True)
         obj.store.set("e2ee_megolm_!r:h", _s.to_dict())
         obj.store.set("e2ee_key_shared_!r:h", True)
-        # attach provided but room is E2EE -> attachment skipped, send ok
         assert obj.send(body="body", attach=attach) is True
+
+        # Two PUTs: encrypted message + encrypted attachment event
+        assert mock_put.call_count == 2
+
+    finally:
+        os.unlink(attach_path)
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_e2ee_send_attachment_errors(
+    mock_post, mock_get, mock_put
+):
+    """_e2ee_send_attachment error branches: OSError, network, HTTP fail."""
+    import tempfile
+
+    from apprise.plugins.matrix.e2ee import (
+        MatrixMegOlmSession,
+        MatrixOlmAccount,
+    )
+
+    def _mk_resp(d, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(d).encode()
+        return r
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["!r:h"],
+        e2ee=True,
+        secure=True,
+        discovery=False,
+    )
+    obj.access_token = "tok"
+    obj.home_server = "h"
+    obj.user_id = "@u:h"
+    obj.device_id = "DEV"
+    obj._e2ee_account = MatrixOlmAccount()
+    session = MatrixMegOlmSession()
+
+    # OSError reading file -> False
+    with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+        f.write(b"data")
+        tmp_path = f.name
+
+    try:
+
+        class _BadAttach:
+            path = tmp_path
+            name = "f.txt"
+            mimetype = "text/plain"
+
+        with mock.patch("builtins.open", side_effect=OSError("no read")):
+            assert (
+                obj._e2ee_send_attachment(_BadAttach(), "!r:h", session)
+                is False
+            )
+
+        # Network error during upload -> False
+        with mock.patch(
+            "requests.post",
+            side_effect=requests.RequestException("boom"),
+        ):
+            assert (
+                obj._e2ee_send_attachment(_BadAttach(), "!r:h", session)
+                is False
+            )
+
+        # HTTP error from media server -> False
+        with mock.patch("requests.post", return_value=_mk_resp({}, code=500)):
+            assert (
+                obj._e2ee_send_attachment(_BadAttach(), "!r:h", session)
+                is False
+            )
+
+        # Upload succeeds but response body is not valid JSON -> treated as
+        # missing content_uri -> False
+        bad_json_resp = mock.Mock()
+        bad_json_resp.status_code = requests.codes.ok
+        bad_json_resp.content = b"not-json"
+        with mock.patch("requests.post", return_value=bad_json_resp):
+            assert (
+                obj._e2ee_send_attachment(_BadAttach(), "!r:h", session)
+                is False
+            )
+
+        # base_url raises -> False
+        with mock.patch(
+            "apprise.plugins.matrix.base.NotifyMatrix.base_url",
+            new_callable=mock.PropertyMock,
+            side_effect=Exception("discovery fail"),
+        ):
+            assert (
+                obj._e2ee_send_attachment(_BadAttach(), "!r:h", session)
+                is False
+            )
+
+        # No access_token -> Authorization header omitted, upload still works
+        obj_noauth = NotifyMatrix(
+            host="h",
+            user="u",
+            password="pass",
+            targets=["!r:h"],
+            e2ee=True,
+            secure=True,
+            discovery=False,
+        )
+        obj_noauth.access_token = None
+        obj_noauth.home_server = "h"
+        obj_noauth.user_id = "@u:h"
+        obj_noauth.device_id = "DEV"
+        obj_noauth._e2ee_account = MatrixOlmAccount()
+        sess_noauth = MatrixMegOlmSession()
+        with mock.patch(
+            "requests.post",
+            return_value=_mk_resp({"content_uri": "mxc://h/y"}),
+        ):
+            mock_put.return_value = _mk_resp({})
+            assert (
+                obj_noauth._e2ee_send_attachment(
+                    _BadAttach(), "!r:h", sess_noauth
+                )
+                is True
+            )
+
+        # access_token == password -> transaction ID not incremented
+        obj2 = NotifyMatrix(
+            host="h",
+            user="u",
+            password="tok",
+            targets=["!r:h"],
+            e2ee=True,
+            secure=True,
+            discovery=False,
+        )
+        obj2.access_token = "tok"
+        obj2.password = "tok"
+        obj2.home_server = "h"
+        obj2.user_id = "@u:h"
+        obj2.device_id = "DEV"
+        obj2._e2ee_account = MatrixOlmAccount()
+        sess2 = MatrixMegOlmSession()
+        txn_before = obj2.transaction_id
+        upload_r = _mk_resp({"content_uri": "mxc://h/x"})
+        put_r = _mk_resp({})
+        with mock.patch("requests.post", return_value=upload_r):
+            mock_put.return_value = put_r
+            result = obj2._e2ee_send_attachment(_BadAttach(), "!r:h", sess2)
+        assert result is True
+        assert obj2.transaction_id == txn_before
+
+    finally:
+        os.unlink(tmp_path)
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_e2ee_send_attachment_invalid(
+    mock_post, mock_get, mock_put
+):
+    """Invalid attachment and _e2ee_send_attachment failure mark has_error."""
+    import tempfile
+
+    login_resp = {
+        "access_token": "tok",
+        "user_id": "@u:h",
+        "home_server": "h",
+        "device_id": "DEV",
+    }
+
+    def _mk_resp(d):
+        r = mock.Mock()
+        r.status_code = requests.codes.ok
+        r.content = dumps(d).encode()
+        return r
+
+    mock_post.side_effect = [
+        _mk_resp(login_resp),
+        _mk_resp({}),  # keys/upload
+        _mk_resp({"room_id": "!r:h"}),  # join
+        _mk_resp({}),  # logout
+    ]
+    mock_get.return_value = _mk_resp({})
+    mock_put.return_value = _mk_resp({})
+
+    with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+        f.write(b"data")
+        attach_path = f.name
+
+    try:
+        from apprise.plugins.matrix.e2ee import MatrixMegOlmSession
+
+        obj = NotifyMatrix(
+            host="h",
+            user="u",
+            password="pass",
+            targets=["!r:h"],
+            e2ee=True,
+            secure=True,
+            discovery=False,
+        )
+        _s = MatrixMegOlmSession()
+        obj.store.set("e2ee_room_enc_!r:h", True)
+        obj.store.set("e2ee_megolm_!r:h", _s.to_dict())
+        obj.store.set("e2ee_key_shared_!r:h", True)
+
+        attach = AppriseAttachment()
+        attach.add(attach_path)
+
+        # _e2ee_send_attachment fails -> send returns False
+        with mock.patch.object(
+            obj, "_e2ee_send_attachment", return_value=False
+        ):
+            assert obj.send(body="body", attach=attach) is False
+
+        # Invalid attachment (falsy) in list -> has_error set and loop breaks
+        mock_post.reset_mock()
+        mock_post.side_effect = [
+            _mk_resp(login_resp),
+            _mk_resp({}),  # keys/upload
+            _mk_resp({"room_id": "!r:h"}),  # join
+            _mk_resp({}),  # logout
+        ]
+        obj2 = NotifyMatrix(
+            host="h",
+            user="u",
+            password="pass",
+            targets=["!r:h"],
+            e2ee=True,
+            secure=True,
+            discovery=False,
+        )
+        _s2 = MatrixMegOlmSession()
+        obj2.store.set("e2ee_room_enc_!r:h", True)
+        obj2.store.set("e2ee_megolm_!r:h", _s2.to_dict())
+        obj2.store.set("e2ee_key_shared_!r:h", True)
+        # Add a non-existent file to get a falsy attachment
+        bad_attach = AppriseAttachment()
+        bad_attach.add("/nonexistent/path/file.txt")
+        with mock.patch.object(obj2, "_e2ee_send_to_room", return_value=True):
+            assert obj2.send(body="body", attach=bad_attach) is False
 
     finally:
         os.unlink(attach_path)

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -913,6 +913,38 @@ def test_plugin_matrix_rooms(mock_post, mock_get, mock_put):
     assert obj._room_create("#abc123:localhost") is None
     del obj
 
+    # _room_create with e2ee=True/secure=True embeds initial_state and
+    # pre-seeds the room encryption cache so a subsequent
+    # _e2ee_room_encrypted() call does not need a network round-trip.
+    request.status_code = requests.codes.ok
+    request.content = dumps(response_obj)
+    obj_e2ee = NotifyMatrix(
+        host="localhost",
+        user="u",
+        password="p",
+        e2ee=True,
+        secure=True,
+        discovery=False,
+    )
+    obj_e2ee.access_token = "tok"
+    obj_e2ee.home_server = "localhost"
+    captured_payloads = []
+    _orig_fetch = obj_e2ee._fetch
+
+    def _capture_fetch(path, payload=None, **kw):
+        if path == "/createRoom":
+            captured_payloads.append(payload)
+        return _orig_fetch(path, payload=payload, **kw)
+
+    obj_e2ee._fetch = _capture_fetch
+    room_id = obj_e2ee._room_create("e2ee_room")
+    assert room_id == response_obj["room_id"]
+    assert len(captured_payloads) == 1
+    init_state = captured_payloads[0].get("initial_state", [])
+    assert any(s.get("type") == "m.room.encryption" for s in init_state)
+    assert obj_e2ee.store.get("e2ee_room_enc_{}".format(room_id)) is True
+    del obj_e2ee
+
     # Room detection
     request.status_code = requests.codes.ok
     request.content = dumps(response_obj)
@@ -4098,4 +4130,59 @@ def test_plugin_matrix_dm_room_create_no_user_id(
     assert room_id == "!nodm:h"
     # No GET and no PUT for m.direct since user_id is None
     assert mock_get.call_count == 0
-    assert mock_put.call_count == 0
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_dm_room_create_e2ee(mock_post, mock_get, mock_put):
+    """_dm_room_find_or_create with e2ee=True/secure=True embeds
+    initial_state and pre-seeds the room encryption cache."""
+    from apprise.plugins.matrix.base import MATRIX_E2EE_SUPPORT
+
+    if not MATRIX_E2EE_SUPPORT:
+        pytest.skip("cryptography package not installed")
+
+    def _mk_resp(d, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(d).encode()
+        return r
+
+    mock_get.return_value = _mk_resp({})
+    mock_post.return_value = _mk_resp({"room_id": "!dm_e2ee:h"})
+    mock_put.return_value = _mk_resp({})
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["@alice"],
+        e2ee=True,
+        secure=True,
+        discovery=False,
+    )
+    obj.access_token = "tok"
+    obj.user_id = "@u:h"
+    obj.home_server = "h"
+
+    captured_payloads = []
+    _orig_fetch = obj._fetch
+
+    def _capture_fetch(path, payload=None, **kw):
+        if path == "/createRoom":
+            captured_payloads.append(payload or {})
+        return _orig_fetch(path, payload=payload, **kw)
+
+    obj._fetch = _capture_fetch
+
+    room_id = obj._dm_room_find_or_create("@alice")
+    assert room_id == "!dm_e2ee:h"
+
+    # Verify initial_state was sent with m.room.encryption
+    assert len(captured_payloads) == 1
+    init_state = captured_payloads[0].get("initial_state", [])
+    assert any(s.get("type") == "m.room.encryption" for s in init_state)
+
+    # Room encryption cache must be pre-seeded
+    assert obj.store.get("e2ee_room_enc_!dm_e2ee:h") is True

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -3735,6 +3735,15 @@ def test_plugin_matrix_e2ee_account_bad_store_data():
     assert obj2._e2ee_account is None
 
 
+def test_plugin_matrix_del_suppresses_logout_exceptions():
+    """__del__ should never raise if logout fails during GC cleanup."""
+    obj = NotifyMatrix(host="h", user="u", password="pass", targets=["#r"])
+    obj.access_token = "tok"
+
+    with mock.patch.object(obj, "_logout", side_effect=RuntimeError("boom")):
+        obj.__del__()
+
+
 # ---------------------------------------------------------------------------
 # DM / direct-message tests
 # ---------------------------------------------------------------------------

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -2138,6 +2138,22 @@ def _rand_b64_32():
     return base64.b64encode(os.urandom(32)).decode()
 
 
+def _make_signed_otk(account, user_id, device_id, key_b64=None):
+    """Return a signed_curve25519 OTK dict signed by *account*.
+
+    Produces {"key": ..., "signatures": {user_id: {"ed25519:DEV": ...}}}
+    suitable for inclusion in a /keys/claim mock response.
+    """
+    from apprise.plugins.matrix.e2ee import _canonical_json
+
+    if key_b64 is None:
+        key_b64 = _rand_b64_32()
+    payload = {"key": key_b64}
+    sig = account.sign(_canonical_json(payload))
+    payload["signatures"] = {user_id: {"ed25519:{}".format(device_id): sig}}
+    return payload
+
+
 def test_plugin_matrix_e2ee_helpers():
     """e2ee helper functions."""
     from apprise.plugins.matrix.e2ee import (
@@ -2241,6 +2257,69 @@ def test_plugin_matrix_e2ee_olm_session():
     assert result2["type"] == 0
 
 
+def test_plugin_matrix_e2ee_verify_keys():
+    """verify_device_keys and verify_signed_otk accept/reject signatures."""
+    from apprise.plugins.matrix.e2ee import (
+        MatrixOlmAccount,
+        _canonical_json,
+        verify_device_keys,
+        verify_signed_otk,
+    )
+
+    acct = MatrixOlmAccount()
+    uid = "@alice:h"
+    dev = "DEVID"
+
+    # --- verify_device_keys ---
+
+    # Valid self-signed device keys -> True
+    dk = acct.device_keys_payload(uid, dev)
+    assert verify_device_keys(dk, uid, dev) is True
+
+    # Missing signatures field -> False
+    no_sig = {k: v for k, v in dk.items() if k != "signatures"}
+    assert verify_device_keys(no_sig, uid, dev) is False
+
+    # Wrong user_id in signatures -> False
+    wrong_uid = {
+        **dk,
+        "signatures": {"@wrong:h": dk["signatures"][uid]},
+    }
+    assert verify_device_keys(wrong_uid, uid, dev) is False
+
+    # Tampered key value -> False
+    tampered = {**dk, "keys": {**dk["keys"], f"ed25519:{dev}": "bad"}}
+    assert verify_device_keys(tampered, uid, dev) is False
+
+    # Missing ed25519 key entry -> False
+    no_keys = {**dk, "keys": {f"curve25519:{dev}": acct.identity_key}}
+    assert verify_device_keys(no_keys, uid, dev) is False
+
+    # --- verify_signed_otk ---
+
+    key_b64 = _rand_b64_32()
+    otk_obj = {"key": key_b64}
+    sig = acct.sign(_canonical_json(otk_obj))
+    signed_otk = {
+        **otk_obj,
+        "signatures": {uid: {f"ed25519:{dev}": sig}},
+    }
+
+    # Valid OTK -> True
+    assert verify_signed_otk(signed_otk, uid, dev, acct.signing_key) is True
+
+    # Missing signatures -> False
+    assert verify_signed_otk(otk_obj, uid, dev, acct.signing_key) is False
+
+    # Wrong signing key -> False
+    other = MatrixOlmAccount()
+    assert verify_signed_otk(signed_otk, uid, dev, other.signing_key) is False
+
+    # Tampered key value -> False
+    tampered_otk = {**signed_otk, "key": _rand_b64_32()}
+    assert verify_signed_otk(tampered_otk, uid, dev, acct.signing_key) is False
+
+
 def test_plugin_matrix_e2ee_megolm_session():
     """MatrixMegOlmSession encrypt, session_key, rotation, serialisation."""
     from apprise.plugins.matrix.e2ee import (
@@ -2273,24 +2352,26 @@ def test_plugin_matrix_e2ee_megolm_session():
     old = MatrixMegOlmSession(created_at=0.0)
     assert old.should_rotate()
 
-    # _advance branches
-    # -- normal step (else branch, counter starts at 0 so always else first)
-    s3 = MatrixMegOlmSession()
-    s3._advance()  # counter 0 -> 1  (else: R[3] only)
+    # _advance branches -- cascade fires when (n+1) % threshold == 0,
+    # i.e. when the counter is one less than a threshold multiple.
 
-    # -- %256 branch: counter == 256 before advance
+    # -- normal step (else branch)
+    s3 = MatrixMegOlmSession()
+    s3._advance()  # counter 0 -> 1  (1 % 256 != 0, else: R[3] only)
+
+    # -- %256 branch: next counter will be 256
     s4 = MatrixMegOlmSession()
-    s4._counter = 256
+    s4._counter = 255
     s4._advance()
 
-    # -- %65536 branch
+    # -- %65536 branch: next counter will be 65536
     s5 = MatrixMegOlmSession()
-    s5._counter = 65536
+    s5._counter = 65535
     s5._advance()
 
-    # -- %2^24 branch
+    # -- %2^24 branch: next counter will be 2^24
     s6 = MatrixMegOlmSession()
-    s6._counter = 1 << 24
+    s6._counter = (1 << 24) - 1
     s6._advance()
 
 
@@ -2410,7 +2491,6 @@ def test_plugin_matrix_e2ee_send(mock_post, mock_get, mock_put):
 
     # Recipient device (acts as a room member)
     recipient = MatrixOlmAccount()
-    their_ik = recipient.identity_key
 
     login_resp = {
         "access_token": "tok123",
@@ -2419,32 +2499,22 @@ def test_plugin_matrix_e2ee_send(mock_post, mock_get, mock_put):
         "device_id": "SENDERDEV",
     }
 
-    # One-time key value (32 bytes, base64)
-    otk_val = _rand_b64_32()
-
     members_resp = {
         "joined": {"@other:localhost": {}},
     }
 
+    # Properly signed device keys (required by verify_device_keys)
+    signed_dev = recipient.device_keys_payload("@other:localhost", "OTHERDEV")
     query_resp = {
-        "device_keys": {
-            "@other:localhost": {
-                "OTHERDEV": {
-                    "keys": {
-                        "curve25519:OTHERDEV": their_ik,
-                        "ed25519:OTHERDEV": recipient.signing_key,
-                    }
-                }
-            }
-        }
+        "device_keys": {"@other:localhost": {"OTHERDEV": signed_dev}}
     }
 
+    # Properly signed OTK (required by verify_signed_otk)
+    signed_otk = _make_signed_otk(recipient, "@other:localhost", "OTHERDEV")
     claim_resp = {
         "one_time_keys": {
             "@other:localhost": {
-                "OTHERDEV": {
-                    "curve25519:KEYID": otk_val,
-                }
+                "OTHERDEV": {"signed_curve25519:KEYID": signed_otk}
             }
         }
     }
@@ -2634,6 +2704,48 @@ def test_plugin_matrix_e2ee_upload_keys_http_fail(
 @mock.patch("requests.put")
 @mock.patch("requests.get")
 @mock.patch("requests.post")
+def test_plugin_matrix_whoami(mock_post, mock_get, mock_put):
+    """_whoami() resolves user_id and device_id from GET /account/whoami."""
+
+    def _mk_resp(d, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(d).encode()
+        return r
+
+    obj = NotifyMatrix(
+        host="h",
+        password="rawtoken",
+        targets=["#r"],
+        e2ee=True,
+    )
+    obj.access_token = "rawtoken"
+    obj.home_server = "h"
+
+    # Success: server returns user_id and device_id; home_server is
+    # extracted from user_id so DM targets resolve correctly.
+    mock_get.return_value = _mk_resp(
+        {"user_id": "@tok:h", "device_id": "TOKDEV"}
+    )
+    assert obj._whoami() is True
+    assert obj.user_id == "@tok:h"
+    assert obj.device_id == "TOKDEV"
+    assert obj.home_server == "h"
+    assert obj.store.get("user_id") == "@tok:h"
+    assert obj.store.get("device_id") == "TOKDEV"
+    assert obj.store.get("home_server") == "h"
+
+    # Failure: server returns non-200
+    obj.user_id = None
+    obj.device_id = None
+    mock_get.return_value = _mk_resp({}, code=401)
+    assert obj._whoami() is False
+    assert obj.user_id is None
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
 def test_plugin_matrix_e2ee_get_megolm_rotation(mock_post, mock_get, mock_put):
     """_e2ee_get_megolm rotates session after threshold."""
     from apprise.plugins.matrix.e2ee import (
@@ -2740,8 +2852,10 @@ def test_plugin_matrix_e2ee_room_members(mock_post, mock_get, mock_put):
     mock_post.return_value = _mk_resp({}, code=500)
     assert obj._e2ee_room_members("!r:h") is None
 
-    # Success
-    query_resp = {
+    # Unsigned device key -> device is rejected (empty result for that uid)
+    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
+
+    unsigned_resp = {
         "device_keys": {
             "@u:h": {
                 "DEV": {
@@ -2749,14 +2863,25 @@ def test_plugin_matrix_e2ee_room_members(mock_post, mock_get, mock_put):
                         "curve25519:DEV": "IK",
                         "ed25519:DEV": "SK",
                     }
+                    # no "signatures" field
                 }
             }
         }
     }
+    mock_get.return_value = _mk_resp({"joined": {"@u:h": {}}})
+    mock_post.return_value = _mk_resp(unsigned_resp)
+    result = obj._e2ee_room_members("!r:h")
+    assert result["@u:h"] == {}
+
+    # Properly signed device key -> device included
+    acct = MatrixOlmAccount()
+    signed_dev = acct.device_keys_payload("@u:h", "DEV")
+    query_resp = {"device_keys": {"@u:h": {"DEV": signed_dev}}}
+    mock_get.return_value = _mk_resp({"joined": {"@u:h": {}}})
     mock_post.return_value = _mk_resp(query_resp)
     result = obj._e2ee_room_members("!r:h")
     assert "@u:h" in result
-    assert result["@u:h"]["DEV"]["curve25519"] == "IK"
+    assert result["@u:h"]["DEV"]["curve25519"] == acct.identity_key
 
 
 @mock.patch("requests.put")
@@ -2811,7 +2936,7 @@ def test_plugin_matrix_e2ee_share_room_key_branches(
     }
     otk_resp = {
         "one_time_keys": {
-            "@sender:h": {"SDEV": {"curve25519:KID": _rand_b64_32()}}
+            "@sender:h": {"SDEV": {"signed_curve25519:KID": _rand_b64_32()}}
         }
     }
     mock_post.return_value = _mk_resp(otk_resp)
@@ -2830,16 +2955,24 @@ def test_plugin_matrix_e2ee_share_room_key_branches(
         )
         assert obj._e2ee_share_room_key("!r:h", session) is True
 
-    # dict-valued OTK (with "key" field) succeeds end-to-end
+    # dict-valued OTK with valid signature succeeds end-to-end
     recipient = MatrixOlmAccount()
     their_ik = recipient.identity_key
-    their_otk = recipient.identity_key  # reuse as OTK
+    their_otk_b64 = _rand_b64_32()
+    signed_otk_dict = _make_signed_otk(
+        recipient, "@other:h", "DEV", their_otk_b64
+    )
     dict_members = {
-        "@other:h": {"DEV": {"curve25519": their_ik, "ed25519": "SK"}}
+        "@other:h": {
+            "DEV": {
+                "curve25519": their_ik,
+                "ed25519": recipient.signing_key,
+            }
+        }
     }
     dict_otk = {
         "one_time_keys": {
-            "@other:h": {"DEV": {"curve25519:KID": {"key": their_otk}}}
+            "@other:h": {"DEV": {"signed_curve25519:KID": signed_otk_dict}}
         }
     }
     mock_post.return_value = _mk_resp(dict_otk)
@@ -2849,12 +2982,33 @@ def test_plugin_matrix_e2ee_share_room_key_branches(
     ):
         assert obj._e2ee_share_room_key("!r:h", session) is True
 
-    # string-valued OTK (plain base64 string, not a dict)
+    # dict-valued OTK with no signatures -> OTK rejected, device skipped
+    unsigned_otk_dict = {"key": their_otk_b64}  # no "signatures" field
+    unsigned_otk_resp = {
+        "one_time_keys": {
+            "@other:h": {"DEV": {"signed_curve25519:KID": unsigned_otk_dict}}
+        }
+    }
+    mock_post.return_value = _mk_resp(unsigned_otk_resp)
+    with mock.patch.object(
+        obj, "_e2ee_room_members", return_value=dict_members
+    ):
+        # No valid OTK -> no messages built -> True (nothing to send)
+        assert obj._e2ee_share_room_key("!r:h", session) is True
+
+    # string-valued OTK (plain base64 string -- unverified legacy fallback)
     str_members = {
-        "@other:h": {"DEV": {"curve25519": their_ik, "ed25519": "SK"}}
+        "@other:h": {
+            "DEV": {
+                "curve25519": their_ik,
+                "ed25519": recipient.signing_key,
+            }
+        }
     }
     str_otk = {
-        "one_time_keys": {"@other:h": {"DEV": {"curve25519:KID": their_otk}}}
+        "one_time_keys": {
+            "@other:h": {"DEV": {"signed_curve25519:KID": their_otk_b64}}
+        }
     }
     mock_post.return_value = _mk_resp(str_otk)
     mock_put.return_value = _mk_resp({})
@@ -2863,9 +3017,9 @@ def test_plugin_matrix_e2ee_share_room_key_branches(
     ):
         assert obj._e2ee_share_room_key("!r:h", session) is True
 
-    # OTK key not prefixed with "curve25519:" -> skipped, no OTK found
+    # OTK key not prefixed with "signed_curve25519:" -> skipped, no OTK found
     bad_key_otk = {
-        "one_time_keys": {"@other:h": {"DEV": {"ed25519:KID": their_otk}}}
+        "one_time_keys": {"@other:h": {"DEV": {"ed25519:KID": their_otk_b64}}}
     }
     mock_post.return_value = _mk_resp(bad_key_otk)
     with mock.patch.object(
@@ -2883,7 +3037,7 @@ def test_plugin_matrix_e2ee_share_room_key_branches(
 
     # OTK value is neither dict nor str (e.g. integer) -> skipped
     non_str_otk = {
-        "one_time_keys": {"@other:h": {"DEV": {"curve25519:KID": 42}}}
+        "one_time_keys": {"@other:h": {"DEV": {"signed_curve25519:KID": 42}}}
     }
     mock_post.return_value = _mk_resp(non_str_otk)
     with mock.patch.object(
@@ -2892,8 +3046,11 @@ def test_plugin_matrix_e2ee_share_room_key_branches(
         assert obj._e2ee_share_room_key("!r:h", session) is True
 
     # create_outbound_session raises -> device is skipped gracefully
+    # Uses a string OTK (no sig check) so the Olm call is actually reached
     create_fail_otk = {
-        "one_time_keys": {"@other:h": {"DEV": {"curve25519:KID": their_otk}}}
+        "one_time_keys": {
+            "@other:h": {"DEV": {"signed_curve25519:KID": their_otk_b64}}
+        }
     }
     mock_post.return_value = _mk_resp(create_fail_otk)
     with (
@@ -2906,16 +3063,22 @@ def test_plugin_matrix_e2ee_share_room_key_branches(
     ):
         assert obj._e2ee_share_room_key("!r:h", session) is True
 
-    # sendToDevice PUT fails -> warning logged but returns True
-    full_members = {
-        "@other:h": {"DEV": {"curve25519": their_ik, "ed25519": "SK"}}
+    # sendToDevice PUT fails -> returns False (key-shared flag not set)
+    # Uses a signed OTK so the full Olm path is exercised before the PUT
+    full_signed_otk = _make_signed_otk(
+        recipient, "@other:h", "DEV", their_otk_b64
+    )
+    full_otk_resp = {
+        "one_time_keys": {
+            "@other:h": {"DEV": {"signed_curve25519:KID": full_signed_otk}}
+        }
     }
-    mock_post.return_value = _mk_resp(str_otk)
+    mock_post.return_value = _mk_resp(full_otk_resp)
     mock_put.return_value = _mk_resp({}, code=500)
     with mock.patch.object(
-        obj, "_e2ee_room_members", return_value=full_members
+        obj, "_e2ee_room_members", return_value=dict_members
     ):
-        assert obj._e2ee_share_room_key("!r:h", session) is True
+        assert obj._e2ee_share_room_key("!r:h", session) is False
 
 
 @mock.patch("requests.put")

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -3746,6 +3746,38 @@ def test_plugin_matrix_e2ee_share_room_key_branches(
     ):
         assert obj._e2ee_share_room_key("!r:h", session) is False
 
+    # token-as-password mode: transaction_id is a UUID, not an int.
+    # Previously, the unconditional `+= 1` raised TypeError (UUID + int).
+    # With the guard in place the UUID is used as-is and the send succeeds.
+    import uuid as _uuid_mod
+
+    uuid_obj = NotifyMatrix(
+        host="h", password="rawtoken", targets=["#r"], e2ee=True
+    )
+    uuid_obj.access_token = "rawtoken"
+    uuid_obj.password = "rawtoken"
+    uuid_obj.transaction_id = _uuid_mod.uuid4()  # UUID, not int
+    uuid_obj.home_server = "h"
+    uuid_obj.user_id = "@tok:h"
+    uuid_obj.device_id = "TOKDEV"
+    uuid_obj._e2ee_account = MatrixOlmAccount()
+
+    uuid_session = MatrixMegOlmSession()
+    uuid_otk = _make_signed_otk(recipient, "@other:h", "DEV", their_otk_b64)
+    uuid_claim = {
+        "one_time_keys": {
+            "@other:h": {"DEV": {"signed_curve25519:KID": uuid_otk}}
+        }
+    }
+    mock_post.return_value = _mk_resp(uuid_claim)
+    mock_put.return_value = _mk_resp({})
+    with mock.patch.object(
+        uuid_obj, "_e2ee_room_members", return_value=dict_members
+    ):
+        # Must not raise TypeError; transaction_id stays as UUID
+        assert uuid_obj._e2ee_share_room_key("!r:h", uuid_session) is True
+        assert isinstance(uuid_obj.transaction_id, _uuid_mod.UUID)
+
 
 @mock.patch("requests.post")
 @pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -2118,3 +2118,1085 @@ def test_plugin_matrix_room_create_on_not_found_join(
     assert mock_post.call_count == 4
     assert mock_get.call_count == 1
     assert mock_put.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# E2EE unit tests (require the cryptography package)
+# ---------------------------------------------------------------------------
+
+# Skip all E2EE tests when cryptography is unavailable
+_cryptography = pytest.importorskip(
+    "cryptography",
+    reason="Requires cryptography",
+    exc_type=ImportError,
+)
+
+
+def _rand_b64_32():
+    """32 bytes of random data encoded as unpadded base64."""
+    import base64
+
+    return base64.b64encode(os.urandom(32)).decode()
+
+
+def test_plugin_matrix_e2ee_helpers():
+    """e2ee helper functions."""
+    from apprise.plugins.matrix.e2ee import (
+        _b64dec,
+        _b64enc,
+        _canonical_json,
+        _hmac_sha256,
+        _pb_bytes,
+        _pb_varint_field,
+        _varint,
+    )
+
+    # _b64enc / _b64dec round-trip
+    raw = b"\x00\x01\x02\x03"
+    assert _b64dec(_b64enc(raw)) == raw
+
+    # _b64dec tolerates missing padding and URL-safe chars
+    # "AA==" -> decode "AA" (2 chars, pad=2)
+    assert _b64dec("AA") == b"\x00"
+    # URL-safe chars are normalised
+    assert _b64dec("AA--") == _b64dec("AA++")
+
+    # _hmac_sha256 returns 32 bytes
+    mac = _hmac_sha256(b"\x00" * 32, b"data")
+    assert isinstance(mac, bytes) and len(mac) == 32
+
+    # _varint: n==0 -> single zero byte
+    assert _varint(0) == b"\x00"
+    # n>0 is encoded as multi-byte varint
+    assert _varint(128) == b"\x80\x01"
+
+    # _pb_bytes / _pb_varint_field produce bytes
+    pb = _pb_bytes(1, b"hello")
+    assert isinstance(pb, bytes) and len(pb) > 5
+    pv = _pb_varint_field(2, 42)
+    assert isinstance(pv, bytes)
+
+    # _canonical_json produces sorted-key JSON bytes
+    data = {"z": 1, "a": 2}
+    out = _canonical_json(data)
+    assert out.startswith(b'{"a"')
+
+
+def test_plugin_matrix_e2ee_olm_account():
+    """MatrixOlmAccount creation, signing, serialisation."""
+    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
+
+    # Fresh account
+    acct = MatrixOlmAccount()
+    assert isinstance(acct.identity_key, str)
+    assert isinstance(acct.signing_key, str)
+
+    # sign() accepts str and bytes
+    sig = acct.sign("hello")
+    assert isinstance(sig, str)
+    sig2 = acct.sign(b"hello")
+    assert isinstance(sig2, str)
+
+    # to_dict / from_dict round-trip
+    d = acct.to_dict()
+    assert "ik" in d and "sk" in d
+    restored = MatrixOlmAccount.from_dict(d)
+    assert restored.identity_key == acct.identity_key
+    assert restored.signing_key == acct.signing_key
+
+    # Explicit key construction from stored keys
+    acct2 = MatrixOlmAccount(
+        ik_priv_b64=d["ik"],
+        sk_priv_b64=d["sk"],
+    )
+    assert acct2.identity_key == acct.identity_key
+
+    # device_keys_payload produces a signed dict
+    payload = acct.device_keys_payload("@u:h", "DEVID")
+    assert "signatures" in payload
+    assert "algorithms" in payload
+
+
+def test_plugin_matrix_e2ee_olm_session():
+    """MatrixOlmSession encrypts and produces correct structure."""
+    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
+
+    acct = MatrixOlmAccount()
+    # Create a second account to act as recipient
+    recipient = MatrixOlmAccount()
+
+    session = acct.create_outbound_session(
+        recipient.identity_key,
+        recipient.identity_key,  # reuse IK as a stand-in OTK
+    )
+
+    assert session.their_identity_key == recipient.identity_key
+
+    # str plaintext
+    result = session.encrypt("test plaintext")
+    assert result["type"] == 0
+    assert isinstance(result["body"], str)
+
+    # bytes plaintext also accepted
+    result2 = session.encrypt(b"bytes input")
+    assert result2["type"] == 0
+
+
+def test_plugin_matrix_e2ee_megolm_session():
+    """MatrixMegOlmSession encrypt, session_key, rotation, serialisation."""
+    from apprise.plugins.matrix.e2ee import (
+        MEGOLM_ROTATION_MSGS,
+        MatrixMegOlmSession,
+    )
+
+    s = MatrixMegOlmSession()
+    assert isinstance(s.session_id, str)
+
+    # encrypt returns base64 ciphertext
+    ct = s.encrypt({"type": "m.room.message", "content": {}})
+    assert isinstance(ct, str)
+
+    # session_key returns base64
+    sk = s.session_key()
+    assert isinstance(sk, str)
+
+    # to_dict / from_dict round-trip
+    d = s.to_dict()
+    s2 = MatrixMegOlmSession.from_dict(d)
+    assert s2.session_id == s.session_id
+    assert s2._counter == s._counter
+
+    # should_rotate: explicit count threshold
+    assert not s.should_rotate(msg_count=MEGOLM_ROTATION_MSGS - 1)
+    assert s.should_rotate(msg_count=MEGOLM_ROTATION_MSGS)
+
+    # should_rotate: time threshold (old created_at)
+    old = MatrixMegOlmSession(created_at=0.0)
+    assert old.should_rotate()
+
+    # _advance branches
+    # -- normal step (else branch, counter starts at 0 so always else first)
+    s3 = MatrixMegOlmSession()
+    s3._advance()  # counter 0 -> 1  (else: R[3] only)
+
+    # -- %256 branch: counter == 256 before advance
+    s4 = MatrixMegOlmSession()
+    s4._counter = 256
+    s4._advance()
+
+    # -- %65536 branch
+    s5 = MatrixMegOlmSession()
+    s5._counter = 65536
+    s5._advance()
+
+    # -- %2^24 branch
+    s6 = MatrixMegOlmSession()
+    s6._counter = 1 << 24
+    s6._advance()
+
+
+# ---------------------------------------------------------------------------
+# E2EE integration tests -- URL parsing and send flow
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_matrix_e2ee_url_roundtrip():
+    """e2ee default is True; disabled state survives url() / parse_url()."""
+    # Default (no e2ee param) is now True
+    obj = NotifyMatrix(
+        host="matrix.example.com",
+        user="user",
+        password="pass",
+        targets=["#room"],
+    )
+    assert obj.e2ee is True
+    # Enabled is the default -- not written to URL
+    assert "e2ee" not in obj.url()
+
+    # Disabled survives round-trip
+    obj2 = NotifyMatrix(
+        host="matrix.example.com",
+        user="user",
+        password="pass",
+        targets=["#room"],
+        e2ee=False,
+    )
+    assert obj2.e2ee is False
+    u2 = obj2.url()
+    assert "e2ee=no" in u2
+
+    result = NotifyMatrix.parse_url(u2)
+    assert result is not None
+    assert result.get("e2ee") is False or str(result.get("e2ee")).lower() in (
+        "false",
+        "no",
+        "0",
+    )
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_e2ee_insecure_connection(mock_post, mock_get, mock_put):
+    """e2ee=yes over insecure (matrix://) falls back to unencrypted."""
+    resp = mock.Mock()
+    resp.status_code = requests.codes.ok
+    resp.content = dumps(
+        {
+            "access_token": "tok",
+            "user_id": "@u:h",
+            "home_server": "h",
+            "device_id": "DEV",
+            "room_id": "!r:h",
+        }
+    ).encode()
+    mock_post.return_value = resp
+    mock_get.return_value = resp
+    mock_put.return_value = resp
+
+    # matrix:// (not matrixs://) -- E2EE silently skipped, plain delivery
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#room"],
+        e2ee=True,
+        # secure=False is the default for matrix:// URLs
+    )
+    assert not obj.secure
+    assert obj.send(body="test") is True
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_e2ee_no_support(mock_post, mock_get, mock_put):
+    """e2ee=yes with MATRIX_E2EE_SUPPORT=False sends unencrypted."""
+    resp = mock.Mock()
+    resp.status_code = requests.codes.ok
+    resp.content = dumps(
+        {
+            "access_token": "tok",
+            "user_id": "@u:h",
+            "home_server": "h",
+            "device_id": "DEV",
+            "room_id": "!r:h",
+        }
+    ).encode()
+    mock_post.return_value = resp
+    mock_get.return_value = resp
+    mock_put.return_value = resp
+
+    with mock.patch(
+        "apprise.plugins.matrix.base.MATRIX_E2EE_SUPPORT",
+        False,
+    ):
+        obj = NotifyMatrix(
+            host="h",
+            user="u",
+            password="pass",
+            targets=["#room"],
+            e2ee=True,
+        )
+        # Should succeed (falls back to unencrypted)
+        assert obj.send(body="test") is True
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_e2ee_send(mock_post, mock_get, mock_put):
+    """Full E2EE send path via _send_server_notification."""
+    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
+
+    # Recipient device (acts as a room member)
+    recipient = MatrixOlmAccount()
+    their_ik = recipient.identity_key
+
+    login_resp = {
+        "access_token": "tok123",
+        "user_id": "@sender:localhost",
+        "home_server": "localhost",
+        "device_id": "SENDERDEV",
+    }
+
+    # One-time key value (32 bytes, base64)
+    otk_val = _rand_b64_32()
+
+    members_resp = {
+        "joined": {"@other:localhost": {}},
+    }
+
+    query_resp = {
+        "device_keys": {
+            "@other:localhost": {
+                "OTHERDEV": {
+                    "keys": {
+                        "curve25519:OTHERDEV": their_ik,
+                        "ed25519:OTHERDEV": recipient.signing_key,
+                    }
+                }
+            }
+        }
+    }
+
+    claim_resp = {
+        "one_time_keys": {
+            "@other:localhost": {
+                "OTHERDEV": {
+                    "curve25519:KEYID": otk_val,
+                }
+            }
+        }
+    }
+
+    def _mk_resp(d):
+        r = mock.Mock()
+        r.status_code = requests.codes.ok
+        r.content = dumps(d).encode()
+        return r
+
+    # POST sequence: login, keys/upload, join, keys/query, keys/claim, logout
+    mock_post.side_effect = [
+        _mk_resp(login_resp),
+        _mk_resp({}),  # keys/upload
+        _mk_resp({"room_id": "!room:localhost"}),  # join
+        _mk_resp(query_resp),  # keys/query
+        _mk_resp(claim_resp),  # keys/claim
+        _mk_resp({}),  # logout
+    ]
+    mock_get.return_value = _mk_resp(members_resp)
+    mock_put.return_value = _mk_resp({})
+
+    obj = NotifyMatrix(
+        host="localhost",
+        user="sender",
+        password="pass",
+        targets=["#room"],
+        e2ee=True,
+        secure=True,
+        discovery=False,
+    )
+    assert obj.send(body="hello", title="hi") is True
+
+    # PUT was called: sendToDevice + rooms/send/encrypted
+    assert mock_put.call_count >= 2
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_e2ee_send_cached_session(mock_post, mock_get, mock_put):
+    """E2EE send skips key-share when session key already shared."""
+    login_resp = {
+        "access_token": "tok",
+        "user_id": "@u:h",
+        "home_server": "h",
+        "device_id": "DEV",
+    }
+
+    def _mk_resp(d):
+        r = mock.Mock()
+        r.status_code = requests.codes.ok
+        r.content = dumps(d).encode()
+        return r
+
+    # POST: login, keys/upload, join, logout
+    mock_post.side_effect = [
+        _mk_resp(login_resp),
+        _mk_resp({}),  # keys/upload
+        _mk_resp({"room_id": "!r:h"}),  # join
+        _mk_resp({}),  # logout
+    ]
+    mock_put.return_value = _mk_resp({})
+
+    from apprise.plugins.matrix.e2ee import MatrixMegOlmSession
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["!r:h"],
+        e2ee=True,
+        secure=True,
+        discovery=False,
+    )
+    # Pre-seed room encryption state, MegOLM session, and key-shared flag
+    # so that no additional GETs or key-exchange PUTs are issued.
+    _sess = MatrixMegOlmSession()
+    obj.store.set("e2ee_room_enc_!r:h", True)
+    obj.store.set("e2ee_megolm_!r:h", _sess.to_dict())
+    obj.store.set("e2ee_key_shared_!r:h", True)
+    assert obj.send(body="silent") is True
+    # Only one PUT for the encrypted message itself
+    assert mock_put.call_count == 1
+
+
+def test_plugin_matrix_e2ee_setup_restored():
+    """E2EE account restores from store via _e2ee_setup and __init__."""
+    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
+
+    acct = MatrixOlmAccount()
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+    )
+    # Seed account + mark keys already uploaded
+    obj.store.set("e2ee_account", acct.to_dict())
+    obj.store.set("e2ee_keys_uploaded", True)
+
+    # Simulate state where account is not yet loaded in memory
+    obj._e2ee_account = None
+
+    # _e2ee_setup should restore the account from the store
+    assert obj._e2ee_setup() is True
+    assert obj._e2ee_account is not None
+    assert obj._e2ee_account.identity_key == acct.identity_key
+
+    # Bad account data in store -> _e2ee_setup creates a fresh account;
+    # the try/except in _e2ee_setup is exercised when from_dict raises.
+    obj._e2ee_account = None
+    obj.store.set("e2ee_account", {"bad": "data"})
+    obj.store.clear("e2ee_keys_uploaded")
+    with mock.patch.object(obj, "_e2ee_upload_keys", return_value=True):
+        result = obj._e2ee_setup()
+    assert result is True
+    assert obj._e2ee_account is not None
+
+    # Patch the store so __init__ sees a valid pre-existing account,
+    # exercising the success path of the contextlib.suppress block.
+    valid_data = obj._e2ee_account.to_dict()
+    with mock.patch(
+        "apprise.persistent_store.PersistentStore.get",
+        return_value=valid_data,
+    ):
+        obj2 = NotifyMatrix(
+            host="h",
+            user="u",
+            password="pass",
+            targets=["#r"],
+            e2ee=True,
+        )
+    assert obj2._e2ee_account is not None
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_e2ee_upload_keys_no_ids(mock_post, mock_get, mock_put):
+    """_e2ee_upload_keys returns False when user_id/device_id missing."""
+    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+    )
+    obj._e2ee_account = MatrixOlmAccount()
+    # No user_id / device_id set
+    assert obj._e2ee_upload_keys() is False
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_e2ee_upload_keys_http_fail(
+    mock_post, mock_get, mock_put
+):
+    """_e2ee_upload_keys returns False on HTTP error."""
+    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
+
+    resp = mock.Mock()
+    resp.status_code = 500
+    resp.content = dumps({}).encode()
+    mock_post.return_value = resp
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+    )
+    obj._e2ee_account = MatrixOlmAccount()
+    obj.access_token = "tok"
+    obj.user_id = "@u:h"
+    obj.device_id = "DEV"
+    obj.home_server = "h"
+    assert obj._e2ee_upload_keys() is False
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_e2ee_get_megolm_rotation(mock_post, mock_get, mock_put):
+    """_e2ee_get_megolm rotates session after threshold."""
+    from apprise.plugins.matrix.e2ee import (
+        MEGOLM_ROTATION_MSGS,
+        MatrixMegOlmSession,
+    )
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+    )
+
+    # Seed a session that is already past the rotation threshold
+    stale = MatrixMegOlmSession()
+    stale._counter = MEGOLM_ROTATION_MSGS
+    obj.store.set("e2ee_megolm_!r:h", stale.to_dict())
+    obj.store.set("e2ee_key_shared_!r:h", True)
+
+    new_session = obj._e2ee_get_megolm("!r:h")
+    assert new_session.session_id != stale.session_id
+
+    # The shared flag should be cleared on rotation
+    assert obj.store.get("e2ee_key_shared_!r:h") is None
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_e2ee_room_encrypted(mock_post, mock_get, mock_put):
+    """_e2ee_room_encrypted: cached, GET success, GET failure paths."""
+
+    def _mk_resp(d, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(d).encode()
+        return r
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+    )
+    obj.access_token = "tok"
+    obj.home_server = "h"
+
+    # Cache hit -- no GET fired
+    obj.store.set("e2ee_room_enc_!r:h", True)
+    assert obj._e2ee_room_encrypted("!r:h") is True
+    assert mock_get.call_count == 0
+
+    # Cache miss, GET returns 200 with content -> True
+    obj.store.clear("e2ee_room_enc_!r:h")
+    mock_get.return_value = _mk_resp({"algorithm": "m.megolm.v1.aes-sha2"})
+    assert obj._e2ee_room_encrypted("!r:h") is True
+    assert mock_get.call_count == 1
+
+    # Cache is now populated
+    assert obj.store.get("e2ee_room_enc_!r:h") is True
+
+    # Cache miss, GET returns 404 -> False
+    obj.store.clear("e2ee_room_enc_!r:h")
+    mock_get.return_value = _mk_resp({}, code=404)
+    assert obj._e2ee_room_encrypted("!r:h") is False
+    assert obj.store.get("e2ee_room_enc_!r:h") is False
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_e2ee_room_members(mock_post, mock_get, mock_put):
+    """_e2ee_room_members handles HTTP failures and empty rooms."""
+
+    def _mk_resp(d, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(d).encode()
+        return r
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+    )
+    obj.access_token = "tok"
+    obj.home_server = "h"
+
+    # joined_members HTTP failure -> None
+    mock_get.return_value = _mk_resp({}, code=500)
+    assert obj._e2ee_room_members("!r:h") is None
+
+    # No joined members -> empty dict
+    mock_get.return_value = _mk_resp({"joined": {}})
+    assert obj._e2ee_room_members("!r:h") == {}
+
+    # keys/query failure -> None
+    mock_get.return_value = _mk_resp({"joined": {"@u:h": {}}})
+    mock_post.return_value = _mk_resp({}, code=500)
+    assert obj._e2ee_room_members("!r:h") is None
+
+    # Success
+    query_resp = {
+        "device_keys": {
+            "@u:h": {
+                "DEV": {
+                    "keys": {
+                        "curve25519:DEV": "IK",
+                        "ed25519:DEV": "SK",
+                    }
+                }
+            }
+        }
+    }
+    mock_post.return_value = _mk_resp(query_resp)
+    result = obj._e2ee_room_members("!r:h")
+    assert "@u:h" in result
+    assert result["@u:h"]["DEV"]["curve25519"] == "IK"
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_e2ee_share_room_key_branches(
+    mock_post, mock_get, mock_put
+):
+    """_e2ee_share_room_key edge cases."""
+    from apprise.plugins.matrix.e2ee import (
+        MatrixMegOlmSession,
+        MatrixOlmAccount,
+    )
+
+    def _mk_resp(d, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(d).encode()
+        return r
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+    )
+    obj.access_token = "tok"
+    obj.home_server = "h"
+    obj.user_id = "@sender:h"
+    obj.device_id = "SDEV"
+    obj._e2ee_account = MatrixOlmAccount()
+    session = MatrixMegOlmSession()
+
+    # members failure -> False
+    with mock.patch.object(obj, "_e2ee_room_members", return_value=None):
+        assert obj._e2ee_share_room_key("!r:h", session) is False
+
+    # empty members -> True (nothing to send)
+    with mock.patch.object(obj, "_e2ee_room_members", return_value={}):
+        assert obj._e2ee_share_room_key("!r:h", session) is True
+
+    # keys/claim failure -> False
+    members = {"@other:h": {"DEV": {"curve25519": "IK", "ed25519": "SK"}}}
+    mock_post.return_value = _mk_resp({}, code=500)
+    with mock.patch.object(obj, "_e2ee_room_members", return_value=members):
+        assert obj._e2ee_share_room_key("!r:h", session) is False
+
+    # own device is skipped (sender uid + device match)
+    own_members = {
+        "@sender:h": {"SDEV": {"curve25519": "IK", "ed25519": "SK"}}
+    }
+    otk_resp = {
+        "one_time_keys": {
+            "@sender:h": {"SDEV": {"curve25519:KID": _rand_b64_32()}}
+        }
+    }
+    mock_post.return_value = _mk_resp(otk_resp)
+    mock_put.return_value = _mk_resp({})
+    with mock.patch.object(
+        obj, "_e2ee_room_members", return_value=own_members
+    ):
+        # All devices skipped -> no PUT; still returns True
+        assert obj._e2ee_share_room_key("!r:h", session) is True
+
+    # missing curve25519 key -> device skipped
+    no_ik = {"@other:h": {"DEV": {"curve25519": "", "ed25519": "SK"}}}
+    with mock.patch.object(obj, "_e2ee_room_members", return_value=no_ik):
+        mock_post.return_value = _mk_resp(
+            {"one_time_keys": {"@other:h": {"DEV": {}}}}
+        )
+        assert obj._e2ee_share_room_key("!r:h", session) is True
+
+    # dict-valued OTK (with "key" field) succeeds end-to-end
+    recipient = MatrixOlmAccount()
+    their_ik = recipient.identity_key
+    their_otk = recipient.identity_key  # reuse as OTK
+    dict_members = {
+        "@other:h": {"DEV": {"curve25519": their_ik, "ed25519": "SK"}}
+    }
+    dict_otk = {
+        "one_time_keys": {
+            "@other:h": {"DEV": {"curve25519:KID": {"key": their_otk}}}
+        }
+    }
+    mock_post.return_value = _mk_resp(dict_otk)
+    mock_put.return_value = _mk_resp({})
+    with mock.patch.object(
+        obj, "_e2ee_room_members", return_value=dict_members
+    ):
+        assert obj._e2ee_share_room_key("!r:h", session) is True
+
+    # string-valued OTK (plain base64 string, not a dict)
+    str_members = {
+        "@other:h": {"DEV": {"curve25519": their_ik, "ed25519": "SK"}}
+    }
+    str_otk = {
+        "one_time_keys": {"@other:h": {"DEV": {"curve25519:KID": their_otk}}}
+    }
+    mock_post.return_value = _mk_resp(str_otk)
+    mock_put.return_value = _mk_resp({})
+    with mock.patch.object(
+        obj, "_e2ee_room_members", return_value=str_members
+    ):
+        assert obj._e2ee_share_room_key("!r:h", session) is True
+
+    # OTK key not prefixed with "curve25519:" -> skipped, no OTK found
+    bad_key_otk = {
+        "one_time_keys": {"@other:h": {"DEV": {"ed25519:KID": their_otk}}}
+    }
+    mock_post.return_value = _mk_resp(bad_key_otk)
+    with mock.patch.object(
+        obj, "_e2ee_room_members", return_value=str_members
+    ):
+        assert obj._e2ee_share_room_key("!r:h", session) is True
+
+    # OTK entry is not a dict (unexpected server response format)
+    non_dict_otk = {"one_time_keys": {"@other:h": {"DEV": "invalid_format"}}}
+    mock_post.return_value = _mk_resp(non_dict_otk)
+    with mock.patch.object(
+        obj, "_e2ee_room_members", return_value=str_members
+    ):
+        assert obj._e2ee_share_room_key("!r:h", session) is True
+
+    # OTK value is neither dict nor str (e.g. integer) -> skipped
+    non_str_otk = {
+        "one_time_keys": {"@other:h": {"DEV": {"curve25519:KID": 42}}}
+    }
+    mock_post.return_value = _mk_resp(non_str_otk)
+    with mock.patch.object(
+        obj, "_e2ee_room_members", return_value=str_members
+    ):
+        assert obj._e2ee_share_room_key("!r:h", session) is True
+
+    # create_outbound_session raises -> device is skipped gracefully
+    create_fail_otk = {
+        "one_time_keys": {"@other:h": {"DEV": {"curve25519:KID": their_otk}}}
+    }
+    mock_post.return_value = _mk_resp(create_fail_otk)
+    with (
+        mock.patch.object(obj, "_e2ee_room_members", return_value=str_members),
+        mock.patch.object(
+            obj._e2ee_account,
+            "create_outbound_session",
+            side_effect=Exception("olm error"),
+        ),
+    ):
+        assert obj._e2ee_share_room_key("!r:h", session) is True
+
+    # sendToDevice PUT fails -> warning logged but returns True
+    full_members = {
+        "@other:h": {"DEV": {"curve25519": their_ik, "ed25519": "SK"}}
+    }
+    mock_post.return_value = _mk_resp(str_otk)
+    mock_put.return_value = _mk_resp({}, code=500)
+    with mock.patch.object(
+        obj, "_e2ee_room_members", return_value=full_members
+    ):
+        assert obj._e2ee_share_room_key("!r:h", session) is True
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_e2ee_send_to_room_formats(
+    mock_post, mock_get, mock_put
+):
+    """_e2ee_send_to_room: HTML/Markdown format paths and key-share fail."""
+    from apprise.common import NotifyFormat
+    from apprise.plugins.matrix.e2ee import (
+        MatrixMegOlmSession,
+        MatrixOlmAccount,
+    )
+
+    def _mk_resp(d):
+        r = mock.Mock()
+        r.status_code = requests.codes.ok
+        r.content = dumps(d).encode()
+        return r
+
+    mock_put.return_value = _mk_resp({})
+
+    def _make_obj(fmt):
+        obj = NotifyMatrix(
+            host="h",
+            user="u",
+            password="pass",
+            targets=["#r"],
+            e2ee=True,
+        )
+        obj.notify_format = fmt
+        obj.access_token = "tok"
+        obj.home_server = "h"
+        obj.user_id = "@u:h"
+        obj.device_id = "DEV"
+        obj._e2ee_account = MatrixOlmAccount()
+        obj.store.set("e2ee_key_shared_!r:h", True)
+        return obj
+
+    # HTML format
+    obj = _make_obj(NotifyFormat.HTML)
+    session = MatrixMegOlmSession()
+    obj.store.set("e2ee_megolm_!r:h", session.to_dict())
+    assert (
+        obj._e2ee_send_to_room(
+            "!r:h", "<b>body</b>", "<h1>title</h1>", NotifyType.INFO
+        )
+        is True
+    )
+
+    # Markdown format
+    obj = _make_obj(NotifyFormat.MARKDOWN)
+    session = MatrixMegOlmSession()
+    obj.store.set("e2ee_megolm_!r:h", session.to_dict())
+    assert (
+        obj._e2ee_send_to_room("!r:h", "**bold**", "title", NotifyType.INFO)
+        is True
+    )
+
+    # key-share flags set after successful share (no pre-seeded flag)
+    obj = _make_obj(NotifyFormat.TEXT)
+    session = MatrixMegOlmSession()
+    obj.store.set("e2ee_megolm_!r:h", session.to_dict())
+    with mock.patch.object(obj, "_e2ee_share_room_key", return_value=True):
+        assert (
+            obj._e2ee_send_to_room("!r:h", "body", "", NotifyType.INFO) is True
+        )
+
+    # token-as-password mode: access_token == password skips txn increment
+    obj = _make_obj(NotifyFormat.TEXT)
+    obj.access_token = "same"
+    obj.password = "same"
+    session2 = MatrixMegOlmSession()
+    obj.store.set("e2ee_megolm_!r:h", session2.to_dict())
+    assert obj._e2ee_send_to_room("!r:h", "body", "", NotifyType.INFO) is True
+
+    # key-share failure aborts send
+    obj = _make_obj(NotifyFormat.TEXT)
+    obj.store.clear("e2ee_key_shared_!r:h")
+    with mock.patch.object(obj, "_e2ee_share_room_key", return_value=False):
+        assert (
+            obj._e2ee_send_to_room("!r:h", "body", "", NotifyType.INFO)
+            is False
+        )
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_e2ee_setup_failure(mock_post, mock_get, mock_put):
+    """When E2EE setup fails, send falls back to unencrypted."""
+    resp = mock.Mock()
+    resp.status_code = requests.codes.ok
+    resp.content = dumps(
+        {
+            "access_token": "tok",
+            "user_id": "@u:h",
+            "home_server": "h",
+            "device_id": "DEV",
+            "room_id": "!r:h",
+        }
+    ).encode()
+    # upload keys call fails
+    fail_resp = mock.Mock()
+    fail_resp.status_code = 500
+    fail_resp.content = dumps({}).encode()
+    mock_put.return_value = resp
+
+    mock_post.side_effect = [
+        resp,  # login
+        fail_resp,  # keys/upload -> failure
+        resp,  # join
+        resp,  # logout
+    ]
+    mock_get.return_value = resp
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["!r:h"],
+        e2ee=True,
+        secure=True,
+        discovery=False,
+    )
+    # Falls back to unencrypted -> send succeeds
+    assert obj.send(body="fallback") is True
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_e2ee_attachment_skip(mock_post, mock_get, mock_put):
+    """E2EE mode warns and skips attachments."""
+    import tempfile
+
+    login_resp = {
+        "access_token": "tok",
+        "user_id": "@u:h",
+        "home_server": "h",
+        "device_id": "DEV",
+    }
+
+    def _mk_resp(d):
+        r = mock.Mock()
+        r.status_code = requests.codes.ok
+        r.content = dumps(d).encode()
+        return r
+
+    mock_post.side_effect = [
+        _mk_resp(login_resp),
+        _mk_resp({}),  # keys/upload
+        _mk_resp({"room_id": "!r:h"}),  # join
+        _mk_resp({}),  # logout
+    ]
+    mock_get.return_value = _mk_resp({"joined": {}})
+    mock_put.return_value = _mk_resp({})
+
+    with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+        f.write(b"test attachment")
+        attach_path = f.name
+
+    try:
+        attach = AppriseAttachment()
+        attach.add(attach_path)
+
+        obj = NotifyMatrix(
+            host="h",
+            user="u",
+            password="pass",
+            targets=["!r:h"],
+            e2ee=True,
+            secure=True,
+            discovery=False,
+        )
+        # Pre-seed room encryption state, session, and shared flag so
+        # E2EE is active without any key-share or room-enc GET round-trips.
+        from apprise.plugins.matrix.e2ee import MatrixMegOlmSession
+
+        _s = MatrixMegOlmSession()
+        obj.store.set("e2ee_room_enc_!r:h", True)
+        obj.store.set("e2ee_megolm_!r:h", _s.to_dict())
+        obj.store.set("e2ee_key_shared_!r:h", True)
+        # attach provided but room is E2EE -> attachment skipped, send ok
+        assert obj.send(body="body", attach=attach) is True
+
+    finally:
+        os.unlink(attach_path)
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_e2ee_send_room_failure(mock_post, mock_get, mock_put):
+    """E2EE path returns False when _e2ee_send_to_room fails."""
+    login_resp = {
+        "access_token": "tok",
+        "user_id": "@u:h",
+        "home_server": "h",
+        "device_id": "DEV",
+    }
+
+    def _mk_resp(d):
+        r = mock.Mock()
+        r.status_code = requests.codes.ok
+        r.content = dumps(d).encode()
+        return r
+
+    mock_post.side_effect = [
+        _mk_resp(login_resp),
+        _mk_resp({}),  # keys/upload
+        _mk_resp({"room_id": "!r:h"}),  # join
+        _mk_resp({}),  # logout
+    ]
+    mock_get.return_value = _mk_resp({})
+    mock_put.return_value = _mk_resp({})
+
+    from apprise.plugins.matrix.e2ee import MatrixMegOlmSession
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["!r:h"],
+        e2ee=True,
+        secure=True,
+        discovery=False,
+    )
+    obj.store.set("e2ee_room_enc_!r:h", True)
+    _s = MatrixMegOlmSession()
+    obj.store.set("e2ee_megolm_!r:h", _s.to_dict())
+    obj.store.set("e2ee_key_shared_!r:h", True)
+
+    with mock.patch.object(obj, "_e2ee_send_to_room", return_value=False):
+        assert obj.send(body="fail") is False
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_register_with_device_id(mock_post, mock_get, mock_put):
+    """Registration response that includes device_id persists it."""
+    r = mock.Mock()
+    r.status_code = requests.codes.ok
+    r.content = dumps(
+        {
+            "access_token": "tok",
+            "user_id": "@u:h",
+            "home_server": "h",
+            "device_id": "REG_DEV",
+        }
+    ).encode()
+    mock_post.return_value = r
+
+    obj = NotifyMatrix(host="h", discovery=False)
+    assert obj._register() is True
+    assert obj.device_id == "REG_DEV"
+    assert obj.store.get("device_id") == "REG_DEV"
+
+
+def test_plugin_matrix_e2ee_account_bad_store_data():
+    """Corrupt e2ee_account in store is silently ignored."""
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+    )
+    obj.store.set("e2ee_account", {"ik": "NOTVALID", "sk": "NOTVALID"})
+
+    # Re-instantiate with the same store to trigger the restore path
+    obj2 = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+        store=obj.store,
+    )
+    # Bad data is suppressed; account is None until setup is called
+    assert obj2._e2ee_account is None

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -2359,6 +2359,18 @@ def test_plugin_matrix_e2ee_olm_account():
     assert "signatures" in payload
     assert "algorithms" in payload
 
+    # fallback_keys_payload: first call generates the fallback OTK (487->499
+    # branch: _fallback_otk is None so it is created, then the common path
+    # at line 499 runs).  Second call reuses the already-generated key
+    # (branch where _fallback_otk is already set is also covered).
+    fb1 = acct.fallback_keys_payload("@u:h", "DEVID")
+    assert len(fb1) == 1
+    fb_key_id1 = next(iter(fb1.keys()))
+    assert fb_key_id1.startswith("signed_curve25519:")
+    fb2 = acct.fallback_keys_payload("@u:h", "DEVID")
+    # second call returns the same key id (key not regenerated)
+    assert next(iter(fb2.keys())) == fb_key_id1
+
 
 def test_plugin_matrix_e2ee_olm_session():
     """MatrixOlmSession encrypts and produces correct wire format."""
@@ -2520,13 +2532,19 @@ def test_plugin_matrix_e2ee_olm_roundtrip():
 
     raw = _b64dec(result["body"])
 
-    # Outer format: version(1) | pb_fields | outer_mac(8)
+    # Outer pre-key message format (Olm spec Section 5.2):
+    #   version(1) | protobuf(field1=OTK, field2=base_key,
+    #                          field3=IK, field4=inner_message)
+    #
+    # There is NO outer MAC on the pre-key message.  Only the inner
+    # normal-message (field 4) has its own 8-byte MAC appended.
+    # Reference: olm.md Section 5.2; libolm session.cpp
+    # encode_one_time_key_message_length() (no MAC bytes allocated);
+    # vodozemac src/olm/messages/pre_key.rs decode() (no MAC consumed).
     assert raw[0:1] == b"\x03", "outer version must be 0x03"
-    outer_body = raw[:-8]  # everything before the outer MAC
-    outer_mac_received = raw[-8:]
 
-    # Parse outer fields (skip version byte)
-    outer_fields = _parse_pb_fields(outer_body[1:])
+    # Parse the full outer protobuf body (all bytes after the version byte)
+    outer_fields = _parse_pb_fields(raw[1:])
     otk_pub_in_msg = outer_fields[1]  # field 1: Bob's OTK public bytes
     base_key = outer_fields[2]  # field 2: Alice's ephemeral E_A
     alice_ik_pub = outer_fields[3]  # field 3: Alice's identity key
@@ -2557,30 +2575,24 @@ def test_plugin_matrix_e2ee_olm_roundtrip():
     chain_key = keys64[32:]
     del root_key  # not needed for first-message decryption
 
-    # Derive message keys
+    # Derive message keys from the initial chain key
     msg_key = _hmac(chain_key, b"\x01")
     keys80 = _hkdf(msg_key, 80, salt=b"\x00" * 32, info=b"OLM_KEYS")
     aes_key = keys80[:32]
     mac_key = keys80[32:64]
     iv = keys80[64:80]
 
-    # Verify outer MAC
-    outer_mac_expected = _hmac(mac_key, outer_body)[:8]
-    assert _hmac_stdlib.compare_digest(
-        outer_mac_expected, outer_mac_received
-    ), "outer MAC verification failed"
-
-    # Parse field 4 (inner message + inner_mac)
+    # Field 4 = inner_normal_message || 8-byte MAC.
+    # The inner normal message itself starts with version byte 0x03 followed
+    # by the protobuf body; the MAC covers the version + protobuf body.
     inner_with_mac = outer_fields[4]
-    inner_body = inner_with_mac[:-8]
+    inner_body = inner_with_mac[:-8]  # version(1) + pb_fields
     inner_mac_received = inner_with_mac[-8:]
 
-    # Verify inner MAC
-    _hmac(mac_key, b"\x03" + inner_body[1:])[:8]
-    # inner_body already starts with 0x03; mac over the full inner body
-    inner_mac_expected2 = _hmac(mac_key, inner_body)[:8]
+    # Verify the inner MAC (HMAC-SHA-256 of inner_body, truncated to 8 bytes)
+    inner_mac_expected = _hmac(mac_key, inner_body)[:8]
     assert _hmac_stdlib.compare_digest(
-        inner_mac_expected2, inner_mac_received
+        inner_mac_expected, inner_mac_received
     ), "inner MAC verification failed"
 
     # Parse inner fields
@@ -3498,6 +3510,17 @@ def test_plugin_matrix_e2ee_share_room_key_branches(
     with mock.patch.object(obj, "_e2ee_room_members", return_value=members):
         assert obj._e2ee_share_room_key("!r:h", session) is False
 
+    # keys/claim succeeds but server reports failures{} for remote servers
+    # (line 2160 branch: failures dict is non-empty -> debug log, still
+    # continues normally; no OTKs returned so built_count=0 -> True).
+    failures_resp = {
+        "one_time_keys": {},
+        "failures": {"remote.example": {"errcode": "M_UNREACHABLE"}},
+    }
+    mock_post.return_value = _mk_resp(failures_resp)
+    with mock.patch.object(obj, "_e2ee_room_members", return_value=members):
+        assert obj._e2ee_share_room_key("!r:h", session) is True
+
     # own device is skipped (sender uid + device match)
     own_members = {
         "@sender:h": {"SDEV": {"curve25519": "IK", "ed25519": "SK"}}
@@ -3551,9 +3574,11 @@ def test_plugin_matrix_e2ee_share_room_key_branches(
         assert obj._e2ee_share_room_key("!r:h", session) is True
         payload = loads(mock_put.call_args.kwargs["data"])
         dev_payload = payload["messages"]["@other:h"]["DEV"]
-        assert dev_payload["recipient_key"] == their_ik
         assert dev_payload["sender_key"] == obj._e2ee_account.identity_key
-        assert "org.matrix.msgid" in dev_payload
+        # recipient_key and org.matrix.msgid are non-standard fields
+        # that were removed; verify they are absent
+        assert "recipient_key" not in dev_payload
+        assert "org.matrix.msgid" not in dev_payload
 
     # dict-valued OTK with no signatures -> OTK rejected, device skipped
     unsigned_otk_dict = {"key": their_otk_b64}  # no "signatures" field
@@ -4721,3 +4746,151 @@ def test_plugin_matrix_dm_room_create_e2ee(mock_post, mock_get, mock_put):
 
     # Room encryption cache must be pre-seeded
     assert obj.store.get("e2ee_room_enc_!dm_e2ee:h") is True
+
+
+# ---------------------------------------------------------------------------
+# home_server recovery-from-user_id coverage tests
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_matrix_init_recovers_home_server_from_user_id(tmpdir):
+    """__init__ extracts home_server from a cached user_id when home_server
+    was not stored (older cache entries that predate the home_server field)."""
+    # A disk-backed asset ensures two separate NotifyMatrix instances that
+    # share the same url_id() also share the same persistent store file.
+    asset = AppriseAsset(
+        storage_mode=PersistentStoreMode.FLUSH,
+        storage_path=str(tmpdir),
+    )
+
+    # First instance: simulate a login that wrote user_id/access_token but
+    # did NOT write home_server (older Apprise behaviour).
+    obj = NotifyMatrix(
+        host="h", user="u", password="pass", targets=["#r"], asset=asset
+    )
+    obj.store.set("user_id", "@u:recovered.com")
+    obj.store.set("access_token", "tok")
+    # Flush to disk before the second instance reads it.
+    obj.store.flush()
+
+    # Second instance with the same credentials (same url_id) reads the store.
+    # The recovery branch (lines 506-509) should derive home_server from
+    # the stored user_id.
+    obj2 = NotifyMatrix(
+        host="h", user="u", password="pass", targets=["#r"], asset=asset
+    )
+    assert obj2.home_server == "recovered.com"
+
+
+def test_plugin_matrix_init_no_home_server_recovery_without_colon(tmpdir):
+    """__init__ leaves home_server as None when the cached user_id has no
+    colon -- the recovery split yields a single part and the assignment is
+    skipped (covers the False branch of line 508)."""
+    asset = AppriseAsset(
+        storage_mode=PersistentStoreMode.FLUSH,
+        storage_path=str(tmpdir),
+    )
+
+    obj = NotifyMatrix(
+        host="h", user="u", password="pass", targets=["#r"], asset=asset
+    )
+    # user_id with no colon -- split(":", 1) produces only one element.
+    obj.store.set("user_id", "nocolon")
+    obj.store.set("access_token", "tok")
+    obj.store.flush()
+
+    obj2 = NotifyMatrix(
+        host="h", user="u", password="pass", targets=["#r"], asset=asset
+    )
+    # No colon in user_id means home_server cannot be extracted.
+    assert obj2.home_server is None
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_whoami_recovers_home_server_from_user_id(
+    mock_post, mock_get, mock_put
+):
+    """_whoami() extracts home_server from user_id when the server does not
+    return a home_server field and self.home_server is unset."""
+    r = mock.Mock()
+    r.status_code = requests.codes.ok
+    r.content = dumps(
+        {"user_id": "@u:whoami.example.com", "device_id": "DEVX"}
+    ).encode()
+    mock_get.return_value = r
+
+    obj = NotifyMatrix(host="h", user="u", password="pass", discovery=False)
+    obj.access_token = "tok"
+    obj.home_server = None
+
+    assert obj._whoami() is True
+    assert obj.home_server == "whoami.example.com"
+
+
+def test_plugin_matrix_room_create_recovers_home_server_from_user_id():
+    """_room_create() falls back to extracting home_server from user_id when
+    both the room alias and self.home_server carry no homeserver part."""
+    obj = NotifyMatrix(host="h", user="u", password="pass", targets=["#r"])
+    obj.access_token = "tok"
+    obj.home_server = None
+    obj.user_id = "@u:create.example.com"
+
+    # Capture the /createRoom POST so we can verify the room name used.
+    captured = {}
+
+    def _fake_fetch(path, payload=None, **kw):
+        if path == "/createRoom":
+            captured["payload"] = payload
+            return True, {"room_id": "!newroom:create.example.com"}, 200
+        return False, {}, 404
+
+    with mock.patch.object(obj, "_fetch", side_effect=_fake_fetch):
+        room_id = obj._room_create("#bare_alias")
+
+    assert room_id == "!newroom:create.example.com"
+    # The room name in the request must use the homeserver from user_id.
+    assert captured["payload"]["room_alias_name"] == "bare_alias"
+
+
+def test_plugin_matrix_room_create_returns_none_without_home_server():
+    """_room_create() returns None when neither the alias, self.home_server,
+    nor self.user_id can supply a homeserver component."""
+    obj = NotifyMatrix(host="h", user="u", password="pass", targets=["#r"])
+    obj.access_token = "tok"
+    obj.home_server = None
+    # user_id with no colon -> extraction yields nothing.
+    obj.user_id = "nocolon"
+
+    result = obj._room_create("#bare_alias")
+    assert result is None
+
+
+def test_plugin_matrix_room_id_recovers_home_server_from_user_id():
+    """_room_id() falls back to extracting home_server from user_id when both
+    the alias and self.home_server carry no homeserver part."""
+    obj = NotifyMatrix(host="h", user="u", password="pass", targets=["#r"])
+    obj.access_token = "tok"
+    obj.home_server = None
+    obj.user_id = "@u:lookup.example.com"
+
+    def _fake_fetch(path, payload=None, **kw):
+        return True, {"room_id": "!found:lookup.example.com"}, 200
+
+    with mock.patch.object(obj, "_fetch", side_effect=_fake_fetch):
+        room_id = obj._room_id("#bare_alias")
+
+    assert room_id == "!found:lookup.example.com"
+
+
+def test_plugin_matrix_room_id_returns_none_without_home_server():
+    """_room_id() returns None when neither the alias, self.home_server,
+    nor self.user_id can supply a homeserver component."""
+    obj = NotifyMatrix(host="h", user="u", password="pass", targets=["#r"])
+    obj.access_token = "tok"
+    obj.home_server = None
+    obj.user_id = "nocolon"
+
+    result = obj._room_id("#bare_alias")
+    assert result is None

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -2224,11 +2224,12 @@ def test_plugin_matrix_room_create_on_not_found_join(
 # E2EE unit tests (require the cryptography package)
 # ---------------------------------------------------------------------------
 
-# Skip all E2EE tests when cryptography is unavailable
-_cryptography = pytest.importorskip(
-    "cryptography",
-    reason="Requires cryptography",
-)
+try:
+    import cryptography  # noqa: F401
+
+    CRYPTOGRAPHY_AVAILABLE = True
+except ImportError:
+    CRYPTOGRAPHY_AVAILABLE = False
 
 
 def _rand_b64_32():
@@ -2254,6 +2255,7 @@ def _make_signed_otk(account, user_id, device_id, key_b64=None):
     return payload
 
 
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_helpers():
     """e2ee helper functions."""
     from apprise.plugins.matrix.e2ee import (
@@ -2325,6 +2327,7 @@ def test_plugin_matrix_e2ee_no_cryptography():
         importlib.reload(e2ee_mod)
 
 
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_olm_account():
     """MatrixOlmAccount creation, signing, serialisation."""
     from apprise.plugins.matrix.e2ee import MatrixOlmAccount
@@ -2372,6 +2375,7 @@ def test_plugin_matrix_e2ee_olm_account():
     assert next(iter(fb2.keys())) == fb_key_id1
 
 
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_olm_session():
     """MatrixOlmSession encrypts and produces correct wire format."""
     from apprise.plugins.matrix.e2ee import MatrixOlmAccount, _b64dec
@@ -2410,6 +2414,7 @@ def test_plugin_matrix_e2ee_olm_session():
     assert result2["type"] == 0
 
 
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_olm_roundtrip():
     """Full Olm round-trip: Alice encrypts, Bob manually decrypts.
 
@@ -2620,6 +2625,7 @@ def test_plugin_matrix_e2ee_olm_roundtrip():
     )
 
 
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_verify_keys():
     """verify_device_keys and verify_signed_otk accept/reject signatures."""
     from apprise.plugins.matrix.e2ee import (
@@ -2695,6 +2701,7 @@ def test_plugin_matrix_e2ee_verify_keys():
     assert verify_signed_otk(tampered_otk, uid, dev, acct.signing_key) is False
 
 
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_megolm_session():
     """MatrixMegOlmSession encrypt, session_key, rotation, serialisation."""
     from apprise.plugins.matrix.e2ee import (
@@ -2774,6 +2781,7 @@ def test_plugin_matrix_e2ee_megolm_session():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_url_roundtrip():
     """e2ee default is True; disabled state survives url() / parse_url()."""
     # Default (no e2ee param) is now True
@@ -2811,6 +2819,7 @@ def test_plugin_matrix_e2ee_url_roundtrip():
 @mock.patch("requests.put")
 @mock.patch("requests.get")
 @mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_insecure_connection(mock_post, mock_get, mock_put):
     """e2ee=yes over insecure (matrix://) falls back to unencrypted."""
     resp = mock.Mock()
@@ -2844,6 +2853,7 @@ def test_plugin_matrix_e2ee_insecure_connection(mock_post, mock_get, mock_put):
 @mock.patch("requests.put")
 @mock.patch("requests.get")
 @mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_no_support(mock_post, mock_get, mock_put):
     """e2ee=yes with MATRIX_E2EE_SUPPORT=False sends unencrypted."""
     resp = mock.Mock()
@@ -2879,6 +2889,7 @@ def test_plugin_matrix_e2ee_no_support(mock_post, mock_get, mock_put):
 @mock.patch("requests.put")
 @mock.patch("requests.get")
 @mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_send(mock_post, mock_get, mock_put):
     """Full E2EE send path via _send_server_notification."""
     from apprise.plugins.matrix.e2ee import MatrixOlmAccount
@@ -2949,6 +2960,7 @@ def test_plugin_matrix_e2ee_send(mock_post, mock_get, mock_put):
 @mock.patch("requests.put")
 @mock.patch("requests.get")
 @mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_send_cached_session(mock_post, mock_get, mock_put):
     """E2EE send skips key-share when session key already shared."""
     login_resp = {
@@ -2998,6 +3010,7 @@ def test_plugin_matrix_e2ee_send_cached_session(mock_post, mock_get, mock_put):
 @mock.patch("requests.put")
 @mock.patch("requests.get")
 @mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_send_legacy_shared_flag_rekeys(
     mock_post, mock_get, mock_put
 ):
@@ -3037,6 +3050,7 @@ def test_plugin_matrix_e2ee_send_legacy_shared_flag_rekeys(
     assert obj.store.get("e2ee_key_shared_!r:h") == session.session_id
 
 
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_setup_restored():
     """E2EE account restores from store via _e2ee_setup and __init__."""
     from apprise.plugins.matrix.e2ee import MatrixOlmAccount
@@ -3098,6 +3112,7 @@ def test_plugin_matrix_e2ee_setup_restored():
     assert obj2._e2ee_account is not None
 
 
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_setup_reuploads_on_binding_change():
     """Changed device/account identity forces a fresh key upload."""
     from apprise.plugins.matrix.e2ee import MatrixOlmAccount
@@ -3128,6 +3143,7 @@ def test_plugin_matrix_e2ee_setup_reuploads_on_binding_change():
 @mock.patch("requests.put")
 @mock.patch("requests.get")
 @mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_upload_keys_no_ids(mock_post, mock_get, mock_put):
     """_e2ee_upload_keys returns False when user_id/device_id missing."""
     from apprise.plugins.matrix.e2ee import MatrixOlmAccount
@@ -3147,6 +3163,7 @@ def test_plugin_matrix_e2ee_upload_keys_no_ids(mock_post, mock_get, mock_put):
 @mock.patch("requests.put")
 @mock.patch("requests.get")
 @mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_upload_keys_http_fail(
     mock_post, mock_get, mock_put
 ):
@@ -3176,6 +3193,7 @@ def test_plugin_matrix_e2ee_upload_keys_http_fail(
 @mock.patch("requests.put")
 @mock.patch("requests.get")
 @mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_upload_keys_success_marks_published(
     mock_post, mock_get, mock_put
 ):
@@ -3316,6 +3334,7 @@ def test_plugin_matrix_send_cached_token_recovers_home_server(
 @mock.patch("requests.put")
 @mock.patch("requests.get")
 @mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_get_megolm_rotation(mock_post, mock_get, mock_put):
     """_e2ee_get_megolm rotates session after threshold."""
     from apprise.plugins.matrix.e2ee import (
@@ -3357,6 +3376,7 @@ def test_plugin_matrix_e2ee_get_megolm_rotation(mock_post, mock_get, mock_put):
 @mock.patch("requests.put")
 @mock.patch("requests.get")
 @mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_room_encrypted(mock_post, mock_get, mock_put):
     """_e2ee_room_encrypted: cached, GET success, GET failure paths."""
 
@@ -3400,6 +3420,7 @@ def test_plugin_matrix_e2ee_room_encrypted(mock_post, mock_get, mock_put):
 @mock.patch("requests.put")
 @mock.patch("requests.get")
 @mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_room_members(mock_post, mock_get, mock_put):
     """_e2ee_room_members handles HTTP failures and empty rooms."""
 
@@ -3467,6 +3488,7 @@ def test_plugin_matrix_e2ee_room_members(mock_post, mock_get, mock_put):
 @mock.patch("requests.put")
 @mock.patch("requests.get")
 @mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_share_room_key_branches(
     mock_post, mock_get, mock_put
 ):
@@ -3688,6 +3710,7 @@ def test_plugin_matrix_e2ee_share_room_key_branches(
 @mock.patch("requests.put")
 @mock.patch("requests.get")
 @mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_send_to_room_formats(
     mock_post, mock_get, mock_put
 ):
@@ -3775,6 +3798,7 @@ def test_plugin_matrix_e2ee_send_to_room_formats(
 @mock.patch("requests.put")
 @mock.patch("requests.get")
 @mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_setup_failure(mock_post, mock_get, mock_put):
     """When E2EE setup fails, send falls back to unencrypted."""
     resp = mock.Mock()
@@ -3818,6 +3842,7 @@ def test_plugin_matrix_e2ee_setup_failure(mock_post, mock_get, mock_put):
 @mock.patch("requests.put")
 @mock.patch("requests.get")
 @mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_attachment_encrypted(
     mock_post, mock_get, mock_put
 ):
@@ -3883,6 +3908,7 @@ def test_plugin_matrix_e2ee_attachment_encrypted(
 @mock.patch("requests.put")
 @mock.patch("requests.get")
 @mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_send_attachment_errors(
     mock_post, mock_get, mock_put
 ):
@@ -4051,6 +4077,7 @@ def test_plugin_matrix_e2ee_send_attachment_errors(
 @mock.patch("requests.put")
 @mock.patch("requests.get")
 @mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_send_attachment_invalid(
     mock_post, mock_get, mock_put
 ):
@@ -4143,6 +4170,7 @@ def test_plugin_matrix_e2ee_send_attachment_invalid(
 @mock.patch("requests.put")
 @mock.patch("requests.get")
 @mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_send_room_failure(mock_post, mock_get, mock_put):
     """E2EE path returns False when _e2ee_send_to_room fails."""
     login_resp = {
@@ -4262,6 +4290,7 @@ def test_plugin_matrix_register_reuses_device_id(
     assert '"device_id": "DEV_REUSED"' in payload
 
 
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_account_bad_store_data():
     """Corrupt e2ee_account in store is silently ignored."""
     obj = NotifyMatrix(

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -3447,3 +3447,401 @@ def test_plugin_matrix_e2ee_account_bad_store_data():
     )
     # Bad data is suppressed; account is None until setup is called
     assert obj2._e2ee_account is None
+
+
+# ---------------------------------------------------------------------------
+# DM / direct-message tests
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_matrix_dm_target_separation():
+    """@user targets are separated from room targets at init time."""
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#general", "@alice", "@bob:other.com", "!room:h"],
+        discovery=False,
+    )
+    assert "#general" in obj.rooms
+    assert "!room:h" in obj.rooms
+    assert "@alice" in obj.users
+    assert "@bob:other.com" in obj.users
+    assert len(obj.rooms) == 2
+    assert len(obj.users) == 2
+
+    # __len__ accounts for both rooms and users
+    assert len(obj) == 4
+
+
+def test_plugin_matrix_dm_url_roundtrip():
+    """@user targets survive a url() -> parse_url() -> NotifyMatrix cycle."""
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#room", "@alice"],
+        discovery=False,
+        secure=True,
+    )
+    url = obj.url()
+    # @ is URL-encoded to %40 inside the path segment
+    assert "%40alice" in url
+
+    result = NotifyMatrix.parse_url(url)
+    assert result is not None
+    obj2 = NotifyMatrix(**result)
+    assert "@alice" in obj2.users
+    assert any("room" in r for r in obj2.rooms)
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_dm_room_find_cached(mock_post, mock_get, mock_put):
+    """_dm_room_find_or_create returns cached room ID without HTTP calls."""
+
+    def _mk_resp(d, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(d).encode()
+        return r
+
+    mock_post.return_value = _mk_resp({})
+    mock_get.return_value = _mk_resp({})
+    mock_put.return_value = _mk_resp({})
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["@alice"],
+        discovery=False,
+    )
+    obj.access_token = "tok"
+    obj.user_id = "@u:h"
+    obj.home_server = "h"
+
+    # Seed the cache
+    obj.store.set("dm_room_@alice:h", "!dm123:h")
+
+    room_id = obj._dm_room_find_or_create("@alice")
+    assert room_id == "!dm123:h"
+    # No HTTP calls should have been made
+    assert mock_get.call_count == 0
+    assert mock_post.call_count == 0
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_dm_room_find_via_mdirect(mock_post, mock_get, mock_put):
+    """_dm_room_find_or_create finds existing room from m.direct data."""
+
+    def _mk_resp(d, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(d).encode()
+        return r
+
+    mdirect = {"@alice:h": ["!existing_dm:h"]}
+    mock_get.return_value = _mk_resp(mdirect)
+    mock_post.return_value = _mk_resp({})
+    mock_put.return_value = _mk_resp({})
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["@alice"],
+        discovery=False,
+    )
+    obj.access_token = "tok"
+    obj.user_id = "@u:h"
+    obj.home_server = "h"
+
+    room_id = obj._dm_room_find_or_create("@alice")
+    assert room_id == "!existing_dm:h"
+
+    # Result is now cached
+    assert obj.store.get("dm_room_@alice:h") == "!existing_dm:h"
+
+    # No createRoom POST should have been made
+    assert mock_post.call_count == 0
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_dm_room_create_new(mock_post, mock_get, mock_put):
+    """_dm_room_find_or_create creates a new room when none exists."""
+
+    def _mk_resp(d, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(d).encode()
+        return r
+
+    # GET m.direct returns empty (no existing DM for alice)
+    mock_get.return_value = _mk_resp({})
+    # First POST = createRoom, second = (not called)
+    mock_post.return_value = _mk_resp({"room_id": "!new_dm:h"})
+    mock_put.return_value = _mk_resp({})
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["@alice"],
+        discovery=False,
+    )
+    obj.access_token = "tok"
+    obj.user_id = "@u:h"
+    obj.home_server = "h"
+
+    room_id = obj._dm_room_find_or_create("@alice")
+    assert room_id == "!new_dm:h"
+
+    # Should be cached
+    assert obj.store.get("dm_room_@alice:h") == "!new_dm:h"
+
+    # m.direct PUT should have been called to update the mapping
+    assert mock_put.call_count >= 1
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_dm_room_create_failure(mock_post, mock_get, mock_put):
+    """_dm_room_find_or_create returns None when createRoom fails."""
+
+    def _mk_resp(d, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(d).encode()
+        return r
+
+    mock_get.return_value = _mk_resp({})
+    mock_post.return_value = _mk_resp(
+        {"errcode": "M_FORBIDDEN"}, code=requests.codes.forbidden
+    )
+    mock_put.return_value = _mk_resp({})
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["@alice"],
+        discovery=False,
+    )
+    obj.access_token = "tok"
+    obj.user_id = "@u:h"
+    obj.home_server = "h"
+
+    assert obj._dm_room_find_or_create("@alice") is None
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_dm_room_create_no_room_id(
+    mock_post, mock_get, mock_put
+):
+    """_dm_room_find_or_create returns None when createRoom omits room_id."""
+
+    def _mk_resp(d, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(d).encode()
+        return r
+
+    mock_get.return_value = _mk_resp({})
+    # createRoom returns 200 but no room_id key
+    mock_post.return_value = _mk_resp({})
+    mock_put.return_value = _mk_resp({})
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["@alice"],
+        discovery=False,
+    )
+    obj.access_token = "tok"
+    obj.user_id = "@u:h"
+    obj.home_server = "h"
+
+    assert obj._dm_room_find_or_create("@alice") is None
+
+
+def test_plugin_matrix_dm_invalid_user():
+    """_dm_room_find_or_create returns None for a malformed user target."""
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        discovery=False,
+    )
+    obj.access_token = "tok"
+    obj.user_id = "@u:h"
+    obj.home_server = "h"
+
+    # No @ prefix -- not a valid user target
+    assert obj._dm_room_find_or_create("notauser") is None
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_dm_send_notification(mock_post, mock_get, mock_put):
+    """Sending to @user target resolves DM room and delivers message."""
+
+    def _mk_resp(d, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(d).encode()
+        return r
+
+    mock_get.return_value = _mk_resp({})
+    mock_put.return_value = _mk_resp({})
+    mock_post.side_effect = [
+        _mk_resp(
+            {"access_token": "tok", "user_id": "@u:h", "home_server": "h"}
+        ),  # login
+        _mk_resp({"room_id": "!new_dm:h"}),  # createRoom
+        _mk_resp({}),  # logout
+    ]
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["@alice"],
+        discovery=False,
+        e2ee=False,
+    )
+
+    # Pre-seed DM room so _room_join succeeds
+    def _join_side(*a, **kw):
+        return "!new_dm:h"
+
+    with (
+        mock.patch.object(obj, "_room_join", side_effect=_join_side),
+        mock.patch.object(
+            obj, "_dm_room_find_or_create", return_value="!new_dm:h"
+        ),
+    ):
+        assert obj.send(body="hello DM") is True
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_dm_only_users_no_rooms_skips_joined(
+    mock_post, mock_get, mock_put
+):
+    """When only @user targets are present, _joined_rooms is not queried."""
+
+    def _mk_resp(d, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(d).encode()
+        return r
+
+    mock_get.return_value = _mk_resp({})
+    mock_put.return_value = _mk_resp({})
+    mock_post.side_effect = [
+        _mk_resp(
+            {"access_token": "tok", "user_id": "@u:h", "home_server": "h"}
+        ),  # login
+        _mk_resp({}),  # logout
+    ]
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["@alice"],
+        discovery=False,
+        e2ee=False,
+    )
+
+    with (
+        mock.patch.object(obj, "_joined_rooms", return_value=[]) as mock_jr,
+        mock.patch.object(obj, "_dm_room_find_or_create", return_value=None),
+    ):
+        obj.send(body="hi")
+        # _joined_rooms must NOT have been called
+        assert mock_jr.call_count == 0
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_dm_room_create_mdirect_get_fails(
+    mock_post, mock_get, mock_put
+):
+    """_dm_room_find_or_create still creates room if m.direct GET fails."""
+
+    def _mk_resp(d, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(d).encode()
+        return r
+
+    # GET fails (404)
+    mock_get.return_value = _mk_resp({}, code=404)
+    mock_post.return_value = _mk_resp({"room_id": "!fallback:h"})
+    mock_put.return_value = _mk_resp({})
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["@alice"],
+        discovery=False,
+    )
+    obj.access_token = "tok"
+    obj.user_id = "@u:h"
+    obj.home_server = "h"
+
+    room_id = obj._dm_room_find_or_create("@alice")
+    assert room_id == "!fallback:h"
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_dm_room_create_no_user_id(
+    mock_post, mock_get, mock_put
+):
+    """_dm_room_find_or_create creates room when user_id is None (skips
+    the m.direct GET and PUT)."""
+
+    def _mk_resp(d, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(d).encode()
+        return r
+
+    mock_get.return_value = _mk_resp({})
+    mock_post.return_value = _mk_resp({"room_id": "!nodm:h"})
+    mock_put.return_value = _mk_resp({})
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["@alice"],
+        discovery=False,
+    )
+    obj.access_token = "tok"
+    # user_id intentionally left as None so the m.direct branch is skipped
+    obj.home_server = "h"
+
+    room_id = obj._dm_room_find_or_create("@alice")
+    assert room_id == "!nodm:h"
+    # No GET and no PUT for m.direct since user_id is None
+    assert mock_get.call_count == 0
+    assert mock_put.call_count == 0

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -981,38 +981,6 @@ def test_plugin_matrix_rooms(mock_post, mock_get, mock_put):
     assert obj._room_create("#abc123:localhost") is None
     del obj
 
-    # _room_create with e2ee=True/secure=True embeds initial_state and
-    # pre-seeds the room encryption cache so a subsequent
-    # _e2ee_room_encrypted() call does not need a network round-trip.
-    request.status_code = requests.codes.ok
-    request.content = dumps(response_obj)
-    obj_e2ee = NotifyMatrix(
-        host="localhost",
-        user="u",
-        password="p",
-        e2ee=True,
-        secure=True,
-        discovery=False,
-    )
-    obj_e2ee.access_token = "tok"
-    obj_e2ee.home_server = "localhost"
-    captured_payloads = []
-    _orig_fetch = obj_e2ee._fetch
-
-    def _capture_fetch(path, payload=None, **kw):
-        if path == "/createRoom":
-            captured_payloads.append(payload)
-        return _orig_fetch(path, payload=payload, **kw)
-
-    obj_e2ee._fetch = _capture_fetch
-    room_id = obj_e2ee._room_create("e2ee_room")
-    assert room_id == response_obj["room_id"]
-    assert len(captured_payloads) == 1
-    init_state = captured_payloads[0].get("initial_state", [])
-    assert any(s.get("type") == "m.room.encryption" for s in init_state)
-    assert obj_e2ee.store.get("e2ee_room_enc_{}".format(room_id)) is True
-    del obj_e2ee
-
     # Room detection
     request.status_code = requests.codes.ok
     request.content = dumps(response_obj)
@@ -2230,6 +2198,56 @@ try:
     CRYPTOGRAPHY_AVAILABLE = True
 except ImportError:
     CRYPTOGRAPHY_AVAILABLE = False
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_room_create_e2ee_initial_state(
+    mock_post, mock_get, mock_put
+):
+    """_room_create with e2ee=True/secure=True embeds m.room.encryption in
+    initial_state and pre-seeds the room encryption cache."""
+    response_obj = {
+        "access_token": "tok",
+        "user_id": "@u:localhost",
+        "home_server": "localhost",
+        "room_id": "!abc123",
+    }
+    r = mock.Mock()
+    r.status_code = requests.codes.ok
+    r.content = dumps(response_obj).encode()
+    mock_post.return_value = r
+    mock_get.return_value = r
+    mock_put.return_value = r
+
+    obj = NotifyMatrix(
+        host="localhost",
+        user="u",
+        password="p",
+        e2ee=True,
+        secure=True,
+        discovery=False,
+    )
+    obj.access_token = "tok"
+    obj.home_server = "localhost"
+
+    captured_payloads = []
+    _orig_fetch = obj._fetch
+
+    def _capture_fetch(path, payload=None, **kw):
+        if path == "/createRoom":
+            captured_payloads.append(payload)
+        return _orig_fetch(path, payload=payload, **kw)
+
+    obj._fetch = _capture_fetch
+    room_id = obj._room_create("e2ee_room")
+    assert room_id == response_obj["room_id"]
+    assert len(captured_payloads) == 1
+    init_state = captured_payloads[0].get("initial_state", [])
+    assert any(s.get("type") == "m.room.encryption" for s in init_state)
+    assert obj.store.get("e2ee_room_enc_{}".format(room_id)) is True
 
 
 def _rand_b64_32():

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -2197,6 +2197,34 @@ def test_plugin_matrix_e2ee_helpers():
     assert out.startswith(b'{"a"')
 
 
+def test_plugin_matrix_e2ee_no_cryptography():
+    """MATRIX_E2EE_SUPPORT is False when cryptography is unavailable."""
+    import importlib
+    import sys
+
+    # Block 'cryptography' so the ImportError branch is taken on reload
+    saved = {
+        k: v for k, v in sys.modules.items() if k.startswith("cryptography")
+    }
+    for key in list(saved):
+        sys.modules[key] = None  # type: ignore[assignment]
+
+    try:
+        import apprise.plugins.matrix.e2ee as e2ee_mod
+
+        importlib.reload(e2ee_mod)
+        assert e2ee_mod.MATRIX_E2EE_SUPPORT is False
+    finally:
+        # Restore everything so subsequent tests are not broken
+        for key in list(saved):
+            if saved[key] is None:
+                del sys.modules[key]
+            else:
+                sys.modules[key] = saved[key]
+        # Force a clean reload so MATRIX_E2EE_SUPPORT is True again
+        importlib.reload(e2ee_mod)
+
+
 def test_plugin_matrix_e2ee_olm_account():
     """MatrixOlmAccount creation, signing, serialisation."""
     from apprise.plugins.matrix.e2ee import MatrixOlmAccount
@@ -2233,7 +2261,9 @@ def test_plugin_matrix_e2ee_olm_account():
 
 
 def test_plugin_matrix_e2ee_olm_session():
-    """MatrixOlmSession encrypts and produces correct structure."""
+    """MatrixOlmSession encrypts and produces correct wire format."""
+    import base64
+
     from apprise.plugins.matrix.e2ee import MatrixOlmAccount
 
     acct = MatrixOlmAccount()
@@ -2251,6 +2281,14 @@ def test_plugin_matrix_e2ee_olm_session():
     result = session.encrypt("test plaintext")
     assert result["type"] == 0
     assert isinstance(result["body"], str)
+
+    # Decode and check the outer pre-key wire format.
+    # The outer body is: version(0x03) | protobuf_fields | mac(8)
+    # The inner message embedded in field 4 must contain the ciphertext
+    # at protobuf field 4 (tag 0x22 = (4<<3)|2), NOT field 3 (tag 0x1A).
+    raw = base64.b64decode(result["body"])
+    assert raw[0:1] == b"\x03", "outer version must be 0x03"
+    assert b"\x22" in raw, "ciphertext field tag 0x22 must be present"
 
     # bytes plaintext also accepted
     result2 = session.encrypt(b"bytes input")
@@ -2275,6 +2313,18 @@ def test_plugin_matrix_e2ee_verify_keys():
     # Valid self-signed device keys -> True
     dk = acct.device_keys_payload(uid, dev)
     assert verify_device_keys(dk, uid, dev) is True
+
+    # Payload user_id doesn't match -> False (identity binding check)
+    mismatched_uid = {**dk, "user_id": "@other:h"}
+    assert verify_device_keys(mismatched_uid, uid, dev) is False
+
+    # Payload device_id doesn't match -> False (identity binding check)
+    mismatched_dev = {**dk, "device_id": "WRONGDEV"}
+    assert verify_device_keys(mismatched_dev, uid, dev) is False
+
+    # Missing user_id in payload -> False
+    no_user_id = {k: v for k, v in dk.items() if k != "user_id"}
+    assert verify_device_keys(no_user_id, uid, dev) is False
 
     # Missing signatures field -> False
     no_sig = {k: v for k, v in dk.items() if k != "signatures"}
@@ -2735,6 +2785,25 @@ def test_plugin_matrix_whoami(mock_post, mock_get, mock_put):
     assert obj.store.get("device_id") == "TOKDEV"
     assert obj.store.get("home_server") == "h"
 
+    # user_id without homeserver component (@alice, no colon) -> home_server
+    # is not extracted (branch where len(parts) != 2 is not taken).
+    obj.user_id = None
+    obj.home_server = None
+    mock_get.return_value = _mk_resp(
+        {"user_id": "@noserver", "device_id": "DEV2"}
+    )
+    assert obj._whoami() is True
+    assert obj.user_id == "@noserver"
+    assert obj.home_server is None  # no colon -> not extracted
+
+    # home_server already known -> not overwritten
+    obj.home_server = "existing.h"
+    mock_get.return_value = _mk_resp(
+        {"user_id": "@tok:other.h", "device_id": "DEV3"}
+    )
+    assert obj._whoami() is True
+    assert obj.home_server == "existing.h"
+
     # Failure: server returns non-200
     obj.user_id = None
     obj.device_id = None
@@ -2996,7 +3065,7 @@ def test_plugin_matrix_e2ee_share_room_key_branches(
         # No valid OTK -> no messages built -> True (nothing to send)
         assert obj._e2ee_share_room_key("!r:h", session) is True
 
-    # string-valued OTK (plain base64 string -- unverified legacy fallback)
+    # Plain-string OTK for signed_curve25519 -> rejected (not a KeyObject)
     str_members = {
         "@other:h": {
             "DEV": {
@@ -3011,10 +3080,10 @@ def test_plugin_matrix_e2ee_share_room_key_branches(
         }
     }
     mock_post.return_value = _mk_resp(str_otk)
-    mock_put.return_value = _mk_resp({})
     with mock.patch.object(
         obj, "_e2ee_room_members", return_value=str_members
     ):
+        # No valid KeyObject OTK -> no messages built -> True (nothing sent)
         assert obj._e2ee_share_room_key("!r:h", session) is True
 
     # OTK key not prefixed with "signed_curve25519:" -> skipped, no OTK found
@@ -3035,7 +3104,7 @@ def test_plugin_matrix_e2ee_share_room_key_branches(
     ):
         assert obj._e2ee_share_room_key("!r:h", session) is True
 
-    # OTK value is neither dict nor str (e.g. integer) -> skipped
+    # OTK value is an integer (unknown format) -> skipped
     non_str_otk = {
         "one_time_keys": {"@other:h": {"DEV": {"signed_curve25519:KID": 42}}}
     }
@@ -3046,15 +3115,21 @@ def test_plugin_matrix_e2ee_share_room_key_branches(
         assert obj._e2ee_share_room_key("!r:h", session) is True
 
     # create_outbound_session raises -> device is skipped gracefully
-    # Uses a string OTK (no sig check) so the Olm call is actually reached
+    # Use a properly signed OTK so verification passes and the Olm call
+    # is actually reached.
+    create_fail_signed = _make_signed_otk(
+        recipient, "@other:h", "DEV", their_otk_b64
+    )
     create_fail_otk = {
         "one_time_keys": {
-            "@other:h": {"DEV": {"signed_curve25519:KID": their_otk_b64}}
+            "@other:h": {"DEV": {"signed_curve25519:KID": create_fail_signed}}
         }
     }
     mock_post.return_value = _mk_resp(create_fail_otk)
     with (
-        mock.patch.object(obj, "_e2ee_room_members", return_value=str_members),
+        mock.patch.object(
+            obj, "_e2ee_room_members", return_value=dict_members
+        ),
         mock.patch.object(
             obj._e2ee_account,
             "create_outbound_session",

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -3397,6 +3397,9 @@ def test_plugin_matrix_e2ee_send_attachment_errors(
             name = "f.txt"
             mimetype = "text/plain"
 
+            def __len__(self):
+                return 0
+
         with mock.patch("builtins.open", side_effect=OSError("no read")):
             assert (
                 obj._e2ee_send_attachment(_BadAttach(), "!r:h", session)
@@ -3495,6 +3498,20 @@ def test_plugin_matrix_e2ee_send_attachment_errors(
             result = obj2._e2ee_send_attachment(_BadAttach(), "!r:h", sess2)
         assert result is True
         assert obj2.transaction_id == txn_before
+
+        # Image mimetype -> is_image branch (no 'filename' field added)
+        class _ImageAttach:
+            path = tmp_path
+            name = "photo.png"
+            mimetype = "image/png"
+
+            def __len__(self):
+                return 4
+
+        with mock.patch("requests.post", return_value=upload_r):
+            mock_put.return_value = put_r
+            result = obj2._e2ee_send_attachment(_ImageAttach(), "!r:h", sess2)
+        assert result is True
 
     finally:
         os.unlink(tmp_path)

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -710,6 +710,54 @@ def test_plugin_matrix_auth(mock_post, mock_get, mock_put):
     assert obj.access_token is None
     del obj
 
+    # Modern Matrix servers omit home_server from login/register responses.
+    # Apprise must derive it from user_id so room-alias resolution works.
+    modern_resp = {
+        "access_token": "tok99",
+        "user_id": "@bot:matrix.org",
+        "device_id": "DEVXYZ",
+        # no "home_server" key -- matches real matrix.org behaviour
+    }
+    request.status_code = requests.codes.ok
+    request.content = dumps(modern_resp)
+
+    # No home_server in response + no prior home_server -> derive from user_id
+    obj2 = NotifyMatrix(host="matrix.org", user="bot", password="pass")
+    assert obj2._login() is True
+    assert obj2.home_server == "matrix.org"
+
+    obj3 = NotifyMatrix(host="matrix.org", user="bot", password="pass")
+    assert obj3._register() is True
+    assert obj3.home_server == "matrix.org"
+
+    # No home_server in response + home_server already set -> not overwritten
+    obj4 = NotifyMatrix(host="matrix.org", user="bot", password="pass")
+    obj4.home_server = "already.set"
+    assert obj4._login() is True
+    assert obj4.home_server == "already.set"
+
+    obj5 = NotifyMatrix(host="matrix.org", user="bot", password="pass")
+    obj5.home_server = "already.set"
+    assert obj5._register() is True
+    assert obj5.home_server == "already.set"
+
+    # No home_server in response + user_id has no colon ->
+    # home_server stays None
+    no_colon_resp = {
+        "access_token": "tok88",
+        "user_id": "@nocoilon",
+        "device_id": "DEV88",
+    }
+    request.content = dumps(no_colon_resp)
+    obj6 = NotifyMatrix(host="matrix.org", user="bot", password="pass")
+    assert obj6._login() is True
+    assert obj6.home_server is None
+
+    obj7 = NotifyMatrix(host="matrix.org", user="bot", password="pass")
+    assert obj7._register() is True
+    assert obj7.home_server is None
+    del obj2, obj3, obj4, obj5, obj6, obj7
+
 
 @mock.patch("requests.put")
 @mock.patch("requests.get")
@@ -833,6 +881,19 @@ def test_plugin_matrix_rooms(mock_post, mock_get, mock_put):
     assert obj.store.get("#abc123:localhost")["id"] == response_obj["room_id"]
     assert obj._room_join("abc123") == response_obj["room_id"]
 
+    # If home_server is missing, recover it from user_id so we never try
+    # to join a '#room:None' alias.
+    obj.store.clear()
+    obj.home_server = None
+    obj.user_id = "@apprise:localhost"
+    mock_post.reset_mock()
+    assert obj._room_join("abc123") == response_obj["room_id"]
+    assert mock_post.call_count == 1
+    assert (
+        mock_post.call_args_list[0][0][0]
+        == "http://host/_matrix/client/v3/join/%23abc123%3Alocalhost"
+    )
+
     obj.store.clear()
     assert obj._room_join("abc123:localhost") == response_obj["room_id"]
     # Use cache to get same results
@@ -850,6 +911,13 @@ def test_plugin_matrix_rooms(mock_post, mock_get, mock_put):
     obj.store.clear()
     assert obj._room_join("%") is None
     assert obj._room_join(None) is None
+
+    obj.store.clear()
+    obj.home_server = None
+    obj.user_id = "@apprise"
+    mock_post.reset_mock()
+    assert obj._room_join("abc123") is None
+    assert mock_post.call_count == 0
 
     # 403 response; this will push for a room creation for alias based rooms
     # and these will fail
@@ -2294,9 +2362,7 @@ def test_plugin_matrix_e2ee_olm_account():
 
 def test_plugin_matrix_e2ee_olm_session():
     """MatrixOlmSession encrypts and produces correct wire format."""
-    import base64
-
-    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
+    from apprise.plugins.matrix.e2ee import MatrixOlmAccount, _b64dec
 
     acct = MatrixOlmAccount()
     # Create a second account to act as recipient
@@ -2315,16 +2381,231 @@ def test_plugin_matrix_e2ee_olm_session():
     assert isinstance(result["body"], str)
 
     # Decode and check the outer pre-key wire format.
-    # The outer body is: version(0x03) | protobuf_fields | mac(8)
-    # The inner message embedded in field 4 must contain the ciphertext
-    # at protobuf field 4 (tag 0x22 = (4<<3)|2), NOT field 3 (tag 0x1A).
-    raw = base64.b64decode(result["body"])
+    # Outer: version(0x03) | field1(OTK) | field2(EK) | field3(IK) |
+    #        field4(inner+mac) | outer_mac(8)
+    # Inner (in field 4): version(0x03) | field1(ratchet_key) |
+    #        field2(chain_index) | field4(ciphertext,tag=0x22) | inner_mac(8)
+    raw = _b64dec(result["body"])
     assert raw[0:1] == b"\x03", "outer version must be 0x03"
+    # field 4, wire-type 2 -> tag = (4<<3)|2 = 0x22 -- ciphertext in inner msg
     assert b"\x22" in raw, "ciphertext field tag 0x22 must be present"
+    # Outer field 1 (OTK, tag 0x0A), field 2 (EK, tag 0x12) must appear
+    assert b"\x0a" in raw, "outer OTK field (tag 0x0A) must be present"
+    assert b"\x12" in raw, "outer EK field (tag 0x12) must be present"
 
     # bytes plaintext also accepted
     result2 = session.encrypt(b"bytes input")
     assert result2["type"] == 0
+
+
+def test_plugin_matrix_e2ee_olm_roundtrip():
+    """Full Olm round-trip: Alice encrypts, Bob manually decrypts.
+
+    This test implements the Bob (inbound) side of the Olm X3DH and
+    message-decryption protocol using the same cryptography primitives,
+    verifying that our Alice-side implementation produces wire bytes that
+    a conformant receiver can decrypt.
+
+    Critical invariant verified: the outer base-key (pre-key field 2)
+    equals the inner ratchet-key (normal-message field 1).  They MUST be
+    the same ephemeral key E_A or the receiver cannot reconstruct the
+    session and decryption fails.
+    """
+    import hmac as _hmac_stdlib
+
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import hashes, hmac as _hmac_mod
+    from cryptography.hazmat.primitives.asymmetric.x25519 import (
+        X25519PrivateKey,
+    )
+    from cryptography.hazmat.primitives.ciphers import (
+        Cipher,
+        algorithms,
+        modes,
+    )
+    from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+    from cryptography.hazmat.primitives.padding import PKCS7
+    from cryptography.hazmat.primitives.serialization import (
+        Encoding,
+        PublicFormat,
+    )
+
+    from apprise.plugins.matrix.e2ee import (
+        MatrixOlmAccount,
+        _b64dec,
+        _b64enc,
+    )
+
+    # -- helpers (Bob-side) -------------------------------------------
+
+    def _hmac(key, data):
+        h = _hmac_mod.HMAC(key, hashes.SHA256(), backend=default_backend())
+        h.update(data)
+        return h.finalize()
+
+    def _hkdf(ikm, length, salt, info):
+        return HKDF(
+            algorithm=hashes.SHA256(),
+            length=length,
+            salt=salt,
+            info=info,
+            backend=default_backend(),
+        ).derive(ikm)
+
+    def _aes_cbc_decrypt(key, iv, ciphertext):
+        cipher = Cipher(
+            algorithms.AES(key), modes.CBC(iv), backend=default_backend()
+        )
+        dec = cipher.decryptor()
+        padded = dec.update(ciphertext) + dec.finalize()
+        unpadder = PKCS7(128).unpadder()
+        return unpadder.update(padded) + unpadder.finalize()
+
+    def _read_varint(data, pos):
+        val, shift = 0, 0
+        while True:
+            b = data[pos]
+            pos += 1
+            val |= (b & 0x7F) << shift
+            shift += 7
+            if not (b & 0x80):
+                return val, pos
+
+    def _parse_pb_fields(data):
+        """Parse length-delimited protobuf body; return {field_num: bytes}."""
+        fields = {}
+        pos = 0
+        while pos < len(data):
+            tag, pos = _read_varint(data, pos)
+            field_num = tag >> 3
+            wire_type = tag & 0x07
+            if wire_type == 2:
+                length, pos = _read_varint(data, pos)
+                fields[field_num] = data[pos : pos + length]
+                pos += length
+            elif wire_type == 0:
+                val, pos = _read_varint(data, pos)
+                fields[field_num] = val
+            else:
+                raise ValueError("Unexpected wire type {}".format(wire_type))
+        return fields
+
+    # -- test setup ---------------------------------------------------
+
+    # Alice's account (sender)
+    alice = MatrixOlmAccount()
+
+    # Bob's account: identity key + a separate one-time key
+    bob = MatrixOlmAccount()
+    bob_otk_priv = X25519PrivateKey.generate()
+    bob_otk_pub = bob_otk_priv.public_key().public_bytes(
+        Encoding.Raw, PublicFormat.Raw
+    )
+    bob_otk_pub_b64 = _b64enc(bob_otk_pub)
+
+    # Bob's identity-key private (for DH computation)
+    bob_ik_priv = bob._ik
+
+    # Alice creates an outbound session to Bob using his real OTK
+    session = alice.create_outbound_session(
+        bob.identity_key,  # Bob's Curve25519 identity key
+        bob_otk_pub_b64,  # Bob's one-time key
+    )
+
+    plaintext = "hello from Alice"
+    result = session.encrypt(plaintext)
+    assert result["type"] == 0
+
+    # -- Bob-side decryption ------------------------------------------
+
+    raw = _b64dec(result["body"])
+
+    # Outer format: version(1) | pb_fields | outer_mac(8)
+    assert raw[0:1] == b"\x03", "outer version must be 0x03"
+    outer_body = raw[:-8]  # everything before the outer MAC
+    outer_mac_received = raw[-8:]
+
+    # Parse outer fields (skip version byte)
+    outer_fields = _parse_pb_fields(outer_body[1:])
+    otk_pub_in_msg = outer_fields[1]  # field 1: Bob's OTK public bytes
+    base_key = outer_fields[2]  # field 2: Alice's ephemeral E_A
+    alice_ik_pub = outer_fields[3]  # field 3: Alice's identity key
+
+    # The OTK bytes in the message must equal Bob's OTK public key
+    assert otk_pub_in_msg == bob_otk_pub, (
+        "OTK in pre-key message must match the OTK that was claimed"
+    )
+
+    # Bob computes X3DH (mirroring Alice's DH operations)
+    #   DH1 = X25519(OTK_B_priv, IK_A_pub)
+    #   DH2 = X25519(IK_B_priv, E_A_pub)
+    #   DH3 = X25519(OTK_B_priv, E_A_pub)
+    from cryptography.hazmat.primitives.asymmetric.x25519 import (
+        X25519PublicKey,
+    )
+
+    alice_ik = X25519PublicKey.from_public_bytes(alice_ik_pub)
+    e_a = X25519PublicKey.from_public_bytes(base_key)
+
+    dh1 = bob_otk_priv.exchange(alice_ik)
+    dh2 = bob_ik_priv.exchange(e_a)
+    dh3 = bob_otk_priv.exchange(e_a)
+
+    ikm = dh1 + dh2 + dh3
+    keys64 = _hkdf(ikm, 64, salt=None, info=b"OLM_ROOT")
+    root_key = keys64[:32]
+    chain_key = keys64[32:]
+    del root_key  # not needed for first-message decryption
+
+    # Derive message keys
+    msg_key = _hmac(chain_key, b"\x01")
+    keys80 = _hkdf(msg_key, 80, salt=b"\x00" * 32, info=b"OLM_KEYS")
+    aes_key = keys80[:32]
+    mac_key = keys80[32:64]
+    iv = keys80[64:80]
+
+    # Verify outer MAC
+    outer_mac_expected = _hmac(mac_key, outer_body)[:8]
+    assert _hmac_stdlib.compare_digest(
+        outer_mac_expected, outer_mac_received
+    ), "outer MAC verification failed"
+
+    # Parse field 4 (inner message + inner_mac)
+    inner_with_mac = outer_fields[4]
+    inner_body = inner_with_mac[:-8]
+    inner_mac_received = inner_with_mac[-8:]
+
+    # Verify inner MAC
+    _hmac(mac_key, b"\x03" + inner_body[1:])[:8]
+    # inner_body already starts with 0x03; mac over the full inner body
+    inner_mac_expected2 = _hmac(mac_key, inner_body)[:8]
+    assert _hmac_stdlib.compare_digest(
+        inner_mac_expected2, inner_mac_received
+    ), "inner MAC verification failed"
+
+    # Parse inner fields
+    # inner_body = version(0x03) | pb_fields
+    assert inner_body[0:1] == b"\x03", "inner version must be 0x03"
+    inner_fields = _parse_pb_fields(inner_body[1:])
+
+    # CRITICAL invariant:
+    # ratchet_key (inner field 1) == base_key (outer field 2)
+    ratchet_key = inner_fields[1]
+    assert ratchet_key == base_key, (
+        "Olm invariant violated: inner ratchet_key must equal outer base_key "
+        "(E_A must be used in BOTH positions per Olm spec Section 5.1). "
+        "Got ratchet_key={} base_key={}".format(
+            _b64enc(ratchet_key), _b64enc(base_key)
+        )
+    )
+
+    # Decrypt the AES-256-CBC ciphertext (inner field 4)
+    ciphertext = inner_fields[4]
+    decrypted = _aes_cbc_decrypt(aes_key, iv, ciphertext)
+
+    assert decrypted.decode("utf-8") == plaintext, (
+        "round-trip decryption failed: got {!r}".format(decrypted)
+    )
 
 
 def test_plugin_matrix_e2ee_verify_keys():
@@ -2405,6 +2686,7 @@ def test_plugin_matrix_e2ee_verify_keys():
 def test_plugin_matrix_e2ee_megolm_session():
     """MatrixMegOlmSession encrypt, session_key, rotation, serialisation."""
     from apprise.plugins.matrix.e2ee import (
+        MATRIX_MEGOLM_STORE_VERSION,
         MEGOLM_ROTATION_MSGS,
         MatrixMegOlmSession,
     )
@@ -2416,12 +2698,30 @@ def test_plugin_matrix_e2ee_megolm_session():
     ct = s.encrypt({"type": "m.room.message", "content": {}})
     assert isinstance(ct, str)
 
-    # session_key returns base64
+    # Verify MegOLM wire format (libolm message.cpp):
+    #   version(0x03) | field1_varint(msg_index,tag=0x08) |
+    #   field2_bytes(ciphertext,tag=0x12) | mac(8) | sig(64)
+    from apprise.plugins.matrix.e2ee import _b64dec
+
+    raw = _b64dec(ct)
+    assert raw[0:1] == b"\x03", "MegOLM version must be 0x03"
+    assert raw[1:2] == b"\x08", "MegOLM field 1 tag must be 0x08 (varint)"
+    # After tag 0x08: the varint counter value (0 -> single byte 0x00),
+    # then the ciphertext tag 0x12.
+    assert b"\x12" in raw, "MegOLM ciphertext field tag 0x12 must be present"
+
+    # session_key returns base64 -- verify wire format per libolm
+    # outbound_group_session.c: version(1) + counter(4) + ratchet(128)
+    # + ed25519_pub(32) + ed25519_sig(64) = 229 bytes raw = 308 base64 chars
     sk = s.session_key()
     assert isinstance(sk, str)
+    sk_raw = _b64dec(sk)
+    assert len(sk_raw) == 229, "session_key must be 229 bytes (sig included)"
+    assert sk_raw[0:1] == b"\x02", "session_key version must be 0x02"
 
     # to_dict / from_dict round-trip
     d = s.to_dict()
+    assert d["version"] == MATRIX_MEGOLM_STORE_VERSION
     s2 = MatrixMegOlmSession.from_dict(d)
     assert s2.session_id == s.session_id
     assert s2._counter == s._counter
@@ -2677,10 +2977,52 @@ def test_plugin_matrix_e2ee_send_cached_session(mock_post, mock_get, mock_put):
     _sess = MatrixMegOlmSession()
     obj.store.set("e2ee_room_enc_!r:h", True)
     obj.store.set("e2ee_megolm_!r:h", _sess.to_dict())
-    obj.store.set("e2ee_key_shared_!r:h", True)
+    obj.store.set("e2ee_key_shared_!r:h", _sess.session_id)
     assert obj.send(body="silent") is True
     # Only one PUT for the encrypted message itself
     assert mock_put.call_count == 1
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_e2ee_send_legacy_shared_flag_rekeys(
+    mock_post, mock_get, mock_put
+):
+    """Legacy boolean key-share cache forces a fresh room-key share."""
+    from apprise.plugins.matrix.e2ee import (
+        MatrixMegOlmSession,
+        MatrixOlmAccount,
+    )
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+    )
+    obj.access_token = "tok"
+    obj.home_server = "h"
+    obj.user_id = "@u:h"
+    obj.device_id = "DEV"
+    obj._e2ee_account = MatrixOlmAccount()
+    session = MatrixMegOlmSession()
+    obj.store.set("e2ee_megolm_!r:h", session.to_dict())
+    obj.store.set("e2ee_key_shared_!r:h", True)
+
+    with (
+        mock.patch.object(
+            obj, "_e2ee_share_room_key", return_value=True
+        ) as share,
+        mock.patch.object(obj, "_fetch", return_value=(True, {}, 200)),
+    ):
+        assert (
+            obj._e2ee_send_to_room("!r:h", "body", "", NotifyType.INFO) is True
+        )
+
+    assert share.call_count == 1
+    assert obj.store.get("e2ee_key_shared_!r:h") == session.session_id
 
 
 def test_plugin_matrix_e2ee_setup_restored():
@@ -2699,6 +3041,15 @@ def test_plugin_matrix_e2ee_setup_restored():
     # Seed account + mark keys already uploaded
     obj.store.set("e2ee_account", acct.to_dict())
     obj.store.set("e2ee_keys_uploaded", True)
+    obj.store.set(
+        "e2ee_device_binding",
+        "{}|{}|{}|{}".format(
+            obj.user_id or "",
+            obj.device_id or "",
+            acct.identity_key,
+            acct.signing_key,
+        ),
+    )
 
     # Simulate state where account is not yet loaded in memory
     obj._e2ee_account = None
@@ -2733,6 +3084,33 @@ def test_plugin_matrix_e2ee_setup_restored():
             e2ee=True,
         )
     assert obj2._e2ee_account is not None
+
+
+def test_plugin_matrix_e2ee_setup_reuploads_on_binding_change():
+    """Changed device/account identity forces a fresh key upload."""
+    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
+
+    acct = MatrixOlmAccount()
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+    )
+    obj.user_id = "@u:h"
+    obj.device_id = "DEV_NEW"
+    obj._e2ee_account = acct
+    obj.store.set("e2ee_account", acct.to_dict())
+    obj.store.set("e2ee_keys_uploaded", True)
+    obj.store.set("e2ee_device_binding", "@u:h|DEV_OLD|oldik|oldsk")
+
+    with mock.patch.object(
+        obj, "_e2ee_upload_keys", return_value=True
+    ) as upload:
+        assert obj._e2ee_setup() is True
+
+    assert upload.call_count == 1
 
 
 @mock.patch("requests.put")
@@ -2781,6 +3159,44 @@ def test_plugin_matrix_e2ee_upload_keys_http_fail(
     obj.device_id = "DEV"
     obj.home_server = "h"
     assert obj._e2ee_upload_keys() is False
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_e2ee_upload_keys_success_marks_published(
+    mock_post, mock_get, mock_put
+):
+    """Successful upload clears the current unpublished OTK batch."""
+    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
+
+    resp = mock.Mock()
+    resp.status_code = requests.codes.ok
+    resp.content = dumps(
+        {"one_time_key_counts": {"signed_curve25519": 10}}
+    ).encode()
+    mock_post.return_value = resp
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+    )
+    obj._e2ee_account = MatrixOlmAccount()
+    obj.access_token = "tok"
+    obj.user_id = "@u:h"
+    obj.device_id = "DEV"
+    obj.home_server = "h"
+
+    # Pre-generate one-time keys so we can verify they are marked published.
+    obj._e2ee_account.one_time_keys_payload(
+        obj.user_id, obj.device_id, count=3
+    )
+    assert obj._e2ee_account._otks
+    assert obj._e2ee_upload_keys() is True
+    assert obj._e2ee_account._otks == {}
 
 
 @mock.patch("requests.put")
@@ -2841,7 +3257,48 @@ def test_plugin_matrix_whoami(mock_post, mock_get, mock_put):
     obj.device_id = None
     mock_get.return_value = _mk_resp({}, code=401)
     assert obj._whoami() is False
-    assert obj.user_id is None
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_send_cached_token_recovers_home_server(
+    mock_post, mock_get, mock_put
+):
+    """Cached auth without home_server should be repaired via _whoami()."""
+
+    obj = NotifyMatrix(
+        host="matrix.org",
+        user="apprise",
+        password="pass",
+        targets=["#general"],
+    )
+    obj.access_token = "cached-token"
+    obj.user_id = None
+    obj.device_id = None
+    obj.home_server = None
+
+    whoami_called = {"count": 0}
+
+    def _fake_whoami():
+        whoami_called["count"] += 1
+        obj.user_id = "@apprise:matrix.org"
+        obj.device_id = "DEV42"
+        obj.home_server = "matrix.org"
+        return True
+
+    with (
+        mock.patch.object(obj, "_room_join", return_value="!room:matrix.org"),
+        mock.patch.object(obj, "_whoami", side_effect=_fake_whoami),
+        mock.patch.object(
+            obj, "_fetch", return_value=(True, {"event_id": "$1"}, 200)
+        ),
+    ):
+        assert obj.send("body", title="test") is True
+
+    assert whoami_called["count"] == 1
+    assert obj.home_server == "matrix.org"
+    assert obj.user_id == "@apprise:matrix.org"
 
 
 @mock.patch("requests.put")
@@ -2872,6 +3329,16 @@ def test_plugin_matrix_e2ee_get_megolm_rotation(mock_post, mock_get, mock_put):
     assert new_session.session_id != stale.session_id
 
     # The shared flag should be cleared on rotation
+    assert obj.store.get("e2ee_key_shared_!r:h") is None
+
+    # Legacy cached sessions without the current version marker are
+    # invalidated and replaced with a fresh session.
+    legacy = stale.to_dict()
+    del legacy["version"]
+    obj.store.set("e2ee_megolm_!r:h", legacy)
+    obj.store.set("e2ee_key_shared_!r:h", stale.session_id)
+    replaced = obj._e2ee_get_megolm("!r:h")
+    assert replaced.session_id != stale.session_id
     assert obj.store.get("e2ee_key_shared_!r:h") is None
 
 
@@ -3082,6 +3549,11 @@ def test_plugin_matrix_e2ee_share_room_key_branches(
         obj, "_e2ee_room_members", return_value=dict_members
     ):
         assert obj._e2ee_share_room_key("!r:h", session) is True
+        payload = loads(mock_put.call_args.kwargs["data"])
+        dev_payload = payload["messages"]["@other:h"]["DEV"]
+        assert dev_payload["recipient_key"] == their_ik
+        assert dev_payload["sender_key"] == obj._e2ee_account.identity_key
+        assert "org.matrix.msgid" in dev_payload
 
     # dict-valued OTK with no signatures -> OTK rejected, device skipped
     unsigned_otk_dict = {"key": their_otk_b64}  # no "signatures" field
@@ -3223,13 +3695,13 @@ def test_plugin_matrix_e2ee_send_to_room_formats(
         obj.user_id = "@u:h"
         obj.device_id = "DEV"
         obj._e2ee_account = MatrixOlmAccount()
-        obj.store.set("e2ee_key_shared_!r:h", True)
         return obj
 
     # HTML format
     obj = _make_obj(NotifyFormat.HTML)
     session = MatrixMegOlmSession()
     obj.store.set("e2ee_megolm_!r:h", session.to_dict())
+    obj.store.set("e2ee_key_shared_!r:h", session.session_id)
     assert (
         obj._e2ee_send_to_room(
             "!r:h", "<b>body</b>", "<h1>title</h1>", NotifyType.INFO
@@ -3241,6 +3713,7 @@ def test_plugin_matrix_e2ee_send_to_room_formats(
     obj = _make_obj(NotifyFormat.MARKDOWN)
     session = MatrixMegOlmSession()
     obj.store.set("e2ee_megolm_!r:h", session.to_dict())
+    obj.store.set("e2ee_key_shared_!r:h", session.session_id)
     assert (
         obj._e2ee_send_to_room("!r:h", "**bold**", "title", NotifyType.INFO)
         is True
@@ -3261,6 +3734,7 @@ def test_plugin_matrix_e2ee_send_to_room_formats(
     obj.password = "same"
     session2 = MatrixMegOlmSession()
     obj.store.set("e2ee_megolm_!r:h", session2.to_dict())
+    obj.store.set("e2ee_key_shared_!r:h", session2.session_id)
     assert obj._e2ee_send_to_room("!r:h", "body", "", NotifyType.INFO) is True
 
     # key-share failure aborts send
@@ -3371,7 +3845,7 @@ def test_plugin_matrix_e2ee_attachment_encrypted(
         _s = MatrixMegOlmSession()
         obj.store.set("e2ee_room_enc_!r:h", True)
         obj.store.set("e2ee_megolm_!r:h", _s.to_dict())
-        obj.store.set("e2ee_key_shared_!r:h", True)
+        obj.store.set("e2ee_key_shared_!r:h", _s.session_id)
         assert obj.send(body="body", attach=attach) is True
 
         # Two PUTs: encrypted message + encrypted attachment event
@@ -3599,7 +4073,7 @@ def test_plugin_matrix_e2ee_send_attachment_invalid(
         _s = MatrixMegOlmSession()
         obj.store.set("e2ee_room_enc_!r:h", True)
         obj.store.set("e2ee_megolm_!r:h", _s.to_dict())
-        obj.store.set("e2ee_key_shared_!r:h", True)
+        obj.store.set("e2ee_key_shared_!r:h", _s.session_id)
 
         attach = AppriseAttachment()
         attach.add(attach_path)
@@ -3630,7 +4104,7 @@ def test_plugin_matrix_e2ee_send_attachment_invalid(
         _s2 = MatrixMegOlmSession()
         obj2.store.set("e2ee_room_enc_!r:h", True)
         obj2.store.set("e2ee_megolm_!r:h", _s2.to_dict())
-        obj2.store.set("e2ee_key_shared_!r:h", True)
+        obj2.store.set("e2ee_key_shared_!r:h", _s2.session_id)
         # Add a non-existent file to get a falsy attachment
         bad_attach = AppriseAttachment()
         bad_attach.add("/nonexistent/path/file.txt")
@@ -3682,7 +4156,7 @@ def test_plugin_matrix_e2ee_send_room_failure(mock_post, mock_get, mock_put):
     obj.store.set("e2ee_room_enc_!r:h", True)
     _s = MatrixMegOlmSession()
     obj.store.set("e2ee_megolm_!r:h", _s.to_dict())
-    obj.store.set("e2ee_key_shared_!r:h", True)
+    obj.store.set("e2ee_key_shared_!r:h", _s.session_id)
 
     with mock.patch.object(obj, "_e2ee_send_to_room", return_value=False):
         assert obj.send(body="fail") is False
@@ -3709,6 +4183,58 @@ def test_plugin_matrix_register_with_device_id(mock_post, mock_get, mock_put):
     assert obj._register() is True
     assert obj.device_id == "REG_DEV"
     assert obj.store.get("device_id") == "REG_DEV"
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_login_reuses_device_id(mock_post, mock_get, mock_put):
+    """Login payload reuses the stored device ID when present."""
+    r = mock.Mock()
+    r.status_code = requests.codes.ok
+    r.content = dumps(
+        {
+            "access_token": "tok",
+            "user_id": "@u:h",
+            "home_server": "h",
+            "device_id": "DEV_REUSED",
+        }
+    ).encode()
+    mock_post.return_value = r
+
+    obj = NotifyMatrix(host="h", user="u", password="pass", discovery=False)
+    obj.device_id = "DEV_REUSED"
+    assert obj._login() is True
+
+    payload = mock_post.call_args.kwargs["data"]
+    assert '"device_id": "DEV_REUSED"' in payload
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_register_reuses_device_id(
+    mock_post, mock_get, mock_put
+):
+    """Register payload reuses the stored device ID when present."""
+    r = mock.Mock()
+    r.status_code = requests.codes.ok
+    r.content = dumps(
+        {
+            "access_token": "tok",
+            "user_id": "@u:h",
+            "home_server": "h",
+            "device_id": "DEV_REUSED",
+        }
+    ).encode()
+    mock_post.return_value = r
+
+    obj = NotifyMatrix(host="h", user="u", password="pass", discovery=False)
+    obj.device_id = "DEV_REUSED"
+    assert obj._register() is True
+
+    payload = mock_post.call_args.kwargs["data"]
+    assert '"device_id": "DEV_REUSED"' in payload
 
 
 def test_plugin_matrix_e2ee_account_bad_store_data():

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -55,6 +55,10 @@ MATRIX_GOOD_RESPONSE = dumps(
         "joined_rooms": ["!abc123:localhost", "!def456:localhost"],
         "access_token": "abcd1234",
         "home_server": "localhost",
+        # user_id is returned by /login and /account/whoami; including it
+        # here ensures self.user_id is set after login so _whoami() is not
+        # called unnecessarily (it only fires when user_id is still absent).
+        "user_id": "@apprise:localhost",
         # Simulate .well-known
         "m.homeserver": {"base_url": "https://matrix.example.com"},
         "m.identity_server": {"base_url": "https://vector.im"},

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -2128,7 +2128,6 @@ def test_plugin_matrix_room_create_on_not_found_join(
 _cryptography = pytest.importorskip(
     "cryptography",
     reason="Requires cryptography",
-    exc_type=ImportError,
 )
 
 


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #305 , #794, and #795

## Matrix E2EE + DM Support

Upgrades the Matrix plugin end-to-end encryption (E2EE), encrypted attachment delivery, and direct messaging
(DM) to `@user` targets. :rocket: 
- E2EE and encrypted attachments require the `cryptography` Python package (`pip install cryptography`).
- DM support has no additional dependencies.

### URL Examples

```
# Auto E2EE (default, encrypts rooms that have it enabled):
matrixs://user:pass@matrix.example.com/#general

# Disable E2EE entirely (behave as matrix:// did prior to this PR):
matrixs://user:pass@matrix.example.com/#general?e2ee=no

# DM a user (homeserver inferred from login):
matrixs://user:pass@matrix.example.com/@alice

# DM with explicit homeserver:
matrixs://user:pass@matrix.example.com/@alice:other.com

# Mix rooms and DM targets:
matrixs://user:pass@matrix.example.com/#general/!roomid:h/@alice
```

## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/35](https://github.com/caronc/apprise-docs/pull/35)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@305-matrix-e2ee-support

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "matrixs://user:pass@matrix.example.com/#general"
```
