### PR TITLE
Added blink(1) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The table below identifies the services this tool supports and some example serv
 | [Apprise API](https://appriseit.com/services/apprise_api/)  | apprise:// or apprises:// | (TCP) 80 or 443 | apprise://hostname/Token
 | [AWS SES](https://appriseit.com/services/ses/)  | ses://   | (TCP) 443   | ses://user@domain/AccessKeyID/AccessSecretKey/RegionName<br/>ses://user@domain/AccessKeyID/AccessSecretKey/RegionName/email1/email2/emailN
 | [Bark](https://appriseit.com/services/bark/)  | bark://   | (TCP) 80 or 443   | bark://hostname<br />bark://hostname/device_key<br />bark://hostname/device_key1/device_key2/device_keyN<br/>barks://hostname<br />barks://hostname/device_key<br />barks://hostname/device_key1/device_key2/device_keyN
+| [Blink(1)](https://appriseit.com/services/blink1/) | blink1:// | USB | blink1://<br />blink1://serial/
 | [BlueSky](https://appriseit.com/services/bluesky/) | bluesky://  | (TCP) 443   | bluesky://Handle:AppPw<br />bluesky://Handle:AppPw/TargetHandle<br />bluesky://Handle:AppPw/TargetHandle1/TargetHandle2/TargetHandleN
 | [Brevo](https://appriseit.com/services/brevo/) | brevo://  | (TCP) 443   | brevo://APIToken:FromEmail/<br />brevo://APIToken:FromEmail/ToEmail<br />brevo://APIToken:FromEmail/ToEmail1/ToEmail2/ToEmailN/
 | [Chanify](https://appriseit.com/services/chanify/) | chantify://    | (TCP) 443    | chantify://token

--- a/all-plugin-requirements.txt
+++ b/all-plugin-requirements.txt
@@ -17,6 +17,9 @@ paho-mqtt != 2.0.*
 # Pretty Good Privacy (PGP) Provides mailto:// and deltachat:// support
 PGPy
 
+# Provides blink1:// support
+hidapi
+
 # Provides smpp:// support
 smpplib
 

--- a/apprise/plugins/blink1.py
+++ b/apprise/plugins/blink1.py
@@ -1,0 +1,396 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Sources:
+# - https://blink1.thingm.com/
+# - https://github.com/todbot/blink1-python
+# - https://github.com/todbot/blink1/blob/main/docs/blink1-hid-commands.md
+
+import time
+
+from ..common import NotifyType
+from ..locale import gettext_lazy as _
+from .base import NotifyBase
+
+# Default our global support flag
+NOTIFY_BLINK1_ENABLED = False
+
+try:
+    import hid as blink1_hid
+
+    NOTIFY_BLINK1_ENABLED = True
+
+except ImportError:
+    # No problem -- hidapi is an optional dependency.  Users who wish to
+    # use this plugin must install it:  pip install hidapi
+    pass
+
+#
+# blink(1) USB HID constants
+#
+
+# USB vendor / product identifiers for all blink(1) revisions
+BLINK1_VENDOR_ID = 0x27B8
+BLINK1_PRODUCT_ID = 0x01ED
+
+# HID report size (report ID byte + 8 payload bytes)
+BLINK1_REPORT_ID = 0x01
+BLINK1_REPORT_SIZE = 9
+
+# Command byte: 'c' == fade to RGB with a time argument
+BLINK1_CMD_FADE = ord("c")
+
+
+class Blink1LED:
+    """
+    Defines the LED to focus on
+    """
+
+    ALL = 0
+    FIRST = 1
+    SECOND = 2
+
+
+BLINK1_LED_CHOICES = {
+    Blink1LED.ALL: "all",
+    Blink1LED.FIRST: "1",
+    Blink1LED.SECOND: "2",
+}
+
+# Maps inbound strings to Blink1LED constants; unknown values fall back to ALL
+BLINK1_LED_MAP = {
+    "0": Blink1LED.ALL,
+    "all": Blink1LED.ALL,
+    "a": Blink1LED.ALL,
+    "1": Blink1LED.FIRST,
+    "2": Blink1LED.SECOND,
+}
+
+# How long (ms) to hold the LED colour after the fade completes
+BLINK1_DEFAULT_DURATION_MS = 5000
+BLINK1_MIN_DURATION_MS = 0
+BLINK1_MAX_DURATION_MS = 300000  # 5 minutes
+
+# Fade transition time (ms); 0 = instant
+BLINK1_DEFAULT_FADE_MS = 0
+BLINK1_MIN_FADE_MS = 0
+BLINK1_MAX_FADE_MS = 10000  # 10 seconds
+
+
+def _blink1_fade_buf(red, green, blue, fade_ms, ledn):
+    """Build the 9-byte HID feature-report buffer for a fade-to-RGB command.
+
+    The blink(1) wire format (all values unsigned 8-bit unless noted):
+      [0] REPORT_ID (0x01)
+      [1] command 'c' (0x63)
+      [2] red
+      [3] green
+      [4] blue
+      [5] fade_time high byte  (fade_time = fade_ms // 10, 16-bit big-endian)
+      [6] fade_time low byte
+      [7] ledn (0=all, 1=LED1, 2=LED2)
+      [8] 0x00 (padding)
+    """
+    fade_time = int(fade_ms) // 10
+    th = (fade_time >> 8) & 0xFF
+    tl = fade_time & 0xFF
+    return [
+        BLINK1_REPORT_ID,
+        BLINK1_CMD_FADE,
+        int(red),
+        int(green),
+        int(blue),
+        th,
+        tl,
+        int(ledn),
+        0x00,
+    ]
+
+
+class NotifyBlink1(NotifyBase):
+    """A wrapper for blink(1) USB LED notifications.
+
+    Colors are driven by Apprise's notification-type color map
+    (info=blue, success=green, warning=yellow, failure=red).
+    No external blink1 library is required; the USB HID wire protocol
+    is implemented directly via the hidapi package.
+    """
+
+    # Set our global enabled flag
+    enabled = NOTIFY_BLINK1_ENABLED
+
+    requirements = {
+        "packages_required": "hidapi",
+    }
+
+    # The default descriptive name associated with the notification
+    service_name = _("blink(1)")
+
+    # The services URL
+    service_url = "https://blink1.thingm.com/"
+
+    # The default protocol
+    protocol = "blink1"
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = "https://appriseit.com/services/blink1/"
+
+    # blink(1) is a local USB device; a title field has no meaning here.
+    title_maxlen = 0
+
+    # No throttling needed for a local USB device
+    request_rate_per_sec = 0
+
+    # URL templates
+    templates = (
+        "{schema}://",
+        "{schema}://{serial}/",
+    )
+
+    template_tokens = dict(
+        NotifyBase.template_tokens,
+        **{
+            "serial": {
+                "name": _("Serial Number"),
+                "type": "string",
+            },
+        },
+    )
+
+    template_args = dict(
+        NotifyBase.template_args,
+        **{
+            "duration": {
+                "name": _("Duration (ms)"),
+                "type": "int",
+                "min": BLINK1_MIN_DURATION_MS,
+                "max": BLINK1_MAX_DURATION_MS,
+                "default": BLINK1_DEFAULT_DURATION_MS,
+            },
+            "fade": {
+                "name": _("Fade Time (ms)"),
+                "type": "int",
+                "min": BLINK1_MIN_FADE_MS,
+                "max": BLINK1_MAX_FADE_MS,
+                "default": BLINK1_DEFAULT_FADE_MS,
+            },
+            "ledn": {
+                "name": _("LED Number"),
+                "type": "choice:int",
+                "values": BLINK1_LED_CHOICES,
+                "default": Blink1LED.ALL,
+            },
+        },
+    )
+
+    def __init__(
+        self,
+        serial=None,
+        duration=None,
+        fade=None,
+        ledn=None,
+        **kwargs,
+    ):
+        """Initialize Blink1 Object."""
+
+        super().__init__(**kwargs)
+
+        # Device serial number; None means "first available device".
+        # An underscore is accepted as a URL placeholder meaning "any".
+        serial = serial.strip() if isinstance(serial, str) else None
+        self.serial = serial if serial and serial != "_" else None
+
+        # Duration (ms) to hold the LED colour before turning it off
+        try:
+            self.duration = int(
+                BLINK1_DEFAULT_DURATION_MS if duration is None else duration
+            )
+            if not (
+                BLINK1_MIN_DURATION_MS
+                <= self.duration
+                <= BLINK1_MAX_DURATION_MS
+            ):
+                raise ValueError("out of range")
+
+        except (TypeError, ValueError):
+            msg = (
+                f"blink(1) duration ({duration}) must be between"
+                f" {BLINK1_MIN_DURATION_MS} and"
+                f" {BLINK1_MAX_DURATION_MS} ms."
+            )
+            self.logger.warning(msg)
+            raise TypeError(msg) from None
+
+        # Fade transition time (ms)
+        try:
+            self.fade = int(BLINK1_DEFAULT_FADE_MS if fade is None else fade)
+            if not (BLINK1_MIN_FADE_MS <= self.fade <= BLINK1_MAX_FADE_MS):
+                raise ValueError("out of range")
+
+        except (TypeError, ValueError):
+            msg = (
+                f"blink(1) fade ({fade}) must be between"
+                f" {BLINK1_MIN_FADE_MS} and {BLINK1_MAX_FADE_MS} ms."
+            )
+            self.logger.warning(msg)
+            raise TypeError(msg) from None
+
+        # LED selector; unrecognised values silently fall back to ALL
+        self.ledn = (
+            BLINK1_LED_MAP.get(str(ledn).lower(), Blink1LED.ALL)
+            if ledn is not None
+            else Blink1LED.ALL
+        )
+
+    def _open_device(self):
+        """Open and return a hidapi device handle for the blink(1).
+
+        Returns None and logs a warning when the device cannot be found.
+        """
+        try:
+            dev = blink1_hid.device()
+            dev.open(
+                BLINK1_VENDOR_ID,
+                BLINK1_PRODUCT_ID,
+                self.serial,
+            )
+            return dev
+
+        except OSError:
+            msg = "Failed to open blink(1) device"
+            if self.serial:
+                msg += f" (serial={self.serial})"
+            msg += "."
+            self.logger.warning(msg)
+            return None
+
+    def _send_fade(self, dev, red, green, blue, fade_ms):
+        """Send a single fade-to-RGB HID feature report.
+
+        Returns True on success, False if the report could not be sent.
+        """
+        buf = _blink1_fade_buf(red, green, blue, fade_ms, self.ledn)
+        try:
+            rc = dev.send_feature_report(buf)
+
+        except OSError as e:
+            self.logger.warning("blink(1) HID write failed: %s", e)
+            return False
+
+        if rc != BLINK1_REPORT_SIZE:
+            self.logger.warning(
+                "blink(1) HID write returned %d (expected %d).",
+                rc,
+                BLINK1_REPORT_SIZE,
+            )
+            return False
+
+        return True
+
+    @property
+    def url_identifier(self):
+        """Returns all fields that uniquely identify this connection."""
+        return (
+            self.protocol,
+            self.serial,
+            self.ledn,
+        )
+
+    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+        """Perform blink(1) Notification."""
+
+        # Resolve the RGB triple for this notification type
+        r, g, b = self.color(notify_type=notify_type, color_type=tuple)
+
+        dev = self._open_device()
+        if dev is None:
+            return False
+
+        try:
+            # Always throttle before any device I/O
+            self.throttle()
+
+            if not self._send_fade(dev, r, g, b, self.fade):
+                return False
+
+            # Hold for fade + duration, then switch off
+            time.sleep((self.fade + self.duration) / 1000.0)
+
+            # Turn off: instant fade to black
+            if not self._send_fade(dev, 0, 0, 0, 0):
+                return False
+
+        finally:
+            dev.close()
+
+        self.logger.info("Sent blink(1) notification.")
+        return True
+
+    def url(self, privacy=False, *args, **kwargs):
+        """Returns the URL built dynamically based on specified arguments."""
+
+        params = {
+            "duration": str(self.duration),
+            "fade": str(self.fade),
+            "ledn": str(self.ledn),
+        }
+        params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
+
+        serial = self.serial if self.serial else "_"
+        return f"{self.protocol}://{serial}/?{NotifyBlink1.urlencode(params)}"
+
+    @staticmethod
+    def parse_url(url):
+        """Parses the URL and returns enough arguments to re-instantiate."""
+
+        results = NotifyBase.parse_url(url, verify_host=False)
+        if not results:
+            return results
+
+        # The hostname, when present, is the device serial number.
+        # An underscore or empty value means "first available device".
+        host = results.get("host", "")
+        if host and host != "_":
+            results["serial"] = NotifyBlink1.unquote(host)
+
+        if results["qsd"].get("duration"):
+            results["duration"] = NotifyBlink1.unquote(
+                results["qsd"]["duration"]
+            )
+
+        if results["qsd"].get("fade"):
+            results["fade"] = NotifyBlink1.unquote(results["qsd"]["fade"])
+
+        if results["qsd"].get("ledn"):
+            results["ledn"] = NotifyBlink1.unquote(results["qsd"]["ledn"])
+
+        return results
+
+    @staticmethod
+    def runtime_deps():
+        """Return optional runtime dependency package names."""
+        return ("hid",)

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -59,7 +59,7 @@ Apprise is a Python package that simplifies access to many popular \
 notification services. It supports sending alerts to platforms such as: \
 \
 `46elks`, `AfricasTalking`, `Apprise API`, `APRS`, `AWS SES`, `AWS SNS`, \
-`Bark`, `BlueSky`, `Brevo`, `Burst SMS`, `BulkSMS`, `BulkVS`, `Chanify`, \
+`Bark`, `Blink(1)`, `BlueSky`, `Brevo`, `Burst SMS`, `BulkSMS`, `BulkVS`, `Chanify`, \
 `Clickatell`, `ClickSend`, `DAPNET`, `DingTalk`, `Discord`, \
 `Dot. (Quote/0)`, `E-Mail`, `Emby`, `Evolution API`, \
 `FCM`, `Feishu`, `Flock`, `Fluxer`, \
@@ -143,6 +143,7 @@ Requires: python3dist(cryptography)
 Requires: python3dist(certifi)
 Requires: python3dist(pyyaml)
 
+Recommends: python3dist(hidapi)
 Recommends: python3dist(paho-mqtt)
 Recommends: python3dist(slixmpp)
 

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -59,13 +59,12 @@ Apprise is a Python package that simplifies access to many popular \
 notification services. It supports sending alerts to platforms such as: \
 \
 `46elks`, `AfricasTalking`, `Apprise API`, `APRS`, `AWS SES`, `AWS SNS`, \
-`Bark`, `Blink(1)`, `BlueSky`, `Brevo`, `Burst SMS`, `BulkSMS`, `BulkVS`, `Chanify`, \
-`Clickatell`, `ClickSend`, `DAPNET`, `DingTalk`, `Discord`, \
-`Dot. (Quote/0)`, `E-Mail`, `Emby`, `Evolution API`, \
-`FCM`, `Feishu`, `Flock`, `Fluxer`, \
-`Free Mobile`, `Google Chat`, `Gotify`, `Growl`, `Guilded`, \
-`Home Assistant`, `httpSMS`, `IFTTT`, `IRC`, `Jellyfin`, `Jira`, `Join`, \
-`Kavenegar`, `KODI`, `Kumulos`, `LaMetric`, `Lark`, `Line`, `MacOSX`, \
+`Bark`, `Blink(1)`, `BlueSky`, `Brevo`, `Burst SMS`, `BulkSMS`, `BulkVS`, \
+`Chanify`, `Clickatell`, `ClickSend`, `DAPNET`, `DingTalk`, `Discord`, \
+`Dot. (Quote/0)`, `E-Mail`, `Emby`, `Evolution API`, `FCM`, `Feishu`, \
+`Flock`, `Fluxer`, `Free Mobile`, `Google Chat`, `Gotify`, `Growl`, \
+`Guilded`, `Home Assistant`, `httpSMS`, `IFTTT`, `IRC`, `Jellyfin`, `Jira`, \
+`Join`, `Kavenegar`, `KODI`, `Kumulos`, `LaMetric`, `Lark`, `Line`, `MacOSX`, \
 `Mailgun`, `Mastodon`, `Mattermost`, `Matrix`, `MessageBird`, \
 `Microsoft Windows`, `Microsoft Teams`, `Misskey`, `MQTT`, `MSG91`, \
 `MyAndroid`, `Nexmo`, `Nextcloud`, `NextcloudTalk`, `Notica`, \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ keywords = [
     "Automated Packet Reporting System",
     "AWS",
     "Bark",
+    "Blink(1)",
     "BlueSky",
     "Brevo",
     "BulkSMS",
@@ -228,6 +229,9 @@ all-plugins = [
 
      # Pretty Good Privacy (PGP) Provides mailto:// and deltachat:// support
     "PGPy",
+
+    # Provides blink1:// support
+    "hidapi",
 
     # Provides smpp:// support
     "smpplib",

--- a/tests/test_notification_manager.py
+++ b/tests/test_notification_manager.py
@@ -728,6 +728,7 @@ def test_manager_known_plugin_runtime_deps():
     """Plugins known to carry optional deps must declare runtime_deps()."""
     N_MGR.unload_modules()
 
+    from apprise.plugins.blink1 import NotifyBlink1
     from apprise.plugins.fcm import NotifyFCM
     from apprise.plugins.growl import NotifyGrowl
     from apprise.plugins.mqtt import NotifyMQTT
@@ -736,6 +737,7 @@ def test_manager_known_plugin_runtime_deps():
     from apprise.plugins.vapid import NotifyVapid
     from apprise.plugins.xmpp.base import NotifyXMPP
 
+    assert "hid" in NotifyBlink1.runtime_deps()
     assert "paho" in NotifyMQTT.runtime_deps()
     assert "gntp" in NotifyGrowl.runtime_deps()
     assert "smpplib" in NotifySMPP.runtime_deps()

--- a/tests/test_plugin_blink1.py
+++ b/tests/test_plugin_blink1.py
@@ -1,0 +1,460 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import logging
+import sys
+from unittest import mock
+
+from helpers import AppriseURLTester
+import pytest
+
+from apprise import Apprise, NotifyType
+from apprise.plugins.blink1 import (
+    BLINK1_DEFAULT_DURATION_MS,
+    BLINK1_DEFAULT_FADE_MS,
+    BLINK1_MAX_DURATION_MS,
+    BLINK1_MAX_FADE_MS,
+    BLINK1_REPORT_SIZE,
+    Blink1LED,
+    NotifyBlink1,
+    _blink1_fade_buf,
+)
+
+logging.disable(logging.CRITICAL)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mk_device(report_size=BLINK1_REPORT_SIZE, open_exc=None):
+    """Return a mock hidapi device that succeeds by default."""
+    dev = mock.Mock()
+    dev.send_feature_report.return_value = report_size
+    if open_exc is not None:
+        dev.open.side_effect = open_exc
+    return dev
+
+
+# ---------------------------------------------------------------------------
+# URL matrix used by AppriseURLTester
+# ---------------------------------------------------------------------------
+
+apprise_url_tests = (
+    # First available device, all defaults
+    (
+        "blink1://",
+        {
+            "instance": NotifyBlink1,
+        },
+    ),
+    # Explicit underscore placeholder for first device
+    (
+        "blink1://_/",
+        {
+            "instance": NotifyBlink1,
+        },
+    ),
+    # Specific device by serial number
+    (
+        "blink1://ABCD1234/",
+        {
+            "instance": NotifyBlink1,
+        },
+    ),
+    # Minimum allowed parameter values
+    (
+        "blink1://?duration=0&fade=0&ledn=0",
+        {
+            "instance": NotifyBlink1,
+        },
+    ),
+    # LED 1 (first LED only)
+    (
+        "blink1://?ledn=1",
+        {
+            "instance": NotifyBlink1,
+        },
+    ),
+    # LED 2 (second LED only)
+    (
+        "blink1://?ledn=2",
+        {
+            "instance": NotifyBlink1,
+        },
+    ),
+    # Maximum allowed duration
+    (
+        f"blink1://?duration={BLINK1_MAX_DURATION_MS}",
+        {
+            "instance": NotifyBlink1,
+        },
+    ),
+    # Maximum allowed fade
+    (
+        f"blink1://?fade={BLINK1_MAX_FADE_MS}",
+        {
+            "instance": NotifyBlink1,
+        },
+    ),
+    # Non-numeric duration -> TypeError
+    (
+        "blink1://?duration=abc",
+        {
+            "instance": TypeError,
+        },
+    ),
+    # Negative duration -> TypeError
+    (
+        "blink1://?duration=-1",
+        {
+            "instance": TypeError,
+        },
+    ),
+    # Duration exceeds maximum -> TypeError
+    (
+        f"blink1://?duration={BLINK1_MAX_DURATION_MS + 1}",
+        {
+            "instance": TypeError,
+        },
+    ),
+    # Non-numeric fade -> TypeError
+    (
+        "blink1://?fade=abc",
+        {
+            "instance": TypeError,
+        },
+    ),
+    # Negative fade -> TypeError
+    (
+        "blink1://?fade=-1",
+        {
+            "instance": TypeError,
+        },
+    ),
+    # Fade exceeds maximum -> TypeError
+    (
+        f"blink1://?fade={BLINK1_MAX_FADE_MS + 1}",
+        {
+            "instance": TypeError,
+        },
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Import-error path (run only when hidapi is NOT installed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    "hid" in sys.modules,
+    reason="Requires that hidapi NOT be installed",
+)
+def test_plugin_blink1_import_error():
+    """NotifyBlink1() returns None when hidapi is absent."""
+
+    obj = Apprise.instantiate("blink1://")
+    assert obj is None
+
+
+# ---------------------------------------------------------------------------
+# All remaining tests require hidapi to be installed
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_blink1_urls():
+    """NotifyBlink1() Apprise URL matrix."""
+
+    pytest.importorskip("hid")
+
+    with (
+        mock.patch("apprise.plugins.blink1.blink1_hid") as mock_hid,
+        mock.patch("apprise.plugins.blink1.time") as mock_time,
+    ):
+        mock_dev = _mk_device()
+        mock_hid.device.return_value = mock_dev
+        mock_time.sleep.return_value = None
+
+        AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+def test_plugin_blink1_device_open_failure():
+    """NotifyBlink1() returns False when the USB device cannot be opened."""
+
+    pytest.importorskip("hid")
+
+    with mock.patch("apprise.plugins.blink1.blink1_hid") as mock_hid:
+        mock_dev = _mk_device(open_exc=OSError("no device"))
+        mock_hid.device.return_value = mock_dev
+
+        obj = Apprise.instantiate("blink1://ABCD1234/")
+        assert obj is not None
+        assert obj.notify(body="test") is False
+
+
+def test_plugin_blink1_device_open_failure_no_serial():
+    """NotifyBlink1() failure log omits serial when none is configured."""
+
+    pytest.importorskip("hid")
+
+    with mock.patch("apprise.plugins.blink1.blink1_hid") as mock_hid:
+        mock_dev = _mk_device(open_exc=OSError("no device"))
+        mock_hid.device.return_value = mock_dev
+
+        obj = Apprise.instantiate("blink1://")
+        assert obj is not None
+        assert obj.notify(body="test") is False
+
+
+def test_plugin_blink1_send_feature_report_exception():
+    """NotifyBlink1() returns False and closes device on HID write error."""
+
+    pytest.importorskip("hid")
+
+    with (
+        mock.patch("apprise.plugins.blink1.blink1_hid") as mock_hid,
+        mock.patch("apprise.plugins.blink1.time") as mock_time,
+    ):
+        mock_dev = mock.Mock()
+        mock_dev.send_feature_report.side_effect = OSError("USB error")
+        mock_hid.device.return_value = mock_dev
+        mock_time.sleep.return_value = None
+
+        obj = Apprise.instantiate("blink1://")
+        assert obj is not None
+        assert obj.notify(body="test") is False
+
+        # close() must always be called
+        assert mock_dev.close.called
+
+
+def test_plugin_blink1_short_report_fails():
+    """NotifyBlink1() returns False when the HID report is truncated."""
+
+    pytest.importorskip("hid")
+
+    with (
+        mock.patch("apprise.plugins.blink1.blink1_hid") as mock_hid,
+        mock.patch("apprise.plugins.blink1.time") as mock_time,
+    ):
+        mock_dev = _mk_device(report_size=BLINK1_REPORT_SIZE - 1)
+        mock_hid.device.return_value = mock_dev
+        mock_time.sleep.return_value = None
+
+        obj = Apprise.instantiate("blink1://")
+        assert obj is not None
+        assert obj.notify(body="test") is False
+
+
+def test_plugin_blink1_notify_types():
+    """NotifyBlink1() sends one fade per notification type."""
+
+    pytest.importorskip("hid")
+
+    with (
+        mock.patch("apprise.plugins.blink1.blink1_hid") as mock_hid,
+        mock.patch("apprise.plugins.blink1.time") as mock_time,
+    ):
+        mock_dev = _mk_device()
+        mock_hid.device.return_value = mock_dev
+        mock_time.sleep.return_value = None
+
+        obj = Apprise.instantiate("blink1://ABCD1234/?fade=100&duration=50")
+        assert obj is not None
+
+        for notify_type in (
+            NotifyType.INFO,
+            NotifyType.SUCCESS,
+            NotifyType.WARNING,
+            NotifyType.FAILURE,
+        ):
+            assert obj.notify(body="test", notify_type=notify_type) is True
+
+        # Each notification sends two reports (color + off)
+        assert mock_dev.send_feature_report.call_count == 8
+        assert mock_dev.close.call_count == 4
+
+
+def test_plugin_blink1_fade_buf_layout():
+    """_blink1_fade_buf() constructs the correct 9-byte HID payload."""
+
+    buf = _blink1_fade_buf(255, 128, 0, 1000, ledn=1)
+
+    assert len(buf) == 9
+    assert buf[0] == 0x01  # REPORT_ID
+    assert buf[1] == ord("c")  # command byte
+    assert buf[2] == 255  # red
+    assert buf[3] == 128  # green
+    assert buf[4] == 0  # blue
+    # fade_time = 1000 // 10 = 100 = 0x0064
+    assert buf[5] == 0x00  # th
+    assert buf[6] == 0x64  # tl
+    assert buf[7] == 1  # ledn
+    assert buf[8] == 0x00  # padding
+
+
+def test_plugin_blink1_fade_rgb_args():
+    """NotifyBlink1() passes correct ledn and RGB values to the device."""
+
+    pytest.importorskip("hid")
+
+    with (
+        mock.patch("apprise.plugins.blink1.blink1_hid") as mock_hid,
+        mock.patch("apprise.plugins.blink1.time") as mock_time,
+    ):
+        mock_dev = _mk_device()
+        mock_hid.device.return_value = mock_dev
+        mock_time.sleep.return_value = None
+
+        obj = Apprise.instantiate("blink1://?fade=200&duration=100&ledn=2")
+        assert obj is not None
+        assert obj.notify(body="test", notify_type=NotifyType.INFO) is True
+
+        first_call_buf = mock_dev.send_feature_report.call_args_list[0][0][0]
+        assert first_call_buf[1] == ord("c")  # command byte
+        assert first_call_buf[7] == 2  # ledn
+        # fade_time = 200 // 10 = 20 = 0x0014
+        assert first_call_buf[5] == 0x00
+        assert first_call_buf[6] == 0x14
+
+
+def test_plugin_blink1_off_sent_after_duration():
+    """NotifyBlink1() sends an off command after sleeping for fade+duration."""
+
+    pytest.importorskip("hid")
+
+    with (
+        mock.patch("apprise.plugins.blink1.blink1_hid") as mock_hid,
+        mock.patch("apprise.plugins.blink1.time") as mock_time,
+    ):
+        mock_dev = _mk_device()
+        mock_hid.device.return_value = mock_dev
+        mock_time.sleep.return_value = None
+
+        obj = Apprise.instantiate("blink1://?fade=500&duration=2000")
+        assert obj is not None
+        assert obj.notify(body="test") is True
+
+        mock_time.sleep.assert_called_once_with(2.5)
+
+        # Second report should be the "off" command (all zeros for RGB)
+        off_buf = mock_dev.send_feature_report.call_args_list[1][0][0]
+        assert off_buf[2] == 0  # red
+        assert off_buf[3] == 0  # green
+        assert off_buf[4] == 0  # blue
+
+
+def test_plugin_blink1_off_command_failure_returns_false():
+    """NotifyBlink1() returns False when the off HID write fails."""
+
+    pytest.importorskip("hid")
+
+    with (
+        mock.patch("apprise.plugins.blink1.blink1_hid") as mock_hid,
+        mock.patch("apprise.plugins.blink1.time") as mock_time,
+    ):
+        mock_dev = mock.Mock()
+        # First call (color fade) succeeds; second call (off) fails.
+        mock_dev.send_feature_report.side_effect = [
+            BLINK1_REPORT_SIZE,
+            BLINK1_REPORT_SIZE - 1,
+        ]
+        mock_hid.device.return_value = mock_dev
+        mock_time.sleep.return_value = None
+
+        obj = Apprise.instantiate("blink1://")
+        assert obj is not None
+        assert obj.notify(body="test") is False
+
+        # close() must still be called
+        assert mock_dev.close.called
+
+
+def test_plugin_blink1_url_round_trip():
+    """NotifyBlink1() URL reconstructs an equivalent object."""
+
+    obj = NotifyBlink1(serial="ABCD1234", duration=3000, fade=500, ledn=1)
+    rebuilt = NotifyBlink1(**NotifyBlink1.parse_url(obj.url()))
+
+    assert rebuilt.serial == "ABCD1234"
+    assert rebuilt.duration == 3000
+    assert rebuilt.fade == 500
+    assert rebuilt.ledn == 1
+
+
+def test_plugin_blink1_url_round_trip_no_serial():
+    """NotifyBlink1() URL round-trips correctly without a serial."""
+
+    obj = NotifyBlink1()
+    rebuilt = NotifyBlink1(**NotifyBlink1.parse_url(obj.url()))
+
+    assert rebuilt.serial is None
+    assert rebuilt.duration == BLINK1_DEFAULT_DURATION_MS
+    assert rebuilt.fade == BLINK1_DEFAULT_FADE_MS
+    assert rebuilt.ledn == Blink1LED.ALL
+
+
+def test_plugin_blink1_url_identifier():
+    """NotifyBlink1() url_identifier distinguishes different connections."""
+
+    obj_a = NotifyBlink1()
+    obj_b = NotifyBlink1(serial="ABCD1234")
+    obj_c = NotifyBlink1(ledn=1)
+
+    assert obj_a.url_identifier != obj_b.url_identifier
+    assert obj_a.url_identifier != obj_c.url_identifier
+    assert obj_b.url_identifier != obj_c.url_identifier
+
+
+def test_plugin_blink1_invalid_ledn_defaults():
+    """NotifyBlink1() silently falls back to ALL for an unrecognised ledn."""
+
+    obj = NotifyBlink1(ledn="99")
+    assert obj.ledn == Blink1LED.ALL
+
+
+def test_plugin_blink1_runtime_deps():
+    """NotifyBlink1.runtime_deps() returns the importable hid module name."""
+
+    assert NotifyBlink1.runtime_deps() == ("hid",)
+
+
+def test_plugin_blink1_parse_url_underscore():
+    """NotifyBlink1() treats underscore host as first-device placeholder."""
+
+    result = NotifyBlink1.parse_url("blink1://_/")
+    assert result is not None
+    assert result.get("serial") is None
+
+
+def test_plugin_blink1_parse_url_serial():
+    """NotifyBlink1() extracts serial number from URL host field."""
+
+    result = NotifyBlink1.parse_url("blink1://DEADBEEF/")
+    assert result is not None
+    assert result["serial"] == "DEADBEEF"


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #959 

## *ServiceName* Notifications
* **Source**: https://blink1.thingm.com/
* **Image Support**:  No
* **Message Format**: n/a
* **Message Limit**: n/a

## Account Setup
Blink(1) is a small USB RGB LED notification light made by ThingM. Plug it into any USB port and Apprise can flash it in a color that reflects the notification type:

- **Notification Type / Color**
- Info / Blue
- Success / Green
- Warning / Yellow
- Failure / Red

The plugin talks to the device directly over USB HID using the `hidapi` Python package. There is no cloud service, no API key, and no network connection required.

## Syntax

Valid syntax is as follows:
- `blink1://`
- `blink1://{serial}`

## Parameter Breakdown

| Variable  | Required |  Description   |
|-----------|----------|----------------|
| serial | No      |USB serial number of the target device. Omit (or use ) to use the first available device. |
| duration | No       | How long in milliseconds to hold the notification color before switching the LED off. Default: 5000. Range: 0-300000. |
| fade | No       | Fade transition time in milliseconds. 0 = instant. Default: 0. Range: 0-10000.|
| ledn | No       | Which LED to address: 0 = all (default), 1 = first LED only, 2 = second LED only (mk2 devices).
 |

## Examples

Sends a simple example:
```bash
apprise -vv -t "Title" -b "Message content" \
    blink1://
```

## New Service Completion Status
* [x] apprise/plugins/blink1.py
* [x] pyproject.toml
    - Update keywords section to identify the new service (alphabetically).
* [x] README.md
    - Add entry for the new service (quick reference only).
* [x] packaging/redhat/python-apprise.spec
    - add new service into the `%global common_description`

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/36](https://github.com/caronc/apprise-docs/pull/36)
* [ ] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@/blink-1-support

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
   "blink1://"
```
