### PR TITLE
Preserve HTML in generic payload services

### DIFF
--- a/apprise/apprise.py
+++ b/apprise/apprise.py
@@ -578,13 +578,15 @@ class Apprise:
             # was set to None), or we did define a tag and the logic above
             # determined we need to notify the service it's associated with
 
+            notify_format = server.effective_notify_format(body_format)
+
             # First we need to generate a key we will use to determine if we
             # need to build our data out.  Entries without are merged with
             # the body at this stage.
             key = (
-                server.notify_format
+                notify_format
                 if server.title_maxlen > 0
-                else f"_{server.notify_format}"
+                else f"_{notify_format}"
             )
 
             if server.interpret_emojis:
@@ -601,13 +603,13 @@ class Apprise:
                 if conversion_title_map[key] and server.title_maxlen <= 0:
                     conversion_title_map[key] = convert_between(
                         body_format,
-                        server.notify_format,
+                        notify_format,
                         content=conversion_title_map[key],
                     )
 
                 # Our body is always converted no matter what
                 conversion_body_map[key] = convert_between(
-                    body_format, server.notify_format, content=body
+                    body_format, notify_format, content=body
                 )
 
                 if interpret_escapes:

--- a/apprise/plugins/base.py
+++ b/apprise/plugins/base.py
@@ -202,6 +202,11 @@ class NotifyBase(URLBase):
     # Default Notify Format
     notify_format = NotifyFormat.TEXT
 
+    # Supported Notify Formats. When more than one value is provided, the
+    # first remains the default unless a matching input format can be passed
+    # through without conversion.
+    notify_formats = ()
+
     # Default Overflow Mode
     overflow_mode = OverflowMode.UPSTREAM
 
@@ -383,6 +388,7 @@ class NotifyBase(URLBase):
                 )
             )
 
+        self._notify_format_explicit = False
         if "format" in kwargs:
             value = kwargs["format"]
             try:
@@ -398,6 +404,8 @@ class NotifyBase(URLBase):
                 )
                 self.logger.warning(err)
                 raise TypeError(err) from None
+
+            self._notify_format_explicit = True
 
         if "tz" in kwargs:
             value = kwargs["tz"]
@@ -904,6 +912,35 @@ class NotifyBase(URLBase):
                     )
 
         return response
+
+    def effective_notify_format(
+        self, body_format: Optional[NotifyFormat] = None
+    ) -> NotifyFormat:
+        """Return the notification format to use for the provided body.
+
+        Services that declare multiple supported formats can pass through an
+        input format they support unless the URL explicitly requested a
+        specific output format.
+        """
+
+        if self._notify_format_explicit or not self.notify_formats:
+            return self.notify_format
+
+        try:
+            body_format = (
+                body_format
+                if isinstance(body_format, NotifyFormat)
+                else NotifyFormat(body_format.lower())
+            )
+
+        except (AttributeError, ValueError):
+            return self.notify_format
+
+        return (
+            body_format
+            if body_format in self.notify_formats
+            else self.notify_format
+        )
 
     def send(
         self,

--- a/apprise/plugins/custom_form.py
+++ b/apprise/plugins/custom_form.py
@@ -29,7 +29,7 @@ import re
 
 import requests
 
-from ..common import NotifyImageSize, NotifyType
+from ..common import NotifyFormat, NotifyImageSize, NotifyType
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from .base import NotifyBase
@@ -99,6 +99,9 @@ class NotifyForm(NotifyBase):
 
     # Allows the user to specify the NotifyImageSize object
     image_size = NotifyImageSize.XY_128
+
+    # Preserve supported input formats for pass-through payloads
+    notify_formats = (NotifyFormat.TEXT, NotifyFormat.HTML)
 
     # Disable throttle rate for Form requests since they are normally
     # local anyway

--- a/apprise/plugins/custom_json.py
+++ b/apprise/plugins/custom_json.py
@@ -31,7 +31,7 @@ import logging
 import requests
 
 from .. import exception
-from ..common import NotifyImageSize, NotifyType
+from ..common import NotifyFormat, NotifyImageSize, NotifyType
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.sanitize import sanitize_payload
@@ -81,6 +81,9 @@ class NotifyJSON(NotifyBase):
 
     # Allows the user to specify the NotifyImageSize object
     image_size = NotifyImageSize.XY_128
+
+    # Preserve supported input formats for pass-through payloads
+    notify_formats = (NotifyFormat.TEXT, NotifyFormat.HTML)
 
     # Disable throttle rate for JSON requests since they are normally
     # local anyway

--- a/apprise/plugins/custom_xml.py
+++ b/apprise/plugins/custom_xml.py
@@ -31,7 +31,7 @@ import re
 import requests
 
 from .. import exception
-from ..common import NotifyImageSize, NotifyType
+from ..common import NotifyFormat, NotifyImageSize, NotifyType
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.sanitize import sanitize_payload
@@ -80,6 +80,9 @@ class NotifyXML(NotifyBase):
 
     # Allows the user to specify the NotifyImageSize object
     image_size = NotifyImageSize.XY_128
+
+    # Preserve supported input formats for pass-through payloads
+    notify_formats = (NotifyFormat.TEXT, NotifyFormat.HTML)
 
     # Disable throttle rate for JSON requests since they are normally
     # local anyway

--- a/tests/test_plugin_custom_form.py
+++ b/tests/test_plugin_custom_form.py
@@ -33,7 +33,7 @@ from unittest import mock
 from helpers import AppriseURLTester
 import requests
 
-from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise import Apprise, AppriseAttachment, NotifyFormat, NotifyType
 from apprise.plugins.custom_form import NotifyForm
 
 logging.disable(logging.CRITICAL)
@@ -233,6 +233,24 @@ def test_plugin_custom_form_urls():
 
     # Run our general tests
     AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+@mock.patch("requests.request")
+def test_plugin_custom_form_preserves_html_input(mock_request):
+    """NotifyForm() preserves HTML input in pass-through payloads."""
+
+    response = requests.Request()
+    response.status_code = requests.codes.ok
+    mock_request.return_value = response
+
+    body = "A really <strong>bold</strong> message!"
+
+    obj = Apprise()
+    assert obj.add("form://localhost") is True
+    assert obj.notify(body=body, body_format=NotifyFormat.HTML) is True
+
+    payload = mock_request.call_args_list[0][1]["data"]
+    assert payload["message"] == body
 
 
 @mock.patch("requests.request")

--- a/tests/test_plugin_custom_json.py
+++ b/tests/test_plugin_custom_json.py
@@ -35,7 +35,7 @@ from unittest import mock
 from helpers import AppriseURLTester
 import requests
 
-from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise import Apprise, AppriseAttachment, NotifyFormat, NotifyType
 from apprise.plugins.custom_json import NotifyJSON
 
 logging.disable(logging.CRITICAL)
@@ -229,6 +229,24 @@ def test_plugin_custom_json_urls():
 
     # Run our general tests
     AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+@mock.patch("requests.request")
+def test_plugin_custom_json_preserves_html_input(mock_request):
+    """NotifyJSON() preserves HTML input in pass-through payloads."""
+
+    response = requests.Request()
+    response.status_code = requests.codes.ok
+    mock_request.return_value = response
+
+    body = "A really <strong>bold</strong> message!"
+
+    obj = Apprise()
+    assert obj.add("json://localhost") is True
+    assert obj.notify(body=body, body_format=NotifyFormat.HTML) is True
+
+    payload = json.loads(mock_request.call_args_list[0][1]["data"])
+    assert payload["message"] == body
 
 
 @mock.patch("requests.request")

--- a/tests/test_plugin_custom_xml.py
+++ b/tests/test_plugin_custom_xml.py
@@ -34,7 +34,7 @@ from unittest import mock
 from helpers import AppriseURLTester
 import requests
 
-from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise import Apprise, AppriseAttachment, NotifyFormat, NotifyType
 from apprise.plugins.custom_xml import NotifyXML
 
 logging.disable(logging.CRITICAL)
@@ -261,6 +261,24 @@ def test_plugin_custom_xml_urls():
 
     # Run our general tests
     AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+@mock.patch("requests.request")
+def test_plugin_custom_xml_preserves_html_input(mock_request):
+    """NotifyXML() preserves HTML input in pass-through payloads."""
+
+    response = requests.Request()
+    response.status_code = requests.codes.ok
+    mock_request.return_value = response
+
+    body = "A really <strong>bold</strong> message!"
+
+    obj = Apprise()
+    assert obj.add("xml://localhost") is True
+    assert obj.notify(body=body, body_format=NotifyFormat.HTML) is True
+
+    payload = mock_request.call_args_list[0][1]["data"]
+    assert "A really &lt;strong&gt;bold&lt;/strong&gt; message!" in payload
 
 
 @mock.patch("requests.request")


### PR DESCRIPTION
## Summary
- add supported-format selection for services that can pass through multiple body formats
- mark custom JSON/Form/XML payload services as text+HTML pass-through so HTML input is not converted to text unless `?format=` explicitly overrides it
- add regressions for generic JSON/Form/XML HTML payloads

Fixes #1600

## Tests
- `PYTHONPATH=. pytest tests/test_plugin_custom_json.py tests/test_plugin_custom_form.py tests/test_plugin_custom_xml.py`
- `PYTHONPATH=. ruff check apprise/apprise.py apprise/plugins/base.py apprise/plugins/custom_json.py apprise/plugins/custom_form.py apprise/plugins/custom_xml.py tests/test_plugin_custom_json.py tests/test_plugin_custom_form.py tests/test_plugin_custom_xml.py`
- `git diff --check`