### PR TITLE
Added Postmark support

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The table below identifies the services this tool supports and some example serv
 | [PagerTree](https://appriseit.com/services/pagertree/) | pagertree:// | (TCP) 443 | pagertree://integration_id
 | [ParsePlatform](https://appriseit.com/services/parseplatform/) | parsep:// or parseps:// | (TCP) 80 or 443 | parsep://AppID:MasterKey@Hostname<br/>parseps://AppID:MasterKey@Hostname
 | [PopcornNotify](https://appriseit.com/services/popcornnotify/) | popcorn://  | (TCP) 443   | popcorn://ApiKey/ToPhoneNo<br/>popcorn://ApiKey/ToPhoneNo1/ToPhoneNo2/ToPhoneNoN/<br/>popcorn://ApiKey/ToEmail<br/>popcorn://ApiKey/ToEmail1/ToEmail2/ToEmailN/<br/>popcorn://ApiKey/ToPhoneNo1/ToEmail1/ToPhoneNoN/ToEmailN
+| [Postmark](https://appriseit.com/services/postmark/) | postmark://  | (TCP) 443   | postmark://APIToken:FromEmail/<br />postmark://APIToken:FromEmail/ToEmail<br />postmark://APIToken:FromEmail/ToEmail1/ToEmail2/ToEmailN/
 | [Prowl](https://appriseit.com/services/prowl/) | prowl://   | (TCP) 443    | prowl://apikey<br />prowl://apikey/providerkey
 | [PushBullet](https://appriseit.com/services/pushbullet/) | pbul://    | (TCP) 443    | pbul://accesstoken<br />pbul://accesstoken/#channel<br/>pbul://accesstoken/A_DEVICE_ID<br />pbul://accesstoken/email@address.com<br />pbul://accesstoken/#channel/#channel2/email@address.net/DEVICE
 | [Pushjet](https://appriseit.com/services/pushjet/) | pjet:// or pjets:// | (TCP) 80 or 443 | pjet://hostname/secret<br />pjet://hostname:port/secret<br />pjets://secret@hostname/secret<br />pjets://hostname:port/secret

--- a/apprise/plugins/postmark.py
+++ b/apprise/plugins/postmark.py
@@ -1,0 +1,641 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Steps to get your Postmark Server API Token:
+#  1. Visit https://account.postmarkapp.com/ and sign in.
+#  2. Select the server you wish to send from (or create a new one).
+#  3. In the server settings, click "API Tokens".
+#  4. Copy the Server API Token shown on that page.
+#
+#  Your sender address (From Email) must be a verified sender signature
+#  or belong to a verified sending domain in Postmark.  Visit:
+#    https://account.postmarkapp.com/signature_domains
+#
+#  Build your Apprise URL as follows:
+#    postmark://{apikey}:{from_email}
+#    postmark://{apikey}:{from_email}/{to_email}
+#    postmark://{apikey}:{from_email}/{to_email1}/{to_email2}/{to_emailN}
+#
+#  Use the optional query parameters to add CC, BCC, Reply-To:
+#    postmark://{apikey}:{from_email}?bcc=bcc@example.com
+#    postmark://{apikey}:{from_email}?cc=cc@example.com
+#    postmark://{apikey}:{from_email}?reply=reply@example.com
+#    postmark://{apikey}:{from_email}?name=Display+Name
+#
+#  API Reference:
+#    https://postmarkapp.com/developer/api/email-api
+
+from email.utils import formataddr
+from json import dumps
+import logging
+
+import requests
+
+from .. import exception
+from ..common import NotifyFormat, NotifyType
+from ..locale import gettext_lazy as _
+from ..utils.parse import is_email, parse_emails, validate_regex
+from ..utils.sanitize import sanitize_payload
+from .base import NotifyBase
+
+# Provide some known codes Postmark uses and what they translate to.
+# Reference: https://postmarkapp.com/developer/api/overview#error-codes
+POSTMARK_HTTP_ERROR_MAP = {
+    401: "Unauthorized - Invalid or missing Server API Token.",
+    422: "Unprocessable Entity - Invalid payload or configuration.",
+    429: "Too Many Requests - Rate limit exceeded.",
+    500: "Internal Server Error.",
+}
+
+
+class NotifyPostmark(NotifyBase):
+    """A wrapper for Postmark Notifications."""
+
+    # The default descriptive name associated with the Notification
+    service_name = "Postmark"
+
+    # The services URL
+    service_url = "https://postmarkapp.com/"
+
+    # The default secure protocol
+    secure_protocol = "postmark"
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = "https://appriseit.com/services/postmark/"
+
+    # Default to HTML
+    notify_format = NotifyFormat.HTML
+
+    # The Postmark email API endpoint
+    notify_url = "https://api.postmarkapp.com/email"
+
+    # Support attachments
+    attachment_support = True
+
+    # Postmark practical send rate is ~50 messages/second.
+    # 60 / 50 = 1.2
+    request_rate_per_sec = 1.2
+
+    # The default subject to use if one is not specified
+    default_empty_subject = "<no subject>"
+
+    # Define object URL templates
+    templates = (
+        "{schema}://{apikey}:{from_email}",
+        "{schema}://{apikey}:{from_email}/{targets}",
+    )
+
+    # Define our template tokens
+    template_tokens = dict(
+        NotifyBase.template_tokens,
+        **{
+            "apikey": {
+                "name": _("API Key"),
+                "type": "string",
+                "private": True,
+                "required": True,
+            },
+            "from_email": {
+                "name": _("Source Email"),
+                "type": "string",
+                "required": True,
+            },
+            "target_email": {
+                "name": _("Target Email"),
+                "type": "string",
+                "map_to": "targets",
+            },
+            "targets": {
+                "name": _("Targets"),
+                "type": "list:string",
+            },
+        },
+    )
+
+    # Define our template arguments
+    template_args = dict(
+        NotifyBase.template_args,
+        **{
+            "name": {
+                "name": _("From Name"),
+                "type": "string",
+                "map_to": "from_name",
+            },
+            "reply": {
+                "name": _("Reply To Email"),
+                "type": "list:string",
+                "map_to": "reply_to",
+            },
+            "to": {
+                "alias_of": "targets",
+            },
+            "cc": {
+                "name": _("Carbon Copy"),
+                "type": "list:string",
+            },
+            "bcc": {
+                "name": _("Blind Carbon Copy"),
+                "type": "list:string",
+            },
+        },
+    )
+
+    def __init__(
+        self,
+        apikey,
+        from_email,
+        targets=None,
+        cc=None,
+        bcc=None,
+        from_name=None,
+        reply_to=None,
+        **kwargs,
+    ):
+        """Initialize Notify Postmark Object."""
+        super().__init__(**kwargs)
+
+        # API Key (Server Token)
+        self.apikey = validate_regex(apikey)
+        if not self.apikey:
+            msg = f"An invalid Postmark API Key ({apikey}) was specified."
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # Validate our from email address
+        result = is_email(from_email)
+        if not result:
+            msg = (
+                f"An invalid Postmark From email ({from_email}) was specified."
+            )
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # Store our from address as a (name, email) tuple
+        self.from_addr = (
+            result["name"] if result["name"] is not None else False,
+            result["full_email"],
+        )
+
+        # from_name overrides any name embedded in the from email string
+        if from_name:
+            self.from_addr = (from_name, self.from_addr[1])
+
+        # For tracking email -> display name lookups
+        self.names = {}
+
+        # Acquire Targets (To Emails)
+        self.targets = []
+
+        # Acquire Carbon Copies
+        self.cc = set()
+
+        # Acquire Blind Carbon Copies
+        self.bcc = set()
+
+        # Acquire Reply-To addresses
+        self.reply_to = set()
+
+        # Validate recipients (to:) and drop bad ones:
+        if targets:
+            for recipient in parse_emails(targets):
+                result = is_email(recipient)
+                if result:
+                    self.targets.append(result["full_email"])
+                    # Index name if one exists
+                    self.names[result["full_email"]] = (
+                        result["name"] if result["name"] else False
+                    )
+                    continue
+
+                self.logger.warning(
+                    "Dropped invalid Postmark To email "
+                    f"({recipient}) specified.",
+                )
+
+        else:
+            # Default to the from address when no targets are specified
+            self.targets.append(self.from_addr[1])
+
+        # Validate recipients (cc:) and drop bad ones:
+        for recipient in parse_emails(cc):
+            result = is_email(recipient)
+            if result:
+                self.cc.add(result["full_email"])
+                # Index name if one exists
+                self.names[result["full_email"]] = (
+                    result["name"] if result["name"] else False
+                )
+                continue
+
+            self.logger.warning(
+                "Dropped invalid Postmark Carbon Copy email "
+                f"({recipient}) specified.",
+            )
+
+        # Validate recipients (bcc:) and drop bad ones:
+        for recipient in parse_emails(bcc):
+            result = is_email(recipient)
+            if result:
+                self.bcc.add(result["full_email"])
+                continue
+
+            self.logger.warning(
+                "Dropped invalid Postmark Blind Carbon Copy "
+                f"email ({recipient}) specified.",
+            )
+
+        # Validate reply-to addresses and drop bad ones:
+        for recipient in parse_emails(reply_to):
+            result = is_email(recipient)
+            if result:
+                self.reply_to.add(result["full_email"])
+                # Index name if one exists
+                self.names[result["full_email"]] = (
+                    result["name"] if result["name"] else False
+                )
+                continue
+
+            self.logger.warning(
+                "Dropped invalid Postmark Reply To email "
+                f"({recipient}) specified.",
+            )
+
+        return
+
+    @property
+    def url_identifier(self):
+        """Returns all of the identifiers that make this URL unique from
+        another simliar one.
+
+        Targets or end points should never be identified here.
+        """
+        return (self.secure_protocol, self.apikey, self.from_addr[1])
+
+    def url(self, privacy=False, *args, **kwargs):
+        """Returns the URL built dynamically based on specified arguments."""
+
+        # Our URL parameters
+        params = self.url_parameters(privacy=privacy, *args, **kwargs)
+
+        # Include from display name if one is set
+        if self.from_addr[0]:
+            params["name"] = self.from_addr[0]
+
+        if self.cc:
+            # Handle our Carbon Copy Addresses
+            params["cc"] = ",".join(
+                [
+                    formataddr(
+                        (self.names.get(e, False), e),
+                        charset="utf-8",
+                    ).replace(",", "%2C")
+                    for e in self.cc
+                ]
+            )
+
+        if self.bcc:
+            # Handle our Blind Carbon Copy Addresses
+            params["bcc"] = ",".join(self.bcc)
+
+        if self.reply_to:
+            # Handle our Reply-To Addresses
+            params["reply"] = ",".join(
+                [
+                    formataddr(
+                        (self.names.get(e, False), e),
+                        charset="utf-8",
+                    ).replace(",", "%2C")
+                    for e in self.reply_to
+                ]
+            )
+
+        # Determine whether to display target emails in the URL
+        has_targets = not (
+            len(self.targets) == 1 and self.targets[0] == self.from_addr[1]
+        )
+
+        return "{schema}://{apikey}:{from_email}/{targets}?{params}".format(
+            schema=self.secure_protocol,
+            apikey=self.pprint(self.apikey, privacy, safe=""),
+            # never encode email since it plays a role in our hostname
+            from_email=self.from_addr[1],
+            targets=(
+                ""
+                if not has_targets
+                else "/".join(
+                    [NotifyPostmark.quote(x, safe="@") for x in self.targets]
+                )
+            ),
+            params=NotifyPostmark.urlencode(params),
+        )
+
+    def __len__(self):
+        """Returns the number of targets associated with this notification."""
+        return max(len(self.targets), 1)
+
+    def send(
+        self,
+        body,
+        title="",
+        notify_type=NotifyType.INFO,
+        attach=None,
+        **kwargs,
+    ):
+        """Perform Postmark Notification."""
+
+        if not self.targets:
+            # There is no one to email; we're done
+            self.logger.warning(
+                "There are no Postmark email recipients to notify"
+            )
+            return False
+
+        # Prepare our headers
+        headers = {
+            "User-Agent": self.app_id,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "X-Postmark-Server-Token": self.apikey,
+        }
+
+        # error tracking (used for function return)
+        has_error = False
+
+        # Prepare the From field (with optional display name)
+        from_field = formataddr(self.from_addr, charset="utf-8")
+
+        # Base payload template (shared across all targets)
+        payload_ = {
+            "From": from_field,
+            "Subject": (title if title else self.default_empty_subject),
+        }
+
+        # Set body content based on the notify format
+        if self.notify_format == NotifyFormat.HTML:
+            payload_["HtmlBody"] = body
+        else:
+            payload_["TextBody"] = body
+
+        if attach and self.attachment_support:
+            # Prepare attachment list
+            attachments = []
+
+            for no, attachment in enumerate(attach, start=1):
+                # Perform some simple error checking
+                if not attachment:
+                    # We could not access the attachment
+                    self.logger.error(
+                        "Could not access Postmark attachment"
+                        f" {attachment.url(privacy=True)}."
+                    )
+                    return False
+
+                try:
+                    # Append base64-encoded attachment to list
+                    attachments.append(
+                        {
+                            "Name": (
+                                attachment.name
+                                if attachment.name
+                                else f"file{no:03}.dat"
+                            ),
+                            "Content": attachment.base64(),
+                            "ContentType": attachment.mimetype,
+                        }
+                    )
+
+                except exception.AppriseException:
+                    # We could not access the attachment
+                    self.logger.error(
+                        "Could not access Postmark attachment"
+                        f" {attachment.url(privacy=True)}."
+                    )
+                    return False
+
+                self.logger.debug(
+                    "Appending Postmark attachment"
+                    f" {attachment.url(privacy=True)}"
+                )
+
+            # Append our attachment list to the base payload
+            payload_["Attachments"] = attachments
+
+        # Iterate over each recipient target
+        targets = list(self.targets)
+        while len(targets) > 0:
+            target = targets.pop(0)
+
+            # Create a per-target copy of our base payload
+            payload = payload_.copy()
+
+            # Unique cc/bcc/reply-to management -- remove target from each
+            cc = self.cc - self.bcc - {target}
+            bcc = self.bcc - {target}
+            reply_to = self.reply_to - {target}
+
+            # Set our main recipient
+            payload["To"] = target
+
+            if cc:
+                # Format CC addresses with optional display names
+                payload["Cc"] = ",".join(
+                    [
+                        formataddr(
+                            (self.names.get(a, False), a),
+                            charset="utf-8",
+                        )
+                        for a in cc
+                    ]
+                )
+
+            if bcc:
+                # BCC addresses (plain, no display names)
+                payload["Bcc"] = ",".join(bcc)
+
+            if reply_to:
+                # Format Reply-To addresses with optional display names
+                payload["ReplyTo"] = ",".join(
+                    [
+                        formataddr(
+                            (self.names.get(a, False), a),
+                            charset="utf-8",
+                        )
+                        for a in reply_to
+                    ]
+                )
+
+            # Some Debug Logging
+            if self.logger.isEnabledFor(logging.DEBUG):
+                # Due to attachments, output can be quite heavy; only
+                # show the debug payload when debug logging is active.
+                self.logger.debug(
+                    "Postmark POST URL:"
+                    f" {self.notify_url} "
+                    f"(cert_verify={self.verify_certificate!r})"
+                )
+                self.logger.debug(
+                    "Postmark Payload: %s", sanitize_payload(payload)
+                )
+
+            # Always call throttle before any remote server i/o is made
+            self.throttle()
+
+            try:
+                r = requests.post(
+                    self.notify_url,
+                    data=dumps(payload),
+                    headers=headers,
+                    verify=self.verify_certificate,
+                    timeout=self.request_timeout,
+                )
+                if r.status_code != requests.codes.ok:
+                    # We had a problem
+                    status_str = NotifyPostmark.http_response_code_lookup(
+                        r.status_code, POSTMARK_HTTP_ERROR_MAP
+                    )
+
+                    self.logger.warning(
+                        "Failed to send Postmark notification to "
+                        "{}: {}{}error={}.".format(
+                            target,
+                            status_str,
+                            ", " if status_str else "",
+                            r.status_code,
+                        )
+                    )
+
+                    self.logger.debug(
+                        "Response Details:\r\n%r",
+                        (r.content or b"")[:2000],
+                    )
+
+                    # Mark our failure
+                    has_error = True
+                    continue
+
+                else:
+                    self.logger.info(
+                        f"Sent Postmark notification to {target}."
+                    )
+
+            except requests.RequestException as e:
+                self.logger.warning(
+                    "A Connection error occurred sending Postmark "
+                    f"notification to {target}."
+                )
+                self.logger.debug(f"Socket Exception: {e!s}")
+
+                # Mark our failure
+                has_error = True
+                continue
+
+        return not has_error
+
+    @staticmethod
+    def parse_url(url):
+        """Parses the URL and returns enough arguments that can allow us
+        to re-instantiate this object."""
+
+        results = NotifyBase.parse_url(url, verify_host=False)
+        if not results:
+            # We're done early as we couldn't load the results
+            return results
+
+        # Our URL looks like this:
+        #    {schema}://{apikey}:{from_email}/{targets}
+        #
+        # which actually equates to:
+        #    {schema}://{user}:{password}@{host}/{email1}/{email2}/etc
+        #                  ^       ^         ^
+        #                  |       |         |
+        #               apikey    user     domain
+        #                              (from email parts)
+
+        # Handle apikey= query param override
+        if "apikey" in results["qsd"] and results["qsd"]["apikey"]:
+            results["apikey"] = NotifyPostmark.unquote(
+                results["qsd"]["apikey"]
+            )
+        else:
+            # Fall back to the user field
+            results["apikey"] = NotifyPostmark.unquote(results["user"])
+
+        # Our targets list
+        results["targets"] = []
+
+        # Handle from= query param (alternative from address)
+        if "from" in results["qsd"] and results["qsd"]["from"]:
+            results["from_email"] = NotifyPostmark.unquote(
+                results["qsd"]["from"]
+            )
+            # Treat the host as a target when from= is given explicitly
+            if results.get("host"):
+                results["targets"].append(
+                    NotifyPostmark.unquote(results["host"])
+                )
+
+        else:
+            # Reconstruct from_email from {password}@{host}
+            results["from_email"] = "{}@{}".format(
+                NotifyPostmark.unquote(
+                    results["password"]
+                    if results["password"]
+                    else results["user"]
+                ),
+                NotifyPostmark.unquote(results["host"]),
+            )
+
+        # Handle from display name
+        if "name" in results["qsd"] and results["qsd"]["name"]:
+            results["from_name"] = NotifyPostmark.unquote(
+                results["qsd"]["name"]
+            )
+
+        # Acquire targets from the URL path
+        results["targets"].extend(
+            NotifyPostmark.split_path(results["fullpath"])
+        )
+
+        # Support ?to= for additional targets
+        if "to" in results["qsd"] and results["qsd"]["to"]:
+            results["targets"] += NotifyPostmark.parse_list(
+                results["qsd"]["to"]
+            )
+
+        # Handle Carbon Copy Addresses
+        if "cc" in results["qsd"] and results["qsd"]["cc"]:
+            results["cc"] = NotifyPostmark.parse_list(results["qsd"]["cc"])
+
+        # Handle Blind Carbon Copy Addresses
+        if "bcc" in results["qsd"] and results["qsd"]["bcc"]:
+            results["bcc"] = NotifyPostmark.parse_list(results["qsd"]["bcc"])
+
+        # Handle Reply-To Addresses
+        if "reply" in results["qsd"] and results["qsd"]["reply"]:
+            results["reply_to"] = results["qsd"]["reply"]
+
+        return results

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -71,7 +71,7 @@ notification services. It supports sending alerts to platforms such as: \
 `NextcloudTalk`, `Notica`, `NotificationAPI`, `Notifiarr`, `Notifico`, \
 `ntfy`, `Octopush`, `Office365`, `OneSignal`, `Opsgenie`, `PagerDuty`, \
 `PagerTree`, `ParsePlatform`, `Plivo`, `PopcornNotify`, `Prowl`, \
-`Pushalot`, `PushBullet`, \
+`Postmark`, `Pushalot`, `PushBullet`, \
 `Pushjet`, `PushMe`, `Pushover`, `Pushplus`, `PushSafer`, `Pushy`, `PushDeer`, \
 `QQ Push`, `Revolt`, `Reddit`, `Resend`, `Rocket.Chat`, `RSyslog`, `SendGrid`, \
 `SendPulse`, `ServerChan`, `Seven`, `SFR`, `Signal`, `SIGNL4`, `SimplePush`, \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ keywords = [
     "ParsePlatform",
     "Plivo",
     "PopcornNotify",
+    "Postmark",
     "Power Automate",
     "Prowl",
     "Push Notifications",

--- a/tests/test_plugin_postmark.py
+++ b/tests/test_plugin_postmark.py
@@ -1,0 +1,582 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Disable logging for a cleaner testing output
+import logging
+import os
+from unittest import mock
+
+from helpers import AppriseURLTester
+import pytest
+import requests
+
+from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise.plugins.postmark import NotifyPostmark
+
+logging.disable(logging.CRITICAL)
+
+# Attachment Directory
+TEST_VAR_DIR = os.path.join(os.path.dirname(__file__), "var")
+
+# Our Testing URLs
+apprise_url_tests = (
+    (
+        "postmark://",
+        {
+            # No credentials
+            "instance": TypeError,
+        },
+    ),
+    (
+        "postmark://:@/",
+        {
+            # Empty credentials
+            "instance": TypeError,
+        },
+    ),
+    (
+        "postmark://abcd",
+        {
+            # API key only, no from email
+            "instance": TypeError,
+        },
+    ),
+    (
+        "postmark://abcd@host",
+        {
+            # API key only, no from email
+            "instance": TypeError,
+        },
+    ),
+    (
+        "postmark://abcd:user@example.com",
+        {
+            # No targets; defaults to from address
+            "instance": NotifyPostmark,
+        },
+    ),
+    (
+        "postmark://abcd:user@example.com?format=text",
+        {
+            # Text format override
+            "instance": NotifyPostmark,
+        },
+    ),
+    (
+        "postmark://abcd:user@example.com/newuser1@example.com",
+        {
+            # A good email with explicit target
+            "instance": NotifyPostmark,
+            "force_debug": True,
+        },
+    ),
+    (
+        "postmark://abcd:user@example.com/newuser2@example.com?name=John",
+        {
+            # With From display name
+            "instance": NotifyPostmark,
+            "privacy_url": (
+                "postmark://a...d:user@example.com/newuser2@example.com"
+            ),
+            "url_matches": r"name=John",
+        },
+    ),
+    (
+        (
+            "postmark://abcd:user@example.com/newuser3@example.com"
+            "?reply=reply@example.com"
+        ),
+        {
+            # With Reply-To
+            "instance": NotifyPostmark,
+            "url_matches": r"reply=",
+        },
+    ),
+    (
+        (
+            "postmark://abcd:user@example.com/newuser4@example.com"
+            "?bcc=bcc@nuxref.com"
+        ),
+        {
+            # With Blind Carbon Copy
+            "instance": NotifyPostmark,
+        },
+    ),
+    (
+        (
+            "postmark://abcd:user@example.com/newuser5@example.com"
+            "?cc=cc@nuxref.com"
+        ),
+        {
+            # With Carbon Copy
+            "instance": NotifyPostmark,
+        },
+    ),
+    (
+        (
+            "postmark://abcd:user@example.com/newuser5@example.com"
+            "?cc=Chris<cc@nuxref.com>"
+        ),
+        {
+            # With named Carbon Copy
+            "instance": NotifyPostmark,
+        },
+    ),
+    (
+        (
+            "postmark://abcd:user@example.com/newuser6@example.com"
+            "?to=extra@nuxref.com"
+        ),
+        {
+            # Via ?to= for additional targets
+            "instance": NotifyPostmark,
+        },
+    ),
+    (
+        "postmark://abcd:user@example.com/bademailaddress",
+        {
+            # Invalid target dropped; no valid recipients -- fails to send
+            "instance": NotifyPostmark,
+            "notify_response": False,
+        },
+    ),
+    (
+        "postmark://abcd:user@example.ca/newuser@example.ca",
+        {
+            "instance": NotifyPostmark,
+            # force a failure
+            "response": False,
+            "requests_response_code": requests.codes.internal_server_error,
+        },
+    ),
+    (
+        "postmark://abcd:user@example.uk/newuser@example.uk",
+        {
+            "instance": NotifyPostmark,
+            # throw a bizarre code forcing us to fail to look it up
+            "response": False,
+            "requests_response_code": 999,
+        },
+    ),
+    (
+        "postmark://abcd:user@example.au/newuser@example.au",
+        {
+            "instance": NotifyPostmark,
+            # Throws a series of connection exceptions with this flag
+            "test_requests_exceptions": True,
+        },
+    ),
+)
+
+
+def test_plugin_postmark_urls():
+    """NotifyPostmark() Apprise URLs."""
+
+    # Run our general tests
+    AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_postmark_edge_cases(mock_post, mock_get):
+    """NotifyPostmark() Edge Cases."""
+
+    # No API key
+    with pytest.raises(TypeError):
+        NotifyPostmark(apikey=None, from_email="user@example.com")
+
+    # Invalid from email
+    with pytest.raises(TypeError):
+        NotifyPostmark(apikey="abcd", from_email="!invalid")
+
+    # No from email (None)
+    with pytest.raises(TypeError):
+        NotifyPostmark(apikey="abcd", from_email=None)
+
+    # Invalid target email -- plugin loads but target is dropped
+    obj = NotifyPostmark(
+        apikey="abcd",
+        from_email="user@example.com",
+        targets="!invalid",
+    )
+    # All targets dropped -> send() returns False
+    assert isinstance(obj, NotifyPostmark)
+
+    # Test invalid bcc/cc entries mixed with valid ones
+    assert isinstance(
+        NotifyPostmark(
+            apikey="abcd",
+            from_email="l2g@example.com",
+            bcc=("abc@def.com", "!invalid"),
+            cc=("abc@test.org", "!invalid"),
+        ),
+        NotifyPostmark,
+    )
+
+    # Test invalid reply_to entries mixed with valid ones
+    assert isinstance(
+        NotifyPostmark(
+            apikey="abcd",
+            from_email="l2g@example.com",
+            reply_to=("reply@def.com", "!invalid"),
+        ),
+        NotifyPostmark,
+    )
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_postmark_send(mock_post, mock_get):
+    """NotifyPostmark() Send."""
+
+    def _mk_resp(code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = b""
+        return r
+
+    mock_post.return_value = _mk_resp()
+    mock_get.return_value = _mk_resp()
+
+    # Basic send to self (no explicit target)
+    obj = Apprise.instantiate("postmark://abcd:user@example.com")
+    assert isinstance(obj, NotifyPostmark)
+    assert obj.notify(body="body", title="title") is True
+
+    # Verify the X-Postmark-Server-Token header was set
+    assert mock_post.call_count == 1
+    call_kwargs = mock_post.call_args
+    import json
+
+    posted = json.loads(call_kwargs[1]["data"])
+    assert posted["To"] == "user@example.com"
+    assert "X-Postmark-Server-Token" in call_kwargs[1]["headers"]
+
+    mock_post.reset_mock()
+
+    # Send with an explicit target
+    obj = Apprise.instantiate(
+        "postmark://abcd:user@example.com/target@example.com"
+    )
+    assert obj.notify(body="body", title="title") is True
+    posted = json.loads(mock_post.call_args[1]["data"])
+    assert posted["To"] == "target@example.com"
+    mock_post.reset_mock()
+
+    # Send with cc and bcc
+    obj = NotifyPostmark(
+        apikey="abcd",
+        from_email="user@example.com",
+        targets=["target@example.com"],
+        cc=["cc@example.com"],
+        bcc=["bcc@example.com"],
+    )
+    assert obj.notify(body="body", title="title") is True
+    posted = json.loads(mock_post.call_args[1]["data"])
+    assert "Cc" in posted
+    assert "Bcc" in posted
+    mock_post.reset_mock()
+
+    # Send with reply_to
+    obj = NotifyPostmark(
+        apikey="abcd",
+        from_email="user@example.com",
+        reply_to=["reply@example.com"],
+    )
+    assert obj.notify(body="body", title="title") is True
+    posted = json.loads(mock_post.call_args[1]["data"])
+    assert "ReplyTo" in posted
+    mock_post.reset_mock()
+
+    # Empty title falls back to default_empty_subject
+    obj = NotifyPostmark(
+        apikey="abcd",
+        from_email="user@example.com",
+    )
+    assert obj.notify(body="body", title="") is True
+    posted = json.loads(mock_post.call_args[1]["data"])
+    assert posted["Subject"] == NotifyPostmark.default_empty_subject
+    mock_post.reset_mock()
+
+    # Text format
+    obj = NotifyPostmark(
+        apikey="abcd",
+        from_email="user@example.com",
+    )
+    from apprise.common import NotifyFormat
+
+    obj.notify_format = NotifyFormat.TEXT
+    assert obj.notify(body="body", title="title") is True
+    posted = json.loads(mock_post.call_args[1]["data"])
+    assert "TextBody" in posted
+    assert "HtmlBody" not in posted
+    mock_post.reset_mock()
+
+    # HTTP error response
+    mock_post.return_value = _mk_resp(requests.codes.internal_server_error)
+    obj = Apprise.instantiate(
+        "postmark://abcd:user@example.com/target@example.com"
+    )
+    assert obj.notify(body="body", title="title") is False
+    mock_post.reset_mock()
+
+    # Unknown HTTP code
+    mock_post.return_value = _mk_resp(999)
+    assert obj.notify(body="body", title="title") is False
+    mock_post.reset_mock()
+
+    # RequestException
+    mock_post.side_effect = requests.RequestException("Connection failed")
+    assert obj.notify(body="body", title="title") is False
+    mock_post.side_effect = None
+    mock_post.reset_mock()
+
+    # No valid targets -> False without any HTTP call
+    obj = NotifyPostmark(
+        apikey="abcd",
+        from_email="user@example.com",
+        targets=["!invalid"],
+    )
+    mock_post.return_value = _mk_resp()
+    assert obj.notify(body="body", title="title") is False
+    assert mock_post.call_count == 0
+
+    # Multiple targets -- partial failure
+    mock_post.reset_mock()
+    responses = [_mk_resp(), _mk_resp(requests.codes.bad_request)]
+    mock_post.side_effect = responses
+    obj = NotifyPostmark(
+        apikey="abcd",
+        from_email="user@example.com",
+        targets=["t1@example.com", "t2@example.com"],
+    )
+    assert obj.notify(body="body", title="title") is False
+    assert mock_post.call_count == 2
+    mock_post.side_effect = None
+
+
+@mock.patch("requests.post")
+def test_plugin_postmark_attachments(mock_post):
+    """NotifyPostmark() Attachments."""
+
+    def _mk_resp(code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = b""
+        return r
+
+    mock_post.return_value = _mk_resp()
+
+    # Single attachment success
+    path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
+    attach = AppriseAttachment(path)
+    obj = Apprise.instantiate("postmark://abcd:user@example.com")
+    assert isinstance(obj, NotifyPostmark)
+    assert (
+        obj.notify(
+            body="body",
+            title="title",
+            notify_type=NotifyType.INFO,
+            attach=attach,
+        )
+        is True
+    )
+
+    import json
+
+    posted = json.loads(mock_post.call_args[1]["data"])
+    assert "Attachments" in posted
+    assert len(posted["Attachments"]) == 1
+    assert posted["Attachments"][0]["Name"] == "apprise-test.gif"
+    mock_post.reset_mock()
+
+    # Multiple attachments
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
+    attach.add(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
+    assert (
+        obj.notify(
+            body="body",
+            title="title",
+            notify_type=NotifyType.INFO,
+            attach=attach,
+        )
+        is True
+    )
+    posted = json.loads(mock_post.call_args[1]["data"])
+    assert len(posted["Attachments"]) == 2
+    mock_post.reset_mock()
+
+    # Attachment inaccessible (file not found)
+    with mock.patch("os.path.isfile", return_value=False):
+        assert (
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=AppriseAttachment(
+                    os.path.join(TEST_VAR_DIR, "apprise-test.gif")
+                ),
+            )
+            is False
+        )
+
+    # Attachment read error (OSError)
+    with mock.patch("builtins.open", side_effect=OSError):
+        assert (
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=AppriseAttachment(
+                    os.path.join(TEST_VAR_DIR, "apprise-test.gif")
+                ),
+            )
+            is False
+        )
+
+
+@mock.patch("requests.post")
+def test_plugin_postmark_url_parsing(mock_post):
+    """NotifyPostmark() URL parsing and round-trip."""
+
+    def _mk_resp(code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = b""
+        return r
+
+    mock_post.return_value = _mk_resp()
+
+    # Basic round-trip
+    obj = NotifyPostmark(
+        apikey="mytoken",
+        from_email="user@example.com",
+    )
+    url = obj.url()
+    result = NotifyPostmark.parse_url(url)
+    assert result is not None
+    obj2 = NotifyPostmark(**result)
+    assert obj.url_identifier == obj2.url_identifier
+
+    # With explicit target
+    obj = NotifyPostmark(
+        apikey="mytoken",
+        from_email="user@example.com",
+        targets=["target@example.com"],
+    )
+    url = obj.url()
+    result = NotifyPostmark.parse_url(url)
+    assert result is not None
+    obj2 = NotifyPostmark(**result)
+    assert len(obj.targets) == len(obj2.targets)
+
+    # With from_name
+    obj = NotifyPostmark(
+        apikey="mytoken",
+        from_email="user@example.com",
+        from_name="Alice",
+    )
+    url = obj.url()
+    assert "name=Alice" in url
+    result = NotifyPostmark.parse_url(url)
+    assert result is not None
+    obj2 = NotifyPostmark(**result)
+    assert obj2.from_addr[0] == "Alice"
+
+    # With bcc and cc
+    obj = NotifyPostmark(
+        apikey="mytoken",
+        from_email="user@example.com",
+        targets=["target@example.com"],
+        cc=["cc@example.com"],
+        bcc=["bcc@example.com"],
+    )
+    url = obj.url()
+    result = NotifyPostmark.parse_url(url)
+    assert result is not None
+    obj2 = NotifyPostmark(**result)
+    assert "cc@example.com" in obj2.cc
+    assert "bcc@example.com" in obj2.bcc
+
+    # With reply_to
+    obj = NotifyPostmark(
+        apikey="mytoken",
+        from_email="user@example.com",
+        reply_to=["reply@example.com"],
+    )
+    url = obj.url()
+    result = NotifyPostmark.parse_url(url)
+    assert result is not None
+    obj2 = NotifyPostmark(**result)
+    assert "reply@example.com" in obj2.reply_to
+
+    # parse_url returns None for completely unparseable input
+    assert NotifyPostmark.parse_url(None) is None
+
+    # ?apikey= override
+    result = NotifyPostmark.parse_url(
+        "postmark://?apikey=overridekey&from=sender@example.com"
+        "&to=target@example.com"
+    )
+    assert result is not None
+    assert result["apikey"] == "overridekey"
+
+    # ?from= override (from address via query param)
+    result = NotifyPostmark.parse_url(
+        "postmark://tok@example.com/path@example.com?from=sender@example.com"
+    )
+    assert result is not None
+    assert result["from_email"] == "sender@example.com"
+
+    # privacy_url hides the API key
+    obj = NotifyPostmark(
+        apikey="secrettoken",
+        from_email="user@example.com",
+    )
+    privacy = obj.url(privacy=True)
+    assert "secrettoken" not in privacy
+    assert "s...n" in privacy or "..." in privacy
+
+    # __len__
+    obj = NotifyPostmark(
+        apikey="mytoken",
+        from_email="user@example.com",
+        targets=["a@example.com", "b@example.com"],
+    )
+    assert len(obj) == 2
+
+    # url_identifier
+    obj1 = NotifyPostmark(
+        apikey="tok",
+        from_email="user@example.com",
+    )
+    obj2 = NotifyPostmark(
+        apikey="tok",
+        from_email="user@example.com",
+        targets=["other@example.com"],
+    )
+    assert obj1.url_identifier == obj2.url_identifier


### PR DESCRIPTION
## Description
**Related issue (if applicable):** n/a
## *Postmark* Notifications
* **Source**: https://postmarkapp.com
* **Image Support**: No
* **Message Format**: HTML / Plain Text
* **Message Limit**: 10 MB (attachment + body combined per Postmark limits)

This plugin integrates Postmark with Apprise

## Account Setup
1. Sign in at https://account.postmarkapp.com/ and select or create a Server.
2. In the server settings, click **API Tokens** and copy the Server API Token.
3. Verify your sender address at https://account.postmarkapp.com/signature_domains.

## Syntax

Valid syntax is as follows:
- `postmark://{APIToken}:{FromEmail}`
- `postmark://{APIToken}:{FromEmail}/{ToEmail}`
- `postmark://{APIToken}:{FromEmail}/{ToEmail1}/{ToEmail2}/{ToEmailN}`

Optional query parameters: `?name=`, `?cc=`, `?bcc=`, `?reply=`, `?to=`, `?format=`

## Parameter Breakdown

| Variable   | Required | Description                                      |
|------------|----------|--------------------------------------------------|
| APIToken   | Yes      | Postmark Server API Token                        |
| FromEmail  | Yes      | Verified sender address or domain                |
| ToEmail    | No       | Recipient(s) in URL path; defaults to FromEmail  |
| to         | No       | Additional recipients via query string           |
| name       | No       | Display name for the sender                      |
| cc         | No       | Carbon-copy recipients, comma-separated          |
| bcc        | No       | Blind carbon-copy recipients, comma-separated    |
| reply      | No       | Reply-To address (named recipients supported)    |
| format     | No       | `html` (default) or `text`                       |

## Examples

Sends a simple example:
```bash
apprise -vv -t "Test Title" -b "Test Message" \
    postmark://APIToken:user@example.com
```

Send to an explicit recipient with CC and BCC:
```bash
apprise -vv -t "Alert" -b "Something happened." \
    "postmark://APIToken:alerts@example.com/ops@example.com?cc=lead@example.com&bcc=manager@example.com"
```

Send with an attachment:
```bash
apprise -vv -t "Report" -b "See attached." \
    --attach /path/to/report.pdf \
    postmark://APIToken:user@example.com/recipient@example.com
```

## New Service Completion Status
* [x] apprise/plugins/postmark.py
* [x] pyproject.toml
    - Updated keywords section to identify Postmark (alphabetically after PopcornNotify).
* [x] README.md
    - Added entry for Postmark (alphabetically after PopcornNotify).
* [x] packaging/redhat/python-apprise.spec
    - Add Postmark into the `%global common_description`

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/49](https://github.com/caronc/apprise-docs/pull/49)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`). -- 100% line + branch via `tox -e minimal`

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@postmark-support

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    postmark://YourServerToken:sender@yourdomain.com/recipient@example.com
```
