### PR TITLE
improvements to workflow:// based on recent slack:// changes

### DIFF
--- a/apprise/plugins/workflows.py
+++ b/apprise/plugins/workflows.py
@@ -259,6 +259,11 @@ class NotifyWorkflows(NotifyBase):
         if template:
             # Add our definition to our template
             self.template.add(template)
+            if not len(self.template):
+                # add() failed (unsupported schema, unparseable URL, etc.)
+                msg = "The Workflows template specified could not be loaded."
+                self.logger.warning(msg)
+                raise TypeError(msg)
             # Enforce maximum file size
             self.template[0].max_file_size = self.max_workflows_template_size
 
@@ -388,24 +393,84 @@ class NotifyWorkflows(NotifyBase):
         # Enforce Application mode
         tokens["app_mode"] = TemplateType.JSON
 
+        # Coerce all substitution values to str before JSON-escaping.
+        # apply_template's _escape_json() calls json.dumps(v)[1:-1] which
+        # is only correct for strings; None produces "ul" and other non-
+        # string types produce similarly corrupted output.  app_mode is a
+        # TemplateType sentinel passed as a named parameter, not a
+        # substitution value, so it is left as-is.
+        safe_tokens = {
+            k: (
+                v
+                if k == "app_mode" or isinstance(v, str)
+                else ("" if v is None else str(v))
+            )
+            for k, v in tokens.items()
+        }
+
         try:
             with open(template.path) as fp:
-                content = json.loads(apply_template(fp.read(), **tokens))
+                content = json.loads(apply_template(fp.read(), **safe_tokens))
 
         except OSError:
             self.logger.error(
-                f"MSTeam template {template.url(privacy=True)} could not be"
-                " read."
+                "Workflow template"
+                f" {template.url(privacy=True)} could not be read."
             )
-            return None
+            return False
 
         except JSONDecodeError as e:
             self.logger.error(
-                f"MSTeam template {template.url(privacy=True)} contains"
-                " invalid JSON."
+                "Workflow template"
+                f" {template.url(privacy=True)} contains invalid JSON."
             )
             self.logger.debug(f"JSONDecodeError: {e}")
-            return None
+            return False
+
+        # Validate the required payload structure for Workflows/Power Automate
+
+        # Template must parse to a JSON object, not an array or scalar
+        if not isinstance(content, dict):
+            self.logger.error(
+                "Workflow template"
+                f" {template.url(privacy=True)} must be a JSON object"
+                " (got {}).".format(type(content).__name__)
+            )
+            return False
+
+        # Root payload must be a Workflows/Power Automate 'message' type
+        if content.get("type") != "message":
+            self.logger.error(
+                "Workflow template"
+                f" {template.url(privacy=True)} must have"
+                " 'type': 'message'"
+                " (got {!r}).".format(content.get("type"))
+            )
+            return False
+
+        # Payload must carry a non-empty attachments list
+        if (
+            not isinstance(content.get("attachments"), list)
+            or not content["attachments"]
+        ):
+            self.logger.error(
+                "Workflow template"
+                f" {template.url(privacy=True)} must contain"
+                " a non-empty 'attachments' list."
+            )
+            return False
+
+        # Each attachment must be a dict with a contentType string
+        if not all(
+            isinstance(a, dict) and isinstance(a.get("contentType"), str)
+            for a in content["attachments"]
+        ):
+            self.logger.error(
+                "Workflow template"
+                f" {template.url(privacy=True)} contains an"
+                " attachment missing a 'contentType' string."
+            )
+            return False
 
         return content
 

--- a/tests/test_plugin_workflows.py
+++ b/tests/test_plugin_workflows.py
@@ -679,7 +679,9 @@ def test_plugin_workflows_template_add_failure():
             )
 
 
-def test_plugin_workflows_templating_content_not_dict(workflows_url, tmpdir):
+def test_plugin_workflows_templating_content_not_dict(
+    request_mock, workflows_url, tmpdir
+):
     """NotifyWorkflows() Templating - template that parses to a JSON
     array is rejected cleanly."""
     # Valid JSON but a list rather than an object; no HTTP call is made
@@ -692,10 +694,11 @@ def test_plugin_workflows_templating_content_not_dict(workflows_url, tmpdir):
         obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
         is False
     )
+    assert request_mock.called is False
 
 
 def test_plugin_workflows_templating_attachment_not_dict(
-    workflows_url, tmpdir
+    request_mock, workflows_url, tmpdir
 ):
     """NotifyWorkflows() Templating - non-dict in attachments rejected."""
     # attachments list contains a string rather than a dict; no HTTP call made
@@ -708,6 +711,7 @@ def test_plugin_workflows_templating_attachment_not_dict(
         obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
         is False
     )
+    assert request_mock.called is False
 
 
 def test_plugin_workflows_templating_none_token_value(

--- a/tests/test_plugin_workflows.py
+++ b/tests/test_plugin_workflows.py
@@ -245,9 +245,10 @@ def simple_template(tmpdir):
         "type": "message",
         "attachments": [{
             "contentType": "application/vnd.microsoft.card.adaptive",
-            "contentUrl": None,
+            "contentUrl": null,
             "content": {
-                "$schema":"http://adaptivecards.io/schemas/adaptive-card.json",
+                "$schema":
+                    "http://adaptivecards.io/schemas/adaptive-card.json",
                 "type": "AdaptiveCard",
                 "version": "1.4",
                 "msteams": { "width": "full" },
@@ -256,10 +257,10 @@ def simple_template(tmpdir):
                         "type": "TextBlock",
                         "text": "**Test**",
                         "style": "heading"
-                    },
+                    }
                 ]
             }
-        ]
+        }]
     }
     """)
     )
@@ -407,17 +408,23 @@ def test_plugin_workflows_templating_basic_success(
     template.write(
         cleandoc("""
     {
-      "@type": "MessageCard",
-      "@context": "https://schema.org/extensions",
-      "summary": "{{app_id}}",
-      "themeColor": "{{app_color}}",
-      "sections": [
-        {
-          "activityImage": null,
-          "activityTitle": "{{app_title}}",
-          "text": "{{app_body}}"
+      "type": "message",
+      "attachments": [{
+        "contentType": "application/vnd.microsoft.card.adaptive",
+        "contentUrl": null,
+        "content": {
+          "$schema":
+            "http://adaptivecards.io/schemas/adaptive-card.json",
+          "type": "AdaptiveCard",
+          "version": "1.4",
+          "body": [
+            {"type": "TextBlock", "id": "app_id", "text": "{{app_id}}"},
+            {"type": "TextBlock", "id": "color", "text": "{{app_color}}"},
+            {"type": "TextBlock", "id": "title", "text": "{{app_title}}"},
+            {"type": "TextBlock", "id": "body", "text": "{{app_body}}"}
+          ]
         }
-      ]
+      }]
     }
     """)
     )
@@ -445,11 +452,15 @@ def test_plugin_workflows_templating_basic_success(
     # Our Posted JSON Object
     posted_json = json.loads(request_mock.call_args_list[0][1]["data"])
     assert "NotifyType." not in request_mock.call_args_list[0][1]["data"]
-    assert "summary" in posted_json
-    assert posted_json["summary"] == "Apprise"
-    assert posted_json["themeColor"] == "#3AA3E3"
-    assert posted_json["sections"][0]["activityTitle"] == "title"
-    assert posted_json["sections"][0]["text"] == "body"
+    # Verify the Adaptive Card envelope
+    assert posted_json["type"] == "message"
+    content = posted_json["attachments"][0]["content"]
+    # Index body blocks by their id for easy lookup
+    blocks = {b["id"]: b["text"] for b in content["body"] if "id" in b}
+    assert blocks["app_id"] == "Apprise"
+    assert blocks["color"] == "#3AA3E3"
+    assert blocks["title"] == "title"
+    assert blocks["body"] == "body"
 
 
 def test_plugin_workflows_templating_invalid_json(
@@ -506,39 +517,37 @@ def test_plugin_workflows_templating_target_success(
 ):
     """
     NotifyWorkflows() Templating - success with target.
-    A more complicated example; uses a target.
+    A more complicated example; uses a custom token.
     """
 
     template = tmpdir.join("more_complicated_example.json")
     template.write(
         cleandoc("""
     {
-      "@type": "MessageCard",
-      "@context": "https://schema.org/extensions",
-      "summary": "{{app_desc}}",
-      "themeColor": "{{app_color}}",
-      "sections": [
-        {
-          "activityImage": null,
-          "activityTitle": "{{app_title}}",
-          "text": "{{app_body}}"
+      "type": "message",
+      "attachments": [{
+        "contentType": "application/vnd.microsoft.card.adaptive",
+        "contentUrl": null,
+        "content": {
+          "$schema":
+            "http://adaptivecards.io/schemas/adaptive-card.json",
+          "type": "AdaptiveCard",
+          "version": "1.4",
+          "body": [
+            {"type": "TextBlock", "id": "desc", "text": "{{app_desc}}"},
+            {"type": "TextBlock", "id": "color", "text": "{{app_color}}"},
+            {"type": "TextBlock", "id": "title", "text": "{{app_title}}"},
+            {"type": "TextBlock", "id": "body", "text": "{{app_body}}"}
+          ],
+          "actions": [
+            {
+              "type": "Action.OpenUrl",
+              "title": "Open",
+              "url": "{{ target }}"
+            }
+          ]
         }
-      ],
-     "potentialAction": [{
-        "@type": "ActionCard",
-        "name": "Add a comment",
-        "inputs": [{
-            "@type": "TextInput",
-            "id": "comment",
-            "isMultiline": false,
-            "title": "Add a comment here for this task."
-        }],
-        "actions": [{
-            "@type": "HttpPOST",
-            "name": "Add Comment",
-            "target": "{{ target }}"
-        }]
-     }]
+      }]
     }
     """)
     )
@@ -566,17 +575,173 @@ def test_plugin_workflows_templating_target_success(
     # Our Posted JSON Object
     posted_json = json.loads(request_mock.call_args_list[0][1]["data"])
     assert "NotifyType." not in request_mock.call_args_list[0][1]["data"]
-    assert "summary" in posted_json
-    assert posted_json["summary"] == "Apprise Notifications"
-    assert posted_json["themeColor"] == "#3AA3E3"
-    assert posted_json["sections"][0]["activityTitle"] == "title"
-    assert posted_json["sections"][0]["text"] == "body"
+    # Verify the Adaptive Card envelope
+    assert posted_json["type"] == "message"
+    content = posted_json["attachments"][0]["content"]
+    # Index body blocks by their id for easy lookup
+    blocks = {b["id"]: b["text"] for b in content["body"] if "id" in b}
+    assert blocks["desc"] == "Apprise Notifications"
+    assert blocks["color"] == "#3AA3E3"
+    assert blocks["title"] == "title"
+    assert blocks["body"] == "body"
+    # The custom :target token must be substituted into the action URL
+    assert content["actions"][0]["url"] == "http://localhost"
 
-    # We even parsed our entry out of the URL
-    assert (
-        posted_json["potentialAction"][0]["actions"][0]["target"]
-        == "http://localhost"
+
+def test_plugin_workflows_templating_invalid_type(
+    request_mock, workflows_url, tmpdir
+):
+    """NotifyWorkflows() Templating - root 'type' != 'message' is rejected."""
+
+    template = tmpdir.join("bad_type.json")
+    template.write(
+        cleandoc("""
+    {
+      "type": "wrongtype",
+      "attachments": [{
+        "contentType": "application/vnd.microsoft.card.adaptive",
+        "contentUrl": null,
+        "content": {}
+      }]
+    }
+    """)
     )
+
+    obj = Apprise.instantiate(f"{workflows_url}/?template={template!s}")
+    assert isinstance(obj, NotifyWorkflows)
+    # Validation rejects incorrect 'type' value
+    assert (
+        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        is False
+    )
+    assert request_mock.called is False
+
+
+def test_plugin_workflows_templating_missing_attachments(
+    request_mock, workflows_url, tmpdir
+):
+    """NotifyWorkflows() Templating - absent or empty attachments fails."""
+
+    template = tmpdir.join("no_attachments.json")
+
+    # Missing 'attachments' key entirely
+    template.write('{"type": "message"}')
+    obj = Apprise.instantiate(f"{workflows_url}/?template={template!s}")
+    assert isinstance(obj, NotifyWorkflows)
+    assert (
+        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        is False
+    )
+    assert request_mock.called is False
+
+    # Empty list is also rejected
+    template.write('{"type": "message", "attachments": []}')
+    obj2 = Apprise.instantiate(f"{workflows_url}/?template={template!s}")
+    assert isinstance(obj2, NotifyWorkflows)
+    assert (
+        obj2.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        is False
+    )
+    assert request_mock.called is False
+
+
+def test_plugin_workflows_templating_invalid_contenttype(
+    request_mock, workflows_url, tmpdir
+):
+    """NotifyWorkflows() Templating - attachment missing contentType fails."""
+
+    template = tmpdir.join("no_contenttype.json")
+    template.write('{"type": "message", "attachments": [{"content": {}}]}')
+
+    obj = Apprise.instantiate(f"{workflows_url}/?template={template!s}")
+    assert isinstance(obj, NotifyWorkflows)
+    # An attachment without a 'contentType' string is rejected
+    assert (
+        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        is False
+    )
+    assert request_mock.called is False
+
+
+def test_plugin_workflows_template_add_failure():
+    """NotifyWorkflows() - TypeError when add() drops the entry."""
+    # Simulate add() silently failing (len stays 0); no HTTP call needed
+    with mock.patch("apprise.plugins.workflows.AppriseAttachment") as mock_cls:
+        inst = mock.MagicMock()
+        inst.__len__ = mock.Mock(return_value=0)
+        mock_cls.return_value = inst
+
+        with pytest.raises(TypeError):
+            NotifyWorkflows(
+                workflow="T00000000001",
+                signature="AbCdEfGhIjKlMnOpQrStUvWx",
+                template="file:///some/template.json",
+            )
+
+
+def test_plugin_workflows_templating_content_not_dict(workflows_url, tmpdir):
+    """NotifyWorkflows() Templating - template that parses to a JSON
+    array is rejected cleanly."""
+    # Valid JSON but a list rather than an object; no HTTP call is made
+    template = tmpdir.join("array.json")
+    template.write('[{"type": "message"}]')
+
+    obj = Apprise.instantiate(f"{workflows_url}/?template={template!s}")
+    assert isinstance(obj, NotifyWorkflows)
+    assert (
+        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        is False
+    )
+
+
+def test_plugin_workflows_templating_attachment_not_dict(
+    workflows_url, tmpdir
+):
+    """NotifyWorkflows() Templating - non-dict in attachments rejected."""
+    # attachments list contains a string rather than a dict; no HTTP call made
+    template = tmpdir.join("bad_attach.json")
+    template.write('{"type": "message", "attachments": ["not-a-dict"]}')
+
+    obj = Apprise.instantiate(f"{workflows_url}/?template={template!s}")
+    assert isinstance(obj, NotifyWorkflows)
+    assert (
+        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        is False
+    )
+
+
+def test_plugin_workflows_templating_none_token_value(
+    request_mock, workflows_url, tmpdir
+):
+    """NotifyWorkflows() Templating - None token value (e.g. app_image_url)
+    is coerced to empty string before JSON-escaping."""
+    # Template references app_image_url which will be None when
+    # include_image=False; old code produced corrupted JSON ("ul" from None)
+    template = tmpdir.join("img_ref.json")
+    template.write(
+        '{"type": "message", "attachments": [{'
+        '"contentType": "application/vnd.microsoft.card.adaptive",'
+        '"content": {"body": [{"type": "TextBlock",'
+        '"text": "{{app_body}} img={{app_image_url}}"}]}}]}'
+    )
+
+    # image=no forces app_image_url to None, exercising the None->""
+    # coercion in safe_tokens
+    obj = Apprise.instantiate(
+        f"{workflows_url}/?image=no&template={template!s}"
+    )
+    assert isinstance(obj, NotifyWorkflows)
+    # Must succeed -- None coerced to "" keeps the JSON valid
+    assert (
+        obj.notify(body="hello", title="t", notify_type=NotifyType.INFO)
+        is True
+    )
+    assert request_mock.called is True
+    posted_data = json.loads(request_mock.call_args_list[0][1]["data"])
+    body_text = posted_data["attachments"][0]["content"]["body"][0]["text"]
+    # app_image_url should expand to "" not "ul"
+    assert "img=" in body_text
+    assert "ul" not in body_text
 
 
 def test_workflows_yaml_config_missing_template_filename(

--- a/tests/test_plugin_workflows.py
+++ b/tests/test_plugin_workflows.py
@@ -30,6 +30,7 @@ import json
 
 # Disable logging for a cleaner testing output
 import logging
+import sys
 from unittest import mock
 
 from helpers import AppriseURLTester
@@ -663,6 +664,10 @@ def test_plugin_workflows_templating_invalid_contenttype(
     assert request_mock.called is False
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="Python <3.10: see test_plugin_workflows_template_add_failure_py39",
+)
 def test_plugin_workflows_template_add_failure():
     """NotifyWorkflows() - TypeError when add() drops the entry."""
     # Simulate add() silently failing (len stays 0); no HTTP call needed
@@ -677,6 +682,41 @@ def test_plugin_workflows_template_add_failure():
                 signature="AbCdEfGhIjKlMnOpQrStUvWx",
                 template="file:///some/template.json",
             )
+
+
+# --- Python v3.9 Support ---
+# On Python 3.9, mock.patch() resolves a dotted target ("a.b.c.Name") by
+# walking getattr(pkg, "sub") chains rather than going straight to
+# sys.modules (that was fixed in Python 3.10+).
+# Delete this test once Python 3.9 reaches end-of-life.
+@pytest.mark.skipif(
+    sys.version_info >= (3, 10),
+    reason="Python 3.10+ mock.patch resolves via sys.modules directly",
+)
+def test_plugin_workflows_template_add_failure_py39_compat():
+    """NotifyWorkflows() - TypeError when add() drops the entry (Py 3.9)."""
+    import importlib
+
+    # Resolve the live module so patch.object and the class share the same
+    # module dict regardless of any sys.modules manipulation by earlier tests.
+    wf_mod = importlib.import_module("apprise.plugins.workflows")
+    _NotifyWorkflows = wf_mod.NotifyWorkflows
+
+    # Simulate add() silently failing (len stays 0); no HTTP call needed
+    with mock.patch.object(wf_mod, "AppriseAttachment") as mock_cls:
+        inst = mock.MagicMock()
+        inst.__len__ = mock.Mock(return_value=0)
+        mock_cls.return_value = inst
+
+        with pytest.raises(TypeError):
+            _NotifyWorkflows(
+                workflow="T00000000001",
+                signature="AbCdEfGhIjKlMnOpQrStUvWx",
+                template="file:///some/template.json",
+            )
+
+
+# --- End Python v3.9 Compat ---
 
 
 def test_plugin_workflows_templating_content_not_dict(


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1604

Recent changes to `slack://` provided a bit of a lesson-learned setup to enforce bulletproofing of the `workflow://` templates as well.

This is just a improvement to what already works.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [ ] Documentation ticket created (if applicable): n/a
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@workflow-lessons-learned

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    workflow://credentials?template=input
```
