### PR TITLE
fixed templating references impacting url generation

### DIFF
--- a/apprise/plugins/mailgun.py
+++ b/apprise/plugins/mailgun.py
@@ -124,8 +124,8 @@ class NotifyMailgun(NotifyBase):
 
     # Define object templates
     templates = (
-        "{schema}://{user}@{host}:{apikey}/",
-        "{schema}://{user}@{host}:{apikey}/{targets}",
+        "{schema}://{user}@{host}/{apikey}/",
+        "{schema}://{user}@{host}/{apikey}/{targets}",
     )
 
     # Define our template tokens

--- a/apprise/plugins/smtp2go.py
+++ b/apprise/plugins/smtp2go.py
@@ -96,8 +96,8 @@ class NotifySMTP2Go(NotifyBase):
 
     # Define object templates
     templates = (
-        "{schema}://{user}@{host}:{apikey}/",
-        "{schema}://{user}@{host}:{apikey}/{targets}",
+        "{schema}://{user}@{host}/{apikey}/",
+        "{schema}://{user}@{host}/{apikey}/{targets}",
     )
 
     # Define our template tokens

--- a/apprise/plugins/sparkpost.py
+++ b/apprise/plugins/sparkpost.py
@@ -147,8 +147,8 @@ class NotifySparkPost(NotifyBase):
 
     # Define object templates
     templates = (
-        "{schema}://{user}@{host}:{apikey}/",
-        "{schema}://{user}@{host}:{apikey}/{targets}",
+        "{schema}://{user}@{host}/{apikey}/",
+        "{schema}://{user}@{host}/{apikey}/{targets}",
     )
 
     # Define our template tokens


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1576

Fixed URL templating/generation surrounding Mailgun, Smtp2go and Sparkpost per reported bug.

This fix will also allow the URL Builder to correctly assemble URLs using these plugins as well.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [ ] Documentation ticket created (if applicable): n/a - documentation reflects correctly.
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1576-mailgun-invalid-api-key

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "mailgun://host/api-key/targets"
```
