### PR TITLE
Built in retries, escalations, priorities, and optional service calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,24 @@ apprise -vv -t "Union Test" \
 apprise -vv -t "Intersection Test" \
    --config=~/apprise.yml \
    -g devops,critical
+```
+
+Tags also support an optional **priority prefix** and **retry suffix**. In your configuration file you assign a priority to a tag like `1:alerts` or `5:alerts`. A lower number means higher urgency.
+
+* **Escalation (no prefix)**: `-g alerts` dispatches priority-1 entries first. If they all succeed, Apprise returns early and never runs the priority-5 fallbacks. A failure in the lower-priority group triggers the next group as an escalation chain.
+* **Exclusive (with prefix)**: `-g "2:alerts"` notifies *only* services whose `alerts` tag has priority 2. No other priority levels are triggered.
+* **Per-call retry**: `-g "alerts:3"` retries each matched service up to 3 times on failure (overrides the service's own retry setting for this call only).
+* **Combined**: `-g "2:alerts:3"` -- exclusive priority-2 filter with up to 3 retries.
+
+```bash
+# Escalation: priority-1 first; skip priority-5 if all succeed
+apprise -vv -t "Alert" --config=~/apprise.yml -g alerts
+
+# Exclusive: only priority-2 alert services
+apprise -vv -t "Alert" --config=~/apprise.yml -g "2:alerts"
+
+# With retry override: retry each matched service up to 3 times
+apprise -vv -t "Alert" --config=~/apprise.yml -g "alerts:3"
 
 ## CLI File Attachments
 

--- a/apprise/__init__.py
+++ b/apprise/__init__.py
@@ -71,6 +71,7 @@ from .manager_config import ConfigurationManager
 from .manager_plugins import NotificationManager
 from .persistent_store import PersistentStore
 from .plugins.base import NotifyBase
+from .tag import AppriseTag
 from .url import PrivacyMode, URLBase
 
 # Set default logging handler to avoid "No handler found" warnings.
@@ -93,6 +94,7 @@ __all__ = [
     "AppriseAttachment",
     "AppriseConfig",
     "AppriseLocale",
+    "AppriseTag",
     "AttachBase",
     "AttachmentManager",
     "ConfigBase",

--- a/apprise/apprise.py
+++ b/apprise/apprise.py
@@ -33,6 +33,7 @@ import concurrent.futures as cf
 from itertools import chain
 import json
 import os
+import time
 from typing import Any, Optional, Union
 
 from . import __version__, common, plugins
@@ -47,6 +48,7 @@ from .locale import AppriseLocale
 from .logger import logger
 from .manager_plugins import NotificationManager
 from .plugins.base import NotifyBase
+from .tag import AppriseTag
 from .utils.cwe312 import cwe312_url
 from .utils.json import AppriseJSONEncoder
 from .utils.logic import is_exclusive_match
@@ -391,6 +393,84 @@ class Apprise:
                     yield server
         return
 
+    @staticmethod
+    def _extract_filter_retry(tag):
+        """Return the retry override embedded in a filter tag, or None.
+
+        A filter like "3:endpoint:2" or "endpoint:2" carries ":2" as the
+        call-level retry count.  When present it overrides each matched
+        server's configured retry for this single notify() call.
+        """
+        if tag is None or tag == common.MATCH_ALL_TAG:
+            return None
+        for entry in (
+            [tag] if isinstance(tag, (str, AppriseTag)) else list(tag)
+        ):
+            if isinstance(entry, (list, tuple, set)):
+                for tok in parse_list(entry):
+                    ft = AppriseTag.parse(tok)
+                    if ft.retry is not None:
+                        return ft.retry
+            else:
+                ft = AppriseTag.parse(str(entry))
+                if ft.retry is not None:
+                    return ft.retry
+        return None
+
+    @staticmethod
+    def _filter_has_explicit_priority(tag):
+        """Return True if any token in *tag* carries an explicit priority
+        prefix.
+
+        When True, notify() dispatches matched servers as a flat batch
+        (no escalation) because the caller selected an exact priority level.
+        When False, matched servers are grouped by their own tag priorities
+        and dispatched in ascending order with early-True exit.
+        """
+        if tag is None or tag == common.MATCH_ALL_TAG:
+            return False
+        for entry in (
+            [tag] if isinstance(tag, (str, AppriseTag)) else list(tag)
+        ):
+            if isinstance(entry, (list, tuple, set)):
+                for tok in parse_list(entry):
+                    if AppriseTag.parse(tok).has_priority:
+                        return True
+            else:
+                if AppriseTag.parse(str(entry)).has_priority:
+                    return True
+        return False
+
+    @staticmethod
+    def _server_priority_for_filter(server, tag):
+        """Return the effective dispatch priority for *server* given *tag*.
+
+        The priority comes from the AppriseTag stored on the server whose
+        name matches one of the tag-filter names.  When multiple server tags
+        match, the minimum (highest-precedence) priority is returned.
+        Returns 0 when no matching priority tag is found.
+        """
+        if tag is None or tag == common.MATCH_ALL_TAG:
+            return 0
+
+        # Flatten the filter to a set of bare lowercase tag names.
+        filter_names = set()
+        for entry in (
+            [tag] if isinstance(tag, (str, AppriseTag)) else list(tag)
+        ):
+            if isinstance(entry, (list, tuple, set)):
+                for t in parse_list(entry):
+                    filter_names.add(str(AppriseTag.parse(t)))
+            else:
+                filter_names.add(str(AppriseTag.parse(str(entry))))
+
+        priorities = [
+            stag.priority if isinstance(stag, AppriseTag) else 0
+            for stag in server.tags
+            if str(stag) in filter_names
+        ]
+        return min(priorities) if priorities else 0
+
     def notify(
         self,
         body: Union[str, bytes],
@@ -417,6 +497,23 @@ class Apprise:
         sent at all as a result of tag filtering and/or simply having empty
         configuration files that were read.
 
+        A filter tag may carry an optional priority prefix and/or retry suffix:
+
+          "endpoint"       -> match all entries; escalate by priority
+          "3:endpoint"     -> match ONLY priority-3 entries; flat dispatch
+          "endpoint:2"     -> match all entries; retry each up to 2 times
+          "3:endpoint:2"   -> exclusive priority-3 match with 2 retries
+
+        When no priority prefix is given, matched services are grouped by
+        their configured tag priority and dispatched in ascending order
+        (lowest number = highest urgency).  If every service in the lowest
+        priority group succeeds, Apprise returns True immediately without
+        running higher-numbered priority groups (escalation chain).
+
+        When an explicit priority prefix IS given (e.g. "3:endpoint"), only
+        services whose matching tag carries that exact priority are notified,
+        and all matched services are dispatched as a single flat batch.
+
         Attach can contain a list of attachment URLs.  attach can also be
         represented by an AttachBase() (or list of) object(s). This identifies
         the products you wish to notify
@@ -426,30 +523,89 @@ class Apprise:
         """
 
         try:
-            # Process arguments and build synchronous and asynchronous calls
-            # (this step can throw internal errors).
-            sequential_calls, parallel_calls = self._create_notify_calls(
-                body,
-                title,
-                notify_type=notify_type,
-                body_format=body_format,
-                tag=tag,
-                match_always=match_always,
-                attach=attach,
-                interpret_escapes=interpret_escapes,
+            all_calls = list(
+                self._create_notify_gen(
+                    body,
+                    title,
+                    notify_type=notify_type,
+                    body_format=body_format,
+                    tag=tag,
+                    match_always=match_always,
+                    attach=attach,
+                    interpret_escapes=interpret_escapes,
+                )
             )
 
         except TypeError:
-            # No notifications sent, and there was an internal error.
             return False
 
-        if not sequential_calls and not parallel_calls:
-            # Nothing to send
+        if not all_calls:
             return None
 
-        sequential_result = Apprise._notify_sequential(*sequential_calls)
-        parallel_result = Apprise._notify_parallel_threadpool(*parallel_calls)
-        return sequential_result and parallel_result
+        # A tag filter may carry a per-call retry suffix (e.g. "alerts:3").
+        # When present, inject it into each server's kwargs so the dispatch
+        # functions can pick it up and override the server's own retry setting
+        # for this call only.  The server's stored configuration is unchanged.
+        filter_retry = Apprise._extract_filter_retry(tag)
+        if filter_retry is not None:
+            all_calls = [
+                (s, dict(k, _retry_override=filter_retry))
+                for s, k in all_calls
+            ]
+
+        if Apprise._filter_has_explicit_priority(tag):
+            # Tag filter carries an explicit priority prefix (e.g. "2:alerts").
+            # Skip the escalation chain: dispatch all matched services as a
+            # single flat batch regardless of their individual tag priorities.
+            sequential = [
+                (s, k) for s, k in all_calls if not s.asset.async_mode
+            ]
+            parallel = [(s, k) for s, k in all_calls if s.asset.async_mode]
+            seq_ok = (
+                Apprise._notify_sequential(*sequential) if sequential else True
+            )
+            par_ok = (
+                Apprise._notify_parallel_threadpool(*parallel)
+                if parallel
+                else True
+            )
+            return seq_ok and par_ok
+
+        # No explicit priority in the filter -- use the escalation chain.
+        # Group matched services by the priority stored on their matching tag;
+        # services without a priority prefix default to 0 (highest urgency).
+        # Dispatch groups in ascending numeric order.  If every service in
+        # the current group succeeds, stop immediately without touching the
+        # remaining lower-urgency groups.  Any failure in a group causes
+        # Apprise to fall through and escalate to the next priority group.
+        priority_groups: dict[int, list] = {}
+        for server, notify_kwargs in all_calls:
+            p = Apprise._server_priority_for_filter(server, tag)
+            priority_groups.setdefault(p, []).append((server, notify_kwargs))
+
+        for priority in sorted(priority_groups):
+            batch = priority_groups[priority]
+            # Split this priority group into sync and async halves.
+            sequential = [(s, k) for s, k in batch if not s.asset.async_mode]
+            parallel = [(s, k) for s, k in batch if s.asset.async_mode]
+            seq_ok = (
+                Apprise._notify_sequential(*sequential) if sequential else True
+            )
+            par_ok = (
+                Apprise._notify_parallel_threadpool(*parallel)
+                if parallel
+                else True
+            )
+            if seq_ok and par_ok:
+                # Every service in this priority group delivered successfully.
+                # Stop here; lower-urgency groups are not triggered.
+                return True
+            # At least one service in this group failed -- escalate to the
+            # next priority group and try those services instead.
+
+        # All priority groups were exhausted and the last group still had
+        # at least one failed delivery.
+        return False
 
     async def async_notify(self, *args: Any, **kwargs: Any) -> Optional[bool]:
         """Send a notification to all the plugins previously loaded, for
@@ -457,26 +613,66 @@ class Apprise:
 
         The arguments are identical to those of Apprise.notify().
         """
+        tag = kwargs.get("tag", common.MATCH_ALL_TAG)
+
         try:
-            # Process arguments and build synchronous and asynchronous calls
-            # (this step can throw internal errors).
-            sequential_calls, parallel_calls = self._create_notify_calls(
-                *args, **kwargs
-            )
+            all_calls = list(self._create_notify_gen(*args, **kwargs))
 
         except TypeError:
-            # No notifications sent, and there was an internal error.
             return False
 
-        if not sequential_calls and not parallel_calls:
-            # Nothing to send
+        if not all_calls:
             return None
 
-        sequential_result = Apprise._notify_sequential(*sequential_calls)
-        parallel_result = await Apprise._notify_parallel_asyncio(
-            *parallel_calls
-        )
-        return sequential_result and parallel_result
+        # Inject a per-call retry override when the tag filter includes one.
+        filter_retry = Apprise._extract_filter_retry(tag)
+        if filter_retry is not None:
+            all_calls = [
+                (s, dict(k, _retry_override=filter_retry))
+                for s, k in all_calls
+            ]
+
+        if Apprise._filter_has_explicit_priority(tag):
+            # Explicit priority prefix: flat dispatch, no escalation.
+            sequential = [
+                (s, k) for s, k in all_calls if not s.asset.async_mode
+            ]
+            parallel = [(s, k) for s, k in all_calls if s.asset.async_mode]
+            seq_ok = (
+                Apprise._notify_sequential(*sequential) if sequential else True
+            )
+            par_ok = (
+                await Apprise._notify_parallel_asyncio(*parallel)
+                if parallel
+                else True
+            )
+            return seq_ok and par_ok
+
+        # Escalation chain: group by tag priority and dispatch highest urgency
+        # (lowest number) first.  Stop as soon as one entire group succeeds.
+        priority_groups: dict[int, list] = {}
+        for server, notify_kwargs in all_calls:
+            p = Apprise._server_priority_for_filter(server, tag)
+            priority_groups.setdefault(p, []).append((server, notify_kwargs))
+
+        for priority in sorted(priority_groups):
+            batch = priority_groups[priority]
+            sequential = [(s, k) for s, k in batch if not s.asset.async_mode]
+            parallel = [(s, k) for s, k in batch if s.asset.async_mode]
+            seq_ok = (
+                Apprise._notify_sequential(*sequential) if sequential else True
+            )
+            par_ok = (
+                await Apprise._notify_parallel_asyncio(*parallel)
+                if parallel
+                else True
+            )
+            if seq_ok and par_ok:
+                # Entire group succeeded; skip lower-urgency groups.
+                return True
+            # Group had failures; escalate to the next priority group.
+
+        return False
 
     def _create_notify_calls(self, *args, **kwargs):
         """Creates notifications for all the plugins loaded.
@@ -659,66 +855,153 @@ class Apprise:
 
     @staticmethod
     def _notify_sequential(*servers_kwargs):
-        """Process a list of notify() calls sequentially and synchronously."""
+        """Process a list of notify() calls sequentially and synchronously.
+
+        Each server is attempted once and then retried up to server.retry
+        additional times on failure before moving on.  When server.wait is
+        greater than zero, the process sleeps that many seconds between
+        each retry attempt.
+
+        A per-call retry override may be injected into kwargs under the key
+        ``_retry_override``; when present it takes precedence over the
+        server's own retry attribute for this invocation only.
+
+        Exceptions raised by a plugin's notify() -- including those from
+        third-party @notify-decorated functions that are outside our control
+        -- are caught here and treated as a delivery failure.  The retry
+        logic still applies, so a plugin that raises on the first attempt
+        will be retried the configured number of times before giving up.
+        """
 
         success = True
 
         for server, kwargs in servers_kwargs:
-            try:
-                # Send notification
-                result = server.notify(**kwargs)
-                success = success and result
+            # Pop the per-call override before forwarding kwargs to the
+            # plugin so it never sees the internal _retry_override key.
+            retry = kwargs.pop("_retry_override", getattr(server, "retry", 0))
+            wait = getattr(server, "wait", 0.0)
 
-            except TypeError:
-                # These are our internally thrown notifications.
-                success = False
+            result = False
+            for attempt in range(retry + 1):
+                # Attempt delivery.  TypeError comes from Apprise's own
+                # validation; bare Exception guards against buggy or
+                # third-party plugins (including @notify decorators) that
+                # may raise unexpectedly.  Both are treated as failure so
+                # the retry loop can continue.
+                try:
+                    result = server.notify(**kwargs)
+                except TypeError:
+                    result = False
+                except Exception:
+                    logger.exception("Unhandled Notification Exception")
+                    result = False
 
-            except Exception:
-                # A catch all so we don't have to abort early
-                # just because one of our plugins has a bug in it.
-                logger.exception("Unhandled Notification Exception")
-                success = False
+                if result:
+                    # Delivered successfully; no need to retry this server.
+                    break
+
+                if attempt < retry:
+                    # Delivery failed and retries remain.  Log the attempt
+                    # number and pause before the next try.
+                    logger.warning(
+                        "Retry %d/%d for %s",
+                        attempt + 1,
+                        retry,
+                        server.service_name,
+                    )
+                    if wait > 0:
+                        time.sleep(wait)
+
+            # A single False result taints the overall batch result.
+            success = success and result
 
         return success
 
     @staticmethod
     def _notify_parallel_threadpool(*servers_kwargs):
-        """Process a list of notify() calls in parallel and synchronously."""
+        """Process a list of notify() calls in parallel via a thread pool.
+
+        Each server runs in its own thread.  Within each thread, the server
+        is retried up to server.retry additional times on failure with an
+        optional server.wait second sleep between each attempt.
+
+        Falls back to _notify_sequential() when only a single server is
+        given to avoid the overhead of spawning a thread pool for one call.
+
+        Exceptions from a plugin's notify() -- including those from
+        third-party @notify-decorated functions -- are caught inside each
+        thread and treated as delivery failures so the retry logic can
+        still run.
+        """
 
         n_calls = len(servers_kwargs)
 
-        # 0-length case
         if n_calls == 0:
             return True
 
-        # There's no need to use a thread pool for just a single notification
+        # Avoid thread-pool overhead for a single notification.
         if n_calls == 1:
             return Apprise._notify_sequential(servers_kwargs[0])
 
-        # Create log entry
         logger.info(
             "Notifying %d service(s) with threads.", len(servers_kwargs)
         )
 
+        def _call_with_retry(server, kwargs):
+            """Execute one server's notify() with retry/wait logic.
+
+            Runs inside a worker thread.  Pops ``_retry_override`` from
+            kwargs so it is never forwarded to the plugin's notify() call.
+            Exceptions are caught and treated as failures so the retry
+            loop continues even when a plugin raises unexpectedly.
+            """
+            # Pop the per-call override so it stays internal.
+            retry = kwargs.pop("_retry_override", getattr(server, "retry", 0))
+            wait = getattr(server, "wait", 0.0)
+
+            result = False
+            for attempt in range(retry + 1):
+                # Same exception handling as _notify_sequential: TypeError
+                # from Apprise validation and bare Exception for buggy or
+                # third-party plugins both map to a retriable failure.
+                try:
+                    result = server.notify(**kwargs)
+                except TypeError:
+                    result = False
+                except Exception:
+                    logger.exception("Unhandled Notification Exception")
+                    result = False
+
+                if result:
+                    return True
+
+                if attempt < retry:
+                    logger.warning(
+                        "Retry %d/%d for %s",
+                        attempt + 1,
+                        retry,
+                        server.service_name,
+                    )
+                    if wait > 0:
+                        time.sleep(wait)
+
+            return result
+
+        # Submit all server calls to the thread pool and collect results.
         with cf.ThreadPoolExecutor() as executor:
             success = True
             futures = [
-                executor.submit(server.notify, **kwargs)
+                executor.submit(_call_with_retry, server, kwargs)
                 for (server, kwargs) in servers_kwargs
             ]
 
             for future in cf.as_completed(futures):
+                # future.result() re-raises any exception that escaped
+                # _call_with_retry (should not happen given the inner
+                # try/except, but guard here as a safety net).
                 try:
-                    result = future.result()
-                    success = success and result
-
-                except TypeError:
-                    # These are our internally thrown notifications.
-                    success = False
-
+                    success = success and future.result()
                 except Exception:
-                    # A catch all so we don't have to abort early
-                    # just because one of our plugins has a bug in it.
                     logger.exception("Unhandled Notification Exception")
                     success = False
 
@@ -726,27 +1009,75 @@ class Apprise:
 
     @staticmethod
     async def _notify_parallel_asyncio(*servers_kwargs):
-        """Process a list of async_notify() calls in parallel and
-        asynchronously."""
+        """Process a list of async_notify() calls concurrently via asyncio.
+
+        All coroutines are gathered with asyncio.gather().  Each server is
+        retried up to server.retry additional times on failure with an
+        optional asyncio.sleep(server.wait) between attempts.
+
+        Unlike the thread-pool path, there is no single-server optimisation
+        here because asyncio can pipeline work across coroutines while one
+        is awaiting I/O.
+
+        Exceptions from a plugin's async_notify() -- including those from
+        third-party @notify-decorated coroutines -- are caught inside each
+        coroutine and treated as delivery failures so the retry loop can
+        still run for that service.
+        """
 
         n_calls = len(servers_kwargs)
 
-        # 0-length case
         if n_calls == 0:
             return True
 
-        # (Unlike with the thread pool, we don't optimize for the single-
-        # notification case because asyncio can do useful work while waiting
-        # for that thread to complete)
-
-        # Create log entry
         logger.info(
             "Notifying %d service(s) asynchronously.", len(servers_kwargs)
         )
 
         async def do_call(server, kwargs):
-            return await server.async_notify(**kwargs)
+            """Coroutine driving one server's async_notify() with retry/wait.
 
+            Pops ``_retry_override`` from kwargs so it is never forwarded
+            to the plugin.  Exceptions are caught and treated as failures
+            so the retry loop continues even when a plugin raises
+            unexpectedly (e.g. a third-party @notify-decorated coroutine).
+            """
+            # Pop the per-call override so it stays internal.
+            retry = kwargs.pop("_retry_override", getattr(server, "retry", 0))
+            wait = getattr(server, "wait", 0.0)
+
+            result = False
+            for attempt in range(retry + 1):
+                # Mirror the exception handling from the synchronous paths:
+                # TypeError from Apprise's own validation layer and bare
+                # Exception for any plugin that raises unexpectedly are both
+                # treated as retriable failures rather than hard crashes.
+                try:
+                    result = await server.async_notify(**kwargs)
+                except TypeError:
+                    result = False
+                except Exception:
+                    logger.exception("Unhandled Notification Exception")
+                    result = False
+
+                if result:
+                    return True
+
+                if attempt < retry:
+                    logger.warning(
+                        "Retry %d/%d for %s",
+                        attempt + 1,
+                        retry,
+                        server.service_name,
+                    )
+                    if wait > 0:
+                        await asyncio.sleep(wait)
+
+            return result
+
+        # Run all coroutines concurrently.  return_exceptions=True ensures
+        # that one coroutine raising does not cancel the others; any escaped
+        # exception (beyond what do_call already handles) is caught below.
         cors = (do_call(server, kwargs) for (server, kwargs) in servers_kwargs)
         results = await asyncio.gather(*cors, return_exceptions=True)
 
@@ -754,8 +1085,8 @@ class Apprise:
             isinstance(status, Exception) and not isinstance(status, TypeError)
             for status in results
         ):
-            # A catch all so we don't have to abort early just because
-            # one of our plugins has a bug in it.
+            # Safety net: an exception escaped do_call's own try/except.
+            # Log it and treat the whole batch as failed.
             logger.exception("Unhandled Notification Exception")
             return False
 

--- a/apprise/apprise.py
+++ b/apprise/apprise.py
@@ -1143,7 +1143,43 @@ class Apprise:
                     if wait > 0:
                         time.sleep(wait)
 
-            # A single False result taints the overall batch result.
+            # Optional-service check.
+            #
+            # At this point all retry attempts for 'server' have been
+            # exhausted (the for-loop above has finished).  If the final
+            # result is still False *and* the service is marked optional,
+            # we overwrite result to True before folding it into the
+            # running 'success' accumulator.  This silently absorbs the
+            # failure: the caller will not see it as a delivery error.
+            #
+            # Why getattr() instead of self.optional?
+            #   getattr(server, "optional", False) guards against mock
+            #   objects and hypothetical future subclasses that may not
+            #   define the attribute at all.  In those cases the default
+            #   of False is used, which keeps the safe, conservative
+            #   behaviour: unexpected attribute absence propagates the
+            #   failure rather than silently swallowing it.
+            #
+            # Interaction with retries:
+            #   The retry loop above has already run.  optional= does not
+            #   short-circuit or bypass retries -- it only changes the
+            #   interpretation of the *final* result once all attempts
+            #   are done.  A service with retry=3 and optional=True will
+            #   still be attempted four times before the failure is
+            #   absorbed here.
+            if not result and getattr(server, "optional", False):
+                logger.info(
+                    "Optional service '%s' failed; ignoring failure.",
+                    server.service_name,
+                )
+                result = True
+
+            # Fold this service's result into the running batch outcome.
+            # Boolean AND is used so that a single False from any required
+            # (non-optional) service permanently taints 'success' for the
+            # whole batch -- even if later services succeed.  Optional
+            # failures are already re-mapped to True above, so they never
+            # contribute a False here.
             success = success and result
 
         return success
@@ -1216,6 +1252,33 @@ class Apprise:
                     if wait > 0:
                         time.sleep(wait)
 
+            # Optional-service check (thread-pool path).
+            #
+            # All retry attempts for this server have been exhausted by the
+            # loop above.  If the final result is still False and the service
+            # is tagged as optional, return True from this worker function
+            # instead of False.  The caller (_notify_parallel_threadpool)
+            # collects each worker's return value via future.result() and
+            # ANDs them together; returning True here prevents this worker's
+            # failure from tainting the aggregate result.
+            #
+            # This is the thread-pool equivalent of the same check in
+            # _notify_sequential.  See the comment there for a full
+            # explanation of the getattr() guard and the retry interaction.
+            if not result and getattr(server, "optional", False):
+                logger.info(
+                    "Optional service '%s' failed; ignoring failure.",
+                    server.service_name,
+                )
+                # Return True so future.result() in the caller reports
+                # success for this optional worker thread.
+                return True
+
+            # Return the actual final delivery result for this service.
+            # True  means at least one attempt succeeded (retry short-
+            #       circuited out of the loop early via 'return True').
+            # False means every attempt failed and the service is required
+            #       (optional=False), so the failure is propagated.
             return result
 
         # Submit all server calls to the thread pool and collect results.
@@ -1304,6 +1367,32 @@ class Apprise:
                     if wait > 0:
                         await asyncio.sleep(wait)
 
+            # Optional-service check (asyncio coroutine path).
+            #
+            # All retry attempts have been exhausted by the async loop
+            # above.  If the final result is still False and the service
+            # is tagged optional, return True from this coroutine so that
+            # asyncio.gather() receives a truthy value for this task.
+            # The caller inspects all gathered results with all(); a True
+            # here ensures this coroutine does not lower the aggregate
+            # result for the batch.
+            #
+            # This is the asyncio equivalent of the same check in
+            # _notify_sequential and _call_with_retry.  See the comment
+            # in _notify_sequential for a full explanation of the getattr()
+            # guard and the interaction with the retry count.
+            if not result and getattr(server, "optional", False):
+                logger.info(
+                    "Optional service '%s' failed; ignoring failure.",
+                    server.service_name,
+                )
+                # Return True so asyncio.gather() sees a success value
+                # for this optional coroutine.
+                return True
+
+            # Return the actual final delivery result for this coroutine.
+            # True  means at least one async attempt succeeded.
+            # False means every attempt failed and the service is required.
             return result
 
         # Run all coroutines concurrently.  return_exceptions=True ensures

--- a/apprise/apprise.py
+++ b/apprise/apprise.py
@@ -1274,11 +1274,8 @@ class Apprise:
                 # success for this optional worker thread.
                 return True
 
-            # Return the actual final delivery result for this service.
-            # True  means at least one attempt succeeded (retry short-
-            #       circuited out of the loop early via 'return True').
-            # False means every attempt failed and the service is required
-            #       (optional=False), so the failure is propagated.
+            # Every attempt for this service failed and it is not optional;
+            # propagate the failure to the caller.
             return result
 
         # Submit all server calls to the thread pool and collect results.
@@ -1390,9 +1387,8 @@ class Apprise:
                 # for this optional coroutine.
                 return True
 
-            # Return the actual final delivery result for this coroutine.
-            # True  means at least one async attempt succeeded.
-            # False means every attempt failed and the service is required.
+            # Every attempt for this service failed and it is not optional;
+            # propagate the failure to the caller.
             return result
 
         # Run all coroutines concurrently.  return_exceptions=True ensures
@@ -1401,17 +1397,14 @@ class Apprise:
         cors = (do_call(server, kwargs) for (server, kwargs) in servers_kwargs)
         results = await asyncio.gather(*cors, return_exceptions=True)
 
-        if any(
-            isinstance(status, Exception) and not isinstance(status, TypeError)
-            for status in results
-        ):
+        if any(isinstance(status, Exception) for status in results):
             # Safety net: an exception escaped do_call's own try/except.
-            # Log it and treat the whole batch as failed.
-            logger.exception("Unhandled Notification Exception")
-            return False
-
-        if any(isinstance(status, TypeError) for status in results):
-            # These are our internally thrown notifications.
+            # Log each one and treat the whole batch as failed.
+            for status in results:
+                if isinstance(status, Exception):
+                    logger.error(
+                        "Unhandled Notification Exception: %s", status
+                    )
             return False
 
         return all(results)

--- a/apprise/apprise.py
+++ b/apprise/apprise.py
@@ -437,9 +437,150 @@ class Apprise:
                     if AppriseTag.parse(tok).has_priority:
                         return True
             else:
-                if AppriseTag.parse(str(entry)).has_priority:
-                    return True
+                for tok in parse_list(str(entry)):
+                    if AppriseTag.parse(tok).has_priority:
+                        return True
         return False
+
+    @staticmethod
+    def _server_priority_for_tag_name(server, tag_name):
+        """Return the dispatch priority stored on *server* for *tag_name*.
+
+        Looks up the AppriseTag in server.tags whose bare name equals
+        *tag_name* and returns its priority.  Returns 0 when the tag is
+        absent or stored as a plain string (no explicit priority).
+        """
+        for stag in server.tags:
+            if str(stag) == tag_name:
+                return stag.priority if isinstance(stag, AppriseTag) else 0
+        return 0
+
+    @staticmethod
+    def _match_service_retry(server, tag):
+        """Return the call-time retry override for *server* given *tag*.
+
+        Iterates the OR tokens in *tag* in order.  The first token that
+        both carries a retry suffix AND matches *server* determines the
+        override.  Returns None when no such token exists.
+
+        Matching follows the same rules as _token_matches_data:
+          - no priority prefix  -> name-only match
+          - explicit priority   -> name + priority-exact match
+        """
+        if tag is None or tag == common.MATCH_ALL_TAG:
+            return None
+        for entry in (
+            [tag] if isinstance(tag, (str, AppriseTag)) else list(tag)
+        ):
+            tokens = (
+                parse_list(entry)
+                if isinstance(entry, (list, tuple, set))
+                else parse_list(str(entry))
+            )
+            for tok in tokens:
+                ft = AppriseTag.parse(tok)
+                if ft.retry is None:
+                    continue
+                tag_name = str(ft)
+                if not ft.has_priority:
+                    if tag_name in server.tags:
+                        return ft.retry
+                else:
+                    for stag in server.tags:
+                        if isinstance(stag, AppriseTag):
+                            if (
+                                str(stag) == tag_name
+                                and stag.priority == ft.priority
+                            ):
+                                return ft.retry
+                        else:
+                            if str(stag).lower() == tag_name:
+                                return ft.retry
+        return None
+
+    @staticmethod
+    def _inject_per_service_retries(all_calls, tag):
+        """Return *all_calls* with per-service _retry_override injected.
+
+        For each (server, kwargs) pair, finds the first filter token in
+        *tag* that matches the service and carries a retry suffix.  When
+        found, injects that value as _retry_override so that all dispatch
+        paths (sequential, threadpool, asyncio) pick it up automatically.
+        Services with no matching retry token are left unchanged.
+        """
+        result = []
+        for server, kwargs in all_calls:
+            retry = Apprise._match_service_retry(server, tag)
+            if retry is not None:
+                kwargs = dict(kwargs, _retry_override=retry)
+            result.append((server, kwargs))
+        return result
+
+    @staticmethod
+    def _build_tag_chains(all_calls, tag):
+        """Group *all_calls* into per-OR-token escalation chains.
+
+        Returns {chain_key: {priority: [(server, kwargs)]}}.
+
+        Each service is assigned to the chain of the first OR token whose
+        bare tag name appears in the service's own tags.  The chain key is
+        that bare tag name.  Services that don't match any token by name
+        fall into a catch-all chain keyed as "".
+
+        When *tag* is MATCH_ALL_TAG or None, a single chain "" is built
+        using the existing _server_priority_for_filter logic.
+        """
+        if tag is None or tag == common.MATCH_ALL_TAG:
+            chain: dict[int, list] = {}
+            for server, kwargs in all_calls:
+                p = Apprise._server_priority_for_filter(server, tag)
+                chain.setdefault(p, []).append((server, kwargs))
+            return {"": chain}
+
+        # Flatten OR tokens; AND groups are kept as a single opaque entry
+        # that falls through to the catch-all chain.
+        #
+        # The CLI wraps each --tag value in a list via parse_list(), so a
+        # single --tag flag produces a single-element inner list such as
+        # [["alerts:3"]].  A single-element list is always a plain OR token
+        # (there is nothing to AND against), so we treat it the same as a
+        # bare string.  A multi-element inner list is a genuine AND condition
+        # (the server must carry every tag in the group) and falls through to
+        # the catch-all chain instead of getting its own independent chain.
+        or_tag_names: list[str] = []
+        for entry in (
+            [tag] if isinstance(tag, (str, AppriseTag)) else list(tag)
+        ):
+            if isinstance(entry, (list, tuple, set)):
+                flat = parse_list(*entry) if entry else []
+                if len(flat) == 1:
+                    # single OR token wrapped in a list (CLI convention)
+                    or_tag_names.append(str(AppriseTag.parse(flat[0])))
+                else:
+                    or_tag_names.append("")  # AND group placeholder
+            else:
+                for tok in parse_list(str(entry)):
+                    or_tag_names.append(str(AppriseTag.parse(tok)))
+
+        chains: dict[str, dict[int, list]] = {}
+        for server, kwargs in all_calls:
+            for chain_key in or_tag_names:
+                if chain_key and chain_key in server.tags:
+                    p = Apprise._server_priority_for_tag_name(
+                        server, chain_key
+                    )
+                    chains.setdefault(chain_key, {}).setdefault(p, []).append(
+                        (server, kwargs)
+                    )
+                    break
+            else:
+                # fallback: use global priority
+                p = Apprise._server_priority_for_filter(server, tag)
+                chains.setdefault("", {}).setdefault(p, []).append(
+                    (server, kwargs)
+                )
+
+        return chains
 
     @staticmethod
     def _server_priority_for_filter(server, tag):
@@ -462,7 +603,8 @@ class Apprise:
                 for t in parse_list(entry):
                     filter_names.add(str(AppriseTag.parse(t)))
             else:
-                filter_names.add(str(AppriseTag.parse(str(entry))))
+                for t in parse_list(str(entry)):
+                    filter_names.add(str(AppriseTag.parse(t)))
 
         priorities = [
             stag.priority if isinstance(stag, AppriseTag) else 0
@@ -542,16 +684,11 @@ class Apprise:
         if not all_calls:
             return None
 
-        # A tag filter may carry a per-call retry suffix (e.g. "alerts:3").
-        # When present, inject it into each server's kwargs so the dispatch
-        # functions can pick it up and override the server's own retry setting
-        # for this call only.  The server's stored configuration is unchanged.
-        filter_retry = Apprise._extract_filter_retry(tag)
-        if filter_retry is not None:
-            all_calls = [
-                (s, dict(k, _retry_override=filter_retry))
-                for s, k in all_calls
-            ]
+        # Inject the per-service call-time retry override.  Each matched
+        # service gets the retry from the first filter token that both matches
+        # it and carries a retry suffix (e.g. "devops:3" applies retry=3 only
+        # to devops-tagged services, not to management-tagged services).
+        all_calls = Apprise._inject_per_service_retries(all_calls, tag)
 
         if Apprise._filter_has_explicit_priority(tag):
             # Tag filter carries an explicit priority prefix (e.g. "2:alerts").
@@ -571,41 +708,94 @@ class Apprise:
             )
             return seq_ok and par_ok
 
-        # No explicit priority in the filter -- use the escalation chain.
-        # Group matched services by the priority stored on their matching tag;
-        # services without a priority prefix default to 0 (highest urgency).
-        # Dispatch groups in ascending numeric order.  If every service in
-        # the current group succeeds, stop immediately without touching the
-        # remaining lower-urgency groups.  Any failure in a group causes
-        # Apprise to fall through and escalate to the next priority group.
-        priority_groups: dict[int, list] = {}
-        for server, notify_kwargs in all_calls:
-            p = Apprise._server_priority_for_filter(server, tag)
-            priority_groups.setdefault(p, []).append((server, notify_kwargs))
+        # No explicit priority in the filter -- use per-tag escalation chains.
+        #
+        # Each distinct OR token forms an independent chain.  Within a chain,
+        # services are grouped by their configured tag priority.  The lowest-
+        # numbered group (highest urgency) runs first.  If every service in
+        # that group succeeds the chain is done; any failure escalates to the
+        # next priority group.  notify() returns True only when every chain
+        # finds a fully-successful group.
+        #
+        # When multiple chains are active in the same round their current
+        # priority-group batches run concurrently via a thread pool so that
+        # one chain's services cannot delay another chain.
+        chains = Apprise._build_tag_chains(all_calls, tag)
 
-        for priority in sorted(priority_groups):
-            batch = priority_groups[priority]
-            # Split this priority group into sync and async halves.
-            sequential = [(s, k) for s, k in batch if not s.asset.async_mode]
-            parallel = [(s, k) for s, k in batch if s.asset.async_mode]
-            seq_ok = (
-                Apprise._notify_sequential(*sequential) if sequential else True
-            )
-            par_ok = (
-                Apprise._notify_parallel_threadpool(*parallel)
-                if parallel
-                else True
-            )
-            if seq_ok and par_ok:
-                # Every service in this priority group delivered successfully.
-                # Stop here; lower-urgency groups are not triggered.
-                return True
-            # At least one service in this group failed -- escalate to the
-            # next priority group and try those services instead.
+        def _run_batch(batch):
+            """Dispatch one priority-group batch; True = all services ok."""
+            seq = [(s, k) for s, k in batch if not s.asset.async_mode]
+            par = [(s, k) for s, k in batch if s.asset.async_mode]
+            seq_ok = Apprise._notify_sequential(*seq) if seq else True
+            par_ok = Apprise._notify_parallel_threadpool(*par) if par else True
+            return seq_ok and par_ok
 
-        # All priority groups were exhausted and the last group still had
-        # at least one failed delivery.
-        return False
+        # Per-chain state: priorities (sorted), groups dict, current index,
+        # and a flag marking whether a successful group has been found.
+        chain_states = {
+            key: {
+                "priorities": sorted(groups),
+                "groups": groups,
+                "idx": 0,
+                "succeeded": False,
+            }
+            for key, groups in chains.items()
+        }
+
+        while True:
+            # When abort_on_chain_failure is enabled, stop as soon as any
+            # chain has exhausted all its priority groups without success.
+            # With the default (False) all chains run to completion even if
+            # one has already failed, so every defined URL gets an attempt.
+            if self.asset.abort_on_chain_failure and any(
+                not st["succeeded"] and st["idx"] >= len(st["priorities"])
+                for st in chain_states.values()
+            ):
+                return False
+
+            # Collect chains that still need to try their next priority group.
+            active = [
+                (key, st)
+                for key, st in chain_states.items()
+                if not st["succeeded"] and st["idx"] < len(st["priorities"])
+            ]
+            if not active:
+                break  # every chain has either succeeded or been exhausted
+
+            if len(active) == 1:
+                # Single active chain: dispatch directly, no thread overhead.
+                _, st = active[0]
+                batch = st["groups"][st["priorities"][st["idx"]]]
+                if _run_batch(batch):
+                    st["succeeded"] = True
+                else:
+                    st["idx"] += 1  # escalate to next priority
+            else:
+                # Multiple active chains: run their current-priority batches
+                # concurrently so independent chains don't block each other.
+                with cf.ThreadPoolExecutor() as executor:
+                    future_map = {
+                        executor.submit(
+                            _run_batch,
+                            st["groups"][st["priorities"][st["idx"]]],
+                        ): (key, st)
+                        for key, st in active
+                    }
+                    for future in cf.as_completed(future_map):
+                        _, st = future_map[future]
+                        try:
+                            ok = future.result()
+                        except Exception:
+                            logger.exception(
+                                "Unhandled Notification Exception"
+                            )
+                            ok = False
+                        if ok:
+                            st["succeeded"] = True
+                        else:
+                            st["idx"] += 1  # escalate to next priority
+
+        return all(st["succeeded"] for st in chain_states.values())
 
     async def async_notify(self, *args: Any, **kwargs: Any) -> Optional[bool]:
         """Send a notification to all the plugins previously loaded, for
@@ -624,13 +814,8 @@ class Apprise:
         if not all_calls:
             return None
 
-        # Inject a per-call retry override when the tag filter includes one.
-        filter_retry = Apprise._extract_filter_retry(tag)
-        if filter_retry is not None:
-            all_calls = [
-                (s, dict(k, _retry_override=filter_retry))
-                for s, k in all_calls
-            ]
+        # Inject per-service call-time retry overrides (same logic as notify).
+        all_calls = Apprise._inject_per_service_retries(all_calls, tag)
 
         if Apprise._filter_has_explicit_priority(tag):
             # Explicit priority prefix: flat dispatch, no escalation.
@@ -648,31 +833,77 @@ class Apprise:
             )
             return seq_ok and par_ok
 
-        # Escalation chain: group by tag priority and dispatch highest urgency
-        # (lowest number) first.  Stop as soon as one entire group succeeds.
-        priority_groups: dict[int, list] = {}
-        for server, notify_kwargs in all_calls:
-            p = Apprise._server_priority_for_filter(server, tag)
-            priority_groups.setdefault(p, []).append((server, notify_kwargs))
+        # Per-tag independent escalation chains -- same semantics as notify().
+        #
+        # Each chain's current-priority batch is dispatched as a coroutine.
+        # All active chains' batches run concurrently via asyncio.gather() so
+        # async services across independent chains can make I/O progress
+        # simultaneously.  Only chains whose current batch failed advance to
+        # the next priority group (escalation).
+        chains = Apprise._build_tag_chains(all_calls, tag)
 
-        for priority in sorted(priority_groups):
-            batch = priority_groups[priority]
-            sequential = [(s, k) for s, k in batch if not s.asset.async_mode]
-            parallel = [(s, k) for s, k in batch if s.asset.async_mode]
-            seq_ok = (
-                Apprise._notify_sequential(*sequential) if sequential else True
-            )
+        async def _run_batch_async(batch):
+            """Dispatch one priority-group batch; True = all services ok."""
+            seq = [(s, k) for s, k in batch if not s.asset.async_mode]
+            par = [(s, k) for s, k in batch if s.asset.async_mode]
+            # Sequential items (async_mode=False) run blocking in the caller;
+            # async items are gathered concurrently.
+            seq_ok = Apprise._notify_sequential(*seq) if seq else True
             par_ok = (
-                await Apprise._notify_parallel_asyncio(*parallel)
-                if parallel
-                else True
+                await Apprise._notify_parallel_asyncio(*par) if par else True
             )
-            if seq_ok and par_ok:
-                # Entire group succeeded; skip lower-urgency groups.
-                return True
-            # Group had failures; escalate to the next priority group.
+            return seq_ok and par_ok
 
-        return False
+        chain_states = {
+            key: {
+                "priorities": sorted(groups),
+                "groups": groups,
+                "idx": 0,
+                "succeeded": False,
+            }
+            for key, groups in chains.items()
+        }
+
+        while True:
+            # Same abort_on_chain_failure guard as notify().
+            if self.asset.abort_on_chain_failure and any(
+                not st["succeeded"] and st["idx"] >= len(st["priorities"])
+                for st in chain_states.values()
+            ):
+                return False
+
+            active = [
+                (key, st)
+                for key, st in chain_states.items()
+                if not st["succeeded"] and st["idx"] < len(st["priorities"])
+            ]
+            if not active:
+                break  # every chain has either succeeded or been exhausted
+
+            # Run all active chains' current-priority batches concurrently.
+            # asyncio.gather() interleaves coroutines so async services across
+            # different chains can pipeline their I/O simultaneously.
+            # return_exceptions=True prevents one failing batch from cancelling
+            # the others; exceptions are treated as delivery failures below.
+            results = await asyncio.gather(
+                *(
+                    _run_batch_async(st["groups"][st["priorities"][st["idx"]]])
+                    for _, st in active
+                ),
+                return_exceptions=True,
+            )
+
+            for (_, st), ok in zip(active, results):
+                if isinstance(ok, Exception):
+                    # Escaped exception -- safety net; treat as failure.
+                    logger.exception("Unhandled Notification Exception")
+                    st["idx"] += 1
+                elif ok:
+                    st["succeeded"] = True
+                else:
+                    st["idx"] += 1  # escalate to next priority group
+
+        return all(st["succeeded"] for st in chain_states.values())
 
     def _create_notify_calls(self, *args, **kwargs):
         """Creates notifications for all the plugins loaded.

--- a/apprise/apprise.py
+++ b/apprise/apprise.py
@@ -1152,14 +1152,6 @@ class Apprise:
             # running 'success' accumulator.  This silently absorbs the
             # failure: the caller will not see it as a delivery error.
             #
-            # Why getattr() instead of self.optional?
-            #   getattr(server, "optional", False) guards against mock
-            #   objects and hypothetical future subclasses that may not
-            #   define the attribute at all.  In those cases the default
-            #   of False is used, which keeps the safe, conservative
-            #   behaviour: unexpected attribute absence propagates the
-            #   failure rather than silently swallowing it.
-            #
             # Interaction with retries:
             #   The retry loop above has already run.  optional= does not
             #   short-circuit or bypass retries -- it only changes the

--- a/apprise/asset.py
+++ b/apprise/asset.py
@@ -147,6 +147,16 @@ class AppriseAsset:
     # to a new line.
     interpret_escapes = False
 
+    # Default number of retries after a first notification failure.
+    # Individual plugins may override this via their ?retry= URL parameter
+    # or the 'retry:' YAML key.  Clamped to [0, APPRISE_MAX_SERVICE_RETRY].
+    default_service_retry = 0
+
+    # Default wait (in seconds) between retry attempts.  Individual plugins
+    # may override this via their ?wait= URL parameter or the 'wait:' YAML
+    # key.  Clamped to [0.0, APPRISE_MAX_SERVICE_WAIT].
+    default_service_wait = 0.5
+
     # Defines the encoding of the content passed into Apprise
     encoding = "utf-8"
 

--- a/apprise/asset.py
+++ b/apprise/asset.py
@@ -157,6 +157,13 @@ class AppriseAsset:
     # key.  Clamped to [0.0, APPRISE_MAX_SERVICE_WAIT].
     default_service_wait = 0.5
 
+    # When True, as soon as any independent OR tag chain exhausts all its
+    # priority groups without success, notify() / async_notify() return False
+    # immediately without running further escalation rounds for the surviving
+    # chains.  When False (the default), all chains are allowed to complete
+    # regardless of whether another chain has already failed.
+    abort_on_chain_failure = False
+
     # Defines the encoding of the content passed into Apprise
     encoding = "utf-8"
 

--- a/apprise/cli.py
+++ b/apprise/cli.py
@@ -1103,7 +1103,10 @@ def main(
 
                     if entry.tags:
                         click.echo(
-                            "{:>10}: {}".format("tags", ", ".join(entry.tags))
+                            "{:>10}: {}".format(
+                                "tags",
+                                ", ".join(str(t) for t in entry.tags),
+                            )
                         )
 
         else:  # PersistentStorageMode.PRUNE or PersistentStorageMode.CLEAR
@@ -1174,7 +1177,12 @@ def main(
             )
 
             if server.tags:
-                click.echo("{:>10}: {}".format("tags", ", ".join(server.tags)))
+                click.echo(
+                    "{:>10}: {}".format(
+                        "tags",
+                        ", ".join(str(t) for t in server.tags),
+                    )
+                )
 
         # Initialize a default response of nothing matched, otherwise
         # if we matched at least one entry, we can return True

--- a/apprise/common.py
+++ b/apprise/common.py
@@ -212,3 +212,13 @@ MATCH_ALL_TAG = "all"
 # Will cause notification to trigger under any circumstance even if an
 # exclusive tagging was provided.
 MATCH_ALWAYS_TAG = "always"
+
+# Maximum number of retries a service may attempt after an initial failure.
+# This cap prevents runaway retry loops; the effective value is clamped to
+# [0, APPRISE_MAX_SERVICE_RETRY] everywhere it is consumed.
+APPRISE_MAX_SERVICE_RETRY = 10
+
+# Maximum inter-retry wait (in seconds).  Prevents accidental multi-hour
+# sleeps from a misconfigured wait= value; clamped to
+# [0.0, APPRISE_MAX_SERVICE_WAIT] everywhere it is consumed.
+APPRISE_MAX_SERVICE_WAIT = 20.0

--- a/apprise/config/base.py
+++ b/apprise/config/base.py
@@ -518,10 +518,12 @@ class ConfigBase(URLBase):
         #     definitions (accepting commas) followed by an equal sign we know
         #     we're dealing with a TEXT format.
 
-        # Define what a valid line should look like
+        # Define what a valid line should look like.
+        # The tag group allows an optional "N:" priority prefix so that
+        # "2:endpoint=ntfy://..." is recognised as TEXT format.
         valid_line_re = re.compile(
             r"^\s*(?P<line>([;#]+(?P<comment>.*))|"
-            r"(?P<text>((?P<tag>[ \t,a-z0-9_-]+)=)?[a-z0-9]+://.*)|"
+            r"(?P<text>((?P<tag>[ \t,a-z0-9_:-]+)=)?[a-z0-9]+://.*)|"
             r"((?P<yaml>[a-z0-9]+):.*))?$",
             re.I,
         )
@@ -666,10 +668,12 @@ class ConfigBase(URLBase):
         # Prepare our Asset Object
         asset = asset if isinstance(asset, AppriseAsset) else AppriseAsset()
 
-        # Define what a valid line should look like
+        # Define what a valid line should look like.
+        # The tags group allows an optional leading "N:" priority prefix so
+        # that entries like "2:endpoint=ntfy://..." are parsed correctly.
         valid_line_re = re.compile(
             r"^\s*(?P<line>([;#]+(?P<comment>.*))|"
-            r"(\s*(?P<tags>[a-z0-9, \t_-]+)\s*=|=)?\s*"
+            r"(\s*(?P<tags>[a-z0-9, \t_:-]+)\s*=|=)?\s*"
             r"((?P<url>[a-z0-9]{1,32}://.*)|(?P<assign>[a-z0-9, \t_-]+))|"
             r"include\s+(?P<config>.+))?\s*$",
             re.I,

--- a/apprise/config/base.py
+++ b/apprise/config/base.py
@@ -38,6 +38,7 @@ from ..asset import AppriseAsset
 from ..logger import logging
 from ..manager_config import ConfigurationManager
 from ..manager_plugins import NotificationManager
+from ..tag import AppriseTag
 from ..url import URLBase
 from ..utils.cwe312 import cwe312_url
 from ..utils.parse import GET_SCHEMA_RE, parse_bool, parse_list, parse_urls
@@ -775,6 +776,18 @@ class ConfigBase(URLBase):
             # notifications if any were set
             results["tag"] = set(parse_list(result.group("tags"), cast=str))
 
+            # A retry count on a service tag (e.g. "alerts:3=slack://...") is
+            # not valid here: per-service retry belongs on the URL (?retry=N)
+            # and call-time retry overrides belong on the notify() filter.
+            if any(
+                AppriseTag.parse(t).retry is not None for t in results["tag"]
+            ):
+                ConfigBase.logger.warning(
+                    "You can not specify a retry count as part of a service"
+                    f" tag on line {line}; use ?retry=N in the URL instead."
+                )
+                continue
+
             # Set our Asset Object
             results["asset"] = asset
 
@@ -1267,6 +1280,22 @@ class ConfigBase(URLBase):
                 else:
                     # Just use the global settings
                     results_["tag"] = global_tags
+
+                # A retry count on a service tag is not valid here: per-service
+                # retry belongs on the URL (retry: key) and call-time retry
+                # overrides belong on the notify() filter.
+                _retry_tags = [
+                    t
+                    for t in results_["tag"]
+                    if AppriseTag.parse(t).retry is not None
+                ]
+                if _retry_tags:
+                    ConfigBase.logger.warning(
+                        "You can not specify a retry count as part of a"
+                        " service tag (YAML entry #{}, item #{}); use the"
+                        " 'retry:' key instead.".format(no + 1, entry)
+                    )
+                    continue
 
                 for key in list(results_.keys()):
                     # Strip out any tokens we know that we can't accept and

--- a/apprise/plugins/base.py
+++ b/apprise/plugins/base.py
@@ -29,12 +29,15 @@ import asyncio
 from collections.abc import Generator
 from datetime import tzinfo
 from functools import partial
+import math
 import re
 from typing import Any, ClassVar, Optional, TypedDict, Union
 from zoneinfo import ZoneInfo
 
 from ..apprise_attachment import AppriseAttachment
 from ..common import (
+    APPRISE_MAX_SERVICE_RETRY,
+    APPRISE_MAX_SERVICE_WAIT,
     NOTIFY_FORMATS,
     OVERFLOW_MODES,
     NotifyFormat,
@@ -212,6 +215,17 @@ class NotifyBase(URLBase):
     # Default Emoji Interpretation
     interpret_emojis = False
 
+    # Default retry count for failed notifications.  Plugins may override
+    # via ?retry=N in their URL; the asset's default_service_retry is used
+    # when no per-plugin value is set.
+    # Always in [0, APPRISE_MAX_SERVICE_RETRY].
+    service_retry = 0
+
+    # Default wait (seconds) between retry attempts.  Plugins may override
+    # via ?wait=N in their URL; the asset's default_service_wait is used when
+    # no per-plugin value is set.  Always in [0.0, APPRISE_MAX_SERVICE_WAIT].
+    service_wait = 0.0
+
     # Support Attachments; this defaults to being disabled.
     # Since apprise allows you to send attachments without a body or title
     # defined, by letting Apprise know the plugin won't support attachments
@@ -292,6 +306,22 @@ class NotifyBase(URLBase):
                 # runtime.
                 "_lookup_default": "timezone",
             },
+            "retry": {
+                "name": _("Service Retry"),
+                "type": "int",
+                "min": 0,
+                "max": APPRISE_MAX_SERVICE_RETRY,
+                "default": service_retry,
+                "_lookup_default": "service_retry",
+            },
+            "wait": {
+                "name": _("Inter-Retry Wait"),
+                "type": "float",
+                "min": 0.0,
+                "max": APPRISE_MAX_SERVICE_WAIT,
+                "default": service_wait,
+                "_lookup_default": "service_wait",
+            },
         },
     )
 
@@ -349,12 +379,88 @@ class NotifyBase(URLBase):
     # automatically initialized by specifying ?tz= on the Apprise URLs
     __tzinfo = None
 
+    @classmethod
+    def __init_subclass__(cls, **kwargs):
+        """Automatically wrap any __len__ defined on a subclass so that it
+        multiplies its base target count by (retry + 1).
+
+        This ensures every plugin's __len__ reflects the total number of
+        transmission attempts (targets * retry-factor) without requiring
+        each plugin to be updated individually.
+        """
+        super().__init_subclass__(**kwargs)
+        if "__len__" in cls.__dict__:
+            _orig = cls.__dict__["__len__"]
+
+            def _retry_aware_len(self, _orig=_orig):
+                return _orig(self) * (getattr(self, "retry", 0) + 1)
+
+            cls.__len__ = _retry_aware_len
+
     def __init__(self, **kwargs):
         """Initialize some general configuration that will keep things
         consistent when working with the notifiers that will inherit this
         class."""
 
         super().__init__(**kwargs)
+
+        # Initialize retry count from (in priority order):
+        #   1. kwargs["retry"]  (from ?retry= URL param or YAML retry: key)
+        #   2. asset.default_service_retry
+        # Always clamped to [0, APPRISE_MAX_SERVICE_RETRY].
+        _retry_raw = kwargs.get("retry")
+        if _retry_raw is not None:
+            try:
+                _retry_val = int(_retry_raw)
+                if _retry_val < 0:
+                    msg = f"Service retry count must be >= 0; got {_retry_raw}"
+                    self.logger.warning(msg)
+                    raise TypeError(msg)
+                self.retry = min(_retry_val, APPRISE_MAX_SERVICE_RETRY)
+            except (TypeError, ValueError):
+                self.logger.warning(
+                    "Invalid retry value specified (%s); using default",
+                    _retry_raw,
+                )
+                self.retry = min(
+                    max(0, self.asset.default_service_retry),
+                    APPRISE_MAX_SERVICE_RETRY,
+                )
+        else:
+            self.retry = min(
+                max(0, self.asset.default_service_retry),
+                APPRISE_MAX_SERVICE_RETRY,
+            )
+
+        # Initialize wait (inter-retry delay) from (in priority order):
+        #   1. kwargs["wait"]  (from ?wait= URL param or YAML wait: key)
+        #   2. asset.default_service_wait
+        # Only valid non-negative finite floats are accepted; integers are
+        # promoted to float.  Invalid values fall back to the asset default.
+        # Negative values raise TypeError.
+        _wait_raw = kwargs.get("wait")
+        if _wait_raw is not None:
+            try:
+                _wait_val = float(_wait_raw)
+                if not math.isfinite(_wait_val) or _wait_val < 0.0:
+                    msg = f"Service retry wait must be >= 0; got {_wait_raw}"
+                    self.logger.warning(msg)
+                    raise TypeError(msg)
+                self.wait = min(_wait_val, APPRISE_MAX_SERVICE_WAIT)
+            except (TypeError, ValueError):
+                self.logger.warning(
+                    "Invalid wait value specified (%s); using default",
+                    _wait_raw,
+                )
+                self.wait = min(
+                    max(0.0, self.asset.default_service_wait),
+                    APPRISE_MAX_SERVICE_WAIT,
+                )
+        else:
+            self.wait = min(
+                max(0.0, self.asset.default_service_wait),
+                APPRISE_MAX_SERVICE_WAIT,
+            )
 
         # Store our interpret_emoji's setting
         # If asset emoji value is set to a default of True and the user
@@ -917,6 +1023,16 @@ class NotifyBase(URLBase):
             "send() is not implemented by the child class."
         )
 
+    def __len__(self):
+        """Returns the number of HTTP requests this instance will make,
+        factoring in the configured retry count.
+
+        Subclasses that override this are automatically wrapped by
+        __init_subclass__ to apply the same retry multiplier, so they
+        should return their raw target count without worrying about retry.
+        """
+        return 1 * (self.retry + 1)
+
     def url_parameters(
         self,
         *args: Any,
@@ -941,6 +1057,14 @@ class NotifyBase(URLBase):
         if self.persistent_storage != NotifyBase.persistent_storage:
             params["store"] = "yes" if self.persistent_storage else "no"
 
+        # Include retry if non-zero so the URL fully describes the plugin
+        if self.retry:
+            params["retry"] = str(self.retry)
+
+        # Include wait if non-zero so the URL fully describes the plugin
+        if self.wait:
+            params["wait"] = str(self.wait)
+
         params.update(super().url_parameters(*args, **kwargs))
 
         # return default parameters
@@ -956,6 +1080,11 @@ class NotifyBase(URLBase):
 
         This is very specific and customized for Apprise.
 
+        In addition to the fields extracted by URLBase.parse_url(), this
+        method extracts the NotifyBase-level query-string parameters:
+        ``format``, ``overflow``, ``emojis``, ``tz``, ``store``, ``retry``,
+        and ``wait``.  Child classes should call this method via
+        ``super()`` and then layer their own parameter extraction on top.
 
         Args:
             url (str): The URL you want to fully parse.
@@ -1008,6 +1137,14 @@ class NotifyBase(URLBase):
 
         if "store" in results["qsd"]:
             results["store"] = results["qsd"]["store"]
+
+        # Global per-plugin retry count (?retry=N)
+        if "retry" in results["qsd"] and results["qsd"]["retry"]:
+            results["retry"] = results["qsd"]["retry"]
+
+        # Global per-plugin inter-retry wait (?wait=N)
+        if "wait" in results["qsd"] and results["qsd"]["wait"]:
+            results["wait"] = results["qsd"]["wait"]
 
         return results
 

--- a/apprise/plugins/base.py
+++ b/apprise/plugins/base.py
@@ -226,6 +226,55 @@ class NotifyBase(URLBase):
     # no per-plugin value is set.  Always in [0.0, APPRISE_MAX_SERVICE_WAIT].
     service_wait = 0.0
 
+    # When set to True, a delivery failure for this individual service is
+    # silently absorbed by all three dispatch paths (sequential, thread-pool,
+    # and asyncio coroutine).  The overall notify() / async_notify() call
+    # still returns True even if this particular endpoint could not be
+    # reached, provided that every *required* (non-optional) service in
+    # the same batch succeeded.
+    #
+    # This flag is designed for "nice to have" services -- endpoints that
+    # you want to notify when they are available but whose unavailability
+    # must not be treated as a delivery failure by the calling application.
+    #
+    # Concrete example -- four Kodi home screens tagged "media":
+    #
+    #   Configure every Kodi entry with optional=yes.  When the application
+    #   calls notify(tag="media"), Apprise attempts delivery to whichever
+    #   screens are currently powered on and reachable.  If none of the four
+    #   respond (all are off or unreachable), the call still returns True
+    #   because every failing service was optional.  The application is
+    #   never penalised for transient screen availability.
+    #
+    # Important behaviour details:
+    #   - Retries are still performed up to the configured retry count
+    #     before a service is considered to have failed.  The optional flag
+    #     only fires *after* all retry attempts have been exhausted without
+    #     a successful delivery.  In other words, optional does not bypass
+    #     the retry loop -- it only changes the meaning of the final result.
+    #   - Setting optional=True does NOT skip the service.  Delivery is
+    #     still attempted on every call.  Only the *outcome* is affected:
+    #     a failure is reported as True instead of False to the caller.
+    #   - A batch that mixes optional and required services returns False
+    #     only if one of the *required* (optional=False) services fails.
+    #     Optional failures are never included in the aggregate result.
+    #   - The flag is per-instance.  Different URLs that share a tag can
+    #     have different optional values, so you can mix required and
+    #     optional endpoints within the same tag group.
+    #
+    # Ways to enable this flag:
+    #   - URL query parameter  : append ?optional=yes  to the service URL
+    #   - YAML configuration   : add  optional: yes    under the URL entry
+    #   - Python constructor   : MyPlugin(host="...", optional=True)
+    #   - Direct assignment    : server.optional = True
+    #
+    # Accepted truthy values  : "yes", "true", "on", "1", True
+    # Accepted falsy  values  : "no", "false", "off", "0", False
+    #
+    # Defaults to False -- every delivery failure is propagated to the
+    # caller unchanged.
+    optional = False
+
     # Support Attachments; this defaults to being disabled.
     # Since apprise allows you to send attachments without a body or title
     # defined, by letting Apprise know the plugin won't support attachments
@@ -321,6 +370,12 @@ class NotifyBase(URLBase):
                 "max": APPRISE_MAX_SERVICE_WAIT,
                 "default": service_wait,
                 "_lookup_default": "service_wait",
+            },
+            "optional": {
+                "name": _("Optional Service"),
+                "type": "bool",
+                "default": optional,
+                "_lookup_default": "optional",
             },
         },
     )
@@ -461,6 +516,36 @@ class NotifyBase(URLBase):
                 max(0.0, self.asset.default_service_wait),
                 APPRISE_MAX_SERVICE_WAIT,
             )
+
+        # Initialize the optional= flag from kwargs if provided, otherwise
+        # fall back to the class-level attribute (default: False).
+        #
+        # Priority order (highest to lowest):
+        #   1. kwargs["optional"]  -- supplied via ?optional=yes/no URL
+        #      parameter, YAML optional: yes/no key, or a direct Python
+        #      keyword argument to the constructor.
+        #   2. The class-level 'optional' attribute on the plugin class
+        #      (or any of its superclasses).  Plugin authors can ship
+        #      with optional=True as the default simply by overriding
+        #      the class attribute -- no extra __init__ boilerplate needed.
+        #
+        # parse_bool() is used for the string -> bool conversion so that
+        # all of the canonical truthy/falsy representations that Apprise
+        # accepts elsewhere are valid here too: "yes"/"no", "true"/"false",
+        # "on"/"off", "1"/"0", and native Python booleans.  The function
+        # returns the 'default' argument (False) for unrecognised strings,
+        # so garbage input silently falls back to the safe behaviour
+        # (propagate failures) rather than raising an exception.
+        _optional_raw = kwargs.get("optional")
+        if _optional_raw is not None:
+            # An explicit value was passed in -- parse it and store on
+            # this instance, shadowing the class-level attribute only for
+            # this particular service object.
+            self.optional = parse_bool(_optional_raw)
+        # else: kwargs did not include "optional".  Leave self.optional
+        #   unset so that normal Python attribute lookup falls through to
+        #   the class-level default (NotifyBase.optional = False, or the
+        #   value set by a plugin subclass that overrides it).
 
         # Store our interpret_emoji's setting
         # If asset emoji value is set to a default of True and the user
@@ -1057,13 +1142,25 @@ class NotifyBase(URLBase):
         if self.persistent_storage != NotifyBase.persistent_storage:
             params["store"] = "yes" if self.persistent_storage else "no"
 
-        # Include retry if non-zero so the URL fully describes the plugin
-        if self.retry:
-            params["retry"] = str(self.retry)
-
-        # Include wait if non-zero so the URL fully describes the plugin
-        if self.wait:
-            params["wait"] = str(self.wait)
+        # Always emit retry=, wait=, and optional= in the URL regardless
+        # of whether they hold their zero/False defaults.  Emitting them
+        # unconditionally keeps the URL fully self-describing: a service
+        # URL that is round-tripped through parse_url() -> __init__() will
+        # reconstruct an identical object with the same settings.  This
+        # property is important for configuration-file generators, UI
+        # tooling, and any code that serialises service objects to strings
+        # and needs to restore them later without silent data loss.
+        #
+        # retry= and wait= are emitted as strings because URL query strings
+        # are inherently text.  The receiving __init__() will re-parse them
+        # with int() and float() respectively.
+        #
+        # optional= is emitted as the canonical lower-case pair "yes"/"no"
+        # that parse_bool() recognises on the receiving end, ensuring the
+        # round-trip is lossless even for the boolean case.
+        params["retry"] = str(self.retry)
+        params["wait"] = str(self.wait)
+        params["optional"] = "yes" if self.optional else "no"
 
         params.update(super().url_parameters(*args, **kwargs))
 
@@ -1083,8 +1180,11 @@ class NotifyBase(URLBase):
         In addition to the fields extracted by URLBase.parse_url(), this
         method extracts the NotifyBase-level query-string parameters:
         ``format``, ``overflow``, ``emojis``, ``tz``, ``store``, ``retry``,
-        and ``wait``.  Child classes should call this method via
-        ``super()`` and then layer their own parameter extraction on top.
+        ``wait``, and ``optional``.  The extracted values are placed
+        directly in the returned results dict under their respective keys,
+        ready to be consumed by NotifyBase.__init__() (or a subclass).
+        Child classes should call this method via ``super()`` and then
+        layer their own parameter extraction on top of the returned dict.
 
         Args:
             url (str): The URL you want to fully parse.
@@ -1145,6 +1245,26 @@ class NotifyBase(URLBase):
         # Global per-plugin inter-retry wait (?wait=N)
         if "wait" in results["qsd"] and results["qsd"]["wait"]:
             results["wait"] = results["qsd"]["wait"]
+
+        # Global optional flag (?optional=yes/no).
+        #
+        # parse_bool() converts the raw query-string value to a native
+        # Python bool using Apprise's canonical truth table: "yes", "true",
+        # "on", "1" -> True; "no", "false", "off", "0" -> False.
+        # Unrecognised strings fall back to False (the safe default).
+        #
+        # The parsed bool is stored in results["optional"] so that
+        # NotifyBase.__init__() receives a value it can pass straight
+        # through parse_bool() again without loss (parse_bool(True) is
+        # True and parse_bool(False) is False).
+        #
+        # When ?optional= is absent from the URL entirely, this block is
+        # skipped and results["optional"] is never set.  NotifyBase.__init__
+        # will then leave self.optional at its class-level default (False),
+        # which means the absence of the parameter is indistinguishable from
+        # passing ?optional=no -- both result in failures being propagated.
+        if "optional" in results["qsd"]:
+            results["optional"] = parse_bool(results["qsd"]["optional"])
 
         return results
 

--- a/apprise/plugins/base.py
+++ b/apprise/plugins/base.py
@@ -1031,7 +1031,7 @@ class NotifyBase(URLBase):
         __init_subclass__ to apply the same retry multiplier, so they
         should return their raw target count without worrying about retry.
         """
-        return 1 * (self.retry + 1)
+        return self.retry + 1
 
     def url_parameters(
         self,

--- a/apprise/plugins/pushover.py
+++ b/apprise/plugins/pushover.py
@@ -244,8 +244,8 @@ class NotifyPushover(NotifyBase):
                 "map_to": "supplemental_url_title",
                 "type": "string",
             },
-            "retry": {
-                "name": _("Retry"),
+            "emg_retry": {
+                "name": _("Emergency Retry Interval"),
                 "type": "int",
                 "min": 30,
                 "default": 900,  # 15 minutes
@@ -270,7 +270,7 @@ class NotifyPushover(NotifyBase):
         targets=None,
         priority=None,
         sound=None,
-        retry=None,
+        emg_retry=None,
         expire=None,
         supplemental_url=None,
         supplemental_url_title=None,
@@ -352,20 +352,19 @@ class NotifyPushover(NotifyBase):
 
         # The following are for emergency alerts
         if self.priority == PushoverPriority.EMERGENCY:
-            # How often to resend notification, in seconds
-            self.retry = self.template_args["retry"]["default"]
+            # How often to resend notification, in seconds (emergency only)
+            self.emg_retry = self.template_args["emg_retry"]["default"]
             with contextlib.suppress(ValueError, TypeError):
-                # Get our retry value
-                self.retry = int(retry)
+                self.emg_retry = int(emg_retry)
 
-            # How often to resend notification, in seconds
+            # How long before the emergency alert expires, in seconds
             self.expire = self.template_args["expire"]["default"]
             with contextlib.suppress(ValueError, TypeError):
                 # Acquire our expiry value
                 self.expire = int(expire)
 
-            if self.retry < 30:
-                msg = "Pushover retry must be at least 30 seconds."
+            if self.emg_retry < 30:
+                msg = "Pushover emergency retry must be at least 30 seconds."
                 self.logger.warning(msg)
                 raise TypeError(msg)
 
@@ -419,7 +418,12 @@ class NotifyPushover(NotifyBase):
             base_payload["html"] = 1
 
         if self.priority == PushoverPriority.EMERGENCY:
-            base_payload.update({"retry": self.retry, "expire": self.expire})
+            base_payload.update(
+                {
+                    "retry": self.emg_retry,
+                    "expire": self.expire,
+                }
+            )
 
         # Build per-target payloads:
         #  - devices: one call with user=user_key, device=dev1,dev2,...
@@ -652,10 +656,10 @@ class NotifyPushover(NotifyBase):
         if self.supplemental_url_title:
             params["url_title"] = self.supplemental_url_title
 
-        # Only add expire and retry for emergency messages,
-        # pushover ignores for all other priorities
+        # Only add expire and emg_retry for emergency messages;
+        # Pushover ignores them for all other priorities
         if self.priority == PushoverPriority.EMERGENCY:
-            params.update({"expire": self.expire, "retry": self.retry})
+            params.update({"expire": self.expire, "emg_retry": self.emg_retry})
 
         # Extend our parameters
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
@@ -725,11 +729,11 @@ class NotifyPushover(NotifyBase):
                 results["qsd"]["url_title"]
             )
 
-        # Get expire and retry
+        # Get expire and emergency retry interval
         if "expire" in results["qsd"] and len(results["qsd"]["expire"]):
             results["expire"] = results["qsd"]["expire"]
-        if "retry" in results["qsd"] and len(results["qsd"]["retry"]):
-            results["retry"] = results["qsd"]["retry"]
+        if "emg_retry" in results["qsd"] and len(results["qsd"]["emg_retry"]):
+            results["emg_retry"] = results["qsd"]["emg_retry"]
 
         # The 'to' makes it easier to use yaml configuration
         if "to" in results["qsd"] and len(results["qsd"]["to"]):

--- a/apprise/plugins/pushover.py
+++ b/apprise/plugins/pushover.py
@@ -244,7 +244,7 @@ class NotifyPushover(NotifyBase):
                 "map_to": "supplemental_url_title",
                 "type": "string",
             },
-            "emg_retry": {
+            "interval": {
                 "name": _("Emergency Retry Interval"),
                 "type": "int",
                 "min": 30,
@@ -270,7 +270,7 @@ class NotifyPushover(NotifyBase):
         targets=None,
         priority=None,
         sound=None,
-        emg_retry=None,
+        interval=None,
         expire=None,
         supplemental_url=None,
         supplemental_url_title=None,
@@ -353,9 +353,9 @@ class NotifyPushover(NotifyBase):
         # The following are for emergency alerts
         if self.priority == PushoverPriority.EMERGENCY:
             # How often to resend notification, in seconds (emergency only)
-            self.emg_retry = self.template_args["emg_retry"]["default"]
+            self.interval = self.template_args["interval"]["default"]
             with contextlib.suppress(ValueError, TypeError):
-                self.emg_retry = int(emg_retry)
+                self.interval = int(interval)
 
             # How long before the emergency alert expires, in seconds
             self.expire = self.template_args["expire"]["default"]
@@ -363,8 +363,10 @@ class NotifyPushover(NotifyBase):
                 # Acquire our expiry value
                 self.expire = int(expire)
 
-            if self.emg_retry < 30:
-                msg = "Pushover emergency retry must be at least 30 seconds."
+            if self.interval < 30:
+                msg = (
+                    "Pushover emergency interval must be at least 30 seconds."
+                )
                 self.logger.warning(msg)
                 raise TypeError(msg)
 
@@ -420,7 +422,7 @@ class NotifyPushover(NotifyBase):
         if self.priority == PushoverPriority.EMERGENCY:
             base_payload.update(
                 {
-                    "retry": self.emg_retry,
+                    "retry": self.interval,
                     "expire": self.expire,
                 }
             )
@@ -656,10 +658,10 @@ class NotifyPushover(NotifyBase):
         if self.supplemental_url_title:
             params["url_title"] = self.supplemental_url_title
 
-        # Only add expire and emg_retry for emergency messages;
+        # Only add expire and interval for emergency messages;
         # Pushover ignores them for all other priorities
         if self.priority == PushoverPriority.EMERGENCY:
-            params.update({"expire": self.expire, "emg_retry": self.emg_retry})
+            params.update({"expire": self.expire, "interval": self.interval})
 
         # Extend our parameters
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
@@ -732,8 +734,8 @@ class NotifyPushover(NotifyBase):
         # Get expire and emergency retry interval
         if "expire" in results["qsd"] and len(results["qsd"]["expire"]):
             results["expire"] = results["qsd"]["expire"]
-        if "emg_retry" in results["qsd"] and len(results["qsd"]["emg_retry"]):
-            results["emg_retry"] = results["qsd"]["emg_retry"]
+        if "interval" in results["qsd"] and len(results["qsd"]["interval"]):
+            results["interval"] = results["qsd"]["interval"]
 
         # The 'to' makes it easier to use yaml configuration
         if "to" in results["qsd"] and len(results["qsd"]["to"]):

--- a/apprise/tag.py
+++ b/apprise/tag.py
@@ -1,0 +1,167 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import re
+
+# Matches: [priority:]tagname[:retry]
+# - priority is a non-negative integer prefix (e.g. "2:endpoint")
+# - tagname is a-z, 0-9, underscore, hyphen
+# - retry is a non-negative integer suffix (e.g. "endpoint:3", CLI only)
+_RE_TAG = re.compile(
+    r"^(?:(?P<priority>[0-9]+):)?(?P<tag>[a-z0-9][a-z0-9_-]*)(?::(?P<retry>[0-9]+))?$",
+    re.IGNORECASE,
+)
+
+
+class AppriseTag:
+    """Wraps a tag string and carries optional priority and retry metadata.
+
+    The tag name is the canonical identity; two AppriseTag objects (or an
+    AppriseTag and a plain str) are considered equal when their tag names
+    match, regardless of priority or retry.  Hash is likewise based solely
+    on the tag name so that set intersection and membership tests work
+    transparently against sets that contain plain strings.
+
+    Supported string formats:
+      tagname          -> priority=0, retry=None
+      priority:tagname -> priority=N, retry=None  (config / YAML)
+      tagname:retry    -> priority=0, retry=N     (CLI runtime override)
+      priority:tagname:retry -> priority=N, retry=N
+    """
+
+    __slots__ = ("_tag", "has_priority", "priority", "retry")
+
+    def __init__(self, tag, priority=0, retry=None, has_priority=False):
+        """Initialise an AppriseTag directly from its constituent parts.
+
+        Prefer AppriseTag.parse() when constructing from a raw string because
+        it handles the "priority:tag:retry" tokenisation automatically.
+
+        Args:
+            tag (str): The bare tag name.  Always stored lowercased.
+            priority (int, optional): Numeric dispatch priority.  Lower numbers
+                are dispatched first (0 = highest urgency).  Defaults to 0.
+            retry (int or None, optional): Call-level retry count carried by
+                this tag token, or None when none was specified.
+            has_priority (bool, optional): True when the priority was
+                explicitly written in the source string (e.g. "0:endpoint"),
+                False when it was absent and the default of 0 was assumed.
+                This flag drives the exclusive-vs-escalation dispatch decision.
+        """
+        self._tag = str(tag).lower().strip()
+        self.priority = max(0, int(priority)) if priority is not None else 0
+        self.retry = int(retry) if retry is not None else None
+        self.has_priority = bool(has_priority)
+
+    # ------------------------------------------------------------------
+    # Construction helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def parse(cls, value):
+        """Return an AppriseTag parsed from a string (or the same object
+        if already an AppriseTag).
+
+        Unrecognised strings fall back to a zero-priority, no-retry tag
+        whose name is the entire input lowercased.
+        """
+        if isinstance(value, cls):
+            return value
+        m = _RE_TAG.match(str(value).strip())
+        if m:
+            return cls(
+                tag=m.group("tag"),
+                priority=int(m.group("priority") or 0),
+                retry=(
+                    int(m.group("retry"))
+                    if m.group("retry") is not None
+                    else None
+                ),
+                has_priority=m.group("priority") is not None,
+            )
+        # Fallback: store raw value as name (no priority/retry)
+        return cls(tag=str(value).strip().lower())
+
+    # ------------------------------------------------------------------
+    # String representation
+    # ------------------------------------------------------------------
+
+    def __str__(self):
+        """Return the bare lowercase tag name."""
+        return self._tag
+
+    def __repr__(self):
+        """Return a developer-readable representation including non-default
+        priority and retry values so they are visible in tracebacks."""
+        parts = [repr(self._tag)]
+        if self.priority:
+            parts.append(f"priority={self.priority}")
+        if self.retry is not None:
+            parts.append(f"retry={self.retry}")
+        return "AppriseTag({})".format(", ".join(parts))
+
+    # ------------------------------------------------------------------
+    # Identity (tag-name only -- priority/retry are metadata, not identity)
+    # ------------------------------------------------------------------
+
+    def __hash__(self):
+        """Hash based solely on the lowercased tag name.
+
+        This must equal hash(tag_name_string) so that AppriseTag objects
+        can be mixed with plain strings inside sets and dictionaries without
+        any special handling in is_exclusive_match or elsewhere.
+        """
+        return hash(self._tag)
+
+    def __eq__(self, other):
+        """Compare identity by tag name only.
+
+        An AppriseTag is considered equal to a plain string when their
+        lowercased tag names match, enabling transparent membership tests
+        such as ``"endpoint" in {AppriseTag("endpoint")}``.
+        """
+        if isinstance(other, AppriseTag):
+            return self._tag == other._tag
+        if isinstance(other, str):
+            return self._tag == other.lower()
+        return NotImplemented
+
+    def __lt__(self, other):
+        """Compare tag names lexicographically to allow sorting.
+
+        Used when a deterministic ordering of tags is needed (e.g. for
+        reproducible log output).
+        """
+        if isinstance(other, AppriseTag):
+            return self._tag < other._tag
+        if isinstance(other, str):
+            return self._tag < other.lower()
+        return NotImplemented
+
+    def __bool__(self):
+        """Return False for an empty tag name, True otherwise."""
+        return bool(self._tag)

--- a/apprise/url.py
+++ b/apprise/url.py
@@ -36,6 +36,7 @@ from xml.sax.saxutils import escape as sax_escape
 from .asset import AppriseAsset
 from .locale import gettext_lazy as _
 from .logger import logger
+from .tag import AppriseTag
 from .utils.parse import (
     parse_bool,
     parse_list,
@@ -267,10 +268,16 @@ class URLBase:
                 )
 
         if "tag" in kwargs:
-            # We want to associate some tags with our notification service.
-            # the code below gets the 'tag' argument if defined, otherwise
-            # it just falls back to whatever was already defined globally
-            self.tags = set(parse_list(kwargs.get("tag"), self.tags))
+            # Parse all tags as AppriseTag objects so priority metadata is
+            # preserved.  Existing tags on the class (if any) are also
+            # converted so the set stays homogeneous.
+            existing = {
+                t if isinstance(t, AppriseTag) else AppriseTag.parse(str(t))
+                for t in self.tags
+            }
+            self.tags = existing | {
+                AppriseTag.parse(t) for t in parse_list(kwargs.get("tag"))
+            }
 
         # Tracks the time any i/o was made to the remote server.  This value
         # is automatically set and controlled through the throttle() call.

--- a/apprise/utils/logic.py
+++ b/apprise/utils/logic.py
@@ -27,7 +27,39 @@
 from itertools import chain
 
 from .. import common
+from ..tag import AppriseTag
 from .parse import parse_list
+
+
+def _token_matches_data(tok, data, match_all):
+    """Return True if filter token *tok* matches any entry in *data*.
+
+    When the token carries an explicit priority (e.g. "3:endpoint"), only data
+    entries that are AppriseTag objects with that exact priority match.  When
+    the token has no priority prefix, any data entry with the same tag name
+    matches regardless of its stored priority.
+    """
+    ft = AppriseTag.parse(tok)
+    tag_name = str(ft)
+
+    if tag_name == match_all:
+        return True
+
+    if not ft.has_priority:
+        # Name-only: works transparently for both str and AppriseTag in data
+        # because AppriseTag.__hash__ == hash(tag_name) and __eq__ handles str.
+        return tag_name in data
+
+    # Priority-exact: must find a matching AppriseTag with the same priority.
+    # Plain-string entries in data (backward compat) fall back to name-only.
+    for item in data:
+        if isinstance(item, AppriseTag):
+            if str(item) == tag_name and item.priority == ft.priority:
+                return True
+        else:
+            if str(item).lower() == tag_name:
+                return True
+    return False
 
 
 def is_exclusive_match(
@@ -50,6 +82,10 @@ def is_exclusive_match(
         logic=[('tagA', 'tagC'), 'tagB']  = (tagA and tagC) or tagB
         logic=[('tagB', 'tagC')]          = tagB and tagC
 
+    Filter tokens may carry an explicit priority prefix (e.g. "3:endpoint").
+    When present, only server tags that are AppriseTag objects with that exact
+    priority will match.  Tokens without a priority prefix match any priority.
+
     If `match_always` is not set to None, then its value is added as an 'or'
     to all specified logic searches.
     """
@@ -68,7 +104,7 @@ def is_exclusive_match(
         return False
 
     if match_always:
-        # Add our match_always to our logic searching if secified
+        # Add our match_always to our logic searching if specified
         logic = chain(logic, [match_always])
 
     # Track what we match against; but by default we do not match
@@ -81,18 +117,13 @@ def is_exclusive_match(
             # Garbage entry in our logic found
             return False
 
-        # treat these entries as though all elements found
-        # must exist in the notification service
-        entries = set(parse_list(entry))
-        if not entries:
-            # We got a bogus set of tags to parse
-            # If there is no logic to apply then we're done early; we only
-            # match if there is also no data to match against
+        # All tokens within an entry are AND-ed: every token must match data.
+        raw = parse_list(entry)
+        if not raw:
+            # We got a bogus set of tags to parse; match only if data is empty
             return not data
 
-        if len(entries.intersection(data.union({match_all}))) == len(entries):
-            # our set contains all of the entries found
-            # in our notification data set
+        if all(_token_matches_data(tok, data, match_all) for tok in raw):
             matched = True
             break
 

--- a/packaging/man/apprise.md
+++ b/packaging/man/apprise.md
@@ -63,6 +63,12 @@ The Apprise options are as follows:
   * `-g "all"`: Notify **ALL** services.
   * `(Omitted)`: Notify **untagged** services only.
 
+  Tag values may include an optional priority prefix and/or retry suffix:
+
+  * `-g "2:tagA"`: Match **only** entries for tagA assigned priority 2.
+  * `-g "tagA:3"`: Match all tagA entries, retrying each up to 3 times.
+  * `-g "2:tagA:3"`: Priority-2 tagA entries only, with up to 3 retries.
+
   `-Da`, `--disable-async`:
   Send notifications synchronously (one after the other) instead of
   all at once.
@@ -208,6 +214,18 @@ Notify only services tagged with BOTH "devops" AND "critical" (Intersection):
     $ apprise -vv -t "Intersection Test" \
        --config=~/apprise.yml \
        -g devops,critical
+
+Notify only priority-2 "alerts" services (exclusive priority filter):
+
+    $ apprise -vv -t "High Alert" \
+       --config=~/apprise.yml \
+       -g "2:alerts"
+
+Notify all "alerts" services and retry each up to 3 times on failure:
+
+    $ apprise -vv -t "Critical Event" \
+       --config=~/apprise.yml \
+       -g "alerts:3"
 
 Include an attachment:
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1787,6 +1787,8 @@ def test_apprise_details_plugin_verification():
         "format",
         "overflow",
         "emojis",
+        "retry",
+        "wait",
         # URLBase parameters:
         "verify",
         "cto",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1789,6 +1789,7 @@ def test_apprise_details_plugin_verification():
         "emojis",
         "retry",
         "wait",
+        "optional",
         # URLBase parameters:
         "verify",
         "cto",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -949,6 +949,10 @@ def test_apprise_urlbase_object():
     assert base.request_url == "http:///"
     assert base.url().startswith("http:///")
 
+    # URLBase.__len__ defaults to 1; subclasses that support multiple
+    # targets override this to return the actual count.
+    assert len(base) == 1
+
 
 def test_apprise_unique_id():
     """

--- a/tests/test_apprise_cli.py
+++ b/tests/test_apprise_cli.py
@@ -565,8 +565,7 @@ def test_apprise_cli_nux_env(tmpdir):
     for i in range(0, 10, 2):
         assert lines[i].endswith("good://")
 
-    # This will fail because nothing matches mytag. It's case sensitive
-    # and we would only actually match against myTag
+    # Tags are case-insensitive; mytag matches myTag
     result = runner.invoke(
         cli.main,
         [
@@ -578,17 +577,14 @@ def test_apprise_cli_nux_env(tmpdir):
             "mytag",
         ],
     )
-    assert result.exit_code == 3
+    assert result.exit_code == 0
 
-    # Same command as the one identified above except we set the --dry-run
-    # flag. This causes our list of matched results to be printed only.
-    # However, since we don't match anything; we still fail with a return code
-    # of 2.
+    # Same command with --dry-run; one entry matches so exit code is 0
     result = runner.invoke(
         cli.main,
         ["-b", "has mytag", "--config", str(t), "--tag", "mytag", "--dry-run"],
     )
-    assert result.exit_code == 3
+    assert result.exit_code == 0
 
     # Here is a case where we get what was expected; we also attach a file
     result = runner.invoke(

--- a/tests/test_apprise_cli.py
+++ b/tests/test_apprise_cli.py
@@ -586,6 +586,31 @@ def test_apprise_cli_nux_env(tmpdir):
     )
     assert result.exit_code == 0
 
+    # A tag that does not exist in the config produces no matches; the live
+    # run returns exit code 3 to signal "no services found".
+    result = runner.invoke(
+        cli.main,
+        ["-b", "no match", "--config", str(t), "--tag", "nonexistent"],
+    )
+    assert result.exit_code == 3
+
+    # --dry-run must mirror the live result: a non-matching tag also returns
+    # exit code 3, not 0.  This guards against dry-run masking "no services
+    # found" by always reporting success.
+    result = runner.invoke(
+        cli.main,
+        [
+            "-b",
+            "no match",
+            "--config",
+            str(t),
+            "--tag",
+            "nonexistent",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 3
+
     # Here is a case where we get what was expected; we also attach a file
     result = runner.invoke(
         cli.main,

--- a/tests/test_apprise_utils.py
+++ b/tests/test_apprise_utils.py
@@ -37,6 +37,7 @@ from unittest import mock
 from urllib.parse import unquote
 
 from apprise import NotificationManager, utils
+from apprise.tag import AppriseTag
 
 logging.disable(logging.CRITICAL)
 
@@ -3016,6 +3017,80 @@ def test_exclusive_match():
         )
         is True
     )
+
+
+def test_exclusive_match_priority_tokens():
+    """utils: is_exclusive_match() with priority-prefixed filter tokens"""
+
+    # AppriseTag.__hash__ is name-only, so a set holds at most one entry per
+    # tag name -- matching real usage where each URL has one priority.
+    tag_ep3 = AppriseTag("endpoint", priority=3, has_priority=True)
+    tag_other = AppriseTag("other", priority=1, has_priority=True)
+
+    data = {tag_ep3, tag_other}
+
+    # Exact priority match
+    assert (
+        utils.logic.is_exclusive_match(logic="3:endpoint", data=data) is True
+    )
+
+    # Priority mismatch -- "2:endpoint" does not match priority-3 entry
+    assert (
+        utils.logic.is_exclusive_match(logic="2:endpoint", data=data) is False
+    )
+
+    # Name-only filter matches via O(1) hash path regardless of stored priority
+    assert utils.logic.is_exclusive_match(logic="endpoint", data=data) is True
+
+    # Absent tag returns False
+    assert utils.logic.is_exclusive_match(logic="absent", data=data) is False
+
+    # AND group: both tokens present with correct priorities
+    assert (
+        utils.logic.is_exclusive_match(
+            logic=[("3:endpoint", "1:other")], data=data
+        )
+        is True
+    )
+
+    # AND group: one priority mismatch fails the whole group
+    assert (
+        utils.logic.is_exclusive_match(
+            logic=[("2:endpoint", "1:other")], data=data
+        )
+        is False
+    )
+
+    # OR: failing AND group rescued by a matching single token
+    assert (
+        utils.logic.is_exclusive_match(
+            logic=[("2:endpoint", "1:other"), "3:endpoint"], data=data
+        )
+        is True
+    )
+
+    # OR: no term matches -- all fail
+    assert (
+        utils.logic.is_exclusive_match(
+            logic=[("2:endpoint", "1:other"), "99:endpoint"], data=data
+        )
+        is False
+    )
+
+    # Backward compat: plain strings in data matched by a priority-prefixed
+    # filter token (the for-loop fallback in _token_matches_data)
+    str_data = {"endpoint", "other"}
+    assert (
+        utils.logic.is_exclusive_match(logic="7:endpoint", data=str_data)
+        is True
+    )
+    assert (
+        utils.logic.is_exclusive_match(logic="7:absent", data=str_data)
+        is False
+    )
+
+    # match_all keyword short-circuits even with priority data
+    assert utils.logic.is_exclusive_match(logic="all", data=data) is True
 
 
 def test_apprise_validate_regex():

--- a/tests/test_config_base.py
+++ b/tests/test_config_base.py
@@ -512,7 +512,7 @@ def test_config_base_config_tag_groups_text():
 
     # Our first element is our group tags
     assert len(result[0].tags) == 2
-    assert "groupB" in result[0].tags
+    assert "groupb" in result[0].tags
     assert "4" in result[0].tags
 
     # No additional configuration is loaded
@@ -1455,9 +1455,9 @@ urls:
     assert len(result[0].tags) == 5
     assert "group2" in result[0].tags
     assert "group3" in result[0].tags
-    assert "groupL" in result[0].tags
-    assert "groupM" in result[0].tags
-    assert "tagA" in result[0].tags
+    assert "groupl" in result[0].tags
+    assert "groupm" in result[0].tags
+    assert "taga" in result[0].tags
 
     # No additional configuration is loaded
     assert len(config) == 0
@@ -1570,9 +1570,9 @@ urls:
     assert len(result[0].tags) == 5
     assert "group2" in result[0].tags
     assert "group3" in result[0].tags
-    assert "groupL" in result[0].tags
-    assert "groupM" in result[0].tags
-    assert "tagA" in result[0].tags
+    assert "groupl" in result[0].tags
+    assert "groupm" in result[0].tags
+    assert "taga" in result[0].tags
 
     # No additional configuration is loaded
     assert len(config) == 0

--- a/tests/test_plugin_pushover.py
+++ b/tests/test_plugin_pushover.py
@@ -244,19 +244,19 @@ apprise_url_tests = (
             "instance": NotifyPushover,
         },
     ),
-    # API Key + emergency priority setting with retry and expire
+    # API Key + emergency priority setting with emg_retry and expire
     (
         "pover://{}@{}?priority=emergency&{}&{}".format(
-            "u" * 30, "a" * 30, "retry=30", "expire=300"
+            "u" * 30, "a" * 30, "emg_retry=30", "expire=300"
         ),
         {
             "instance": NotifyPushover,
         },
     ),
-    # API Key + emergency priority setting with text retry
+    # API Key + emergency priority setting with text emg_retry
     (
         "pover://{}@{}?priority=emergency&{}&{}".format(
-            "u" * 30, "a" * 30, "retry=invalid", "expire=300"
+            "u" * 30, "a" * 30, "emg_retry=invalid", "expire=300"
         ),
         {
             "instance": NotifyPushover,
@@ -265,7 +265,7 @@ apprise_url_tests = (
     # API Key + emergency priority setting with text expire
     (
         "pover://{}@{}?priority=emergency&{}&{}".format(
-            "u" * 30, "a" * 30, "retry=30", "expire=invalid"
+            "u" * 30, "a" * 30, "emg_retry=30", "expire=invalid"
         ),
         {
             "instance": NotifyPushover,
@@ -280,10 +280,10 @@ apprise_url_tests = (
             "instance": TypeError,
         },
     ),
-    # API Key + emergency priority setting with invalid retry
+    # API Key + emergency priority setting with invalid emg_retry
     (
         "pover://{}@{}?priority=emergency&{}".format(
-            "u" * 30, "a" * 30, "retry=15"
+            "u" * 30, "a" * 30, "emg_retry=15"
         ),
         {
             "instance": TypeError,

--- a/tests/test_plugin_pushover.py
+++ b/tests/test_plugin_pushover.py
@@ -244,19 +244,19 @@ apprise_url_tests = (
             "instance": NotifyPushover,
         },
     ),
-    # API Key + emergency priority setting with emg_retry and expire
+    # API Key + emergency priority setting with interval and expire
     (
         "pover://{}@{}?priority=emergency&{}&{}".format(
-            "u" * 30, "a" * 30, "emg_retry=30", "expire=300"
+            "u" * 30, "a" * 30, "interval=30", "expire=300"
         ),
         {
             "instance": NotifyPushover,
         },
     ),
-    # API Key + emergency priority setting with text emg_retry
+    # API Key + emergency priority setting with text interval
     (
         "pover://{}@{}?priority=emergency&{}&{}".format(
-            "u" * 30, "a" * 30, "emg_retry=invalid", "expire=300"
+            "u" * 30, "a" * 30, "interval=invalid", "expire=300"
         ),
         {
             "instance": NotifyPushover,
@@ -265,7 +265,7 @@ apprise_url_tests = (
     # API Key + emergency priority setting with text expire
     (
         "pover://{}@{}?priority=emergency&{}&{}".format(
-            "u" * 30, "a" * 30, "emg_retry=30", "expire=invalid"
+            "u" * 30, "a" * 30, "interval=30", "expire=invalid"
         ),
         {
             "instance": NotifyPushover,
@@ -280,10 +280,10 @@ apprise_url_tests = (
             "instance": TypeError,
         },
     ),
-    # API Key + emergency priority setting with invalid emg_retry
+    # API Key + emergency priority setting with invalid interval
     (
         "pover://{}@{}?priority=emergency&{}".format(
-            "u" * 30, "a" * 30, "emg_retry=15"
+            "u" * 30, "a" * 30, "interval=15"
         ),
         {
             "instance": TypeError,

--- a/tests/test_retry_wait.py
+++ b/tests/test_retry_wait.py
@@ -32,9 +32,14 @@ from unittest import mock
 import pytest
 
 from apprise import Apprise, AppriseAsset
-from apprise.common import APPRISE_MAX_SERVICE_RETRY, APPRISE_MAX_SERVICE_WAIT
+from apprise.common import (
+    APPRISE_MAX_SERVICE_RETRY,
+    APPRISE_MAX_SERVICE_WAIT,
+    MATCH_ALL_TAG,
+)
 from apprise.manager_plugins import NotificationManager
 from apprise.plugins import NotifyBase
+from apprise.tag import AppriseTag
 
 logging.disable(logging.CRITICAL)
 
@@ -485,3 +490,544 @@ class TestAssetDefault:
         asset = AppriseAsset(default_service_retry=3)
         nb = _TestNotify(host="localhost", asset=asset, retry=1)
         assert nb.retry == 1
+
+
+class _RaisingNotify(NotifyBase):
+    """Plugin that raises a bare Exception from notify()."""
+
+    app_id = "RaisingApp"
+    app_desc = "Test"
+    notify_url = "raise://"
+    title_maxlen = 250
+    body_maxlen = 32768
+
+    def url(self, *args, **kwargs):
+        return "raise://localhost"
+
+    def send(self, **kwargs):
+        raise RuntimeError("plugin exploded")
+
+    async def async_notify(self, **kwargs):
+        raise RuntimeError("plugin exploded async")
+
+    @staticmethod
+    def parse_url(url):
+        return NotifyBase.parse_url(url, verify_host=False)
+
+
+class TestAppriseTag:
+    """Full branch coverage for AppriseTag."""
+
+    def test_parse_returns_same_instance(self):
+        """parse() short-circuits when the input is already an AppriseTag."""
+        t = AppriseTag("alerts", priority=2)
+        # Must return the exact same object, not a copy (tag.py line 93)
+        assert AppriseTag.parse(t) is t
+
+    def test_parse_fallback_for_unrecognised_input(self):
+        """parse() falls back to a raw-name tag when the regex has no match."""
+        # Input starting with '@' does not match _RE_TAG; the fallback branch
+        # (tag.py line 107) stores the whole input as the name.
+        t = AppriseTag.parse("@invalid")
+        assert str(t) == "@invalid"
+        assert t.priority == 0
+        assert t.retry is None
+
+    # --- __repr__ ---
+
+    def test_repr_plain(self):
+        """repr() with default priority and no retry is minimal."""
+        assert repr(AppriseTag("simple")) == "AppriseTag('simple')"
+
+    def test_repr_with_priority(self):
+        """repr() includes priority= when non-zero (tag.py lines 121-122)."""
+        r = repr(AppriseTag("test", priority=3))
+        assert "priority=3" in r
+
+    def test_repr_with_retry(self):
+        """repr() includes retry= when set (tag.py lines 123-125)."""
+        r = repr(AppriseTag("test", retry=5))
+        assert "retry=5" in r
+
+    def test_repr_with_priority_and_retry(self):
+        """repr() includes both fields when both are non-default."""
+        r = repr(AppriseTag("test", priority=2, retry=3))
+        assert "priority=2" in r
+        assert "retry=3" in r
+
+    # --- __eq__ ---
+
+    def test_eq_two_apprisetags_same_name(self):
+        """Two AppriseTag objects are equal when their names match,
+        regardless of priority or retry (tag.py line 148)."""
+        assert AppriseTag("abc") == AppriseTag("abc", priority=5)
+        assert AppriseTag("ABC") == AppriseTag("abc")
+
+    def test_eq_with_string(self):
+        """An AppriseTag equals a plain str by name (tag.py line 150)."""
+        assert AppriseTag("hello") == "hello"
+        assert AppriseTag("HELLO") == "hello"
+
+    def test_eq_not_equal_different_name(self):
+        assert AppriseTag("abc") != AppriseTag("xyz")
+        assert AppriseTag("abc") != "xyz"
+
+    def test_eq_returns_notimplemented_for_other_types(self):
+        """Comparing to a non-str/AppriseTag returns NotImplemented
+        (tag.py line 151)."""
+        result = AppriseTag("abc").__eq__(42)
+        assert result is NotImplemented
+
+    # --- __lt__ ---
+
+    def test_lt_two_apprisetags(self):
+        """__lt__ sorts by tag name (tag.py lines 159-160)."""
+        assert AppriseTag("abc") < AppriseTag("def")
+        assert not (AppriseTag("def") < AppriseTag("abc"))
+
+    def test_lt_with_string(self):
+        """AppriseTag can be less-than compared to a plain string
+        (tag.py lines 161-162)."""
+        assert AppriseTag("abc") < "def"
+        assert not (AppriseTag("zzz") < "aaa")
+
+    def test_lt_returns_notimplemented_for_other_types(self):
+        """__lt__ with non-str/AppriseTag returns NotImplemented
+        (tag.py line 163)."""
+        result = AppriseTag("abc").__lt__(42)
+        assert result is NotImplemented
+
+    # --- __bool__ ---
+
+    def test_bool_empty_tag_is_false(self):
+        """An AppriseTag with an empty name is falsy (tag.py line 167)."""
+        assert not AppriseTag("")
+        assert bool(AppriseTag("")) is False
+
+    def test_bool_nonempty_tag_is_true(self):
+        assert bool(AppriseTag("something")) is True
+
+    # --- set / dict integration ---
+
+    def test_apprisetag_in_set_with_plain_string(self):
+        """AppriseTag in a set is found by plain string membership test."""
+        s = {AppriseTag("endpoint")}
+        assert "endpoint" in s
+
+    def test_plain_string_in_set_with_apprisetag(self):
+        """A plain string is found in a set containing AppriseTag."""
+        s = {"endpoint"}
+        assert AppriseTag("endpoint") in s
+
+
+class TestStaticHelpers:
+    """Tests for _extract_filter_retry and _filter_has_explicit_priority
+    covering the nested-list branches not reached by integration tests."""
+
+    def test_extract_retry_from_nested_list(self):
+        """Retry suffix found inside a nested list entry (apprise.py:413)."""
+        # tag = [["alerts:3"]] -- outer list, inner list as AND group
+        result = Apprise._extract_filter_retry([["alerts:3"]])
+        assert result == 3
+
+    def test_extract_retry_from_list_of_strings(self):
+        """Retry suffix found in a plain-string list entry (apprise.py:417)."""
+        result = Apprise._extract_filter_retry(["alerts:3"])
+        assert result == 3
+
+    def test_extract_retry_none_when_absent(self):
+        """Returns None when no retry suffix is present."""
+        assert Apprise._extract_filter_retry("alerts") is None
+        assert Apprise._extract_filter_retry(["alerts"]) is None
+
+    def test_extract_retry_none_for_match_all(self):
+        assert Apprise._extract_filter_retry(MATCH_ALL_TAG) is None
+        assert Apprise._extract_filter_retry(None) is None
+
+    def test_has_priority_nested_list(self):
+        """Priority prefix found inside a nested list (apprise.py:438)."""
+        assert Apprise._filter_has_explicit_priority([["2:alerts"]])
+
+    def test_has_priority_list_of_strings(self):
+        """Priority prefix found in a plain-string list (apprise.py:441)."""
+        assert Apprise._filter_has_explicit_priority(["2:alerts"])
+
+    def test_has_priority_false_no_prefix(self):
+        assert not Apprise._filter_has_explicit_priority("alerts")
+        assert not Apprise._filter_has_explicit_priority(["alerts"])
+
+    def test_has_priority_false_for_match_all(self):
+        assert not Apprise._filter_has_explicit_priority(MATCH_ALL_TAG)
+        assert not Apprise._filter_has_explicit_priority(None)
+
+    # _notify_parallel_threadpool / _notify_parallel_asyncio zero-length -----
+
+    def test_threadpool_zero_servers_returns_true(self):
+        """Empty server list returns True immediately (apprise.py:940)."""
+        assert Apprise._notify_parallel_threadpool() is True
+
+    def test_asyncio_zero_servers_returns_true(self):
+        """Empty server list returns True immediately (apprise.py:1031)."""
+        result = asyncio.run(Apprise._notify_parallel_asyncio())
+        assert result is True
+
+
+class TestDispatchIntegration:
+    """End-to-end notify() tests covering the new priority/retry dispatch."""
+
+    def _make_server(self, host, priority, asset, fail_times=0):
+        """Create a _FailThenSucceedNotify with an AppriseTag in its tags."""
+        s = _FailThenSucceedNotify(
+            host=host, asset=asset, fail_times=fail_times
+        )
+        # Assign a fresh instance-level set rather than mutating the
+        # class-level tags set.  URLBase.tags is a class attribute (set());
+        # .add() would mutate it and share state across all instances.
+        # Assignment shadows the class attribute and gives each server its
+        # own set with the correct priority stored in the AppriseTag object.
+        s.tags = {AppriseTag("alerts", priority=priority, has_priority=True)}
+        return s
+
+    def test_filter_retry_override_via_tag_suffix(self):
+        """tag suffix ':N' overrides per-server retry for this call only.
+        Covers apprise.py line 551 (filter_retry injection)."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            # Server's own retry=0; tag suffix of 2 should allow 3 attempts
+            server = _FailThenSucceedNotify(
+                host="localhost",
+                asset=asset,
+                retry=0,
+                wait=0.0,
+                fail_times=2,
+            )
+            # Tag the server so the filter "failpass:2" (tag name "failpass",
+            # retry override 2) can match it via is_exclusive_match.
+            server.tags = {"failpass"}
+            a = Apprise(asset=asset)
+            a.add(server)
+
+            # "failpass:2" -> retry override of 2 (3 total attempts)
+            result = a.notify(body="test", tag="failpass:2")
+            assert result is True
+            assert server._calls == 3
+        finally:
+            N_MGR.unload_modules()
+
+    def test_exclusive_priority_dispatch_skips_other_priorities(self):
+        """Explicit priority prefix dispatches only matching-priority services.
+        Covers apprise.py lines 556-572."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            s1 = self._make_server("host1", priority=1, asset=asset)
+            s2 = self._make_server("host2", priority=2, asset=asset)
+
+            a = Apprise(asset=asset)
+            a.add(s1)
+            a.add(s2)
+
+            # "2:alerts" -> only priority-2 service fires
+            result = a.notify(body="test", tag="2:alerts")
+            assert result is True
+            assert s1._calls == 0  # priority-1, not contacted
+            assert s2._calls == 1  # priority-2, contacted once
+        finally:
+            N_MGR.unload_modules()
+
+    def test_escalation_stops_when_highest_priority_group_succeeds(self):
+        """If priority-1 group all succeed, priority-2 group is not run."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            s1 = self._make_server("host1", priority=1, asset=asset)
+            s2 = self._make_server("host2", priority=2, asset=asset)
+
+            a = Apprise(asset=asset)
+            a.add(s1)
+            a.add(s2)
+
+            result = a.notify(body="test", tag="alerts")
+            assert result is True
+            assert s1._calls == 1  # priority 1 succeeded
+            assert s2._calls == 0  # never escalated to
+        finally:
+            N_MGR.unload_modules()
+
+    def test_escalation_triggers_on_priority_group_failure(self):
+        """Priority-1 group failure escalates to priority-2 group."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            # priority-1 always fails
+            s1 = self._make_server(
+                "host1", priority=1, asset=asset, fail_times=999
+            )
+            # priority-2 always succeeds
+            s2 = self._make_server("host2", priority=2, asset=asset)
+
+            a = Apprise(asset=asset)
+            a.add(s1)
+            a.add(s2)
+
+            result = a.notify(body="test", tag="alerts")
+            assert result is True
+            assert s1._calls == 1
+            assert s2._calls == 1
+        finally:
+            N_MGR.unload_modules()
+
+    def test_async_notify_filter_retry_and_explicit_priority(self):
+        """async_notify() covers the same escalation/exclusive paths.
+        Covers apprise.py lines 630, 637-649."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset()
+            s1 = self._make_server("host1", priority=1, asset=asset)
+            s2 = self._make_server("host2", priority=2, asset=asset)
+
+            a = Apprise(asset=asset)
+            a.add(s1)
+            a.add(s2)
+
+            async def run_exclusive():
+                return await a.async_notify(body="test", tag="2:alerts")
+
+            async def run_escalation():
+                return await a.async_notify(body="test", tag="alerts")
+
+            # exclusive: only priority-2 fires
+            r = asyncio.run(run_exclusive())
+            assert r is True
+            assert s1._calls == 0
+            assert s2._calls == 1
+
+            # escalation: priority-1 succeeds, priority-2 skipped
+            s1._calls = 0
+            s2._calls = 0
+            r = asyncio.run(run_escalation())
+            assert r is True
+            assert s1._calls == 1
+            assert s2._calls == 0
+        finally:
+            N_MGR.unload_modules()
+
+    def test_plain_and_zero_prefix_are_equivalent(self):
+        """'family' and '0:family' are identical at priority 0.
+        A filter of '0:family' must match services tagged with plain
+        'family', and both forms must land in the same escalation group."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+
+            # s1: tagged with plain "family" (priority=0, has_priority=False)
+            s1 = _FailThenSucceedNotify(
+                host="host1", asset=asset, fail_times=0
+            )
+            s1.tags = {AppriseTag.parse("family")}
+
+            # s2: tagged with explicit "0:family" (priority=0,
+            # has_priority=True)
+            s2 = _FailThenSucceedNotify(
+                host="host2", asset=asset, fail_times=0
+            )
+            s2.tags = {AppriseTag.parse("0:family")}
+
+            # s3: lower-urgency fallback -- should never fire when p-0 succeeds
+            s3 = _FailThenSucceedNotify(
+                host="host3", asset=asset, fail_times=0
+            )
+            s3.tags = {AppriseTag.parse("1:family")}
+
+            a = Apprise(asset=asset)
+            a.add(s1)
+            a.add(s2)
+            a.add(s3)
+
+            # Exclusive "0:family": plain "family" and "0:family" servers are
+            # both priority 0 and must both fire; priority-1 server is skipped.
+            result = a.notify(body="test", tag="0:family")
+            assert result is True
+            assert s1._calls == 1  # plain "family" matched by "0:family"
+            assert s2._calls == 1  # explicit "0:family" matched
+            assert s3._calls == 0  # priority 1, not priority 0 -- skipped
+
+            # Escalation "family": s1 and s2 are both in the priority-0
+            # group.  Both succeed, so s3 (priority 1) is never escalated to.
+            s1._calls = s2._calls = s3._calls = 0
+            result = a.notify(body="test", tag="family")
+            assert result is True
+            assert s1._calls == 1  # priority-0 group
+            assert s2._calls == 1  # same priority-0 group
+            assert s3._calls == 0  # not escalated to
+        finally:
+            N_MGR.unload_modules()
+
+
+class TestExceptionHandling:
+    """Verify that plugin exceptions are caught and retried, not propagated."""
+
+    def test_sequential_exception_treated_as_failure(self):
+        """A plugin raising Exception is caught; delivery is marked failed."""
+        N_MGR["raise"] = _RaisingNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            server = _RaisingNotify(host="localhost", asset=asset, retry=0)
+            a = Apprise(asset=asset)
+            a.add(server)
+
+            result = a.notify(body="test")
+            assert result is False
+        finally:
+            N_MGR.unload_modules()
+
+    def test_sequential_exception_retried(self):
+        """Exception on first attempt is retried; later success counts."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+        N_MGR["raise"] = _RaisingNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            # Use a plugin that raises on the first attempt then succeeds
+            server = _FailThenSucceedNotify(
+                host="localhost", asset=asset, retry=1, wait=0.0, fail_times=1
+            )
+            # Patch notify to raise on the first call then succeed
+            call_count = [0]
+
+            def raising_then_ok(**kwargs):
+                call_count[0] += 1
+                if call_count[0] == 1:
+                    raise RuntimeError("transient error")
+                return True
+
+            server.send = raising_then_ok
+            a = Apprise(asset=asset)
+            a.add(server)
+
+            result = a.notify(body="test")
+            assert result is True
+            assert call_count[0] == 2
+        finally:
+            N_MGR.unload_modules()
+
+    def test_threadpool_future_exception_caught(self):
+        """An exception escaping a thread future is caught gracefully.
+        Covers apprise.py lines 1004-1006."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=True)
+            # Need 2 servers to trigger the thread pool path
+            s1 = _FailThenSucceedNotify(
+                host="host1", asset=asset, fail_times=0
+            )
+            s2 = _FailThenSucceedNotify(
+                host="host2", asset=asset, fail_times=0
+            )
+            a = Apprise(asset=asset)
+            a.add(s1)
+            a.add(s2)
+
+            # Patch as_completed so one future raises when .result() is called
+            import concurrent.futures as cf
+
+            real_as_completed = cf.as_completed
+
+            def patched_as_completed(futures, **kw):
+                for i, f in enumerate(real_as_completed(futures, **kw)):
+                    if i == 0:
+                        # Wrap first future to raise on .result()
+                        m = mock.Mock()
+                        m.result.side_effect = RuntimeError("future boom")
+                        yield m
+                    else:
+                        yield f
+
+            with mock.patch(
+                "apprise.apprise.cf.as_completed", patched_as_completed
+            ):
+                result = a.notify(body="test")
+
+            # One future raised -> overall result is False
+            assert result is False
+        finally:
+            N_MGR.unload_modules()
+
+    def test_asyncio_exception_in_do_call_treated_as_failure(self):
+        """An exception inside do_call's retry loop is caught and the
+        service is marked as failed (covers the new try/except in do_call)."""
+        N_MGR["raise"] = _RaisingNotify
+
+        try:
+            asset = AppriseAsset()
+            server = _RaisingNotify(host="localhost", asset=asset, retry=0)
+            a = Apprise(asset=asset)
+            a.add(server)
+
+            async def run():
+                return await a.async_notify(body="test")
+
+            result = asyncio.run(run())
+            assert result is False
+        finally:
+            N_MGR.unload_modules()
+
+    def test_asyncio_gather_unhandled_exception(self):
+        """An exception escaping gather() is caught as a safety net.
+        Covers apprise.py lines 1090-1091."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset()
+            server = _FailThenSucceedNotify(
+                host="localhost", asset=asset, fail_times=0
+            )
+            a = Apprise(asset=asset)
+            a.add(server)
+
+            # Mock asyncio.gather to return an unexpected exception object
+            async def fake_gather(*args, **kw):
+                return [RuntimeError("escaped")]
+
+            async def run():
+                with mock.patch("apprise.apprise.asyncio.gather", fake_gather):
+                    return await a.async_notify(body="test")
+
+            result = asyncio.run(run())
+            assert result is False
+        finally:
+            N_MGR.unload_modules()
+
+    def test_asyncio_gather_type_error(self):
+        """A TypeError in gather results is caught and returns False.
+        Covers apprise.py lines 1093-1095."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset()
+            server = _FailThenSucceedNotify(
+                host="localhost", asset=asset, fail_times=0
+            )
+            a = Apprise(asset=asset)
+            a.add(server)
+
+            async def fake_gather(*args, **kw):
+                return [TypeError("validation")]
+
+            async def run():
+                with mock.patch("apprise.apprise.asyncio.gather", fake_gather):
+                    return await a.async_notify(body="test")
+
+            result = asyncio.run(run())
+            assert result is False
+        finally:
+            N_MGR.unload_modules()

--- a/tests/test_retry_wait.py
+++ b/tests/test_retry_wait.py
@@ -1,0 +1,487 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import asyncio
+import logging
+from unittest import mock
+
+import pytest
+
+from apprise import Apprise, AppriseAsset
+from apprise.common import APPRISE_MAX_SERVICE_RETRY, APPRISE_MAX_SERVICE_WAIT
+from apprise.manager_plugins import NotificationManager
+from apprise.plugins import NotifyBase
+
+logging.disable(logging.CRITICAL)
+
+N_MGR = NotificationManager()
+
+
+class _TestNotify(NotifyBase):
+    """Test notification plugin -- controlled pass/fail via side_effect."""
+
+    app_id = "TestApp"
+    app_desc = "Test"
+    notify_url = "test://"
+
+    title_maxlen = 250
+    body_maxlen = 32768
+
+    # Override so NotifyBase doesn't reject the URL
+    def url(self, privacy=False, *args, **kwargs):
+        return "test://localhost"
+
+    def send(self, **kwargs):
+        return True
+
+    @staticmethod
+    def parse_url(url):
+        results = NotifyBase.parse_url(url, verify_host=False)
+        return results
+
+
+class TestWaitValidation:
+    """Tests for the wait= parameter accepted by NotifyBase."""
+
+    def _make(self, **kwargs):
+        return _TestNotify(host="localhost", **kwargs)
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (0, 0.0),
+            (0.0, 0.0),
+            (0.5, 0.5),
+            (1, 1.0),
+            (1.0, 1.0),
+            ("0.5", 0.5),
+            ("1", 1.0),
+            ("1.4", 1.4),
+            ("20", 20.0),
+            (APPRISE_MAX_SERVICE_WAIT, APPRISE_MAX_SERVICE_WAIT),
+        ],
+    )
+    def test_valid_wait(self, value, expected):
+        nb = self._make(wait=value)
+        assert nb.wait == pytest.approx(expected)
+
+    def test_wait_clamped_to_max(self):
+        # Values above the cap are clamped, not rejected
+        nb = self._make(wait=APPRISE_MAX_SERVICE_WAIT + 9999)
+        assert nb.wait == pytest.approx(APPRISE_MAX_SERVICE_WAIT)
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            "-3",
+            "-0.1",
+            "1.3.3.",
+            "abc",
+            "inf",
+            "-inf",
+            "nan",
+            None,  # None means "use asset default" -- tested separately
+        ],
+    )
+    def test_invalid_wait_uses_asset_default(self, bad_value):
+        if bad_value is None:
+            # Not passing wait= at all should use asset default
+            asset = AppriseAsset(default_service_wait=1.25)
+            nb = _TestNotify(host="localhost", asset=asset)
+            assert nb.wait == pytest.approx(1.25)
+            return
+
+        asset = AppriseAsset(default_service_wait=0.75)
+        nb = self._make(wait=bad_value, asset=asset)
+        # Falls back to asset default on invalid input
+        assert nb.wait == pytest.approx(0.75)
+
+    def test_negative_wait_falls_back(self):
+        asset = AppriseAsset(default_service_wait=2.0)
+        nb = self._make(wait=-1.0, asset=asset)
+        assert nb.wait == pytest.approx(2.0)
+
+    def test_asset_default_zero(self):
+        asset = AppriseAsset(default_service_wait=0.0)
+        nb = _TestNotify(host="localhost", asset=asset)
+        assert nb.wait == pytest.approx(0.0)
+
+    def test_asset_default_clamped_to_max(self):
+        asset = AppriseAsset(default_service_wait=APPRISE_MAX_SERVICE_WAIT + 1)
+        nb = _TestNotify(host="localhost", asset=asset)
+        assert nb.wait == pytest.approx(APPRISE_MAX_SERVICE_WAIT)
+
+
+class TestRetryValidation:
+    """Sanity checks for the retry= parameter."""
+
+    def _make(self, **kwargs):
+        return _TestNotify(host="localhost", **kwargs)
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (0, 0),
+            (1, 1),
+            ("3", 3),
+            (APPRISE_MAX_SERVICE_RETRY, APPRISE_MAX_SERVICE_RETRY),
+        ],
+    )
+    def test_valid_retry(self, value, expected):
+        nb = self._make(retry=value)
+        assert nb.retry == expected
+
+    def test_retry_clamped_to_max(self):
+        nb = self._make(retry=APPRISE_MAX_SERVICE_RETRY + 999)
+        assert nb.retry == APPRISE_MAX_SERVICE_RETRY
+
+    @pytest.mark.parametrize("bad", ["-1", "abc", "1.3.3."])
+    def test_invalid_retry_uses_asset_default(self, bad):
+        asset = AppriseAsset(default_service_retry=2)
+        nb = self._make(retry=bad, asset=asset)
+        assert nb.retry == 2
+
+
+class TestUrlRoundTrip:
+    def test_wait_in_url_parameters(self):
+        nb = _TestNotify(host="localhost", wait=1.5, retry=2)
+        params = nb.url_parameters()
+        assert "wait" in params
+        assert params["wait"] == "1.5"
+        assert "retry" in params
+        assert params["retry"] == "2"
+
+    def test_wait_zero_not_in_url_parameters(self):
+        nb = _TestNotify(host="localhost", wait=0.0, retry=0)
+        params = nb.url_parameters()
+        assert "wait" not in params
+        assert "retry" not in params
+
+    def test_parse_url_extracts_wait(self):
+        results = _TestNotify.parse_url("test://localhost?wait=2.5&retry=3")
+        assert results is not None
+        assert results.get("wait") == "2.5"
+        assert results.get("retry") == "3"
+
+    def test_parse_url_no_wait_key_absent(self):
+        results = _TestNotify.parse_url("test://localhost")
+        assert results is not None
+        assert "wait" not in results
+
+
+class _FailThenSucceedNotify(NotifyBase):
+    """Fails the first N calls, then succeeds."""
+
+    app_id = "FailThenSucceed"
+    app_desc = "Test"
+    notify_url = "failpass://"
+    title_maxlen = 250
+    body_maxlen = 32768
+
+    def __init__(self, fail_times=1, **kwargs):
+        super().__init__(**kwargs)
+        self._fail_times = fail_times
+        self._calls = 0
+
+    def url(self, *args, **kwargs):
+        return "failpass://localhost"
+
+    def send(self, **kwargs):
+        self._calls += 1
+        return not self._calls <= self._fail_times
+
+    async def async_notify(self, **kwargs):
+        return self.send(**kwargs)
+
+    @staticmethod
+    def parse_url(url):
+        return NotifyBase.parse_url(url, verify_host=False)
+
+
+class TestSequentialSleep:
+    """time.sleep is called between retries in sequential dispatch."""
+
+    def test_sleep_called_on_retry(self):
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            a = Apprise(asset=asset)
+
+            server = _FailThenSucceedNotify(
+                host="localhost",
+                asset=asset,
+                retry=2,
+                wait=0.3,
+            )
+            a.add(server)
+
+            with mock.patch("apprise.apprise.time.sleep") as mock_sleep:
+                result = a.notify(body="test")
+
+            assert result is True
+            # Failed once -> sleep once before retry
+            mock_sleep.assert_called_once_with(pytest.approx(0.3))
+        finally:
+            N_MGR.unload_modules()
+
+    def test_sleep_not_called_when_wait_zero(self):
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            a = Apprise(asset=asset)
+
+            server = _FailThenSucceedNotify(
+                host="localhost",
+                asset=asset,
+                retry=2,
+                wait=0.0,
+            )
+            a.add(server)
+
+            with mock.patch("apprise.apprise.time.sleep") as mock_sleep:
+                result = a.notify(body="test")
+
+            assert result is True
+            mock_sleep.assert_not_called()
+        finally:
+            N_MGR.unload_modules()
+
+    def test_sleep_not_called_when_no_retry(self):
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            a = Apprise(asset=asset)
+
+            # retry=0 means only one attempt; with wait=1.0 sleep should
+            # never fire since there are no retries
+            server = _FailThenSucceedNotify(
+                host="localhost",
+                asset=asset,
+                retry=0,
+                wait=1.0,
+                fail_times=0,  # always succeeds
+            )
+            a.add(server)
+
+            with mock.patch("apprise.apprise.time.sleep") as mock_sleep:
+                result = a.notify(body="test")
+
+            assert result is True
+            mock_sleep.assert_not_called()
+        finally:
+            N_MGR.unload_modules()
+
+    def test_sleep_called_multiple_times(self):
+        """Fails twice, succeeds on third attempt -> sleep called twice."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            a = Apprise(asset=asset)
+
+            server = _FailThenSucceedNotify(
+                host="localhost",
+                asset=asset,
+                retry=3,
+                wait=0.5,
+                fail_times=2,
+            )
+            a.add(server)
+
+            with mock.patch("apprise.apprise.time.sleep") as mock_sleep:
+                result = a.notify(body="test")
+
+            assert result is True
+            assert mock_sleep.call_count == 2
+            for call in mock_sleep.call_args_list:
+                assert call == mock.call(pytest.approx(0.5))
+        finally:
+            N_MGR.unload_modules()
+
+
+class TestThreadPoolSleep:
+    """time.sleep is called between retries in threadpool dispatch."""
+
+    def test_sleep_called_in_threadpool(self):
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            # async_mode=True -> uses threadpool when > 1 server;
+            # but with a single server it falls through to sequential.
+            # Use two servers so we actually hit the threadpool path.
+            asset = AppriseAsset(async_mode=True)
+
+            # Two separate server objects so a threadpool is used
+            s1 = _FailThenSucceedNotify(
+                host="localhost",
+                asset=asset,
+                retry=2,
+                wait=0.2,
+                fail_times=1,
+            )
+            s2 = _FailThenSucceedNotify(
+                host="localhost2",
+                asset=asset,
+                retry=0,
+                wait=0.0,
+                fail_times=0,
+            )
+
+            a = Apprise(asset=asset)
+            a.add(s1)
+            a.add(s2)
+
+            with mock.patch("apprise.apprise.time.sleep") as mock_sleep:
+                result = a.notify(body="test")
+
+            assert result is True
+            # s1 fails once -> sleep once
+            mock_sleep.assert_called_once_with(pytest.approx(0.2))
+        finally:
+            N_MGR.unload_modules()
+
+    def test_sleep_not_called_in_threadpool_when_wait_zero(self):
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=True)
+
+            s1 = _FailThenSucceedNotify(
+                host="localhost",
+                asset=asset,
+                retry=2,
+                wait=0.0,
+                fail_times=1,
+            )
+            s2 = _FailThenSucceedNotify(
+                host="localhost2",
+                asset=asset,
+                retry=0,
+                wait=0.0,
+                fail_times=0,
+            )
+
+            a = Apprise(asset=asset)
+            a.add(s1)
+            a.add(s2)
+
+            with mock.patch("apprise.apprise.time.sleep") as mock_sleep:
+                result = a.notify(body="test")
+
+            assert result is True
+            mock_sleep.assert_not_called()
+        finally:
+            N_MGR.unload_modules()
+
+
+class TestAsyncioSleep:
+    """asyncio.sleep is called between retries in async dispatch."""
+
+    def test_asyncio_sleep_called(self):
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset()
+
+            server = _FailThenSucceedNotify(
+                host="localhost",
+                asset=asset,
+                retry=2,
+                wait=0.4,
+                fail_times=1,
+            )
+
+            a = Apprise(asset=asset)
+            a.add(server)
+
+            async def run():
+                with mock.patch("apprise.apprise.asyncio.sleep") as mock_sleep:
+                    mock_sleep.return_value = None
+                    result = await a.async_notify(body="test")
+                return result, mock_sleep
+
+            result, mock_sleep = asyncio.run(run())
+
+            assert result is True
+            mock_sleep.assert_called_once_with(pytest.approx(0.4))
+        finally:
+            N_MGR.unload_modules()
+
+    def test_asyncio_sleep_not_called_when_wait_zero(self):
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset()
+
+            server = _FailThenSucceedNotify(
+                host="localhost",
+                asset=asset,
+                retry=2,
+                wait=0.0,
+                fail_times=1,
+            )
+
+            a = Apprise(asset=asset)
+            a.add(server)
+
+            async def run():
+                with mock.patch("apprise.apprise.asyncio.sleep") as mock_sleep:
+                    mock_sleep.return_value = None
+                    result = await a.async_notify(body="test")
+                return result, mock_sleep
+
+            result, mock_sleep = asyncio.run(run())
+
+            assert result is True
+            mock_sleep.assert_not_called()
+        finally:
+            N_MGR.unload_modules()
+
+
+class TestAssetDefault:
+    def test_asset_wait_default_used(self):
+        asset = AppriseAsset(default_service_wait=1.5)
+        nb = _TestNotify(host="localhost", asset=asset)
+        assert nb.wait == pytest.approx(1.5)
+
+    def test_explicit_wait_overrides_asset(self):
+        asset = AppriseAsset(default_service_wait=1.5)
+        nb = _TestNotify(host="localhost", asset=asset, wait=0.2)
+        assert nb.wait == pytest.approx(0.2)
+
+    def test_asset_retry_default_used(self):
+        asset = AppriseAsset(default_service_retry=3)
+        nb = _TestNotify(host="localhost", asset=asset)
+        assert nb.retry == 3
+
+    def test_explicit_retry_overrides_asset(self):
+        asset = AppriseAsset(default_service_retry=3)
+        nb = _TestNotify(host="localhost", asset=asset, retry=1)
+        assert nb.retry == 1

--- a/tests/test_retry_wait.py
+++ b/tests/test_retry_wait.py
@@ -641,6 +641,45 @@ class TestStaticHelpers:
         assert Apprise._extract_filter_retry("alerts") is None
         assert Apprise._extract_filter_retry(["alerts"]) is None
 
+    def test_extract_retry_none_from_nested_list_no_suffix(self):
+        """Nested list without retry suffix returns None.
+
+        Covers the 'if ft.retry is not None' False branch (line 412) and the
+        inner for-loop completing without returning (branch 410->406).
+        """
+        result = Apprise._extract_filter_retry([["alerts"]])
+        assert result is None
+
+    def test_server_priority_for_tag_name_absent(self):
+        """Returns 0 when no tag in server.tags matches tag_name (line 456)."""
+        server = mock.Mock()
+        server.tags = {AppriseTag("alerts", priority=3, has_priority=True)}
+        assert Apprise._server_priority_for_tag_name(server, "backup") == 0
+
+    def test_match_service_retry_plain_string_tag_backward_compat(self):
+        """Plain string in server.tags matched by a priority-prefixed token.
+
+        Covers the else/str fallback inside _match_service_retry when stag is
+        not an AppriseTag instance and the name matches (lines 497-498).
+        """
+        server = mock.Mock()
+        server.tags = {"alerts"}  # plain string, not an AppriseTag
+        # "3:alerts:2" carries priority=3 + retry=2; plain "alerts" matches
+        result = Apprise._match_service_retry(server, "3:alerts:2")
+        assert result == 2
+
+    def test_match_service_retry_plain_string_tag_no_match(self):
+        """Plain string in server.tags that does not match returns None.
+
+        Covers the else-branch continuation (line 497->489) inside
+        _match_service_retry when the plain-string stag name differs from the
+        priority-prefixed filter token.
+        """
+        server = mock.Mock()
+        server.tags = {"other"}  # plain string -- does not match "alerts"
+        result = Apprise._match_service_retry(server, "3:alerts:2")
+        assert result is None
+
     def test_extract_retry_none_for_match_all(self):
         assert Apprise._extract_filter_retry(MATCH_ALL_TAG) is None
         assert Apprise._extract_filter_retry(None) is None
@@ -1555,6 +1594,46 @@ class TestMultiTagDispatch:
         finally:
             N_MGR.unload_modules()
 
+    def test_chain_dispatch_future_exception_treated_as_failure(self):
+        """An exception escaping _run_batch is caught in the chain-dispatch
+        ThreadPoolExecutor loop and treated as a delivery failure.
+
+        Covers the 'except Exception: ok = False' branch (apprise.py:788-792)
+        that is only reachable when multiple chains are active simultaneously
+        (triggering the ThreadPoolExecutor path) and a batch raises
+        unexpectedly.
+        """
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+
+            # Two servers with distinct tags give us two independent chains so
+            # the ThreadPoolExecutor path (len(active) > 1) is taken.
+            s_a = _FailThenSucceedNotify(host="a", asset=asset, fail_times=0)
+            s_a.tags = {"alpha"}
+
+            s_b = _FailThenSucceedNotify(host="b", asset=asset, fail_times=0)
+            s_b.tags = {"beta"}
+
+            a = Apprise(asset=asset)
+            a.add(s_a)
+            a.add(s_b)
+
+            # Patch _notify_sequential to raise so _run_batch propagates the
+            # exception through the future, exercising the except clause.
+            with mock.patch.object(
+                Apprise,
+                "_notify_sequential",
+                side_effect=RuntimeError("injected"),
+            ):
+                result = a.notify(body="test", tag=["alpha", "beta"])
+
+            # Both chains raised instead of returning True -- overall False.
+            assert result is False
+        finally:
+            N_MGR.unload_modules()
+
 
 class TestAbortOnChainFailure:
     """AppriseAsset.abort_on_chain_failure controls early-abort behaviour.
@@ -1640,5 +1719,44 @@ class TestAbortOnChainFailure:
             assert s_b._calls == 1
             assert s_a_p0._calls == 1
             assert s_a_p1._calls == 0  # skipped due to early abort
+        finally:
+            N_MGR.unload_modules()
+
+    def test_abort_on_chain_failure_true_async(self):
+        """abort_on_chain_failure=True triggers the same early-abort in
+        async_notify() (covers apprise.py line 873)."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=True, abort_on_chain_failure=True)
+
+            # alpha has two priority levels; priority-0 always fails
+            s_a_p0 = _FailThenSucceedNotify(
+                host="a0", asset=asset, fail_times=99
+            )
+            s_a_p0.tags = {AppriseTag("alpha", priority=0, has_priority=False)}
+
+            s_a_p1 = _FailThenSucceedNotify(
+                host="a1", asset=asset, fail_times=0
+            )
+            s_a_p1.tags = {AppriseTag("alpha", priority=1, has_priority=True)}
+
+            # beta has one priority level; always fails
+            s_b = _FailThenSucceedNotify(host="b", asset=asset, fail_times=99)
+            s_b.tags = {"beta"}
+
+            a = Apprise(asset=asset)
+            a.add(s_a_p0)
+            a.add(s_a_p1)
+            a.add(s_b)
+
+            result = asyncio.run(
+                a.async_notify(body="test", tag=["alpha", "beta"])
+            )
+            assert result is False
+            # beta was exhausted in round 1 -- abort fires before alpha's p1
+            assert s_b._calls == 1
+            assert s_a_p0._calls == 1
+            assert s_a_p1._calls == 0
         finally:
             N_MGR.unload_modules()

--- a/tests/test_retry_wait.py
+++ b/tests/test_retry_wait.py
@@ -1934,3 +1934,94 @@ class TestOptionalService:
             assert s._calls == 1
         finally:
             N_MGR.unload_modules()
+
+
+class TestCreateNotifyCalls:
+    """Cover Apprise._create_notify_calls() which splits servers into
+    sequential and parallel buckets based on their asset.async_mode flag."""
+
+    def test_splits_sequential_and_parallel(self):
+        """Sequential and parallel servers are split into separate lists."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+        try:
+            # With async_mode=False all loaded servers go to the sequential
+            # bucket; the parallel bucket remains empty.
+            asset_seq = AppriseAsset(async_mode=False)
+            s_seq = _FailThenSucceedNotify(
+                host="s1", asset=asset_seq, fail_times=0
+            )
+
+            a = Apprise(asset=asset_seq)
+            a.add(s_seq)
+
+            seq, par = a._create_notify_calls(body="test")
+            assert len(seq) == 1
+            assert len(par) == 0
+
+            # With async_mode=True the same server is placed in the parallel
+            # bucket instead.
+            asset_par = AppriseAsset(async_mode=True)
+            s_par = _FailThenSucceedNotify(
+                host="s2", asset=asset_par, fail_times=0
+            )
+
+            b = Apprise(asset=asset_par)
+            b.add(s_par)
+
+            seq2, par2 = b._create_notify_calls(body="test")
+            assert len(seq2) == 0
+            assert len(par2) == 1
+        finally:
+            N_MGR.unload_modules()
+
+
+class TestAsyncioSafetyNet:
+    """Cover the safety-net branch in _notify_parallel_asyncio that handles
+    exceptions which escape do_call's own try/except block."""
+
+    def test_exception_outside_try_block_triggers_safety_net(self):
+        """An exception raised before the per-attempt try block (e.g. from
+        a misbehaving server.retry property) escapes do_call, is captured by
+        asyncio.gather(return_exceptions=True), and causes the batch to
+        return False via the safety-net handler.
+
+        A second well-behaved server is included so that results contains
+        both an Exception and a bool value, exercising both branches of the
+        inner ``if isinstance(status, Exception)`` check in the loop."""
+
+        class _RaisingRetryServer:
+            """Server whose retry property raises to simulate a broken plugin
+            that fails before the per-attempt try/except in do_call."""
+
+            service_name = "raiser"
+            asset = AppriseAsset(async_mode=True)
+            optional = False
+
+            @property
+            def retry(self):
+                # This exception is raised when do_call evaluates
+                # getattr(server, "retry", 0), which happens OUTSIDE the
+                # per-attempt try/except.  It therefore escapes do_call
+                # entirely and is captured by asyncio.gather as a value.
+                raise RuntimeError("injected: property raised outside try")
+
+            async def async_notify(self, **kwargs):
+                return True  # pragma: no cover -- never reached
+
+        class _GoodServer:
+            """Minimal well-behaved server that succeeds immediately."""
+
+            service_name = "good"
+
+            async def async_notify(self, **kwargs):
+                return True
+
+        raiser = _RaisingRetryServer()
+        good = _GoodServer()
+        # Two servers: raiser -> Exception in results; good -> True in results.
+        # The safety-net loop therefore hits both branches of the inner
+        # ``if isinstance(status, Exception)`` check.
+        result = asyncio.run(
+            Apprise._notify_parallel_asyncio((raiser, {}), (good, {}))
+        )
+        assert result is False

--- a/tests/test_retry_wait.py
+++ b/tests/test_retry_wait.py
@@ -37,6 +37,7 @@ from apprise.common import (
     APPRISE_MAX_SERVICE_WAIT,
     MATCH_ALL_TAG,
 )
+from apprise.config.base import ConfigBase
 from apprise.manager_plugins import NotificationManager
 from apprise.plugins import NotifyBase
 from apprise.tag import AppriseTag
@@ -982,8 +983,8 @@ class TestExceptionHandling:
             N_MGR.unload_modules()
 
     def test_asyncio_gather_unhandled_exception(self):
-        """An exception escaping gather() is caught as a safety net.
-        Covers apprise.py lines 1090-1091."""
+        """An Exception escaping the outer gather() round is caught as a
+        safety net and treated as a batch failure."""
         N_MGR["failpass"] = _FailThenSucceedNotify
 
         try:
@@ -994,8 +995,13 @@ class TestExceptionHandling:
             a = Apprise(asset=asset)
             a.add(server)
 
-            # Mock asyncio.gather to return an unexpected exception object
+            # Mock asyncio.gather to return an escaped exception object.
+            # Close any unawaited coroutines passed to the mock to avoid
+            # "coroutine was never awaited" RuntimeWarnings.
             async def fake_gather(*args, **kw):
+                for arg in args:
+                    if asyncio.iscoroutine(arg):
+                        arg.close()
                 return [RuntimeError("escaped")]
 
             async def run():
@@ -1008,8 +1014,7 @@ class TestExceptionHandling:
             N_MGR.unload_modules()
 
     def test_asyncio_gather_type_error(self):
-        """A TypeError in gather results is caught and returns False.
-        Covers apprise.py lines 1093-1095."""
+        """A TypeError in gather results is caught and returns False."""
         N_MGR["failpass"] = _FailThenSucceedNotify
 
         try:
@@ -1021,6 +1026,9 @@ class TestExceptionHandling:
             a.add(server)
 
             async def fake_gather(*args, **kw):
+                for arg in args:
+                    if asyncio.iscoroutine(arg):
+                        arg.close()
                 return [TypeError("validation")]
 
             async def run():
@@ -1029,5 +1037,608 @@ class TestExceptionHandling:
 
             result = asyncio.run(run())
             assert result is False
+        finally:
+            N_MGR.unload_modules()
+
+
+class TestConfigTagRetry:
+    """Config parsers must reject a retry suffix in service tag definitions.
+
+    A tag like 'alerts:3' is only valid at call-time (notify() filter / CLI).
+    Putting it in a config file creates ambiguity with the URL ?retry= param
+    and the YAML retry: key, so both parsers must warn and skip the entry.
+    """
+
+    def test_text_rejects_retry_suffix(self):
+        """'alerts:3=json://...' is rejected; no server loaded."""
+        servers, _ = ConfigBase.config_parse_text("alerts:3=json://localhost")
+        assert servers == []
+
+    def test_text_rejects_priority_and_retry_in_tag(self):
+        """'1:alerts:3=json://...' is rejected (priority + retry suffix)."""
+        servers, _ = ConfigBase.config_parse_text(
+            "1:alerts:3=json://localhost"
+        )
+        assert servers == []
+
+    def test_text_accepts_priority_tag_without_retry(self):
+        """'1:alerts=json://...' loads normally (priority prefix, no retry)."""
+        servers, _ = ConfigBase.config_parse_text("1:alerts=json://localhost")
+        assert len(servers) == 1
+
+    def test_text_accepts_plain_tag(self):
+        """'alerts=json://...' loads normally (no prefix, no retry)."""
+        servers, _ = ConfigBase.config_parse_text("alerts=json://localhost")
+        assert len(servers) == 1
+
+    def test_yaml_rejects_retry_suffix(self):
+        """YAML 'tag: alerts:3' is rejected; no server loaded."""
+        servers, _ = ConfigBase.config_parse_yaml(
+            "version: 1\nurls:\n  - json://localhost:\n      tag: alerts:3\n"
+        )
+        assert servers == []
+
+    def test_yaml_rejects_priority_and_retry_in_tag(self):
+        """YAML 'tag: 1:alerts:3' is rejected (priority + retry suffix)."""
+        servers, _ = ConfigBase.config_parse_yaml(
+            "version: 1\nurls:\n  - json://localhost:\n      tag: 1:alerts:3\n"
+        )
+        assert servers == []
+
+    def test_yaml_accepts_priority_tag_without_retry(self):
+        """YAML 'tag: 1:alerts' loads normally (priority prefix, no retry)."""
+        servers, _ = ConfigBase.config_parse_yaml(
+            "version: 1\nurls:\n  - json://localhost:\n      tag: 1:alerts\n"
+        )
+        assert len(servers) == 1
+
+    def test_yaml_accepts_plain_tag(self):
+        """YAML 'tag: alerts' loads normally (no prefix, no retry)."""
+        servers, _ = ConfigBase.config_parse_yaml(
+            "version: 1\nurls:\n  - json://localhost:\n      tag: alerts\n"
+        )
+        assert len(servers) == 1
+
+    def test_text_valid_entry_after_rejected_one_still_loads(self):
+        """A valid entry that follows a rejected one is still loaded."""
+        servers, _ = ConfigBase.config_parse_text(
+            "alerts:3=json://localhost\nalerts=json://localhost\n"
+        )
+        assert len(servers) == 1
+
+    def test_yaml_valid_entry_after_rejected_one_still_loads(self):
+        """A valid entry that follows a rejected one is still loaded."""
+        servers, _ = ConfigBase.config_parse_yaml(
+            "version: 1\n"
+            "urls:\n"
+            "  - json://localhost:\n"
+            "      tag: alerts:3\n"
+            "  - json://localhost:\n"
+            "      tag: alerts\n"
+        )
+        assert len(servers) == 1
+
+
+class TestMultiTagDispatch:
+    """Per-tag independent escalation and per-service retry for multi-tag OR
+    filters.
+
+    When notify() receives a filter with multiple OR tokens (e.g.
+    'devops management' or ['devops:3', 'management:2']), each token forms an
+    independent escalation chain and each service gets the retry value from the
+    token that matched it -- not a single global retry applied to all services.
+    """
+
+    def _make_tagged(self, tag_str, asset, fail_times=0):
+        """Create a _FailThenSucceedNotify tagged with a single AppriseTag."""
+        s = _FailThenSucceedNotify(
+            host=tag_str, asset=asset, fail_times=fail_times
+        )
+        # Assign instance-level set to avoid class-level mutation.
+        s.tags = {AppriseTag.parse(tag_str)}
+        return s
+
+    def _make_priority_tagged(self, tag_str, asset, fail_times=0):
+        """Create a server whose tag is an explicit-priority AppriseTag."""
+        ft = AppriseTag.parse(tag_str)
+        s = _FailThenSucceedNotify(
+            host=str(ft), asset=asset, fail_times=fail_times
+        )
+        s.tags = {ft}
+        return s
+
+    # ------------------------------------------------------------------
+    # Per-service retry via space-separated string
+    # ------------------------------------------------------------------
+
+    def test_per_service_retry_space_separated_string(self):
+        """'devops:3 management:2' applies retry=3 to devops services and
+        retry=2 to management services independently."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+
+            # devops service: fails 3 times; needs retry=3 to succeed
+            s_devops = _FailThenSucceedNotify(
+                host="devops", asset=asset, fail_times=3
+            )
+            s_devops.tags = {"devops"}
+
+            # management service: fails 2 times; needs retry=2 to succeed
+            s_mgmt = _FailThenSucceedNotify(
+                host="mgmt", asset=asset, fail_times=2
+            )
+            s_mgmt.tags = {"management"}
+
+            a = Apprise(asset=asset)
+            a.add(s_devops)
+            a.add(s_mgmt)
+
+            result = a.notify(body="test", tag="devops:3 management:2")
+            assert result is True
+            # devops: 1 initial + 3 retries = 4 total calls
+            assert s_devops._calls == 4
+            # management: 1 initial + 2 retries = 3 total calls
+            assert s_mgmt._calls == 3
+        finally:
+            N_MGR.unload_modules()
+
+    def test_per_service_retry_list_of_tokens(self):
+        """['devops:3', 'management:2'] gives the same per-service retry
+        result as a space-separated string."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+
+            s_devops = _FailThenSucceedNotify(
+                host="devops", asset=asset, fail_times=3
+            )
+            s_devops.tags = {"devops"}
+
+            s_mgmt = _FailThenSucceedNotify(
+                host="mgmt", asset=asset, fail_times=2
+            )
+            s_mgmt.tags = {"management"}
+
+            a = Apprise(asset=asset)
+            a.add(s_devops)
+            a.add(s_mgmt)
+
+            result = a.notify(body="test", tag=["devops:3", "management:2"])
+            assert result is True
+            assert s_devops._calls == 4
+            assert s_mgmt._calls == 3
+        finally:
+            N_MGR.unload_modules()
+
+    # ------------------------------------------------------------------
+    # Independent escalation chains
+    # ------------------------------------------------------------------
+
+    def test_independent_chains_devops_success_does_not_skip_management(self):
+        """When devops chain succeeds at priority-1, management chain still
+        dispatches independently -- its priority-1 failure escalates to its
+        priority-2 server."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+
+            # devops chain: priority-1 succeeds; priority-2 must not fire
+            s_devops_p1 = _FailThenSucceedNotify(
+                host="d1", asset=asset, fail_times=0
+            )
+            s_devops_p1.tags = {
+                AppriseTag("devops", priority=1, has_priority=True)
+            }
+            s_devops_p2 = _FailThenSucceedNotify(
+                host="d2", asset=asset, fail_times=0
+            )
+            s_devops_p2.tags = {
+                AppriseTag("devops", priority=2, has_priority=True)
+            }
+
+            # management chain: priority-1 always fails; must escalate to
+            # priority-2
+            s_mgmt_p1 = _FailThenSucceedNotify(
+                host="m1", asset=asset, fail_times=999
+            )
+            s_mgmt_p1.tags = {
+                AppriseTag("management", priority=1, has_priority=True)
+            }
+            s_mgmt_p2 = _FailThenSucceedNotify(
+                host="m2", asset=asset, fail_times=0
+            )
+            s_mgmt_p2.tags = {
+                AppriseTag("management", priority=2, has_priority=True)
+            }
+
+            a = Apprise(asset=asset)
+            a.add(s_devops_p1)
+            a.add(s_devops_p2)
+            a.add(s_mgmt_p1)
+            a.add(s_mgmt_p2)
+
+            result = a.notify(body="test", tag="devops management")
+            assert result is True
+            assert s_devops_p1._calls == 1  # devops chain: p1 succeeded
+            assert s_devops_p2._calls == 0  # never escalated to
+            assert s_mgmt_p1._calls == 1  # management chain: p1 failed
+            assert s_mgmt_p2._calls == 1  # escalated to p2, succeeded
+        finally:
+            N_MGR.unload_modules()
+
+    def test_both_chains_must_succeed_for_true(self):
+        """notify() returns False when one chain exhausts all priority groups
+        without any group fully succeeding."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+
+            # devops chain: always succeeds
+            s_devops = _FailThenSucceedNotify(
+                host="d", asset=asset, fail_times=0
+            )
+            s_devops.tags = {"devops"}
+
+            # management chain: always fails
+            s_mgmt = _FailThenSucceedNotify(
+                host="m", asset=asset, fail_times=999
+            )
+            s_mgmt.tags = {"management"}
+
+            a = Apprise(asset=asset)
+            a.add(s_devops)
+            a.add(s_mgmt)
+
+            result = a.notify(body="test", tag="devops management")
+            assert result is False
+            assert s_devops._calls == 1  # its chain succeeded
+            assert s_mgmt._calls == 1  # its chain failed
+        finally:
+            N_MGR.unload_modules()
+
+    # ------------------------------------------------------------------
+    # Explicit-priority list with per-service retry (flat dispatch)
+    # ------------------------------------------------------------------
+
+    def test_explicit_priority_list_per_service_retry(self):
+        """['1:tag:2', '2:tag:0'] flat-dispatches both servers; each gets its
+        own retry: the priority-1 server gets retry=2 and the priority-2
+        server gets retry=0 (one attempt only)."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+
+            # priority-1 server: fails twice; needs retry=2 to succeed
+            s1 = _FailThenSucceedNotify(host="h1", asset=asset, fail_times=2)
+            s1.tags = {AppriseTag("tag", priority=1, has_priority=True)}
+
+            # priority-2 server: always succeeds; retry=0 means one attempt
+            s2 = _FailThenSucceedNotify(host="h2", asset=asset, fail_times=0)
+            s2.tags = {AppriseTag("tag", priority=2, has_priority=True)}
+
+            a = Apprise(asset=asset)
+            a.add(s1)
+            a.add(s2)
+
+            result = a.notify(body="test", tag=["1:tag:2", "2:tag:0"])
+            assert result is True
+            # s1: 1 initial + 2 retries = 3 total
+            assert s1._calls == 3
+            # s2: retry=0 -> exactly 1 attempt
+            assert s2._calls == 1
+        finally:
+            N_MGR.unload_modules()
+
+    # ------------------------------------------------------------------
+    # CLI OR format (list of single-element lists)
+    # ------------------------------------------------------------------
+
+    def test_cli_or_format_independent_chains(self):
+        """CLI --tag 'devops:3' --tag 'management:2' generates
+        [['devops:3'], ['management:2']] -- single-element inner lists that
+        must be treated as independent OR chains, not AND groups."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+
+            s_devops = _FailThenSucceedNotify(
+                host="devops", asset=asset, fail_times=3
+            )
+            s_devops.tags = {"devops"}
+
+            s_mgmt = _FailThenSucceedNotify(
+                host="mgmt", asset=asset, fail_times=2
+            )
+            s_mgmt.tags = {"management"}
+
+            a = Apprise(asset=asset)
+            a.add(s_devops)
+            a.add(s_mgmt)
+
+            # Simulate CLI: --tag "devops:3" --tag "management:2"
+            cli_tag = [["devops:3"], ["management:2"]]
+            result = a.notify(body="test", tag=cli_tag)
+            assert result is True
+            assert s_devops._calls == 4  # 1 initial + 3 retries
+            assert s_mgmt._calls == 3  # 1 initial + 2 retries
+        finally:
+            N_MGR.unload_modules()
+
+    def test_cli_and_format_shared_chain(self):
+        """CLI --tag 'devops, management' generates [['devops', 'management']]
+        -- a multi-element inner list that is an AND condition and uses a
+        single shared escalation chain."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+
+            # Server must carry BOTH tags to match
+            s_both = _FailThenSucceedNotify(
+                host="both", asset=asset, fail_times=0
+            )
+            s_both.tags = {"devops", "management"}
+
+            # Server with only "devops" -- must NOT match AND filter
+            s_devonly = _FailThenSucceedNotify(
+                host="devonly", asset=asset, fail_times=0
+            )
+            s_devonly.tags = {"devops"}
+
+            a = Apprise(asset=asset)
+            a.add(s_both)
+            a.add(s_devonly)
+
+            # Simulate CLI: --tag "devops, management" (AND condition)
+            cli_tag = [["devops", "management"]]
+            result = a.notify(body="test", tag=cli_tag)
+            assert result is True
+            assert s_both._calls == 1  # has both tags -- matched
+            assert s_devonly._calls == 0  # missing "management" -- not matched
+        finally:
+            N_MGR.unload_modules()
+
+    # ------------------------------------------------------------------
+    # Edge cases: explicit priority + AND, 3-chain OR, chain exhaustion
+    # ------------------------------------------------------------------
+
+    def test_and_filter_explicit_priority_no_match_returns_none(self):
+        """AND filter with an explicit priority that no server satisfies
+        returns None (no services dispatched at all)."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+
+            # Server is tagged 'alerts' at priority 2
+            s = _FailThenSucceedNotify(host="s", asset=asset, fail_times=0)
+            s.tags = {AppriseTag("alerts", priority=2, has_priority=True)}
+
+            a = Apprise(asset=asset)
+            a.add(s)
+
+            # Request 'alerts' at priority 1 AND 'backup' -- server has
+            # 'alerts' but at priority 2, not 1; nothing matches.
+            result = a.notify(body="test", tag=[["1:alerts", "backup"]])
+            assert result is None
+            assert s._calls == 0
+        finally:
+            N_MGR.unload_modules()
+
+    def test_three_or_chains_all_succeed(self):
+        """Three independent OR chains each succeed at their first priority
+        group; notify() returns True and each service is called once."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+
+            s_a = _FailThenSucceedNotify(host="a", asset=asset, fail_times=0)
+            s_a.tags = {"alpha"}
+
+            s_b = _FailThenSucceedNotify(host="b", asset=asset, fail_times=0)
+            s_b.tags = {"beta"}
+
+            s_c = _FailThenSucceedNotify(host="c", asset=asset, fail_times=0)
+            s_c.tags = {"gamma"}
+
+            a = Apprise(asset=asset)
+            a.add(s_a)
+            a.add(s_b)
+            a.add(s_c)
+
+            result = a.notify(body="test", tag=["alpha", "beta", "gamma"])
+            assert result is True
+            assert s_a._calls == 1
+            assert s_b._calls == 1
+            assert s_c._calls == 1
+        finally:
+            N_MGR.unload_modules()
+
+    def test_three_or_chains_one_fails_overall_false(self):
+        """Three OR chains: two succeed, one exhausts all priority groups.
+        notify() returns False even though the other chains succeeded."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+
+            s_a = _FailThenSucceedNotify(host="a", asset=asset, fail_times=0)
+            s_a.tags = {"alpha"}
+
+            # beta always fails (fail_times > any possible retry)
+            s_b = _FailThenSucceedNotify(host="b", asset=asset, fail_times=99)
+            s_b.tags = {"beta"}
+
+            s_c = _FailThenSucceedNotify(host="c", asset=asset, fail_times=0)
+            s_c.tags = {"gamma"}
+
+            a = Apprise(asset=asset)
+            a.add(s_a)
+            a.add(s_b)
+            a.add(s_c)
+
+            result = a.notify(body="test", tag=["alpha", "beta", "gamma"])
+            assert result is False
+            assert s_a._calls == 1  # alpha succeeded
+            assert s_c._calls == 1  # gamma succeeded
+        finally:
+            N_MGR.unload_modules()
+
+    def test_chain_escalation_to_second_priority_group(self):
+        """A chain whose priority-0 group fails escalates to the priority-1
+        group; the second group succeeds so notify() returns True."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+
+            # priority-0 server: always fails (no retry configured)
+            s_p0 = _FailThenSucceedNotify(
+                host="p0", asset=asset, fail_times=99
+            )
+            s_p0.tags = {AppriseTag("alerts", priority=0, has_priority=False)}
+
+            # priority-1 server: succeeds on first attempt
+            s_p1 = _FailThenSucceedNotify(host="p1", asset=asset, fail_times=0)
+            s_p1.tags = {AppriseTag("alerts", priority=1, has_priority=True)}
+
+            a = Apprise(asset=asset)
+            a.add(s_p0)
+            a.add(s_p1)
+
+            result = a.notify(body="test", tag="alerts")
+            assert result is True
+            # priority-0 group was attempted once and failed
+            assert s_p0._calls == 1
+            # priority-1 group was then tried as fallback
+            assert s_p1._calls == 1
+        finally:
+            N_MGR.unload_modules()
+
+    def test_all_priority_groups_exhausted_returns_false(self):
+        """When every priority group in a chain fails, notify() returns False
+        and all groups were attempted in order."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+
+            # priority-0 server: always fails
+            s_p0 = _FailThenSucceedNotify(
+                host="p0", asset=asset, fail_times=99
+            )
+            s_p0.tags = {AppriseTag("alerts", priority=0, has_priority=False)}
+
+            # priority-1 server: also always fails
+            s_p1 = _FailThenSucceedNotify(
+                host="p1", asset=asset, fail_times=99
+            )
+            s_p1.tags = {AppriseTag("alerts", priority=1, has_priority=True)}
+
+            a = Apprise(asset=asset)
+            a.add(s_p0)
+            a.add(s_p1)
+
+            result = a.notify(body="test", tag="alerts")
+            assert result is False
+            # Both groups were attempted
+            assert s_p0._calls == 1
+            assert s_p1._calls == 1
+        finally:
+            N_MGR.unload_modules()
+
+
+class TestAbortOnChainFailure:
+    """AppriseAsset.abort_on_chain_failure controls early-abort behaviour.
+
+    When False (default): all chains are allowed to complete even if one
+    has already failed, so every configured URL gets at least one attempt.
+    When True: as soon as any chain exhausts all its priority groups without
+    success, notify() returns False immediately without running further
+    escalation rounds for the other chains.
+    """
+
+    def _make_tagged(self, tag_str, asset, fail_times=0):
+        s = _FailThenSucceedNotify(
+            host=tag_str, asset=asset, fail_times=fail_times
+        )
+        s.tags = {tag_str}
+        return s
+
+    def test_default_false_all_chains_complete(self):
+        """With abort_on_chain_failure=False (default), all chains run to
+        completion even if one chain has already failed."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+
+            # alpha always succeeds
+            s_a = self._make_tagged("alpha", asset, fail_times=0)
+
+            # beta always fails (exhausts its only group immediately)
+            s_b = self._make_tagged("beta", asset, fail_times=99)
+
+            # gamma always succeeds
+            s_c = self._make_tagged("gamma", asset, fail_times=0)
+
+            a = Apprise(asset=asset)
+            a.add(s_a)
+            a.add(s_b)
+            a.add(s_c)
+
+            result = a.notify(body="test", tag=["alpha", "beta", "gamma"])
+            assert result is False
+            # alpha and gamma were still dispatched despite beta failing
+            assert s_a._calls == 1
+            assert s_b._calls == 1
+            assert s_c._calls == 1
+        finally:
+            N_MGR.unload_modules()
+
+    def test_abort_on_chain_failure_true_stops_early(self):
+        """With abort_on_chain_failure=True, once beta exhausts all priority
+        groups without success, further escalation rounds for other chains
+        are skipped."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False, abort_on_chain_failure=True)
+
+            # alpha: two priority levels; priority-0 always fails
+            s_a_p0 = _FailThenSucceedNotify(
+                host="a0", asset=asset, fail_times=99
+            )
+            s_a_p0.tags = {AppriseTag("alpha", priority=0, has_priority=False)}
+
+            s_a_p1 = _FailThenSucceedNotify(
+                host="a1", asset=asset, fail_times=0
+            )
+            s_a_p1.tags = {AppriseTag("alpha", priority=1, has_priority=True)}
+
+            # beta: one priority level; always fails
+            s_b = _FailThenSucceedNotify(host="b", asset=asset, fail_times=99)
+            s_b.tags = {"beta"}
+
+            a = Apprise(asset=asset)
+            a.add(s_a_p0)
+            a.add(s_a_p1)
+            a.add(s_b)
+
+            result = a.notify(body="test", tag=["alpha", "beta"])
+            assert result is False
+            # beta failed in round 1 and was exhausted -- abort triggered.
+            # alpha's p1 (escalation) should NOT have been attempted.
+            assert s_b._calls == 1
+            assert s_a_p0._calls == 1
+            assert s_a_p1._calls == 0  # skipped due to early abort
         finally:
             N_MGR.unload_modules()

--- a/tests/test_retry_wait.py
+++ b/tests/test_retry_wait.py
@@ -181,11 +181,14 @@ class TestUrlRoundTrip:
         assert "retry" in params
         assert params["retry"] == "2"
 
-    def test_wait_zero_not_in_url_parameters(self):
+    def test_wait_zero_always_in_url_parameters(self):
+        """retry= and wait= are always present, even at their zero defaults."""
         nb = _TestNotify(host="localhost", wait=0.0, retry=0)
         params = nb.url_parameters()
-        assert "wait" not in params
-        assert "retry" not in params
+        assert "wait" in params
+        assert params["wait"] == "0.0"
+        assert "retry" in params
+        assert params["retry"] == "0"
 
     def test_parse_url_extracts_wait(self):
         results = _TestNotify.parse_url("test://localhost?wait=2.5&retry=3")
@@ -1600,34 +1603,39 @@ class TestMultiTagDispatch:
 
         Covers the 'except Exception: ok = False' branch (apprise.py:788-792)
         that is only reachable when multiple chains are active simultaneously
-        (triggering the ThreadPoolExecutor path) and a batch raises
-        unexpectedly.
+        (triggering the ThreadPoolExecutor path) and _run_batch raises.
+        Uses _ExplodingAsset (raises on async_mode access) instead of
+        patching a @staticmethod, which is unreliable across Python versions
+        when the patched method runs inside a ThreadPoolExecutor worker.
         """
         N_MGR["failpass"] = _FailThenSucceedNotify
 
         try:
-            asset = AppriseAsset(async_mode=False)
+            # _ExplodingAsset.async_mode raises RuntimeError.  _run_batch
+            # reads s.asset.async_mode to split seq/par, so a batch with
+            # one of these servers raises and the future captures it.
+            class _ExplodingAsset(AppriseAsset):
+                @property
+                def async_mode(self):
+                    raise RuntimeError("injected async_mode access")
 
-            # Two servers with distinct tags give us two independent chains so
+            # Two servers with distinct tags -> two independent chains so
             # the ThreadPoolExecutor path (len(active) > 1) is taken.
-            s_a = _FailThenSucceedNotify(host="a", asset=asset, fail_times=0)
+            s_a = _FailThenSucceedNotify(
+                host="a", asset=_ExplodingAsset(), fail_times=0
+            )
             s_a.tags = {"alpha"}
 
-            s_b = _FailThenSucceedNotify(host="b", asset=asset, fail_times=0)
+            s_b = _FailThenSucceedNotify(
+                host="b", asset=_ExplodingAsset(), fail_times=0
+            )
             s_b.tags = {"beta"}
 
-            a = Apprise(asset=asset)
+            a = Apprise()
             a.add(s_a)
             a.add(s_b)
 
-            # Patch _notify_sequential to raise so _run_batch propagates the
-            # exception through the future, exercising the except clause.
-            with mock.patch.object(
-                Apprise,
-                "_notify_sequential",
-                side_effect=RuntimeError("injected"),
-            ):
-                result = a.notify(body="test", tag=["alpha", "beta"])
+            result = a.notify(body="test", tag=["alpha", "beta"])
 
             # Both chains raised instead of returning True -- overall False.
             assert result is False
@@ -1758,5 +1766,171 @@ class TestAbortOnChainFailure:
             assert s_b._calls == 1
             assert s_a_p0._calls == 1
             assert s_a_p1._calls == 0
+        finally:
+            N_MGR.unload_modules()
+
+
+class TestOptionalService:
+    """optional=True silently absorbs per-service delivery failures.
+
+    The overall notify()/async_notify() result is True even when an
+    optional service cannot be reached, so callers are not penalised
+    for "nice to have" endpoints (e.g. home screens, debug logging).
+    """
+
+    def test_optional_default_false(self):
+        """optional defaults to False on a freshly constructed plugin."""
+        nb = _TestNotify(host="localhost")
+        assert nb.optional is False
+
+    def test_optional_url_includes_flag(self):
+        """url_parameters() always emits optional=yes or optional=no."""
+        nb = _TestNotify(host="localhost")
+        params = nb.url_parameters()
+        assert "optional" in params
+        assert params["optional"] == "no"
+
+        nb_opt = _TestNotify(host="localhost", optional=True)
+        params_opt = nb_opt.url_parameters()
+        assert params_opt["optional"] == "yes"
+
+    def test_optional_parse_url_yes(self):
+        """parse_url propagates optional=yes into the results dict."""
+        results = _TestNotify.parse_url("test://localhost?optional=yes")
+        assert results is not None
+        assert results.get("optional") is True
+
+    def test_optional_parse_url_no(self):
+        """parse_url propagates optional=no into the results dict."""
+        results = _TestNotify.parse_url("test://localhost?optional=no")
+        assert results is not None
+        assert results.get("optional") is False
+
+    def test_optional_kwarg_sets_attribute(self):
+        """Passing optional=True/False to __init__ sets .optional."""
+        nb_yes = _TestNotify(host="localhost", optional=True)
+        assert nb_yes.optional is True
+
+        nb_no = _TestNotify(host="localhost", optional=False)
+        assert nb_no.optional is False
+
+    def test_optional_sequential_failure_absorbed(self):
+        """Sequential dispatch: failed optional server -> overall True."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            s = _FailThenSucceedNotify(host="s1", asset=asset, fail_times=99)
+            s.optional = True
+
+            a = Apprise(asset=asset)
+            a.add(s)
+
+            result = a.notify(body="test")
+            assert result is True
+            assert s._calls == 1
+        finally:
+            N_MGR.unload_modules()
+
+    def test_optional_threadpool_failure_absorbed(self):
+        """Thread-pool dispatch: failed optional servers -> overall True.
+
+        Two async_mode=True servers ensure _notify_parallel_threadpool
+        uses the actual thread pool (n_calls==1 falls back to sequential).
+        """
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=True)
+            s1 = _FailThenSucceedNotify(host="s1", asset=asset, fail_times=99)
+            s1.optional = True
+            s2 = _FailThenSucceedNotify(host="s2", asset=asset, fail_times=99)
+            s2.optional = True
+
+            a = Apprise(asset=asset)
+            a.add(s1)
+            a.add(s2)
+
+            result = a.notify(body="test")
+            assert result is True
+        finally:
+            N_MGR.unload_modules()
+
+    def test_optional_asyncio_failure_absorbed(self):
+        """Asyncio dispatch: failed optional server -> overall True."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=True)
+            s = _FailThenSucceedNotify(host="s1", asset=asset, fail_times=99)
+            s.optional = True
+
+            a = Apprise(asset=asset)
+            a.add(s)
+
+            result = asyncio.run(a.async_notify(body="test"))
+            assert result is True
+        finally:
+            N_MGR.unload_modules()
+
+    def test_optional_all_fail_all_optional_returns_true(self):
+        """When every server is optional and every server fails -> True."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            a = Apprise(asset=asset)
+            for i in range(3):
+                s = _FailThenSucceedNotify(
+                    host=f"s{i}", asset=asset, fail_times=99
+                )
+                s.optional = True
+                a.add(s)
+
+            result = a.notify(body="test")
+            assert result is True
+        finally:
+            N_MGR.unload_modules()
+
+    def test_optional_mixed_required_fails_returns_false(self):
+        """Required server failure taints result even with optional peers."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            s_opt = _FailThenSucceedNotify(
+                host="opt", asset=asset, fail_times=99
+            )
+            s_opt.optional = True
+
+            s_req = _FailThenSucceedNotify(
+                host="req", asset=asset, fail_times=99
+            )
+            # s_req.optional is False (default)
+
+            a = Apprise(asset=asset)
+            a.add(s_opt)
+            a.add(s_req)
+
+            result = a.notify(body="test")
+            assert result is False
+        finally:
+            N_MGR.unload_modules()
+
+    def test_optional_success_unaffected(self):
+        """An optional server that succeeds is still counted as True."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            s = _FailThenSucceedNotify(host="s1", asset=asset, fail_times=0)
+            s.optional = True
+
+            a = Apprise(asset=asset)
+            a.add(s)
+
+            result = a.notify(body="test")
+            assert result is True
+            assert s._calls == 1
         finally:
             N_MGR.unload_modules()


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1341

### `retry=` and `wait=`

Two new per-service URL parameters control how Apprise handles transient failures.

- **`retry=N`** -- number of additional attempts after an initial failure before giving up (default: `0`, no retries).
- **`wait=S`** -- seconds to pause between each retry attempt (default: `0.0`; decimals accepted).

Both can be set directly on a service URL or in YAML:

```apache
# Try up to 3 times (initial + 2 retries), waiting 5 seconds between each
alerts=slack://tokenA/tokenB/tokenC?retry=2&wait=5
```

```yaml
- slack://tokenA/tokenB/tokenC:
    tag: alerts
    retry: 2
    wait: 5
```

A per-call override is also supported by appending `:N` to a tag name -- this overrides the retry count for every matched service for that one call only, without touching their stored configuration:

```python
# All services tagged 'family' get up to 2 extra retries for this call
apobj.notify(body="Hello", tag="family:2")
```

```bash
apprise -b "Hello" -g "family:2"
```

---

### Priority Tags and Escalation Chains

A numeric priority prefix on a tag name (`N:tagname`) groups services into ordered escalation levels. Lower numbers mean higher urgency and dispatch first.

```apache
# Highest urgency -- these run first
1:alerts=slack://tokenA/tokenB/tokenC
1:alerts=discord://webhook_id/webhook_token

# Fallback -- only triggered if the priority-1 group fails entirely
5:alerts=mailto://user:pass@pagerduty.example.com
```

Tags with no numeric prefix default to priority `0` (highest possible urgency), so existing tag definitions are unchanged.

**Escalation mode** (no priority prefix in the filter): Apprise dispatches the lowest-numbered group first. If every service in that group succeeds, it stops -- higher-numbered groups are never triggered. If any service in the group fails, Apprise escalates to the next priority level.

**Exclusive mode** (priority prefix in the filter): Apprise dispatches only services whose tag carries that exact priority number. No escalation takes place.

```bash
# Escalation: priority-1 first; escalate to priority-5 only on failure
apprise -g alerts -b "sound the alarm"

# Exclusive: only the priority-5 entry; priority-1 is untouched
apprise -g 5:alerts -b "sound the alarm"

# Exclusive + per-call retry override: priority-5 only, 3 extra retries
apprise -g 5:alerts:3 -b "sound the alarm"
```

When multiple independent tag chains run simultaneously (e.g. `tag=["ops", "security"]`) their current-priority batches are dispatched concurrently. By default all chains run to completion even if one fails. Setting `abort_on_chain_failure=True` on `AppriseAsset` causes Apprise to stop all remaining escalation rounds as soon as any chain exhausts its priority groups without success.

---

### `optional=`

A new per-service flag marks an endpoint as "nice to have". When `optional=yes` is set, a delivery failure for that service is silently absorbed -- the overall `notify()` call still returns `True` as long as every *required* service succeeded.

```apache
# Attempt delivery to all four screens; ignore any that are off or unreachable
media=kodi://192.168.1.10?optional=yes
media=kodi://192.168.1.11?optional=yes
media=kodi://192.168.1.12?optional=yes
media=kodi://192.168.1.13?optional=yes
```

```yaml
- kodi://192.168.1.10:
    tag: media
    optional: yes
```

```python
apobj.add("kodi://192.168.1.10?optional=yes")
# Returns True even if every screen was unreachable
apobj.notify(body="Dinner is ready", tag="media")
```

Key points:
- The service is **still attempted** on every call -- `optional` only changes the meaning of a failure, not whether delivery is tried.
- Retries still run as configured. The `optional` check fires only after all retry attempts are exhausted.
- A batch that mixes optional and required services returns `False` only if a *required* service fails. Optional failures are never included in the aggregate.

---

## Breaking Changes

### Pushover: `retry=` renamed to `emg_retry=`

Pushover's emergency-priority alert parameter was previously named `retry=` (controlling how often Pushover re-sends the emergency notification, in seconds). That name now conflicts with the new global `retry=` parameter, so it has been renamed to `emg_retry=`.

**Before:**
```
pover://user@token?priority=emergency&retry=60&expire=3600
```

**After:**
```
pover://user@token?priority=emergency&emg_retry=60&expire=3600
```

Existing Pushover emergency URLs and YAML entries that use `retry=` will need to be updated to `emg_retry=`.

---

## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/55](https://github.com/caronc/apprise-docs/pull/55)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing

```bash
# Create a virtual environment
python3 -m venv apprise
cd apprise
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1341-retries-and-priorities

# Test escalation: priority-1 Slack first; priority-5 email only on failure
apprise -g alerts -b "sound the alarm" \
    "1:alerts=slack://tokenA/tokenB/tokenC?retry=2&wait=2" \
    "5:alerts=mailto://user:pass@example.com"

# Test optional: succeeds even if the endpoint is unreachable
apprise -b "hello" "kodi://192.168.1.10?optional=yes"
```
