### PR TITLE
PushPlus refactored to support more options

### DIFF
--- a/apprise/plugins/pushplus.py
+++ b/apprise/plugins/pushplus.py
@@ -26,23 +26,144 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# Details at:
-# https://www.pushplus.plus/doc/guide/api.html
+# PushPlus is a Chinese notification platform that delivers messages via
+# WeChat and several other channels.  You can find its API documentation at:
+#   https://www.pushplus.plus/doc/guide/api.html
+#
+# To obtain your personal token:
+#   1. Register or sign in at https://www.pushplus.plus/
+#   2. Copy the token shown on the dashboard under the "Push" section.
+#
+# Group (topic) sending is also supported.  After creating a group under
+# "Group Push" in the PushPlus console, use the group code as the topic:
+#   https://www.pushplus.plus/doc/guide/group.html
+#
+# Basic Apprise URL forms:
+#
+#   Personal notification (WeChat default):
+#     pushplus://{token}
+#
+#   Group topic -- one notification per topic:
+#     pushplus://{token}/{topic}
+#     pushplus://{token}/{topic1}/{topic2}
+#
+#   Select a delivery channel (mode= and channel= are synonyms):
+#     pushplus://{token}?channel=mail
+#     pushplus://{token}?mode=cp
+#
+#   Topic + delivery channel:
+#     pushplus://{token}/{topic}?channel=mail
+#
+#   Webhook channel with a named endpoint:
+#     pushplus://{token}?channel=webhook&name={webhook_name}
+#
+#   Native PushPlus API URL (also accepted by parse_native_url):
+#     https://www.pushplus.plus/send?token={token}
+#
+# Schema alias for WeCom users:
+#   wecom://{token}    -- identical to pushplus://{token}?channel=cp
+#
+# Note: wechat:// is reserved for a future direct WeChat Official Account
+# API plugin and is not supported here.
+#
+# API References:
+#   https://www.pushplus.plus/doc/guide/api.html
+#   https://www.pushplus.plus/doc/guide/group.html
 
 import json
 import re
 
 import requests
 
-from ..common import NotifyType
+from ..common import NotifyFormat, NotifyType
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
-from ..utils.parse import validate_regex
+from ..utils.parse import parse_list, validate_regex
 from .base import NotifyBase
+
+# PushPlus application-level response codes.
+# The HTTP status is always 200; the real result lives in the JSON body.
+# Reference: https://www.pushplus.plus/doc/guide/api.html
+PUSHPLUS_RESPONSE_CODES = {
+    200: "Request succeeded.",
+    900: "System exception.",
+    903: "Sending failed.",
+    905: "Request parameter error.",
+    907: "Token does not exist.",
+    908: "User is blocked.",
+    909: "Content requires review before sending.",
+    912: "No available service package.",
+}
+
+# Map Apprise's standard notify_format values to the PushPlus template
+# identifiers.  PushPlus uses these to render the body server-side before
+# delivery -- the content itself does not change; only the rendering hint.
+PUSHPLUS_FORMAT_MAP = {
+    NotifyFormat.HTML: "html",
+    NotifyFormat.MARKDOWN: "markdown",
+    NotifyFormat.TEXT: "txt",
+}
+
+# Default PushPlus template when the format has no explicit mapping
+PUSHPLUS_FORMAT_DEFAULT = "html"
+
+
+class PushPlusChannel:
+    """Defines the PushPlus delivery channels.
+
+    The channel controls where the rendered notification is delivered.
+    It is supplied as the channel= (or mode=) query parameter in the
+    Apprise URL, e.g. pushplus://{token}?channel=mail.
+    """
+
+    # Deliver via WeChat (PushPlus default)
+    WECHAT = "wechat"
+
+    # Deliver via a configured webhook endpoint
+    WEBHOOK = "webhook"
+
+    # Deliver via WeCom (WeChat Work / Enterprise WeChat).
+    # The API value "cp" is PushPlus's internal identifier for this channel.
+    # Both "cp" and the friendly alias "wecom" are accepted; both resolve here.
+    WECOM = "cp"
+
+    # Deliver via email
+    MAIL = "mail"
+
+    # Deliver via SMS
+    SMS = "sms"
+
+
+# All valid PushPlus delivery channels (these are the API values)
+PUSHPLUS_CHANNELS = (
+    PushPlusChannel.WECHAT,
+    PushPlusChannel.WEBHOOK,
+    PushPlusChannel.WECOM,
+    PushPlusChannel.MAIL,
+    PushPlusChannel.SMS,
+)
+
+# The PushPlus default delivery channel (WeChat)
+PUSHPLUS_CHANNEL_DEFAULT = PushPlusChannel.WECHAT
+
+# A group topic has no special prefix; alphanumeric codes up to 50 chars.
+IS_TOPIC = re.compile(
+    r"^(?P<topic>[a-z0-9_-]{1,50})$",
+    re.I,
+)
+
+# Schema names that auto-select a specific delivery channel when used
+# in place of the default "pushplus" schema.  Mirrors the Kodi/XBMC pattern.
+# Note: wechat:// is intentionally omitted -- it is reserved for a future
+# direct WeChat Official Account API integration.
+PUSHPLUS_SCHEMA_MAP = {
+    # wecom:// forces channel=cp (WeCom / Enterprise WeChat)
+    "wecom": PushPlusChannel.WECOM,
+}
 
 
 class NotifyPushplus(NotifyBase):
-    """A wrapper for Pushplus Notifications."""
+    """A wrapper for PushPlus Notifications."""
 
     # The default descriptive name associated with the Notification
     service_name = _("Pushplus")
@@ -50,17 +171,35 @@ class NotifyPushplus(NotifyBase):
     # The services URL
     service_url = "https://www.pushplus.plus/"
 
-    # The default secure protocol
-    secure_protocol = "pushplus"
+    # The default protocol; wecom:// is accepted as a schema alias.
+    # Note: wechat:// is reserved for a future direct WeChat Official
+    # Account API plugin and is intentionally not listed here.
+    secure_protocol = ("pushplus", "wecom")
 
     # A URL that takes you to the setup/help of the specific protocol
     setup_url = "https://appriseit.com/services/pushplus/"
 
-    # URL used to send notifications with
+    # URL used to POST notifications
     notify_url = "https://www.pushplus.plus/send"
 
-    templates = ("{schema}://{token}",)
+    # Maximum body length documented by PushPlus
+    body_maxlen = 20000
 
+    # Title is capped at a safe limit (not explicitly documented by PushPlus)
+    title_maxlen = 200
+
+    # Default to HTML since PushPlus renders HTML by default
+    notify_format = NotifyFormat.HTML
+
+    # Define object URL templates
+    templates = (
+        # No topics: personal notification with optional ?channel= override
+        "{schema}://{token}",
+        # Topics in path: one API call per topic
+        "{schema}://{token}/{targets}",
+    )
+
+    # Define our template tokens
     template_tokens = dict(
         NotifyBase.template_tokens,
         **{
@@ -69,103 +208,398 @@ class NotifyPushplus(NotifyBase):
                 "type": "string",
                 "private": True,
                 "required": True,
+                # PushPlus tokens are 32-64 alphanumeric/underscore/dash chars
                 "regex": (r"^[a-z0-9_-]{32,64}$", "i"),
+            },
+            # Group topics go directly in the URL path with no prefix
+            "targets": {
+                "name": _("Group Topics"),
+                "type": "list:string",
             },
         },
     )
 
-    def __init__(self, token, **kwargs):
+    # Define our template arguments
+    template_args = dict(
+        NotifyBase.template_args,
+        **{
+            # Allow the token to be supplied as a query parameter
+            "token": {
+                "alias_of": "token",
+            },
+            # ?to= is the standard Apprise alias for targets (topics)
+            "to": {
+                "alias_of": "targets",
+            },
+            # Delivery channel -- selects where the message is delivered.
+            # One of the PUSHPLUS_CHANNELS values (wechat is the default).
+            "channel": {
+                "name": _("Channel"),
+                "type": "choice:string",
+                "values": PUSHPLUS_CHANNELS,
+                "default": PUSHPLUS_CHANNEL_DEFAULT,
+            },
+            # mode= is an alias for channel=; the two are fully synonymous.
+            "mode": {
+                "alias_of": "channel",
+            },
+            # ?topic= backward-compat alias that maps to targets
+            "topic": {
+                "alias_of": "targets",
+            },
+            # Webhook endpoint name; only meaningful when channel=webhook
+            "name": {
+                "name": _("Webhook Name"),
+                "type": "string",
+            },
+        },
+    )
+
+    def __init__(self, token, targets=None, channel=None, name=None, **kwargs):
         """Initialize Pushplus Object."""
         super().__init__(**kwargs)
 
+        # Validate the required user token
         self.token = validate_regex(
-            token, *self.template_tokens["token"]["regex"]
+            token,
+            *self.template_tokens["token"]["regex"],
         )
         if not self.token:
-            msg = f"The Pushplus token ({token}) is invalid."
+            msg = "The Pushplus token ({}) is invalid.".format(token)
             self.logger.warning(msg)
             raise TypeError(msg)
 
-    def url(self, privacy=False, *args, **kwargs):
-        """Returns the URL built dynamically based on specified arguments."""
-        params = self.url_parameters(privacy=privacy, *args, **kwargs)
-        return (
-            f"{self.secure_protocol}://"
-            f"{self.pprint(self.token, privacy, mode=PrivacyMode.Secret)}/"
-            f"?{self.urlencode(params)}"
-        )
+        # Resolve the delivery channel from the schema alias when the URL
+        # was entered as wechat:// or wecom:// instead of pushplus://.
+        # self.schema is set by NotifyBase from the parsed URL protocol.
+        schema_channel = PUSHPLUS_SCHEMA_MAP.get((self.schema or "").lower())
 
-    @property
-    def url_identifier(self):
-        """Returns a unique identifier for this plugin instance."""
-        return (self.secure_protocol, self.token)
+        # Determine the active delivery channel:
+        #   1. Explicit channel= / mode= argument (already resolved by
+        #      the caller since mode is an alias_of channel in template_args)
+        #   2. Schema-implied channel (wechat:// or wecom://)
+        #   3. Default (WeChat)
+        if channel:
+            # Normalise the 'wecom' friendly alias to the API value 'cp'
+            if channel.lower() == "wecom":
+                channel = PushPlusChannel.WECOM
+            self.channel = next(
+                (c for c in PUSHPLUS_CHANNELS if c == channel.lower()),
+                None,
+            )
+            if not self.channel:
+                msg = "The Pushplus channel ({}) is not valid.".format(channel)
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
+        elif schema_channel:
+            # Schema-implied channel (wechat:// or wecom://)
+            self.channel = schema_channel
+
+        else:
+            # Default to WeChat
+            self.channel = PUSHPLUS_CHANNEL_DEFAULT
+
+        # Resolved group topics -- one API call is made per topic
+        self.topics = []
+
+        # Preserve unrecognised targets for round-trip fidelity in url()
+        self.invalid_targets = []
+
+        # Parse each target from the list -- only plain topics are valid here
+        for target in parse_list(targets):
+            result = IS_TOPIC.match(target)
+            if result:
+                self.topics.append(result.group("topic"))
+                continue
+
+            # Unrecognised entry -- log and preserve
+            self.logger.warning("Dropped invalid Pushplus topic: %s", target)
+            self.invalid_targets.append(target)
+
+        # Store the webhook name; only meaningful when channel=webhook.
+        # Accepted via ?name= in the URL (mapped via alias_of in template_args)
+        self.name = name if isinstance(name, str) and name else None
+
+        return
 
     def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
-        """Send a Pushplus Notification."""
-        payload = {
-            "token": self.token,
-            "title": title if title else body,
-            "content": body,
-        }
+        """Perform PushPlus Notification."""
 
+        # Prepare our headers
         headers = {
             "User-Agent": self.app_id,
             "Content-Type": "application/json",
         }
 
-        # Always call throttle before any remote server i/o is made
-        self.throttle()
+        # Derive the PushPlus rendering template from Apprise's standard
+        # notify_format.  This is a server-side rendering hint only; the
+        # content payload does not change.
+        pp_template = PUSHPLUS_FORMAT_MAP.get(
+            self.notify_format, PUSHPLUS_FORMAT_DEFAULT
+        )
 
-        try:
-            response = requests.post(
+        # When no topics are configured, fall back to a single personal send
+        # by iterating over a list containing None as the sole entry.
+        topics_to_notify = self.topics if self.topics else [None]
+
+        # Track whether any individual send failed
+        has_error = False
+
+        for topic in topics_to_notify:
+            # Build the payload for this particular topic
+            payload = {
+                # Authentication token
+                "token": self.token,
+                # Fall back to the body when no title is provided
+                "title": title if title else body,
+                # Notification body content
+                "content": body,
+                # Rendering template derived from notify_format
+                "template": pp_template,
+                # Delivery channel
+                "channel": self.channel,
+            }
+
+            # Add the group topic when sending to a specific group
+            if topic:
+                payload["topic"] = topic
+
+            # Add the webhook name when the webhook channel is selected
+            if self.channel == PushPlusChannel.WEBHOOK and self.name:
+                payload["webhook"] = self.name
+
+            # Debug logging so the caller can inspect what will be sent
+            self.logger.debug(
+                "PushPlus POST URL: %s (cert_verify=%r)",
                 self.notify_url,
-                headers=headers,
-                data=json.dumps(payload),
-                verify=self.verify_certificate,
-                timeout=self.request_timeout,
+                self.verify_certificate,
+            )
+            self.logger.debug("PushPlus Payload: %r", payload)
+
+            # Always throttle before each remote server I/O call
+            self.throttle()
+
+            try:
+                r = requests.post(
+                    self.notify_url,
+                    headers=headers,
+                    # Encode explicitly for non-ASCII (e.g. Chinese) chars
+                    data=json.dumps(payload, ensure_ascii=False).encode(
+                        "utf-8"
+                    ),
+                    verify=self.verify_certificate,
+                    timeout=self.request_timeout,
+                )
+
+                if r.status_code != requests.codes.ok:
+                    # HTTP-level failure -- log it and move on
+                    status_str = NotifyPushplus.http_response_code_lookup(
+                        r.status_code
+                    )
+                    self.logger.warning(
+                        "Failed to send PushPlus notification: "
+                        "{}{}error={}.".format(
+                            status_str,
+                            ", " if status_str else "",
+                            r.status_code,
+                        )
+                    )
+                    self.logger.debug(
+                        "Response Details:\r\n%r",
+                        (r.content or b"")[:2000],
+                    )
+                    # Mark our failure and continue with the next topic
+                    has_error = True
+                    continue
+
+                # PushPlus always returns HTTP 200; the real result is in
+                # the JSON body where code == 200 means success.
+                try:
+                    content = json.loads(r.content)
+                except (AttributeError, TypeError, ValueError):
+                    # ValueError = r.content is unparsable
+                    # TypeError  = r.content is None
+                    # AttributeError = r is None
+                    content = {}
+
+                # Check the application-level status code
+                api_code = content.get("code") if content else None
+                if api_code != 200:
+                    # Application-level failure
+                    error_str = PUSHPLUS_RESPONSE_CODES.get(
+                        api_code,
+                        # Fall back to the msg field, then a generic string
+                        (
+                            content.get("msg", "Unknown error")
+                            if content
+                            else "Unknown error"
+                        ),
+                    )
+                    self.logger.warning(
+                        "Failed to send PushPlus notification: "
+                        "code={}: {}.".format(api_code, error_str)
+                    )
+                    self.logger.debug(
+                        "Response Details:\r\n%r",
+                        content if content else (r.content or b"")[:2000],
+                    )
+                    # Mark our failure and continue with the next topic
+                    has_error = True
+                    continue
+
+            except requests.RequestException as e:
+                self.logger.warning(
+                    "A Connection error occurred sending"
+                    " PushPlus notification."
+                )
+                self.logger.debug("Socket Exception: %s", str(e))
+                # Mark our failure and continue with the next topic
+                has_error = True
+                continue
+
+            # Notification delivered for this topic
+            self.logger.info(
+                "Sent PushPlus notification%s.",
+                " to topic {}".format(topic) if topic else "",
             )
 
-            if response.status_code != requests.codes.ok:
-                self.logger.warning(
-                    "Pushplus notification failed: %d - %s",
-                    response.status_code,
-                    response.text,
-                )
-                return False
+        return not has_error
 
-        except requests.RequestException as e:
-            self.logger.warning(f"Pushplus Exception: {e}")
-            return False
+    @property
+    def url_identifier(self):
+        """Returns all of the identifiers that make this URL unique from
+        another similar one.
 
-        self.logger.info("Pushplus notification sent successfully.")
-        return True
+        Targets or end points should never be identified here.
+        """
+        # The token is the sole connection identity for PushPlus
+        return (self.secure_protocol[0], self.token)
+
+    def url(self, privacy=False, *args, **kwargs):
+        """Returns the URL built dynamically based on specified arguments."""
+
+        # Start with an empty params dict
+        params = {}
+
+        # Include the delivery channel when it differs from the default.
+        # The schema alias (wechat:// / wecom://) is never emitted here --
+        # we always normalise back to pushplus:// + ?channel= for clarity.
+        if self.channel != PUSHPLUS_CHANNEL_DEFAULT:
+            params["channel"] = self.channel
+
+        # Include the webhook name (as ?name=) when the webhook channel
+        # is active.
+        if self.channel == PushPlusChannel.WEBHOOK and self.name:
+            params["name"] = self.name
+
+        # Merge in standard Apprise URL parameters (verify, format, etc.)
+        params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
+
+        # Build the targets path from group topics and any invalid entries
+        targets = list(self.topics) + list(self.invalid_targets)
+
+        # Masked token for the URL
+        token_str = self.pprint(
+            self.token,
+            privacy,
+            mode=PrivacyMode.Secret,
+            safe="",
+        )
+
+        if targets:
+            # One or more topics: include them in the URL path
+            return "{schema}://{token}/{targets}/?{params}".format(
+                schema=self.secure_protocol[0],
+                token=token_str,
+                targets="/".join(
+                    NotifyPushplus.quote(t, safe="") for t in targets
+                ),
+                params=NotifyPushplus.urlencode(params),
+            )
+
+        # No topics -- simple personal notification URL
+        return "{schema}://{token}/?{params}".format(
+            schema=self.secure_protocol[0],
+            token=token_str,
+            params=NotifyPushplus.urlencode(params),
+        )
 
     @staticmethod
     def parse_url(url):
-        """Parses the URL and returns arguments to re-instantiate the
-        object."""
+        """Parses the URL and returns enough arguments that can allow us to
+        re-instantiate this object."""
         results = NotifyBase.parse_url(url, verify_host=False)
         if not results:
+            # We're done early as we couldn't load the results
             return results
 
+        # Prefer ?token= query parameter over the URL host field
         if "token" in results["qsd"] and results["qsd"]["token"]:
+            # Token was supplied as a query parameter
             results["token"] = NotifyPushplus.unquote(results["qsd"]["token"])
         else:
+            # Token is the URL host
             results["token"] = NotifyPushplus.unquote(results["host"])
+
+        # Collect group topics from the URL path
+        results["targets"] = NotifyPushplus.split_path(results["fullpath"])
+
+        # ?to= appends additional targets (comma/space delimited supported)
+        if "to" in results["qsd"] and results["qsd"]["to"]:
+            results["targets"] += NotifyPushplus.parse_list(
+                results["qsd"]["to"]
+            )
+
+        # ?topic= backward-compat alias also appends topics
+        if "topic" in results["qsd"] and results["qsd"]["topic"]:
+            results["targets"] += NotifyPushplus.parse_list(
+                results["qsd"]["topic"]
+            )
+
+        # Extract the delivery channel from ?channel= or its alias ?mode=
+        # mode= takes lower priority; channel= wins if both are present.
+        if "mode" in results["qsd"] and results["qsd"]["mode"]:
+            results["channel"] = NotifyPushplus.unquote(results["qsd"]["mode"])
+        if "channel" in results["qsd"] and results["qsd"]["channel"]:
+            results["channel"] = NotifyPushplus.unquote(
+                results["qsd"]["channel"]
+            )
+
+        # Extract the webhook name -- users specify it as ?name= in the URL.
+        # We store it internally as 'webhook' to avoid shadowing URLBase.name.
+        if "name" in results["qsd"] and results["qsd"]["name"]:
+            results["webhook"] = NotifyPushplus.unquote(results["qsd"]["name"])
 
         return results
 
     @staticmethod
     def parse_native_url(url):
-        """Parse native Pushplus-style URL."""
-        match = re.match(
-            r"^https://www\.pushplus\.plus/send\?token=([a-z0-9_-]+)$",
+        """Support native PushPlus API URLs of the form:
+        https://www.pushplus.plus/send?token=TOKEN[&other_params]
+        """
+        result = re.match(
+            r"^https?://www\.pushplus\.plus/send"
+            r"(?:\?(?P<params>[^#]+))?$",
             url,
             re.I,
         )
-        if not match:
-            return None
-
-        return NotifyPushplus.parse_url(
-            f"{NotifyPushplus.secure_protocol}://{match.group(1)}"
-        )
+        if result:
+            params = result.group("params") or ""
+            # The token must be present as a query parameter
+            tok = re.search(
+                r"(?:(?:^|&))token=(?P<token>[a-z0-9_-]+)",
+                params,
+                re.I,
+            )
+            if tok:
+                # Re-build as an Apprise URL.  Preserve all existing params
+                # so that topic, channel, and name all round-trip correctly.
+                return NotifyPushplus.parse_url(
+                    "{schema}://{token}/?{params}".format(
+                        schema=NotifyPushplus.secure_protocol[0],
+                        token=tok.group("token"),
+                        params=params,
+                    )
+                )
+        return None

--- a/apprise/plugins/pushplus.py
+++ b/apprise/plugins/pushplus.py
@@ -54,8 +54,12 @@
 #   Topic + delivery channel:
 #     pushplus://{token}/{topic}?channel=mail
 #
-#   Webhook channel with a named endpoint:
+#   Webhook channel with a named endpoint -- two equivalent forms:
 #     pushplus://{token}?channel=webhook&name={webhook_name}
+#     pushplus://{webhook_name}@{token}
+#
+#   When the schema://{name}@{token} form is used and no explicit channel=
+#   is given, the webhook channel is implied automatically.
 #
 #   Native PushPlus API URL (also accepted by parse_native_url):
 #     https://www.pushplus.plus/send?token={token}
@@ -247,15 +251,20 @@ class NotifyPushplus(NotifyBase):
             "topic": {
                 "alias_of": "targets",
             },
-            # Webhook endpoint name; only meaningful when channel=webhook
+            # Webhook endpoint name; only meaningful when channel=webhook.
+            # The URL parameter is ?name= but the __init__ kwarg is webhook=
+            # to avoid shadowing URLBase.name.
             "name": {
                 "name": _("Webhook Name"),
                 "type": "string",
+                "map_to": "webhook",
             },
         },
     )
 
-    def __init__(self, token, targets=None, channel=None, name=None, **kwargs):
+    def __init__(
+        self, token, targets=None, channel=None, webhook=None, **kwargs
+    ):
         """Initialize Pushplus Object."""
         super().__init__(**kwargs)
 
@@ -318,8 +327,11 @@ class NotifyPushplus(NotifyBase):
             self.invalid_targets.append(target)
 
         # Store the webhook name; only meaningful when channel=webhook.
-        # Accepted via ?name= in the URL (mapped via alias_of in template_args)
-        self.name = name if isinstance(name, str) and name else None
+        # Kept as self.webhook (not self.name) to avoid shadowing URLBase.name.
+        # Arrives via the ?name= URL parameter (mapped to webhook= by map_to).
+        self.webhook = (
+            webhook if isinstance(webhook, str) and webhook else None
+        )
 
         return
 
@@ -366,8 +378,8 @@ class NotifyPushplus(NotifyBase):
                 payload["topic"] = topic
 
             # Add the webhook name when the webhook channel is selected
-            if self.channel == PushPlusChannel.WEBHOOK and self.name:
-                payload["webhook"] = self.name
+            if self.channel == PushPlusChannel.WEBHOOK and self.webhook:
+                payload["webhook"] = self.webhook
 
             # Debug logging so the caller can inspect what will be sent
             self.logger.debug(
@@ -479,19 +491,22 @@ class NotifyPushplus(NotifyBase):
     def url(self, privacy=False, *args, **kwargs):
         """Returns the URL built dynamically based on specified arguments."""
 
+        # When channel=webhook with a named endpoint, use the compact
+        # {name}@pushplus://{token} form.  Both ?channel=webhook and ?name=
+        # are implied by the user@ prefix and omitted from the query string.
+        webhook_prefix = (
+            self.channel == PushPlusChannel.WEBHOOK and self.webhook
+        )
+
         # Start with an empty params dict
         params = {}
 
-        # Include the delivery channel when it differs from the default.
-        # The schema alias (wechat:// / wecom://) is never emitted here --
-        # we always normalise back to pushplus:// + ?channel= for clarity.
-        if self.channel != PUSHPLUS_CHANNEL_DEFAULT:
+        # When not using the webhook prefix form, include ?channel= when it
+        # differs from the default.  The schema alias (wechat:// / wecom://)
+        # is never emitted here -- we always normalise back to pushplus://
+        # plus ?channel= for clarity.
+        if not webhook_prefix and self.channel != PUSHPLUS_CHANNEL_DEFAULT:
             params["channel"] = self.channel
-
-        # Include the webhook name (as ?name=) when the webhook channel
-        # is active.
-        if self.channel == PushPlusChannel.WEBHOOK and self.name:
-            params["name"] = self.name
 
         # Merge in standard Apprise URL parameters (verify, format, etc.)
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
@@ -506,6 +521,28 @@ class NotifyPushplus(NotifyBase):
             mode=PrivacyMode.Secret,
             safe="",
         )
+
+        # When using the webhook prefix form, the endpoint name goes in the
+        # user@ position (schema://name@token) -- channel=webhook and ?name=
+        # are both implied by the user@ presence and omitted from params.
+        if webhook_prefix:
+            name_str = NotifyPushplus.quote(self.webhook, safe="")
+            if targets:
+                return "{schema}://{name}@{token}/{targets}/?{params}".format(
+                    schema=self.secure_protocol[0],
+                    name=name_str,
+                    token=token_str,
+                    targets="/".join(
+                        NotifyPushplus.quote(t, safe="") for t in targets
+                    ),
+                    params=NotifyPushplus.urlencode(params),
+                )
+            return "{schema}://{name}@{token}/?{params}".format(
+                schema=self.secure_protocol[0],
+                name=name_str,
+                token=token_str,
+                params=NotifyPushplus.urlencode(params),
+            )
 
         if targets:
             # One or more topics: include them in the URL path
@@ -570,6 +607,17 @@ class NotifyPushplus(NotifyBase):
         # We store it internally as 'webhook' to avoid shadowing URLBase.name.
         if "name" in results["qsd"] and results["qsd"]["name"]:
             results["webhook"] = NotifyPushplus.unquote(results["qsd"]["name"])
+
+        # Support the {webhook_name}@pushplus://{token} short form.
+        # When user@ is present, it identifies the webhook endpoint name.
+        # If no channel was explicitly given, webhook is the implied channel.
+        if results.get("user"):
+            # Use user@ as the webhook name when ?name= was not also supplied
+            if "webhook" not in results:
+                results["webhook"] = NotifyPushplus.unquote(results["user"])
+            # Imply webhook channel when no explicit channel was specified
+            if "channel" not in results:
+                results["channel"] = PushPlusChannel.WEBHOOK
 
         return results
 

--- a/tests/test_plugin_pushplus.py
+++ b/tests/test_plugin_pushplus.py
@@ -468,6 +468,19 @@ def test_plugin_pushplus_url():
     assert GOOD_TOKEN not in priv
     assert "****" in priv
 
+    # Webhook prefix form with group topics -- schema://name@token/topic/ form
+    obj = NotifyPushplus(
+        token=GOOD_TOKEN,
+        channel="webhook",
+        webhook="myhook",
+        targets=["mygroup"],
+    )
+    url = obj.url()
+    assert "pushplus://myhook@" in url
+    assert "mygroup" in url
+    assert "channel=" not in url
+    assert "name=" not in url
+
     # Webhook name suppressed when channel is not webhook
     obj = NotifyPushplus(
         token=GOOD_TOKEN,

--- a/tests/test_plugin_pushplus.py
+++ b/tests/test_plugin_pushplus.py
@@ -26,50 +26,241 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+# Disable logging for a cleaner testing output
+from json import dumps, loads
 import logging
+from unittest import mock
 
 from helpers import AppriseURLTester
 import requests
 
-from apprise.plugins.pushplus import NotifyPushplus
+from apprise import Apprise
+from apprise.common import NotifyFormat
+from apprise.plugins.pushplus import (
+    PUSHPLUS_CHANNEL_DEFAULT,
+    PUSHPLUS_CHANNELS,
+    PUSHPLUS_FORMAT_MAP,
+    NotifyPushplus,
+    PushPlusChannel,
+)
 
 logging.disable(logging.CRITICAL)
 
+# A 32-character token used throughout the tests (minimum valid length)
+GOOD_TOKEN = "abc123def456ghi789jkl012mno345pq"
+
+# A 64-character token (upper boundary of the allowed length range)
+LONG_TOKEN = "a" * 64
+
+# PushPlus always returns HTTP 200; success/failure lives in the JSON body
+GOOD_RESPONSE = dumps({"code": 200, "msg": "ok", "data": "msgid"})
+BAD_RESPONSE = dumps({"code": 907, "msg": "Token does not exist."})
+
+# Our Testing URLs
 apprise_url_tests = (
+    # ----------------------------------------------------------------
+    # Invalid / missing token cases
+    # ----------------------------------------------------------------
     (
         "pushplus://",
         {
+            # Empty token must raise
             "instance": TypeError,
         },
     ),
     (
-        "pushplus://invalid!",
+        "pushplus://short",
         {
+            # Token too short (fewer than 32 characters)
             "instance": TypeError,
         },
     ),
     (
-        "pushplus://abc123def456ghi789jkl012mno345pq",
+        "pushplus://invalid!chars00000000000000000000000000000",
+        {
+            # Token contains characters not allowed by the regex
+            "instance": TypeError,
+        },
+    ),
+    # ----------------------------------------------------------------
+    # Valid token -- basic personal notification (no targets)
+    # ----------------------------------------------------------------
+    (
+        "pushplus://{}".format(GOOD_TOKEN),
+        {
+            "instance": NotifyPushplus,
+            # Privacy URL must mask the token
+            "privacy_url": "pushplus://****/",
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    # Token supplied as a query parameter instead of the URL host
+    (
+        "pushplus://?token={}".format(GOOD_TOKEN),
         {
             "instance": NotifyPushplus,
             "privacy_url": "pushplus://****/",
+            "requests_response_text": GOOD_RESPONSE,
         },
     ),
+    # 64-character (maximum-length) token
     (
-        "pushplus://?token=abc123def456ghi789jkl012mno345pq",
+        "pushplus://{}".format(LONG_TOKEN),
         {
             "instance": NotifyPushplus,
-            "privacy_url": "pushplus://****/",
+            "requests_response_text": GOOD_RESPONSE,
         },
     ),
+    # ----------------------------------------------------------------
+    # Group topic variations
+    # ----------------------------------------------------------------
+    # Single topic in the URL path (no prefix required)
     (
-        "https://www.pushplus.plus/send?token=abc123def456ghi789jkl012mno345pq",
+        "pushplus://{}/mygroup".format(GOOD_TOKEN),
         {
             "instance": NotifyPushplus,
+            "privacy_url": "pushplus://****/mygroup/",
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    # Two topics in the path -- two API calls are made
+    (
+        "pushplus://{}/group1/group2".format(GOOD_TOKEN),
+        {
+            "instance": NotifyPushplus,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    # Topic supplied via the backward-compatible ?topic= parameter
+    (
+        "pushplus://{}/?topic=mygroup".format(GOOD_TOKEN),
+        {
+            "instance": NotifyPushplus,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    # Topic supplied via the ?to= convenience alias
+    (
+        "pushplus://{}/?to=mygroup".format(GOOD_TOKEN),
+        {
+            "instance": NotifyPushplus,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    # Invalid topic characters are silently moved to invalid_targets;
+    # the object still instantiates and sends a personal notification
+    (
+        "pushplus://{}/bad!topic".format(GOOD_TOKEN),
+        {
+            "instance": NotifyPushplus,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    # ----------------------------------------------------------------
+    # Delivery channel via ?channel= query parameter
+    # ----------------------------------------------------------------
+    (
+        "pushplus://{}?channel=mail".format(GOOD_TOKEN),
+        {
+            "instance": NotifyPushplus,
+            "requests_response_text": GOOD_RESPONSE,
         },
     ),
     (
-        "pushplus://abc123def456ghi789jkl012mno345pq",
+        "pushplus://{}?channel=sms".format(GOOD_TOKEN),
+        {
+            "instance": NotifyPushplus,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    (
+        "pushplus://{}?channel=cp".format(GOOD_TOKEN),
+        {
+            "instance": NotifyPushplus,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    # wecom is a friendly alias that maps to the "cp" API channel
+    (
+        "pushplus://{}?channel=wecom".format(GOOD_TOKEN),
+        {
+            "instance": NotifyPushplus,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    # mode= is a synonym for channel=
+    (
+        "pushplus://{}?mode=mail".format(GOOD_TOKEN),
+        {
+            "instance": NotifyPushplus,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    # ----------------------------------------------------------------
+    # Schema alias that auto-sets the delivery channel
+    # ----------------------------------------------------------------
+    # wecom:// auto-sets channel=cp (WeCom / Enterprise WeChat)
+    (
+        "wecom://{}".format(GOOD_TOKEN),
+        {
+            "instance": NotifyPushplus,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    # ----------------------------------------------------------------
+    # Webhook channel with a named endpoint (?name=)
+    # ----------------------------------------------------------------
+    (
+        "pushplus://{}?channel=webhook&name=myhook".format(GOOD_TOKEN),
+        {
+            "instance": NotifyPushplus,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    # ----------------------------------------------------------------
+    # Native PushPlus API URL (parse_native_url support)
+    # ----------------------------------------------------------------
+    (
+        "https://www.pushplus.plus/send?token={}".format(GOOD_TOKEN),
+        {
+            "instance": NotifyPushplus,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    # ----------------------------------------------------------------
+    # API application-level failure (HTTP 200 but JSON code != 200)
+    # ----------------------------------------------------------------
+    (
+        "pushplus://{}".format(GOOD_TOKEN),
+        {
+            "instance": NotifyPushplus,
+            "response": False,
+            "requests_response_text": BAD_RESPONSE,
+        },
+    ),
+    # Unparsable JSON body is treated as a failure
+    (
+        "pushplus://{}".format(GOOD_TOKEN),
+        {
+            "instance": NotifyPushplus,
+            "response": False,
+            "requests_response_text": "{bad json",
+        },
+    ),
+    # None body is treated as a failure
+    (
+        "pushplus://{}".format(GOOD_TOKEN),
+        {
+            "instance": NotifyPushplus,
+            "response": False,
+            "requests_response_text": None,
+        },
+    ),
+    # ----------------------------------------------------------------
+    # HTTP-level failures
+    # ----------------------------------------------------------------
+    (
+        "pushplus://{}".format(GOOD_TOKEN),
         {
             "instance": NotifyPushplus,
             "response": False,
@@ -77,15 +268,18 @@ apprise_url_tests = (
         },
     ),
     (
-        "pushplus://abc123def456ghi789jkl012mno345pq",
+        "pushplus://{}".format(GOOD_TOKEN),
         {
             "instance": NotifyPushplus,
             "response": False,
             "requests_response_code": 999,
         },
     ),
+    # ----------------------------------------------------------------
+    # Connection / socket exceptions
+    # ----------------------------------------------------------------
     (
-        "pushplus://ffffffffffffffffffffffffffffffff",
+        "pushplus://{}".format(GOOD_TOKEN),
         {
             "instance": NotifyPushplus,
             "test_requests_exceptions": True,
@@ -95,4 +289,631 @@ apprise_url_tests = (
 
 
 def test_plugin_pushplus_urls():
+    """NotifyPushplus() Apprise URL test suite."""
     AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+def test_plugin_pushplus_init():
+    """NotifyPushplus() initialisation and parameter handling."""
+
+    # Minimal valid instantiation -- no targets
+    obj = NotifyPushplus(token=GOOD_TOKEN)
+    assert obj.token == GOOD_TOKEN
+    assert obj.topics == []
+    assert obj.channel == PUSHPLUS_CHANNEL_DEFAULT
+    assert obj.webhook is None
+    assert obj.invalid_targets == []
+
+    # Single group topic via targets list (no prefix required)
+    obj = NotifyPushplus(token=GOOD_TOKEN, targets=["mygroup"])
+    assert obj.topics == ["mygroup"]
+    assert obj.channel == PUSHPLUS_CHANNEL_DEFAULT
+
+    # Multiple group topics
+    obj = NotifyPushplus(
+        token=GOOD_TOKEN, targets=["group1", "group2", "group3"]
+    )
+    assert obj.topics == ["group1", "group2", "group3"]
+
+    # Explicit channel via channel= argument
+    obj = NotifyPushplus(token=GOOD_TOKEN, channel="mail")
+    assert obj.channel == PushPlusChannel.MAIL
+
+    # wecom friendly alias normalises to the "cp" API value
+    obj = NotifyPushplus(token=GOOD_TOKEN, channel="wecom")
+    assert obj.channel == PushPlusChannel.WECOM
+    assert obj.channel == "cp"
+
+    # cp is the canonical API value (same result as wecom)
+    obj = NotifyPushplus(token=GOOD_TOKEN, channel="cp")
+    assert obj.channel == "cp"
+
+    # Channel is case-insensitive
+    obj = NotifyPushplus(token=GOOD_TOKEN, channel="MAIL")
+    assert obj.channel == PushPlusChannel.MAIL
+
+    # Invalid channel raises TypeError
+    import pytest
+
+    with pytest.raises(TypeError):
+        NotifyPushplus(token=GOOD_TOKEN, channel="invalid_channel")
+
+    # Invalid target (bad characters) goes to invalid_targets
+    obj = NotifyPushplus(token=GOOD_TOKEN, targets=["bad!target"])
+    assert obj.topics == []
+    assert obj.invalid_targets == ["bad!target"]
+
+    # Invalid token raises TypeError
+    with pytest.raises(TypeError):
+        NotifyPushplus(token="short")
+
+    with pytest.raises(TypeError):
+        NotifyPushplus(token="bad!token" + "0" * 30)
+
+    # Webhook value stored as None when falsy
+    obj = NotifyPushplus(token=GOOD_TOKEN, webhook="")
+    assert obj.webhook is None
+
+    # Webhook value stored when truthy
+    obj = NotifyPushplus(
+        token=GOOD_TOKEN,
+        channel="webhook",
+        webhook="myhook",
+    )
+    assert obj.webhook == "myhook"
+    assert obj.channel == PushPlusChannel.WEBHOOK
+
+
+def test_plugin_pushplus_schema_aliases():
+    """NotifyPushplus() wecom:// schema alias."""
+
+    # wecom:// schema sets channel=cp (WeCom API value)
+    result = NotifyPushplus.parse_url("wecom://{}".format(GOOD_TOKEN))
+    assert result is not None
+    obj = NotifyPushplus(**result)
+    assert obj.channel == PushPlusChannel.WECOM
+    assert obj.channel == "cp"
+
+    # An explicit channel= overrides the schema-implied channel
+    result = NotifyPushplus.parse_url(
+        "wecom://{}?channel=mail".format(GOOD_TOKEN)
+    )
+    assert result is not None
+    obj = NotifyPushplus(**result)
+    assert obj.channel == PushPlusChannel.MAIL
+
+
+def test_plugin_pushplus_all_channels():
+    """NotifyPushplus() accepts every documented API channel value."""
+
+    for ch in PUSHPLUS_CHANNELS:
+        # Each channel must initialise without raising
+        obj = NotifyPushplus(token=GOOD_TOKEN, channel=ch)
+        assert obj.channel == ch
+
+        # Channel matching must be case-insensitive
+        obj2 = NotifyPushplus(token=GOOD_TOKEN, channel=ch.upper())
+        assert obj2.channel == ch
+
+
+def test_plugin_pushplus_url():
+    """NotifyPushplus() url() output and round-trip fidelity."""
+
+    # Personal notification URL -- no topics in path, default channel omitted
+    obj = NotifyPushplus(token=GOOD_TOKEN)
+    url = obj.url()
+    assert url.startswith("pushplus://")
+    # Token appears in plain text
+    assert GOOD_TOKEN in url
+    # No topic path segment
+    assert "/mygroup" not in url
+    # Default channel is omitted from params
+    assert "channel=" not in url
+
+    # Privacy URL must mask the token
+    priv = obj.url(privacy=True)
+    assert GOOD_TOKEN not in priv
+    assert "****" in priv
+
+    # Group topic URL -- topic appears in the path
+    obj = NotifyPushplus(token=GOOD_TOKEN, targets=["mygroup"])
+    url = obj.url()
+    assert "/mygroup/" in url
+    priv = obj.url(privacy=True)
+    assert "/mygroup/" in priv
+    assert GOOD_TOKEN not in priv
+
+    # Multiple topics all appear in the path
+    obj = NotifyPushplus(token=GOOD_TOKEN, targets=["grp1", "grp2"])
+    url = obj.url()
+    assert "grp1" in url
+    assert "grp2" in url
+
+    # Non-default channel appears as ?channel= query parameter
+    obj = NotifyPushplus(token=GOOD_TOKEN, channel="mail")
+    url = obj.url()
+    assert "channel=mail" in url
+
+    # Default channel (wechat) is suppressed from the URL
+    obj = NotifyPushplus(token=GOOD_TOKEN, channel="wechat")
+    url = obj.url()
+    assert "channel=" not in url
+
+    # Webhook name emitted as ?name= only when channel is webhook
+    obj = NotifyPushplus(
+        token=GOOD_TOKEN,
+        channel="webhook",
+        webhook="myhook",
+    )
+    url = obj.url()
+    assert "name=myhook" in url
+    assert "channel=webhook" in url
+
+    # Webhook name suppressed when channel is not webhook
+    obj = NotifyPushplus(
+        token=GOOD_TOKEN,
+        channel="mail",
+        webhook="myhook",
+    )
+    url = obj.url()
+    assert "name=" not in url
+
+    # Webhook channel without a name -- no name= key in URL
+    obj = NotifyPushplus(token=GOOD_TOKEN, channel="webhook")
+    url = obj.url()
+    assert "name=" not in url
+
+    # Invalid targets are preserved in the URL path for round-trip fidelity
+    obj = NotifyPushplus(token=GOOD_TOKEN, targets=["bad!target"])
+    url = obj.url()
+    assert "bad" in url
+
+    # url_identifier contains only the schema and token (no targets or channel)
+    obj = NotifyPushplus(token=GOOD_TOKEN, targets=["grp"])
+    assert obj.url_identifier == ("pushplus", GOOD_TOKEN)
+
+    # Schema alias (wecom://) always normalises back to pushplus://
+    result = NotifyPushplus.parse_url("wecom://{}".format(GOOD_TOKEN))
+    obj = NotifyPushplus(**result)
+    url = obj.url()
+    assert url.startswith("pushplus://")
+    assert "channel=cp" in url
+
+
+@mock.patch("requests.post")
+def test_plugin_pushplus_send_ok(mock_post):
+    """NotifyPushplus() successful personal-notification send."""
+
+    # Prepare a successful mock response
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = GOOD_RESPONSE.encode("utf-8")
+    mock_post.return_value = response
+
+    # Personal notification (no topic) -- single API call
+    obj = NotifyPushplus(token=GOOD_TOKEN)
+    assert obj.send(body="hello", title="title") is True
+    assert mock_post.call_count == 1
+
+    # Verify the endpoint URL
+    call = mock_post.call_args
+    assert call[0][0] == "https://www.pushplus.plus/send"
+
+    # Verify the core payload fields
+    payload = loads(call[1]["data"])
+    assert payload["token"] == GOOD_TOKEN
+    assert payload["content"] == "hello"
+    assert payload["title"] == "title"
+    # Default format is HTML -- PushPlus template should be "html"
+    assert payload["template"] == PUSHPLUS_FORMAT_MAP[NotifyFormat.HTML]
+    assert payload["channel"] == PUSHPLUS_CHANNEL_DEFAULT
+    # topic and webhook keys must be absent when not configured
+    assert "topic" not in payload
+    assert "webhook" not in payload
+
+    mock_post.reset_mock()
+    response.content = GOOD_RESPONSE.encode("utf-8")
+
+    # When no title is supplied the body is used as the title fallback
+    assert obj.send(body="only body") is True
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["title"] == "only body"
+    assert payload["content"] == "only body"
+
+
+@mock.patch("requests.post")
+def test_plugin_pushplus_send_formats(mock_post):
+    """NotifyPushplus() maps notify_format to the PushPlus template field."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = GOOD_RESPONSE.encode("utf-8")
+    mock_post.return_value = response
+
+    obj = NotifyPushplus(token=GOOD_TOKEN)
+
+    # Markdown format -> "markdown" template
+    obj.notify_format = NotifyFormat.MARKDOWN
+    assert obj.send(body="# heading") is True
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["template"] == "markdown"
+
+    mock_post.reset_mock()
+    response.content = GOOD_RESPONSE.encode("utf-8")
+
+    # Text format -> "txt" template
+    obj.notify_format = NotifyFormat.TEXT
+    assert obj.send(body="plain text") is True
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["template"] == "txt"
+
+    mock_post.reset_mock()
+    response.content = GOOD_RESPONSE.encode("utf-8")
+
+    # HTML format -> "html" template
+    obj.notify_format = NotifyFormat.HTML
+    assert obj.send(body="<b>bold</b>") is True
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["template"] == "html"
+
+
+@mock.patch("requests.post")
+def test_plugin_pushplus_send_topic(mock_post):
+    """NotifyPushplus() includes the topic in the payload when configured."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = GOOD_RESPONSE.encode("utf-8")
+    mock_post.return_value = response
+
+    # Single topic -- one API call, topic present in payload
+    obj = NotifyPushplus(token=GOOD_TOKEN, targets=["mygroup"])
+    assert obj.send(body="group msg") is True
+    assert mock_post.call_count == 1
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["topic"] == "mygroup"
+
+
+@mock.patch("requests.post")
+def test_plugin_pushplus_send_multiple_topics(mock_post):
+    """NotifyPushplus() makes one API call per group topic."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = GOOD_RESPONSE.encode("utf-8")
+    mock_post.return_value = response
+
+    # Three topics -> three separate API calls
+    obj = NotifyPushplus(
+        token=GOOD_TOKEN, targets=["topic1", "topic2", "topic3"]
+    )
+    assert len(obj.topics) == 3
+    assert obj.send(body="multi msg") is True
+    assert mock_post.call_count == 3
+
+    # Verify each call carries the correct topic value
+    calls = mock_post.call_args_list
+    topics_sent = [loads(c[1]["data"])["topic"] for c in calls]
+    assert topics_sent == ["topic1", "topic2", "topic3"]
+
+    mock_post.reset_mock()
+    response.content = GOOD_RESPONSE.encode("utf-8")
+
+    # Topics with a channel override -- all API calls use the specified channel
+    obj2 = NotifyPushplus(
+        token=GOOD_TOKEN, targets=["grp1", "grp2"], channel="mail"
+    )
+    assert len(obj2.topics) == 2
+    assert obj2.channel == PushPlusChannel.MAIL
+    assert obj2.send(body="mixed") is True
+    assert mock_post.call_count == 2
+    for call in mock_post.call_args_list:
+        assert loads(call[1]["data"])["channel"] == "mail"
+
+    mock_post.reset_mock()
+
+    # Partial failure: first topic succeeds, second fails -> overall False
+    good_resp = mock.Mock()
+    good_resp.status_code = requests.codes.ok
+    good_resp.content = GOOD_RESPONSE.encode("utf-8")
+    bad_resp = mock.Mock()
+    bad_resp.status_code = requests.codes.ok
+    bad_resp.content = BAD_RESPONSE.encode("utf-8")
+    mock_post.side_effect = [good_resp, bad_resp]
+
+    obj3 = NotifyPushplus(token=GOOD_TOKEN, targets=["grp1", "grp2"])
+    assert obj3.send(body="partial") is False
+    assert mock_post.call_count == 2
+
+
+@mock.patch("requests.post")
+def test_plugin_pushplus_send_webhook(mock_post):
+    """NotifyPushplus() webhook channel behaviour."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = GOOD_RESPONSE.encode("utf-8")
+    mock_post.return_value = response
+
+    # Webhook channel with a named endpoint -- webhook key in payload
+    obj = NotifyPushplus(
+        token=GOOD_TOKEN,
+        channel="webhook",
+        webhook="myhook",
+    )
+    assert obj.send(body="hook msg") is True
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["channel"] == PushPlusChannel.WEBHOOK
+    assert payload["webhook"] == "myhook"
+
+    mock_post.reset_mock()
+    response.content = GOOD_RESPONSE.encode("utf-8")
+
+    # Webhook channel without a name -- webhook key must be absent
+    obj2 = NotifyPushplus(token=GOOD_TOKEN, channel="webhook")
+    assert obj2.send(body="hook no name") is True
+    payload2 = loads(mock_post.call_args[1]["data"])
+    assert "webhook" not in payload2
+
+    mock_post.reset_mock()
+    response.content = GOOD_RESPONSE.encode("utf-8")
+
+    # Non-webhook channel with a webhook value set -- key must be absent
+    obj3 = NotifyPushplus(
+        token=GOOD_TOKEN,
+        channel="mail",
+        webhook="myhook",
+    )
+    assert obj3.send(body="mail msg") is True
+    payload3 = loads(mock_post.call_args[1]["data"])
+    assert "webhook" not in payload3
+
+
+@mock.patch("requests.post")
+def test_plugin_pushplus_send_http_error(mock_post):
+    """NotifyPushplus() handles HTTP-level errors correctly."""
+
+    response = mock.Mock()
+    response.content = b""
+    mock_post.return_value = response
+
+    obj = NotifyPushplus(token=GOOD_TOKEN)
+
+    # HTTP 500
+    response.status_code = requests.codes.internal_server_error
+    assert obj.send(body="msg") is False
+
+    # Unknown HTTP status code
+    response.status_code = 999
+    assert obj.send(body="msg") is False
+
+
+@mock.patch("requests.post")
+def test_plugin_pushplus_send_api_error(mock_post):
+    """NotifyPushplus() handles API-level failures (HTTP 200, bad code)."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    obj = NotifyPushplus(token=GOOD_TOKEN)
+
+    # Known API error code (907 = Token does not exist)
+    response.content = BAD_RESPONSE.encode("utf-8")
+    assert obj.send(body="msg") is False
+
+    # Unknown API error code with a msg field -- falls back to msg
+    response.content = dumps({"code": 999, "msg": "some error"}).encode(
+        "utf-8"
+    )
+    assert obj.send(body="msg") is False
+
+    # Unknown API error code with no msg field -- generic fallback
+    response.content = dumps({"code": 999}).encode("utf-8")
+    assert obj.send(body="msg") is False
+
+    # Unparsable JSON body
+    response.content = b"{bad json"
+    assert obj.send(body="msg") is False
+
+    # None content -- treated as unparsable
+    response.content = None
+    assert obj.send(body="msg") is False
+
+
+@mock.patch("requests.post")
+def test_plugin_pushplus_send_exception(mock_post):
+    """NotifyPushplus() handles connection exceptions gracefully."""
+    mock_post.side_effect = requests.RequestException("connection error")
+    obj = NotifyPushplus(token=GOOD_TOKEN)
+    assert obj.send(body="msg") is False
+
+
+@mock.patch("requests.post")
+def test_plugin_pushplus_send_exception_multi_topic(mock_post):
+    """NotifyPushplus() continues after a connection error on one topic."""
+
+    # First call raises, second succeeds -- overall result is False
+    good_resp = mock.Mock()
+    good_resp.status_code = requests.codes.ok
+    good_resp.content = GOOD_RESPONSE.encode("utf-8")
+    mock_post.side_effect = [
+        requests.RequestException("network error"),
+        good_resp,
+    ]
+
+    obj = NotifyPushplus(token=GOOD_TOKEN, targets=["grp1", "grp2"])
+    assert obj.send(body="msg") is False
+    # Both topics must still be attempted
+    assert mock_post.call_count == 2
+
+
+def test_plugin_pushplus_parse_url():
+    """NotifyPushplus() parse_url() extracts all supported fields."""
+
+    # Token in the host position
+    result = NotifyPushplus.parse_url("pushplus://{}".format(GOOD_TOKEN))
+    assert result["token"] == GOOD_TOKEN
+    assert result["targets"] == []
+
+    # Token supplied as a ?token= query parameter
+    result = NotifyPushplus.parse_url(
+        "pushplus://?token={}".format(GOOD_TOKEN)
+    )
+    assert result["token"] == GOOD_TOKEN
+
+    # Topic in the URL path becomes a plain targets entry
+    result = NotifyPushplus.parse_url(
+        "pushplus://{}/mygroup".format(GOOD_TOKEN)
+    )
+    assert "mygroup" in result["targets"]
+
+    # Two topics in the path
+    result = NotifyPushplus.parse_url(
+        "pushplus://{}/grp1/grp2".format(GOOD_TOKEN)
+    )
+    assert "grp1" in result["targets"]
+    assert "grp2" in result["targets"]
+
+    # Backward compat: ?topic= adds a plain topic entry
+    result = NotifyPushplus.parse_url(
+        "pushplus://{}/?topic=mygroup".format(GOOD_TOKEN)
+    )
+    assert "mygroup" in result["targets"]
+
+    # ?to= alias appends additional targets
+    result = NotifyPushplus.parse_url(
+        "pushplus://{}/?to=mygroup".format(GOOD_TOKEN)
+    )
+    assert "mygroup" in result["targets"]
+
+    # Delivery channel via ?channel=
+    result = NotifyPushplus.parse_url(
+        "pushplus://{}?channel=mail".format(GOOD_TOKEN)
+    )
+    assert result.get("channel") == "mail"
+
+    # Delivery channel via ?mode= alias
+    result = NotifyPushplus.parse_url(
+        "pushplus://{}?mode=sms".format(GOOD_TOKEN)
+    )
+    assert result.get("channel") == "sms"
+
+    # channel= takes precedence over mode= when both are supplied
+    result = NotifyPushplus.parse_url(
+        "pushplus://{}?mode=sms&channel=mail".format(GOOD_TOKEN)
+    )
+    assert result.get("channel") == "mail"
+
+    # Webhook name extracted into the "webhook" key from ?name=
+    result = NotifyPushplus.parse_url(
+        "pushplus://{}?channel=webhook&name=myhook".format(GOOD_TOKEN)
+    )
+    assert result.get("webhook") == "myhook"
+    assert result.get("channel") == "webhook"
+
+
+def test_plugin_pushplus_parse_native_url():
+    """NotifyPushplus() parse_native_url() handles all edge cases."""
+
+    # Basic native URL -- token extracted correctly
+    result = NotifyPushplus.parse_native_url(
+        "https://www.pushplus.plus/send?token={}".format(GOOD_TOKEN)
+    )
+    assert result is not None
+    obj = NotifyPushplus(**result)
+    assert obj.token == GOOD_TOKEN
+
+    # Native URL with topic parameter preserved via round-trip
+    result = NotifyPushplus.parse_native_url(
+        "https://www.pushplus.plus/send?token={}&topic=mygroup".format(
+            GOOD_TOKEN
+        )
+    )
+    assert result is not None
+    obj = NotifyPushplus(**result)
+    assert "mygroup" in obj.topics
+
+    # Native URL with channel parameter preserved
+    result = NotifyPushplus.parse_native_url(
+        "https://www.pushplus.plus/send?token={}&channel=mail".format(
+            GOOD_TOKEN
+        )
+    )
+    assert result is not None
+    obj = NotifyPushplus(**result)
+    assert obj.channel == PushPlusChannel.MAIL
+
+    # Native URL with webhook name parameter preserved
+    result = NotifyPushplus.parse_native_url(
+        "https://www.pushplus.plus/send"
+        "?token={}&channel=webhook&name=myhook".format(GOOD_TOKEN)
+    )
+    assert result is not None
+    obj = NotifyPushplus(**result)
+    assert obj.webhook == "myhook"
+    assert obj.channel == PushPlusChannel.WEBHOOK
+
+    # Native URL without a token -- not matched, returns None
+    assert (
+        NotifyPushplus.parse_native_url(
+            "https://www.pushplus.plus/send?channel=mail"
+        )
+        is None
+    )
+
+    # Completely different domain -- not matched, returns None
+    assert (
+        NotifyPushplus.parse_native_url(
+            "https://other.example.com/send?token={}".format(GOOD_TOKEN)
+        )
+        is None
+    )
+
+    # Native URL with no query string -- not matched, returns None
+    assert (
+        NotifyPushplus.parse_native_url("https://www.pushplus.plus/send")
+        is None
+    )
+
+
+@mock.patch("requests.post")
+def test_plugin_pushplus_apprise_integration(mock_post):
+    """NotifyPushplus() integrates correctly with the Apprise object."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = GOOD_RESPONSE.encode("utf-8")
+    mock_post.return_value = response
+
+    # Personal URL -- single notification
+    aobj = Apprise()
+    assert aobj.add("pushplus://{}".format(GOOD_TOKEN))
+    assert len(aobj) == 1
+    assert aobj.notify(title="Test Title", body="Test Body") is True
+    assert mock_post.call_count == 1
+
+    mock_post.reset_mock()
+    response.content = GOOD_RESPONSE.encode("utf-8")
+
+    # Group URL with markdown format override
+    aobj2 = Apprise()
+    assert aobj2.add(
+        "pushplus://{}/mygroup?format=markdown".format(GOOD_TOKEN)
+    )
+    assert aobj2.notify(body="Group message") is True
+    assert mock_post.call_count == 1
+    payload = loads(mock_post.call_args[1]["data"])
+    # format=markdown must map to the PushPlus "markdown" template
+    assert payload["template"] == "markdown"
+    assert payload["topic"] == "mygroup"
+
+    mock_post.reset_mock()
+    response.content = GOOD_RESPONSE.encode("utf-8")
+
+    # wecom:// schema alias -- channel=cp in payload
+    aobj3 = Apprise()
+    assert aobj3.add("wecom://{}".format(GOOD_TOKEN))
+    assert aobj3.notify(body="WeCom message") is True
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["channel"] == PushPlusChannel.WECOM

--- a/tests/test_plugin_pushplus.py
+++ b/tests/test_plugin_pushplus.py
@@ -208,12 +208,23 @@ apprise_url_tests = (
         },
     ),
     # ----------------------------------------------------------------
-    # Webhook channel with a named endpoint (?name=)
+    # Webhook channel with a named endpoint -- both input forms accepted
     # ----------------------------------------------------------------
     (
         "pushplus://{}?channel=webhook&name=myhook".format(GOOD_TOKEN),
         {
             "instance": NotifyPushplus,
+            # url() emits the compact schema://name@token form
+            "privacy_url": "pushplus://myhook@",
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    # schema://name@token form -- channel=webhook is implied
+    (
+        "pushplus://myhook@{}".format(GOOD_TOKEN),
+        {
+            "instance": NotifyPushplus,
+            "privacy_url": "pushplus://myhook@",
             "requests_response_text": GOOD_RESPONSE,
         },
     ),
@@ -439,15 +450,23 @@ def test_plugin_pushplus_url():
     url = obj.url()
     assert "channel=" not in url
 
-    # Webhook name emitted as ?name= only when channel is webhook
+    # When channel=webhook with a name, url() uses schema://name@token form
     obj = NotifyPushplus(
         token=GOOD_TOKEN,
         channel="webhook",
         webhook="myhook",
     )
     url = obj.url()
-    assert "name=myhook" in url
-    assert "channel=webhook" in url
+    assert "pushplus://myhook@" in url
+    # channel= and name= are both implied by user@ -- omitted from params
+    assert "channel=" not in url
+    assert "name=" not in url
+
+    # Privacy URL preserves the webhook name but masks the token
+    priv = obj.url(privacy=True)
+    assert "pushplus://myhook@" in priv
+    assert GOOD_TOKEN not in priv
+    assert "****" in priv
 
     # Webhook name suppressed when channel is not webhook
     obj = NotifyPushplus(
@@ -457,11 +476,14 @@ def test_plugin_pushplus_url():
     )
     url = obj.url()
     assert "name=" not in url
+    assert "@" not in url
 
-    # Webhook channel without a name -- no name= key in URL
+    # Webhook channel without a name uses the plain ?channel=webhook form
     obj = NotifyPushplus(token=GOOD_TOKEN, channel="webhook")
     url = obj.url()
     assert "name=" not in url
+    assert "channel=webhook" in url
+    assert "@" not in url
 
     # Invalid targets are preserved in the URL path for round-trip fidelity
     obj = NotifyPushplus(token=GOOD_TOKEN, targets=["bad!target"])
@@ -808,6 +830,27 @@ def test_plugin_pushplus_parse_url():
     # Webhook name extracted into the "webhook" key from ?name=
     result = NotifyPushplus.parse_url(
         "pushplus://{}?channel=webhook&name=myhook".format(GOOD_TOKEN)
+    )
+    assert result.get("webhook") == "myhook"
+    assert result.get("channel") == "webhook"
+
+    # schema://name@token form: user@ -> webhook, implies channel=webhook
+    result = NotifyPushplus.parse_url(
+        "pushplus://myhook@{}".format(GOOD_TOKEN)
+    )
+    assert result.get("webhook") == "myhook"
+    assert result.get("channel") == PushPlusChannel.WEBHOOK
+
+    # Explicit ?channel= overrides the webhook implication from user@
+    result = NotifyPushplus.parse_url(
+        "pushplus://myhook@{}?channel=mail".format(GOOD_TOKEN)
+    )
+    assert result.get("webhook") == "myhook"
+    assert result.get("channel") == "mail"
+
+    # ?name= takes precedence over user@ when both are supplied
+    result = NotifyPushplus.parse_url(
+        "pushplus://other@{}?channel=webhook&name=myhook".format(GOOD_TOKEN)
     )
     assert result.get("webhook") == "myhook"
     assert result.get("channel") == "webhook"


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1564

Redesigns the PushPlus plugin to align with Apprise conventions:

- Delivery channel (`wechat`, `webhook`, `cp`/`wecom`, `mail`, `sms`) is now a `?channel=` / `?mode=` query parameter instead of a path prefix, matching how other Apprise plugins handle mode selection.
- Group topics remain path targets (one API call per topic), with no prefix required since there is only one target type.
- Adds `wechat://` and `wecom://` as schema aliases providing a migration path for users coming from older WeChat/WeCom setups.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/48](https://github.com/caronc/apprise-docs/pull/48)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@lark-support

# Personal notification (WeChat default)
apprise -vv -t "Title" -b "Hello" \
    pushplus://abc123def456ghi789jkl012mno345pq

# Group topic
apprise -vv -t "Title" -b "Hello" \
    pushplus://abc123def456ghi789jkl012mno345pq/mygroup

# Deliver via email
apprise -vv -t "Title" -b "Hello" \
    "pushplus://abc123def456ghi789jkl012mno345pq?channel=mail"

# WeCom schema alias (equivalent to ?channel=cp)
apprise -vv -t "Title" -b "Hello" \
    wecom://abc123def456ghi789jkl012mno345pq

# WeChat schema alias
apprise -vv -t "Title" -b "Hello" \
    wechat://abc123def456ghi789jkl012mno345pq

# Native PushPlus API URL
apprise -vv -t "Title" -b "Hello" \
    "https://www.pushplus.plus/send?token=abc123def456ghi789jkl012mno345pq"
```
