### PR TITLE
o365:// saveToSentItems configurable - ?savesent=no

### DIFF
--- a/apprise/plugins/office365.py
+++ b/apprise/plugins/office365.py
@@ -623,7 +623,7 @@ class NotifyOffice365(NotifyBase):
                 },
             },
             # Below takes a string (not bool) of either 'true' or 'false'
-            "saveToSentItems": self.save_sent,
+            "saveToSentItems": "true" if self.save_sent else "false",
         }
 
         if self.from_email:

--- a/apprise/plugins/office365.py
+++ b/apprise/plugins/office365.py
@@ -55,7 +55,7 @@ from .. import exception
 from ..common import NotifyFormat, NotifyType, PersistentStoreMode
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
-from ..utils.parse import is_email, parse_emails, validate_regex
+from ..utils.parse import is_email, parse_bool, parse_emails, validate_regex
 from ..utils.sanitize import sanitize_payload
 from .base import NotifyBase
 
@@ -321,6 +321,11 @@ class NotifyOffice365(NotifyBase):
                 "values": OFFICE365_MODES,
                 "default": Office365Mode.ORG,
             },
+            "savesent": {
+                "name": _("Save to Sent Items"),
+                "type": "bool",
+                "default": True,
+            },
         },
     )
 
@@ -335,6 +340,7 @@ class NotifyOffice365(NotifyBase):
         bcc=None,
         reply_to=None,
         mode=None,
+        savesent=None,
         **kwargs,
     ):
         """Initialize Office 365 Object."""
@@ -395,6 +401,13 @@ class NotifyOffice365(NotifyBase):
         else:
             # Personal mode requires no tenant
             self.tenant = None
+
+        # Define whether or not we should operate in batch mode
+        self.save_sent = (
+            self.template_args["savesent"]["default"]
+            if savesent is None
+            else bool(savesent)
+        )
 
         # For tracking our email -> name lookups
         self.names = {}
@@ -610,7 +623,7 @@ class NotifyOffice365(NotifyBase):
                 },
             },
             # Below takes a string (not bool) of either 'true' or 'false'
-            "saveToSentItems": "true",
+            "saveToSentItems": self.save_sent,
         }
 
         if self.from_email:
@@ -1269,8 +1282,13 @@ class NotifyOffice365(NotifyBase):
     def url(self, privacy=False, *args, **kwargs):
         """Returns the URL built dynamically based on specified arguments."""
 
+        # Define any URL parameters
+        params = {
+            "savesent": "yes" if self.save_sent else "no",
+        }
+
         # Extend our parameters
-        params = self.url_parameters(privacy=privacy, *args, **kwargs)
+        params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
 
         # Include mode only for personal — org is the default and omitting
         # it keeps existing org URLs clean
@@ -1498,4 +1516,11 @@ class NotifyOffice365(NotifyBase):
         if "reply_to" in results["qsd"] and len(results["qsd"]["reply_to"]):
             results["reply_to"] = results["qsd"]["reply_to"]
 
+        # Get Save Sent Items Flag
+        results["savesent"] = parse_bool(
+            results["qsd"].get(
+                "savesent",
+                NotifyOffice365.template_args["savesent"]["default"],
+            )
+        )
         return results

--- a/tests/test_plugin_office365.py
+++ b/tests/test_plugin_office365.py
@@ -322,6 +322,27 @@ apprise_url_tests = (
             ),
         },
     ),
+    # Disable Save Sent Items
+    (
+        "o365://{aid}/{tenant}/{cid}/{secret}/{targets}?savesent=no".format(
+            tenant="tenant",
+            cid="ab-cd-ef-gh",
+            aid="user@example.edu",
+            secret="abcd/123/3343/@jack/test",
+            targets="email1@test.ca",
+        ),
+        {
+            "instance": NotifyOffice365,
+            "requests_response_text": {
+                "expires_in": 2000,
+                "access_token": "abcd1234",
+                "mail": "user@example.ca",
+            },
+            "privacy_url": (
+                "azure://user@example.edu/t...t/a...h/****/email1@test.ca/"
+            ),
+        },
+    ),
     # reply_to with URL-encoded (+) spaces in name
     (
         "o365://{aid}/{tenant}/{cid}/{secret}/{targets}"


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1595

use `?savesent=no` to disable  saveToSentItems flag which defaults to `yes` otherwise.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/53](https://github.com/caronc/apprise-docs/pull/53)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1595-o365-configurable-sent-items

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "o365://credentials/?savesent=no"
```
