### PR TITLE
fix(fcm): add apns-push-type header for reliable iOS delivery

### DIFF
--- a/apprise/plugins/fcm/priority.py
+++ b/apprise/plugins/fcm/priority.py
@@ -132,7 +132,7 @@ class FCMPriorityManager:
             FCMMode.OAuth2: {
                 "message": {
                     "android": {"priority": NotificationPriority.HIGH},
-                    "apns": {"headers": {"apns-priority": "10"}},
+                    "apns": {"headers": {"apns-priority": "10", "apns-push-type": "alert"}},
                     "webpush": {"headers": {"Urgency": "high"}},
                 }
             },
@@ -144,7 +144,7 @@ class FCMPriorityManager:
             FCMMode.OAuth2: {
                 "message": {
                     "android": {"priority": NotificationPriority.HIGH},
-                    "apns": {"headers": {"apns-priority": "10"}},
+                    "apns": {"headers": {"apns-priority": "10", "apns-push-type": "alert"}},
                     "webpush": {"headers": {"Urgency": "high"}},
                 }
             },

--- a/apprise/plugins/fcm/priority.py
+++ b/apprise/plugins/fcm/priority.py
@@ -132,7 +132,12 @@ class FCMPriorityManager:
             FCMMode.OAuth2: {
                 "message": {
                     "android": {"priority": NotificationPriority.HIGH},
-                    "apns": {"headers": {"apns-priority": "10", "apns-push-type": "alert"}},
+                    "apns": {
+                        "headers": {
+                            "apns-priority": "10",
+                            "apns-push-type": "alert",
+                        }
+                    },
                     "webpush": {"headers": {"Urgency": "high"}},
                 }
             },
@@ -144,7 +149,12 @@ class FCMPriorityManager:
             FCMMode.OAuth2: {
                 "message": {
                     "android": {"priority": NotificationPriority.HIGH},
-                    "apns": {"headers": {"apns-priority": "10", "apns-push-type": "alert"}},
+                    "apns": {
+                        "headers": {
+                            "apns-priority": "10",
+                            "apns-push-type": "alert",
+                        }
+                    },
                     "webpush": {"headers": {"Urgency": "high"}},
                 }
             },


### PR DESCRIPTION
## Description

When sending FCM notifications with high/max priority, the `apns` section includes `apns-priority: 10` but omits the `apns-push-type` header.

iOS 13+ requires `apns-push-type: alert` to reliably deliver push
  notifications, especially when the app is in the foreground.
Without it, APNs may silently drop or delay the notification even though FCM returns  HTTP 200.

This adds `apns-push-type: alert` to the HIGH and MAX priority payloads.