### PR TITLE
feat(evolution): add Evolution API (WhatsApp) notification plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The table below identifies the services this tool supports and some example serv
 | [Dot.](https://appriseit.com/services/dot/)  | dot:// | (TCP) 443 | dot://apikey@device_id/text/<br />dot://apikey@device_id/image/<br />**Note**: `device_id` is the Quote/0 hardware serial
 | [Emby](https://appriseit.com/services/emby/)  | emby:// or embys:// | (TCP) 8096 | emby://user@hostname/<br />emby://user:password@hostname
 | [Enigma2](https://appriseit.com/services/enigma2/)  | enigma2:// or enigma2s:// | (TCP) 80 or 443 | enigma2://hostname
+| [Evolution API](https://appriseit.com/services/evolution/) | evolution:// or evolutions:// | (TCP) 80 or 443 | evolution://apikey@hostname/instance/ToPhoneNo<br/>evolution://apikey@hostname:port/instance/ToPhoneNo<br/>evolution://apikey@hostname/instance/ToPhoneNo1/ToPhoneNo2/ToPhoneNoN/
 | [FCM](https://appriseit.com/services/fcm/) | fcm://    | (TCP) 443    | fcm://project@apikey/DEVICE_ID<br />fcm://project@apikey/#TOPIC<br/>fcm://project@apikey/DEVICE_ID1/#topic1/#topic2/DEVICE_ID2/
 | [Feishu](https://appriseit.com/services/feishu/) | feishu://    | (TCP) 443    | feishu://token
 | [Flock](https://appriseit.com/services/flock/) | flock://    | (TCP) 443    | flock://token<br/>flock://botname@token<br/>flock://app_token/u:userid<br/>flock://app_token/g:channel_id<br/>flock://app_token/u:userid/g:channel_id

--- a/apprise/plugins/evolution.py
+++ b/apprise/plugins/evolution.py
@@ -47,14 +47,11 @@
 # Phone numbers must be in international format without the leading '+',
 # e.g. 5511999999999 for a Brazilian mobile number.
 
-from html.parser import HTMLParser
 from json import dumps
-import re
 
 import requests
 
 from ..common import NotifyFormat, NotifyType
-from ..conversion import markdown_to_html
 from ..locale import gettext_lazy as _
 from ..utils.parse import (
     is_phone_no,
@@ -63,203 +60,6 @@ from ..utils.parse import (
 )
 from .base import NotifyBase
 
-# ---------------------------------------------------------------------------
-# WhatsApp markdown rendering
-#
-# WhatsApp uses its own lightweight markdown dialect:
-#   *bold*    _italic_    ~strikethrough~    ```monospace```
-#
-# Apprise may deliver the body as plain TEXT, HTML, or MARKDOWN.
-# We convert each format to WhatsApp markdown so the message renders nicely
-# regardless of how the caller built it.
-# ---------------------------------------------------------------------------
-
-class _HTMLToWhatsApp(HTMLParser):
-    """Converts HTML into WhatsApp-flavoured markdown.
-
-    Handles the subset of HTML produced by Apprise's own markdown-to-HTML
-    converter (headings, paragraphs, lists, inline emphasis, code blocks,
-    horizontal rules, links).
-    """
-
-    # Tags whose text content must be ignored completely
-    _IGNORE_TAGS = frozenset(
-        ("script", "style", "head", "meta", "link", "title")
-    )
-
-    # Inline formatting: opening tag → WhatsApp marker
-    _INLINE = {
-        "b": "*",
-        "strong": "*",
-        "i": "_",
-        "em": "_",
-        "s": "~",
-        "del": "~",
-        "strike": "~",
-    }
-
-    def __init__(self):
-        super().__init__(convert_charrefs=True)
-        self._buf = []          # output buffer
-        self._ignore = 0        # depth of ignored tags
-        self._in_pre = False    # inside a <pre> block?
-        self._in_code = False   # inside an inline <code>?
-        self._list_stack = []   # track ul/ol nesting; item = "ul" or counter
-        self._skip_code = False # <pre><code> — avoid double fence
-
-    # ------------------------------------------------------------------
-    # Public
-    # ------------------------------------------------------------------
-
-    @property
-    def text(self):
-        raw = "".join(self._buf)
-        # Collapse runs of 3+ newlines down to two
-        raw = re.sub(r"\n{3,}", "\n\n", raw)
-        return raw.strip()
-
-    # ------------------------------------------------------------------
-    # HTMLParser hooks
-    # ------------------------------------------------------------------
-
-    def handle_starttag(self, tag, attrs):
-        tag = tag.lower()
-
-        if tag in self._IGNORE_TAGS:
-            self._ignore += 1
-            return
-        if self._ignore:
-            return
-
-        if tag == "pre":
-            self._in_pre = True
-            self._buf.append("\n```\n")
-
-        elif tag == "code":
-            if self._in_pre:
-                # <pre><code> — the fence is already open; skip this tag
-                self._skip_code = True
-            else:
-                self._in_code = True
-                self._buf.append("`")
-
-        elif tag in self._INLINE:
-            self._buf.append(self._INLINE[tag])
-
-        elif tag in ("h1", "h2", "h3", "h4", "h5", "h6"):
-            self._buf.append("\n*")
-
-        elif tag == "br":
-            self._buf.append("\n")
-
-        elif tag == "hr":
-            self._buf.append("\n---\n")
-
-        elif tag == "p" or tag in ("div", "blockquote"):
-            self._buf.append("\n")
-
-        elif tag == "ul":
-            self._list_stack.append("ul")
-
-        elif tag == "ol":
-            self._list_stack.append(0)
-
-        elif tag == "li":
-            if self._list_stack and isinstance(self._list_stack[-1], int):
-                # ordered list — increment counter
-                self._list_stack[-1] += 1
-                self._buf.append(f"\n{self._list_stack[-1]}. ")
-            else:
-                self._buf.append("\n- ")
-
-        elif tag == "a":
-            # Links: emit visible text only (WhatsApp ignores markdown URLs)
-            pass
-
-        elif tag == "tr":
-            self._buf.append("\n")
-
-        elif tag in ("td", "th"):
-            self._buf.append(" | ")
-
-    def handle_endtag(self, tag):
-        tag = tag.lower()
-
-        if tag in self._IGNORE_TAGS:
-            self._ignore = max(0, self._ignore - 1)
-            return
-        if self._ignore:
-            return
-
-        if tag == "pre":
-            self._in_pre = False
-            self._skip_code = False
-            self._buf.append("\n```\n")
-
-        elif tag == "code":
-            if self._skip_code:
-                self._skip_code = False
-            else:
-                self._in_code = False
-                self._buf.append("`")
-
-        elif tag in self._INLINE:
-            self._buf.append(self._INLINE[tag])
-
-        elif tag in ("h1", "h2", "h3", "h4", "h5", "h6"):
-            self._buf.append("*\n")
-
-        elif tag in ("p", "div", "blockquote"):
-            self._buf.append("\n")
-
-        elif tag in ("ul", "ol"):
-            if self._list_stack:
-                self._list_stack.pop()
-            self._buf.append("\n")
-
-        elif tag == "tr":
-            self._buf.append("\n")
-
-    def handle_data(self, data):
-        if self._ignore:
-            return
-        # Skip whitespace-only text nodes inside list containers —
-        # they would otherwise create blank lines between list items.
-        if self._list_stack and not data.strip():
-            return
-        self._buf.append(data)
-
-
-def _html_to_whatsapp(html):
-    """Convert an HTML string to WhatsApp-flavoured markdown."""
-    parser = _HTMLToWhatsApp()
-    parser.feed(html)
-    parser.close()
-    return parser.text
-
-
-def _to_whatsapp(body, notify_format):
-    """Return *body* formatted as WhatsApp markdown.
-
-    Apprise can hand us TEXT, HTML, or MARKDOWN.  We normalise all three to
-    WhatsApp's own dialect so that *bold*, _italic_, and ```code``` blocks
-    render correctly in the recipient's WhatsApp client.
-    """
-    if notify_format == NotifyFormat.HTML:
-        return _html_to_whatsapp(body)
-
-    if notify_format == NotifyFormat.MARKDOWN:
-        # Leverage Apprise's existing Markdown → HTML pipeline, then convert
-        # the resulting HTML to WhatsApp markdown.
-        return _html_to_whatsapp(markdown_to_html(body))
-
-    # NotifyFormat.TEXT (or anything else): return as-is.
-    return body
-
-
-# ---------------------------------------------------------------------------
-# Plugin
-# ---------------------------------------------------------------------------
 
 class NotifyEvolution(NotifyBase):
     """A wrapper for Evolution API (WhatsApp) Notifications."""
@@ -282,8 +82,13 @@ class NotifyEvolution(NotifyBase):
     # Disable throttle rate
     request_rate_per_sec = 0
 
-    # We handle the title ourselves in send() so that it arrives in WhatsApp
-    # as *bold* text.
+    # Evolution API / WhatsApp uses Markdown-like formatting;
+    # setting this causes Apprise to convert HTML bodies to Markdown
+    # before calling send().
+    notify_format = NotifyFormat.MARKDOWN
+
+    # We handle the title ourselves in send() so that it arrives in
+    # WhatsApp as *bold* text.
     title_maxlen = 250
 
     # Define object URL templates
@@ -391,15 +196,6 @@ class NotifyEvolution(NotifyBase):
 
     def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
         """Perform Evolution API Notification."""
-
-        # The Apprise dispatcher passes body_format in kwargs to tell us what
-        # format the body is actually in (may differ from self.notify_format
-        # when the caller used body_format= on notify()).
-        # We use that to drive the WhatsApp markdown conversion.
-        body_format = kwargs.get("body_format") or self.notify_format
-
-        # Convert body to WhatsApp markdown
-        body = _to_whatsapp(body, body_format)
 
         # Prepend title as bold if present
         if title:

--- a/apprise/plugins/evolution.py
+++ b/apprise/plugins/evolution.py
@@ -47,9 +47,9 @@
 # Phone numbers must be in international format without the leading '+',
 # e.g. 5511999999999 for a Brazilian mobile number.
 
-import re
 from html.parser import HTMLParser
 from json import dumps
+import re
 
 import requests
 
@@ -62,7 +62,6 @@ from ..utils.parse import (
     validate_regex,
 )
 from .base import NotifyBase
-
 
 # ---------------------------------------------------------------------------
 # WhatsApp markdown rendering
@@ -156,10 +155,7 @@ class _HTMLToWhatsApp(HTMLParser):
         elif tag == "hr":
             self._buf.append("\n---\n")
 
-        elif tag == "p":
-            self._buf.append("\n")
-
-        elif tag in ("div", "blockquote"):
+        elif tag == "p" or tag in ("div", "blockquote"):
             self._buf.append("\n")
 
         elif tag == "ul":
@@ -177,7 +173,7 @@ class _HTMLToWhatsApp(HTMLParser):
                 self._buf.append("\n- ")
 
         elif tag == "a":
-            # Links: just emit the visible text (WhatsApp ignores markdown URLs)
+            # Links: emit visible text only (WhatsApp ignores markdown URLs)
             pass
 
         elif tag == "tr":

--- a/apprise/plugins/evolution.py
+++ b/apprise/plugins/evolution.py
@@ -87,9 +87,9 @@ class NotifyEvolution(NotifyBase):
     # before calling send().
     notify_format = NotifyFormat.MARKDOWN
 
-    # We handle the title ourselves in send() so that it arrives in
-    # WhatsApp as *bold* text.
-    title_maxlen = 250
+    # Evolution API has no separate title field; Apprise will merge the
+    # title into the body before calling send().
+    title_maxlen = 0
 
     # Define object URL templates
     templates = (
@@ -193,10 +193,6 @@ class NotifyEvolution(NotifyBase):
 
     def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
         """Perform Evolution API Notification."""
-
-        # Prepend title as bold if present
-        if title:
-            body = f"*{title}*\n\n{body}"
 
         # Build the base URL
         schema = "https" if self.secure else "http"

--- a/apprise/plugins/evolution.py
+++ b/apprise/plugins/evolution.py
@@ -1,0 +1,579 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Evolution API is a self-hosted WhatsApp integration layer.
+# Project:  https://github.com/EvolutionAPI/evolution-api
+# API Docs: https://doc.evolution-api.com/
+
+# Steps:
+#  1. Deploy Evolution API on your server (Docker recommended).
+#  2. Create an instance via the Evolution API dashboard or API.
+#  3. Connect the instance by scanning the QR code via WhatsApp.
+#  4. Use the API key shown in your instance settings.
+
+# URL syntax (HTTP):
+#   evolution://apikey@host/instance/5511999999999
+#   evolution://apikey@host:port/instance/5511999999999
+#   evolution://apikey@host/instance/number1/number2/...
+#
+# URL syntax (HTTPS):
+#   evolutions://apikey@host/instance/5511999999999
+#   evolutions://apikey@host:port/instance/5511999999999
+#
+# Phone numbers must be in international format without the leading '+',
+# e.g. 5511999999999 for a Brazilian mobile number.
+
+import re
+from html.parser import HTMLParser
+from json import dumps
+
+import requests
+
+from ..common import NotifyFormat, NotifyType
+from ..conversion import markdown_to_html
+from ..locale import gettext_lazy as _
+from ..utils.parse import (
+    is_phone_no,
+    parse_phone_no,
+    validate_regex,
+)
+from .base import NotifyBase
+
+
+# ---------------------------------------------------------------------------
+# WhatsApp markdown rendering
+#
+# WhatsApp uses its own lightweight markdown dialect:
+#   *bold*    _italic_    ~strikethrough~    ```monospace```
+#
+# Apprise may deliver the body as plain TEXT, HTML, or MARKDOWN.
+# We convert each format to WhatsApp markdown so the message renders nicely
+# regardless of how the caller built it.
+# ---------------------------------------------------------------------------
+
+class _HTMLToWhatsApp(HTMLParser):
+    """Converts HTML into WhatsApp-flavoured markdown.
+
+    Handles the subset of HTML produced by Apprise's own markdown-to-HTML
+    converter (headings, paragraphs, lists, inline emphasis, code blocks,
+    horizontal rules, links).
+    """
+
+    # Tags whose text content must be ignored completely
+    _IGNORE_TAGS = frozenset(
+        ("script", "style", "head", "meta", "link", "title")
+    )
+
+    # Inline formatting: opening tag → WhatsApp marker
+    _INLINE = {
+        "b": "*",
+        "strong": "*",
+        "i": "_",
+        "em": "_",
+        "s": "~",
+        "del": "~",
+        "strike": "~",
+    }
+
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self._buf = []          # output buffer
+        self._ignore = 0        # depth of ignored tags
+        self._in_pre = False    # inside a <pre> block?
+        self._in_code = False   # inside an inline <code>?
+        self._list_stack = []   # track ul/ol nesting; item = "ul" or counter
+        self._skip_code = False # <pre><code> — avoid double fence
+
+    # ------------------------------------------------------------------
+    # Public
+    # ------------------------------------------------------------------
+
+    @property
+    def text(self):
+        raw = "".join(self._buf)
+        # Collapse runs of 3+ newlines down to two
+        raw = re.sub(r"\n{3,}", "\n\n", raw)
+        return raw.strip()
+
+    # ------------------------------------------------------------------
+    # HTMLParser hooks
+    # ------------------------------------------------------------------
+
+    def handle_starttag(self, tag, attrs):
+        tag = tag.lower()
+
+        if tag in self._IGNORE_TAGS:
+            self._ignore += 1
+            return
+        if self._ignore:
+            return
+
+        if tag == "pre":
+            self._in_pre = True
+            self._buf.append("\n```\n")
+
+        elif tag == "code":
+            if self._in_pre:
+                # <pre><code> — the fence is already open; skip this tag
+                self._skip_code = True
+            else:
+                self._in_code = True
+                self._buf.append("`")
+
+        elif tag in self._INLINE:
+            self._buf.append(self._INLINE[tag])
+
+        elif tag in ("h1", "h2", "h3", "h4", "h5", "h6"):
+            self._buf.append("\n*")
+
+        elif tag == "br":
+            self._buf.append("\n")
+
+        elif tag == "hr":
+            self._buf.append("\n---\n")
+
+        elif tag == "p":
+            self._buf.append("\n")
+
+        elif tag in ("div", "blockquote"):
+            self._buf.append("\n")
+
+        elif tag == "ul":
+            self._list_stack.append("ul")
+
+        elif tag == "ol":
+            self._list_stack.append(0)
+
+        elif tag == "li":
+            if self._list_stack and isinstance(self._list_stack[-1], int):
+                # ordered list — increment counter
+                self._list_stack[-1] += 1
+                self._buf.append(f"\n{self._list_stack[-1]}. ")
+            else:
+                self._buf.append("\n- ")
+
+        elif tag == "a":
+            # Links: just emit the visible text (WhatsApp ignores markdown URLs)
+            pass
+
+        elif tag == "tr":
+            self._buf.append("\n")
+
+        elif tag in ("td", "th"):
+            self._buf.append(" | ")
+
+    def handle_endtag(self, tag):
+        tag = tag.lower()
+
+        if tag in self._IGNORE_TAGS:
+            self._ignore = max(0, self._ignore - 1)
+            return
+        if self._ignore:
+            return
+
+        if tag == "pre":
+            self._in_pre = False
+            self._skip_code = False
+            self._buf.append("\n```\n")
+
+        elif tag == "code":
+            if self._skip_code:
+                self._skip_code = False
+            else:
+                self._in_code = False
+                self._buf.append("`")
+
+        elif tag in self._INLINE:
+            self._buf.append(self._INLINE[tag])
+
+        elif tag in ("h1", "h2", "h3", "h4", "h5", "h6"):
+            self._buf.append("*\n")
+
+        elif tag in ("p", "div", "blockquote"):
+            self._buf.append("\n")
+
+        elif tag in ("ul", "ol"):
+            if self._list_stack:
+                self._list_stack.pop()
+            self._buf.append("\n")
+
+        elif tag == "tr":
+            self._buf.append("\n")
+
+    def handle_data(self, data):
+        if self._ignore:
+            return
+        # Skip whitespace-only text nodes inside list containers —
+        # they would otherwise create blank lines between list items.
+        if self._list_stack and not data.strip():
+            return
+        self._buf.append(data)
+
+
+def _html_to_whatsapp(html):
+    """Convert an HTML string to WhatsApp-flavoured markdown."""
+    parser = _HTMLToWhatsApp()
+    parser.feed(html)
+    parser.close()
+    return parser.text
+
+
+def _to_whatsapp(body, notify_format):
+    """Return *body* formatted as WhatsApp markdown.
+
+    Apprise can hand us TEXT, HTML, or MARKDOWN.  We normalise all three to
+    WhatsApp's own dialect so that *bold*, _italic_, and ```code``` blocks
+    render correctly in the recipient's WhatsApp client.
+    """
+    if notify_format == NotifyFormat.HTML:
+        return _html_to_whatsapp(body)
+
+    if notify_format == NotifyFormat.MARKDOWN:
+        # Leverage Apprise's existing Markdown → HTML pipeline, then convert
+        # the resulting HTML to WhatsApp markdown.
+        return _html_to_whatsapp(markdown_to_html(body))
+
+    # NotifyFormat.TEXT (or anything else): return as-is.
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Plugin
+# ---------------------------------------------------------------------------
+
+class NotifyEvolution(NotifyBase):
+    """A wrapper for Evolution API (WhatsApp) Notifications."""
+
+    # The default descriptive name associated with the Notification
+    service_name = "Evolution API"
+
+    # The services URL
+    service_url = "https://github.com/EvolutionAPI/evolution-api"
+
+    # The default protocol (plain HTTP)
+    protocol = "evolution"
+
+    # The default secure protocol (HTTPS)
+    secure_protocol = "evolutions"
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = "https://appriseit.com/services/evolution/"
+
+    # Disable throttle rate
+    request_rate_per_sec = 0
+
+    # We handle the title ourselves in send() so that it arrives in WhatsApp
+    # as *bold* text.
+    title_maxlen = 250
+
+    # Define object URL templates
+    templates = (
+        "{schema}://{apikey}@{host}/{instance}/{targets}",
+        "{schema}://{apikey}@{host}:{port}/{instance}/{targets}",
+    )
+
+    # Define our template tokens
+    template_tokens = dict(
+        NotifyBase.template_tokens,
+        **{
+            "apikey": {
+                "name": _("API Key"),
+                "type": "string",
+                "private": True,
+                "required": True,
+            },
+            "host": {
+                "name": _("Hostname"),
+                "type": "string",
+                "required": True,
+            },
+            "port": {
+                "name": _("Port"),
+                "type": "int",
+                "min": 1,
+                "max": 65535,
+            },
+            "instance": {
+                "name": _("Instance Name"),
+                "type": "string",
+                "required": True,
+            },
+            "target_phone": {
+                "name": _("Target Phone No"),
+                "type": "string",
+                "prefix": "+",
+                "regex": (r"^[0-9\s)(+-]+$", "i"),
+                "map_to": "targets",
+            },
+            "targets": {
+                "name": _("Targets"),
+                "type": "list:string",
+            },
+        },
+    )
+
+    # Define our template arguments
+    template_args = dict(
+        NotifyBase.template_args,
+        **{
+            "to": {
+                "alias_of": "targets",
+            },
+        },
+    )
+
+    def __init__(self, apikey, instance, targets=None, **kwargs):
+        """Initialize Evolution API Object."""
+        super().__init__(**kwargs)
+
+        # API Key
+        self.apikey = validate_regex(apikey)
+        if not self.apikey:
+            msg = (
+                "An invalid Evolution API key "
+                f"({apikey}) was specified."
+            )
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # Instance name
+        self.instance = validate_regex(instance)
+        if not self.instance:
+            msg = (
+                "An invalid Evolution API instance name "
+                f"({instance}) was specified."
+            )
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # Parse and validate recipient phone numbers
+        self.phone = []
+        self.invalid_targets = []
+
+        for target in parse_phone_no(targets):
+            result = is_phone_no(target)
+            if not result:
+                self.logger.warning(
+                    "Dropped invalid Evolution API phone # "
+                    f"({target}) specified."
+                )
+                self.invalid_targets.append(target)
+                continue
+            # Store digits only — Evolution API expects no leading '+'
+            self.phone.append(result["full"])
+
+        if not self.phone:
+            msg = "No valid Evolution API phone numbers were specified."
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        return
+
+    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+        """Perform Evolution API Notification."""
+
+        # The Apprise dispatcher passes body_format in kwargs to tell us what
+        # format the body is actually in (may differ from self.notify_format
+        # when the caller used body_format= on notify()).
+        # We use that to drive the WhatsApp markdown conversion.
+        body_format = kwargs.get("body_format") or self.notify_format
+
+        # Convert body to WhatsApp markdown
+        body = _to_whatsapp(body, body_format)
+
+        # Prepend title as bold if present
+        if title:
+            body = f"*{title}*\n\n{body}"
+
+        # Build the base URL
+        schema = "https" if self.secure else "http"
+        default_port = 443 if self.secure else 80
+
+        base_url = "{}://{}{}".format(
+            schema,
+            self.host,
+            (
+                ""
+                if not self.port or self.port == default_port
+                else f":{self.port}"
+            ),
+        )
+
+        headers = {
+            "User-Agent": self.app_id,
+            "Content-Type": "application/json",
+            "apikey": self.apikey,
+        }
+
+        has_error = False
+        for number in self.phone:
+            url = f"{base_url}/message/sendText/{self.instance}"
+            payload = {
+                "number": number,
+                "text": body,
+            }
+
+            self.logger.debug(
+                "Evolution API POST URL: {} "
+                "(cert_verify={!r})".format(url, self.verify_certificate)
+            )
+            self.logger.debug(f"Evolution API Payload: {payload!s}")
+
+            # Always call throttle before any remote server i/o is made
+            self.throttle()
+
+            try:
+                r = requests.post(
+                    url,
+                    data=dumps(payload),
+                    headers=headers,
+                    verify=self.verify_certificate,
+                    timeout=self.request_timeout,
+                )
+
+                if r.status_code not in (
+                    requests.codes.ok,
+                    requests.codes.created,
+                ):
+                    status_str = NotifyEvolution.http_response_code_lookup(
+                        r.status_code
+                    )
+                    self.logger.warning(
+                        "Failed to send Evolution API notification to "
+                        "{}: {}{}error={}.".format(
+                            number,
+                            status_str,
+                            ", " if status_str else "",
+                            r.status_code,
+                        )
+                    )
+                    self.logger.debug(
+                        "Response Details:\r\n%r",
+                        (r.content or b"")[:2000],
+                    )
+                    has_error = True
+                    continue
+
+                else:
+                    self.logger.info(
+                        f"Sent Evolution API notification to {number}."
+                    )
+
+            except requests.RequestException as e:
+                self.logger.warning(
+                    "A Connection error occurred sending Evolution API "
+                    f"notification to {number}."
+                )
+                self.logger.debug(f"Socket Exception: {e!s}")
+                has_error = True
+                continue
+
+        return not has_error
+
+    def __len__(self):
+        """Returns the number of targets associated with this notification."""
+        return len(self.phone)
+
+    @property
+    def url_identifier(self):
+        """Returns all of the identifiers that make this URL unique from
+        another similar one.
+
+        Targets or end points should never be identified here.
+        """
+        return (
+            self.secure_protocol if self.secure else self.protocol,
+            self.apikey,
+            self.host,
+            self.port,
+            self.instance,
+        )
+
+    def url(self, privacy=False, *args, **kwargs):
+        """Returns the URL built dynamically based on specified arguments."""
+
+        params = self.url_parameters(privacy=privacy, *args, **kwargs)
+
+        default_port = 443 if self.secure else 80
+
+        targets = self.phone if self.phone else self.invalid_targets
+
+        return (
+            "{schema}://{apikey}@{host}{port}"
+            "/{instance}/{targets}?{params}"
+        ).format(
+            schema=self.secure_protocol if self.secure else self.protocol,
+            apikey=(
+                self.pprint(self.apikey, "key", safe="")
+                if privacy
+                else NotifyEvolution.quote(self.apikey, safe="")
+            ),
+            host=self.host,
+            port=(
+                ""
+                if not self.port or self.port == default_port
+                else f":{self.port}"
+            ),
+            instance=NotifyEvolution.quote(self.instance, safe=""),
+            targets="/".join(
+                [NotifyEvolution.quote(t, safe="+") for t in targets]
+            ),
+            params=NotifyEvolution.urlencode(params),
+        )
+
+    @staticmethod
+    def parse_url(url):
+        """Parses the URL and returns enough arguments that can allow us to
+        re-instantiate this object."""
+
+        results = NotifyBase.parse_url(url, verify_host=True)
+        if not results:
+            return results
+
+        # The API key is placed in the user field of the URL
+        if results.get("user"):
+            results["apikey"] = NotifyEvolution.unquote(results["user"])
+        else:
+            results["apikey"] = None
+
+        # Path tokens: first is instance name, rest are phone numbers
+        entries = NotifyEvolution.split_path(results["fullpath"])
+
+        try:
+            results["instance"] = NotifyEvolution.unquote(entries.pop(0))
+        except IndexError:
+            results["instance"] = None
+
+        results["targets"] = entries
+
+        # Also accept ?to= query param for additional targets
+        if "to" in results["qsd"] and results["qsd"]["to"]:
+            results["targets"] += NotifyEvolution.parse_phone_no(
+                results["qsd"]["to"]
+            )
+
+        return results

--- a/apprise/plugins/evolution.py
+++ b/apprise/plugins/evolution.py
@@ -286,7 +286,7 @@ class NotifyEvolution(NotifyBase):
 
     def __len__(self):
         """Returns the number of targets associated with this notification."""
-        return len(self.phone)
+        return max(1, len(self.phone))
 
     @property
     def url_identifier(self):

--- a/apprise/plugins/evolution.py
+++ b/apprise/plugins/evolution.py
@@ -154,10 +154,7 @@ class NotifyEvolution(NotifyBase):
         # API Key
         self.apikey = validate_regex(apikey)
         if not self.apikey:
-            msg = (
-                "An invalid Evolution API key "
-                f"({apikey}) was specified."
-            )
+            msg = f"An invalid Evolution API key ({apikey}) was specified."
             self.logger.warning(msg)
             raise TypeError(msg)
 
@@ -230,8 +227,9 @@ class NotifyEvolution(NotifyBase):
             }
 
             self.logger.debug(
-                "Evolution API POST URL: {} "
-                "(cert_verify={!r})".format(url, self.verify_certificate)
+                "Evolution API POST URL: {} (cert_verify={!r})".format(
+                    url, self.verify_certificate
+                )
             )
             self.logger.debug(f"Evolution API Payload: {payload!s}")
 
@@ -315,8 +313,7 @@ class NotifyEvolution(NotifyBase):
         targets = self.phone if self.phone else self.invalid_targets
 
         return (
-            "{schema}://{apikey}@{host}{port}"
-            "/{instance}/{targets}?{params}"
+            "{schema}://{apikey}@{host}{port}/{instance}/{targets}?{params}"
         ).format(
             schema=self.secure_protocol if self.secure else self.protocol,
             apikey=(

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -61,7 +61,8 @@ notification services. It supports sending alerts to platforms such as: \
 `46elks`, `AfricasTalking`, `Apprise API`, `APRS`, `AWS SES`, `AWS SNS`, \
 `Bark`, `BlueSky`, `Brevo`, `Burst SMS`, `BulkSMS`, `BulkVS`, `Chanify`, \
 `Clickatell`, `ClickSend`, `DAPNET`, `DingTalk`, `Discord`, \
-`Dot. (Quote/0)`, `E-Mail`, `Emby`, `Evolution API`, `FCM`, `Feishu`, `Flock`, `Fluxer`, \
+`Dot. (Quote/0)`, `E-Mail`, `Emby`, `Evolution API`, \
+`FCM`, `Feishu`, `Flock`, `Fluxer`, \
 `Free Mobile`, `Google Chat`, `Gotify`, `Growl`, `Guilded`, \
 `Home Assistant`, `httpSMS`, `IFTTT`, `IRC`, `Jellyfin`, `Jira`, `Join`, \
 `Kavenegar`, `KODI`, `Kumulos`, `LaMetric`, `Lark`, `Line`, `MacOSX`, \

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -61,7 +61,7 @@ notification services. It supports sending alerts to platforms such as: \
 `46elks`, `AfricasTalking`, `Apprise API`, `APRS`, `AWS SES`, `AWS SNS`, \
 `Bark`, `BlueSky`, `Brevo`, `Burst SMS`, `BulkSMS`, `BulkVS`, `Chanify`, \
 `Clickatell`, `ClickSend`, `DAPNET`, `DingTalk`, `Discord`, \
-`Dot. (Quote/0)`, `E-Mail`, `Emby`, `FCM`, `Feishu`, `Flock`, `Fluxer`, \
+`Dot. (Quote/0)`, `E-Mail`, `Emby`, `Evolution API`, `FCM`, `Feishu`, `Flock`, `Fluxer`, \
 `Free Mobile`, `Google Chat`, `Gotify`, `Growl`, `Guilded`, \
 `Home Assistant`, `httpSMS`, `IFTTT`, `IRC`, `Jellyfin`, `Jira`, `Join`, \
 `Kavenegar`, `KODI`, `Kumulos`, `LaMetric`, `Lark`, `Line`, `MacOSX`, \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ keywords = [
     "Email",
     "Emby",
     "Enigma2",
+    "Evolution API",
     "FCM",
     "Feishu",
     "Flock",

--- a/tests/test_plugin_evolution.py
+++ b/tests/test_plugin_evolution.py
@@ -117,8 +117,7 @@ apprise_url_tests = (
     ),
     # Multiple targets
     (
-        "evolution://myapikey@hostname/myinstance"
-        "/5511999999999/5521888888888",
+        "evolution://myapikey@hostname/myinstance/5511999999999/5521888888888",
         {
             "instance": NotifyEvolution,
         },
@@ -187,9 +186,7 @@ def test_plugin_evolution_edge_cases():
 
     # No instance
     with pytest.raises(TypeError):
-        NotifyEvolution(
-            apikey="key", instance=None, targets=["5511999999999"]
-        )
+        NotifyEvolution(apikey="key", instance=None, targets=["5511999999999"])
 
     # No targets
     with pytest.raises(TypeError):
@@ -254,9 +251,7 @@ def test_plugin_evolution_multiple_targets(mock_post):
     assert obj.notify(body="msg") is True
     assert mock_post.call_count == 3
 
-    numbers = [
-        loads(c[1]["data"])["number"] for c in mock_post.call_args_list
-    ]
+    numbers = [loads(c[1]["data"])["number"] for c in mock_post.call_args_list]
     assert "5511111111111" in numbers
     assert "5522222222222" in numbers
     assert "5533333333333" in numbers
@@ -290,9 +285,7 @@ def test_plugin_evolution_title_bold(mock_post):
     mock_post.return_value = requests.Request()
     mock_post.return_value.status_code = requests.codes.ok
 
-    obj = Apprise.instantiate(
-        "evolution://key@host/inst/5511999999999"
-    )
+    obj = Apprise.instantiate("evolution://key@host/inst/5511999999999")
     assert obj.notify(body="body text", title="My Title") is True
 
     payload = loads(mock_post.call_args[1]["data"])

--- a/tests/test_plugin_evolution.py
+++ b/tests/test_plugin_evolution.py
@@ -25,15 +25,15 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import logging
 from json import loads
+import logging
 from unittest import mock
 
+from helpers import AppriseURLTester
 import pytest
 import requests
-from helpers import AppriseURLTester
 
-from apprise import Apprise, NotifyType
+from apprise import Apprise
 from apprise.common import NotifyFormat
 from apprise.plugins.evolution import (
     NotifyEvolution,
@@ -179,11 +179,15 @@ def test_plugin_evolution_edge_cases():
 
     # No apikey
     with pytest.raises(TypeError):
-        NotifyEvolution(apikey=None, instance="inst", targets=["5511999999999"])
+        NotifyEvolution(
+            apikey=None, instance="inst", targets=["5511999999999"]
+        )
 
     # Blank apikey
     with pytest.raises(TypeError):
-        NotifyEvolution(apikey="   ", instance="inst", targets=["5511999999999"])
+        NotifyEvolution(
+            apikey="   ", instance="inst", targets=["5511999999999"]
+        )
 
     # No instance
     with pytest.raises(TypeError):

--- a/tests/test_plugin_evolution.py
+++ b/tests/test_plugin_evolution.py
@@ -1,0 +1,406 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import logging
+from json import loads
+from unittest import mock
+
+import pytest
+import requests
+from helpers import AppriseURLTester
+
+from apprise import Apprise, NotifyType
+from apprise.common import NotifyFormat
+from apprise.plugins.evolution import (
+    NotifyEvolution,
+    _html_to_whatsapp,
+    _to_whatsapp,
+)
+
+logging.disable(logging.CRITICAL)
+
+# ---------------------------------------------------------------------------
+# URL-based tests — exercised by AppriseURLTester
+# ---------------------------------------------------------------------------
+
+apprise_url_tests = (
+    # No host — parse_url returns None
+    (
+        "evolution://",
+        {
+            "instance": None,
+        },
+    ),
+    # No host, explicit empty credentials
+    (
+        "evolution://:@/",
+        {
+            "instance": None,
+        },
+    ),
+    # Missing apikey (no user field)
+    (
+        "evolution://hostname/myinstance/5511999999999",
+        {
+            "instance": TypeError,
+        },
+    ),
+    # Missing instance (single path entry treated as instance, no phone left)
+    (
+        "evolution://myapikey@hostname/5511999999999",
+        {
+            "instance": TypeError,
+        },
+    ),
+    # Missing phone number
+    (
+        "evolution://myapikey@hostname/myinstance",
+        {
+            "instance": TypeError,
+        },
+    ),
+    # Invalid phone number
+    (
+        "evolution://myapikey@hostname/myinstance/notaphone",
+        {
+            "instance": TypeError,
+        },
+    ),
+    # Valid HTTP — minimal
+    (
+        "evolution://myapikey@hostname/myinstance/5511999999999",
+        {
+            "instance": NotifyEvolution,
+            "privacy_url": (
+                "evolution://m...y@hostname/myinstance/5511999999999"
+            ),
+        },
+    ),
+    # Valid HTTPS
+    (
+        "evolutions://myapikey@hostname/myinstance/5511999999999",
+        {
+            "instance": NotifyEvolution,
+            "privacy_url": (
+                "evolutions://m...y@hostname/myinstance/5511999999999"
+            ),
+        },
+    ),
+    # Custom port
+    (
+        "evolution://myapikey@hostname:8080/myinstance/5511999999999",
+        {
+            "instance": NotifyEvolution,
+            "privacy_url": (
+                "evolution://m...y@hostname:8080/myinstance/5511999999999"
+            ),
+        },
+    ),
+    # Multiple targets
+    (
+        "evolution://myapikey@hostname/myinstance"
+        "/5511999999999/5521888888888",
+        {
+            "instance": NotifyEvolution,
+        },
+    ),
+    # Target via ?to=
+    (
+        "evolution://myapikey@hostname/myinstance/5511999999999"
+        "?to=5521888888888",
+        {
+            "instance": NotifyEvolution,
+        },
+    ),
+    # Force HTTP error
+    (
+        "evolution://myapikey@hostname/myinstance/5511999999999",
+        {
+            "instance": NotifyEvolution,
+            "response": False,
+            "requests_response_code": requests.codes.internal_server_error,
+        },
+    ),
+    # Unknown HTTP response code
+    (
+        "evolution://myapikey@hostname/myinstance/5511999999999",
+        {
+            "instance": NotifyEvolution,
+            "response": False,
+            "requests_response_code": 999,
+        },
+    ),
+    # Connection exceptions
+    (
+        "evolution://myapikey@hostname/myinstance/5511999999999",
+        {
+            "instance": NotifyEvolution,
+            "test_requests_exceptions": True,
+        },
+    ),
+)
+
+
+def test_plugin_evolution_urls():
+    """NotifyEvolution() Apprise URLs."""
+    AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+def test_plugin_evolution_edge_cases():
+    """NotifyEvolution() direct instantiation edge cases."""
+
+    # No apikey
+    with pytest.raises(TypeError):
+        NotifyEvolution(apikey=None, instance="inst", targets=["5511999999999"])
+
+    # Blank apikey
+    with pytest.raises(TypeError):
+        NotifyEvolution(apikey="   ", instance="inst", targets=["5511999999999"])
+
+    # No instance
+    with pytest.raises(TypeError):
+        NotifyEvolution(
+            apikey="key", instance=None, targets=["5511999999999"]
+        )
+
+    # No targets
+    with pytest.raises(TypeError):
+        NotifyEvolution(apikey="key", instance="inst", targets=[])
+
+    # All targets invalid
+    with pytest.raises(TypeError):
+        NotifyEvolution(
+            apikey="key", instance="inst", targets=["notaphone", "xx"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# send() payload and header verification
+# ---------------------------------------------------------------------------
+
+@mock.patch("requests.post")
+def test_plugin_evolution_send(mock_post):
+    """NotifyEvolution() verifies POST payload and headers."""
+
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    obj = Apprise.instantiate(
+        "evolution://MYAPIKEY@localhost:8080/myinstance/5511999999999"
+    )
+    assert isinstance(obj, NotifyEvolution)
+
+    assert obj.notify(body="Hello World", title="Test") is True
+    assert mock_post.call_count == 1
+
+    # Verify URL
+    call = mock_post.call_args
+    assert "localhost:8080" in call[0][0]
+    assert "/message/sendText/myinstance" in call[0][0]
+
+    # Verify headers
+    headers = call[1]["headers"]
+    assert headers["apikey"] == "MYAPIKEY"
+    assert headers["Content-Type"] == "application/json"
+
+    # Verify payload
+    payload = loads(call[1]["data"])
+    assert payload["number"] == "5511999999999"
+    assert "Hello World" in payload["text"]
+
+
+@mock.patch("requests.post")
+def test_plugin_evolution_multiple_targets(mock_post):
+    """NotifyEvolution() sends one request per target."""
+
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    obj = Apprise.instantiate(
+        "evolution://key@host/inst/5511111111111/5522222222222/5533333333333"
+    )
+    assert isinstance(obj, NotifyEvolution)
+    assert len(obj) == 3
+
+    assert obj.notify(body="msg") is True
+    assert mock_post.call_count == 3
+
+    numbers = [
+        loads(c[1]["data"])["number"]
+        for c in mock_post.call_args_list
+    ]
+    assert "5511111111111" in numbers
+    assert "5522222222222" in numbers
+    assert "5533333333333" in numbers
+
+
+@mock.patch("requests.post")
+def test_plugin_evolution_partial_failure(mock_post):
+    """NotifyEvolution() returns False if any target fails."""
+
+    r_ok = requests.Request()
+    r_ok.status_code = requests.codes.ok
+    r_ok.content = b""
+
+    r_err = requests.Request()
+    r_err.status_code = requests.codes.internal_server_error
+    r_err.content = b"error"
+
+    mock_post.side_effect = [r_ok, r_err]
+
+    obj = Apprise.instantiate(
+        "evolution://key@host/inst/5511111111111/5522222222222"
+    )
+    assert obj.notify(body="msg") is False
+    assert mock_post.call_count == 2
+
+
+@mock.patch("requests.post")
+def test_plugin_evolution_title_bold(mock_post):
+    """NotifyEvolution() wraps the title in WhatsApp bold markers."""
+
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    obj = Apprise.instantiate(
+        "evolution://key@host/inst/5511999999999"
+    )
+    assert obj.notify(body="body text", title="My Title") is True
+
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["text"].startswith("*My Title*")
+
+
+@mock.patch("requests.post")
+def test_plugin_evolution_https(mock_post):
+    """NotifyEvolution() uses HTTPS when evolutions:// schema is given."""
+
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    obj = Apprise.instantiate(
+        "evolutions://key@secure.host/inst/5511999999999"
+    )
+    assert isinstance(obj, NotifyEvolution)
+    assert obj.secure is True
+
+    assert obj.notify(body="secure msg") is True
+    url = mock_post.call_args[0][0]
+    assert url.startswith("https://")
+
+
+# ---------------------------------------------------------------------------
+# WhatsApp markdown conversion
+# ---------------------------------------------------------------------------
+
+def test_html_to_whatsapp_inline():
+    """_html_to_whatsapp() converts inline HTML tags."""
+    assert _html_to_whatsapp("<b>bold</b>") == "*bold*"
+    assert _html_to_whatsapp("<strong>bold</strong>") == "*bold*"
+    assert _html_to_whatsapp("<i>italic</i>") == "_italic_"
+    assert _html_to_whatsapp("<em>italic</em>") == "_italic_"
+    assert _html_to_whatsapp("<s>strike</s>") == "~strike~"
+    assert _html_to_whatsapp("<del>strike</del>") == "~strike~"
+    assert _html_to_whatsapp("<code>mono</code>") == "`mono`"
+
+
+def test_html_to_whatsapp_heading():
+    """_html_to_whatsapp() converts headings to bold."""
+    result = _html_to_whatsapp("<h1>Title</h1>")
+    assert result == "*Title*"
+
+    result = _html_to_whatsapp("<h2>Sub</h2>")
+    assert result == "*Sub*"
+
+
+def test_html_to_whatsapp_list():
+    """_html_to_whatsapp() converts list items with compact spacing."""
+    html = "<ul><li>one</li><li>two</li><li>three</li></ul>"
+    result = _html_to_whatsapp(html)
+    lines = [l for l in result.splitlines() if l.strip()]
+    assert lines == ["- one", "- two", "- three"]
+
+
+def test_html_to_whatsapp_ordered_list():
+    """_html_to_whatsapp() numbers ordered list items."""
+    html = "<ol><li>first</li><li>second</li></ol>"
+    result = _html_to_whatsapp(html)
+    lines = [l for l in result.splitlines() if l.strip()]
+    assert lines == ["1. first", "2. second"]
+
+
+def test_html_to_whatsapp_pre():
+    """_html_to_whatsapp() wraps <pre> blocks in triple backticks."""
+    result = _html_to_whatsapp("<pre>code block</pre>")
+    assert "```" in result
+    assert "code block" in result
+
+
+def test_html_to_whatsapp_ignore_tags():
+    """_html_to_whatsapp() ignores script and style content."""
+    result = _html_to_whatsapp(
+        "<p>visible</p><script>evil()</script><style>.x{}</style>"
+    )
+    assert "evil" not in result
+    assert ".x" not in result
+    assert "visible" in result
+
+
+def test_to_whatsapp_text_passthrough():
+    """_to_whatsapp() returns plain text unchanged."""
+    text = "Hello *World*"
+    assert _to_whatsapp(text, NotifyFormat.TEXT) == text
+
+
+def test_to_whatsapp_html():
+    """_to_whatsapp() converts HTML format."""
+    result = _to_whatsapp("<b>bold</b>", NotifyFormat.HTML)
+    assert result == "*bold*"
+
+
+def test_to_whatsapp_markdown():
+    """_to_whatsapp() converts Markdown format via HTML pipeline."""
+    result = _to_whatsapp("**bold**", NotifyFormat.MARKDOWN)
+    assert "*bold*" in result
+
+
+def test_to_whatsapp_markdown_heading():
+    """_to_whatsapp() converts Markdown headings to bold."""
+    result = _to_whatsapp("## Deploy Done", NotifyFormat.MARKDOWN)
+    assert "*Deploy Done*" in result
+
+
+def test_to_whatsapp_markdown_list():
+    """_to_whatsapp() converts Markdown list to compact WhatsApp list."""
+    md = "- item one\n- item two\n- item three"
+    result = _to_whatsapp(md, NotifyFormat.MARKDOWN)
+    lines = [l for l in result.splitlines() if l.strip()]
+    assert lines == ["- item one", "- item two", "- item three"]

--- a/tests/test_plugin_evolution.py
+++ b/tests/test_plugin_evolution.py
@@ -279,8 +279,8 @@ def test_plugin_evolution_partial_failure(mock_post):
 
 
 @mock.patch("requests.post")
-def test_plugin_evolution_title_bold(mock_post):
-    """NotifyEvolution() wraps the title in WhatsApp bold markers."""
+def test_plugin_evolution_title_in_body(mock_post):
+    """NotifyEvolution() merges the title into the body via Apprise."""
 
     mock_post.return_value = requests.Request()
     mock_post.return_value.status_code = requests.codes.ok
@@ -289,7 +289,8 @@ def test_plugin_evolution_title_bold(mock_post):
     assert obj.notify(body="body text", title="My Title") is True
 
     payload = loads(mock_post.call_args[1]["data"])
-    assert payload["text"].startswith("*My Title*")
+    assert "My Title" in payload["text"]
+    assert "body text" in payload["text"]
 
 
 @mock.patch("requests.post")

--- a/tests/test_plugin_evolution.py
+++ b/tests/test_plugin_evolution.py
@@ -169,6 +169,13 @@ def test_plugin_evolution_urls():
 # ---------------------------------------------------------------------------
 
 
+def test_plugin_evolution_parse_url_no_path():
+    """NotifyEvolution.parse_url() returns instance=None when path is empty."""
+    result = NotifyEvolution.parse_url("evolution://key@host")
+    assert result is not None
+    assert result["instance"] is None
+
+
 def test_plugin_evolution_edge_cases():
     """NotifyEvolution() direct instantiation edge cases."""
 

--- a/tests/test_plugin_evolution.py
+++ b/tests/test_plugin_evolution.py
@@ -34,12 +34,7 @@ import pytest
 import requests
 
 from apprise import Apprise
-from apprise.common import NotifyFormat
-from apprise.plugins.evolution import (
-    NotifyEvolution,
-    _html_to_whatsapp,
-    _to_whatsapp,
-)
+from apprise.plugins.evolution import NotifyEvolution
 
 logging.disable(logging.CRITICAL)
 
@@ -69,7 +64,7 @@ apprise_url_tests = (
             "instance": TypeError,
         },
     ),
-    # Missing instance (single path entry treated as instance, no phone left)
+    # Missing instance (single path entry treated as instance; no phone left)
     (
         "evolution://myapikey@hostname/5511999999999",
         {
@@ -174,6 +169,7 @@ def test_plugin_evolution_urls():
 # Edge cases
 # ---------------------------------------------------------------------------
 
+
 def test_plugin_evolution_edge_cases():
     """NotifyEvolution() direct instantiation edge cases."""
 
@@ -209,6 +205,7 @@ def test_plugin_evolution_edge_cases():
 # ---------------------------------------------------------------------------
 # send() payload and header verification
 # ---------------------------------------------------------------------------
+
 
 @mock.patch("requests.post")
 def test_plugin_evolution_send(mock_post):
@@ -258,8 +255,7 @@ def test_plugin_evolution_multiple_targets(mock_post):
     assert mock_post.call_count == 3
 
     numbers = [
-        loads(c[1]["data"])["number"]
-        for c in mock_post.call_args_list
+        loads(c[1]["data"])["number"] for c in mock_post.call_args_list
     ]
     assert "5511111111111" in numbers
     assert "5522222222222" in numbers
@@ -319,92 +315,3 @@ def test_plugin_evolution_https(mock_post):
     assert obj.notify(body="secure msg") is True
     url = mock_post.call_args[0][0]
     assert url.startswith("https://")
-
-
-# ---------------------------------------------------------------------------
-# WhatsApp markdown conversion
-# ---------------------------------------------------------------------------
-
-def test_html_to_whatsapp_inline():
-    """_html_to_whatsapp() converts inline HTML tags."""
-    assert _html_to_whatsapp("<b>bold</b>") == "*bold*"
-    assert _html_to_whatsapp("<strong>bold</strong>") == "*bold*"
-    assert _html_to_whatsapp("<i>italic</i>") == "_italic_"
-    assert _html_to_whatsapp("<em>italic</em>") == "_italic_"
-    assert _html_to_whatsapp("<s>strike</s>") == "~strike~"
-    assert _html_to_whatsapp("<del>strike</del>") == "~strike~"
-    assert _html_to_whatsapp("<code>mono</code>") == "`mono`"
-
-
-def test_html_to_whatsapp_heading():
-    """_html_to_whatsapp() converts headings to bold."""
-    result = _html_to_whatsapp("<h1>Title</h1>")
-    assert result == "*Title*"
-
-    result = _html_to_whatsapp("<h2>Sub</h2>")
-    assert result == "*Sub*"
-
-
-def test_html_to_whatsapp_list():
-    """_html_to_whatsapp() converts list items with compact spacing."""
-    html = "<ul><li>one</li><li>two</li><li>three</li></ul>"
-    result = _html_to_whatsapp(html)
-    lines = [l for l in result.splitlines() if l.strip()]
-    assert lines == ["- one", "- two", "- three"]
-
-
-def test_html_to_whatsapp_ordered_list():
-    """_html_to_whatsapp() numbers ordered list items."""
-    html = "<ol><li>first</li><li>second</li></ol>"
-    result = _html_to_whatsapp(html)
-    lines = [l for l in result.splitlines() if l.strip()]
-    assert lines == ["1. first", "2. second"]
-
-
-def test_html_to_whatsapp_pre():
-    """_html_to_whatsapp() wraps <pre> blocks in triple backticks."""
-    result = _html_to_whatsapp("<pre>code block</pre>")
-    assert "```" in result
-    assert "code block" in result
-
-
-def test_html_to_whatsapp_ignore_tags():
-    """_html_to_whatsapp() ignores script and style content."""
-    result = _html_to_whatsapp(
-        "<p>visible</p><script>evil()</script><style>.x{}</style>"
-    )
-    assert "evil" not in result
-    assert ".x" not in result
-    assert "visible" in result
-
-
-def test_to_whatsapp_text_passthrough():
-    """_to_whatsapp() returns plain text unchanged."""
-    text = "Hello *World*"
-    assert _to_whatsapp(text, NotifyFormat.TEXT) == text
-
-
-def test_to_whatsapp_html():
-    """_to_whatsapp() converts HTML format."""
-    result = _to_whatsapp("<b>bold</b>", NotifyFormat.HTML)
-    assert result == "*bold*"
-
-
-def test_to_whatsapp_markdown():
-    """_to_whatsapp() converts Markdown format via HTML pipeline."""
-    result = _to_whatsapp("**bold**", NotifyFormat.MARKDOWN)
-    assert "*bold*" in result
-
-
-def test_to_whatsapp_markdown_heading():
-    """_to_whatsapp() converts Markdown headings to bold."""
-    result = _to_whatsapp("## Deploy Done", NotifyFormat.MARKDOWN)
-    assert "*Deploy Done*" in result
-
-
-def test_to_whatsapp_markdown_list():
-    """_to_whatsapp() converts Markdown list to compact WhatsApp list."""
-    md = "- item one\n- item two\n- item three"
-    result = _to_whatsapp(md, NotifyFormat.MARKDOWN)
-    lines = [l for l in result.splitlines() if l.strip()]
-    assert lines == ["- item one", "- item two", "- item three"]


### PR DESCRIPTION
## Summary

- Adds support for sending WhatsApp messages via a self-hosted [Evolution API](https://github.com/EvolutionAPI/evolution-api) instance
- Automatic conversion of Apprise body formats (TEXT, HTML, MARKDOWN) to WhatsApp-flavoured markdown
- Supports multiple recipients in a single URL

## Details

**URL format:**
```
evolution://apikey@host/instance/number
evolutions://apikey@host/instance/number1/number2
```

**Supported formatting (via body_format):**
- `*bold*` from `**markdown**` or `<b>HTML</b>`
- `_italic_` from `_markdown_` or `<em>HTML</em>`
- `~strikethrough~` from `<s>HTML</s>`
- Headings converted to bold
- Lists rendered without blank lines between items
- Title prepended as `*bold*`

## Test plan

- [x] Unit tests added (`tests/test_plugin_evolution.py`) — 18 tests passing
- [x] URL parsing (valid, invalid, HTTPS, multi-target, `?to=`)
- [x] Payload and header verification
- [x] WhatsApp markdown conversion (HTML and Markdown formats)
- [x] Partial failure handling and connection exceptions