### PR TITLE
Twitter/X migration to API v2

### DIFF
--- a/apprise/plugins/twitter.py
+++ b/apprise/plugins/twitter.py
@@ -25,8 +25,29 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# See https://developer.twitter.com/en/docs/direct-messages/\
-#           sending-and-receiving/api-reference/new-event.html
+# Migration guide from X API v1.1 to v2:
+#   https://docs.x.com/x-api/migrate/overview
+#
+# X API v2 Tweet endpoint:
+#   https://docs.x.com/x-api/posts/creation/quickstart/post-a-tweet
+#
+# X API v2 Direct Message endpoint:
+#   https://docs.x.com/x-api/direct-messages/manage-direct-messages/
+#       api-reference/post-dm_conversations-dm_conversation_id-messages
+#
+# X API v2 User Lookup endpoint:
+#   https://docs.x.com/x-api/users/user-lookup/api-reference/get-users-by
+#
+# X API v2 Current User endpoint:
+#   https://docs.x.com/x-api/users/user-lookup/api-reference/get-users-me
+#
+# Media upload still uses the v1.1 endpoint (permitted on all access levels):
+#   https://docs.x.com/x-api/v1/media/upload-media/api-reference/
+#       post-media-upload
+#
+# Free-tier accounts can ONLY post tweets (mode=tweet).
+# Sending Direct Messages (mode=dm, the default) requires a paid X API
+# subscription (Basic or higher).
 import contextlib
 from copy import deepcopy
 from datetime import datetime, timezone
@@ -49,10 +70,10 @@ IS_USER = re.compile(r"^\s*@?(?P<user>[A-Z0-9_]+)$", re.I)
 class TwitterMessageMode:
     """Twitter Message Mode."""
 
-    # DM (a Direct Message)
+    # DM (a Direct Message) -- requires Basic+ X API subscription
     DM = "dm"
 
-    # A Public Tweet
+    # A Public Tweet -- available on Free X API tier and above
     TWEET = "tweet"
 
 
@@ -89,26 +110,30 @@ class NotifyTwitter(NotifyBase):
     # Twitter does have titles when creating a message
     title_maxlen = 0
 
-    # Twitter API Reference To Acquire Someone's Twitter ID
-    twitter_lookup = "https://api.twitter.com/1.1/users/lookup.json"
+    # X API v2 Endpoints:
 
-    # Twitter API Reference To Acquire Current Users Information
-    twitter_whoami = (
-        "https://api.twitter.com/1.1/account/verify_credentials.json"
-    )
+    # X API v2 -- Post a Tweet
+    # Available on Free tier and above
+    twitter_tweet = "https://api.twitter.com/2/tweets"
 
-    # Twitter API Reference To Send A Private DM
-    twitter_dm = "https://api.twitter.com/1.1/direct_messages/events/new.json"
+    # X API v2 -- Current authenticated user info
+    twitter_whoami = "https://api.twitter.com/2/users/me"
 
-    # Twitter API Reference To Send A Public Tweet
-    twitter_tweet = "https://api.twitter.com/1.1/statuses/update.json"
+    # X API v2 -- Batch user lookup by username (?usernames=u1,u2,...)
+    twitter_lookup = "https://api.twitter.com/2/users/by"
+
+    # X API v2 -- Direct Message to a participant (format with user_id)
+    # Requires Basic+ X API subscription
+    twitter_dm = "https://api.twitter.com/2/dm_conversations/with/{}/messages"
+
+    # Media upload still uses the v1.1 endpoint (allowed on all access levels):
+
+    # Twitter Media (Attachment) Upload Location
+    twitter_media = "https://upload.twitter.com/1.1/media/upload.json"
 
     # it is documented on the site that the maximum images per tweet
     # is 4 (unless it's a GIF, then it's only 1)
     __tweet_non_gif_images_batch = 4
-
-    # Twitter Media (Attachment) Upload Location
-    twitter_media = "https://upload.twitter.com/1.1/media/upload.json"
 
     # Twitter is kind enough to return how many more requests we're allowed to
     # continue to make within it's header response as:
@@ -406,13 +431,14 @@ class NotifyTwitter(NotifyBase):
         attachments=None,
         **kwargs,
     ):
-        """Twitter Public Tweet."""
+        """Twitter Public Tweet via X API v2."""
 
         # Error Tracking
         has_error = False
 
+        # Base payload; v2 uses "text" instead of the v1.1 "status" key
         payload = {
-            "status": body,
+            "text": body,
         }
 
         payloads = []
@@ -429,6 +455,7 @@ class NotifyTwitter(NotifyBase):
             batches = []
             batch = []
             for attachment in attachments:
+                # v2 media_ids must be strings
                 batch.append(str(attachment["media_id"]))
 
                 # Twitter supports batching images together.  This allows
@@ -451,27 +478,28 @@ class NotifyTwitter(NotifyBase):
                     )
                     or len(batch) >= batch_size
                 ):
-                    batches.append(",".join(batch))
+                    batches.append(list(batch))
                     batch = []
 
             if batch:
-                batches.append(",".join(batch))
+                batches.append(list(batch))
 
             for no, media_ids in enumerate(batches):
                 payload_ = deepcopy(payload)
-                payload_["media_ids"] = media_ids
+                # v2 places media in a nested dict with a list of id strings
+                payload_["media"] = {"media_ids": media_ids}
 
                 if no or not body:
                     # strip text and replace it with the image representation
-                    payload_["status"] = f"{no + 1:02d}/{len(batches):02d}"
+                    payload_["text"] = f"{no + 1:02d}/{len(batches):02d}"
                 payloads.append(payload_)
 
         for no, payload in enumerate(payloads, start=1):
-            # Send Tweet
+            # Send Tweet via v2 (JSON body required)
             postokay, response = self._fetch(
                 self.twitter_tweet,
                 payload=payload,
-                json=False,
+                json=True,
             )
 
             if not postokay:
@@ -479,12 +507,13 @@ class NotifyTwitter(NotifyBase):
                 has_error = True
 
                 errors = []
-                with contextlib.suppress(KeyError, TypeError):
+                with contextlib.suppress(AttributeError, KeyError, TypeError):
                     errors = [
-                        "Error Code {}: {}".format(
-                            e.get("code", "unk"), e.get("message")
+                        "Error {}: {}".format(
+                            e.get("title", e.get("code", "unk")),
+                            e.get("detail", e.get("message", "")),
                         )
-                        for e in response["errors"]
+                        for e in response.get("errors", [])
                     ]
 
                 for error in errors:
@@ -496,10 +525,10 @@ class NotifyTwitter(NotifyBase):
                     )
                 continue
 
+            # v2 response: {"data": {"id": "...", "text": "..."}}
             try:
-                url = "https://twitter.com/{}/status/{}".format(
-                    response["user"]["screen_name"], response["id_str"]
-                )
+                tweet_id = response["data"]["id"]
+                url = f"https://x.com/i/web/status/{tweet_id}"
 
             except (KeyError, TypeError):
                 url = "unknown"
@@ -524,25 +553,14 @@ class NotifyTwitter(NotifyBase):
         attachments=None,
         **kwargs,
     ):
-        """Twitter Direct Message."""
+        """Twitter Direct Message via X API v2.
+
+        Requires a Basic or higher X API subscription.
+        Free-tier accounts will receive a 403 error.
+        """
 
         # Error Tracking
         has_error = False
-
-        payload = {
-            "event": {
-                "type": "message_create",
-                "message_create": {
-                    "target": {
-                        # This gets assigned
-                        "recipient_id": None,
-                    },
-                    "message_data": {
-                        "text": body,
-                    },
-                },
-            }
-        }
 
         # Lookup our users (otherwise we look up ourselves)
         targets = (
@@ -558,37 +576,32 @@ class NotifyTwitter(NotifyBase):
             )
             return False
 
+        # Build our list of payloads; one per attachment (or a single message)
         payloads = []
         if not attachments:
-            payloads.append(payload)
+            # Plain text DM
+            payloads.append({"text": body})
 
         else:
             for no, attachment in enumerate(attachments):
-                payload_ = deepcopy(payload)
-                data = payload_["event"]["message_create"]["message_data"]
-                data["attachment"] = {
-                    "type": "media",
-                    "media": {"id": attachment["media_id"]},
-                    "additional_owners": ",".join(
-                        [str(x) for x in targets.values()]
+                # v2 DM attachment format: attachments list with media_id
+                payload_ = {
+                    "text": (
+                        body
+                        if (not no and body)
+                        else f"{no + 1:02d}/{len(attachments):02d}"
                     ),
+                    "attachments": [{"media_id": str(attachment["media_id"])}],
                 }
-                if no or not body:
-                    # strip text and replace it with the image representation
-                    data["text"] = f"{no + 1:02d}/{len(attachments):02d}"
                 payloads.append(payload_)
 
         for no, payload in enumerate(payloads, start=1):
             for screen_name, user_id in targets.items():
-                # Assign our user
-                target = payload["event"]["message_create"]["target"]
-                target["recipient_id"] = user_id
+                # v2 DM endpoint embeds the recipient user_id in the URL
+                url = self.twitter_dm.format(user_id)
 
                 # Send Twitter DM
-                postokay, _response = self._fetch(
-                    self.twitter_dm,
-                    payload=payload,
-                )
+                postokay, _response = self._fetch(url, payload=payload)
 
                 if not postokay:
                     # Track our error
@@ -603,29 +616,27 @@ class NotifyTwitter(NotifyBase):
         return not has_error
 
     def _whoami(self, lazy=True):
-        """Looks details of current authenticated user."""
+        """Looks up details of the current authenticated user via v2."""
 
         if lazy and self._whoami_cache is not None:
             # Use cached response
             return self._whoami_cache
 
-        # Contains a mapping of screen_name to id
+        # Contains a mapping of username to id
         results = {}
 
-        # Send Twitter DM
+        # Get current user info via v2
         postokay, response = self._fetch(
             self.twitter_whoami,
             method="GET",
-            json=False,
         )
 
         if postokay:
+            # v2 response: {"data": {"id": "...", "username": "...", ...}}
             try:
-                results[response["screen_name"]] = response["id"]
-                self._whoami_cache = {
-                    response["screen_name"]: response["id"],
-                }
-
+                data = response["data"]
+                results[data["username"]] = data["id"]
+                self._whoami_cache = {data["username"]: data["id"]}
                 self._user_cache.update(results)
 
             except (TypeError, KeyError):
@@ -634,12 +645,12 @@ class NotifyTwitter(NotifyBase):
         return results
 
     def _user_lookup(self, screen_name, lazy=True):
-        """Looks up a screen name and returns the user id.
+        """Looks up screen names and returns user IDs via v2.
 
-        the screen_name can be a list/set/tuple as well
+        screen_name can be a list/set/tuple as well.
         """
 
-        # Contains a mapping of screen_name to id
+        # Contains a mapping of username to id
         results = {}
 
         # Build a unique set of names
@@ -656,28 +667,31 @@ class NotifyTwitter(NotifyBase):
             # They're is nothing further to do
             return results
 
-        # Twitters API documents that it can lookup to 100
-        # results at a time.
-        # https://developer.twitter.com/en/docs/accounts-and-users/\
-        #     follow-search-get-users/api-reference/get-users-lookup
+        # v2 supports up to 100 usernames per request
+        # https://docs.x.com/x-api/users/user-lookup/api-reference/
+        #     get-users-by
         for i in range(0, len(names), 100):
-            # Look up our names by their screen_name
-            postokay, response = self._fetch(
+            batch = names[i : i + 100]
+
+            # Build query-string URL for GET /2/users/by?usernames=...
+            lookup_url = "{}?usernames={}".format(
                 self.twitter_lookup,
-                payload={
-                    "screen_name": names[i : i + 100],
-                },
-                json=False,
+                ",".join(NotifyTwitter.quote(n, safe="") for n in batch),
             )
 
-            if not postokay or not isinstance(response, list):
+            postokay, response = self._fetch(
+                lookup_url,
+                method="GET",
+            )
+
+            if not postokay or not isinstance(response, dict):
                 # Track our error
                 continue
 
-            # Update our user index
-            for entry in response:
+            # v2 response: {"data": [{"id": "...", "username": "..."}, ...]}
+            for entry in response.get("data", []):
                 with contextlib.suppress(TypeError, KeyError):
-                    results[entry["screen_name"]] = entry["id"]
+                    results[entry["username"]] = entry["id"]
 
         # Cache our response for future use; this saves on un-nessisary extra
         # hits against the Twitter API when we already know the answer

--- a/apprise/plugins/twitter.py
+++ b/apprise/plugins/twitter.py
@@ -721,12 +721,9 @@ class NotifyTwitter(NotifyBase):
                 ),
             }
 
-        elif json:
+        elif json and payload is not None:
             headers["Content-Type"] = "application/json"
             data = dumps(payload)
-
-        else:
-            data = payload
 
         auth = OAuth1(
             self.ckey,

--- a/apprise/plugins/twitter.py
+++ b/apprise/plugins/twitter.py
@@ -456,7 +456,7 @@ class NotifyTwitter(NotifyBase):
             batch = []
             for attachment in attachments:
                 # v2 media_ids must be strings
-                batch.append(str(attachment["media_id"]))
+                media_id = str(attachment["media_id"])
 
                 # Twitter supports batching images together.  This allows
                 # the batching of multiple images together.  Twitter also
@@ -472,14 +472,21 @@ class NotifyTwitter(NotifyBase):
                 # If you passed in, image, image, gif, image. <- This would
                 # produce 3 images (as the first 2 images could be lumped
                 # together as a batch)
-                if (
-                    not re.match(
-                        r"^image/(png|jpe?g)", attachment["file_mime"], re.I
-                    )
-                    or len(batch) >= batch_size
+                if not re.match(
+                    r"^image/(png|jpe?g)", attachment["file_mime"], re.I
                 ):
-                    batches.append(list(batch))
-                    batch = []
+                    # Non-batchable (e.g. GIF): flush any pending batch
+                    # first, then emit this attachment alone
+                    if batch:
+                        batches.append(list(batch))
+                        batch = []
+                    batches.append([media_id])
+                else:
+                    # PNG/JPEG: accumulate until the batch is full
+                    batch.append(media_id)
+                    if len(batch) >= batch_size:
+                        batches.append(list(batch))
+                        batch = []
 
             if batch:
                 batches.append(list(batch))

--- a/apprise/plugins/twitter.py
+++ b/apprise/plugins/twitter.py
@@ -41,9 +41,8 @@
 # X API v2 Current User endpoint:
 #   https://docs.x.com/x-api/users/user-lookup/api-reference/get-users-me
 #
-# Media upload still uses the v1.1 endpoint (permitted on all access levels):
-#   https://docs.x.com/x-api/v1/media/upload-media/api-reference/
-#       post-media-upload
+# X API v2 Media upload (available on all access tiers, including Free):
+#   https://docs.x.com/x-api/media/upload-media
 #
 # Free-tier accounts can ONLY post tweets (mode=tweet).
 # Sending Direct Messages (mode=dm, the default) requires a paid X API
@@ -126,10 +125,11 @@ class NotifyTwitter(NotifyBase):
     # Requires Basic+ X API subscription
     twitter_dm = "https://api.twitter.com/2/dm_conversations/with/{}/messages"
 
-    # Media upload still uses the v1.1 endpoint (allowed on all access levels):
+    # X API v2 Media Upload (available on all access tiers, including Free)
+    # media_category is required: "tweet_image" or "dm_image"
 
     # Twitter Media (Attachment) Upload Location
-    twitter_media = "https://upload.twitter.com/1.1/media/upload.json"
+    twitter_media = "https://api.x.com/2/media/upload"
 
     # it is documented on the site that the maximum images per tweet
     # is 4 (unless it's a GIF, then it's only 1)
@@ -359,12 +359,20 @@ class NotifyTwitter(NotifyBase):
                     f"{attachment.url(privacy=True)}"
                 )
 
+                # v2 media upload requires media_category:
+                # "tweet_image" for public tweets, "dm_image" for DMs
+                media_category = (
+                    "tweet_image"
+                    if self.mode == TwitterMessageMode.TWEET
+                    else "dm_image"
+                )
+
                 # Upload our image and get our id associated with it
-                # see: https://developer.twitter.com/en/docs/twitter-api/v1/\
-                #         media/upload-media/api-reference/post-media-upload
+                # see: https://docs.x.com/x-api/media/upload-media
                 postokay, response = self._fetch(
                     self.twitter_media,
                     payload=attachment,
+                    extra={"media_category": media_category},
                 )
 
                 if not postokay:
@@ -376,9 +384,13 @@ class NotifyTwitter(NotifyBase):
                     attachment.name if attachment.name else f"file{no:03}.dat"
                 )
 
-                if not (
-                    isinstance(response, dict) and response.get("media_id")
-                ):
+                # v2 response: {"data": {"id": "...", "media_key": "...", ...}}
+                try:
+                    media_id = response["data"]["id"]
+                except (TypeError, KeyError):
+                    media_id = None
+
+                if not media_id:
                     self.logger.debug(
                         "Could not attach the file to Twitter: %s (mime=%s)",
                         filename,
@@ -386,22 +398,10 @@ class NotifyTwitter(NotifyBase):
                     )
                     continue
 
-                # If we get here, our output will look something like this:
-                # {
-                #   "media_id": 710511363345354753,
-                #   "media_id_string": "710511363345354753",
-                #   "media_key": "3_710511363345354753",
-                #   "size": 11065,
-                #   "expires_after_secs": 86400,
-                #   "image": {
-                #     "image_type": "image/jpeg",
-                #     "w": 800,
-                #     "h": 320
-                #   }
-                # }
-
                 response.update(
                     {
+                        # Normalize id for _send_tweet/_send_dm consumption
+                        "media_id": media_id,
                         # Update our response to additionally include the
                         # attachment details
                         "file_name": filename,
@@ -644,17 +644,17 @@ class NotifyTwitter(NotifyBase):
 
         return results
 
-    def _user_lookup(self, screen_name, lazy=True):
-        """Looks up screen names and returns user IDs via v2.
+    def _user_lookup(self, usernames, lazy=True):
+        """Looks up usernames and returns user IDs via v2.
 
-        screen_name can be a list/set/tuple as well.
+        usernames can be a list/set/tuple as well.
         """
 
         # Contains a mapping of username to id
         results = {}
 
         # Build a unique set of names
-        names = parse_list(screen_name)
+        names = parse_list(usernames)
 
         if lazy and self._user_cache:
             # Use cached response
@@ -699,7 +699,7 @@ class NotifyTwitter(NotifyBase):
 
         return results
 
-    def _fetch(self, url, payload=None, method="POST", json=True):
+    def _fetch(self, url, payload=None, method="POST", json=True, extra=None):
         """Wrapper to Twitter API requests object."""
 
         headers = {
@@ -720,10 +720,16 @@ class NotifyTwitter(NotifyBase):
                     open(payload.path, "rb"),  # noqa: SIM115
                 ),
             }
+            # extra holds additional form fields (e.g. media_category)
+            data = extra
 
-        elif json and payload is not None:
-            headers["Content-Type"] = "application/json"
-            data = dumps(payload)
+        elif payload is not None:
+            if json:
+                headers["Content-Type"] = "application/json"
+                data = dumps(payload)
+            else:
+                # form-encoded or raw body (e.g. media upload helper)
+                data = payload
 
         auth = OAuth1(
             self.ckey,
@@ -784,7 +790,7 @@ class NotifyTwitter(NotifyBase):
                 # AttributeError = r is None
                 content = {}
 
-            if r.status_code != requests.codes.ok:
+            if not (200 <= r.status_code < 300):
                 # We had a problem
                 status_str = NotifyTwitter.http_response_code_lookup(
                     r.status_code

--- a/tests/test_plugin_twitter.py
+++ b/tests/test_plugin_twitter.py
@@ -540,6 +540,62 @@ def test_plugin_twitter_general(mocker):
     assert obj.send(body="test") is True
 
 
+def test_plugin_twitter_garbage_responses(mocker):
+    """Verify garbage/invalid server responses are handled gracefully."""
+
+    mock_get = mocker.patch("requests.get")
+    mock_post = mocker.patch("requests.post")
+
+    ckey = "ckey"
+    csecret = "csecret"
+    akey = "akey"
+    asecret = "asecret"
+
+    # Base request mock returning HTTP 200
+    request = Mock()
+    request.status_code = requests.codes.ok
+    request.headers = {}
+
+    mock_get.return_value = request
+    mock_post.return_value = request
+
+    # No targets -> _send_dm calls _whoami
+    obj = NotifyTwitter(ckey=ckey, csecret=csecret, akey=akey, asecret=asecret)
+
+    # _whoami: None content -> TypeError in loads() -> content = {}
+    # -> no "data" key in {} -> KeyError caught -> _whoami returns {}
+    request.content = None
+    assert obj.send(body="test") is False
+
+    # _whoami: malformed JSON -> ValueError in loads() -> content = {}
+    # -> same path as above
+    obj._whoami_cache = None
+    request.content = "{"
+    assert obj.send(body="test") is False
+
+    # _whoami: valid JSON but v1.1-style response (missing "data" key)
+    # -> KeyError in _whoami -> caught -> returns {}
+    obj._whoami_cache = None
+    request.content = json.dumps({"screen_name": "apprise", "id": 9876})
+    assert obj.send(body="test") is False
+
+    # Has targets -> _send_dm calls _user_lookup
+    obj2 = NotifyTwitter(
+        ckey=ckey,
+        csecret=csecret,
+        akey=akey,
+        asecret=asecret,
+        targets=TWITTER_SCREEN_NAME,
+    )
+
+    # _user_lookup: response is a list, not a dict
+    # -> isinstance(response, dict) is False -> continue -> no results
+    request.content = json.dumps(
+        [{"id": "9876", "username": TWITTER_SCREEN_NAME}]
+    )
+    assert obj2.send(body="test") is False
+
+
 def test_plugin_twitter_edge_cases():
     """NotifyTwitter() Edge Cases."""
 

--- a/tests/test_plugin_twitter.py
+++ b/tests/test_plugin_twitter.py
@@ -92,7 +92,7 @@ apprise_url_tests = (
             # No user mean's we message ourselves
             "instance": NotifyTwitter,
             # Expected notify() response False (because we won't be able
-            # to detect our user)
+            # to detect our user); default mock has no v2 data key
             "notify_response": False,
             # Our expected url(privacy=True) startswith() response:
             "privacy_url": "x://c...y/****/a...2/****",
@@ -106,11 +106,9 @@ apprise_url_tests = (
         {
             # No user mean's we message ourselves
             "instance": NotifyTwitter,
-            # However we'll be okay if we return a proper response
+            # v2 whoami format: {"data": {"id": "...", "username": "..."}}
             "requests_response_text": {
-                "id": 12345,
-                "screen_name": "test",
-                # For attachment handling
+                "data": {"id": "12345", "username": "test"},
                 "media_id": 123,
             },
         },
@@ -120,11 +118,9 @@ apprise_url_tests = (
         {
             # No user mean's we message ourselves
             "instance": NotifyTwitter,
-            # However we'll be okay if we return a proper response
+            # v2 whoami format
             "requests_response_text": {
-                "id": 12345,
-                "screen_name": "test",
-                # For attachment handling
+                "data": {"id": "12345", "username": "test"},
                 "media_id": 123,
             },
         },
@@ -135,11 +131,9 @@ apprise_url_tests = (
         {
             # No user mean's we message ourselves
             "instance": NotifyTwitter,
-            # However we'll be okay if we return a proper response
+            # v2 whoami format
             "requests_response_text": {
-                "id": 12345,
-                "screen_name": "test",
-                # For attachment handling
+                "data": {"id": "12345", "username": "test"},
                 "media_id": 123,
             },
         },
@@ -151,10 +145,9 @@ apprise_url_tests = (
         {
             # No user mean's we message ourselves
             "instance": NotifyTwitter,
-            # However we'll be okay if we return a proper response
+            # v1.1-format response (missing "data" key) causes _whoami to fail
             "requests_response_text": {
                 "id": 12345,
-                # For attachment handling
                 "media_id": 123,
             },
             # due to a mangled response_text we'll fail
@@ -179,7 +172,10 @@ apprise_url_tests = (
         {
             # No Cache & No Batch
             "instance": NotifyTwitter,
-            "requests_response_text": [{"id": 12345, "screen_name": "user"}],
+            # v2 user lookup format
+            "requests_response_text": {
+                "data": [{"id": "12345", "username": "user"}]
+            },
         },
     ),
     (
@@ -187,7 +183,10 @@ apprise_url_tests = (
         {
             # We're good!
             "instance": NotifyTwitter,
-            "requests_response_text": [{"id": 12345, "screen_name": "user"}],
+            # v2 user lookup format
+            "requests_response_text": {
+                "data": [{"id": "12345", "username": "user"}]
+            },
         },
     ),
     (
@@ -220,14 +219,17 @@ apprise_url_tests = (
         {
             # We're good!
             "instance": NotifyTwitter,
-            "requests_response_text": [
-                {"id": 12345, "screen_name": "usera"},
-                {"id": 12346, "screen_name": "userb"},
-                {
-                    # A garbage entry we can test exception handling on
-                    "id": 123,
-                },
-            ],
+            # v2 user lookup format with multiple entries and a garbage entry
+            # to test exception handling
+            "requests_response_text": {
+                "data": [
+                    {"id": "12345", "username": "usera"},
+                    {"id": "12346", "username": "userb"},
+                    {
+                        # A garbage entry we can test exception handling on
+                    },
+                ]
+            },
         },
     ),
     (
@@ -288,11 +290,14 @@ def twitter_url():
 
 @pytest.fixture
 def good_message_response():
-    """Prepare a good tweet response."""
+    """Prepare a good v2 whoami response."""
+    # v2 /users/me format: {"data": {"id": "...", "username": "..."}}
     response = good_response(
         {
-            "screen_name": TWITTER_SCREEN_NAME,
-            "id": 9876,
+            "data": {
+                "id": "9876",
+                "username": TWITTER_SCREEN_NAME,
+            }
         }
     )
     return response
@@ -354,7 +359,7 @@ def bad_media_response():
 @pytest.fixture(autouse=True)
 def ensure_get_verify_credentials_is_mocked(mocker, good_message_response):
     """
-    Make sure requests to https://api.twitter.com/1.1/account/verify_credentials.json
+    Make sure requests to https://api.twitter.com/2/users/me
     do not escape the test harness, for all test case functions.
     """
     mock_get = mocker.patch("requests.get")
@@ -379,18 +384,21 @@ def test_plugin_twitter_general(mocker):
     akey = "akey"
     asecret = "asecret"
 
-    response_obj = [
-        {
-            "screen_name": TWITTER_SCREEN_NAME,
-            "id": 9876,
-        }
-    ]
+    # v2 user lookup response: {"data": [{"id": "...", "username": "..."}]}
+    user_lookup_obj = {
+        "data": [
+            {
+                "username": TWITTER_SCREEN_NAME,
+                "id": "9876",
+            }
+        ]
+    }
 
     # Epoch time:
     epoch = datetime.fromtimestamp(0, timezone.utc)
 
     request = Mock()
-    request.content = json.dumps(response_obj)
+    request.content = json.dumps(user_lookup_obj)
     request.status_code = requests.codes.ok
     request.headers = {
         "x-rate-limit-reset": (
@@ -474,18 +482,13 @@ def test_plugin_twitter_general(mocker):
 
     # Alter pending targets
     obj.targets.append("usera")
-    request.content = json.dumps(response_obj)
-    response_obj = [
-        {
-            "screen_name": "usera",
-            "id": 1234,
-        }
-    ]
+    # Response still in v2 user_lookup format from above
+    request.content = json.dumps(user_lookup_obj)
 
     assert obj.send(body="test") is True
 
     # Flush our cache forcing it is re-creating
-    NotifyTwitter._user_cache = {}
+    obj._user_cache = {}
     assert obj.send(body="test") is True
 
     # Cause content response to be None
@@ -506,34 +509,33 @@ def test_plugin_twitter_general(mocker):
     assert TWITTER_SCREEN_NAME in results["targets"]
 
     # cause a json parsing issue now
-    response_obj = None
-    assert obj.send(body="test") is True
-
-    response_obj = "{"
     assert obj.send(body="test") is True
 
     # Set ourselves up to handle whoami calls
 
     # Flush out our cache
-    NotifyTwitter._user_cache = {}
+    obj._user_cache = {}
 
-    response_obj = {
-        "screen_name": TWITTER_SCREEN_NAME,
-        "id": 9876,
+    # v2 whoami response: {"data": {"id": "...", "username": "..."}}
+    whoami_obj = {
+        "data": {
+            "username": TWITTER_SCREEN_NAME,
+            "id": "9876",
+        }
     }
-    request.content = json.dumps(response_obj)
+    request.content = json.dumps(whoami_obj)
 
     obj = NotifyTwitter(ckey=ckey, csecret=csecret, akey=akey, asecret=asecret)
 
     assert obj.send(body="test") is True
 
     # Alter the key forcing us to look up a new value of ourselves again
-    NotifyTwitter._user_cache = {}
-    NotifyTwitter._whoami_cache = None
+    obj._user_cache = {}
+    obj._whoami_cache = None
     obj.ckey = "different.then.it.was"
     assert obj.send(body="test") is True
 
-    NotifyTwitter._whoami_cache = None
+    obj._whoami_cache = None
     obj.ckey = "different.again"
     assert obj.send(body="test") is True
 
@@ -594,7 +596,7 @@ def test_plugin_twitter_dm_caching(
     """Verify that the `NotifyTwitter.{_user_cache,_whoami_cache}` caches work
     as intended."""
 
-    # This is the request to `account/verify_credentials.json`.
+    # This is the request to `https://api.twitter.com/2/users/me`.
     # Explicitly mock it here so the calls to it can be evaluated.
     mock_get = mocker.patch("requests.get")
     mock_get.return_value = good_message_response
@@ -622,14 +624,15 @@ def test_plugin_twitter_dm_caching(
     # Test call counts.
     assert mock_get.call_count == 1
     assert (
+        # v2 current-user endpoint replaced v1.1 verify_credentials
         mock_get.call_args_list[0][0][0]
-        == "https://api.twitter.com/1.1/account/verify_credentials.json"
+        == "https://api.twitter.com/2/users/me"
     )
 
     assert mock_post.call_count == 1
-    assert (
-        mock_post.call_args_list[0][0][0]
-        == "https://api.twitter.com/1.1/direct_messages/events/new.json"
+    # v2 DM endpoint; user id "9876" comes from good_message_response
+    assert mock_post.call_args_list[0][0][0].startswith(
+        "https://api.twitter.com/2/dm_conversations/with/"
     )
 
     # Reset the mocks to start counting calls from scratch.
@@ -642,8 +645,8 @@ def test_plugin_twitter_dm_caching(
         is True
     )
 
-    # Calls to `verify_credentials.json` will get cached by `NotifyTwitter`.
-    # So, the `GET` request to `verify_credentials.json` should only have been
+    # Calls to `users/me` will get cached by `NotifyTwitter`.
+    # So, the `GET` request to `users/me` should only have been
     # issued once.
     assert mock_get.call_count == 0
     assert mock_post.call_count == 1
@@ -691,18 +694,20 @@ def test_plugin_twitter_dm_attachments_basic(
     # Test call counts.
     assert mock_get.call_count == 1
     assert (
+        # v2 whoami endpoint
         mock_get.call_args_list[0][0][0]
-        == "https://api.twitter.com/1.1/account/verify_credentials.json"
+        == "https://api.twitter.com/2/users/me"
     )
 
     assert mock_post.call_count == 2
     assert (
+        # Media upload still uses the v1.1 endpoint (allowed on all plans)
         mock_post.call_args_list[0][0][0]
         == "https://upload.twitter.com/1.1/media/upload.json"
     )
-    assert (
-        mock_post.call_args_list[1][0][0]
-        == "https://api.twitter.com/1.1/direct_messages/events/new.json"
+    assert mock_post.call_args_list[1][0][0].startswith(
+        # v2 DM endpoint
+        "https://api.twitter.com/2/dm_conversations/with/"
     )
 
 
@@ -731,12 +736,13 @@ def test_plugin_twitter_dm_attachments_message_fails(
 
     assert mock_post.call_count == 2
     assert (
+        # Media upload still uses the v1.1 endpoint
         mock_post.call_args_list[0][0][0]
         == "https://upload.twitter.com/1.1/media/upload.json"
     )
-    assert (
-        mock_post.call_args_list[1][0][0]
-        == "https://api.twitter.com/1.1/direct_messages/events/new.json"
+    assert mock_post.call_args_list[1][0][0].startswith(
+        # v2 DM endpoint
+        "https://api.twitter.com/2/dm_conversations/with/"
     )
 
 
@@ -841,6 +847,7 @@ def test_plugin_twitter_dm_attachments_multiple(
     )
 
     assert mock_post.call_count == 8
+    # First 4 calls are media uploads (v1.1 endpoint, unchanged)
     assert (
         mock_post.call_args_list[0][0][0]
         == "https://upload.twitter.com/1.1/media/upload.json"
@@ -857,21 +864,18 @@ def test_plugin_twitter_dm_attachments_multiple(
         mock_post.call_args_list[3][0][0]
         == "https://upload.twitter.com/1.1/media/upload.json"
     )
-    assert (
-        mock_post.call_args_list[4][0][0]
-        == "https://api.twitter.com/1.1/direct_messages/events/new.json"
+    # Last 4 calls are DM sends via v2 endpoint
+    assert mock_post.call_args_list[4][0][0].startswith(
+        "https://api.twitter.com/2/dm_conversations/with/"
     )
-    assert (
-        mock_post.call_args_list[5][0][0]
-        == "https://api.twitter.com/1.1/direct_messages/events/new.json"
+    assert mock_post.call_args_list[5][0][0].startswith(
+        "https://api.twitter.com/2/dm_conversations/with/"
     )
-    assert (
-        mock_post.call_args_list[6][0][0]
-        == "https://api.twitter.com/1.1/direct_messages/events/new.json"
+    assert mock_post.call_args_list[6][0][0].startswith(
+        "https://api.twitter.com/2/dm_conversations/with/"
     )
-    assert (
-        mock_post.call_args_list[7][0][0]
-        == "https://api.twitter.com/1.1/direct_messages/events/new.json"
+    assert mock_post.call_args_list[7][0][0].startswith(
+        "https://api.twitter.com/2/dm_conversations/with/"
     )
 
 
@@ -945,12 +949,13 @@ def test_plugin_twitter_tweet_attachments_basic(
     # Verify API calls.
     assert mock_post.call_count == 2
     assert (
+        # Media upload still uses the v1.1 endpoint
         mock_post.call_args_list[0][0][0]
         == "https://upload.twitter.com/1.1/media/upload.json"
     )
     assert (
-        mock_post.call_args_list[1][0][0]
-        == "https://api.twitter.com/1.1/statuses/update.json"
+        # Tweet now uses the v2 endpoint
+        mock_post.call_args_list[1][0][0] == "https://api.twitter.com/2/tweets"
     )
 
 
@@ -960,18 +965,14 @@ def test_plugin_twitter_tweet_attachments_more_logging(
 ):
     """
     NotifyTwitter() Tweet Attachment Checks - More logging
-
-    TODO: The "more logging" aspect is not verified yet?
     """
 
+    # v2 tweet response: {"data": {"id": "...", "text": "..."}}
     good_tweet_response = good_response(
         {
-            "screen_name": TWITTER_SCREEN_NAME,
-            "id": 9876,
-            # needed for additional logging
-            "id_str": "12345",
-            "user": {
-                "screen_name": TWITTER_SCREEN_NAME,
+            "data": {
+                "id": "12345",
+                "text": "body",
             },
         }
     )
@@ -983,8 +984,7 @@ def test_plugin_twitter_tweet_attachments_more_logging(
     obj = Apprise.instantiate(twitter_url)
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
 
-    # Send our notification (again); this time there will be more logging
-    # TODO: The "more logging" aspect is not verified yet?
+    # Send our notification
     assert (
         obj.notify(
             body="body",
@@ -1002,8 +1002,7 @@ def test_plugin_twitter_tweet_attachments_more_logging(
         == "https://upload.twitter.com/1.1/media/upload.json"
     )
     assert (
-        mock_post.call_args_list[1][0][0]
-        == "https://api.twitter.com/1.1/statuses/update.json"
+        mock_post.call_args_list[1][0][0] == "https://api.twitter.com/2/tweets"
     )
 
 
@@ -1037,8 +1036,7 @@ def test_plugin_twitter_tweet_attachments_bad_message_response(
         == "https://upload.twitter.com/1.1/media/upload.json"
     )
     assert (
-        mock_post.call_args_list[1][0][0]
-        == "https://api.twitter.com/1.1/statuses/update.json"
+        mock_post.call_args_list[1][0][0] == "https://api.twitter.com/2/tweets"
     )
 
 
@@ -1075,8 +1073,7 @@ def test_plugin_twitter_tweet_attachments_bad_message_response_unparseable(
         == "https://upload.twitter.com/1.1/media/upload.json"
     )
     assert (
-        mock_post.call_args_list[1][0][0]
-        == "https://api.twitter.com/1.1/statuses/update.json"
+        mock_post.call_args_list[1][0][0] == "https://api.twitter.com/2/tweets"
     )
 
 
@@ -1114,8 +1111,7 @@ def test_plugin_twitter_tweet_attachments_upload_fails(
         == "https://upload.twitter.com/1.1/media/upload.json"
     )
     assert (
-        mock_post.call_args_list[1][0][0]
-        == "https://api.twitter.com/1.1/statuses/update.json"
+        mock_post.call_args_list[1][0][0] == "https://api.twitter.com/2/tweets"
     )
 
 
@@ -1204,18 +1200,16 @@ def test_plugin_twitter_tweet_attachments_multiple_batch(
         mock_post.call_args_list[3][0][0]
         == "https://upload.twitter.com/1.1/media/upload.json"
     )
+    # v2 tweet endpoint
     assert (
-        mock_post.call_args_list[4][0][0]
-        == "https://api.twitter.com/1.1/statuses/update.json"
+        mock_post.call_args_list[4][0][0] == "https://api.twitter.com/2/tweets"
     )
     assert (
-        mock_post.call_args_list[5][0][0]
-        == "https://api.twitter.com/1.1/statuses/update.json"
+        mock_post.call_args_list[5][0][0] == "https://api.twitter.com/2/tweets"
     )
     # The 2 images are grouped together (batch mode)
     assert (
-        mock_post.call_args_list[6][0][0]
-        == "https://api.twitter.com/1.1/statuses/update.json"
+        mock_post.call_args_list[6][0][0] == "https://api.twitter.com/2/tweets"
     )
 
 
@@ -1275,21 +1269,18 @@ def test_plugin_twitter_tweet_attachments_multiple_nobatch(
         mock_post.call_args_list[3][0][0]
         == "https://upload.twitter.com/1.1/media/upload.json"
     )
+    # v2 tweet endpoint (one per image, no batching)
     assert (
-        mock_post.call_args_list[4][0][0]
-        == "https://api.twitter.com/1.1/statuses/update.json"
+        mock_post.call_args_list[4][0][0] == "https://api.twitter.com/2/tweets"
     )
     assert (
-        mock_post.call_args_list[5][0][0]
-        == "https://api.twitter.com/1.1/statuses/update.json"
+        mock_post.call_args_list[5][0][0] == "https://api.twitter.com/2/tweets"
     )
     assert (
-        mock_post.call_args_list[6][0][0]
-        == "https://api.twitter.com/1.1/statuses/update.json"
+        mock_post.call_args_list[6][0][0] == "https://api.twitter.com/2/tweets"
     )
     assert (
-        mock_post.call_args_list[7][0][0]
-        == "https://api.twitter.com/1.1/statuses/update.json"
+        mock_post.call_args_list[7][0][0] == "https://api.twitter.com/2/tweets"
     )
 
 

--- a/tests/test_plugin_twitter.py
+++ b/tests/test_plugin_twitter.py
@@ -358,7 +358,7 @@ def bad_media_response():
 
 
 @pytest.fixture(autouse=True)
-def ensure_get_verify_credentials_is_mocked(mocker, good_message_response):
+def ensure_whoami_is_mocked(mocker, good_message_response):
     """
     Make sure requests to https://api.twitter.com/2/users/me
     do not escape the test harness, for all test case functions.
@@ -509,7 +509,7 @@ def test_plugin_twitter_general(mocker):
     assert isinstance(results, dict) is True
     assert TWITTER_SCREEN_NAME in results["targets"]
 
-    # cause a json parsing issue now
+    # Valid JSON response; send succeeds
     assert obj.send(body="test") is True
 
     # Set ourselves up to handle whoami calls
@@ -777,7 +777,7 @@ def test_plugin_twitter_dm_attachments_basic(
 
     assert mock_post.call_count == 2
     assert (
-        # Media upload still uses the v1.1 endpoint (allowed on all plans)
+        # v2 media upload endpoint (available on all access tiers)
         mock_post.call_args_list[0][0][0] == "https://api.x.com/2/media/upload"
     )
     assert (
@@ -812,7 +812,7 @@ def test_plugin_twitter_dm_attachments_message_fails(
 
     assert mock_post.call_count == 2
     assert (
-        # Media upload still uses the v1.1 endpoint
+        # v2 media upload endpoint (available on all access tiers)
         mock_post.call_args_list[0][0][0] == "https://api.x.com/2/media/upload"
     )
     assert (
@@ -922,7 +922,7 @@ def test_plugin_twitter_dm_attachments_multiple(
     )
 
     assert mock_post.call_count == 8
-    # First 4 calls are media uploads (v1.1 endpoint, unchanged)
+    # First 4 calls are v2 media uploads
     assert (
         mock_post.call_args_list[0][0][0] == "https://api.x.com/2/media/upload"
     )
@@ -1023,11 +1023,11 @@ def test_plugin_twitter_tweet_attachments_basic(
     # Verify API calls.
     assert mock_post.call_count == 2
     assert (
-        # Media upload still uses the v1.1 endpoint
+        # v2 media upload endpoint (available on all access tiers)
         mock_post.call_args_list[0][0][0] == "https://api.x.com/2/media/upload"
     )
     assert (
-        # Tweet now uses the v2 endpoint
+        # v2 tweet endpoint
         mock_post.call_args_list[1][0][0] == "https://api.twitter.com/2/tweets"
     )
 
@@ -1379,4 +1379,72 @@ def test_plugin_twitter_tweet_attachments_multiple_oserror(
     )
     assert (
         mock_post.call_args_list[1][0][0] == "https://api.x.com/2/media/upload"
+    )
+
+
+@patch("requests.post")
+def test_plugin_twitter_tweet_attachments_jpeg_before_gif(
+    mock_post, twitter_url, good_media_response
+):
+    """
+    Verify that when PNG/JPEG attachments precede a GIF in batch mode,
+    the accumulated PNG/JPEG batch is flushed first, then the GIF is
+    emitted alone.  This exercises the ``if batch:`` flush branch inside
+    the non-batchable (GIF) path of _send_tweet.
+    """
+
+    # v2 tweet response
+    good_tweet_response = good_response(
+        {"data": {"id": "12345", "text": "body"}}
+    )
+
+    # 3 uploads (jpeg, png, gif) + 2 tweet sends = 5 post calls
+    mock_post.side_effect = [
+        good_media_response,
+        good_media_response,
+        good_media_response,
+        good_tweet_response,
+        good_tweet_response,
+    ]
+
+    # instantiate in tweet + batch mode
+    obj = Apprise.instantiate(twitter_url + "?mode=tweet")
+
+    # jpeg and png come first, then gif -- the gif triggers a flush of
+    # the pending jpeg/png batch before being emitted in its own tweet
+    attach = [
+        os.path.join(TEST_VAR_DIR, "apprise-test.jpeg"),
+        os.path.join(TEST_VAR_DIR, "apprise-test.png"),
+        os.path.join(TEST_VAR_DIR, "apprise-test.gif"),
+    ]
+
+    assert (
+        obj.notify(
+            body="body",
+            title="title",
+            notify_type=NotifyType.INFO,
+            attach=attach,
+        )
+        is True
+    )
+
+    # 3 media uploads + 2 tweet sends
+    assert mock_post.call_count == 5
+    # First 3 are v2 media uploads
+    assert (
+        mock_post.call_args_list[0][0][0] == "https://api.x.com/2/media/upload"
+    )
+    assert (
+        mock_post.call_args_list[1][0][0] == "https://api.x.com/2/media/upload"
+    )
+    assert (
+        mock_post.call_args_list[2][0][0] == "https://api.x.com/2/media/upload"
+    )
+    # jpeg + png batched into one tweet
+    assert (
+        mock_post.call_args_list[3][0][0] == "https://api.twitter.com/2/tweets"
+    )
+    # gif emitted alone in its own tweet
+    assert (
+        mock_post.call_args_list[4][0][0] == "https://api.twitter.com/2/tweets"
     )

--- a/tests/test_plugin_twitter.py
+++ b/tests/test_plugin_twitter.py
@@ -321,16 +321,17 @@ def bad_message_response():
 
 @pytest.fixture
 def good_media_response():
-    """Prepare a good media response."""
+    """Prepare a good v2 media upload response."""
+    # v2 /2/media/upload format: {"data": {"id": "...", ...}}
     response = Mock()
     response.content = json.dumps(
         {
-            "media_id": 710511363345354753,
-            "media_id_string": "710511363345354753",
-            "media_key": "3_710511363345354753",
-            "size": 11065,
-            "expires_after_secs": 86400,
-            "image": {"image_type": "image/jpeg", "w": 800, "h": 320},
+            "data": {
+                "id": "710511363345354753",
+                "media_key": "3_710511363345354753",
+                "expires_after_secs": 86400,
+                "size": 11065,
+            }
         }
     )
     response.status_code = requests.codes.ok
@@ -595,6 +596,24 @@ def test_plugin_twitter_garbage_responses(mocker):
     )
     assert obj2.send(body="test") is False
 
+    # _fetch: json=False with a non-None payload -> raw body path
+    request.content = json.dumps({})
+    postokay, _ = obj._fetch(
+        "https://api.twitter.com/2/tweets",
+        payload="raw=data",
+        json=False,
+    )
+    assert postokay is True
+
+    # _fetch: HTTP 201 Created is treated as success (v2 POST endpoints)
+    request.status_code = requests.codes.created
+    request.content = json.dumps({"data": {"id": "1"}})
+    postokay, _response = obj._fetch(
+        "https://api.twitter.com/2/tweets",
+        payload={"text": "hi"},
+    )
+    assert postokay is True
+
 
 def test_plugin_twitter_edge_cases():
     """NotifyTwitter() Edge Cases."""
@@ -687,8 +706,9 @@ def test_plugin_twitter_dm_caching(
 
     assert mock_post.call_count == 1
     # v2 DM endpoint; user id "9876" comes from good_message_response
-    assert mock_post.call_args_list[0][0][0].startswith(
-        "https://api.twitter.com/2/dm_conversations/with/"
+    assert (
+        mock_post.call_args_list[0][0][0]
+        == "https://api.twitter.com/2/dm_conversations/with/9876/messages"
     )
 
     # Reset the mocks to start counting calls from scratch.
@@ -758,12 +778,12 @@ def test_plugin_twitter_dm_attachments_basic(
     assert mock_post.call_count == 2
     assert (
         # Media upload still uses the v1.1 endpoint (allowed on all plans)
-        mock_post.call_args_list[0][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[0][0][0] == "https://api.x.com/2/media/upload"
     )
-    assert mock_post.call_args_list[1][0][0].startswith(
-        # v2 DM endpoint
-        "https://api.twitter.com/2/dm_conversations/with/"
+    assert (
+        # v2 DM endpoint; user id "9876" comes from good_message_response
+        mock_post.call_args_list[1][0][0]
+        == "https://api.twitter.com/2/dm_conversations/with/9876/messages"
     )
 
 
@@ -793,12 +813,12 @@ def test_plugin_twitter_dm_attachments_message_fails(
     assert mock_post.call_count == 2
     assert (
         # Media upload still uses the v1.1 endpoint
-        mock_post.call_args_list[0][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[0][0][0] == "https://api.x.com/2/media/upload"
     )
-    assert mock_post.call_args_list[1][0][0].startswith(
-        # v2 DM endpoint
-        "https://api.twitter.com/2/dm_conversations/with/"
+    assert (
+        # v2 DM endpoint; user id "9876" comes from good_message_response
+        mock_post.call_args_list[1][0][0]
+        == "https://api.twitter.com/2/dm_conversations/with/9876/messages"
     )
 
 
@@ -828,8 +848,7 @@ def test_plugin_twitter_dm_attachments_upload_fails(
     # Test call counts.
     assert mock_post.call_count == 1
     assert (
-        mock_post.call_args_list[0][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[0][0][0] == "https://api.x.com/2/media/upload"
     )
 
 
@@ -905,33 +924,34 @@ def test_plugin_twitter_dm_attachments_multiple(
     assert mock_post.call_count == 8
     # First 4 calls are media uploads (v1.1 endpoint, unchanged)
     assert (
-        mock_post.call_args_list[0][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[0][0][0] == "https://api.x.com/2/media/upload"
     )
     assert (
-        mock_post.call_args_list[1][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[1][0][0] == "https://api.x.com/2/media/upload"
     )
     assert (
-        mock_post.call_args_list[2][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[2][0][0] == "https://api.x.com/2/media/upload"
     )
     assert (
-        mock_post.call_args_list[3][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[3][0][0] == "https://api.x.com/2/media/upload"
     )
-    # Last 4 calls are DM sends via v2 endpoint
-    assert mock_post.call_args_list[4][0][0].startswith(
-        "https://api.twitter.com/2/dm_conversations/with/"
+    # Last 4 calls are DM sends via v2 endpoint; user id "9876" from
+    # good_message_response
+    assert (
+        mock_post.call_args_list[4][0][0]
+        == "https://api.twitter.com/2/dm_conversations/with/9876/messages"
     )
-    assert mock_post.call_args_list[5][0][0].startswith(
-        "https://api.twitter.com/2/dm_conversations/with/"
+    assert (
+        mock_post.call_args_list[5][0][0]
+        == "https://api.twitter.com/2/dm_conversations/with/9876/messages"
     )
-    assert mock_post.call_args_list[6][0][0].startswith(
-        "https://api.twitter.com/2/dm_conversations/with/"
+    assert (
+        mock_post.call_args_list[6][0][0]
+        == "https://api.twitter.com/2/dm_conversations/with/9876/messages"
     )
-    assert mock_post.call_args_list[7][0][0].startswith(
-        "https://api.twitter.com/2/dm_conversations/with/"
+    assert (
+        mock_post.call_args_list[7][0][0]
+        == "https://api.twitter.com/2/dm_conversations/with/9876/messages"
     )
 
 
@@ -967,12 +987,10 @@ def test_plugin_twitter_dm_attachments_multiple_oserror(
 
     assert mock_post.call_count == 2
     assert (
-        mock_post.call_args_list[0][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[0][0][0] == "https://api.x.com/2/media/upload"
     )
     assert (
-        mock_post.call_args_list[1][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[1][0][0] == "https://api.x.com/2/media/upload"
     )
 
 
@@ -1006,8 +1024,7 @@ def test_plugin_twitter_tweet_attachments_basic(
     assert mock_post.call_count == 2
     assert (
         # Media upload still uses the v1.1 endpoint
-        mock_post.call_args_list[0][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[0][0][0] == "https://api.x.com/2/media/upload"
     )
     assert (
         # Tweet now uses the v2 endpoint
@@ -1054,8 +1071,7 @@ def test_plugin_twitter_tweet_attachments_more_logging(
     # Verify API calls.
     assert mock_post.call_count == 2
     assert (
-        mock_post.call_args_list[0][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[0][0][0] == "https://api.x.com/2/media/upload"
     )
     assert (
         mock_post.call_args_list[1][0][0] == "https://api.twitter.com/2/tweets"
@@ -1088,8 +1104,7 @@ def test_plugin_twitter_tweet_attachments_bad_message_response(
     # Verify API calls.
     assert mock_post.call_count == 2
     assert (
-        mock_post.call_args_list[0][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[0][0][0] == "https://api.x.com/2/media/upload"
     )
     assert (
         mock_post.call_args_list[1][0][0] == "https://api.twitter.com/2/tweets"
@@ -1125,8 +1140,7 @@ def test_plugin_twitter_tweet_attachments_bad_message_response_unparseable(
     # Verify API calls.
     assert mock_post.call_count == 2
     assert (
-        mock_post.call_args_list[0][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[0][0][0] == "https://api.x.com/2/media/upload"
     )
     assert (
         mock_post.call_args_list[1][0][0] == "https://api.twitter.com/2/tweets"
@@ -1163,8 +1177,7 @@ def test_plugin_twitter_tweet_attachments_upload_fails(
     # Verify API calls.
     assert mock_post.call_count == 2
     assert (
-        mock_post.call_args_list[0][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[0][0][0] == "https://api.x.com/2/media/upload"
     )
     assert (
         mock_post.call_args_list[1][0][0] == "https://api.twitter.com/2/tweets"
@@ -1241,20 +1254,16 @@ def test_plugin_twitter_tweet_attachments_multiple_batch(
 
     assert mock_post.call_count == 7
     assert (
-        mock_post.call_args_list[0][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[0][0][0] == "https://api.x.com/2/media/upload"
     )
     assert (
-        mock_post.call_args_list[1][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[1][0][0] == "https://api.x.com/2/media/upload"
     )
     assert (
-        mock_post.call_args_list[2][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[2][0][0] == "https://api.x.com/2/media/upload"
     )
     assert (
-        mock_post.call_args_list[3][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[3][0][0] == "https://api.x.com/2/media/upload"
     )
     # v2 tweet endpoint
     assert (
@@ -1310,20 +1319,16 @@ def test_plugin_twitter_tweet_attachments_multiple_nobatch(
 
     assert mock_post.call_count == 8
     assert (
-        mock_post.call_args_list[0][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[0][0][0] == "https://api.x.com/2/media/upload"
     )
     assert (
-        mock_post.call_args_list[1][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[1][0][0] == "https://api.x.com/2/media/upload"
     )
     assert (
-        mock_post.call_args_list[2][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[2][0][0] == "https://api.x.com/2/media/upload"
     )
     assert (
-        mock_post.call_args_list[3][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[3][0][0] == "https://api.x.com/2/media/upload"
     )
     # v2 tweet endpoint (one per image, no batching)
     assert (
@@ -1370,10 +1375,8 @@ def test_plugin_twitter_tweet_attachments_multiple_oserror(
 
     assert mock_post.call_count == 2
     assert (
-        mock_post.call_args_list[0][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[0][0][0] == "https://api.x.com/2/media/upload"
     )
     assert (
-        mock_post.call_args_list[1][0][0]
-        == "https://upload.twitter.com/1.1/media/upload.json"
+        mock_post.call_args_list[1][0][0] == "https://api.x.com/2/media/upload"
     )


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1342

The Twitter (X) plugin used the deprecated v1.1 API endpoints. Free-tier X developer accounts have been blocked from these endpoints since 2023, receiving a 403 error on any attempt to post a tweet or send a DM. This PR migrates all API calls to X API v2, which is supported on the Free tier for tweet posting, while clearly documenting that Direct Messages still require a paid (Basic+) subscription.

## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/59](https://github.com/caronc/apprise-docs/pull/59)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`). Coverage: 99.5% (accepted miss: the `json=False` `else` branch inside `_fetch`, which is no longer reachable from within the plugin but remains available in the API).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1342-x-api-v2-migration

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "x://CONSUMER_KEY/CONSUMER_SECRET/ACCESS_TOKEN/ACCESS_SECRET?mode=tweet"
```

For free-tier X API accounts only `mode=tweet` will succeed.
For Basic+ X API accounts, both `mode=tweet` and `mode=dm` (the default) will succeed.
