### PR TITLE
Matrix Hookshot support added

### DIFF
--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -336,9 +336,10 @@ class NotifyMatrix(NotifyBase):
                 "values": MATRIX_WEBHOOK_MODES,
                 "default": MatrixWebhookMode.DISABLED,
             },
-            "webhook_path": {
+            "path": {
                 "name": _("Webhook Path"),
                 "type": "string",
+                "map_to": "webhook_path",
                 "default": "/webhook",
             },
             "version": {
@@ -434,7 +435,7 @@ class NotifyMatrix(NotifyBase):
 
         # Public webhook path used by matrix-hookshot
         self.webhook_path = (
-            self.template_args["webhook_path"]["default"]
+            self.template_args["path"]["default"]
             if not isinstance(webhook_path, str) or not webhook_path.strip()
             else webhook_path.strip()
         )
@@ -3092,7 +3093,7 @@ class NotifyMatrix(NotifyBase):
         }
 
         if self.mode == MatrixWebhookMode.HOOKSHOT:
-            params["webhook_path"] = self.webhook_path
+            params["path"] = self.webhook_path
 
         if not self.e2ee:
             params["e2ee"] = "no"
@@ -3184,11 +3185,7 @@ class NotifyMatrix(NotifyBase):
             )
         )
 
-        if "webhook_path" in results["qsd"]:
-            results["webhook_path"] = NotifyMatrix.unquote(
-                results["qsd"]["webhook_path"]
-            )
-        elif "path" in results["qsd"]:
+        if "path" in results["qsd"]:
             results["webhook_path"] = NotifyMatrix.unquote(
                 results["qsd"]["path"]
             )

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -155,6 +155,9 @@ class MatrixWebhookMode:
     # Support the t2bot webhook plugin
     T2BOT = "t2bot"
 
+    # Support matrix-hookshot generic webhooks
+    HOOKSHOT = "hookshot"
+
 
 # webhook modes are placed into this list for validation purposes
 MATRIX_WEBHOOK_MODES = (
@@ -162,6 +165,7 @@ MATRIX_WEBHOOK_MODES = (
     MatrixWebhookMode.MATRIX,
     MatrixWebhookMode.SLACK,
     MatrixWebhookMode.T2BOT,
+    MatrixWebhookMode.HOOKSHOT,
 )
 
 
@@ -236,7 +240,8 @@ class NotifyMatrix(NotifyBase):
 
     # Define object templates
     templates = (
-        # Targets are ignored when using t2bot mode; only a token is required
+        # Targets are ignored when using t2bot/hookshot mode; only a token is
+        # required
         "{schema}://{token}",
         "{schema}://{user}@{token}",
         # Matrix Server
@@ -331,6 +336,11 @@ class NotifyMatrix(NotifyBase):
                 "values": MATRIX_WEBHOOK_MODES,
                 "default": MatrixWebhookMode.DISABLED,
             },
+            "webhook_path": {
+                "name": _("Webhook Path"),
+                "type": "string",
+                "default": "/webhook",
+            },
             "version": {
                 "name": _("Matrix API Verion"),
                 "type": "choice:string",
@@ -366,6 +376,7 @@ class NotifyMatrix(NotifyBase):
         include_image=None,
         discovery=None,
         hsreq=None,
+        webhook_path=None,
         e2ee=None,
         **kwargs,
     ):
@@ -420,6 +431,16 @@ class NotifyMatrix(NotifyBase):
         self.hsreq = (
             self.template_args["hsreq"]["default"] if hsreq is None else hsreq
         )
+
+        # Public webhook path used by matrix-hookshot
+        self.webhook_path = (
+            self.template_args["webhook_path"]["default"]
+            if not isinstance(webhook_path, str) or not webhook_path.strip()
+            else webhook_path.strip()
+        )
+        if not self.webhook_path.startswith("/"):
+            self.webhook_path = f"/{self.webhook_path}"
+        self.webhook_path = self.webhook_path.rstrip("/") or "/"
 
         # End-to-end encryption (server mode only; requires cryptography)
         self.e2ee = (
@@ -555,7 +576,31 @@ class NotifyMatrix(NotifyBase):
             "Content-Type": "application/json",
         }
 
-        if self.mode != MatrixWebhookMode.T2BOT:
+        if self.mode == MatrixWebhookMode.T2BOT:
+            #
+            # t2bot Setup
+            #
+
+            # Prepare our URL
+            url = (
+                "https://webhooks.t2bot.io/api/v1/matrix/hook/"
+                f"{self.access_token}"
+            )
+
+        elif self.mode == MatrixWebhookMode.HOOKSHOT:
+            # Acquire our access token from our URL
+            access_token = self.password if self.password else self.user
+
+            # Prepare our public hookshot URL
+            url = "{schema}://{hostname}{port}{webhook_path}/{token}".format(
+                schema="https" if self.secure else "http",
+                hostname=self.host,
+                port=("" if not self.port else f":{self.port}"),
+                webhook_path=self.webhook_path.rstrip("/"),
+                token=access_token,
+            )
+
+        else:
             # Acquire our access token from our URL
             access_token = self.password if self.password else self.user
 
@@ -566,17 +611,6 @@ class NotifyMatrix(NotifyBase):
                 port=("" if not self.port else f":{self.port}"),
                 webhook_path=MATRIX_V1_WEBHOOK_PATH,
                 token=access_token,
-            )
-
-        else:
-            #
-            # t2bot Setup
-            #
-
-            # Prepare our URL
-            url = (
-                "https://webhooks.t2bot.io/api/v1/matrix/hook/"
-                f"{self.access_token}"
             )
 
         # Retrieve our payload
@@ -745,6 +779,46 @@ class NotifyMatrix(NotifyBase):
         if image_url:
             # t2bot can take an avatarUrl Entry
             payload["avatarUrl"] = image_url
+
+        return payload
+
+    def _hookshot_webhook_payload(
+        self, body, title="", notify_type=NotifyType.INFO, **kwargs
+    ):
+        """Format the payload for a matrix-hookshot webhook."""
+
+        payload = {
+            "username": self.user if self.user else self.app_id,
+            "text": "",
+        }
+
+        if self.notify_format == NotifyFormat.HTML:
+            payload["text"] = body if not title else f"{title}\r\n{body}"
+            payload["html"] = "{title}{body}".format(
+                title=(
+                    ""
+                    if not title
+                    else f"<h1>{NotifyMatrix.escape_html(title)}</h1>"
+                ),
+                body=body,
+            )
+
+        elif self.notify_format == NotifyFormat.MARKDOWN:
+            payload["text"] = body if not title else f"{title}\r\n{body}"
+            payload["html"] = "{title}{body}".format(
+                title=(
+                    ""
+                    if not title
+                    else f"<h1>{NotifyMatrix.escape_html(title)}</h1>"
+                ),
+                body=markdown(body),
+            )
+
+        else:  # NotifyFormat.TEXT
+            payload["text"] = body if not title else f"{title}\r\n{body}"
+            payload["html"] = NotifyMatrix.escape_html(
+                payload["text"], convert_new_lines=True, whitespace=False
+            )
 
         return payload
 
@@ -2986,6 +3060,11 @@ class NotifyMatrix(NotifyBase):
                 else self.access_token
             ),
             self.port if self.port else (443 if self.secure else 80),
+            (
+                self.webhook_path
+                if self.mode == MatrixWebhookMode.HOOKSHOT
+                else None
+            ),
             self.user if self.mode != MatrixWebhookMode.T2BOT else None,
             self.password if self.mode != MatrixWebhookMode.T2BOT else None,
         )
@@ -3011,6 +3090,9 @@ class NotifyMatrix(NotifyBase):
             "discovery": "yes" if self.discovery else "no",
             "hsreq": "yes" if self.hsreq else "no",
         }
+
+        if self.mode == MatrixWebhookMode.HOOKSHOT:
+            params["webhook_path"] = self.webhook_path
 
         if not self.e2ee:
             params["e2ee"] = "no"
@@ -3101,6 +3183,15 @@ class NotifyMatrix(NotifyBase):
                 NotifyMatrix.template_args["hsreq"]["default"],
             )
         )
+
+        if "webhook_path" in results["qsd"]:
+            results["webhook_path"] = NotifyMatrix.unquote(
+                results["qsd"]["webhook_path"]
+            )
+        elif "path" in results["qsd"]:
+            results["webhook_path"] = NotifyMatrix.unquote(
+                results["qsd"]["path"]
+            )
 
         # E2EE flag
         if "e2ee" in results["qsd"]:

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -209,7 +209,7 @@ apprise_url_tests = (
     (
         (
             "matrixs://hookuser:hooktoken@hookshot.example"
-            "?mode=hookshot&webhook_path=%2Fpublic-hooks"
+            "?mode=hookshot&path=%2Fpublic-hooks"
         ),
         {
             "instance": NotifyMatrix,
@@ -1798,7 +1798,7 @@ def test_plugin_matrix_hookshot_webhook(mock_post):
 
     obj = Apprise.instantiate(
         "matrixs://apprise:supersecret@hookshot.example"
-        "?mode=hookshot&format=html&webhook_path=%2Fpublic-hooks"
+        "?mode=hookshot&format=html&path=%2Fpublic-hooks"
     )
     assert obj is not None
 
@@ -1825,7 +1825,7 @@ def test_plugin_matrix_hookshot_webhook_empty_title(mock_post):
 
     obj = Apprise.instantiate(
         "matrixs://apprise:supersecret@hookshot.example"
-        "?mode=hookshot&format=markdown&webhook_path=%2Fpublic-hooks"
+        "?mode=hookshot&format=markdown&path=%2Fpublic-hooks"
     )
     assert obj is not None
 
@@ -1842,7 +1842,7 @@ def test_plugin_matrix_hookshot_path_normalization():
 
     obj = Apprise.instantiate(
         "matrixs://apprise:supersecret@hookshot.example"
-        "?mode=hookshot&webhook_path=public-hooks"
+        "?mode=hookshot&path=public-hooks"
     )
     assert obj is not None
     assert obj.webhook_path == "/public-hooks"
@@ -1859,7 +1859,7 @@ def test_plugin_matrix_hookshot_root_path_text(mock_post):
 
     obj = Apprise.instantiate(
         "matrixs://apprise:supersecret@hookshot.example"
-        "?mode=hookshot&format=text&webhook_path=%2F"
+        "?mode=hookshot&format=text&path=%2F"
     )
     assert obj is not None
     assert obj.notify(body="<b>Body</b>") is True

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -206,6 +206,28 @@ apprise_url_tests = (
             "privacy_url": "matrix://b...b/",
         },
     ),
+    (
+        (
+            "matrixs://hookuser:hooktoken@hookshot.example"
+            "?mode=hookshot&webhook_path=%2Fpublic-hooks"
+        ),
+        {
+            "instance": NotifyMatrix,
+            "privacy_url": (
+                "matrixs://hookuser:****@hookshot.example/"
+                "?image=no&mode=hookshot"
+            ),
+        },
+    ),
+    (
+        (
+            "matrixs://hookuser:hooktoken@hookshot.example"
+            "?mode=hookshot&path=public-hooks"
+        ),
+        {
+            "instance": NotifyMatrix,
+        },
+    ),
     # Image Reference
     (
         "matrixs://user:token@localhost?mode=slack&format=markdown&image=True",
@@ -1762,6 +1784,91 @@ def test_plugin_matrix_parse_native_url_no_match():
     assert (
         NotifyMatrix.parse_native_url("https://not-a-t2bot-url.com/some/path")
         is None
+    )
+
+
+@mock.patch("requests.post")
+def test_plugin_matrix_hookshot_webhook(mock_post):
+    """matrix-hookshot webhook mode uses hookshot URL/payload conventions."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = b"{}"
+    mock_post.return_value = response
+
+    obj = Apprise.instantiate(
+        "matrixs://apprise:supersecret@hookshot.example"
+        "?mode=hookshot&format=html&webhook_path=%2Fpublic-hooks"
+    )
+    assert obj is not None
+
+    assert obj.notify(title="Title", body="<b>Body</b>") is True
+
+    assert mock_post.call_args.args[0] == (
+        "https://hookshot.example/public-hooks/supersecret"
+    )
+
+    payload = loads(mock_post.call_args.kwargs["data"])
+    assert payload["username"] == "apprise"
+    assert payload["text"] == "Title\r\n<b>Body</b>"
+    assert payload["html"] == "<h1>Title</h1><b>Body</b>"
+
+
+@mock.patch("requests.post")
+def test_plugin_matrix_hookshot_webhook_empty_title(mock_post):
+    """Hookshot webhook mode avoids extra separators for empty titles."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = b"{}"
+    mock_post.return_value = response
+
+    obj = Apprise.instantiate(
+        "matrixs://apprise:supersecret@hookshot.example"
+        "?mode=hookshot&format=markdown&webhook_path=%2Fpublic-hooks"
+    )
+    assert obj is not None
+
+    assert obj.notify(body="**Body**") is True
+
+    payload = loads(mock_post.call_args.kwargs["data"])
+    assert payload["username"] == "apprise"
+    assert payload["text"] == "**Body**"
+    assert payload["html"] == "<p><strong>Body</strong></p>"
+
+
+def test_plugin_matrix_hookshot_path_normalization():
+    """Hookshot webhook paths normalize missing leading slashes."""
+
+    obj = Apprise.instantiate(
+        "matrixs://apprise:supersecret@hookshot.example"
+        "?mode=hookshot&webhook_path=public-hooks"
+    )
+    assert obj is not None
+    assert obj.webhook_path == "/public-hooks"
+
+
+@mock.patch("requests.post")
+def test_plugin_matrix_hookshot_root_path_text(mock_post):
+    """Hookshot root paths and text mode stay literal."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = b"{}"
+    mock_post.return_value = response
+
+    obj = Apprise.instantiate(
+        "matrixs://apprise:supersecret@hookshot.example"
+        "?mode=hookshot&format=text&webhook_path=%2F"
+    )
+    assert obj is not None
+    assert obj.notify(body="<b>Body</b>") is True
+
+    assert mock_post.call_args.args[0] == (
+        "https://hookshot.example/supersecret"
+    )
+    assert loads(mock_post.call_args.kwargs["data"])["html"] == (
+        "&lt;b&gt;Body&lt;/b&gt;"
     )
 
 


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1484

Adds Matrix Hookshot generic webhook support.

## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/39](https://github.com/caronc/apprise-docs/pull/39)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Validated locally with:

```bash
tox -e lint
tox -e qa
```

Other testing:
```bash
# Default Hookshot public webhook path: /webhook/{token}
apprise -vv -t "Test Message Title" -b "Test Message Body" \
  "matrixs://apprise:HOOKSHOT_TOKEN@hookshot.example.com?mode=hookshot"

# Custom Hookshot public webhook path: /public-hooks/{token}
apprise -vv -t "Test Message Title" -b "Test Message Body" \
  "matrixs://apprise:HOOKSHOT_TOKEN@hookshot.example.com?mode=hookshot&path=/public-hooks"
```