### PR TITLE
Added WeChat Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ The table below identifies the services this tool supports and some example serv
 | [Vapid (WebPush)](https://appriseit.com/services/vapid/) | vapid://    | (TCP) 443    | vapid://subscriber/target<br/>vapid://subscriber/target?subfile=path&keyfile=path
 | [Viber](https://appriseit.com/services/viber/) | viber://    | (TCP) 443    | viber://token/target
 | [Webex Teams (Cisco)](https://appriseit.com/services/wxteams/) | wxteams://  | (TCP) 443   | wxteams://Token
+| [WeChat (WeCom)](https://appriseit.com/services/wechat/) | wechat://  | (TCP) 443   | wechat://CorpID:AppSecret@AgentID/@all<br/>wechat://CorpID:AppSecret@AgentID/UserID
 | [WeCom Bot](https://appriseit.com/services/wecombot/) | wecombot://  | (TCP) 443   | wecombot://BotKey
 | [WhatsApp](https://appriseit.com/services/whatsapp/) | whatsapp://  | (TCP) 443   | whatsapp://AccessToken@FromPhoneID/ToPhoneNo<br/>whatsapp://Template:AccessToken@FromPhoneID/ToPhoneNo
 | [WxPusher](https://appriseit.com/services/wxpusher/) | wxpusher://  | (TCP) 443   | wxpusher://AppToken@UserID1/UserID2/UserIDN<br/>wxpusher://AppToken@Topic1/Topic2/Topic3<br/>wxpusher://AppToken@UserID1/Topic1/

--- a/apprise/plugins/pushplus.py
+++ b/apprise/plugins/pushplus.py
@@ -67,8 +67,8 @@
 # Schema alias for WeCom users:
 #   wecom://{token}    -- identical to pushplus://{token}?channel=cp
 #
-# Note: wechat:// is reserved for a future direct WeChat Official Account
-# API plugin and is not supported here.
+# For direct WeCom Application API notifications (without PushPlus as
+# intermediary), use the wechat:// plugin instead.
 #
 # API References:
 #   https://www.pushplus.plus/doc/guide/api.html
@@ -158,8 +158,7 @@ IS_TOPIC = re.compile(
 
 # Schema names that auto-select a specific delivery channel when used
 # in place of the default "pushplus" schema.  Mirrors the Kodi/XBMC pattern.
-# Note: wechat:// is intentionally omitted -- it is reserved for a future
-# direct WeChat Official Account API integration.
+# wechat:// belongs to the separate direct WeCom Application API plugin.
 PUSHPLUS_SCHEMA_MAP = {
     # wecom:// forces channel=cp (WeCom / Enterprise WeChat)
     "wecom": PushPlusChannel.WECOM,
@@ -176,8 +175,8 @@ class NotifyPushplus(NotifyBase):
     service_url = "https://www.pushplus.plus/"
 
     # The default protocol; wecom:// is accepted as a schema alias.
-    # Note: wechat:// is reserved for a future direct WeChat Official
-    # Account API plugin and is intentionally not listed here.
+    # wechat:// belongs to the direct WeCom Application API plugin and
+    # is intentionally not listed here.
     secure_protocol = ("pushplus", "wecom")
 
     # A URL that takes you to the setup/help of the specific protocol

--- a/apprise/plugins/wechat.py
+++ b/apprise/plugins/wechat.py
@@ -1,0 +1,647 @@
+#
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# WeCom (WeChat Work / Enterprise WeChat) Application Message API.
+#
+# This plugin sends notifications directly to users, departments, or
+# tags within a WeCom enterprise organisation using the WeCom
+# Application API.  No third-party intermediary is required.
+#
+# Setup:
+#   1. Sign in to the WeCom admin console at
+#      https://work.weixin.qq.com/wework_admin/frame#/index
+#   2. Go to "Applications & Mini Programs" -> "Applications" and
+#      create or select a self-built application.
+#   3. Copy the AgentID shown on the application details page.
+#   4. Go to "My Enterprise" -> "Enterprise Information" and note
+#      the CorpID.
+#   5. On the application page click "View" next to Secret and copy it.
+#
+# Basic Apprise URL forms:
+#
+#   Send to all users in the organisation:
+#     wechat://{corpid}:{corpsecret}@{agentid}/@all
+#
+#   Send to specific user(s) by WeCom user ID (@ prefix optional
+#   on input, always emitted in generated URLs):
+#     wechat://{corpid}:{corpsecret}@{agentid}/@{userid}
+#     wechat://{corpid}:{corpsecret}@{agentid}/@{user1}/@{user2}
+#
+#   Send to a department by its numeric ID (# encoded as %23 in URLs):
+#     wechat://{corpid}:{corpsecret}@{agentid}/%23{deptid}
+#
+#   Send to a tag by its numeric ID (prefix with +):
+#     wechat://{corpid}:{corpsecret}@{agentid}/+{tagid}
+#
+#   Mixed recipients:
+#     wechat://{corpid}:{corpsecret}@{agentid}/@{user}/%23{dept}/+{tag}
+#
+#   Notes:
+#     - # must be URL-encoded as %23 in URL paths to avoid being
+#       treated as a fragment separator.
+#     - At least one recipient (user, department, or tag) is required.
+#     - Use @all as a user target to send to the entire organisation.
+#     - Use ?to= to supply comma-separated extra targets as a query
+#       parameter alternative.
+#
+# API References:
+#   https://developer.work.weixin.qq.com/document/path/90235
+#   https://developer.work.weixin.qq.com/document/path/90236
+
+import json
+import re
+
+import requests
+
+from ..common import NotifyFormat, NotifyType, PersistentStoreMode
+from ..locale import gettext_lazy as _
+from ..utils.parse import parse_list, validate_regex
+from .base import NotifyBase
+
+# WeCom API error code map.
+# Reference: https://developer.work.weixin.qq.com/document/path/90313
+WECHAT_ERROR_CODES = {
+    0: "Request succeeded.",
+    40001: "Invalid credential or access token expired.",
+    40003: "Invalid user ID.",
+    40014: "Invalid access token.",
+    42001: "Access token expired.",
+    48001: "API not authorized; check application permissions.",
+    60020: "IP address not in the allowlist.",
+    81013: "All recipients are invalid or unauthorized.",
+}
+
+# Error codes that indicate the cached access token must be discarded
+# so the next send() call will fetch a fresh one.
+WECHAT_TOKEN_ERROR_CODES = frozenset((40001, 40014, 42001))
+
+# Validates a WeCom user ID.  The optional leading @ is stripped by
+# the regex so both "johndoe" and "@johndoe" are accepted.  The
+# special @all broadcast keyword is matched as "all"; the caller
+# re-attaches the @ before storing.  url() always emits the @ prefix.
+IS_USER = re.compile(
+    r"^@?(?P<user>[A-Za-z0-9][A-Za-z0-9_@.\-]*)$",
+)
+
+# Validates a department target: # prefix followed by a numeric ID.
+# The # will arrive already decoded from %23 by the URL path parser.
+IS_DEPT = re.compile(r"^#(?P<dept>[0-9]+)$")
+
+# Validates a tag target: + prefix followed by a numeric ID.
+IS_TAG = re.compile(r"^\+(?P<tag>[0-9]+)$")
+
+
+class NotifyWeChat(NotifyBase):
+    """A wrapper for WeCom (WeChat Work) Application Notifications."""
+
+    # The default descriptive name associated with the Notification
+    service_name = "WeChat (WeCom)"
+
+    # The services URL
+    service_url = "https://work.weixin.qq.com/"
+
+    # The default secure protocol
+    secure_protocol = "wechat"
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = "https://appriseit.com/services/wechat/"
+
+    # WeCom access token endpoint (GET request)
+    token_url = "https://qyapi.weixin.qq.com/cgi-bin/gettoken"
+
+    # WeCom message send endpoint (POST); access_token is a query param
+    notify_url = "https://qyapi.weixin.qq.com/cgi-bin/message/send"
+
+    # WeCom text and markdown bodies are limited to 2048 bytes
+    body_maxlen = 2048
+
+    # WeCom application messages have no native separate title field
+    title_maxlen = 0
+
+    # Default to plain text; markdown is also natively supported
+    notify_format = NotifyFormat.TEXT
+
+    # Enable the persistent store so the access token survives across
+    # plugin instantiations and process restarts
+    storage_mode = PersistentStoreMode.AUTO
+
+    # Cache the access token for slightly less than its 2-hour lifetime
+    # to avoid racing the expiry boundary
+    default_cache_expiry_sec = 7200 - 300  # 1 h 55 min
+
+    # URL templates
+    templates = (
+        # No path targets: recipients supplied via ?to= or @all
+        "{schema}://{user}:{password}@{host}",
+        # One or more targets in the URL path
+        "{schema}://{user}:{password}@{host}/{targets}",
+    )
+
+    # Define our template tokens
+    template_tokens = dict(
+        NotifyBase.template_tokens,
+        **{
+            # Corp ID sits in the URL user field
+            "user": {
+                "name": _("Corp ID"),
+                "type": "string",
+                "required": True,
+                "map_to": "corpid",
+            },
+            # App Secret sits in the URL password field
+            "password": {
+                "name": _("App Secret"),
+                "type": "string",
+                "private": True,
+                "required": True,
+                "map_to": "corpsecret",
+            },
+            # Agent ID sits in the URL host field; always numeric
+            "host": {
+                "name": _("Agent ID"),
+                "type": "string",
+                "required": True,
+                "regex": (r"^[0-9]+$", ""),
+                "map_to": "agentid",
+            },
+            # A WeCom user ID (@ prefix optional on input,
+            # always emitted by url())
+            "target_user": {
+                "name": _("Target User"),
+                "type": "string",
+                "prefix": "@",
+                "map_to": "targets",
+            },
+            # A WeCom department ID (numeric; prefix with #)
+            "target_department": {
+                "name": _("Target Department"),
+                "type": "string",
+                "prefix": "#",
+                "map_to": "targets",
+            },
+            # A WeCom tag ID (numeric; prefix with +)
+            "target_tag": {
+                "name": _("Target Tag"),
+                "type": "string",
+                "prefix": "+",
+                "map_to": "targets",
+            },
+            "targets": {
+                "name": _("Targets"),
+                "type": "list:string",
+            },
+        },
+    )
+
+    # Define our template arguments
+    template_args = dict(
+        NotifyBase.template_args,
+        **{
+            # ?to= is the standard Apprise comma-separated recipient alias
+            "to": {
+                "alias_of": "targets",
+            },
+        },
+    )
+
+    def __init__(self, corpid, corpsecret, agentid, targets=None, **kwargs):
+        """Initialize WeChat (WeCom Application) Object."""
+        super().__init__(**kwargs)
+
+        # Validate the Corp ID
+        self.corpid = validate_regex(corpid)
+        if not self.corpid:
+            msg = "A WeChat (WeCom) Corp ID must be specified."
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # Validate the App Secret
+        self.corpsecret = validate_regex(corpsecret)
+        if not self.corpsecret:
+            msg = "A WeChat (WeCom) App Secret must be specified."
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # Validate the Agent ID (must be a non-negative integer string)
+        self.agentid = validate_regex(
+            str(agentid) if agentid is not None else "",
+            *self.template_tokens["host"]["regex"],
+        )
+        if not self.agentid:
+            msg = (
+                "The WeChat (WeCom) Agent ID ({}) is invalid;"
+                " it must be a non-negative integer.".format(agentid)
+            )
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # Parsed and validated recipient lists
+        self.users = []
+        self.departments = []
+        self.tag_ids = []
+
+        # Preserve unrecognised targets for round-trip URL fidelity
+        self.invalid_targets = []
+
+        # Classify each entry from the targets list
+        for target in parse_list(targets):
+            # Department ID: # prefix + numeric
+            result = IS_DEPT.match(target)
+            if result:
+                self.departments.append(result.group("dept"))
+                continue
+
+            # Tag ID: + prefix + numeric
+            result = IS_TAG.match(target)
+            if result:
+                self.tag_ids.append(result.group("tag"))
+                continue
+
+            # User ID or @all broadcast.
+            # The regex strips the optional leading @ so both "johndoe"
+            # and "@johndoe" match.  "all" (captured from "@all" or bare
+            # "all") is re-normalised to "@all" for the WeCom API.
+            result = IS_USER.match(target)
+            if result:
+                user = result.group("user")
+                self.users.append("@all" if user == "all" else user)
+                continue
+
+            # Unrecognised -- log and preserve for round-trip
+            self.logger.warning(
+                "Invalid/unrecognized WeChat (WeCom) target preserved"
+                " for round-trip fidelity: %s",
+                target,
+            )
+            self.invalid_targets.append(target)
+
+        return
+
+    def _get_access_token(self):
+        """Return the cached WeCom access token, fetching a fresh one
+        if the cache is empty or the token has expired."""
+
+        # Check the persistent store for a cached token
+        token = self.store.get("access_token")
+        if token:
+            # Return the cached token
+            return token
+
+        # Build the query parameters for the token request
+        params = {
+            "corpid": self.corpid,
+            "corpsecret": self.corpsecret,
+        }
+
+        self.logger.debug(
+            "WeChat (WeCom) token GET URL: %s (cert_verify=%r)",
+            self.token_url,
+            self.verify_certificate,
+        )
+
+        # Always throttle before any remote server I/O
+        self.throttle()
+
+        try:
+            r = requests.get(
+                self.token_url,
+                params=params,
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+            )
+
+            if r.status_code != requests.codes.ok:
+                # HTTP-level failure
+                status_str = NotifyWeChat.http_response_code_lookup(
+                    r.status_code
+                )
+                self.logger.warning(
+                    "Failed to fetch WeChat access token: "
+                    "{}{}error={}.".format(
+                        status_str,
+                        ", " if status_str else "",
+                        r.status_code,
+                    )
+                )
+                self.logger.debug(
+                    "Response Details:\r\n%r",
+                    (r.content or b"")[:2000],
+                )
+                # Return None to indicate failure
+                return None
+
+            # Parse the JSON response body
+            try:
+                content = json.loads(r.content)
+            except (AttributeError, TypeError, ValueError):
+                content = {}
+
+            # Check the WeCom application-level error code
+            errcode = content.get("errcode", 0) if content else -1
+            if errcode != 0:
+                errmsg = WECHAT_ERROR_CODES.get(
+                    errcode,
+                    content.get("errmsg", "Unknown error")
+                    if content
+                    else "Unknown error",
+                )
+                self.logger.warning(
+                    "WeChat access token request failed: "
+                    "errcode={}: {}.".format(errcode, errmsg)
+                )
+                # Return None to indicate failure
+                return None
+
+            # Extract the access token from the response
+            token = content.get("access_token") if content else None
+            if not token:
+                self.logger.warning(
+                    "WeChat access token response contained no token."
+                )
+                # Return None to indicate failure
+                return None
+
+            # Derive the cache TTL: expires_in minus a grace period to
+            # avoid racing the expiry boundary
+            expires_in = content.get("expires_in", 7200) if content else 7200
+            ttl = max(60, expires_in - 300)
+
+            # Cache the token for reuse across plugin instances
+            self.store.set("access_token", token, expires=ttl)
+
+            # Return the freshly fetched token
+            return token
+
+        except requests.RequestException as e:
+            self.logger.warning(
+                "A Connection error occurred fetching the WeChat access token."
+            )
+            self.logger.debug("Socket Exception: %s", str(e))
+            # Return None to indicate failure
+            return None
+
+    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+        """Perform WeChat (WeCom Application) Notification."""
+
+        # Compile the recipient lists
+        users = list(self.users)
+        departments = list(self.departments)
+        tags = list(self.tag_ids)
+
+        # At least one valid recipient is required to proceed
+        if not users and not departments and not tags:
+            self.logger.warning(
+                "No WeChat (WeCom) recipients configured; aborting."
+            )
+            return False
+
+        # Obtain (or reuse from cache) a valid access token
+        token = self._get_access_token()
+        if not token:
+            return False
+
+        # Determine the WeCom msgtype from the active notify_format
+        if self.notify_format == NotifyFormat.MARKDOWN:
+            msgtype = "markdown"
+        else:
+            # Both TEXT and HTML fall back to plain text
+            msgtype = "text"
+
+        # Build the message content wrapper
+        msgbody = {"content": body}
+
+        # Assemble the full request payload
+        payload = {
+            "agentid": int(self.agentid),
+            "msgtype": msgtype,
+            msgtype: msgbody,
+        }
+
+        # Add recipient fields -- only include lists that are non-empty
+        if users:
+            payload["touser"] = "|".join(users)
+        if departments:
+            payload["toparty"] = "|".join(departments)
+        if tags:
+            payload["totag"] = "|".join(tags)
+
+        # Prepare the request headers
+        headers = {
+            "User-Agent": self.app_id,
+            "Content-Type": "application/json",
+        }
+
+        # Append the access token as a query parameter on the send URL
+        send_url = "{}?access_token={}".format(self.notify_url, token)
+
+        self.logger.debug(
+            "WeChat (WeCom) POST URL: %s (cert_verify=%r)",
+            self.notify_url,
+            self.verify_certificate,
+        )
+        self.logger.debug("WeChat (WeCom) Payload: %r", payload)
+
+        # Always throttle before any remote server I/O
+        self.throttle()
+
+        try:
+            r = requests.post(
+                send_url,
+                data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+                headers=headers,
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+            )
+
+            if r.status_code != requests.codes.ok:
+                # HTTP-level failure
+                status_str = NotifyWeChat.http_response_code_lookup(
+                    r.status_code
+                )
+                self.logger.warning(
+                    "Failed to send WeChat (WeCom) notification: "
+                    "{}{}error={}.".format(
+                        status_str,
+                        ", " if status_str else "",
+                        r.status_code,
+                    )
+                )
+                self.logger.debug(
+                    "Response Details:\r\n%r",
+                    (r.content or b"")[:2000],
+                )
+                # Return; we're done
+                return False
+
+            # Parse the JSON response body
+            try:
+                content = json.loads(r.content)
+            except (AttributeError, TypeError, ValueError):
+                content = {}
+
+            # Check the WeCom application-level error code
+            errcode = content.get("errcode", 0) if content else -1
+            if errcode != 0:
+                # Token error codes mean the cached token has expired;
+                # evict it so the next call fetches a fresh one
+                if errcode in WECHAT_TOKEN_ERROR_CODES:
+                    self.store.set("access_token", None, expires=1)
+
+                errmsg = WECHAT_ERROR_CODES.get(
+                    errcode,
+                    content.get("errmsg", "Unknown error")
+                    if content
+                    else "Unknown error",
+                )
+                self.logger.warning(
+                    "Failed to send WeChat (WeCom) notification: "
+                    "errcode={}: {}.".format(errcode, errmsg)
+                )
+                self.logger.debug(
+                    "Response Details:\r\n%r",
+                    content if content else (r.content or b"")[:2000],
+                )
+                # Return; we're done
+                return False
+
+        except requests.RequestException as e:
+            self.logger.warning(
+                "A Connection error occurred sending"
+                " WeChat (WeCom) notification."
+            )
+            self.logger.debug("Socket Exception: %s", str(e))
+            # Return; we're done
+            return False
+
+        self.logger.info("Sent WeChat (WeCom) notification.")
+        return True
+
+    @property
+    def url_identifier(self):
+        """Returns all of the identifiers that make this URL unique
+        from another similar one.
+
+        Targets or end points should never be identified here.
+        """
+        # Corp + secret + agentid together uniquely identify the app
+        return (
+            self.secure_protocol,
+            self.corpid,
+            self.corpsecret,
+            self.agentid,
+        )
+
+    def url(self, privacy=False, *args, **kwargs):
+        """Returns the URL built dynamically based on specified
+        arguments."""
+
+        params = {}
+        params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
+
+        # Re-assemble the targets list, restoring each type's prefix.
+        # Department IDs use # which must be percent-encoded in paths.
+        targets = []
+        for user in self.users:
+            if user.startswith("@"):
+                # @all and any other @-prefixed broadcast keyword;
+                # emit as-is since the @ is already present
+                targets.append(NotifyWeChat.quote(user, safe="@"))
+            else:
+                # Regular user ID; always emit with @ prefix so the
+                # URL is self-describing and consistent with the
+                # target_user prefix declaration
+                targets.append("@{}".format(NotifyWeChat.quote(user, safe="")))
+        for dept in self.departments:
+            # Encode # as %23 so it is not treated as a URL fragment
+            targets.append("%23{}".format(dept))
+        for tag in self.tag_ids:
+            targets.append("+{}".format(tag))
+        # Always include invalid entries so the URL round-trips without
+        # silent data loss
+        for inv in self.invalid_targets:
+            targets.append(NotifyWeChat.quote(inv, safe=""))
+
+        default_schema = self.secure_protocol
+
+        if targets:
+            return (
+                "{schema}://{corpid}:{corpsecret}@{agentid}"
+                "/{targets}/?{params}".format(
+                    schema=default_schema,
+                    corpid=NotifyWeChat.quote(self.corpid, safe=""),
+                    corpsecret=self.pprint(self.corpsecret, privacy, safe=""),
+                    agentid=self.agentid,
+                    targets="/".join(targets),
+                    params=NotifyWeChat.urlencode(params),
+                )
+            )
+
+        return "{schema}://{corpid}:{corpsecret}@{agentid}/?{params}".format(
+            schema=default_schema,
+            corpid=NotifyWeChat.quote(self.corpid, safe=""),
+            corpsecret=self.pprint(self.corpsecret, privacy, safe=""),
+            agentid=self.agentid,
+            params=NotifyWeChat.urlencode(params),
+        )
+
+    @staticmethod
+    def parse_url(url):
+        """Parses the URL and returns enough arguments that can allow
+        us to re-instantiate this object."""
+
+        results = NotifyBase.parse_url(url, verify_host=False)
+        if not results:
+            # We're done early as we couldn't load the results
+            return results
+
+        # Corp ID comes from the URL user field
+        results["corpid"] = NotifyWeChat.unquote(results["user"])
+
+        # App Secret comes from the URL password field
+        results["corpsecret"] = NotifyWeChat.unquote(results["password"])
+
+        # Agent ID comes from the URL host field
+        results["agentid"] = NotifyWeChat.unquote(results["host"])
+
+        # Collect targets from the URL path
+        results["targets"] = NotifyWeChat.split_path(results["fullpath"])
+
+        # Support ?to= for additional comma-separated targets
+        if "to" in results["qsd"] and results["qsd"]["to"]:
+            results["targets"] += NotifyWeChat.parse_list(results["qsd"]["to"])
+
+        return results
+
+    @staticmethod
+    def parse_native_url(url):
+        """WeCom does not expose a shareable single-URL credential form,
+        so native URL detection is not supported."""
+        return None

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -79,8 +79,8 @@ notification services. It supports sending alerts to platforms such as: \
 `Splunk`, `Spike`, `Spug Push`, `Super Toasty`, `Streamlabs`, `Stride`, \
 `Synology Chat`, `Syslog`, `Techulus Push`, `Telegram`, `Threema Gateway`, \
 `Twilio`, `Twitter`, `Twist`, `Vapid`, `Viber`, `VictorOps`, `Voipms`, \
-`Vonage`, `WebPush`, `WeCom Bot`, `WhatsApp`, `Webex Teams`, `Workflows`, \
-`WxPusher`, `XBMC`, `XMPP`, `Zoom`, and `Zulip`.}
+`Vonage`, `WebPush`, `WeChat (WeCom)`, `WeCom Bot`, `WhatsApp`, \
+`Webex Teams`, `Workflows`, `WxPusher`, `XBMC`, `XMPP`, `Zoom`, and `Zulip`.}
 
 Name:           python-%{pypi_name}
 Version:        1.10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,7 @@ keywords = [
     "Vonage",
     "Webex",
     "Webpush",
+    "WeChat (WeCom)",
     "WeCom Bot",
     "WhatsApp",
     "Windows",

--- a/tests/test_plugin_wechat.py
+++ b/tests/test_plugin_wechat.py
@@ -1,0 +1,1001 @@
+#
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Disable logging for a cleaner testing output
+from json import dumps
+import logging
+from unittest import mock
+
+from helpers import AppriseURLTester
+import pytest
+import requests
+
+from apprise import Apprise
+from apprise.common import NotifyFormat
+from apprise.plugins.wechat import (
+    WECHAT_ERROR_CODES,
+    WECHAT_TOKEN_ERROR_CODES,
+    NotifyWeChat,
+)
+
+logging.disable(logging.CRITICAL)
+
+# Fixed test credentials
+CORPID = "wwcorpid1234567890"
+CORPSECRET = "abcSecret9"
+AGENTID = "1000002"
+
+# A successful response serves double-duty: the token GET needs
+# access_token and expires_in; the message POST needs errcode == 0.
+GOOD_RESPONSE = dumps(
+    {
+        "errcode": 0,
+        "errmsg": "ok",
+        "access_token": "TOKEN12345678",
+        "expires_in": 7200,
+    }
+)
+
+# pprint(CORPSECRET, privacy=True) -> first + "..." + last char
+# "abcSecret9" -> "a...9"
+PRIVACY_SECRET = "a...9"
+
+# Our Testing URLs
+apprise_url_tests = (
+    # ----------------------------------------------------------------
+    # Invalid / missing credential cases
+    # ----------------------------------------------------------------
+    (
+        "wechat://",
+        {
+            # No credentials at all
+            "instance": TypeError,
+        },
+    ),
+    (
+        # Missing corpsecret and agentid
+        "wechat://{}".format(CORPID),
+        {
+            "instance": TypeError,
+        },
+    ),
+    (
+        # Missing agentid (non-numeric host provided as port only)
+        "wechat://{}:{}@".format(CORPID, CORPSECRET),
+        {
+            "instance": TypeError,
+        },
+    ),
+    (
+        # Non-numeric agentid
+        "wechat://{}:{}@notanumber".format(CORPID, CORPSECRET),
+        {
+            "instance": TypeError,
+        },
+    ),
+    # ----------------------------------------------------------------
+    # No targets -- plugin loads but send() returns False early
+    # ----------------------------------------------------------------
+    (
+        "wechat://{}:{}@{}".format(CORPID, CORPSECRET, AGENTID),
+        {
+            "instance": NotifyWeChat,
+            "notify_response": False,
+            "privacy_url": "wechat://{}:{}@{}/".format(
+                CORPID, PRIVACY_SECRET, AGENTID
+            ),
+        },
+    ),
+    # ----------------------------------------------------------------
+    # @all broadcast -- sends to entire organisation
+    # ----------------------------------------------------------------
+    (
+        "wechat://{}:{}@{}/@all".format(CORPID, CORPSECRET, AGENTID),
+        {
+            "instance": NotifyWeChat,
+            "requests_response_text": GOOD_RESPONSE,
+            "privacy_url": "wechat://{}:{}@{}/@all/".format(
+                CORPID, PRIVACY_SECRET, AGENTID
+            ),
+        },
+    ),
+    # ----------------------------------------------------------------
+    # Single user target (bare form -- no @ prefix)
+    # ----------------------------------------------------------------
+    (
+        "wechat://{}:{}@{}/johndoe".format(CORPID, CORPSECRET, AGENTID),
+        {
+            "instance": NotifyWeChat,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    # ----------------------------------------------------------------
+    # Single user target (@ prefixed form)
+    # ----------------------------------------------------------------
+    (
+        "wechat://{}:{}@{}/@johndoe".format(CORPID, CORPSECRET, AGENTID),
+        {
+            "instance": NotifyWeChat,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    # ----------------------------------------------------------------
+    # Multiple user targets
+    # ----------------------------------------------------------------
+    (
+        "wechat://{}:{}@{}/user1/user2/user3".format(
+            CORPID, CORPSECRET, AGENTID
+        ),
+        {
+            "instance": NotifyWeChat,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    # ----------------------------------------------------------------
+    # Department target (%23 decodes to # prefix)
+    # ----------------------------------------------------------------
+    (
+        "wechat://{}:{}@{}/%23100".format(CORPID, CORPSECRET, AGENTID),
+        {
+            "instance": NotifyWeChat,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    # ----------------------------------------------------------------
+    # Tag target (+ prefix)
+    # ----------------------------------------------------------------
+    (
+        "wechat://{}:{}@{}/+7".format(CORPID, CORPSECRET, AGENTID),
+        {
+            "instance": NotifyWeChat,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    # ----------------------------------------------------------------
+    # Mixed recipients (user + department + tag)
+    # ----------------------------------------------------------------
+    (
+        "wechat://{}:{}@{}/john/%23200/+3".format(CORPID, CORPSECRET, AGENTID),
+        {
+            "instance": NotifyWeChat,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    # ----------------------------------------------------------------
+    # Targets supplied via ?to= query parameter
+    # ----------------------------------------------------------------
+    (
+        "wechat://{}:{}@{}?to=@all".format(CORPID, CORPSECRET, AGENTID),
+        {
+            "instance": NotifyWeChat,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    # ----------------------------------------------------------------
+    # Markdown format
+    # ----------------------------------------------------------------
+    (
+        "wechat://{}:{}@{}/@all?format=markdown".format(
+            CORPID, CORPSECRET, AGENTID
+        ),
+        {
+            "instance": NotifyWeChat,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    # ----------------------------------------------------------------
+    # HTTP error responses -- token GET fails -> overall send fails
+    # ----------------------------------------------------------------
+    (
+        "wechat://{}:{}@{}/@all".format(CORPID, CORPSECRET, AGENTID),
+        {
+            "instance": NotifyWeChat,
+            "response": False,
+            "requests_response_code": requests.codes.internal_server_error,
+        },
+    ),
+    (
+        "wechat://{}:{}@{}/@all".format(CORPID, CORPSECRET, AGENTID),
+        {
+            "instance": NotifyWeChat,
+            "response": False,
+            "requests_response_code": 999,
+        },
+    ),
+    # ----------------------------------------------------------------
+    # Network exception on all requests
+    # ----------------------------------------------------------------
+    (
+        "wechat://{}:{}@{}/@all".format(CORPID, CORPSECRET, AGENTID),
+        {
+            "instance": NotifyWeChat,
+            "test_requests_exceptions": True,
+        },
+    ),
+)
+
+
+def test_plugin_wechat_urls():
+    """Run the standard Apprise URL tester for all wechat:// entries."""
+    AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+def test_plugin_wechat_init():
+    """Verify __init__ validation for required fields."""
+
+    # Valid construction
+    obj = NotifyWeChat(corpid=CORPID, corpsecret=CORPSECRET, agentid=AGENTID)
+    assert isinstance(obj, NotifyWeChat)
+
+    # corpid is required
+    with (
+        mock.patch("apprise.plugins.wechat.validate_regex", return_value=None),
+        mock.patch.object(NotifyWeChat, "logger"),
+        pytest.raises(TypeError),
+    ):
+        NotifyWeChat(corpid="", corpsecret=CORPSECRET, agentid=AGENTID)
+
+    # corpsecret is required
+    with pytest.raises(TypeError):
+        NotifyWeChat(corpid=CORPID, corpsecret="", agentid=AGENTID)
+
+    # agentid must be numeric
+    with pytest.raises(TypeError):
+        NotifyWeChat(corpid=CORPID, corpsecret=CORPSECRET, agentid="notnum")
+
+    # agentid=None must be rejected
+    with pytest.raises(TypeError):
+        NotifyWeChat(corpid=CORPID, corpsecret=CORPSECRET, agentid=None)
+
+    # Invalid targets are silently dropped; valid ones are kept
+    obj = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["validuser", "!!invalid!!", "#42", "+7"],
+    )
+    assert "validuser" in obj.users
+    assert "42" in obj.departments
+    assert "7" in obj.tag_ids
+    assert "!!invalid!!" in obj.invalid_targets
+
+    # The @ prefix on user IDs is optional on input; it is stripped
+    # by the regex before storing so the API payload stays prefix-free.
+    # The bare keyword "all" is normalised to "@all" (WeCom API form).
+    obj = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["@johndoe", "@all", "all"],
+    )
+    assert "johndoe" in obj.users
+    # Both "@all" and bare "all" must normalise to "@all"
+    assert obj.users.count("@all") == 2
+
+
+def test_plugin_wechat_url_round_trip():
+    """Verify that url() and parse_url() form a lossless round-trip."""
+
+    obj1 = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["alice", "#10", "+2", "@all"],
+    )
+    url = obj1.url()
+    result = NotifyWeChat.parse_url(url)
+    assert result is not None
+    obj2 = NotifyWeChat(**result)
+
+    # Connection identity must be preserved
+    assert obj1.url_identifier == obj2.url_identifier
+
+    # Target counts must match
+    assert len(obj1) == len(obj2)
+
+
+def test_plugin_wechat_url():
+    """Verify url() output for various target combinations."""
+
+    # No targets
+    obj = NotifyWeChat(corpid=CORPID, corpsecret=CORPSECRET, agentid=AGENTID)
+    url = obj.url()
+    assert CORPID in url
+    assert CORPSECRET in url
+    assert AGENTID in url
+
+    # Privacy URL masks the corpsecret
+    privacy = obj.url(privacy=True)
+    assert CORPSECRET not in privacy
+    assert PRIVACY_SECRET in privacy
+    assert CORPID in privacy
+
+    # Department gets encoded as %23
+    obj = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["#5"],
+    )
+    assert "%235" in obj.url()
+
+    # Tag gets + prefix
+    obj = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["+3"],
+    )
+    assert "+3" in obj.url()
+
+    # @all is kept as-is
+    obj = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["@all"],
+    )
+    assert "@all" in obj.url()
+
+    # Regular user IDs are always emitted with @ prefix in the URL
+    obj = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["alice"],
+    )
+    assert "@alice" in obj.url()
+
+    # Invalid targets survive the round-trip
+    obj = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["!!bad!!"],
+    )
+    assert obj.invalid_targets
+    # url() must include the invalid target so it round-trips
+    assert obj.url() != ""
+
+
+def test_plugin_wechat_url_identifier():
+    """url_identifier must differ when credentials differ."""
+
+    obj1 = NotifyWeChat(corpid=CORPID, corpsecret=CORPSECRET, agentid=AGENTID)
+    obj2 = NotifyWeChat(
+        corpid="other_corp", corpsecret=CORPSECRET, agentid=AGENTID
+    )
+    obj3 = NotifyWeChat(
+        corpid=CORPID, corpsecret="other_secret", agentid=AGENTID
+    )
+    obj4 = NotifyWeChat(
+        corpid=CORPID, corpsecret=CORPSECRET, agentid="9999999"
+    )
+
+    assert obj1.url_identifier != obj2.url_identifier
+    assert obj1.url_identifier != obj3.url_identifier
+    assert obj1.url_identifier != obj4.url_identifier
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_wechat_send_ok(mock_post, mock_get):
+    """Successful end-to-end send: token GET + message POST both succeed."""
+
+    def _mk_resp(data, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(data).encode("utf-8")
+        return r
+
+    # Token GET -> success + message POST -> success
+    mock_get.return_value = _mk_resp(
+        {
+            "errcode": 0,
+            "errmsg": "ok",
+            "access_token": "MYTOKEN",
+            "expires_in": 7200,
+        }
+    )
+    mock_post.return_value = _mk_resp({"errcode": 0, "errmsg": "ok"})
+
+    obj = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["@all"],
+    )
+    assert obj.send(body="Hello") is True
+    assert mock_get.call_count == 1
+    assert mock_post.call_count == 1
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_wechat_send_cached_token(mock_post, mock_get):
+    """Second send reuses the cached token without a new GET request."""
+
+    def _mk_resp(data, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(data).encode("utf-8")
+        return r
+
+    mock_get.return_value = _mk_resp(
+        {
+            "errcode": 0,
+            "errmsg": "ok",
+            "access_token": "CACHED_TOKEN",
+            "expires_in": 7200,
+        }
+    )
+    mock_post.return_value = _mk_resp({"errcode": 0, "errmsg": "ok"})
+
+    obj = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["@all"],
+    )
+    # First send fetches the token
+    assert obj.send(body="First") is True
+    assert mock_get.call_count == 1
+
+    # Second send reuses the cached token
+    assert obj.send(body="Second") is True
+    assert mock_get.call_count == 1  # still 1 -- no second GET
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_wechat_send_all_targets(mock_post, mock_get):
+    """A single send delivers to users, departments, and tags in one POST."""
+
+    def _mk_resp(data, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(data).encode("utf-8")
+        return r
+
+    mock_get.return_value = _mk_resp(
+        {
+            "errcode": 0,
+            "errmsg": "ok",
+            "access_token": "TOKEN",
+            "expires_in": 7200,
+        }
+    )
+    mock_post.return_value = _mk_resp({"errcode": 0, "errmsg": "ok"})
+
+    obj = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["alice", "bob", "#10", "#20", "+3", "+5"],
+    )
+    assert obj.send(body="Hello") is True
+    assert mock_post.call_count == 1
+
+    # Verify payload recipients
+    import json
+
+    call_kwargs = mock_post.call_args
+    payload = json.loads(call_kwargs[1]["data"])
+    assert set(payload["touser"].split("|")) == {"alice", "bob"}
+    assert set(payload["toparty"].split("|")) == {"10", "20"}
+    assert set(payload["totag"].split("|")) == {"3", "5"}
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_wechat_send_markdown(mock_post, mock_get):
+    """Markdown format produces msgtype=markdown in the payload."""
+
+    def _mk_resp(data, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(data).encode("utf-8")
+        return r
+
+    mock_get.return_value = _mk_resp(
+        {
+            "errcode": 0,
+            "errmsg": "ok",
+            "access_token": "TOKEN",
+            "expires_in": 7200,
+        }
+    )
+    mock_post.return_value = _mk_resp({"errcode": 0, "errmsg": "ok"})
+
+    obj = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["@all"],
+        format=NotifyFormat.MARKDOWN,
+    )
+    assert obj.send(body="# Hello") is True
+
+    import json
+
+    payload = json.loads(mock_post.call_args[1]["data"])
+    assert payload["msgtype"] == "markdown"
+    assert "markdown" in payload
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_wechat_send_no_targets(mock_post, mock_get):
+    """send() returns False immediately when no valid targets are present."""
+
+    obj = NotifyWeChat(corpid=CORPID, corpsecret=CORPSECRET, agentid=AGENTID)
+    # No targets -> early return False, no network calls
+    assert obj.send(body="Hello") is False
+    assert mock_get.call_count == 0
+    assert mock_post.call_count == 0
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_wechat_token_fetch_http_error(mock_post, mock_get):
+    """Token GET returning HTTP 500 causes send() to fail."""
+
+    r = mock.Mock()
+    r.status_code = requests.codes.internal_server_error
+    r.content = b""
+    mock_get.return_value = r
+
+    obj = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["@all"],
+    )
+    assert obj.send(body="Hello") is False
+    assert mock_get.call_count == 1
+    assert mock_post.call_count == 0
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_wechat_token_fetch_api_error(mock_post, mock_get):
+    """Token GET returning errcode != 0 causes send() to fail."""
+
+    def _mk_resp(data, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(data).encode("utf-8")
+        return r
+
+    # errcode 40001 -- invalid credential
+    mock_get.return_value = _mk_resp(
+        {"errcode": 40001, "errmsg": "invalid credential"}
+    )
+
+    obj = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["@all"],
+    )
+    assert obj.send(body="Hello") is False
+    assert mock_post.call_count == 0
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_wechat_token_fetch_no_token_field(mock_post, mock_get):
+    """Token GET returning errcode 0 but no access_token causes failure."""
+
+    def _mk_resp(data, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(data).encode("utf-8")
+        return r
+
+    # errcode 0 but access_token is absent
+    mock_get.return_value = _mk_resp({"errcode": 0, "errmsg": "ok"})
+
+    obj = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["@all"],
+    )
+    assert obj.send(body="Hello") is False
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_wechat_token_fetch_bad_json(mock_post, mock_get):
+    """Token GET returning unparsable JSON is handled gracefully."""
+
+    r = mock.Mock()
+    r.status_code = requests.codes.ok
+    r.content = b"{bad json"
+    mock_get.return_value = r
+
+    obj = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["@all"],
+    )
+    assert obj.send(body="Hello") is False
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_wechat_token_fetch_request_exception(mock_post, mock_get):
+    """RequestException during token GET causes send() to fail."""
+
+    mock_get.side_effect = requests.RequestException("connection error")
+
+    obj = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["@all"],
+    )
+    assert obj.send(body="Hello") is False
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_wechat_send_http_error(mock_post, mock_get):
+    """Message POST returning HTTP 500 causes send() to fail."""
+
+    def _mk_resp(data, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(data).encode("utf-8")
+        return r
+
+    mock_get.return_value = _mk_resp(
+        {
+            "errcode": 0,
+            "errmsg": "ok",
+            "access_token": "TOKEN",
+            "expires_in": 7200,
+        }
+    )
+    mock_post.return_value = _mk_resp(
+        {}, code=requests.codes.internal_server_error
+    )
+    mock_post.return_value.content = b""
+
+    obj = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["@all"],
+    )
+    assert obj.send(body="Hello") is False
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_wechat_send_api_error(mock_post, mock_get):
+    """Message POST returning errcode != 0 causes send() to fail."""
+
+    def _mk_resp(data, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(data).encode("utf-8")
+        return r
+
+    mock_get.return_value = _mk_resp(
+        {
+            "errcode": 0,
+            "errmsg": "ok",
+            "access_token": "TOKEN",
+            "expires_in": 7200,
+        }
+    )
+    # 81013 -- all recipients invalid
+    mock_post.return_value = _mk_resp(
+        {"errcode": 81013, "errmsg": "All recipients invalid"}
+    )
+
+    obj = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["@all"],
+    )
+    assert obj.send(body="Hello") is False
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_wechat_send_token_expiry_evicts_cache(mock_post, mock_get):
+    """A token-expired errcode from the POST evicts the cached token."""
+
+    def _mk_resp(data, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(data).encode("utf-8")
+        return r
+
+    mock_get.return_value = _mk_resp(
+        {
+            "errcode": 0,
+            "errmsg": "ok",
+            "access_token": "TOKEN",
+            "expires_in": 7200,
+        }
+    )
+    # POST returns 42001 -- token expired
+    mock_post.return_value = _mk_resp(
+        {"errcode": 42001, "errmsg": "access_token expired"}
+    )
+
+    obj = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["@all"],
+    )
+    assert obj.send(body="Hello") is False
+
+    # Verify the store no longer holds the token
+    assert obj.store.get("access_token") is None
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_wechat_send_token_expiry_all_codes(mock_post, mock_get):
+    """All WECHAT_TOKEN_ERROR_CODES cause the cached token to be evicted."""
+
+    def _mk_resp(data, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(data).encode("utf-8")
+        return r
+
+    for errcode in WECHAT_TOKEN_ERROR_CODES:
+        mock_get.reset_mock()
+        mock_post.reset_mock()
+
+        mock_get.return_value = _mk_resp(
+            {
+                "errcode": 0,
+                "errmsg": "ok",
+                "access_token": "TOKEN",
+                "expires_in": 7200,
+            }
+        )
+        mock_post.return_value = _mk_resp(
+            {"errcode": errcode, "errmsg": "token error"}
+        )
+
+        obj = NotifyWeChat(
+            corpid=CORPID,
+            corpsecret=CORPSECRET,
+            agentid=AGENTID,
+            targets=["@all"],
+        )
+        assert obj.send(body="Hello") is False
+        assert obj.store.get("access_token") is None
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_wechat_send_bad_json(mock_post, mock_get):
+    """Message POST returning unparsable JSON is handled gracefully."""
+
+    def _mk_resp(data, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(data).encode("utf-8")
+        return r
+
+    mock_get.return_value = _mk_resp(
+        {
+            "errcode": 0,
+            "errmsg": "ok",
+            "access_token": "TOKEN",
+            "expires_in": 7200,
+        }
+    )
+
+    # POST returns unparsable body
+    post_r = mock.Mock()
+    post_r.status_code = requests.codes.ok
+    post_r.content = b"{bad json"
+    mock_post.return_value = post_r
+
+    obj = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["@all"],
+    )
+    # Bad JSON -> content = {} -> errcode = -1 -> failure
+    assert obj.send(body="Hello") is False
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_wechat_send_request_exception(mock_post, mock_get):
+    """RequestException during message POST causes send() to fail."""
+
+    def _mk_resp(data, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(data).encode("utf-8")
+        return r
+
+    mock_get.return_value = _mk_resp(
+        {
+            "errcode": 0,
+            "errmsg": "ok",
+            "access_token": "TOKEN",
+            "expires_in": 7200,
+        }
+    )
+    mock_post.side_effect = requests.RequestException("network error")
+
+    obj = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["@all"],
+    )
+    assert obj.send(body="Hello") is False
+
+
+def test_plugin_wechat_parse_url():
+    """Verify parse_url() handles all supported URL forms."""
+
+    # Standard form: corpid:corpsecret@agentid/targets
+    url = "wechat://{}:{}@{}/alice".format(CORPID, CORPSECRET, AGENTID)
+    result = NotifyWeChat.parse_url(url)
+    assert result is not None
+    assert result["corpid"] == CORPID
+    assert result["corpsecret"] == CORPSECRET
+    assert result["agentid"] == AGENTID
+    assert "alice" in result["targets"]
+
+    # Department target (%23 decodes to #)
+    url = "wechat://{}:{}@{}/%23999".format(CORPID, CORPSECRET, AGENTID)
+    result = NotifyWeChat.parse_url(url)
+    assert "#999" in result["targets"]
+
+    # Tag target
+    url = "wechat://{}:{}@{}/+42".format(CORPID, CORPSECRET, AGENTID)
+    result = NotifyWeChat.parse_url(url)
+    assert "+42" in result["targets"]
+
+    # ?to= adds targets
+    url = "wechat://{}:{}@{}?to=@all".format(CORPID, CORPSECRET, AGENTID)
+    result = NotifyWeChat.parse_url(url)
+    assert "@all" in result["targets"]
+
+    # None and non-string inputs return None
+    assert NotifyWeChat.parse_url(None) is None
+
+
+def test_plugin_wechat_parse_native_url():
+    """parse_native_url() always returns None -- no native URL form."""
+    assert (
+        NotifyWeChat.parse_native_url("https://qyapi.weixin.qq.com/any/url")
+        is None
+    )
+
+
+def test_plugin_wechat_error_codes():
+    """Verify the error code constants are populated correctly."""
+    assert 0 in WECHAT_ERROR_CODES
+    assert 40001 in WECHAT_TOKEN_ERROR_CODES
+    assert 40014 in WECHAT_TOKEN_ERROR_CODES
+    assert 42001 in WECHAT_TOKEN_ERROR_CODES
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_wechat_apprise_integration(mock_post, mock_get):
+    """End-to-end Apprise().notify() integration test."""
+
+    def _mk_resp(data, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(data).encode("utf-8")
+        return r
+
+    mock_get.return_value = _mk_resp(
+        {
+            "errcode": 0,
+            "errmsg": "ok",
+            "access_token": "TOKEN",
+            "expires_in": 7200,
+        }
+    )
+    mock_post.return_value = _mk_resp({"errcode": 0, "errmsg": "ok"})
+
+    app = Apprise()
+    url = "wechat://{}:{}@{}/@all".format(CORPID, CORPSECRET, AGENTID)
+    assert app.add(url) is True
+    assert app.notify(title="T", body="B") is True
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_wechat_send_unknown_api_error(mock_post, mock_get):
+    """An unknown errcode falls back to the errmsg field in the response."""
+
+    def _mk_resp(data, code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps(data).encode("utf-8")
+        return r
+
+    mock_get.return_value = _mk_resp(
+        {
+            "errcode": 0,
+            "errmsg": "ok",
+            "access_token": "TOKEN",
+            "expires_in": 7200,
+        }
+    )
+    # Use an error code not in WECHAT_ERROR_CODES
+    mock_post.return_value = _mk_resp(
+        {"errcode": 99999, "errmsg": "custom error message"}
+    )
+
+    obj = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["@all"],
+    )
+    assert obj.send(body="Hello") is False
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_wechat_token_unknown_api_error(mock_post, mock_get):
+    """Unknown errcode from token GET falls back to errmsg field."""
+
+    r = mock.Mock()
+    r.status_code = requests.codes.ok
+    r.content = dumps(
+        {"errcode": 99999, "errmsg": "custom token error"}
+    ).encode("utf-8")
+    mock_get.return_value = r
+
+    obj = NotifyWeChat(
+        corpid=CORPID,
+        corpsecret=CORPSECRET,
+        agentid=AGENTID,
+        targets=["@all"],
+    )
+    assert obj.send(body="Hello") is False


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #917

## *WeChat (WeCom Application)* Notifications
* **Source**: https://work.weixin.qq.com/
* **Image Support**: No
* **Message Format**: Plain Text / Markdown
* **Message Limit**: 2048 characters

Implements a new `wechat://` plugin that delivers notifications directly to WeCom (WeChat Work / Enterprise WeChat) users, departments, and tags via the WeCom Application Message API -- no third-party intermediary such as PushPlus is required.

**CorpID**, **App Secret**, and **AgentID** can be acquired from the WeCom admin console.

The access token (2-hour TTL) is cached via Apprise's persistent store so subsequent sends reuse it without an extra API call. Token-expiry error codes automatically evict the stale cache entry so the next send
fetches a fresh token. 

This plugin completes the WeChat/WeCom notification picture alongside the existing `wecombot://` (WeCom Bot webhook) and `pushplus://` (PushPlus intermediary) plugins.

## Account Setup
1. Sign in to the WeCom admin console at https://work.weixin.qq.com/.
2. Create or select a self-built application under "Applications & Mini Programs".
3. Note the **AgentID** from the application page.
4. Note the **CorpID** from "My Enterprise" -> "Enterprise Information".
5. Generate and copy the **App Secret** from the application page.

## Syntax

Valid syntax is as follows:
- `wechat://{corpid}:{corpsecret}@{agentid}/@all`
- `wechat://{corpid}:{corpsecret}@{agentid}/{userid}`
- `wechat://{corpid}:{corpsecret}@{agentid}/{user1}/{user2}`
- `wechat://{corpid}:{corpsecret}@{agentid}/%23{deptid}`
- `wechat://{corpid}:{corpsecret}@{agentid}/+{tagid}`
- `wechat://{corpid}:{corpsecret}@{agentid}/{user}/%23{dept}/+{tag}`

## Parameter Breakdown

| Variable | Required | Description |
|----------|----------|-------------|
| corpid | Yes | Corporation ID from the WeCom admin console |
| corpsecret | Yes | App Secret generated for the self-built application |
| agentid | Yes | Numeric Agent ID for the application |
| targets | No | Recipients: user IDs (no prefix), `@all`, `%23`+dept ID, `+`+tag ID |
| to | No | Comma-separated recipient alias via `?to=` query parameter |
| format | No | `markdown` for WeCom Markdown; default is plain text |

## Examples

Sends a notification to all users in the organisation:
```bash
apprise -vv -t "Test Title" -b "Test Message" \
    "wechat://wwCORPID:APPSECRET@1000002/@all"
```

## New Service Completion Status
* [x] apprise/plugins/wechat.py
* [x] pyproject.toml
    - Update keywords section to identify the new service (alphabetically).
* [x] README.md
    - Add entry for the new service (quick reference only).
* [x] packaging/redhat/python-apprise.spec
    - add new service into the `%global common_description`

## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/52](https://github.com/caronc/apprise-docs/pull/52)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@917-wechat-support

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "wechat://YOUR_CORPID:YOUR_CORPSECRET@YOUR_AGENTID/@all"
```

