### PR TITLE
bugfix: KeyError Exception thrown when certain emoji's specified

### DIFF
--- a/apprise/emojis.py
+++ b/apprise/emojis.py
@@ -2146,15 +2146,17 @@ EMOJI_MAP = {
     DELIM + r"wales" + DELIM: "🏴󠁧󠁢󠁷󠁬󠁳󠁿",
 }
 
-# Define our singlton
+# Define our singletons
 EMOJI_COMPILED_MAP = None
+# List of (compiled_fullmatch_pattern, emoji) for resolving alternation keys
+_EMOJI_PATTERN_LIST = None
 
 
 def apply_emojis(content):
     """Takes the content and swaps any matched emoji's found with their utf-8
     encoded mapping."""
 
-    global EMOJI_COMPILED_MAP
+    global EMOJI_COMPILED_MAP, _EMOJI_PATTERN_LIST
 
     if EMOJI_COMPILED_MAP is None:
         t_start = time.time()
@@ -2162,10 +2164,27 @@ def apply_emojis(content):
         EMOJI_COMPILED_MAP = re.compile(
             r"(" + "|".join(EMOJI_MAP.keys()) + r")", re.IGNORECASE
         )
+
+        # - EMOJI_MAP keys are regex patterns (e.g. ":(\+1|thumbsup):")
+        # - x.group() from a match cannot be used as a dict key directly.
+        #
+        # Build a per-entry compiled pattern for fullmatch lookups so
+        # alternation/optional-group keys resolve correctly.
+        _EMOJI_PATTERN_LIST = [
+            (re.compile(r"(?:" + pat + r")", re.IGNORECASE), emoji)
+            for pat, emoji in EMOJI_MAP.items()
+        ]
         logger.trace(f"Emoji engine loaded in {time.time() - t_start:.4f}s")
 
+    def _lookup(m):
+        text = m.group()
+        for pat, emoji in _EMOJI_PATTERN_LIST:
+            if pat.fullmatch(text):
+                return emoji
+        return text
+
     try:
-        return EMOJI_COMPILED_MAP.sub(lambda x: EMOJI_MAP[x.group()], content)
+        return EMOJI_COMPILED_MAP.sub(_lookup, content)
 
     except TypeError:
         # No change; but force string return

--- a/tests/test_apprise_emojis.py
+++ b/tests/test_apprise_emojis.py
@@ -54,3 +54,56 @@ def test_emojis():
     assert emojis.apply_emojis(object) == ""
     assert emojis.apply_emojis(True) == ""
     assert emojis.apply_emojis(4.0) == ""
+
+
+def test_emojis_alternation_aliases():
+    """emojis: apply_emojis() handles regex alternation keys correctly."""
+
+    # thumbsup / +1
+    assert emojis.apply_emojis(":thumbsup:") == "👍"
+    assert emojis.apply_emojis(":+1:") == "👍"
+
+    # thumbsdown / -1
+    assert emojis.apply_emojis(":thumbsdown:") == "👎"
+    assert emojis.apply_emojis(":-1:") == "👎"
+
+    # laughing / satisfied
+    assert emojis.apply_emojis(":laughing:") == "😆"
+    assert emojis.apply_emojis(":satisfied:") == "😆"
+
+    # poop aliases
+    assert emojis.apply_emojis(":poop:") == "💩"
+    assert emojis.apply_emojis(":hankey:") == "💩"
+    assert emojis.apply_emojis(":shit:") == "💩"
+
+    # boom / collision
+    assert emojis.apply_emojis(":boom:") == "💥"
+    assert emojis.apply_emojis(":collision:") == "💥"
+
+    # exclamation aliases
+    assert emojis.apply_emojis(":exclamation:") == "❗"
+    assert emojis.apply_emojis(":heavy_exclamation_mark:") == "❗"
+
+    # knife / hocho
+    assert emojis.apply_emojis(":knife:") == "🔪"
+    assert emojis.apply_emojis(":hocho:") == "🔪"
+
+    # memo / pencil
+    assert emojis.apply_emojis(":memo:") == "📝"
+    assert emojis.apply_emojis(":pencil:") == "📝"
+
+    # uk / gb
+    assert emojis.apply_emojis(":uk:") == "🇬🇧"
+    assert emojis.apply_emojis(":gb:") == "🇬🇧"
+
+    # aliases embedded in text
+    assert emojis.apply_emojis("hello :thumbsup: world") == "hello 👍 world"
+    assert emojis.apply_emojis(":poop::boom:") == "💩💥"
+
+    # optional-group patterns: ':hand:' and ':raised_hand:' both map to ✋
+    assert emojis.apply_emojis(":hand:") == "✋"
+    assert emojis.apply_emojis(":raised_hand:") == "✋"
+
+    # runner / running
+    assert emojis.apply_emojis(":runner:") == "🏃"
+    assert emojis.apply_emojis(":running:") == "🏃"

--- a/tests/test_apprise_emojis.py
+++ b/tests/test_apprise_emojis.py
@@ -107,3 +107,21 @@ def test_emojis_alternation_aliases():
     # runner / running
     assert emojis.apply_emojis(":runner:") == "🏃"
     assert emojis.apply_emojis(":running:") == "🏃"
+
+
+def test_emojis_lookup_no_pattern_match():
+    """emojis: _lookup() returns the raw token when _EMOJI_PATTERN_LIST is
+    empty (defensive fallback -- return text branch)."""
+
+    # Ensure the engine is initialised first.
+    emojis.apply_emojis(":smile:")
+
+    original = emojis._EMOJI_PATTERN_LIST
+    emojis._EMOJI_PATTERN_LIST = []
+    try:
+        # With no patterns to match against, _lookup falls through to
+        # "return text", so the matched token is passed back unchanged.
+        result = emojis.apply_emojis(":smile:")
+        assert result == ":smile:"
+    finally:
+        emojis._EMOJI_PATTERN_LIST = original


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1591 

Fixes KeyError Exception thrown when some emoji's were applied.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [ ] Documentation ticket created (if applicable): n/a
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [ ] Test coverage added or updated (use `tox -e qa`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1591-emoji-pattern-lookup-fix

# If you have cloned the branch and have tox available to you:
tox -e minimal -- -k emoji
```
