### PR TITLE
updated WhatsApp Buisness Graph API to v21

### DIFF
--- a/apprise/plugins/whatsapp.py
+++ b/apprise/plugins/whatsapp.py
@@ -58,8 +58,18 @@ import requests
 
 from ..common import NotifyType
 from ..locale import gettext_lazy as _
-from ..utils.parse import is_phone_no, parse_phone_no, validate_regex
+from ..utils.parse import (
+    is_phone_no,
+    parse_phone_no,
+    validate_regex,
+)
 from .base import NotifyBase
+
+# Matches the numeric-only portion of a WhatsApp Cloud API group ID after any
+# '#' prefix and '@g.us' JID suffix have been stripped.  E.164 phone numbers
+# are capped at 15 digits; group IDs are 18-20 digits, so requiring 16+ gives
+# an unambiguous separation with no overlap.
+IS_GROUP_ID = re.compile(r"^[0-9]{16,}$")
 
 
 class NotifyWhatsApp(NotifyBase):
@@ -138,6 +148,18 @@ class NotifyWhatsApp(NotifyBase):
                 "type": "string",
                 "prefix": "+",
                 "regex": (r"^[0-9\s)(+-]+$", "i"),
+                "map_to": "targets",
+            },
+            # WhatsApp group IDs are purely numeric and 16+ digits long —
+            # safely above the 15-digit E.164 phone number maximum.
+            # The '#' prefix in the Apprise URL is recommended for clarity;
+            # bare 16+ digit strings are also accepted.
+            # The '@g.us' API JID suffix is added automatically at send time.
+            "target_group": {
+                "name": _("Target Group ID"),
+                "type": "string",
+                "prefix": "#",
+                "regex": (r"^[0-9]{16,}$", "i"),
                 "map_to": "targets",
             },
             "targets": {
@@ -250,20 +272,47 @@ class NotifyWhatsApp(NotifyBase):
             #
             self.template = None
 
-        # Parse our targets
+        # Parse our targets (phone numbers and/or group IDs).
+        #
+        # parse_phone_no does the heavy lifting: it handles formatted phone
+        # strings ("+1 (555) 987-6543", dashes, spaces, etc.) and, with the
+        # default store_unparseable=True, passes through anything it cannot
+        # identify as a phone so we can inspect it below.
+        # A '#' prefix on a group ID is silently stripped by the phone regex
+        # (the digits still match); a '@g.us' JID suffix causes the whole
+        # token to be kept as-is (the '@' breaks the phone pattern).
+        #
+        # For each token after parse_phone_no:
+        #   is_phone_no() succeeds -> valid phone, stored as E.164 '+XXX'
+        #   is_phone_no() fails    -> strip '@g.us', run IS_GROUP_ID:
+        #                            16+ pure digits -> group ('#digits')
+        #                            anything else   -> warn and drop
         self.targets = []
 
         for target in parse_phone_no(targets):
-            # Validate targets and drop bad ones:
+            # Validate as a phone number first
             result = is_phone_no(target)
-            if not result:
-                self.logger.warning(
-                    f"Dropped invalid phone # ({target}) specified.",
-                )
+            if result:
+                # Valid phone number; store in E.164 format
+                self.targets.append("+{}".format(result["full"]))
                 continue
 
-            # store valid phone number
-            self.targets.append("+{}".format(result["full"]))
+            # Not a valid phone — check whether it is a group ID.
+            # Strip both the '#' prefix (retained when parse_phone_no uses
+            # its unparseable-store path rather than the phone regex) and the
+            # '@g.us' JID suffix (the native Meta API group ID format).
+            gid = (
+                re.sub(r"@g\.us$", "", target, flags=re.I).strip().lstrip("#")
+            )
+            if IS_GROUP_ID.match(gid):
+                # Store with '#' prefix; '@g.us' is re-added at send time
+                self.targets.append(f"#{gid}")
+                continue
+
+            # Genuinely invalid — warn and drop
+            self.logger.warning(
+                f"Dropped invalid WhatsApp target ({target}) specified.",
+            )
 
         self.template_mapping = {}
         if template_mapping:
@@ -349,7 +398,7 @@ class NotifyWhatsApp(NotifyBase):
 
         payload = {
             "messaging_product": "whatsapp",
-            # The To gets populated in the loop below
+            # 'to' and 'recipient_type' are set per-target in the loop below
             "to": None,
         }
 
@@ -359,6 +408,7 @@ class NotifyWhatsApp(NotifyBase):
             #
             payload.update(
                 {
+                    # recipient_type is overridden per-target below
                     "recipient_type": "individual",
                     "type": "text",
                     "text": {"body": body},
@@ -413,8 +463,16 @@ class NotifyWhatsApp(NotifyBase):
             # Get our target to notify
             target = targets.pop(0)
 
-            # Prepare our user
-            payload["to"] = target
+            # Group targets are stored with a '#' prefix; phone numbers
+            # are stored in E.164 format ('+' prefix).
+            if target.startswith("#"):
+                # Reconstruct the full Meta API group ID (digits + @g.us)
+                payload["to"] = "{}@g.us".format(target[1:])
+                payload["recipient_type"] = "group"
+            else:
+                # Individual phone number
+                payload["to"] = target
+                payload["recipient_type"] = "individual"
 
             # Some Debug Logging
             self.logger.debug(

--- a/apprise/plugins/whatsapp.py
+++ b/apprise/plugins/whatsapp.py
@@ -28,17 +28,28 @@
 # API Source:
 #   https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages
 #
-# 1. Register a developer account with Meta:
-#  https://developers.facebook.com/docs/whatsapp/cloud-api/get-started
-# 2. Enable 2 Factor Authentication (2FA) with your account (if not done
-#  already)
-# 3. Create a App using WhatsApp Product.  There are 2 to create an app from
-#   Do NOT chose the WhatsApp Webhook one (choose the other)
+# The setup is split across two Meta portals:
+#  - https://business.facebook.com  (Business Manager — System Users & tokens)
+#  - https://developers.facebook.com (Developer Dashboard — App & Phone ID)
 #
-#  When you click on the API Setup section of your new app you need to record
-#  both the access token and the From Phone Number ID.  Note that this not the
-#  from phone number itself, but it's ID.  It's displayed below and contains
-#  way more numbers then your typical phone number
+# 1. Create a Meta Business Manager account at https://business.facebook.com
+#    (or use an existing one).  WhatsApp Business Accounts (WABAs) and System
+#    Users live here.
+# 2. Create a Meta Developer account at https://developers.facebook.com and
+#    create a new App.  Add WhatsApp as a product.  If prompted, select the
+#    "Business" app type and choose "Connect to Customers (WhatsApp)" as the
+#    use case (you may need to click "Customise Use Case" on the home page).
+# 3. In Business Manager, go to Settings > Users > System Users, create a
+#    System User (Admin or Employee role), click "Add Assets", assign your
+#    WhatsApp app, and grant the whatsapp_business_messaging permission.
+#    Then click "Generate Token" and copy it — this is your permanent token.
+# 4. Switch back to the Developer Dashboard, open your app, then go to
+#    WhatsApp > API Setup (or Getting Started) to find your From Phone Number
+#    ID.  This is NOT your actual phone number; it is a separate numeric ID
+#    (roughly 14 digits) assigned by Meta to the sender number.
+# 5. During sandbox testing, verify any recipient phone number through Meta's
+#    interface.  For production, your business must be verified and placed on
+#    the appropriate messaging tier.
 
 from json import dumps, loads
 import re
@@ -69,8 +80,9 @@ class NotifyWhatsApp(NotifyBase):
     # 60/300 = 0.2
     request_rate_per_sec = 0.20
 
-    # Facebook Graph version
-    fb_graph_version = "v17.0"
+    # Facebook Graph version; bump this when Meta deprecates the current one.
+    # Release schedule: https://developers.facebook.com/docs/graph-api/changelog
+    fb_graph_version = "v21.0"
 
     # A URL that takes you to the setup/help of the specific protocol
     setup_url = "https://appriseit.com/services/whatsapp/"

--- a/tests/test_plugin_whatsapp.py
+++ b/tests/test_plugin_whatsapp.py
@@ -36,7 +36,7 @@ import pytest
 import requests
 
 from apprise import Apprise, NotifyType
-from apprise.plugins.whatsapp import NotifyWhatsApp
+from apprise.plugins.whatsapp import IS_GROUP_ID, NotifyWhatsApp
 
 logging.disable(logging.CRITICAL)
 
@@ -224,6 +224,41 @@ apprise_url_tests = (
             "test_requests_exceptions": True,
         },
     ),
+    # Group target tests
+    (
+        # Group ID via '#' prefix
+        "whatsapp://{}@12345/%23120363043968066561".format("e" * 32),
+        {
+            "instance": NotifyWhatsApp,
+            "privacy_url": "whatsapp://e...e@1...5/%23120363043968066561/",
+        },
+    ),
+    (
+        # Mix of phone number and group ID
+        "whatsapp://{}@12345/{}/%23120363043968066561".format(
+            "e" * 32, "4" * 11
+        ),
+        {
+            "instance": NotifyWhatsApp,
+        },
+    ),
+    (
+        # Group target with HTTP 500
+        "whatsapp://{}@12345/%23120363043968066561".format("e" * 32),
+        {
+            "instance": NotifyWhatsApp,
+            "response": False,
+            "requests_response_code": requests.codes.internal_server_error,
+        },
+    ),
+    (
+        # Group target with request exception
+        "whatsapp://{}@12345/%23120363043968066561".format("e" * 32),
+        {
+            "instance": NotifyWhatsApp,
+            "test_requests_exceptions": True,
+        },
+    ),
 )
 
 
@@ -268,9 +303,9 @@ def test_plugin_whatsapp_auth(mock_post):
     first_call = mock_post.call_args_list[0]
 
     # URL and message parameters are the same for both calls
-    assert (
-        first_call[0][0]
-        == f"https://graph.facebook.com/v17.0/{from_phone_id}/messages"
+    assert first_call[0][0] == (
+        "https://graph.facebook.com/"
+        f"{NotifyWhatsApp.fb_graph_version}/{from_phone_id}/messages"
     )
     response = loads(first_call[1]["data"])
     assert response["text"]["body"] == message_contents
@@ -357,3 +392,188 @@ def test_plugin_whatsapp_template_notify_type_value(mock_post):
     # Ensure values are injected, not literal strings
     assert params[0]["text"] == NotifyType.INFO.value
     assert params[1]["text"] == "test"
+
+
+@mock.patch("requests.post")
+def test_plugin_whatsapp_groups(mock_post):
+    """NotifyWhatsApp() group target support."""
+
+    def _mk_resp(code=requests.codes.ok):
+        r = mock.Mock()
+        r.content = ""
+        r.status_code = code
+        return r
+
+    mock_post.return_value = _mk_resp()
+
+    token = "e" * 32
+    from_phone_id = "123456787654321"
+    # A realistic-looking numeric group ID
+    group_id = "120363043968066561"
+
+    # IS_GROUP_ID only matches the numeric portion (no prefix/suffix)
+    assert IS_GROUP_ID.match(group_id)
+    assert not IS_GROUP_ID.match(f"#{group_id}")
+    assert not IS_GROUP_ID.match(f"{group_id}@g.us")
+    assert not IS_GROUP_ID.match("abc123")
+
+    # __init__ target classification
+
+    # '#' prefix → group
+    obj = NotifyWhatsApp(
+        token=token,
+        from_phone_id=from_phone_id,
+        targets=[f"#{group_id}"],
+    )
+    assert obj.targets == [f"#{group_id}"]
+
+    # '@g.us' suffix (native API format) → normalised to '#' prefix
+    obj = NotifyWhatsApp(
+        token=token,
+        from_phone_id=from_phone_id,
+        targets=[f"{group_id}@g.us"],
+    )
+    assert obj.targets == [f"#{group_id}"]
+
+    # '#' prefix + '@g.us' suffix (both present) → normalised
+    obj = NotifyWhatsApp(
+        token=token,
+        from_phone_id=from_phone_id,
+        targets=[f"#{group_id}@g.us"],
+    )
+    assert obj.targets == [f"#{group_id}"]
+
+    # Invalid group ID (non-numeric) is dropped with a warning
+    obj = NotifyWhatsApp(
+        token=token,
+        from_phone_id=from_phone_id,
+        targets=["#badgroupid", f"#{group_id}"],
+    )
+    assert obj.targets == [f"#{group_id}"]
+
+    # Mixed: phone number + group ID
+    obj = NotifyWhatsApp(
+        token=token,
+        from_phone_id=from_phone_id,
+        targets=["+14155552671", f"#{group_id}"],
+    )
+    assert len(obj.targets) == 2
+    assert "+14155552671" in obj.targets
+    assert f"#{group_id}" in obj.targets
+
+    # send() payload verification
+
+    mock_post.reset_mock()
+    obj = NotifyWhatsApp(
+        token=token,
+        from_phone_id=from_phone_id,
+        targets=[f"#{group_id}"],
+    )
+    assert obj.send(body="hello group") is True
+    assert mock_post.call_count == 1
+
+    # Group payload must carry recipient_type='group' and 'to'=id@g.us
+    sent = loads(mock_post.call_args_list[0][1]["data"])
+    assert sent["recipient_type"] == "group"
+    assert sent["to"] == f"{group_id}@g.us"
+
+    # send() for individual phone preserves recipient_type='individual'
+    mock_post.reset_mock()
+    obj = NotifyWhatsApp(
+        token=token,
+        from_phone_id=from_phone_id,
+        targets=["+14155552671"],
+    )
+    assert obj.send(body="hello individual") is True
+    sent = loads(mock_post.call_args_list[0][1]["data"])
+    assert sent["recipient_type"] == "individual"
+    assert sent["to"] == "+14155552671"
+
+    # mixed send: one phone + one group makes two POST calls
+    mock_post.reset_mock()
+    obj = NotifyWhatsApp(
+        token=token,
+        from_phone_id=from_phone_id,
+        targets=["+14155552671", f"#{group_id}"],
+    )
+    assert obj.send(body="mixed") is True
+    assert mock_post.call_count == 2
+    payloads = [loads(c[1]["data"]) for c in mock_post.call_args_list]
+    types = {p["recipient_type"] for p in payloads}
+    assert types == {"individual", "group"}
+
+    # HTTP error on group target returns False
+    mock_post.return_value = _mk_resp(requests.codes.internal_server_error)
+    obj = NotifyWhatsApp(
+        token=token,
+        from_phone_id=from_phone_id,
+        targets=[f"#{group_id}"],
+    )
+    assert obj.send(body="should fail") is False
+
+    # partial failure: phone succeeds, group errors → overall False
+    mock_post.side_effect = [
+        _mk_resp(requests.codes.ok),
+        _mk_resp(requests.codes.internal_server_error),
+    ]
+    obj = NotifyWhatsApp(
+        token=token,
+        from_phone_id=from_phone_id,
+        targets=["+14155552671", f"#{group_id}"],
+    )
+    assert obj.send(body="partial") is False
+
+    # URL round-trip: group ID survives url() -> parse_url()
+    mock_post.side_effect = None
+    mock_post.return_value = _mk_resp()
+
+    obj = NotifyWhatsApp(
+        token=token,
+        from_phone_id=from_phone_id,
+        targets=[f"#{group_id}"],
+    )
+    rebuilt = NotifyWhatsApp(**NotifyWhatsApp.parse_url(obj.url()))
+    assert rebuilt.targets == obj.targets
+    assert rebuilt.url_identifier == obj.url_identifier
+
+    # Round-trip with mixed targets
+    obj = NotifyWhatsApp(
+        token=token,
+        from_phone_id=from_phone_id,
+        targets=["+14155552671", f"#{group_id}"],
+    )
+    rebuilt = NotifyWhatsApp(**NotifyWhatsApp.parse_url(obj.url()))
+    assert sorted(rebuilt.targets) == sorted(obj.targets)
+
+    # targets as a plain string (comma-separated, not a list)
+    obj = NotifyWhatsApp(
+        token=token,
+        from_phone_id=from_phone_id,
+        targets=f"#{group_id}",
+    )
+    assert obj.targets == [f"#{group_id}"]
+
+    # whitespace-only list entry is silently skipped
+    obj = NotifyWhatsApp(
+        token=token,
+        from_phone_id=from_phone_id,
+        targets=["   ", f"#{group_id}"],
+    )
+    assert obj.targets == [f"#{group_id}"]
+
+    # ?to= query parameter accepts group IDs
+    url = f"whatsapp://_?token={token}&from={from_phone_id}&to=%23{group_id}"
+    obj = Apprise.instantiate(url)
+    assert isinstance(obj, NotifyWhatsApp)
+    assert f"#{group_id}" in obj.targets
+
+    # privacy_url masks group targets correctly
+    obj = NotifyWhatsApp(
+        token=token,
+        from_phone_id=from_phone_id,
+        targets=[f"#{group_id}"],
+    )
+    priv = obj.url(privacy=True)
+    # The token should be masked; the group ID should still be present
+    assert token not in priv
+    assert group_id in priv


### PR DESCRIPTION
## Description
**Related issue (if applicable):** [apprise-docs/54](https://github.com/caronc/apprise-docs/issues/54) and #915 

The WhatsApp Cloud API account setup documentation and the plugin's Facebook Graph API version were both out of date.

Meta reorganised their portal: System Users and permanent token generation now live in Meta Business Manager (business.facebook.com), not the Developer Dashboard (developers.facebook.com). The old documentation pointed users entirely to the Developer Dashboard for these steps, which no longer works. Additionally, the Graph API version hardcoded in the plugin (v17.0, released May 2023) reached its deprecation window in May 2025 and is no longer valid.

With the newer API version, we can now support WhatsApp Groups; this is added as well into this PR


<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/#56](https://github.com/caronc/apprise-docs/issues/56)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@whatsapp-buisness-graph-v-update

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "whatsapp://{token}@{from_phone_id}/{your_phone_number}"
```
