### PR TITLE
Mastodon supports hashtag/user references

### DIFF
--- a/apprise/plugins/mastodon.py
+++ b/apprise/plugins/mastodon.py
@@ -53,6 +53,18 @@ USER_DETECTION_RE = re.compile(
     r"(@[A-Z0-9_]+(?:@[A-Z0-9_.-]+)?)(?=$|[\s,.&()\[\]]+)", re.I
 )
 
+MENTION_DETECTION_RE = re.compile(
+    r"(?<![\w@])(@[A-Z0-9_]+(?:@[A-Z0-9_.-]+)?)(?=$|[\s,.&()\[\]<>]+)",
+    re.I,
+)
+
+HASHTAG_DETECTION_RE = re.compile(
+    r"(?<![#%\w])(#[^\W_][\w]*)(?![#%\w])",
+    re.I,
+)
+
+HASHTAG_VALUE_RE = re.compile(r"^[^\W_][\w]*$", re.I)
+
 
 class MastodonMessageVisibility:
     """The visibility of any status message made."""
@@ -236,6 +248,13 @@ class NotifyMastodon(NotifyBase):
                 "type": "bool",
                 "default": True,
             },
+            # Explicit mention and hashtag targets. Examples:
+            #  - ping=@caronc,@alice@example.com
+            #  - ping=#apprise,#notifications
+            "ping": {
+                "name": _("Ping Users/Tags"),
+                "type": "list:string",
+            },
         },
     )
 
@@ -250,6 +269,7 @@ class NotifyMastodon(NotifyBase):
         cache=True,
         key=None,
         language=None,
+        ping=None,
         **kwargs,
     ):
         """Initialize Notify Mastodon Object."""
@@ -331,6 +351,8 @@ class NotifyMastodon(NotifyBase):
 
         # Our target users
         self.targets = []
+        self.tags = []
+        tag_seen = set()
 
         # Track any errors
         has_error = False
@@ -342,12 +364,20 @@ class NotifyMastodon(NotifyBase):
                 self.targets.append("@" + match.group("user"))
                 continue
 
+            normalized = self.normalize_ping_token(target)
+            if normalized and normalized.startswith("#"):
+                key = normalized.casefold()
+                if key not in tag_seen:
+                    tag_seen.add(key)
+                    self.tags.append(normalized)
+                continue
+
             has_error = True
             self.logger.warning(
                 f"Dropped invalid Mastodon user ({target}) specified.",
             )
 
-        if has_error and not self.targets:
+        if has_error and not (self.targets or self.tags):
             # We have specified that we want to notify one or more individual
             # and we failed to load any of them.  Since it's also valid to
             # notify no one at all (which means we notify ourselves), it's
@@ -355,6 +385,19 @@ class NotifyMastodon(NotifyBase):
             msg = "No Mastodon targets to notify."
             self.logger.warning(msg)
             raise TypeError(msg)
+
+        # Ping targets (tokens from URL, already split by parse_list)
+        self.ping = []
+        ping_seen = set()
+        for target in parse_list(ping):
+            normalized = self.normalize_ping_token(target)
+            if not normalized:
+                continue
+
+            key = normalized.casefold()
+            if key not in ping_seen:
+                ping_seen.add(key)
+                self.ping.append(normalized)
 
         return
 
@@ -397,6 +440,9 @@ class NotifyMastodon(NotifyBase):
             # Override Language
             params["language"] = self.language
 
+        if self.ping:
+            params["ping"] = ",".join(self.ping)
+
         default_port = 443 if self.secure else 80
         return "{schema}://{token}@{host}{port}/{targets}?{params}".format(
             schema=(
@@ -413,7 +459,10 @@ class NotifyMastodon(NotifyBase):
                 else f":{self.port}"
             ),
             targets="/".join(
-                [NotifyMastodon.quote(x, safe="@") for x in self.targets]
+                [
+                    NotifyMastodon.quote(x, safe="@")
+                    for x in self.targets + self.tags
+                ]
             ),
             params=NotifyMastodon.urlencode(params),
         )
@@ -436,25 +485,21 @@ class NotifyMastodon(NotifyBase):
         # Build a list of our attachments
         attachments = []
 
-        # Smart Target Detection for Direct Messages; this prevents us from
-        # adding @user entries that were already placed in the message body
-        users = set(USER_DETECTION_RE.findall(body))
-        targets = users - set(self.targets.copy())
-        if (
-            not self.targets
-            and self.visibility == MastodonMessageVisibility.DIRECT
-        ):
-            result = self._whoami()
-            if not result:
-                # Could not access our status
-                return False
+        targets = set()
+        if self.visibility == MastodonMessageVisibility.DIRECT:
+            # Smart Target Detection for Direct Messages; this prevents us
+            # from adding @user entries that were already placed in the body.
+            users = set(USER_DETECTION_RE.findall(body))
+            targets = set(self.targets) - users
+            if not self.targets:
+                result = self._whoami()
+                if not result:
+                    # Could not access our status
+                    return False
 
-            myself = "@" + next(iter(result.keys()))
-            if myself in users:
-                targets.remove(myself)
-
-            else:
-                targets.add(myself)
+                myself = "@" + next(iter(result.keys()))
+                if myself not in users:
+                    targets.add(myself)
 
         if attach and self.attachment_support:
             # We need to upload our payload first so that we can source it
@@ -565,10 +610,39 @@ class NotifyMastodon(NotifyBase):
                 # Save our pre-prepared payload for attachment posting
                 attachments.append(response)
 
+        ping_tokens = []
+        seen = {target.casefold() for target in targets}
+        if self.notify_format == NotifyFormat.TEXT:
+            self.ping_tokens(body, seen=seen)
+
+        # Markdown content can carry visible mention and hashtag tokens.
+        # Other formats only append explicitly configured ping values.
+        if self.notify_format == NotifyFormat.MARKDOWN:
+            ping_tokens.extend(self.ping_tokens(body, seen=seen))
+            if self.targets or self.tags or self.ping:
+                ping_tokens.extend(
+                    self.ping_tokens(
+                        " ".join(self.targets + self.tags + self.ping),
+                        normalize=True,
+                        seen=seen,
+                    )
+                )
+
+        # Non-markdown content is not scanned for mention or hashtag tokens.
+        elif self.targets or self.tags or self.ping:
+            ping_tokens.extend(
+                self.ping_tokens(
+                    " ".join(self.targets + self.tags + self.ping),
+                    normalize=True,
+                    seen=seen,
+                )
+            )
+
+        status = "{} {}".format(" ".join(targets), body) if targets else body
+        status += self.ping_payload(ping_tokens)
+
         payload = {
-            "status": (
-                "{} {}".format(" ".join(targets), body) if targets else body
-            ),
+            "status": status,
             "sensitive": self.sensitive,
         }
 
@@ -783,6 +857,79 @@ class NotifyMastodon(NotifyBase):
             )
 
         return not has_error
+
+    def ping_tokens(self, *args, normalize=False, seen=None):
+        """
+        Takes one or more strings and returns Mastodon-recognizable mention
+        and hashtag tokens detected within.
+        """
+
+        results = []
+        seen = seen if seen is not None else set()
+
+        for arg in args:
+            if normalize:
+                for token in parse_list(arg):
+                    normalized = self.normalize_ping_token(token)
+                    if not normalized:
+                        continue
+
+                    key = normalized.casefold()
+                    if key not in seen:
+                        seen.add(key)
+                        results.append(normalized)
+
+                continue
+
+            for token in MENTION_DETECTION_RE.findall(arg):
+                key = token.casefold()
+                if key not in seen:
+                    seen.add(key)
+                    results.append(token)
+
+            for token in HASHTAG_DETECTION_RE.findall(arg):
+                if not self.valid_hashtag(token):
+                    continue
+
+                key = token.casefold()
+                if key not in seen:
+                    seen.add(key)
+                    results.append(token)
+
+        return results
+
+    @staticmethod
+    def ping_payload(tokens):
+        """Return a status suffix from one or more ping tokens."""
+
+        return (" " + " ".join(tokens)) if tokens else ""
+
+    @staticmethod
+    def normalize_ping_token(token):
+        """Normalize a configured ping token into a mention or hashtag."""
+
+        token = token.strip()
+        if not token:
+            return None
+
+        match = IS_USER.match(token)
+        if match and token.startswith("@") and match.group("user"):
+            return "@" + match.group("user")
+
+        if token.startswith("#"):
+            return token if NotifyMastodon.valid_hashtag(token) else None
+
+        return None
+
+    @staticmethod
+    def valid_hashtag(token):
+        """Return True if a token is a valid Mastodon hashtag."""
+
+        value = token[1:] if token.startswith("#") else token
+        if not HASHTAG_VALUE_RE.match(value):
+            return False
+
+        return not value.replace("_", "").isdecimal()
 
     def _whoami(self, lazy=True):
         """Looks details of current authenticated user."""
@@ -999,6 +1146,10 @@ class NotifyMastodon(NotifyBase):
     def parse_url(url):
         """Parses the URL and returns enough arguments that can allow us to re-
         instantiate this object."""
+        if isinstance(url, str):
+            base, sep, query = url.partition("?")
+            url = base.replace("/#", "/%23") + sep + query
+
         results = NotifyBase.parse_url(url)
         if not results:
             # We're done early as we couldn't load the results
@@ -1040,6 +1191,10 @@ class NotifyMastodon(NotifyBase):
             results["language"] = NotifyMastodon.unquote(
                 results["qsd"]["language"]
             )
+
+        # Extract ping targets, comma/space separated
+        if "ping" in results["qsd"]:
+            results["ping"] = NotifyMastodon.unquote(results["qsd"]["ping"])
 
         # Get Sensitive Flag (for Attachments)
         results["sensitive"] = parse_bool(

--- a/apprise/plugins/mastodon.py
+++ b/apprise/plugins/mastodon.py
@@ -144,7 +144,7 @@ class NotifyMastodon(NotifyBase):
     title_maxlen = 0
 
     # The maximum size of the message
-    body_maxlen = 500
+    mastodon_body_maxlen = 500
 
     # Default to text
     notify_format = NotifyFormat.TEXT
@@ -374,7 +374,7 @@ class NotifyMastodon(NotifyBase):
 
             has_error = True
             self.logger.warning(
-                f"Dropped invalid Mastodon user ({target}) specified.",
+                f"Dropped invalid Mastodon target ({target}) specified.",
             )
 
         if has_error and not (self.targets or self.tags):
@@ -413,6 +413,18 @@ class NotifyMastodon(NotifyBase):
             self.token,
             self.host,
             self.port if self.port else (443 if self.secure else 80),
+        )
+
+    @property
+    def body_maxlen(self):
+        """Return the body space available after configured status tokens."""
+
+        tokens = self.ping_tokens(
+            " ".join(self.targets + self.tags + self.ping),
+            normalize=True,
+        )
+        return max(
+            self.mastodon_body_maxlen - len(self.ping_payload(tokens)), 0
         )
 
     def url(self, privacy=False, *args, **kwargs):
@@ -489,7 +501,7 @@ class NotifyMastodon(NotifyBase):
         if self.visibility == MastodonMessageVisibility.DIRECT:
             # Smart Target Detection for Direct Messages; this prevents us
             # from adding @user entries that were already placed in the body.
-            users = set(USER_DETECTION_RE.findall(body))
+            users = set(MENTION_DETECTION_RE.findall(body))
             targets = set(self.targets) - users
             if not self.targets:
                 result = self._whoami()

--- a/tests/test_plugin_mastodon.py
+++ b/tests/test_plugin_mastodon.py
@@ -36,7 +36,7 @@ from unittest import mock
 from helpers import AppriseURLTester
 import requests
 
-from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise import Apprise, AppriseAttachment, NotifyFormat, NotifyType
 from apprise.plugins.mastodon import NotifyMastodon
 
 logging.disable(logging.CRITICAL)
@@ -362,6 +362,211 @@ def test_plugin_mastodon_general(mock_post, mock_get):
         mock_get.call_args_list[0][0][0]
         == "https://host/api/v1/accounts/verify_credentials"
     )
+
+
+@mock.patch("requests.post")
+def test_plugin_mastodon_pings(mock_post):
+    """NotifyMastodon() Ping Checks."""
+    token = "access_key"
+    host = "nuxref.com"
+
+    request = mock.Mock()
+    request.content = dumps({})
+    request.status_code = requests.codes.ok
+    request.headers = {}
+
+    mock_post.return_value = request
+
+    body = (
+        "Body **#déjà_vu** and @abc, plus #再会. "
+        "Ignore ##bad, #bad%, #123, email@miss, and duplicate "
+        "@abc #déjà_vu."
+    )
+
+    obj = NotifyMastodon(
+        token=token,
+        host=host,
+        format=NotifyFormat.MARKDOWN,
+        ping="@abc,#déjà_vu,#radarr,radarr,#123,bad%",
+    )
+
+    assert obj.send(body=body) is True
+    assert mock_post.call_count == 1
+
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+
+    # Mentions and hashtags are appended in a plain form Mastodon can resolve.
+    assert payload["status"] == f"{body} @abc #déjà_vu #再会 #radarr"
+
+    mock_post.reset_mock()
+
+    body = "Body with #solo only."
+
+    obj = NotifyMastodon(
+        token=token,
+        host=host,
+        format=NotifyFormat.MARKDOWN,
+    )
+
+    assert obj.send(body=body) is True
+    assert mock_post.call_count == 1
+
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+
+    # Markdown statuses can contribute visible mention and hashtag tokens.
+    assert payload["status"] == f"{body} #solo"
+
+    mock_post.reset_mock()
+
+    body = "<p>No tags in this formatted body.</p>"
+
+    obj = NotifyMastodon(
+        token=token,
+        host=host,
+        format=NotifyFormat.HTML,
+    )
+
+    assert obj.send(body=body) is True
+    assert mock_post.call_count == 1
+
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+
+    # When no valid tag tokens are found, the status is not decorated.
+    assert payload["status"] == body
+
+    mock_post.reset_mock()
+
+    obj = NotifyMastodon(
+        token=token,
+        host=host,
+        ping="@caronc,#apprise,#alerts",
+    )
+
+    assert isinstance(obj.url(), str)
+    assert "ping=" in obj.url()
+
+    results = NotifyMastodon.parse_url(obj.url())
+    assert results["ping"] == "#alerts,#apprise,@caronc"
+
+    assert NotifyMastodon.normalize_ping_token(" ") is None
+    assert NotifyMastodon.normalize_ping_token("alerts") is None
+    assert NotifyMastodon.valid_hashtag("#bad%") is False
+    assert obj.ping_tokens("bad%", normalize=True) == []
+
+    obj = NotifyMastodon(
+        token=token,
+        host=host,
+        targets="#Apprise,#apprise",
+        ping="#Media,#media",
+    )
+    assert obj.tags == ["#Apprise"]
+    assert obj.ping == ["#Media"]
+
+    mock_post.reset_mock()
+
+    results = NotifyMastodon.parse_url(
+        f"mastodon://{token}@{host}/#apprise?ping=#apprise,#media"
+    )
+    obj = NotifyMastodon(**results)
+
+    assert obj.send(body="Body") is True
+    assert mock_post.call_count == 1
+
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+
+    # Hashtag path entries and configured pings share de-duplication.
+    assert payload["status"] == "Body #apprise #media"
+
+    rebuilt_url = obj.url()
+    assert "/%23apprise" in rebuilt_url
+    assert "ping=%23apprise%2C%23media" in rebuilt_url
+
+    results = NotifyMastodon.parse_url(rebuilt_url)
+    assert results["targets"] == ["#apprise"]
+    assert results["ping"] == "#apprise,#media"
+
+
+@mock.patch("requests.post")
+def test_plugin_mastodon_text(mock_post):
+    """NotifyMastodon() Text Checks."""
+    token = "access_key"
+    host = "nuxref.com"
+
+    request = mock.Mock()
+    request.content = dumps({})
+    request.status_code = requests.codes.ok
+    request.headers = {}
+
+    mock_post.return_value = request
+
+    body = "Plain text keeps #déjà_vu and @abc exactly where they are."
+
+    obj = NotifyMastodon(
+        token=token,
+        host=host,
+        format=NotifyFormat.TEXT,
+    )
+
+    assert obj.send(body=body) is True
+    assert mock_post.call_count == 1
+
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+
+    # Plain text is already suitable for Mastodon and is left untouched.
+    assert payload["status"] == body
+
+    mock_post.reset_mock()
+
+    obj = NotifyMastodon(
+        token=token,
+        host=host,
+        format=NotifyFormat.TEXT,
+        targets="@media,#homeassistant",
+        ping="radarr,@media,#homeassistant,#alerts,#123,bad%",
+    )
+
+    assert obj.send(body=body) is True
+    assert mock_post.call_count == 1
+
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+
+    # Explicit path entries and ping values are appended without scanning for
+    # new plain text body tokens.
+    assert payload["status"] == f"{body} #alerts #homeassistant @media"
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_mastodon_direct(mock_post, mock_get):
+    """NotifyMastodon() Direct Checks."""
+    token = "access_key"
+    host = "nuxref.com"
+
+    request = mock.Mock()
+    request.content = dumps({})
+    request.status_code = requests.codes.ok
+    request.headers = {}
+
+    mock_post.return_value = request
+
+    body = "Direct body already contains @target."
+
+    obj = NotifyMastodon(
+        token=token,
+        host=host,
+        targets="@target",
+        visibility="direct",
+    )
+
+    assert obj.send(body=body) is True
+    assert mock_post.call_count == 1
+    assert mock_get.call_count == 0
+
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+
+    # Explicit direct targets do not require a lookup for the authenticated
+    # account, and duplicate body mentions are not prepended.
+    assert payload["status"] == body
 
 
 @mock.patch("requests.post")

--- a/tests/test_plugin_mastodon.py
+++ b/tests/test_plugin_mastodon.py
@@ -485,6 +485,20 @@ def test_plugin_mastodon_pings(mock_post):
     assert results["targets"] == ["#apprise"]
     assert results["ping"] == "#apprise,#media"
 
+    mock_post.reset_mock()
+
+    obj = NotifyMastodon(token=token, host=host, ping="#apprise")
+
+    assert obj.send(body="a" * obj.body_maxlen) is True
+    assert mock_post.call_count == 1
+
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+
+    # The effective body limit reserves room for configured status tokens.
+    assert obj.body_maxlen == obj.mastodon_body_maxlen - len(" #apprise")
+    assert len(payload["status"]) == obj.mastodon_body_maxlen
+    assert payload["status"].endswith(" #apprise")
+
 
 @mock.patch("requests.post")
 def test_plugin_mastodon_text(mock_post):
@@ -567,6 +581,26 @@ def test_plugin_mastodon_direct(mock_post, mock_get):
     # Explicit direct targets do not require a lookup for the authenticated
     # account, and duplicate body mentions are not prepended.
     assert payload["status"] == body
+
+    mock_post.reset_mock()
+
+    body = "Direct body contains email@target only."
+
+    obj = NotifyMastodon(
+        token=token,
+        host=host,
+        targets="@target",
+        visibility="direct",
+    )
+
+    assert obj.send(body=body) is True
+    assert mock_post.call_count == 1
+    assert mock_get.call_count == 0
+
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+
+    # Email-like text is not treated as a delivered direct-message mention.
+    assert payload["status"] == f"@target {body}"
 
 
 @mock.patch("requests.post")


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1571

Adds explicit Mastodon mention and hashtag support through URL configuration.

This change allows Mastodon URLs to include resolvable user and hashtag references in two ways:

- Path entries:
  - `/@user`
  - `/%23hashtag`
- Query entries:
  - `?ping=@user,#hashtag`

Mastodon resolves mentions and hashtags from the submitted `status` text, so configured entries are appended to the final status when they are not already present. This applies even in plain text mode, where the body is otherwise left unscanned for new mentions or hashtags.

## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/40](https://github.com/caronc/apprise-docs/pull/40)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1571-mastodon-hashtag-support

# Send a status with explicit path references
apprise -vv -t "Test Title" -b "Test Message" \
    "mastodons://TOKEN@HOST/@caronc/%23apprise"

# Send a status with explicit ping references
apprise -vv -t "Test Title" -b "Test Message" \
    "mastodons://TOKEN@HOST?ping=@caronc,#apprise"

# If you have cloned the branch and have tox available to you:
tox -e minimal -- -k mastodon
tox -e format
```
