### PR TITLE
Slack Template/Payload support

### DIFF
--- a/apprise/plugins/slack.py
+++ b/apprise/plugins/slack.py
@@ -73,14 +73,17 @@
 
 import contextlib
 from json import dumps, loads
+from json.decoder import JSONDecodeError
 import re
 from time import time
 
 import requests
 
+from ..apprise_attachment import AppriseAttachment
 from ..common import NotifyFormat, NotifyImageSize, NotifyType
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_email, parse_bool, parse_list, validate_regex
+from ..utils.templates import TemplateType, apply_template
 from .base import NotifyBase
 
 # Extend HTTP Error Messages
@@ -158,6 +161,10 @@ class NotifySlack(NotifyBase):
 
     # The maximum allowable characters allowed in the body per message
     body_maxlen = 35000
+
+    # There is no reason we should exceed 35KB when reading in a JSON file.
+    # If it is more than this, then it is not accepted
+    max_slack_template_size = 35000
 
     # Default Notification Format
     notify_format = NotifyFormat.MARKDOWN
@@ -297,8 +304,21 @@ class NotifySlack(NotifyBase):
             "to": {
                 "alias_of": "targets",
             },
+            "template": {
+                "name": _("Template Path"),
+                "type": "string",
+                "private": True,
+            },
         },
     )
+
+    # Define our token control
+    template_kwargs = {
+        "tokens": {
+            "name": _("Template Tokens"),
+            "prefix": ":",
+        },
+    }
 
     # Formatting requirements are defined here:
     # https://api.slack.com/docs/message-formatting
@@ -352,6 +372,8 @@ class NotifySlack(NotifyBase):
         include_timestamp=None,
         use_blocks=None,
         mode=None,
+        template=None,
+        tokens=None,
         **kwargs,
     ):
         """Initialize Slack Object."""
@@ -468,7 +490,120 @@ class NotifySlack(NotifyBase):
             else include_timestamp
         )
 
+        # Our template object is just an AppriseAttachment object
+        self.template = AppriseAttachment(asset=self.asset)
+        if template:
+            # Add our definition to our template
+            self.template.add(template)
+            # Enforce maximum file size
+            self.template[0].max_file_size = self.max_slack_template_size
+
+        # Template functionality
+        self.tokens = {}
+        if isinstance(tokens, dict):
+            self.tokens.update(tokens)
+
+        elif tokens:
+            msg = (
+                "The specified Slack Template Tokens "
+                f"({tokens}) are not identified as a dictionary."
+            )
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # A template always implies Block Kit mode; there is no meaningful
+        # use for templates outside of blocks mode.
+        if self.template:
+            self.use_blocks = True
+
         return
+
+    def gen_payload(
+        self, body, title="", notify_type=NotifyType.INFO, **kwargs
+    ):
+        """Generate our payload from an external Block Kit JSON template.
+
+        Returns the validated attachment content dict (which must contain
+        a non-empty 'blocks' list with typed entries) to be placed into
+        the Slack attachments array.  Returns False on any failure.
+        """
+        # Acquire the first template attachment
+        template = self.template[0]
+        if not template:
+            # We could not access the attachment
+            self.logger.error(
+                "Could not access Slack template"
+                f" {template.url(privacy=True)}."
+            )
+            return False
+
+        # Acquire our to-be footer icon if configured to do so
+        image_url = (
+            None if not self.include_image else self.image_url(notify_type)
+        )
+
+        # Take a copy of our token dictionary
+        tokens = self.tokens.copy()
+
+        # Apply some defaults template values
+        tokens["app_body"] = body
+        tokens["app_title"] = title
+        tokens["app_type"] = notify_type.value
+        tokens["app_id"] = self.app_id
+        tokens["app_desc"] = self.app_desc
+        tokens["app_color"] = self.color(notify_type)
+        tokens["app_image_url"] = image_url
+        tokens["app_url"] = self.app_url
+
+        # Templates are always Block Kit JSON; enforce JSON escaping
+        tokens["app_mode"] = TemplateType.JSON
+
+        try:
+            with open(template.path) as fp:
+                content = apply_template(fp.read(), **tokens)
+
+        except OSError:
+            self.logger.error(
+                "Slack template"
+                f" {template.url(privacy=True)} could not be read."
+            )
+            return False
+
+        # Parse and validate as JSON
+        try:
+            content = loads(content)
+
+        except JSONDecodeError as e:
+            self.logger.error(
+                "Slack template"
+                f" {template.url(privacy=True)} contains invalid JSON."
+            )
+            self.logger.debug(f"JSONDecodeError: {e}")
+            return False
+
+        # 'blocks' must be a non-empty list (Block Kit requirement)
+        if (
+            not isinstance(content.get("blocks"), list)
+            or not content["blocks"]
+        ):
+            self.logger.error(
+                "Slack template"
+                f" {template.url(privacy=True)} must contain"
+                " a non-empty 'blocks' list."
+            )
+            return False
+
+        # Every block must carry a 'type' string (Block Kit requirement)
+        if not all(isinstance(b.get("type"), str) for b in content["blocks"]):
+            self.logger.error(
+                "Slack template"
+                f" {template.url(privacy=True)} contains"
+                " a block missing a 'type' string."
+            )
+            return False
+
+        # Return the validated attachment content dict
+        return content
 
     def send(
         self,
@@ -487,70 +622,91 @@ class NotifySlack(NotifyBase):
         # Prepare JSON Object (applicable to both WEBHOOK and BOT mode)
         #
         if self.use_blocks:
-            # Our slack format
-            slack_format = (
-                "mrkdwn"
-                if self.notify_format == NotifyFormat.MARKDOWN
-                else "plain_text"
-            )
-
-            payload = {
-                "username": self.user if self.user else self.app_id,
-                "attachments": [
-                    {
-                        "blocks": [
-                            {
-                                "type": "section",
-                                "text": {"type": slack_format, "text": body},
-                            }
-                        ],
-                        "color": self.color(notify_type),
-                    }
-                ],
-            }
-
-            # Slack only accepts non-empty header sections
-            if title:
-                payload["attachments"][0]["blocks"].insert(
-                    0,
-                    {
-                        "type": "header",
-                        "text": {
-                            "type": "plain_text",
-                            "text": title,
-                            "emoji": True,
-                        },
-                    },
+            if self.template:
+                # Template mode: generate blocks attachment from template
+                template_content = self.gen_payload(
+                    body, title, notify_type=notify_type, **kwargs
                 )
+                if template_content is False:
+                    # Template loading or parsing failed; abort early
+                    return False
 
-            # Include the footer only if specified to do so
-            if self.include_footer:
-                # Acquire our to-be footer icon if configured to do so
-                image_url = (
-                    None
-                    if not self.include_image
-                    else self.image_url(notify_type)
-                )
-
-                # Prepare our footer based on the block structure
-                footer = {
-                    "type": "context",
-                    "elements": [{"type": slack_format, "text": self.app_id}],
+                # Wrap the template attachment content in a full payload
+                payload = {
+                    "username": self.user if self.user else self.app_id,
+                    "attachments": [template_content],
                 }
 
-                if image_url:
-                    payload["icon_url"] = image_url
+            else:
+                # Our slack format
+                slack_format = (
+                    "mrkdwn"
+                    if self.notify_format == NotifyFormat.MARKDOWN
+                    else "plain_text"
+                )
 
-                    footer["elements"].insert(
+                payload = {
+                    "username": self.user if self.user else self.app_id,
+                    "attachments": [
+                        {
+                            "blocks": [
+                                {
+                                    "type": "section",
+                                    "text": {
+                                        "type": slack_format,
+                                        "text": body,
+                                    },
+                                }
+                            ],
+                            "color": self.color(notify_type),
+                        }
+                    ],
+                }
+
+                # Slack only accepts non-empty header sections
+                if title:
+                    payload["attachments"][0]["blocks"].insert(
                         0,
                         {
-                            "type": "image",
-                            "image_url": image_url,
-                            "alt_text": notify_type,
+                            "type": "header",
+                            "text": {
+                                "type": "plain_text",
+                                "text": title,
+                                "emoji": True,
+                            },
                         },
                     )
 
-                payload["attachments"][0]["blocks"].append(footer)
+                # Include the footer only if specified to do so
+                if self.include_footer:
+                    # Acquire our to-be footer icon if configured to do so
+                    image_url = (
+                        None
+                        if not self.include_image
+                        else self.image_url(notify_type)
+                    )
+
+                    # Prepare our footer based on the block structure
+                    footer = {
+                        "type": "context",
+                        "elements": [
+                            {"type": slack_format, "text": self.app_id}
+                        ],
+                    }
+
+                    if image_url:
+                        payload["icon_url"] = image_url
+
+                        footer["elements"].insert(
+                            0,
+                            {
+                                "type": "image",
+                                "image_url": image_url,
+                                "alt_text": notify_type,
+                            },
+                        )
+
+                    payload["attachments"][0]["blocks"].append(footer)
 
         else:
             #
@@ -1183,8 +1339,16 @@ class NotifySlack(NotifyBase):
             "mode": self.mode,
         }
 
+        if self.template:
+            params["template"] = NotifySlack.quote(
+                self.template[0].url(), safe=""
+            )
+
         # Extend our parameters
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
+
+        # Store any template token entries if specified
+        params.update({f":{k}": v for k, v in self.tokens.items()})
 
         # Determine if there is a botname present
         botname = ""
@@ -1320,6 +1484,15 @@ class NotifySlack(NotifyBase):
         # Get Mode
         if "mode" in results["qsd"] and len(results["qsd"]["mode"]):
             results["mode"] = NotifySlack.unquote(results["qsd"]["mode"])
+
+        # Template Handling
+        if "template" in results["qsd"] and results["qsd"]["template"]:
+            results["template"] = NotifySlack.unquote(
+                results["qsd"]["template"]
+            )
+
+        # Store our tokens
+        results["tokens"] = results["qsd:"]
 
         return results
 

--- a/tests/test_plugin_slack.py
+++ b/tests/test_plugin_slack.py
@@ -1361,3 +1361,309 @@ def test_plugin_slack_attach_memory(mock_request):
 
     assert obj.notify(body="Test", attach=mem) is True
     assert mock_request.call_count >= 1
+
+
+@mock.patch("requests.request")
+def test_plugin_slack_template_blocks(mock_request, tmpdir):
+    """NotifySlack() - blocks mode with JSON template."""
+    # Valid webhook mock response
+    mock_request.return_value = mock.Mock(
+        **{
+            "content": b"ok",
+            "status_code": requests.codes.ok,
+        }
+    )
+
+    # Write a minimal Block Kit JSON template to disk
+    template = tmpdir.join("blocks.json")
+    template.write(
+        cleandoc("""
+        {
+          "blocks": [
+            {
+              "type": "header",
+              "text": {
+                "type": "plain_text",
+                "text": "{{app_title}}"
+              }
+            },
+            {
+              "type": "section",
+              "text": {
+                "type": "mrkdwn",
+                "text": "{{app_body}}"
+              }
+            }
+          ],
+          "color": "{{app_color}}"
+        }
+        """)
+    )
+
+    # Instantiate via URL with blocks=yes and template path
+    obj = Apprise.instantiate(
+        "slack://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/"
+        "?blocks=yes&template={}&:mykey=myval".format(str(template))
+    )
+    assert isinstance(obj, NotifySlack)
+
+    # Verify tokens and template were parsed correctly
+    assert "mykey" in obj.tokens
+    assert obj.tokens["mykey"] == "myval"
+    assert obj.template
+
+    # Notification should succeed
+    assert (
+        obj.notify(body="hello", title="world", notify_type=NotifyType.INFO)
+        is True
+    )
+    assert mock_request.called is True
+
+    # Inspect the posted payload
+    posted = loads(mock_request.call_args_list[0][1]["data"])
+    assert "attachments" in posted
+    assert "blocks" in posted["attachments"][0]
+    # Header and section blocks should be present
+    blocks = posted["attachments"][0]["blocks"]
+    assert any(b.get("type") == "header" for b in blocks)
+    assert any(b.get("type") == "section" for b in blocks)
+    # Title and body substituted correctly
+    header = next(b for b in blocks if b.get("type") == "header")
+    assert header["text"]["text"] == "world"
+    section = next(b for b in blocks if b.get("type") == "section")
+    assert section["text"]["text"] == "hello"
+
+
+@mock.patch("requests.request")
+def test_plugin_slack_template_blocks_implied(mock_request, tmpdir):
+    """NotifySlack() - template= alone implies blocks=yes."""
+    # Valid webhook mock response
+    mock_request.return_value = mock.Mock(
+        **{
+            "content": b"ok",
+            "status_code": requests.codes.ok,
+        }
+    )
+
+    template = tmpdir.join("implied.json")
+    template.write(
+        cleandoc("""
+        {
+          "blocks": [
+            {
+              "type": "section",
+              "text": {"type": "mrkdwn", "text": "{{app_body}}"}
+            }
+          ]
+        }
+        """)
+    )
+
+    # No blocks=yes in the URL -- should still use the template
+    obj = Apprise.instantiate(
+        "slack://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/"
+        "?template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifySlack)
+    # use_blocks must have been forced on by the template
+    assert obj.use_blocks is True
+    assert (
+        obj.notify(body="implied", title="t", notify_type=NotifyType.INFO)
+        is True
+    )
+    assert mock_request.called is True
+    posted = loads(mock_request.call_args_list[0][1]["data"])
+    blocks = posted["attachments"][0]["blocks"]
+    section = next(b for b in blocks if b.get("type") == "section")
+    assert section["text"]["text"] == "implied"
+
+
+@mock.patch("requests.request")
+def test_plugin_slack_template_invalid_json(mock_request, tmpdir):
+    """NotifySlack() - blocks template with invalid JSON fails gracefully."""
+    mock_request.return_value = mock.Mock(
+        **{"content": b"ok", "status_code": requests.codes.ok}
+    )
+
+    template = tmpdir.join("bad.json")
+    template.write("{ not valid json }")
+
+    obj = Apprise.instantiate(
+        "slack://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/"
+        "?blocks=yes&template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifySlack)
+
+    # Notification must fail due to bad JSON
+    assert (
+        obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+    )
+    # No HTTP call should have been made
+    assert mock_request.called is False
+
+
+@mock.patch("requests.request")
+def test_plugin_slack_template_blocks_not_list(mock_request, tmpdir):
+    """NotifySlack() - blocks template where 'blocks' is not a list fails."""
+    mock_request.return_value = mock.Mock(
+        **{"content": b"ok", "status_code": requests.codes.ok}
+    )
+
+    # 'blocks' present but not a list
+    template = tmpdir.join("bad_blocks.json")
+    template.write('{"blocks": "not-a-list"}')
+
+    obj = Apprise.instantiate(
+        "slack://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/"
+        "?blocks=yes&template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifySlack)
+    assert (
+        obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+    )
+    assert mock_request.called is False
+
+    # Empty list is also rejected
+    template.write('{"blocks": []}')
+    obj2 = Apprise.instantiate(
+        "slack://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/"
+        "?blocks=yes&template={}".format(str(template))
+    )
+    assert isinstance(obj2, NotifySlack)
+    assert (
+        obj2.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+    )
+    assert mock_request.called is False
+
+
+@mock.patch("requests.request")
+def test_plugin_slack_template_block_missing_type(mock_request, tmpdir):
+    """NotifySlack() - block missing 'type' string is rejected."""
+    mock_request.return_value = mock.Mock(
+        **{"content": b"ok", "status_code": requests.codes.ok}
+    )
+
+    # Block present but has no 'type' key
+    template = tmpdir.join("no_type.json")
+    template.write('{"blocks": [{"text": {"type": "mrkdwn", "text": "hi"}}]}')
+
+    obj = Apprise.instantiate(
+        "slack://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/"
+        "?blocks=yes&template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifySlack)
+    assert (
+        obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+    )
+    assert mock_request.called is False
+
+
+@mock.patch("requests.request")
+def test_plugin_slack_template_load_error(mock_request, tmpdir):
+    """NotifySlack() - template OSError during read fails gracefully."""
+    mock_request.return_value = mock.Mock(
+        **{"content": b"ok", "status_code": requests.codes.ok}
+    )
+
+    # Write an empty file so the attachment resolves but open() can be mocked
+    template = tmpdir.join("empty.json")
+    template.write("")
+
+    obj = Apprise.instantiate(
+        "slack://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/"
+        "?blocks=yes&template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifySlack)
+
+    with mock.patch("builtins.open", side_effect=OSError):
+        # Notification must fail because the file cannot be read
+        assert (
+            obj.notify(body="x", title="y", notify_type=NotifyType.INFO)
+            is False
+        )
+    assert mock_request.called is False
+
+
+def test_plugin_slack_template_bad_tokens():
+    """NotifySlack() - invalid tokens type raises TypeError."""
+    with pytest.raises(TypeError):
+        NotifySlack(
+            token_a="T1JJ3T3L2",
+            token_b="A1BRTD4JD",
+            token_c="TIiajkdnlazkcOXrIdevi7FQ",
+            tokens="not-a-dict",
+        )
+
+
+@mock.patch("requests.request")
+def test_plugin_slack_template_url_roundtrip(mock_request, tmpdir):
+    """NotifySlack() - template + tokens survive url()/parse_url()
+    round-trip."""
+    mock_request.return_value = mock.Mock(
+        **{"content": b"ok", "status_code": requests.codes.ok}
+    )
+
+    template = tmpdir.join("rt.json")
+    template.write(
+        cleandoc("""
+        {
+          "blocks": [
+            {
+              "type": "section",
+              "text": {"type": "mrkdwn", "text": "{{app_body}}"}
+            }
+          ]
+        }
+        """)
+    )
+
+    # Build an instance with template and tokens
+    obj1 = NotifySlack(
+        token_a="T1JJ3T3L2",
+        token_b="A1BRTD4JD",
+        token_c="TIiajkdnlazkcOXrIdevi7FQ",
+        use_blocks=True,
+        template=str(template),
+        tokens={"key1": "val1", "key2": "val2"},
+    )
+
+    # Round-trip through url() -> parse_url()
+    url = obj1.url()
+    result = NotifySlack.parse_url(url)
+    assert result is not None
+
+    obj2 = NotifySlack(**result)
+    assert isinstance(obj2, NotifySlack)
+
+    # Connection identity must be preserved
+    assert obj1.url_identifier == obj2.url_identifier
+
+    # Tokens must survive the round-trip
+    assert obj2.tokens.get("key1") == "val1"
+    assert obj2.tokens.get("key2") == "val2"
+
+    # Template must be present after round-trip
+    assert obj2.template
+
+
+@mock.patch("requests.request")
+def test_plugin_slack_template_inaccessible(mock_request, tmpdir):
+    """NotifySlack() - template attachment that cannot be accessed fails."""
+    mock_request.return_value = mock.Mock(
+        **{"content": b"ok", "status_code": requests.codes.ok}
+    )
+
+    # Point to a template file that does not exist
+    missing = str(tmpdir.join("missing.json"))
+
+    obj = Apprise.instantiate(
+        "slack://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/"
+        "?blocks=yes&template={}".format(missing)
+    )
+    assert isinstance(obj, NotifySlack)
+
+    # Template attachment resolves to falsy because the file is missing
+    assert (
+        obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+    )
+    assert mock_request.called is False


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #641

Add template support to the Slack plugin, following the identical pattern already used by MSTeams and Workflows. Users can now point `?template=` at a local file and have `{{app_body}}`, `{{app_title}}`, `{{app_color}}`, `{{app_type}}`, `{{app_id}}`, `{{app_desc}}`, `{{app_image_url}}`, and `{{app_url}}` substituted at send time. Custom tokens are injected via the `:key=value` URL prefix convention.

## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/57](https://github.com/caronc/apprise-docs/pull/57)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@641-slack-plugin-templates

# Block Kit template test -- create /tmp/slack-blocks.json:
# {
#   "blocks": [
#     {"type":"header","text":{"type":"plain_text","text":"{{app_title}}"}},
#     {"type":"section","text":{"type":"mrkdwn","text":"{{app_body}}"}}
#   ],
#   "color": "{{app_color}}"
# }
apprise -vv -t "Alert" -b "Disk at 95%" \
    "slack://T.../A.../C.../?blocks=yes&template=/tmp/slack-blocks.json"

# Custom token injection:
apprise -vv -t "Deploy" -b "v2.3.1" \
    "slack://xoxb-.../#ops/?template=/tmp/tmpl.json&:env=prod&:team=sre"

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "slack://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7F/#general?template=/tmp/slack-blocks.json"
```
