### PR TITLE
Added Zoom (Incoming Webhook) Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ The table below identifies the services this tool supports and some example serv
 | [WxPusher](https://appriseit.com/services/wxpusher/) | wxpusher://  | (TCP) 443   | wxpusher://AppToken@UserID1/UserID2/UserIDN<br/>wxpusher://AppToken@Topic1/Topic2/Topic3<br/>wxpusher://AppToken@UserID1/Topic1/
 | [XBMC](https://appriseit.com/services/xbmc/) | xbmc:// or xbmcs://    | (TCP) 8080 or 443   | xbmc://hostname<br />xbmc://user@hostname<br />xbmc://user:password@hostname:port
 | [XMPP](https://appriseit.com/services/xmpp/) | xmpp:// or xmpps://    | (TCP) 5222 or 5223   | xmpp://user:pass@hostname<br />xmpps://user:pass@hostname/jid<br />xmpps://user:pass@hostname/jid1/jid2@example.ca
+| [Zoom](https://appriseit.com/services/zoom/) | zoom://  | (TCP) 443   | zoom://WebhookID/Token
 | [Zulip Chat](https://appriseit.com/services/zulip/) | zulip://  | (TCP) 443   | zulip://botname@Organization/Token<br />zulip://botname@Organization/Token/Stream<br />zulip://botname@Organization/Token/Email
 
 ## SMS Notifications

--- a/apprise/plugins/zoom.py
+++ b/apprise/plugins/zoom.py
@@ -199,7 +199,9 @@ class NotifyZoom(NotifyBase):
         else:
             # Reject empty or whitespace-only strings before prefix matching;
             # an empty string would match every mode (false positive).
-            normalized_mode = mode.strip().lower() if isinstance(mode, str) else ""
+            normalized_mode = (
+                mode.strip().lower() if isinstance(mode, str) else ""
+            )
             if not normalized_mode:
                 self.mode = None
             else:

--- a/apprise/plugins/zoom.py
+++ b/apprise/plugins/zoom.py
@@ -1,0 +1,383 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Steps to set up a Zoom Team Chat Incoming Webhook:
+#  1. Sign in to https://marketplace.zoom.us and search for
+#     "Incoming Webhook".
+#  2. Click "Add" to install the Incoming Webhook app to your account.
+#  3. In any Zoom Team Chat channel, type the slash command:
+#        /inc connect
+#     Follow the prompts to complete the connection.  You will receive:
+#       - Endpoint URL:
+#           https://inbots.zoom.us/incoming/hook/WEBHOOK_ID
+#       - Verification Token: VERIFICATION_TOKEN
+#
+#  Assemble your Apprise URL using both values:
+#
+#     zoom://WEBHOOK_ID/VERIFICATION_TOKEN
+#
+#  By default, messages are sent in "full" structured format, which renders
+#  the notification title as a heading and the body as the message text.
+#  To send a plain-text message instead, append ?mode=simple:
+#
+#     zoom://WEBHOOK_ID/VERIFICATION_TOKEN?mode=simple
+#
+#  The native webhook URL is also supported when a ?token= parameter is
+#  appended containing the verification token:
+#
+#     https://inbots.zoom.us/incoming/hook/WEBHOOK_ID?token=TOKEN
+#
+# References:
+#  - https://marketplace.zoom.us/apps/eH_dLuquRd-VYcOsNGy-hQ
+#  - https://support.zoom.com/hc/en/article?id=zm_kb&\
+#        sysparm_article=KB0067640
+
+from json import dumps
+import re
+
+import requests
+
+from ..common import NotifyType
+from ..locale import gettext_lazy as _
+from ..utils.parse import validate_regex
+from .base import NotifyBase
+
+# Extend HTTP Error Messages
+ZOOM_HTTP_ERROR_MAP = {
+    401: "Unauthorized - Invalid verification token.",
+    404: "Webhook not found; check the Webhook ID.",
+    429: "Rate limit exceeded; too many consecutive requests.",
+    500: "Zoom internal server error.",
+    503: "Service unavailable; try again later.",
+}
+
+
+class ZoomMode:
+    """Tracks the notification mode for Zoom Team Chat."""
+
+    # Plain-text message; sent without JSON wrapping
+    SIMPLE = "simple"
+
+    # Structured message with head/body sections (supports title)
+    FULL = "full"
+
+
+# Valid Zoom notification modes
+ZOOM_MODES = (
+    ZoomMode.SIMPLE,
+    ZoomMode.FULL,
+)
+
+# Default notification mode
+ZOOM_MODE_DEFAULT = ZoomMode.FULL
+
+
+class NotifyZoom(NotifyBase):
+    """A wrapper for Zoom Team Chat Notifications."""
+
+    # The default descriptive name associated with the Notification
+    service_name = "Zoom"
+
+    # The services URL
+    service_url = "https://zoom.us/"
+
+    # The default secure protocol
+    secure_protocol = "zoom"
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = "https://appriseit.com/services/zoom/"
+
+    # Zoom Team Chat incoming webhooks do not support file attachments
+    attachment_support = False
+
+    # Zoom incoming-webhook base URL
+    zoom_webhook_url = "https://inbots.zoom.us/incoming/hook/{}"
+
+    # The maximum body length for a Zoom notification
+    body_maxlen = 4000
+
+    # Maximum length for the head.text field (full mode only)
+    title_maxlen = 250
+
+    # Define object URL templates
+    templates = ("{schema}://{webhook_id}/{token}",)
+
+    # Define our template tokens
+    template_tokens = dict(
+        NotifyBase.template_tokens,
+        **{
+            "webhook_id": {
+                "name": _("Webhook ID"),
+                "type": "string",
+                "private": True,
+                "required": True,
+            },
+            "token": {
+                "name": _("Verification Token"),
+                "type": "string",
+                "private": True,
+                "required": True,
+            },
+        },
+    )
+
+    # Define our template arguments
+    template_args = dict(
+        NotifyBase.template_args,
+        **{
+            "mode": {
+                "name": _("Mode"),
+                "type": "choice:string",
+                "values": ZOOM_MODES,
+                "default": ZOOM_MODE_DEFAULT,
+            },
+            # token= is already defined in template_tokens; this
+            # alias_of entry simply advertises that ?token= is also
+            # accepted as a query-string override on the URL.
+            "token": {
+                "alias_of": "token",
+            },
+        },
+    )
+
+    def __init__(self, webhook_id, token, mode=None, **kwargs):
+        """Initialize Zoom Object."""
+        super().__init__(**kwargs)
+
+        # Validate our webhook ID
+        self.webhook_id = validate_regex(webhook_id, r"^[A-Za-z0-9_-]+$")
+        if not self.webhook_id:
+            msg = (
+                "A Zoom webhook ID must be specified and contain"
+                " only alphanumeric, hyphen, or underscore"
+                " characters."
+            )
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # Validate our verification token
+        self.token = validate_regex(token)
+        if not self.token:
+            msg = "A Zoom verification token must be specified."
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # Validate notification mode
+        if mode is None:
+            # Default to full structured mode
+            self.mode = ZOOM_MODE_DEFAULT
+
+        else:
+            # Allow partial prefix matching (e.g. "sim" -> "simple")
+            self.mode = next(
+                (m for m in ZOOM_MODES if m.startswith(mode.lower())),
+                None,
+            )
+            if not self.mode:
+                msg = "The Zoom mode ({}) is invalid.".format(mode)
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
+    def send(
+        self,
+        body,
+        title="",
+        notify_type=NotifyType.INFO,
+        attach=None,
+        **kwargs,
+    ):
+        """Perform Zoom Team Chat Notification."""
+
+        # Build the base webhook endpoint URL
+        base_url = self.zoom_webhook_url.format(
+            NotifyZoom.quote(self.webhook_id, safe="")
+        )
+
+        if self.mode == ZoomMode.FULL:
+            # Build the structured content object
+            content = {}
+
+            # Include the head section only when a title is present
+            if title:
+                content["head"] = {"text": title}
+
+            # Always include the body section
+            content["body"] = [
+                {
+                    "type": "message",
+                    "text": body,
+                }
+            ]
+
+            # Append the ?format=full query parameter
+            url = "{}?format=full".format(base_url)
+
+            # Deliver the structured payload as JSON
+            return self._fetch(
+                url,
+                payload=dumps({"content": content}),
+                content_type="application/json",
+            )
+
+        # Simple mode: plain text, title colon-prepended if provided
+        text = "{}: {}".format(title, body) if title else body
+
+        # Deliver plain text directly
+        return self._fetch(base_url, payload=text)
+
+    def _fetch(self, url, payload, content_type=None):
+        """Wrapper to a Zoom webhook POST request."""
+
+        # Prepare our headers
+        headers = {
+            "User-Agent": self.app_id,
+            "Authorization": self.token,
+        }
+
+        # Set Content-Type when a structured payload is provided
+        if content_type:
+            headers["Content-Type"] = content_type
+
+        self.logger.debug(
+            "Zoom POST URL: {} (cert_verify={!r})".format(
+                url, self.verify_certificate
+            )
+        )
+        self.logger.debug("Zoom Payload: {!r}".format(payload))
+
+        # Always call throttle before any remote server i/o is made
+        self.throttle()
+
+        try:
+            r = requests.post(
+                url,
+                data=payload,
+                headers=headers,
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+            )
+            if r.status_code not in (
+                requests.codes.ok,
+                requests.codes.no_content,
+            ):
+                # Report the error
+                status_str = NotifyZoom.http_response_code_lookup(
+                    r.status_code, ZOOM_HTTP_ERROR_MAP
+                )
+                self.logger.warning(
+                    "Failed to send Zoom notification: {}{}error={}.".format(
+                        status_str,
+                        ", " if status_str else "",
+                        r.status_code,
+                    )
+                )
+                self.logger.debug(
+                    "Response Details:\r\n%r",
+                    (r.content or b"")[:2000],
+                )
+                return False
+
+            self.logger.info("Sent Zoom notification.")
+
+        except requests.RequestException as e:
+            self.logger.warning(
+                "A Connection error occurred sending Zoom notification."
+            )
+            self.logger.debug("Socket Exception: {}".format(str(e)))
+            return False
+
+        return True
+
+    @property
+    def url_identifier(self):
+        """Returns all of the identifiers that make this URL unique
+        from another simliar one.
+
+        Targets or end points should never be identified here.
+        """
+        return (self.secure_protocol, self.webhook_id, self.token)
+
+    def url(self, privacy=False, *args, **kwargs):
+        """Returns the URL built dynamically based on specified
+        arguments."""
+
+        # Always include mode so the round-trip is stable
+        params = {"mode": self.mode}
+        params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
+
+        return "{schema}://{webhook_id}/{token}/?{params}".format(
+            schema=self.secure_protocol,
+            webhook_id=self.pprint(self.webhook_id, privacy, safe=""),
+            token=self.pprint(self.token, privacy, safe=""),
+            params=NotifyZoom.urlencode(params),
+        )
+
+    @staticmethod
+    def parse_url(url):
+        """Parses the URL and returns enough arguments that can allow
+        us to re-instantiate this object."""
+        results = NotifyBase.parse_url(url, verify_host=False)
+        if not results:
+            return results
+
+        # The host holds the webhook ID
+        results["webhook_id"] = NotifyZoom.unquote(results["host"])
+
+        # The first path segment carries the verification token
+        path = NotifyZoom.split_path(results["fullpath"])
+        if path:
+            results["token"] = NotifyZoom.unquote(path.pop(0))
+
+        # Support ?token= override (useful with native URLs)
+        if "token" in results["qsd"] and results["qsd"]["token"]:
+            results["token"] = NotifyZoom.unquote(results["qsd"]["token"])
+
+        # Support ?mode= parameter
+        if "mode" in results["qsd"] and results["qsd"]["mode"]:
+            results["mode"] = NotifyZoom.unquote(results["qsd"]["mode"])
+
+        return results
+
+    @staticmethod
+    def parse_native_url(url):
+        """Support https://inbots.zoom.us/incoming/hook/WEBHOOK_ID"""
+        result = re.match(
+            r"^https?://inbots\.zoom\.us/incoming/hook/"
+            r"(?P<webhook_id>[A-Za-z0-9_-]+)/?"
+            r"(?P<params>\?.+)?$",
+            url,
+            re.I,
+        )
+        if result:
+            return NotifyZoom.parse_url(
+                "{schema}://{webhook_id}/{params}".format(
+                    schema=NotifyZoom.secure_protocol,
+                    webhook_id=result.group("webhook_id"),
+                    params=result.group("params") or "",
+                )
+            )
+        return None

--- a/apprise/plugins/zoom.py
+++ b/apprise/plugins/zoom.py
@@ -199,13 +199,13 @@ class NotifyZoom(NotifyBase):
         else:
             # Reject empty or whitespace-only strings before prefix matching;
             # an empty string would match every mode (false positive).
-            _mode = mode.strip().lower() if isinstance(mode, str) else ""
-            if not _mode:
+            normalized_mode = mode.strip().lower() if isinstance(mode, str) else ""
+            if not normalized_mode:
                 self.mode = None
             else:
                 # Allow partial prefix matching (e.g. "sim" -> "simple")
                 self.mode = next(
-                    (m for m in ZOOM_MODES if m.startswith(_mode)),
+                    (m for m in ZOOM_MODES if m.startswith(normalized_mode)),
                     None,
                 )
             if not self.mode:

--- a/apprise/plugins/zoom.py
+++ b/apprise/plugins/zoom.py
@@ -123,6 +123,11 @@ class NotifyZoom(NotifyBase):
     # Maximum length for the head.text field (full mode only)
     title_maxlen = 250
 
+    # In simple mode the title is prepended into the body string, so the
+    # combined payload must stay within body_maxlen.  Setting this flag
+    # ensures Apprise enforces the combined limit across both modes.
+    overflow_amalgamate_title = True
+
     # Define object URL templates
     templates = ("{schema}://{webhook_id}/{token}",)
 
@@ -192,11 +197,17 @@ class NotifyZoom(NotifyBase):
             self.mode = ZOOM_MODE_DEFAULT
 
         else:
-            # Allow partial prefix matching (e.g. "sim" -> "simple")
-            self.mode = next(
-                (m for m in ZOOM_MODES if m.startswith(mode.lower())),
-                None,
-            )
+            # Reject empty or whitespace-only strings before prefix matching;
+            # an empty string would match every mode (false positive).
+            _mode = mode.strip().lower() if isinstance(mode, str) else ""
+            if not _mode:
+                self.mode = None
+            else:
+                # Allow partial prefix matching (e.g. "sim" -> "simple")
+                self.mode = next(
+                    (m for m in ZOOM_MODES if m.startswith(_mode)),
+                    None,
+                )
             if not self.mode:
                 msg = "The Zoom mode ({}) is invalid.".format(mode)
                 self.logger.warning(msg)
@@ -319,7 +330,7 @@ class NotifyZoom(NotifyBase):
 
         Targets or end points should never be identified here.
         """
-        return (self.secure_protocol, self.webhook_id, self.token)
+        return (self.secure_protocol, self.webhook_id, self.token, self.mode)
 
     def url(self, privacy=False, *args, **kwargs):
         """Returns the URL built dynamically based on specified

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -80,7 +80,7 @@ notification services. It supports sending alerts to platforms such as: \
 `Synology Chat`, `Syslog`, `Techulus Push`, `Telegram`, `Threema Gateway`, \
 `Twilio`, `Twitter`, `Twist`, `Vapid`, `Viber`, `VictorOps`, `Voipms`, \
 `Vonage`, `WebPush`, `WeCom Bot`, `WhatsApp`, `Webex Teams`, `Workflows`, \
-`WxPusher`, `XBMC`, `XMPP`, and `Zulip`.}
+`WxPusher`, `XBMC`, `XMPP`, `Zoom`, and `Zulip`.}
 
 Name:           python-%{pypi_name}
 Version:        1.10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,6 +197,7 @@ keywords = [
     "XBMC",
     "XML",
     "XMPP",
+    "Zoom",
     "Zulip",
 ]
 

--- a/tests/test_plugin_zoom.py
+++ b/tests/test_plugin_zoom.py
@@ -269,8 +269,9 @@ def test_plugin_zoom_url_identifier():
     obj_full = NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN, mode="full")
     obj_simple = NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN, mode="simple")
     assert obj_full.url_identifier != obj_simple.url_identifier
-    assert ZoomMode.FULL in obj_full.url_identifier
-    assert ZoomMode.SIMPLE in obj_simple.url_identifier
+    # mode is the 4th element (index 3) of the identifier tuple
+    assert obj_full.url_identifier[3] == ZoomMode.FULL
+    assert obj_simple.url_identifier[3] == ZoomMode.SIMPLE
 
 
 @mock.patch("requests.post")

--- a/tests/test_plugin_zoom.py
+++ b/tests/test_plugin_zoom.py
@@ -1,0 +1,441 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Disable logging for a cleaner testing output
+import logging
+from unittest import mock
+
+from helpers import AppriseURLTester
+import pytest
+import requests
+
+from apprise import Apprise, NotifyType
+from apprise.plugins.zoom import (
+    ZOOM_MODE_DEFAULT,
+    NotifyZoom,
+    ZoomMode,
+)
+
+logging.disable(logging.CRITICAL)
+
+# Reusable test credentials
+WEBHOOK_ID = "abcHook123"
+TOKEN = "xyzVerify456"
+
+# Our Testing URLs
+apprise_url_tests = (
+    # Missing everything
+    (
+        "zoom://",
+        {
+            "instance": TypeError,
+        },
+    ),
+    # Empty user/host segment
+    (
+        "zoom://:@/",
+        {
+            "instance": TypeError,
+        },
+    ),
+    # Missing token (webhook_id present but no path segment)
+    (
+        "zoom://{}".format(WEBHOOK_ID),
+        {
+            "instance": TypeError,
+        },
+    ),
+    # Valid full-mode (default)
+    (
+        "zoom://{}/{}".format(WEBHOOK_ID, TOKEN),
+        {
+            "instance": NotifyZoom,
+            "privacy_url": "zoom://a...3/x...6/",
+        },
+    ),
+    # Explicit mode=full
+    (
+        "zoom://{}/{}?mode=full".format(WEBHOOK_ID, TOKEN),
+        {
+            "instance": NotifyZoom,
+            "privacy_url": "zoom://a...3/x...6/",
+        },
+    ),
+    # Explicit mode=simple
+    (
+        "zoom://{}/{}?mode=simple".format(WEBHOOK_ID, TOKEN),
+        {
+            "instance": NotifyZoom,
+            "privacy_url": "zoom://a...3/x...6/",
+        },
+    ),
+    # Invalid mode
+    (
+        "zoom://{}/{}?mode=invalid".format(WEBHOOK_ID, TOKEN),
+        {
+            "instance": TypeError,
+        },
+    ),
+    # Native URL with ?token= query param
+    (
+        "https://inbots.zoom.us/incoming/hook/{}?token={}".format(
+            WEBHOOK_ID, TOKEN
+        ),
+        {
+            "instance": NotifyZoom,
+        },
+    ),
+    # Full mode: HTTP 500
+    (
+        "zoom://{}/{}".format(WEBHOOK_ID, TOKEN),
+        {
+            "instance": NotifyZoom,
+            "response": False,
+            "requests_response_code": (requests.codes.internal_server_error),
+        },
+    ),
+    # Full mode: unusual status code
+    (
+        "zoom://{}/{}".format(WEBHOOK_ID, TOKEN),
+        {
+            "instance": NotifyZoom,
+            "response": False,
+            "requests_response_code": 999,
+        },
+    ),
+    # Full mode: request exception
+    (
+        "zoom://{}/{}".format(WEBHOOK_ID, TOKEN),
+        {
+            "instance": NotifyZoom,
+            "test_requests_exceptions": True,
+        },
+    ),
+    # Simple mode: HTTP 500
+    (
+        "zoom://{}/{}?mode=simple".format(WEBHOOK_ID, TOKEN),
+        {
+            "instance": NotifyZoom,
+            "response": False,
+            "requests_response_code": (requests.codes.internal_server_error),
+        },
+    ),
+    # Simple mode: unusual status code
+    (
+        "zoom://{}/{}?mode=simple".format(WEBHOOK_ID, TOKEN),
+        {
+            "instance": NotifyZoom,
+            "response": False,
+            "requests_response_code": 999,
+        },
+    ),
+    # Simple mode: request exception
+    (
+        "zoom://{}/{}?mode=simple".format(WEBHOOK_ID, TOKEN),
+        {
+            "instance": NotifyZoom,
+            "test_requests_exceptions": True,
+        },
+    ),
+)
+
+
+def test_plugin_zoom_urls():
+    """NotifyZoom() Apprise URLs."""
+    AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+def test_plugin_zoom_init():
+    """Test NotifyZoom initialization and validation."""
+
+    # Missing webhook_id
+    with pytest.raises(TypeError):
+        NotifyZoom(webhook_id=None, token=TOKEN)
+
+    # Empty webhook_id
+    with pytest.raises(TypeError):
+        NotifyZoom(webhook_id="", token=TOKEN)
+
+    # Webhook ID with invalid characters (slash)
+    with pytest.raises(TypeError):
+        NotifyZoom(webhook_id="bad/id", token=TOKEN)
+
+    # Missing token
+    with pytest.raises(TypeError):
+        NotifyZoom(webhook_id=WEBHOOK_ID, token=None)
+
+    # Empty token
+    with pytest.raises(TypeError):
+        NotifyZoom(webhook_id=WEBHOOK_ID, token="")
+
+    # Invalid mode
+    with pytest.raises(TypeError):
+        NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN, mode="bogus")
+
+    # Valid: default mode
+    obj = NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN)
+    assert obj.mode == ZOOM_MODE_DEFAULT
+
+    # Valid: explicit full mode
+    obj = NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN, mode="full")
+    assert obj.mode == ZoomMode.FULL
+
+    # Valid: explicit simple mode
+    obj = NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN, mode="simple")
+    assert obj.mode == ZoomMode.SIMPLE
+
+    # Partial prefix matching: "sim" -> "simple"
+    obj = NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN, mode="sim")
+    assert obj.mode == ZoomMode.SIMPLE
+
+    # Partial prefix matching: "f" -> "full"
+    obj = NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN, mode="f")
+    assert obj.mode == ZoomMode.FULL
+
+
+def test_plugin_zoom_url_round_trip():
+    """Verify that url() -> parse_url() -> __init__ is lossless."""
+
+    # Full mode round-trip
+    obj1 = NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN, mode="full")
+    result = NotifyZoom.parse_url(obj1.url())
+    obj2 = NotifyZoom(**result)
+    assert obj1.url_identifier == obj2.url_identifier
+    assert obj1.mode == obj2.mode
+
+    # Simple mode round-trip
+    obj1 = NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN, mode="simple")
+    result = NotifyZoom.parse_url(obj1.url())
+    obj2 = NotifyZoom(**result)
+    assert obj1.url_identifier == obj2.url_identifier
+    assert obj1.mode == obj2.mode
+
+
+def test_plugin_zoom_url_privacy():
+    """Verify url(privacy=True) masks webhook_id and token."""
+    obj = NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN)
+    priv = obj.url(privacy=True)
+    assert WEBHOOK_ID not in priv
+    assert TOKEN not in priv
+    # Schema is still present
+    assert priv.startswith("zoom://")
+
+
+def test_plugin_zoom_url_identifier():
+    """Verify url_identifier contains webhook_id and token."""
+    obj = NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN)
+    uid = obj.url_identifier
+    assert "zoom" in uid
+    assert WEBHOOK_ID in uid
+    assert TOKEN in uid
+
+    # Two instances with different tokens are distinct
+    obj2 = NotifyZoom(webhook_id=WEBHOOK_ID, token="other")
+    assert obj.url_identifier != obj2.url_identifier
+
+
+@mock.patch("requests.post")
+def test_plugin_zoom_full_send(mock_post):
+    """Test _send_full() success and failure paths."""
+
+    def _mk_resp(code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = b""
+        return r
+
+    mock_post.return_value = _mk_resp()
+
+    # Success: with title
+    obj = NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN)
+    assert obj.notify(
+        body="body text",
+        title="My Title",
+        notify_type=NotifyType.INFO,
+    )
+    assert mock_post.call_count == 1
+    # Verify ?format=full in URL
+    call_url = mock_post.call_args[0][0]
+    assert "format=full" in call_url
+
+    mock_post.reset_mock()
+
+    # Success: without title (no head section)
+    assert obj.notify(
+        body="body only",
+        title="",
+        notify_type=NotifyType.INFO,
+    )
+    assert mock_post.call_count == 1
+
+    mock_post.reset_mock()
+
+    # HTTP 204 is also a success
+    mock_post.return_value = _mk_resp(requests.codes.no_content)
+    assert obj.notify(body="test", notify_type=NotifyType.INFO)
+
+    mock_post.reset_mock()
+
+    # HTTP 500 -> failure
+    mock_post.return_value = _mk_resp(requests.codes.internal_server_error)
+    assert not obj.notify(body="test", notify_type=NotifyType.INFO)
+
+    mock_post.reset_mock()
+
+    # Unknown status code -> failure
+    mock_post.return_value = _mk_resp(999)
+    assert not obj.notify(body="test", notify_type=NotifyType.INFO)
+
+    mock_post.reset_mock()
+
+    # RequestException -> failure
+    mock_post.side_effect = requests.RequestException("boom")
+    assert not obj.notify(body="test", notify_type=NotifyType.INFO)
+
+
+@mock.patch("requests.post")
+def test_plugin_zoom_simple_send(mock_post):
+    """Test _send_simple() success and failure paths."""
+
+    def _mk_resp(code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = b""
+        return r
+
+    mock_post.return_value = _mk_resp()
+
+    # Create a simple-mode instance
+    obj = NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN, mode="simple")
+
+    # Success: with title (title prepended to body)
+    assert obj.notify(
+        body="msg body",
+        title="Alert",
+        notify_type=NotifyType.INFO,
+    )
+    assert mock_post.call_count == 1
+    # Verify no ?format= in simple mode URL
+    call_url = mock_post.call_args[0][0]
+    assert "format" not in call_url
+
+    mock_post.reset_mock()
+
+    # Success: without title
+    assert obj.notify(
+        body="no title",
+        title="",
+        notify_type=NotifyType.INFO,
+    )
+
+    mock_post.reset_mock()
+
+    # HTTP 204 is also a success
+    mock_post.return_value = _mk_resp(requests.codes.no_content)
+    assert obj.notify(body="test", notify_type=NotifyType.INFO)
+
+    mock_post.reset_mock()
+
+    # HTTP 500 -> failure
+    mock_post.return_value = _mk_resp(requests.codes.internal_server_error)
+    assert not obj.notify(body="test", notify_type=NotifyType.INFO)
+
+    mock_post.reset_mock()
+
+    # Unknown status code -> failure
+    mock_post.return_value = _mk_resp(999)
+    assert not obj.notify(body="test", notify_type=NotifyType.INFO)
+
+    mock_post.reset_mock()
+
+    # RequestException -> failure
+    mock_post.side_effect = requests.RequestException("err")
+    assert not obj.notify(body="test", notify_type=NotifyType.INFO)
+
+
+def test_plugin_zoom_parse_url():
+    """Exercise parse_url() edge cases."""
+
+    # Basic: webhook_id in host, token in path
+    result = NotifyZoom.parse_url("zoom://myhookid/mytoken/")
+    assert result["webhook_id"] == "myhookid"
+    assert result["token"] == "mytoken"
+
+    # ?token= override
+    result = NotifyZoom.parse_url("zoom://myhookid/?token=override123")
+    assert result["webhook_id"] == "myhookid"
+    assert result["token"] == "override123"
+
+    # ?mode= parameter
+    result = NotifyZoom.parse_url("zoom://myhookid/mytoken/?mode=simple")
+    assert result["mode"] == "simple"
+
+    # A URL that fails base parsing returns None
+    result = NotifyZoom.parse_url(None)
+    assert result is None
+
+
+def test_plugin_zoom_parse_native_url():
+    """Exercise parse_native_url()."""
+
+    # Native URL with ?token= appended
+    result = NotifyZoom.parse_native_url(
+        "https://inbots.zoom.us/incoming/hook/{}?token={}".format(
+            WEBHOOK_ID, TOKEN
+        )
+    )
+    assert result is not None
+    assert result["webhook_id"] == WEBHOOK_ID
+    assert result["token"] == TOKEN
+
+    # Native URL without token -> parse succeeds but
+    # token will be None/missing (instantiation would fail)
+    result = NotifyZoom.parse_native_url(
+        "https://inbots.zoom.us/incoming/hook/{}".format(WEBHOOK_ID)
+    )
+    assert result is not None
+    assert result["webhook_id"] == WEBHOOK_ID
+
+    # Non-matching URL -> None
+    assert (
+        NotifyZoom.parse_native_url("https://example.com/not/a/zoom/url")
+        is None
+    )
+
+
+@mock.patch("requests.post")
+def test_plugin_zoom_apprise_integration(mock_post):
+    """Test end-to-end via Apprise.add() and Apprise.notify()."""
+    r = mock.Mock()
+    r.status_code = requests.codes.ok
+    r.content = b""
+    mock_post.return_value = r
+
+    app = Apprise()
+    assert app.add("zoom://{}/{}".format(WEBHOOK_ID, TOKEN))
+    assert app.notify(title="Hello", body="World")
+    assert mock_post.call_count == 1

--- a/tests/test_plugin_zoom.py
+++ b/tests/test_plugin_zoom.py
@@ -196,6 +196,14 @@ def test_plugin_zoom_init():
     with pytest.raises(TypeError):
         NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN, mode="bogus")
 
+    # Empty string mode is also invalid (must not silently resolve to simple)
+    with pytest.raises(TypeError):
+        NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN, mode="")
+
+    # Whitespace-only mode is also invalid
+    with pytest.raises(TypeError):
+        NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN, mode="   ")
+
     # Valid: default mode
     obj = NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN)
     assert obj.mode == ZOOM_MODE_DEFAULT
@@ -246,7 +254,7 @@ def test_plugin_zoom_url_privacy():
 
 
 def test_plugin_zoom_url_identifier():
-    """Verify url_identifier contains webhook_id and token."""
+    """Verify url_identifier contains webhook_id, token, and mode."""
     obj = NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN)
     uid = obj.url_identifier
     assert "zoom" in uid
@@ -256,6 +264,13 @@ def test_plugin_zoom_url_identifier():
     # Two instances with different tokens are distinct
     obj2 = NotifyZoom(webhook_id=WEBHOOK_ID, token="other")
     assert obj.url_identifier != obj2.url_identifier
+
+    # Same credentials but different modes produce different identifiers
+    obj_full = NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN, mode="full")
+    obj_simple = NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN, mode="simple")
+    assert obj_full.url_identifier != obj_simple.url_identifier
+    assert ZoomMode.FULL in obj_full.url_identifier
+    assert ZoomMode.SIMPLE in obj_simple.url_identifier
 
 
 @mock.patch("requests.post")


### PR DESCRIPTION
## Description
**Related issue (if applicable):** n/a

## *Zoom* Notifications
* **Source**: https://zoom.us
* **Image Support**: No
* **Message Format**: Plain Text
* **Message Limit**: 4000 characters

Zoom Team Chat supports Incoming Webhooks that allow external services to post messages into any channel.  The plugin sends messages in two modes: **full** (structured with a heading derived from the notification title and a body section) and **simple** (plain text, title prepended to body).  Both modes require a Webhook ID and a Verification Token obtained from the Zoom Marketplace **Incoming Webhook** app.

## Account Setup
1. Sign in to https://marketplace.zoom.us and search for **Incoming Webhook**.
2. Click **Add** to install the app to your Zoom account.
3. In any Zoom Team Chat channel, type `/inc connect` and follow the prompts.
4. Copy the **Endpoint URL** (e.g. `https://inbots.zoom.us/incoming/hook/WEBHOOK_ID`) and the **Verification Token**.

## Syntax

Valid syntax is as follows:
- `zoom://{webhook_id}/{token}/`
- `zoom://{webhook_id}/{token}/?mode=simple`
- `https://inbots.zoom.us/incoming/hook/{webhook_id}?token={token}`

## Parameter Breakdown

| Variable   | Required | Description |
| ---------- | -------- | ----------- |
| webhook_id | Yes      | The Webhook ID (path segment after `/hook/` in the endpoint URL) |
| token      | Yes      | The Verification Token provided by Zoom |
| mode       | No       | `full` (default, structured with heading) or `simple` (plain text) |

## Examples

```bash
# Full mode (default) -- title becomes the heading
apprise -vv -t "Alert Title" -b "Something happened." \
    zoom://AbCdEfGhIjKl/VerToken123/

# Simple mode -- title prepended to body
apprise -vv -t "Info" -b "Deployment complete." \
    "zoom://AbCdEfGhIjKl/VerToken123/?mode=simple"
```

## New Service Completion Status
* [x] apprise/plugins/zoom.py
* [x] pyproject.toml
    - Updated keywords section to include "Zoom" (alphabetically before "Zulip").
* [x] README.md
    - Added entry for Zoom (quick reference).
* [x] packaging/redhat/python-apprise.spec
    - No new dependencies; no spec changes required.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/51](https://github.com/caronc/apprise-docs/pull/51)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@<this.branch-name>

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "zoom://YOUR_WEBHOOK_ID/YOUR_VERIFICATION_TOKEN/"
```
