### PR TITLE
Added attachment support to Mattermost

### DIFF
--- a/apprise/plugins/mattermost.py
+++ b/apprise/plugins/mattermost.py
@@ -118,6 +118,9 @@ class NotifyMattermost(NotifyBase):
     # Mattermost does not have a title
     title_maxlen = 0
 
+    # Bot mode supports file attachments via /api/v4/files
+    attachment_support = True
+
     # Allow persistent caching of bot channel lookups
     storage_mode = PersistentStoreMode.AUTO
 
@@ -413,6 +416,7 @@ class NotifyMattermost(NotifyBase):
         body: str,
         title: str = "",
         notify_type: NotifyType = NotifyType.INFO,
+        attach=None,
         **kwargs: Any,
     ) -> bool:
         """Perform Mattermost Notification."""
@@ -440,6 +444,11 @@ class NotifyMattermost(NotifyBase):
                 self.schema, self.host, port, self.fullpath.rstrip("/")
             )
 
+            # URL used to upload file attachments before posting
+            upload_url = "{}://{}{}{}/api/v4/files".format(
+                self.schema, self.host, port, self.fullpath.rstrip("/")
+            )
+
             # Append headers
             headers["Authorization"] = f"Bearer {self.token}"
             expected = (requests.codes.created, requests.codes.ok)
@@ -453,6 +462,12 @@ class NotifyMattermost(NotifyBase):
                 self.token,
             )
             expected = (requests.codes.ok,)
+
+            if attach and self.attachment_support:
+                self.logger.warning(
+                    "Mattermost Webhook mode does not support"
+                    " attachments; switch to bot mode."
+                )
 
         # Iterate over our targets
         targets = self.targets.copy()
@@ -468,10 +483,128 @@ class NotifyMattermost(NotifyBase):
                     continue
 
             if self.mode == MattermostMode.BOT:
+                # Upload any attachments first and collect their file IDs.
+                # Each upload is scoped to the current channel_id.
+                file_ids: list[str] = []
+                attach_error = False
+                if attach and self.attachment_support:
+                    upload_headers: dict[str, str] = {
+                        "User-Agent": self.app_id,
+                        "Authorization": f"Bearer {self.token}",
+                    }
+                    for no, attachment in enumerate(attach, start=1):
+                        if not attachment:
+                            self.logger.error(
+                                "Could not access Mattermost attachment %s.",
+                                attachment.url(privacy=True),
+                            )
+                            attach_error = True
+                            break
+
+                        self.logger.debug(
+                            "Posting Mattermost attachment %s",
+                            attachment.url(privacy=True),
+                        )
+
+                        try:
+                            with attachment.open() as fp:
+                                self.throttle()
+                                r = requests.post(
+                                    upload_url,
+                                    data={"channel_id": target},
+                                    headers=upload_headers,
+                                    files={
+                                        "files": (
+                                            attachment.name
+                                            or f"file{no:03}.dat",
+                                            fp,
+                                            attachment.mimetype,
+                                        )
+                                    },
+                                    verify=self.verify_certificate,
+                                    timeout=self.request_timeout,
+                                )
+
+                            if r.status_code not in (
+                                requests.codes.created,
+                                requests.codes.ok,
+                            ):
+                                status = self.http_response_code_lookup(
+                                    r.status_code
+                                )
+                                self.logger.warning(
+                                    "Failed to upload Mattermost"
+                                    " attachment %s: %s, error=%d.",
+                                    attachment.name,
+                                    status,
+                                    r.status_code,
+                                )
+                                self.logger.debug(
+                                    "Response Details:\r\n%r",
+                                    (r.content or b"")[:2000],
+                                )
+                                attach_error = True
+                                break
+
+                            try:
+                                data = loads(r.content.decode("utf-8"))
+                                file_id = data.get("file_infos", [{}])[0].get(
+                                    "id", ""
+                                )
+
+                            except (
+                                AttributeError,
+                                TypeError,
+                                ValueError,
+                                IndexError,
+                            ):
+                                self.logger.warning(
+                                    "Failed to parse Mattermost"
+                                    " file upload response."
+                                )
+                                attach_error = True
+                                break
+
+                            if not file_id:
+                                self.logger.warning(
+                                    "Mattermost file upload"
+                                    " returned no file ID."
+                                )
+                                attach_error = True
+                                break
+
+                            file_ids.append(file_id)
+
+                        except requests.RequestException as e:
+                            self.logger.warning(
+                                "A Connection error occurred"
+                                " uploading Mattermost"
+                                " attachment."
+                            )
+                            self.logger.debug("Socket Exception: %s", e)
+                            attach_error = True
+                            break
+
+                        except OSError as e:
+                            self.logger.warning(
+                                "An I/O error occurred reading"
+                                " Mattermost attachment %s.",
+                                attachment.name or "attachment",
+                            )
+                            self.logger.debug("I/O Exception: %s", e)
+                            attach_error = True
+                            break
+
+                if attach_error:
+                    has_error = True
+                    continue
+
                 payload: dict[str, Any] = {
                     "channel_id": target,
                     "message": body,
                 }
+                if file_ids:
+                    payload["file_ids"] = file_ids
 
             else:
                 payload: dict[str, Any] = {

--- a/apprise/plugins/mattermost.py
+++ b/apprise/plugins/mattermost.py
@@ -44,6 +44,7 @@ This plugin supports 2 modes of operation:
 
 from __future__ import annotations
 
+import io
 from itertools import chain
 
 # Create an incoming webhook; the website will provide you with something like:
@@ -118,7 +119,7 @@ class NotifyMattermost(NotifyBase):
     # Mattermost does not have a title
     title_maxlen = 0
 
-    # Bot mode supports file attachments via /api/v4/files
+    # Attachment support defaults True; toggled off for webhook mode
     attachment_support = True
 
     # Allow persistent caching of bot channel lookups
@@ -261,6 +262,9 @@ class NotifyMattermost(NotifyBase):
                 raise TypeError(msg)
         else:
             self.mode = self.template_args["mode"]["default"]
+
+        # Enable attachment support only in bot mode
+        self.attachment_support = self.mode == MattermostMode.BOT
 
         # Token (webhook token in webhook mode, bearer token in bot mode)
         self.token = validate_regex(token)
@@ -439,6 +443,12 @@ class NotifyMattermost(NotifyBase):
             "Content-Type": "application/json",
         }
 
+        # Pre-read attachment content before the target loop so the same
+        # bytes can be sent to every target via a fresh io.BytesIO wrapper.
+        # AttachMemory streams close after the first read and cannot be
+        # re-opened; reading everything upfront avoids that problem.
+        attach_data: list[tuple[str, bytes, str]] = []
+
         if self.mode == MattermostMode.BOT:
             url = "{}://{}{}{}/api/v4/posts".format(
                 self.schema, self.host, port, self.fullpath.rstrip("/")
@@ -453,6 +463,40 @@ class NotifyMattermost(NotifyBase):
             headers["Authorization"] = f"Bearer {self.token}"
             expected = (requests.codes.created, requests.codes.ok)
 
+            if attach and self.attachment_support:
+                for no, attachment in enumerate(attach, start=1):
+                    if not attachment:
+                        self.logger.error(
+                            "Could not access Mattermost attachment %s.",
+                            attachment.url(privacy=True),
+                        )
+                        return False
+
+                    # Capture name and mimetype before open() so that
+                    # AttachMemory's exists() check (triggered by these
+                    # properties) does not fail on a closed stream.
+                    fname = attachment.name or f"file{no:03}.dat"
+                    mimetype = attachment.mimetype
+
+                    self.logger.debug(
+                        "Reading Mattermost attachment %s",
+                        attachment.url(privacy=True),
+                    )
+                    try:
+                        with attachment.open() as fp:
+                            content = fp.read()
+
+                    except OSError as e:
+                        self.logger.warning(
+                            "An I/O error occurred reading"
+                            " Mattermost attachment %s.",
+                            fname,
+                        )
+                        self.logger.debug("I/O Exception: %s", e)
+                        return False
+
+                    attach_data.append((fname, content, mimetype))
+
         else:  # self.mode == MattermostMode.WEBHOOK
             url = "{}://{}{}{}/hooks/{}".format(
                 self.schema,
@@ -462,12 +506,6 @@ class NotifyMattermost(NotifyBase):
                 self.token,
             )
             expected = (requests.codes.ok,)
-
-            if attach and self.attachment_support:
-                self.logger.warning(
-                    "Mattermost Webhook mode does not support"
-                    " attachments; switch to bot mode."
-                )
 
         # Iterate over our targets
         targets = self.targets.copy()
@@ -483,97 +521,38 @@ class NotifyMattermost(NotifyBase):
                     continue
 
             if self.mode == MattermostMode.BOT:
-                # Upload any attachments first and collect their file IDs.
-                # Each upload is scoped to the current channel_id.
+                # Upload pre-read attachment bytes scoped to this
+                # channel_id.  Fresh io.BytesIO wrappers are created for
+                # each target so all targets receive the same content.
                 file_ids: list[str] = []
                 attach_error = False
-                if attach and self.attachment_support:
+                if attach_data:
                     upload_headers: dict[str, str] = {
                         "User-Agent": self.app_id,
                         "Authorization": f"Bearer {self.token}",
                     }
-                    for no, attachment in enumerate(attach, start=1):
-                        if not attachment:
-                            self.logger.error(
-                                "Could not access Mattermost attachment %s.",
-                                attachment.url(privacy=True),
-                            )
-                            attach_error = True
-                            break
-
+                    for fname, content, mimetype in attach_data:
                         self.logger.debug(
                             "Posting Mattermost attachment %s",
-                            attachment.url(privacy=True),
+                            fname,
                         )
 
                         try:
-                            with attachment.open() as fp:
-                                self.throttle()
-                                r = requests.post(
-                                    upload_url,
-                                    data={"channel_id": target},
-                                    headers=upload_headers,
-                                    files={
-                                        "files": (
-                                            attachment.name
-                                            or f"file{no:03}.dat",
-                                            fp,
-                                            attachment.mimetype,
-                                        )
-                                    },
-                                    verify=self.verify_certificate,
-                                    timeout=self.request_timeout,
-                                )
-
-                            if r.status_code not in (
-                                requests.codes.created,
-                                requests.codes.ok,
-                            ):
-                                status = self.http_response_code_lookup(
-                                    r.status_code
-                                )
-                                self.logger.warning(
-                                    "Failed to upload Mattermost"
-                                    " attachment %s: %s, error=%d.",
-                                    attachment.name,
-                                    status,
-                                    r.status_code,
-                                )
-                                self.logger.debug(
-                                    "Response Details:\r\n%r",
-                                    (r.content or b"")[:2000],
-                                )
-                                attach_error = True
-                                break
-
-                            try:
-                                data = loads(r.content.decode("utf-8"))
-                                file_id = data.get("file_infos", [{}])[0].get(
-                                    "id", ""
-                                )
-
-                            except (
-                                AttributeError,
-                                TypeError,
-                                ValueError,
-                                IndexError,
-                            ):
-                                self.logger.warning(
-                                    "Failed to parse Mattermost"
-                                    " file upload response."
-                                )
-                                attach_error = True
-                                break
-
-                            if not file_id:
-                                self.logger.warning(
-                                    "Mattermost file upload"
-                                    " returned no file ID."
-                                )
-                                attach_error = True
-                                break
-
-                            file_ids.append(file_id)
+                            self.throttle()
+                            r = requests.post(
+                                upload_url,
+                                data={"channel_id": target},
+                                headers=upload_headers,
+                                files={
+                                    "files": (
+                                        fname,
+                                        io.BytesIO(content),
+                                        mimetype,
+                                    )
+                                },
+                                verify=self.verify_certificate,
+                                timeout=self.request_timeout,
+                            )
 
                         except requests.RequestException as e:
                             self.logger.warning(
@@ -585,15 +564,54 @@ class NotifyMattermost(NotifyBase):
                             attach_error = True
                             break
 
-                        except OSError as e:
-                            self.logger.warning(
-                                "An I/O error occurred reading"
-                                " Mattermost attachment %s.",
-                                attachment.name or "attachment",
+                        if r.status_code not in (
+                            requests.codes.created,
+                            requests.codes.ok,
+                        ):
+                            status = self.http_response_code_lookup(
+                                r.status_code
                             )
-                            self.logger.debug("I/O Exception: %s", e)
+                            self.logger.warning(
+                                "Failed to upload Mattermost"
+                                " attachment %s: %s, error=%d.",
+                                fname,
+                                status,
+                                r.status_code,
+                            )
+                            self.logger.debug(
+                                "Response Details:\r\n%r",
+                                (r.content or b"")[:2000],
+                            )
                             attach_error = True
                             break
+
+                        try:
+                            data = loads(r.content.decode("utf-8"))
+                            file_id = data.get("file_infos", [{}])[0].get(
+                                "id", ""
+                            )
+
+                        except (
+                            AttributeError,
+                            TypeError,
+                            ValueError,
+                            IndexError,
+                        ):
+                            self.logger.warning(
+                                "Failed to parse Mattermost"
+                                " file upload response."
+                            )
+                            attach_error = True
+                            break
+
+                        if not file_id:
+                            self.logger.warning(
+                                "Mattermost file upload returned no file ID."
+                            )
+                            attach_error = True
+                            break
+
+                        file_ids.append(file_id)
 
                 if attach_error:
                     has_error = True

--- a/apprise/plugins/mattermost.py
+++ b/apprise/plugins/mattermost.py
@@ -486,7 +486,7 @@ class NotifyMattermost(NotifyBase):
                         with attachment.open() as fp:
                             content = fp.read()
 
-                    except OSError as e:
+                    except (OSError, ValueError) as e:
                         self.logger.warning(
                             "An I/O error occurred reading"
                             " Mattermost attachment %s.",

--- a/tests/test_plugin_mattermost.py
+++ b/tests/test_plugin_mattermost.py
@@ -37,6 +37,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment
+from apprise.attachment.memory import AttachMemory
 from apprise.plugins.mattermost import MattermostMode, NotifyMattermost
 
 # Attachment test fixtures
@@ -650,14 +651,15 @@ def test_plugin_mattermost_bot_channel_lookup_partial_success(
 
 
 def test_plugin_mattermost_webhook_attachment_warning(request_post_mock):
-    """Webhook mode logs a warning when attachments are provided."""
+    """Webhook mode has attachment_support=False; pipeline drops attach."""
     obj = Apprise.instantiate("mmost://localhost/token")
     assert isinstance(obj, NotifyMattermost)
     assert obj.mode == MattermostMode.WEBHOOK
+    assert obj.attachment_support is False
 
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
 
-    # Webhook send still succeeds -- attachments are silently skipped
+    # Pipeline silently drops the attachment; text message still succeeds
     assert obj.notify(body="body", title="title", attach=attach) is True
     assert request_post_mock.call_count == 1
 
@@ -973,3 +975,58 @@ def test_plugin_mattermost_bot_attachment_partial_target_failure(
     assert obj.notify(body="body", title="title", attach=attach) is False
     # 1 upload + 1 post (ch1) + 1 upload-fail (ch2) = 3 calls
     assert request_post_mock.call_count == 3
+
+
+def test_plugin_mattermost_bot_attachment_memory_multi_target(
+    request_post_mock,
+):
+    """AttachMemory streams are re-usable across multiple targets."""
+    bearer = "bearerToken"
+    ch1 = "channel-001"
+    ch2 = "channel-002"
+    fid = "fid-mem"
+
+    ac = AttachMemory(
+        content=b"GIF89a\x01\x00\x01\x00\x00\xff\x00,",
+        name="test.gif",
+        mimetype="image/gif",
+    )
+    attach = AppriseAttachment()
+    attach.add(ac)
+
+    def _mk_upload():
+        r = requests.Request()
+        r.status_code = requests.codes.ok
+        r.content = json.dumps({"file_infos": [{"id": fid}]}).encode("utf-8")
+        return r
+
+    def _mk_post():
+        r = requests.Request()
+        r.status_code = requests.codes.created
+        r.content = b"{}"
+        return r
+
+    # 1 attachment x 2 targets = 2 upload + 2 post calls
+    request_post_mock.side_effect = [
+        _mk_upload(),
+        _mk_post(),
+        _mk_upload(),
+        _mk_post(),
+    ]
+
+    obj = Apprise.instantiate(
+        "mmost://localhost/{b}?mode=bot&to={c1},{c2}".format(
+            b=bearer, c1=ch1, c2=ch2
+        )
+    )
+    assert isinstance(obj, NotifyMattermost)
+    assert obj.notify(body="body", title="title", attach=attach) is True
+    assert request_post_mock.call_count == 4
+
+    post1 = json.loads(request_post_mock.call_args_list[1][1]["data"])
+    assert post1["file_ids"] == [fid]
+    assert post1["channel_id"] == ch1
+
+    post2 = json.loads(request_post_mock.call_args_list[3][1]["data"])
+    assert post2["file_ids"] == [fid]
+    assert post2["channel_id"] == ch2

--- a/tests/test_plugin_mattermost.py
+++ b/tests/test_plugin_mattermost.py
@@ -29,13 +29,18 @@ import json
 
 # Disable logging for a cleaner testing output
 import logging
+import os
+from unittest import mock
 
 from helpers import AppriseURLTester
 import pytest
 import requests
 
-from apprise import Apprise
+from apprise import Apprise, AppriseAttachment
 from apprise.plugins.mattermost import MattermostMode, NotifyMattermost
+
+# Attachment test fixtures
+TEST_VAR_DIR = os.path.join(os.path.dirname(__file__), "var")
 
 logging.disable(logging.CRITICAL)
 
@@ -102,7 +107,11 @@ apprise_url_tests = (
             "mmost://localhost/3ccdd113474722377935511fc85d3dd4"
             "?to=test&team=chester"
         ),
-        {"instance": NotifyMattermost},
+        {
+            "instance": NotifyMattermost,
+            # Provide valid upload response so the attachment test passes
+            "requests_response_text": '{"file_infos": [{"id": "abc"}]}',
+        },
     ),
     (
         (
@@ -191,7 +200,11 @@ apprise_url_tests = (
     ("mmost://localhost/token?mode=w", {"instance": NotifyMattermost}),
     (
         "mmost://localhost/token?mode=b&to=channel-id-1",
-        {"instance": NotifyMattermost},
+        {
+            "instance": NotifyMattermost,
+            # Provide valid upload response so the attachment test passes
+            "requests_response_text": '{"file_infos": [{"id": "abc"}]}',
+        },
     ),
     (
         "mmost://localhost/token?mode=invalid",
@@ -634,3 +647,329 @@ def test_plugin_mattermost_bot_channel_lookup_partial_success(
     assert request_post_mock.call_count == 1
     posted_json = json.loads(request_post_mock.call_args_list[0][1]["data"])
     assert posted_json["channel_id"] == "cid-good"
+
+
+def test_plugin_mattermost_webhook_attachment_warning(request_post_mock):
+    """Webhook mode logs a warning when attachments are provided."""
+    obj = Apprise.instantiate("mmost://localhost/token")
+    assert isinstance(obj, NotifyMattermost)
+    assert obj.mode == MattermostMode.WEBHOOK
+
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
+
+    # Webhook send still succeeds -- attachments are silently skipped
+    assert obj.notify(body="body", title="title", attach=attach) is True
+    assert request_post_mock.call_count == 1
+
+    # No file upload should have been attempted
+    assert "files" not in str(request_post_mock.call_args)
+
+
+def test_plugin_mattermost_webhook_botname_in_url(request_post_mock):
+    """Webhook botname is the {user}@ URL prefix; ?botname= is an alias."""
+    # Both input forms resolve to the same object
+    obj = Apprise.instantiate("mmost://mybot@localhost/token?to=general")
+    obj2 = Apprise.instantiate(
+        "mmost://localhost/token?botname=mybot&to=general"
+    )
+    assert isinstance(obj, NotifyMattermost)
+    assert isinstance(obj2, NotifyMattermost)
+    assert obj.mode == MattermostMode.WEBHOOK
+    assert obj.user == "mybot"
+    assert obj2.user == "mybot"
+
+    # url() uses the {user}@ prefix -- consistent with all Apprise plugins
+    url = obj.url()
+    assert "mybot@" in url
+    assert "botname" not in url
+
+    # Round-trip preserves the botname
+    obj3 = Apprise.instantiate(url)
+    assert isinstance(obj3, NotifyMattermost)
+    assert obj3.user == "mybot"
+    assert obj3.mode == MattermostMode.WEBHOOK
+
+    # Webhook payload carries username = botname
+    request_post_mock.return_value.status_code = requests.codes.ok
+    assert obj.notify(body="body", title="title") is True
+    posted = json.loads(request_post_mock.call_args_list[0][1]["data"])
+    assert posted["username"] == "mybot"
+
+
+def test_plugin_mattermost_bot_team_in_url(request_post_mock):
+    """Bot mode team is the {user}@ URL prefix; ?team= is an alias."""
+    obj = Apprise.instantiate("mmost://myteam@localhost/token?mode=bot&to=id1")
+    assert isinstance(obj, NotifyMattermost)
+    assert obj.mode == MattermostMode.BOT
+    assert obj.user == "myteam"
+
+    # url() uses {user}@ prefix for the team too
+    url = obj.url()
+    assert "myteam@" in url
+    assert "mode=bot" in url
+
+
+def test_plugin_mattermost_bot_attachments(request_post_mock):
+    """Bot mode uploads attachments and includes file_ids in the post."""
+    bearer = "bearerToken"
+    channel_id = "channel-id-123"
+    file_id = "uploaded-file-id-abc"
+
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
+
+    def _mk_resp(content, code=requests.codes.ok):
+        r = requests.Request()
+        r.status_code = code
+        r.content = content
+        return r
+
+    upload_resp = _mk_resp(
+        json.dumps({"file_infos": [{"id": file_id}]}).encode("utf-8")
+    )
+    post_resp = _mk_resp(b"{}", requests.codes.created)
+
+    request_post_mock.side_effect = [upload_resp, post_resp]
+
+    obj = Apprise.instantiate(
+        f"mmost://localhost/{bearer}?mode=bot&to={channel_id}"
+    )
+    assert isinstance(obj, NotifyMattermost)
+    assert obj.mode == MattermostMode.BOT
+
+    assert obj.notify(body="body", title="title", attach=attach) is True
+    assert request_post_mock.call_count == 2
+
+    # First call is the file upload
+    upload_call = request_post_mock.call_args_list[0]
+    assert "/api/v4/files" in upload_call[0][0]
+    assert upload_call[1]["data"] == {"channel_id": channel_id}
+    assert "files" in upload_call[1]["files"]
+
+    # Second call is the post; it must include file_ids
+    post_call = request_post_mock.call_args_list[1]
+    assert "/api/v4/posts" in post_call[0][0]
+    post_json = json.loads(post_call[1]["data"])
+    assert post_json["file_ids"] == [file_id]
+    assert post_json["message"] == "title\r\nbody"
+    assert post_json["channel_id"] == channel_id
+
+
+def test_plugin_mattermost_bot_multi_attach_multi_target(request_post_mock):
+    """Multiple attachments and multiple targets each get their own uploads."""
+    bearer = "bearerToken"
+    ch1 = "channel-001"
+    ch2 = "channel-002"
+    fid1 = "fid-001"
+    fid2 = "fid-002"
+
+    attach = AppriseAttachment()
+    attach.add(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
+    attach.add(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
+
+    def _mk_upload(fid):
+        r = requests.Request()
+        r.status_code = requests.codes.ok
+        r.content = json.dumps({"file_infos": [{"id": fid}]}).encode("utf-8")
+        return r
+
+    def _mk_post():
+        r = requests.Request()
+        r.status_code = requests.codes.created
+        r.content = b"{}"
+        return r
+
+    # 2 attachments x 2 targets = 4 upload calls + 2 post calls
+    request_post_mock.side_effect = [
+        _mk_upload(fid1),
+        _mk_upload(fid2),
+        _mk_post(),
+        _mk_upload(fid1),
+        _mk_upload(fid2),
+        _mk_post(),
+    ]
+
+    obj = Apprise.instantiate(
+        "mmost://localhost/{b}?mode=bot&to={c1},{c2}".format(
+            b=bearer, c1=ch1, c2=ch2
+        )
+    )
+    assert isinstance(obj, NotifyMattermost)
+    assert obj.notify(body="body", title="title", attach=attach) is True
+    assert request_post_mock.call_count == 6
+
+    # Verify file_ids for each post
+    post1 = json.loads(request_post_mock.call_args_list[2][1]["data"])
+    assert post1["file_ids"] == [fid1, fid2]
+    assert post1["channel_id"] == ch1
+
+    post2 = json.loads(request_post_mock.call_args_list[5][1]["data"])
+    assert post2["file_ids"] == [fid1, fid2]
+    assert post2["channel_id"] == ch2
+
+
+def test_plugin_mattermost_bot_attachment_upload_http_error(
+    request_post_mock,
+):
+    """Upload HTTP error marks the whole target as failed."""
+    bearer = "bearerToken"
+    channel_id = "channel-id-123"
+
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
+
+    r = requests.Request()
+    r.status_code = requests.codes.internal_server_error
+    r.content = b""
+    request_post_mock.return_value = r
+
+    obj = Apprise.instantiate(
+        f"mmost://localhost/{bearer}?mode=bot&to={channel_id}"
+    )
+    assert isinstance(obj, NotifyMattermost)
+    assert obj.notify(body="body", title="title", attach=attach) is False
+    # Only the upload was attempted; no post was made
+    assert request_post_mock.call_count == 1
+    assert "/api/v4/files" in request_post_mock.call_args_list[0][0][0]
+
+
+def test_plugin_mattermost_bot_attachment_request_exception(
+    request_post_mock,
+):
+    """RequestException during upload marks the target as failed."""
+    bearer = "bearerToken"
+    channel_id = "channel-id-123"
+
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
+
+    request_post_mock.side_effect = requests.RequestException("boom")
+
+    obj = Apprise.instantiate(
+        f"mmost://localhost/{bearer}?mode=bot&to={channel_id}"
+    )
+    assert isinstance(obj, NotifyMattermost)
+    assert obj.notify(body="body", title="title", attach=attach) is False
+    assert request_post_mock.call_count == 1
+
+
+def test_plugin_mattermost_bot_attachment_ioerror(request_post_mock):
+    """OSError reading the attachment marks the target as failed."""
+    bearer = "bearerToken"
+    channel_id = "channel-id-123"
+
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
+
+    with mock.patch(
+        "apprise.attachment.file.AttachFile.open",
+        side_effect=OSError("disk error"),
+    ):
+        obj = Apprise.instantiate(
+            f"mmost://localhost/{bearer}?mode=bot&to={channel_id}"
+        )
+        assert isinstance(obj, NotifyMattermost)
+        assert obj.notify(body="body", title="title", attach=attach) is False
+
+    # No HTTP request should have been made
+    assert request_post_mock.call_count == 0
+
+
+def test_plugin_mattermost_bot_attachment_bad_response(request_post_mock):
+    """Unparseable upload response marks the target as failed."""
+    bearer = "bearerToken"
+    channel_id = "channel-id-123"
+
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
+
+    r = requests.Request()
+    r.status_code = requests.codes.ok
+    r.content = b"not-json{{{"
+    request_post_mock.return_value = r
+
+    obj = Apprise.instantiate(
+        f"mmost://localhost/{bearer}?mode=bot&to={channel_id}"
+    )
+    assert isinstance(obj, NotifyMattermost)
+    assert obj.notify(body="body", title="title", attach=attach) is False
+    assert request_post_mock.call_count == 1
+
+
+def test_plugin_mattermost_bot_attachment_no_file_id(request_post_mock):
+    """Upload response with empty file_id marks the target as failed."""
+    bearer = "bearerToken"
+    channel_id = "channel-id-123"
+
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
+
+    r = requests.Request()
+    r.status_code = requests.codes.ok
+    # file_infos present but id is empty
+    r.content = json.dumps({"file_infos": [{"id": ""}]}).encode("utf-8")
+    request_post_mock.return_value = r
+
+    obj = Apprise.instantiate(
+        f"mmost://localhost/{bearer}?mode=bot&to={channel_id}"
+    )
+    assert isinstance(obj, NotifyMattermost)
+    assert obj.notify(body="body", title="title", attach=attach) is False
+
+
+def test_plugin_mattermost_bot_attachment_invalid(request_post_mock):
+    """An inaccessible attachment path marks the target as failed."""
+    bearer = "bearerToken"
+    channel_id = "channel-id-123"
+
+    attach = AppriseAttachment("/path/does/not/exist.gif")
+
+    obj = Apprise.instantiate(
+        f"mmost://localhost/{bearer}?mode=bot&to={channel_id}"
+    )
+    assert isinstance(obj, NotifyMattermost)
+    assert obj.notify(body="body", title="title", attach=attach) is False
+    # No upload request should be made for an invalid attachment
+    assert request_post_mock.call_count == 0
+
+
+def test_plugin_mattermost_bot_attachment_partial_target_failure(
+    request_post_mock,
+):
+    """Attachment upload failure on one target does not prevent others."""
+    bearer = "bearerToken"
+    ch1 = "channel-001"
+    ch2 = "channel-002"
+    fid = "fid-001"
+
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
+
+    def _mk_upload_ok():
+        r = requests.Request()
+        r.status_code = requests.codes.ok
+        r.content = json.dumps({"file_infos": [{"id": fid}]}).encode("utf-8")
+        return r
+
+    def _mk_upload_fail():
+        r = requests.Request()
+        r.status_code = requests.codes.internal_server_error
+        r.content = b""
+        return r
+
+    def _mk_post():
+        r = requests.Request()
+        r.status_code = requests.codes.created
+        r.content = b"{}"
+        return r
+
+    # ch1: upload ok, post ok; ch2: upload fails
+    request_post_mock.side_effect = [
+        _mk_upload_ok(),
+        _mk_post(),
+        _mk_upload_fail(),
+    ]
+
+    obj = Apprise.instantiate(
+        "mmost://localhost/{b}?mode=bot&to={c1},{c2}".format(
+            b=bearer, c1=ch1, c2=ch2
+        )
+    )
+    assert isinstance(obj, NotifyMattermost)
+    # One target succeeded, one failed -> overall False
+    assert obj.notify(body="body", title="title", attach=attach) is False
+    # 1 upload + 1 post (ch1) + 1 upload-fail (ch2) = 3 calls
+    assert request_post_mock.call_count == 3

--- a/tests/test_plugin_mattermost.py
+++ b/tests/test_plugin_mattermost.py
@@ -37,7 +37,6 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment
-from apprise.attachment.memory import AttachMemory
 from apprise.plugins.mattermost import MattermostMode, NotifyMattermost
 
 # Attachment test fixtures
@@ -980,19 +979,31 @@ def test_plugin_mattermost_bot_attachment_partial_target_failure(
 def test_plugin_mattermost_bot_attachment_memory_multi_target(
     request_post_mock,
 ):
-    """AttachMemory streams are re-usable across multiple targets."""
+    """Attachment bytes are pre-read once so every target gets a fresh stream.
+
+    Simulates an attachment whose open() raises ValueError on the second
+    call (as AttachMemory does when its BytesIO is closed after the first
+    read).  Our pre-read approach calls open() exactly once per attachment
+    before the target loop, then wraps the bytes in a fresh io.BytesIO for
+    each target upload.
+    """
     bearer = "bearerToken"
     ch1 = "channel-001"
     ch2 = "channel-002"
-    fid = "fid-mem"
+    fid = "fid-001"
 
-    ac = AttachMemory(
-        content=b"GIF89a\x01\x00\x01\x00\x00\xff\x00,",
-        name="test.gif",
-        mimetype="image/gif",
-    )
-    attach = AppriseAttachment()
-    attach.add(ac)
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
+
+    # Simulate a stream that closes after the first read: raise ValueError
+    # on any open() call beyond the first.
+    _orig_open = attach.attachments[0].open
+    open_calls = [0]
+
+    def _open_once(*args, **kwargs):
+        open_calls[0] += 1
+        if open_calls[0] > 1:
+            raise ValueError("stream already closed")
+        return _orig_open(*args, **kwargs)
 
     def _mk_upload():
         r = requests.Request()
@@ -1020,7 +1031,13 @@ def test_plugin_mattermost_bot_attachment_memory_multi_target(
         )
     )
     assert isinstance(obj, NotifyMattermost)
-    assert obj.notify(body="body", title="title", attach=attach) is True
+
+    with mock.patch.object(attach.attachments[0], "open", _open_once):
+        assert obj.notify(body="body", title="title", attach=attach) is True
+
+    # open() was called exactly once (pre-read), not once per target
+    assert open_calls[0] == 1
+    # Both targets received their uploads
     assert request_post_mock.call_count == 4
 
     post1 = json.loads(request_post_mock.call_args_list[1][1]["data"])

--- a/tests/test_plugin_mattermost.py
+++ b/tests/test_plugin_mattermost.py
@@ -872,6 +872,26 @@ def test_plugin_mattermost_bot_attachment_ioerror(request_post_mock):
     assert request_post_mock.call_count == 0
 
 
+def test_plugin_mattermost_bot_attachment_valueerror(request_post_mock):
+    """ValueError from a closed stream is handled the same as OSError."""
+    bearer = "bearerToken"
+    channel_id = "channel-id-123"
+
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
+
+    with mock.patch(
+        "apprise.attachment.file.AttachFile.open",
+        side_effect=ValueError("I/O operation on closed file"),
+    ):
+        obj = Apprise.instantiate(
+            f"mmost://localhost/{bearer}?mode=bot&to={channel_id}"
+        )
+        assert isinstance(obj, NotifyMattermost)
+        assert obj.notify(body="body", title="title", attach=attach) is False
+
+    assert request_post_mock.call_count == 0
+
+
 def test_plugin_mattermost_bot_attachment_bad_response(request_post_mock):
     """Unparseable upload response marks the target as failed."""
     bearer = "bearerToken"


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #801

Add file attachment support to the Mattermost plugin via the Bot (REST API) mode.

Mattermost's `/api/v4/files` endpoint accepts multipart uploads. Each file is uploaded once per target channel, and the returned file IDs are included in the `file_ids` field of the `/api/v4/posts` payload. Webhook mode does not support attachments; a warning is logged and the text message is sent without them.

## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/38](https://github.com/caronc/apprise-docs/pull/38)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing

Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@801-mattermost-attachment-support

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    --attach /path/to/file.png \
    'mmosts://your-server/your-bot-token?mode=bot&to=your-channel-id'
```
