### PR TITLE
Added Slack workflows and trigger support

### DIFF
--- a/apprise/plugins/slack.py
+++ b/apprise/plugins/slack.py
@@ -584,6 +584,11 @@ class NotifySlack(NotifyBase):
         if template:
             # Add our definition to our template
             self.template.add(template)
+            if not len(self.template):
+                # add() failed (unsupported schema, unparseable URL, etc.)
+                msg = f"The Slack template ({template!r}) could not be loaded."
+                self.logger.warning(msg)
+                raise TypeError(msg)
             # Enforce maximum file size
             self.template[0].max_file_size = self.max_slack_template_size
 
@@ -647,9 +652,24 @@ class NotifySlack(NotifyBase):
         # Templates are always Block Kit JSON; enforce JSON escaping
         tokens["app_mode"] = TemplateType.JSON
 
+        # Coerce all substitution values to str before JSON-escaping.
+        # apply_template's _escape_json() calls json.dumps(v)[1:-1] which
+        # is only correct for strings; None produces "ul" and other non-
+        # string types produce similarly corrupted output.  app_mode is a
+        # TemplateType sentinel passed as a named parameter, not a
+        # substitution value, so it is left as-is.
+        safe_tokens = {
+            k: (
+                v
+                if k == "app_mode" or isinstance(v, str)
+                else ("" if v is None else str(v))
+            )
+            for k, v in tokens.items()
+        }
+
         try:
             with open(template.path) as fp:
-                content = apply_template(fp.read(), **tokens)
+                content = apply_template(fp.read(), **safe_tokens)
 
         except OSError:
             self.logger.error(
@@ -670,6 +690,15 @@ class NotifySlack(NotifyBase):
             self.logger.debug(f"JSONDecodeError: {e}")
             return False
 
+        # Template must parse to a JSON object, not an array or scalar
+        if not isinstance(content, dict):
+            self.logger.error(
+                "Slack template"
+                f" {template.url(privacy=True)} must be a JSON object"
+                " (got {}).".format(type(content).__name__)
+            )
+            return False
+
         # 'blocks' must be a non-empty list (Block Kit requirement)
         if (
             not isinstance(content.get("blocks"), list)
@@ -682,8 +711,11 @@ class NotifySlack(NotifyBase):
             )
             return False
 
-        # Every block must carry a 'type' string (Block Kit requirement)
-        if not all(isinstance(b.get("type"), str) for b in content["blocks"]):
+        # Every block must be a dict with a 'type' string (Block Kit)
+        if not all(
+            isinstance(b, dict) and isinstance(b.get("type"), str)
+            for b in content["blocks"]
+        ):
             self.logger.error(
                 "Slack template"
                 f" {template.url(privacy=True)} contains"

--- a/apprise/plugins/slack.py
+++ b/apprise/plugins/slack.py
@@ -403,7 +403,11 @@ class NotifySlack(NotifyBase):
         super().__init__(**kwargs)
 
         # Store our webhook mode
-        if mode and isinstance(mode, str):
+        # Track whether the caller supplied an explicit mode so we can
+        # decide later whether to validate exact segment count or
+        # auto-detect the workflow sub-mode from segment count.
+        _mode_explicit = bool(mode and isinstance(mode, str))
+        if _mode_explicit:
             self.mode = next(
                 (a for a in SLACK_MODES if a.startswith(mode)), None
             )
@@ -413,7 +417,8 @@ class NotifySlack(NotifyBase):
                 raise TypeError(msg)
 
         elif workflow_path:
-            # Workflow path implies workflow mode
+            # Mode will be determined by segment count below;
+            # use WORKFLOW as a sentinel so we enter the right branch.
             self.mode = SlackMode.WORKFLOW
 
         else:  # Detect
@@ -437,14 +442,35 @@ class NotifySlack(NotifyBase):
             else:
                 self.workflow_path = []
 
-            # At least 3 segments required (T.../X.../Y... minimum)
-            if len(self.workflow_path) < 3:
-                msg = (
-                    "A Slack Workflow URL requires at least 3 path"
-                    f" segments ({workflow_path!r} is invalid)."
-                )
-                self.logger.warning(msg)
-                raise TypeError(msg)
+            # Segment counts are fixed by Slack:
+            #   /workflows/ URLs have exactly 4 segments
+            #   /triggers/  URLs have exactly 3 segments
+            seg_count = len(self.workflow_path)
+            if _mode_explicit:
+                # Validate exact count for the declared mode
+                expected = 4 if self.mode == SlackMode.WORKFLOW else 3
+                if seg_count != expected:
+                    msg = (
+                        f"A Slack {self.mode!r} URL requires exactly"
+                        f" {expected} path segments"
+                        f" ({workflow_path!r} has {seg_count})."
+                    )
+                    self.logger.warning(msg)
+                    raise TypeError(msg)
+            else:
+                # Auto-detect sub-mode from segment count
+                if seg_count == 4:
+                    self.mode = SlackMode.WORKFLOW
+                elif seg_count == 3:
+                    self.mode = SlackMode.WORKFLOW_TRIGGER
+                else:
+                    msg = (
+                        "A Slack Workflow URL requires exactly 3 or 4"
+                        f" path segments ({workflow_path!r} has"
+                        f" {seg_count})."
+                    )
+                    self.logger.warning(msg)
+                    raise TypeError(msg)
 
         elif self.mode in (SlackMode.WEBHOOK, SlackMode.WEBHOOK_GOV):
             self.workflow_path = []
@@ -1515,10 +1541,21 @@ class NotifySlack(NotifyBase):
         # Get unquoted path entries
         entries = NotifySlack.split_path(results["fullpath"])
 
-        # Peek at mode early to guide path parsing
-        _mode = results["qsd"].get("mode", "")
+        # Peek at mode early to guide path parsing.
+        # Resolve via the same prefix-matching used in __init__ so that
+        # abbreviated inputs (e.g. mode=tri or mode=work) are handled
+        # identically in both places.
+        _mode_raw = results["qsd"].get("mode", "")
+        _mode = (
+            next(
+                (a for a in SLACK_MODES if a.startswith(_mode_raw)),
+                "",
+            )
+            if _mode_raw
+            else ""
+        )
 
-        if _mode.startswith(("workflow", "trigger")):
+        if _mode in (SlackMode.WORKFLOW, SlackMode.WORKFLOW_TRIGGER):
             # All path segments form the workflow_path
             results["workflow_path"] = "/".join([token, *entries])
             results["targets"] = []

--- a/apprise/plugins/slack.py
+++ b/apprise/plugins/slack.py
@@ -117,12 +117,22 @@ class SlackMode:
     # Our token looks like: xoxb-1234-1234-abc124 or
     BOT = "bot"
 
+    # Slack Workflow Builder webhook
+    # URL: https://hooks.slack.com/workflows/T.../F.../X.../Y...
+    WORKFLOW = "workflow"
+
+    # Slack Workflow trigger webhook (newer format)
+    # URL: https://hooks.slack.com/triggers/T.../X.../Y...
+    WORKFLOW_TRIGGER = "trigger"
+
 
 # Define our Slack Modes
 SLACK_MODES = (
     SlackMode.WEBHOOK,
     SlackMode.WEBHOOK_GOV,
     SlackMode.BOT,
+    SlackMode.WORKFLOW,
+    SlackMode.WORKFLOW_TRIGGER,
 )
 
 
@@ -152,6 +162,11 @@ class NotifySlack(NotifyBase):
     # Slack Webhook URLs
     webhook_url = "https://hooks.slack.com/services"
     webhook_gov_url = "https://hooks.slack-gov.com/services"
+
+    # Slack Workflow Builder webhook URL bases
+    # See: https://slack.com/help/articles/360041352714
+    workflow_url = "https://hooks.slack.com/workflows"
+    workflow_trigger_url = "https://hooks.slack.com/triggers"
 
     # Slack API URL (used with Bots)
     api_url = "https://slack.com/api/{}"
@@ -257,6 +272,13 @@ class NotifySlack(NotifyBase):
             "targets": {
                 "name": _("Targets"),
                 "type": "list:string",
+            },
+            # Workflow Builder path: all URL segments joined with slashes
+            # e.g. T05XXXX/Ft07XXXX/XXXXXXXX/YYYYYYYY
+            "workflow_path": {
+                "name": _("Workflow Path"),
+                "type": "string",
+                "private": True,
             },
         },
     )
@@ -374,6 +396,7 @@ class NotifySlack(NotifyBase):
         mode=None,
         template=None,
         tokens=None,
+        workflow_path=None,
         **kwargs,
     ):
         """Initialize Slack Object."""
@@ -389,10 +412,42 @@ class NotifySlack(NotifyBase):
                 self.logger.warning(msg)
                 raise TypeError(msg)
 
+        elif workflow_path:
+            # Workflow path implies workflow mode
+            self.mode = SlackMode.WORKFLOW
+
         else:  # Detect
             self.mode = SlackMode.BOT if access_token else SlackMode.WEBHOOK
 
-        if self.mode in (SlackMode.WEBHOOK, SlackMode.WEBHOOK_GOV):
+        if self.mode in (
+            SlackMode.WORKFLOW,
+            SlackMode.WORKFLOW_TRIGGER,
+        ):
+            # Workflow Builder mode: no OAuth token, no webhook tokens
+            self.access_token = None
+            self.token_a = None
+            self.token_b = None
+            self.token_c = None
+
+            # Parse workflow path segments from string or list
+            if isinstance(workflow_path, (list, tuple)):
+                self.workflow_path = [str(s) for s in workflow_path if s]
+            elif isinstance(workflow_path, str):
+                self.workflow_path = [s for s in workflow_path.split("/") if s]
+            else:
+                self.workflow_path = []
+
+            # At least 3 segments required (T.../X.../Y... minimum)
+            if len(self.workflow_path) < 3:
+                msg = (
+                    "A Slack Workflow URL requires at least 3 path"
+                    f" segments ({workflow_path!r} is invalid)."
+                )
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
+        elif self.mode in (SlackMode.WEBHOOK, SlackMode.WEBHOOK_GOV):
+            self.workflow_path = []
             self.access_token = None
             self.token_a = validate_regex(
                 token_a, *self.template_tokens["token_a"]["regex"]
@@ -427,6 +482,7 @@ class NotifySlack(NotifyBase):
                 self.logger.warning(msg)
                 raise TypeError(msg)
         else:
+            self.workflow_path = []
             self.token_a = None
             self.token_b = None
             self.token_c = None
@@ -460,7 +516,14 @@ class NotifySlack(NotifyBase):
             # a flag lower to not set the channels
             self.channels.append(
                 None
-                if self.mode in (SlackMode.WEBHOOK, SlackMode.WEBHOOK_GOV)
+                if self.mode
+                in (
+                    SlackMode.WEBHOOK,
+                    SlackMode.WEBHOOK_GOV,
+                    # Workflow mode has no channel concept
+                    SlackMode.WORKFLOW,
+                    SlackMode.WORKFLOW_TRIGGER,
+                )
                 else self.default_notification_channel
             )
 
@@ -617,6 +680,35 @@ class NotifySlack(NotifyBase):
 
         # error tracking (used for function return)
         has_error = False
+
+        #
+        # Workflow Builder mode: fixed endpoint, no channel iteration
+        #
+        if self.mode in (SlackMode.WORKFLOW, SlackMode.WORKFLOW_TRIGGER):
+            if self.template:
+                # Use external Block Kit JSON template
+                payload = self.gen_payload(
+                    body, title, notify_type=notify_type, **kwargs
+                )
+                if payload is False:
+                    return False
+
+            else:
+                # Default payload: combine title and body into a single
+                # 'text' field -- the workflow must accept this variable.
+                payload = {
+                    "text": f"{title}: {body}" if title else body,
+                }
+
+            # Construct the workflow POST URL from stored path segments
+            wf_base = (
+                self.workflow_trigger_url
+                if self.mode is SlackMode.WORKFLOW_TRIGGER
+                else self.workflow_url
+            )
+            url = "{}/{}".format(wf_base, "/".join(self.workflow_path))
+            # _send() returns False on error, non-False on success
+            return self._send(url, payload) is not False
 
         #
         # Prepare JSON Object (applicable to both WEBHOOK and BOT mode)
@@ -1229,6 +1321,13 @@ class NotifySlack(NotifyBase):
                         and b"OK" in r.content
                     )
                 )
+            elif self.mode in (
+                SlackMode.WORKFLOW,
+                SlackMode.WORKFLOW_TRIGGER,
+            ):
+                # Workflow trigger webhooks confirm success via HTTP 200;
+                # the response body may be empty or non-standard JSON.
+                status_okay = r.status_code == requests.codes.ok
             elif r.content == b"ok":
                 # The text 'ok' is returned if this is a Webhook request
                 # So the below captures that as well.
@@ -1319,6 +1418,10 @@ class NotifySlack(NotifyBase):
 
         Targets or end points should never be identified here.
         """
+        if self.mode in (SlackMode.WORKFLOW, SlackMode.WORKFLOW_TRIGGER):
+            # Workflow mode is identified by its path segments
+            return (self.secure_protocol, self.mode, *self.workflow_path)
+
         return (
             self.secure_protocol,
             self.token_a,
@@ -1355,6 +1458,16 @@ class NotifySlack(NotifyBase):
         if self.user:
             botname = "{botname}@".format(
                 botname=NotifySlack.quote(self.user, safe=""),
+            )
+
+        if self.mode in (SlackMode.WORKFLOW, SlackMode.WORKFLOW_TRIGGER):
+            return "{schema}://{path}/?{params}".format(
+                schema=self.secure_protocol,
+                path="/".join(
+                    self.pprint(s, privacy, safe="")
+                    for s in self.workflow_path
+                ),
+                params=NotifySlack.urlencode(params),
             )
 
         if self.mode in (SlackMode.WEBHOOK, SlackMode.WEBHOOK_GOV):
@@ -1399,22 +1512,30 @@ class NotifySlack(NotifyBase):
         # The first token is stored in the hostname
         token = NotifySlack.unquote(results["host"])
 
-        # Get unquoted entries
+        # Get unquoted path entries
         entries = NotifySlack.split_path(results["fullpath"])
 
-        # Verify if our token_a us a bot token or part of a webhook:
-        if token.startswith("xo"):
+        # Peek at mode early to guide path parsing
+        _mode = results["qsd"].get("mode", "")
+
+        if _mode.startswith(("workflow", "trigger")):
+            # All path segments form the workflow_path
+            results["workflow_path"] = "/".join([token, *entries])
+            results["targets"] = []
+
+        # Verify if our token is a bot token or part of a webhook:
+        elif token.startswith("xo"):
             # We're dealing with a bot
             results["access_token"] = token
+            results["targets"] = entries
 
         else:
             # We're dealing with a webhook
             results["token_a"] = token
             results["token_b"] = entries.pop(0) if entries else None
             results["token_c"] = entries.pop(0) if entries else None
-
-        # assign remaining entries to the channels we wish to notify
-        results["targets"] = entries
+            # assign remaining entries to the channels we wish to notify
+            results["targets"] = entries
 
         # Support the token flag where you can set it to the bot token
         # or the webhook token (with slash delimiters)
@@ -1502,8 +1623,41 @@ class NotifySlack(NotifyBase):
         Supports:
           - https://hooks.slack.com/services/TOKEN_A/TOKEN_B/TOKEN_C
           - https://hooks.slack-gov.com/services/TOKEN_A/TOKEN_B/TOKEN_C
+          - https://hooks.slack.com/workflows/T.../F.../X.../Y...
+          - https://hooks.slack.com/triggers/T.../X.../Y...
         """
 
+        # Workflow Builder and trigger webhook URLs
+        wf_result = re.match(
+            r"^https?://hooks\.slack\.com/"
+            r"(?P<wf_type>workflows|triggers)/"
+            r"(?P<path>[A-Z0-9][A-Z0-9/_-]+)/?"
+            r"(?P<params>\?.+)?$",
+            url,
+            re.I,
+        )
+        if wf_result:
+            wf_type = wf_result.group("wf_type").lower()
+            # Map URL path type to Apprise mode string
+            mode = (
+                SlackMode.WORKFLOW_TRIGGER
+                if wf_type == "triggers"
+                else SlackMode.WORKFLOW
+            )
+            path = wf_result.group("path").strip("/")
+            params = wf_result.group("params") or ""
+            sep = "&" if params else "?"
+            return NotifySlack.parse_url(
+                "{schema}://{path}/{params}{sep}mode={mode}".format(
+                    schema=NotifySlack.secure_protocol,
+                    path=path,
+                    params=params,
+                    sep=sep,
+                    mode=mode,
+                )
+            )
+
+        # Standard incoming webhook and government webhook URLs
         result = re.match(
             r"^https?://(?P<host>hooks\.slack(?P<gov>-gov)?\.com)/services/"
             r"(?P<token_a>[A-Z0-9]+)/"

--- a/tests/test_plugin_slack.py
+++ b/tests/test_plugin_slack.py
@@ -510,6 +510,46 @@ apprise_url_tests = (
             "response": False,
         },
     ),
+    # Workflow Builder webhook (4-segment /workflows/ path)
+    (
+        "slack://T1JJ3T3L2/Ft07XXXX/XXXXXXXX/YYYYYYYY/?mode=workflow",
+        {
+            "instance": NotifySlack,
+        },
+    ),
+    # Workflow trigger webhook (3-segment /triggers/ path)
+    (
+        "slack://T1JJ3T3L2/XXXXXXXX/YYYYYYYY/?mode=trigger",
+        {
+            "instance": NotifySlack,
+        },
+    ),
+    # Workflow native URL (/workflows/)
+    (
+        (
+            "https://hooks.slack.com/workflows/"
+            "T1JJ3T3L2/Ft07XXXX/XXXXXXXX/YYYYYYYY"
+        ),
+        {
+            "instance": NotifySlack,
+            "privacy_url": "slack://T...2/F...X/X...X/Y...Y/",
+        },
+    ),
+    # Workflow trigger native URL (/triggers/)
+    (
+        "https://hooks.slack.com/triggers/T1JJ3T3L2/XXXXXXXX/YYYYYYYY",
+        {
+            "instance": NotifySlack,
+            "privacy_url": "slack://T...2/X...X/Y...Y/",
+        },
+    ),
+    # Workflow -- too few path segments
+    (
+        "slack://T1JJ3T3L2/XXXXXXXX/?mode=workflow",
+        {
+            "instance": TypeError,
+        },
+    ),
 )
 
 
@@ -1667,3 +1707,205 @@ def test_plugin_slack_template_inaccessible(mock_request, tmpdir):
         obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
     )
     assert mock_request.called is False
+
+
+@mock.patch("requests.request")
+def test_plugin_slack_workflow_default_payload(mock_request):
+    """NotifySlack() - Workflow Builder mode, default text payload."""
+    mock_request.return_value = mock.Mock(
+        **{"content": b"", "status_code": requests.codes.ok}
+    )
+
+    # 4-segment /workflows/ path via mode=workflow
+    obj = Apprise.instantiate(
+        "slack://T1JJ3T3L2/Ft07XXXX/XXXXXXXX/YYYYYYYY/?mode=workflow"
+    )
+    assert isinstance(obj, NotifySlack)
+    assert obj.mode == "workflow"
+    assert obj.workflow_path == [
+        "T1JJ3T3L2",
+        "Ft07XXXX",
+        "XXXXXXXX",
+        "YYYYYYYY",
+    ]
+
+    # Notification with title
+    assert (
+        obj.notify(body="hello", title="Alert", notify_type=NotifyType.INFO)
+        is True
+    )
+    assert mock_request.called is True
+    # Verify the POST URL uses the workflow base
+    call_url = mock_request.call_args_list[0][0][1]
+    assert "hooks.slack.com/workflows/" in call_url
+    assert "T1JJ3T3L2/Ft07XXXX/XXXXXXXX/YYYYYYYY" in call_url
+    # Verify default payload combines title and body
+    posted = loads(mock_request.call_args_list[0][1]["data"])
+    assert posted["text"] == "Alert: hello"
+
+    mock_request.reset_mock()
+
+    # Notification without title -- body only
+    assert (
+        obj.notify(body="body only", title="", notify_type=NotifyType.INFO)
+        is True
+    )
+    posted = loads(mock_request.call_args_list[0][1]["data"])
+    assert posted["text"] == "body only"
+
+
+@mock.patch("requests.request")
+def test_plugin_slack_workflow_trigger_mode(mock_request):
+    """NotifySlack() - Workflow trigger mode (/triggers/ URL)."""
+    mock_request.return_value = mock.Mock(
+        **{"content": b"", "status_code": requests.codes.ok}
+    )
+
+    # 3-segment /triggers/ path via mode=trigger
+    obj = Apprise.instantiate(
+        "slack://T1JJ3T3L2/XXXXXXXX/YYYYYYYY/?mode=trigger"
+    )
+    assert isinstance(obj, NotifySlack)
+    assert obj.mode == "trigger"
+    assert obj.workflow_path == ["T1JJ3T3L2", "XXXXXXXX", "YYYYYYYY"]
+
+    assert obj.notify(body="hi", title="", notify_type=NotifyType.INFO) is True
+    call_url = mock_request.call_args_list[0][0][1]
+    assert "hooks.slack.com/triggers/" in call_url
+    assert "T1JJ3T3L2/XXXXXXXX/YYYYYYYY" in call_url
+
+
+@mock.patch("requests.request")
+def test_plugin_slack_workflow_native_url(mock_request):
+    """NotifySlack() - parse_native_url() handles workflow/trigger URLs."""
+    mock_request.return_value = mock.Mock(
+        **{"content": b"", "status_code": requests.codes.ok}
+    )
+
+    # /workflows/ native URL
+    obj = Apprise.instantiate(
+        "https://hooks.slack.com/workflows"
+        "/T1JJ3T3L2/Ft07XXXX/XXXXXXXX/YYYYYYYY"
+    )
+    assert isinstance(obj, NotifySlack)
+    assert obj.mode == "workflow"
+    assert obj.workflow_path == [
+        "T1JJ3T3L2",
+        "Ft07XXXX",
+        "XXXXXXXX",
+        "YYYYYYYY",
+    ]
+    assert (
+        obj.notify(body="native", title="", notify_type=NotifyType.INFO)
+        is True
+    )
+    call_url = mock_request.call_args_list[0][0][1]
+    assert "hooks.slack.com/workflows/T1JJ3T3L2" in call_url
+
+    mock_request.reset_mock()
+
+    # /triggers/ native URL
+    obj2 = Apprise.instantiate(
+        "https://hooks.slack.com/triggers/T1JJ3T3L2/XXXXXXXX/YYYYYYYY"
+    )
+    assert isinstance(obj2, NotifySlack)
+    assert obj2.mode == "trigger"
+    assert (
+        obj2.notify(body="trigger", title="", notify_type=NotifyType.INFO)
+        is True
+    )
+    call_url2 = mock_request.call_args_list[0][0][1]
+    assert "hooks.slack.com/triggers/T1JJ3T3L2" in call_url2
+
+
+@mock.patch("requests.request")
+def test_plugin_slack_workflow_url_roundtrip(mock_request):
+    """NotifySlack() - workflow url()/parse_url() round-trip."""
+    mock_request.return_value = mock.Mock(
+        **{"content": b"", "status_code": requests.codes.ok}
+    )
+
+    original = "slack://T1JJ3T3L2/Ft07XXXX/XXXXXXXX/YYYYYYYY/?mode=workflow"
+    obj = Apprise.instantiate(original)
+    assert isinstance(obj, NotifySlack)
+
+    # Reconstruct from url() output and re-instantiate
+    rebuilt = Apprise.instantiate(obj.url())
+    assert isinstance(rebuilt, NotifySlack)
+    assert rebuilt.mode == obj.mode
+    assert rebuilt.workflow_path == obj.workflow_path
+
+
+def test_plugin_slack_workflow_invalid_path():
+    """NotifySlack() - too few path segments raises TypeError."""
+    from apprise.plugins.slack import NotifySlack as _NS
+
+    # Only 2 segments -- must raise
+    with pytest.raises(TypeError):
+        _NS(workflow_path=["T1JJ3T3L2", "XXXXXXXX"], mode="workflow")
+
+    # Empty path -- must raise
+    with pytest.raises(TypeError):
+        _NS(workflow_path=[], mode="workflow")
+
+    # Non-string / non-list type (else branch) -- must also raise
+    with pytest.raises(TypeError):
+        _NS(workflow_path=42, mode="workflow")
+
+    # Providing workflow_path without mode auto-selects WORKFLOW mode
+    obj = _NS(workflow_path=["T1JJ3T3L2", "Ft07XXXX", "XXXXXXXX", "YYY"])
+    assert obj.mode == "workflow"
+    assert obj.workflow_path == ["T1JJ3T3L2", "Ft07XXXX", "XXXXXXXX", "YYY"]
+
+
+@mock.patch("requests.request")
+def test_plugin_slack_workflow_template(mock_request, tmpdir):
+    """NotifySlack() - Workflow mode with Block Kit JSON template."""
+    mock_request.return_value = mock.Mock(
+        **{"content": b"", "status_code": requests.codes.ok}
+    )
+
+    template = tmpdir.join("wf_blocks.json")
+    template.write(
+        cleandoc("""
+        {
+          "blocks": [
+            {
+              "type": "section",
+              "text": {"type": "mrkdwn", "text": "{{app_body}}"}
+            }
+          ]
+        }
+        """)
+    )
+
+    obj = Apprise.instantiate(
+        "slack://T1JJ3T3L2/Ft07XXXX/XXXXXXXX/YYYYYYYY/"
+        "?mode=workflow&template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifySlack)
+    assert obj.mode == "workflow"
+    assert (
+        obj.notify(body="wf-tmpl", title="", notify_type=NotifyType.INFO)
+        is True
+    )
+    assert mock_request.called is True
+    call_url = mock_request.call_args_list[0][0][1]
+    assert "hooks.slack.com/workflows/" in call_url
+    posted = loads(mock_request.call_args_list[0][1]["data"])
+    blocks = posted["blocks"]
+    section = next(b for b in blocks if b.get("type") == "section")
+    assert section["text"]["text"] == "wf-tmpl"
+
+    # Invalid JSON template -- gen_payload() fails, send() returns False
+    bad_template = tmpdir.join("bad.json")
+    bad_template.write("not-json!")
+    obj2 = Apprise.instantiate(
+        "slack://T1JJ3T3L2/Ft07XXXX/XXXXXXXX/YYYYYYYY/"
+        "?mode=workflow&template={}".format(str(bad_template))
+    )
+    assert isinstance(obj2, NotifySlack)
+    assert (
+        obj2.notify(body="x", title="", notify_type=NotifyType.INFO) is False
+    )
+    assert mock_request.call_count == 1  # no new request made

--- a/tests/test_plugin_slack.py
+++ b/tests/test_plugin_slack.py
@@ -1723,6 +1723,102 @@ def test_plugin_slack_template_inaccessible(mock_request, tmpdir):
     assert mock_request.called is False
 
 
+def test_plugin_slack_template_add_failure():
+    """NotifySlack() - TypeError when AppriseAttachment.add() drops entry."""
+    # Simulate add() silently failing (returns 0 / len stays 0)
+    with mock.patch("apprise.plugins.slack.AppriseAttachment") as mock_cls:
+        inst = mock.MagicMock()
+        inst.__len__ = mock.Mock(return_value=0)
+        mock_cls.return_value = inst
+
+        with pytest.raises(TypeError):
+            NotifySlack(
+                token_a="T1JJ3T3L2",
+                token_b="A1BRTD4JD",
+                token_c="TIiajkdnlazkcOXrIdevi7FQ",
+                template="file:///some/template.json",
+            )
+
+
+@mock.patch("requests.request")
+def test_plugin_slack_template_content_not_dict(mock_request, tmpdir):
+    """NotifySlack() - template that parses to a JSON array is rejected."""
+    mock_request.return_value = mock.Mock(
+        **{"content": b"ok", "status_code": requests.codes.ok}
+    )
+
+    # Valid JSON but a list rather than an object
+    template = tmpdir.join("array.json")
+    template.write('[{"type": "section"}]')
+
+    obj = Apprise.instantiate(
+        "slack://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/"
+        "?template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifySlack)
+    assert (
+        obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+    )
+    assert mock_request.called is False
+
+
+@mock.patch("requests.request")
+def test_plugin_slack_template_block_not_dict(mock_request, tmpdir):
+    """NotifySlack() - non-dict entry in blocks list is rejected."""
+    mock_request.return_value = mock.Mock(
+        **{"content": b"ok", "status_code": requests.codes.ok}
+    )
+
+    # blocks list contains a string rather than a dict
+    template = tmpdir.join("bad_block.json")
+    template.write('{"blocks": ["not-a-dict"]}')
+
+    obj = Apprise.instantiate(
+        "slack://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/"
+        "?template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifySlack)
+    assert (
+        obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+    )
+    assert mock_request.called is False
+
+
+@mock.patch("requests.request")
+def test_plugin_slack_template_none_token_value(mock_request, tmpdir):
+    """NotifySlack() - None token value (e.g. app_image_url) is coerced
+    to empty string before JSON-escaping."""
+    mock_request.return_value = mock.Mock(
+        **{"content": b"ok", "status_code": requests.codes.ok}
+    )
+
+    # Template references app_image_url which will be None when
+    # include_image=False; old code produced corrupted JSON ("ul")
+    template = tmpdir.join("img.json")
+    template.write(
+        '{"blocks": [{"type": "section",'
+        ' "text": {"type": "mrkdwn",'
+        ' "text": "{{app_body}} img={{app_image_url}}"}}]}'
+    )
+
+    obj = Apprise.instantiate(
+        "slack://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/"
+        "?image=no&template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifySlack)
+    # Must succeed -- None coerced to "" keeps the JSON valid
+    assert (
+        obj.notify(body="hello", title="t", notify_type=NotifyType.INFO)
+        is True
+    )
+    assert mock_request.called is True
+    payload = loads(mock_request.call_args_list[0][1]["data"])
+    block_text = payload["attachments"][0]["blocks"][0]["text"]["text"]
+    # app_image_url should expand to empty string, not "ul"
+    assert "img=" in block_text
+    assert "ul" not in block_text
+
+
 @mock.patch("requests.request")
 def test_plugin_slack_workflow_default_payload(mock_request):
     """NotifySlack() - Workflow Builder mode, default text payload."""

--- a/tests/test_plugin_slack.py
+++ b/tests/test_plugin_slack.py
@@ -543,9 +543,23 @@ apprise_url_tests = (
             "privacy_url": "slack://T...2/X...X/Y...Y/",
         },
     ),
-    # Workflow -- too few path segments
+    # Workflow mode -- too few segments (2 of required 4)
     (
         "slack://T1JJ3T3L2/XXXXXXXX/?mode=workflow",
+        {
+            "instance": TypeError,
+        },
+    ),
+    # Workflow mode -- wrong count: trigger's 3 segments rejected
+    (
+        "slack://T1JJ3T3L2/XXXXXXXX/YYYYYYYY/?mode=workflow",
+        {
+            "instance": TypeError,
+        },
+    ),
+    # Trigger mode -- wrong count: workflow's 4 segments rejected
+    (
+        "slack://T1JJ3T3L2/Ft07XXXX/XXXXXXXX/YYYYYYYY/?mode=trigger",
         {
             "instance": TypeError,
         },
@@ -1837,25 +1851,48 @@ def test_plugin_slack_workflow_url_roundtrip(mock_request):
 
 
 def test_plugin_slack_workflow_invalid_path():
-    """NotifySlack() - too few path segments raises TypeError."""
+    """NotifySlack() - invalid path segment counts raise TypeError."""
     from apprise.plugins.slack import NotifySlack as _NS
 
-    # Only 2 segments -- must raise
+    # Too few segments for explicit workflow mode (needs 4)
     with pytest.raises(TypeError):
         _NS(workflow_path=["T1JJ3T3L2", "XXXXXXXX"], mode="workflow")
 
-    # Empty path -- must raise
+    # Trigger's 3 segments rejected when mode=workflow is explicit
+    with pytest.raises(TypeError):
+        _NS(
+            workflow_path=["T1JJ3T3L2", "XXXXXXXX", "YYYYYYYY"],
+            mode="workflow",
+        )
+
+    # Workflow's 4 segments rejected when mode=trigger is explicit
+    with pytest.raises(TypeError):
+        _NS(
+            workflow_path=["T1JJ3T3L2", "Ft07XXXX", "XXXXXXXX", "YYYY"],
+            mode="trigger",
+        )
+
+    # Empty path -- must raise (auto-detect path, 0 segments)
     with pytest.raises(TypeError):
         _NS(workflow_path=[], mode="workflow")
 
-    # Non-string / non-list type (else branch) -- must also raise
+    # Non-string / non-list type (else branch) -- 0 segments, must raise
     with pytest.raises(TypeError):
         _NS(workflow_path=42, mode="workflow")
 
-    # Providing workflow_path without mode auto-selects WORKFLOW mode
+    # Auto-detect: 4 segments -> WORKFLOW
     obj = _NS(workflow_path=["T1JJ3T3L2", "Ft07XXXX", "XXXXXXXX", "YYY"])
     assert obj.mode == "workflow"
     assert obj.workflow_path == ["T1JJ3T3L2", "Ft07XXXX", "XXXXXXXX", "YYY"]
+
+    # Auto-detect: 3 segments -> WORKFLOW_TRIGGER
+    obj = _NS(workflow_path=["T1JJ3T3L2", "XXXXXXXX", "YYYYYYYY"])
+    assert obj.mode == "trigger"
+    assert obj.workflow_path == ["T1JJ3T3L2", "XXXXXXXX", "YYYYYYYY"]
+
+    # Auto-detect: 2 segments -> TypeError (neither 3 nor 4)
+    with pytest.raises(TypeError):
+        _NS(workflow_path=["T1JJ3T3L2", "XXXXXXXX"])
 
 
 @mock.patch("requests.request")


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #891

Added support for [Slack Workflow Builder](https://slack.com/help/articles/360041352714) webhooks -- both the `/workflows/` (4-segment) and `/triggers/` (3-segment) URL formats.

- Two new modes: `workflow` and `trigger` (auto-detected from native `hooks.slack.com` URLs via `parse_native_url()`, or set explicitly with `?mode=workflow` / `?mode=trigger`).
- Default payload is `{"text": "Title: Body"}` when a title is present, or `{"text": "Body"}` when the title is blank.
- Full `template=` support: passing a Block Kit JSON template file works in workflow mode just as it does in webhook/bot modes.

Native Slack Workflow Builder URLs can be passed to Apprise as-is:
```
https://hooks.slack.com/workflows/T.../F.../XXXXXXXXXX/YYYYYYYYYY
https://hooks.slack.com/triggers/T.../XXXXXXXXXX/YYYYYYYYYY
```

Or as Apprise-native URLs:
```
slack://{seg1}/{seg2}/{seg3}/{seg4}/?mode=workflow
slack://{seg1}/{seg2}/{seg3}/?mode=trigger
```

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/58](https://github.com/caronc/apprise-docs/pull/58)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@891-slack-workflows

# Test with a Workflow Builder webhook URL (paste yours from Slack):
apprise -vv -t "Test Title" -b "Test Message" \
    "https://hooks.slack.com/workflows/T.../F.../XXXXXXXXXX/YYYYYYYYYY"

# Or using the Apprise-native form with explicit mode:
apprise -vv -t "Test Title" -b "Test Message" \
    "slack://T.../F.../XXXXXXXXXX/YYYYYYYYYY/?mode=workflow"

# Test with a trigger-style webhook:
apprise -vv -t "Test Title" -b "Test Message" \
    "https://hooks.slack.com/triggers/T.../XXXXXXXXXX/YYYYYYYYYY"

# Verify title-omitted case (no -t flag):
apprise -vv -b "Body only message" \
    "https://hooks.slack.com/workflows/T.../F.../XXXXXXXXXX/YYYYYYYYYY"
```

