### PR TITLE
Added redirect= for allowing url redirection control

### DIFF
--- a/apprise/asset.py
+++ b/apprise/asset.py
@@ -190,6 +190,14 @@ class AppriseAsset:
     # that you leave this option as is otherwise.
     secure_logging = True
 
+    # By default, HTTP redirects (3xx responses) are not followed. This
+    # prevents custom headers and credentials from being forwarded to
+    # destinations not explicitly configured by the operator. Set this to
+    # True to restore the historical behaviour globally across all plugins
+    # without having to add redirect=yes to every individual URL.
+    # Individual URLs can still override this via the redirect= parameter.
+    http_redirects = False
+
     # Optionally specify one or more path to attempt to scan for Python modules
     # By default, no paths are scanned.
     __plugin_paths = []

--- a/apprise/asset.py
+++ b/apprise/asset.py
@@ -190,13 +190,12 @@ class AppriseAsset:
     # that you leave this option as is otherwise.
     secure_logging = True
 
-    # By default, HTTP redirects (3xx responses) are not followed. This
-    # prevents custom headers and credentials from being forwarded to
-    # destinations not explicitly configured by the operator. Set this to
-    # True to restore the historical behaviour globally across all plugins
-    # without having to add redirect=yes to every individual URL.
-    # Individual URLs can still override this via the redirect= parameter.
-    http_redirects = False
+    # By default, HTTP redirects (3xx responses) are followed, matching the
+    # behaviour of the underlying requests library. Set this to False to
+    # disable redirect following globally across all plugins without having
+    # to add redirect=no to every individual URL. Individual URLs can still
+    # override this via the redirect= parameter.
+    http_redirects = True
 
     # Optionally specify one or more path to attempt to scan for Python modules
     # By default, no paths are scanned.

--- a/apprise/attachment/http.py
+++ b/apprise/attachment/http.py
@@ -157,6 +157,17 @@ class AttachHTTP(AttachBase):
                     # Handle Errors
                     r.raise_for_status()
 
+                    # raise_for_status() only covers 4xx/5xx; when redirect
+                    # following is disabled a 3xx must be treated as a failure
+                    # so we do not silently stream a redirect HTML stub.
+                    if not self.redirects and r.is_redirect:
+                        self.logger.error(
+                            "HTTP redirect encountered but redirect "
+                            "following is disabled:"
+                            f" {self.url(privacy=True)}"
+                        )
+                        return False
+
                     # Get our file-size (if known)
                     try:
                         file_size = int(r.headers.get("Content-Length", "0"))

--- a/apprise/attachment/http.py
+++ b/apprise/attachment/http.py
@@ -151,6 +151,7 @@ class AttachHTTP(AttachBase):
                     params=self.qsd,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                     stream=True,
                 ) as r:
                     # Handle Errors

--- a/apprise/attachment/http.py
+++ b/apprise/attachment/http.py
@@ -158,9 +158,11 @@ class AttachHTTP(AttachBase):
                     r.raise_for_status()
 
                     # raise_for_status() only covers 4xx/5xx; when redirect
-                    # following is disabled a 3xx must be treated as a failure
-                    # so we do not silently stream a redirect HTML stub.
-                    if not self.redirects and r.is_redirect:
+                    # following is disabled any 3xx must be treated as a
+                    # failure so we do not silently stream a redirect stub.
+                    # Using a status-code range rather than r.is_redirect
+                    # catches 3xx responses that lack a Location header.
+                    if not self.redirects and 300 <= r.status_code < 400:
                         self.logger.error(
                             "HTTP redirect encountered but redirect "
                             "following is disabled:"

--- a/apprise/config/http.py
+++ b/apprise/config/http.py
@@ -192,6 +192,17 @@ class ConfigHTTP(ConfigBase):
                 # Handle Errors
                 r.raise_for_status()
 
+                # raise_for_status() only covers 4xx/5xx; when redirect
+                # following is disabled a 3xx must be treated as a failure
+                # so we do not silently return a redirect HTML stub as config.
+                if not self.redirects and r.is_redirect:
+                    self.logger.error(
+                        "HTTP redirect encountered but redirect "
+                        "following is disabled:"
+                        f" {self.url(privacy=True)}"
+                    )
+                    return None
+
                 # Get our file-size (if known)
                 try:
                     file_size = int(r.headers.get("Content-Length", "0"))

--- a/apprise/config/http.py
+++ b/apprise/config/http.py
@@ -193,9 +193,11 @@ class ConfigHTTP(ConfigBase):
                 r.raise_for_status()
 
                 # raise_for_status() only covers 4xx/5xx; when redirect
-                # following is disabled a 3xx must be treated as a failure
-                # so we do not silently return a redirect HTML stub as config.
-                if not self.redirects and r.is_redirect:
+                # following is disabled any 3xx must be treated as a failure
+                # so we do not silently return a redirect stub as config.
+                # Using a status-code range rather than r.is_redirect
+                # catches 3xx responses that lack a Location header.
+                if not self.redirects and 300 <= r.status_code < 400:
                     self.logger.error(
                         "HTTP redirect encountered but redirect "
                         "following is disabled:"

--- a/apprise/config/http.py
+++ b/apprise/config/http.py
@@ -186,6 +186,7 @@ class ConfigHTTP(ConfigBase):
                 auth=auth,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
                 stream=True,
             ) as r:
                 # Handle Errors

--- a/apprise/plugins/africas_talking.py
+++ b/apprise/plugins/africas_talking.py
@@ -333,6 +333,7 @@ class NotifyAfricasTalking(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
                 # Sample response
                 # {

--- a/apprise/plugins/apprise_api.py
+++ b/apprise/plugins/apprise_api.py
@@ -401,6 +401,7 @@ class NotifyAppriseAPI(NotifyBase):
                 files=files if files else None,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code != requests.codes.ok:
                 # We had a problem

--- a/apprise/plugins/bark.py
+++ b/apprise/plugins/bark.py
@@ -436,6 +436,7 @@ class NotifyBark(NotifyBase):
                     auth=auth,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
                 if r.status_code != requests.codes.ok:
                     # We had a problem

--- a/apprise/plugins/bluesky.py
+++ b/apprise/plugins/bluesky.py
@@ -568,6 +568,7 @@ class NotifyBlueSky(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             # Get our JSON content if it's possible

--- a/apprise/plugins/brevo.py
+++ b/apprise/plugins/brevo.py
@@ -522,6 +522,7 @@ class NotifyBrevo(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
                 if r.status_code not in (
                     requests.codes.ok,

--- a/apprise/plugins/bulksms.py
+++ b/apprise/plugins/bulksms.py
@@ -345,6 +345,7 @@ class NotifyBulkSMS(NotifyBase):
                     auth=auth,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 # The responsne might look like:

--- a/apprise/plugins/bulkvs.py
+++ b/apprise/plugins/bulkvs.py
@@ -257,6 +257,7 @@ class NotifyBulkVS(NotifyBase):
                     auth=auth,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 # A Response may look like:

--- a/apprise/plugins/burstsms.py
+++ b/apprise/plugins/burstsms.py
@@ -316,6 +316,7 @@ class NotifyBurstSMS(NotifyBase):
                     auth=auth,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 if r.status_code != requests.codes.ok:

--- a/apprise/plugins/chanify.py
+++ b/apprise/plugins/chanify.py
@@ -132,6 +132,7 @@ class NotifyChanify(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code != requests.codes.ok:
                 # We had a problem

--- a/apprise/plugins/clickatell.py
+++ b/apprise/plugins/clickatell.py
@@ -230,6 +230,7 @@ class NotifyClickatell(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 if (

--- a/apprise/plugins/clicksend.py
+++ b/apprise/plugins/clicksend.py
@@ -209,6 +209,7 @@ class NotifyClickSend(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
                 if r.status_code != requests.codes.ok:
                     # We had a problem

--- a/apprise/plugins/custom_form.py
+++ b/apprise/plugins/custom_form.py
@@ -406,6 +406,7 @@ class NotifyForm(NotifyBase):
                 auth=auth,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code < 200 or r.status_code >= 300:
                 # We had a problem

--- a/apprise/plugins/custom_json.py
+++ b/apprise/plugins/custom_json.py
@@ -321,6 +321,7 @@ class NotifyJSON(NotifyBase):
                 auth=auth,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code < 200 or r.status_code >= 300:
                 # We had a problem

--- a/apprise/plugins/custom_xml.py
+++ b/apprise/plugins/custom_xml.py
@@ -412,6 +412,7 @@ class NotifyXML(NotifyBase):
                 auth=auth,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code < 200 or r.status_code >= 300:
                 # We had a problem

--- a/apprise/plugins/d7networks.py
+++ b/apprise/plugins/d7networks.py
@@ -273,6 +273,7 @@ class NotifyD7Networks(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 if r.status_code not in (

--- a/apprise/plugins/dapnet.py
+++ b/apprise/plugins/dapnet.py
@@ -272,6 +272,7 @@ class NotifyDapnet(NotifyBase):
                     ),
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
                 if r.status_code != requests.codes.created:
                     # We had a problem

--- a/apprise/plugins/dingtalk.py
+++ b/apprise/plugins/dingtalk.py
@@ -247,6 +247,7 @@ class NotifyDingTalk(NotifyBase):
                 params=params,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             if r.status_code != requests.codes.ok:

--- a/apprise/plugins/discord.py
+++ b/apprise/plugins/discord.py
@@ -550,6 +550,7 @@ class NotifyDiscord(NotifyBase):
                 files=files,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             # Handle rate limiting (if specified)

--- a/apprise/plugins/dot.py
+++ b/apprise/plugins/dot.py
@@ -317,6 +317,7 @@ class NotifyDot(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             if r.status_code == requests.codes.ok:

--- a/apprise/plugins/emby.py
+++ b/apprise/plugins/emby.py
@@ -207,6 +207,7 @@ class NotifyEmby(NotifyBase):
                 data=dumps(payload),
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             if r.status_code != requests.codes.ok:
@@ -374,6 +375,7 @@ class NotifyEmby(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             if r.status_code != requests.codes.ok:
@@ -456,6 +458,7 @@ class NotifyEmby(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             if r.status_code not in (
@@ -560,6 +563,7 @@ class NotifyEmby(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
                 if r.status_code not in (
                     requests.codes.ok,

--- a/apprise/plugins/enigma2.py
+++ b/apprise/plugins/enigma2.py
@@ -291,6 +291,7 @@ class NotifyEnigma2(NotifyBase):
                 auth=auth,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             if r.status_code != requests.codes.ok:

--- a/apprise/plugins/evolution.py
+++ b/apprise/plugins/evolution.py
@@ -239,6 +239,7 @@ class NotifyEvolution(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 if r.status_code not in (

--- a/apprise/plugins/exotel.py
+++ b/apprise/plugins/exotel.py
@@ -481,6 +481,7 @@ class NotifyExotel(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 if r.status_code != requests.codes.ok:

--- a/apprise/plugins/fcm/__init__.py
+++ b/apprise/plugins/fcm/__init__.py
@@ -265,6 +265,7 @@ class NotifyFCM(NotifyBase):
         self.oauth = GoogleOAuth(
             user_agent=self.app_id,
             timeout=self.request_timeout,
+            allow_redirects=self.redirects,
             verify_certificate=self.verify_certificate,
         )
 
@@ -489,6 +490,7 @@ class NotifyFCM(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
                 if r.status_code not in (
                     requests.codes.ok,

--- a/apprise/plugins/fcm/__init__.py
+++ b/apprise/plugins/fcm/__init__.py
@@ -265,7 +265,7 @@ class NotifyFCM(NotifyBase):
         self.oauth = GoogleOAuth(
             user_agent=self.app_id,
             timeout=self.request_timeout,
-            allow_redirects=self.redirects,
+            redirects=self.redirects,
             verify_certificate=self.verify_certificate,
         )
 

--- a/apprise/plugins/fcm/oauth.py
+++ b/apprise/plugins/fcm/oauth.py
@@ -276,6 +276,7 @@ class GoogleOAuth:
                 headers=http_headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code != requests.codes.ok:
                 # We had a problem

--- a/apprise/plugins/fcm/oauth.py
+++ b/apprise/plugins/fcm/oauth.py
@@ -64,12 +64,19 @@ class GoogleOAuth:
     clock_skew = timedelta(seconds=10)
 
     def __init__(
-        self, user_agent=None, timeout=(5, 4), verify_certificate=True
+        self,
+        user_agent=None,
+        timeout=(5, 4),
+        verify_certificate=True,
+        redirects=True,
     ):
         """Initialize our OAuth object."""
 
         # Wether or not to verify ssl
         self.verify_certificate = verify_certificate
+
+        # Whether to follow HTTP 3xx redirects
+        self.redirects = redirects
 
         # Our (connect, read) timeout
         self.request_timeout = timeout

--- a/apprise/plugins/feishu.py
+++ b/apprise/plugins/feishu.py
@@ -143,6 +143,7 @@ class NotifyFeishu(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             #

--- a/apprise/plugins/flock.py
+++ b/apprise/plugins/flock.py
@@ -273,6 +273,7 @@ class NotifyFlock(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code != requests.codes.ok:
                 # We had a problem

--- a/apprise/plugins/fluxer.py
+++ b/apprise/plugins/fluxer.py
@@ -681,6 +681,7 @@ class NotifyFluxer(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             if r.status_code == requests.codes.too_many_requests:

--- a/apprise/plugins/fortysixelks.py
+++ b/apprise/plugins/fortysixelks.py
@@ -225,6 +225,7 @@ class Notify46Elks(NotifyBase):
                     auth=(self.user, self.password),
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
                 if r.status_code != requests.codes.ok:
                     # We had a problem

--- a/apprise/plugins/freemobile.py
+++ b/apprise/plugins/freemobile.py
@@ -151,6 +151,7 @@ class NotifyFreeMobile(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code != requests.codes.ok:
                 # We had a problem

--- a/apprise/plugins/google_chat.py
+++ b/apprise/plugins/google_chat.py
@@ -256,6 +256,7 @@ class NotifyGoogleChat(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code not in (
                 requests.codes.ok,

--- a/apprise/plugins/gotify.py
+++ b/apprise/plugins/gotify.py
@@ -238,6 +238,7 @@ class NotifyGotify(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code != requests.codes.ok:
                 # We had a problem

--- a/apprise/plugins/home_assistant.py
+++ b/apprise/plugins/home_assistant.py
@@ -376,6 +376,7 @@ class NotifyHomeAssistant(NotifyBase):
                 auth=auth,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code != requests.codes.ok:
                 # We had a problem

--- a/apprise/plugins/httpsms.py
+++ b/apprise/plugins/httpsms.py
@@ -214,6 +214,7 @@ class NotifyHttpSMS(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 if r.status_code != requests.codes.ok:

--- a/apprise/plugins/ifttt.py
+++ b/apprise/plugins/ifttt.py
@@ -246,6 +246,7 @@ class NotifyIFTTT(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
                 self.logger.debug(
                     f"IFTTT HTTP response headers: {r.headers!r}"

--- a/apprise/plugins/jira.py
+++ b/apprise/plugins/jira.py
@@ -535,6 +535,7 @@ class NotifyJira(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             # A Response might look like:

--- a/apprise/plugins/join.py
+++ b/apprise/plugins/join.py
@@ -317,6 +317,7 @@ class NotifyJoin(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 if r.status_code != requests.codes.ok:

--- a/apprise/plugins/kavenegar.py
+++ b/apprise/plugins/kavenegar.py
@@ -246,6 +246,7 @@ class NotifyKavenegar(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 if r.status_code not in (

--- a/apprise/plugins/kodi.py
+++ b/apprise/plugins/kodi.py
@@ -274,6 +274,7 @@ class NotifyXBMC(NotifyBase):
                 auth=auth,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code != requests.codes.ok:
                 # We had a problem

--- a/apprise/plugins/kumulos.py
+++ b/apprise/plugins/kumulos.py
@@ -166,6 +166,7 @@ class NotifyKumulos(NotifyBase):
                 auth=auth,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code != requests.codes.ok:
                 # We had a problem

--- a/apprise/plugins/lametric.py
+++ b/apprise/plugins/lametric.py
@@ -838,6 +838,7 @@ class NotifyLametric(NotifyBase):
                 auth=auth,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             # An ideal response would be:
             # {

--- a/apprise/plugins/lark.py
+++ b/apprise/plugins/lark.py
@@ -128,6 +128,7 @@ class NotifyLark(NotifyBase):
                 data=json.dumps(payload),
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code != requests.codes.ok:
                 self.logger.warning(

--- a/apprise/plugins/line.py
+++ b/apprise/plugins/line.py
@@ -197,6 +197,7 @@ class NotifyLine(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
                 if r.status_code != requests.codes.ok:
                     # We had a problem

--- a/apprise/plugins/mailgun.py
+++ b/apprise/plugins/mailgun.py
@@ -557,6 +557,7 @@ class NotifyMailgun(NotifyBase):
                     files=files if files else None,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 if r.status_code != requests.codes.ok:

--- a/apprise/plugins/mastodon.py
+++ b/apprise/plugins/mastodon.py
@@ -1078,6 +1078,7 @@ class NotifyMastodon(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             try:

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -636,6 +636,7 @@ class NotifyMatrix(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code != requests.codes.ok:
                 # We had a problem
@@ -1856,6 +1857,7 @@ class NotifyMatrix(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 # Store status code
@@ -2830,6 +2832,7 @@ class NotifyMatrix(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
         except requests.RequestException as e:
             self.logger.warning(

--- a/apprise/plugins/mattermost.py
+++ b/apprise/plugins/mattermost.py
@@ -367,6 +367,7 @@ class NotifyMattermost(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             if r.status_code != requests.codes.ok:
@@ -552,6 +553,7 @@ class NotifyMattermost(NotifyBase):
                                 },
                                 verify=self.verify_certificate,
                                 timeout=self.request_timeout,
+                                allow_redirects=self.redirects,
                             )
 
                         except requests.RequestException as e:
@@ -658,6 +660,7 @@ class NotifyMattermost(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 if r.status_code not in expected:

--- a/apprise/plugins/messagebird.py
+++ b/apprise/plugins/messagebird.py
@@ -212,6 +212,7 @@ class NotifyMessageBird(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 # Sample output of a successful transmission

--- a/apprise/plugins/misskey.py
+++ b/apprise/plugins/misskey.py
@@ -260,6 +260,7 @@ class NotifyMisskey(NotifyBase):
                 data=dumps(payload),
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code != requests.codes.ok:
                 # We had a problem

--- a/apprise/plugins/msg91.py
+++ b/apprise/plugins/msg91.py
@@ -288,6 +288,7 @@ class NotifyMSG91(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             if r.status_code != requests.codes.ok:

--- a/apprise/plugins/msteams.py
+++ b/apprise/plugins/msteams.py
@@ -492,6 +492,7 @@ class NotifyMSTeams(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code != requests.codes.ok:
                 # We had a problem

--- a/apprise/plugins/nextcloud.py
+++ b/apprise/plugins/nextcloud.py
@@ -344,6 +344,7 @@ class NotifyNextcloud(NotifyBase):
                 auth=auth,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             try:

--- a/apprise/plugins/nextcloudtalk.py
+++ b/apprise/plugins/nextcloudtalk.py
@@ -224,6 +224,7 @@ class NotifyNextcloudTalk(NotifyBase):
                     auth=(self.user, self.password),
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
                 if r.status_code not in (
                     requests.codes.created,

--- a/apprise/plugins/notica.py
+++ b/apprise/plugins/notica.py
@@ -238,6 +238,7 @@ class NotifyNotica(NotifyBase):
                 auth=auth,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code != requests.codes.ok:
                 # We had a problem

--- a/apprise/plugins/notifiarr.py
+++ b/apprise/plugins/notifiarr.py
@@ -365,6 +365,7 @@ class NotifyNotifiarr(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code < 200 or r.status_code >= 300:
                 # We had a problem

--- a/apprise/plugins/notificationapi.py
+++ b/apprise/plugins/notificationapi.py
@@ -880,6 +880,7 @@ class NotifyNotificationAPI(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 try:

--- a/apprise/plugins/notifico.py
+++ b/apprise/plugins/notifico.py
@@ -303,6 +303,7 @@ class NotifyNotifico(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code != requests.codes.ok:
                 # We had a problem

--- a/apprise/plugins/ntfy.py
+++ b/apprise/plugins/ntfy.py
@@ -660,6 +660,7 @@ class NotifyNtfy(NotifyBase):
                 auth=auth,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             if r.status_code != requests.codes.ok:

--- a/apprise/plugins/octopush.py
+++ b/apprise/plugins/octopush.py
@@ -363,6 +363,7 @@ class NotifyOctopush(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 if r.status_code != requests.codes.created:

--- a/apprise/plugins/office365.py
+++ b/apprise/plugins/office365.py
@@ -1169,6 +1169,7 @@ class NotifyOffice365(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             if r.status_code not in (

--- a/apprise/plugins/one_signal.py
+++ b/apprise/plugins/one_signal.py
@@ -472,6 +472,7 @@ class NotifyOneSignal(NotifyBase):
                         headers=headers,
                         verify=self.verify_certificate,
                         timeout=self.request_timeout,
+                        allow_redirects=self.redirects,
                     )
                     if r.status_code not in (
                         requests.codes.ok,

--- a/apprise/plugins/opsgenie.py
+++ b/apprise/plugins/opsgenie.py
@@ -537,6 +537,7 @@ class NotifyOpsgenie(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             # A Response might look like:

--- a/apprise/plugins/pagerduty.py
+++ b/apprise/plugins/pagerduty.py
@@ -406,6 +406,7 @@ class NotifyPagerDuty(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code not in (
                 requests.codes.ok,

--- a/apprise/plugins/pagertree.py
+++ b/apprise/plugins/pagertree.py
@@ -275,6 +275,7 @@ class NotifyPagerTree(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code not in (
                 requests.codes.ok,

--- a/apprise/plugins/parseplatform.py
+++ b/apprise/plugins/parseplatform.py
@@ -236,6 +236,7 @@ class NotifyParsePlatform(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code != requests.codes.ok:
                 # We had a problem

--- a/apprise/plugins/plivo.py
+++ b/apprise/plugins/plivo.py
@@ -257,6 +257,7 @@ class NotifyPlivo(NotifyBase):
                     auth=auth,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 if r.status_code not in (

--- a/apprise/plugins/popcorn_notify.py
+++ b/apprise/plugins/popcorn_notify.py
@@ -197,6 +197,7 @@ class NotifyPopcornNotify(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
                 if r.status_code != requests.codes.ok:
                     # We had a problem

--- a/apprise/plugins/postmark.py
+++ b/apprise/plugins/postmark.py
@@ -511,6 +511,7 @@ class NotifyPostmark(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
                 if r.status_code != requests.codes.ok:
                     # We had a problem

--- a/apprise/plugins/prowl.py
+++ b/apprise/plugins/prowl.py
@@ -228,6 +228,7 @@ class NotifyProwl(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code != requests.codes.ok:
                 # We had a problem

--- a/apprise/plugins/pushbullet.py
+++ b/apprise/plugins/pushbullet.py
@@ -353,6 +353,7 @@ class NotifyPushBullet(NotifyBase):
                 auth=auth,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             try:

--- a/apprise/plugins/pushdeer.py
+++ b/apprise/plugins/pushdeer.py
@@ -147,6 +147,7 @@ class NotifyPushDeer(NotifyBase):
                 notify_url,
                 data=payload,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             if r.status_code != requests.codes.ok:

--- a/apprise/plugins/pushed.py
+++ b/apprise/plugins/pushed.py
@@ -273,6 +273,7 @@ class NotifyPushed(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             if r.status_code != requests.codes.ok:

--- a/apprise/plugins/pushjet.py
+++ b/apprise/plugins/pushjet.py
@@ -218,6 +218,7 @@ class NotifyPushjet(NotifyBase):
                 auth=auth,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code != requests.codes.ok:
                 # We had a problem

--- a/apprise/plugins/pushme.py
+++ b/apprise/plugins/pushme.py
@@ -140,6 +140,7 @@ class NotifyPushMe(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code != requests.codes.ok:
                 # We had a problem

--- a/apprise/plugins/pushover.py
+++ b/apprise/plugins/pushover.py
@@ -563,6 +563,7 @@ class NotifyPushover(NotifyBase):
                 auth=auth,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             if r.status_code != requests.codes.ok:

--- a/apprise/plugins/pushplus.py
+++ b/apprise/plugins/pushplus.py
@@ -401,6 +401,7 @@ class NotifyPushplus(NotifyBase):
                     ),
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 if r.status_code != requests.codes.ok:

--- a/apprise/plugins/pushsafer.py
+++ b/apprise/plugins/pushsafer.py
@@ -752,6 +752,7 @@ class NotifyPushSafer(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             try:

--- a/apprise/plugins/pushy.py
+++ b/apprise/plugins/pushy.py
@@ -245,6 +245,7 @@ class NotifyPushy(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 # Sample response

--- a/apprise/plugins/qq.py
+++ b/apprise/plugins/qq.py
@@ -121,6 +121,7 @@ class NotifyQQ(NotifyBase):
                 data=payload,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             if response.status_code != requests.codes.ok:

--- a/apprise/plugins/reddit.py
+++ b/apprise/plugins/reddit.py
@@ -600,6 +600,7 @@ class NotifyReddit(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             #  We attempt to login again and retry the original request
@@ -637,6 +638,7 @@ class NotifyReddit(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
             # Get our JSON content if it's possible

--- a/apprise/plugins/resend.py
+++ b/apprise/plugins/resend.py
@@ -508,6 +508,7 @@ class NotifyResend(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
                 if r.status_code not in (
                     requests.codes.ok,

--- a/apprise/plugins/revolt.py
+++ b/apprise/plugins/revolt.py
@@ -270,6 +270,7 @@ class NotifyRevolt(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             try:

--- a/apprise/plugins/rocketchat.py
+++ b/apprise/plugins/rocketchat.py
@@ -563,6 +563,7 @@ class NotifyRocketChat(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code != requests.codes.ok:
                 # We had a problem
@@ -618,6 +619,7 @@ class NotifyRocketChat(NotifyBase):
                 data=payload,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code != requests.codes.ok:
                 # We had a problem
@@ -689,6 +691,7 @@ class NotifyRocketChat(NotifyBase):
                 headers=self.headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code != requests.codes.ok:
                 # We had a problem

--- a/apprise/plugins/ryver.py
+++ b/apprise/plugins/ryver.py
@@ -244,6 +244,7 @@ class NotifyRyver(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             if r.status_code != requests.codes.ok:

--- a/apprise/plugins/sendgrid.py
+++ b/apprise/plugins/sendgrid.py
@@ -472,6 +472,7 @@ class NotifySendGrid(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
                 if r.status_code not in (
                     requests.codes.ok,

--- a/apprise/plugins/sendpulse.py
+++ b/apprise/plugins/sendpulse.py
@@ -696,6 +696,7 @@ class NotifySendPulse(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             try:

--- a/apprise/plugins/serverchan.py
+++ b/apprise/plugins/serverchan.py
@@ -115,6 +115,7 @@ class NotifyServerChan(NotifyBase):
                 data=payload,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             if r.status_code != requests.codes.ok:

--- a/apprise/plugins/ses.py
+++ b/apprise/plugins/ses.py
@@ -587,6 +587,7 @@ class NotifySES(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             if r.status_code != requests.codes.ok:

--- a/apprise/plugins/seven.py
+++ b/apprise/plugins/seven.py
@@ -223,6 +223,7 @@ class NotifySeven(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
                 # Sample output of a successful transmission
                 # {

--- a/apprise/plugins/sfr.py
+++ b/apprise/plugins/sfr.py
@@ -293,6 +293,7 @@ class NotifySFR(NotifyBase):
                     params=payload,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 try:

--- a/apprise/plugins/signal_api.py
+++ b/apprise/plugins/signal_api.py
@@ -369,6 +369,7 @@ class NotifySignalAPI(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
                 if r.status_code not in (
                     requests.codes.ok,

--- a/apprise/plugins/signl4.py
+++ b/apprise/plugins/signl4.py
@@ -218,6 +218,7 @@ class NotifySIGNL4(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code not in (
                 requests.codes.ok,

--- a/apprise/plugins/simplepush.py
+++ b/apprise/plugins/simplepush.py
@@ -269,6 +269,7 @@ class NotifySimplePush(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             # Get our SimplePush response (if it's possible)

--- a/apprise/plugins/sinch.py
+++ b/apprise/plugins/sinch.py
@@ -325,6 +325,7 @@ class NotifySinch(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 # The responsne might look like:

--- a/apprise/plugins/slack.py
+++ b/apprise/plugins/slack.py
@@ -1184,6 +1184,7 @@ class NotifySlack(NotifyBase):
                 params=params,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             # Attachment posts return a JSON string
@@ -1350,6 +1351,7 @@ class NotifySlack(NotifyBase):
                 files=files,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
                 params=params if params else None,
             )
 

--- a/apprise/plugins/smseagle.py
+++ b/apprise/plugins/smseagle.py
@@ -522,6 +522,7 @@ class NotifySMSEagle(NotifyBase):
                         headers=headers,
                         verify=self.verify_certificate,
                         timeout=self.request_timeout,
+                        allow_redirects=self.redirects,
                     )
 
                     try:

--- a/apprise/plugins/smsmanager.py
+++ b/apprise/plugins/smsmanager.py
@@ -295,6 +295,7 @@ class NotifySMSManager(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 if r.status_code != requests.codes.ok:

--- a/apprise/plugins/smtp2go.py
+++ b/apprise/plugins/smtp2go.py
@@ -453,6 +453,7 @@ class NotifySMTP2Go(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 if r.status_code != requests.codes.ok:

--- a/apprise/plugins/sns.py
+++ b/apprise/plugins/sns.py
@@ -343,6 +343,7 @@ class NotifySNS(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             if r.status_code != requests.codes.ok:

--- a/apprise/plugins/sparkpost.py
+++ b/apprise/plugins/sparkpost.py
@@ -419,6 +419,7 @@ class NotifySparkPost(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 # A Good response (200) looks like this:

--- a/apprise/plugins/spike.py
+++ b/apprise/plugins/spike.py
@@ -129,6 +129,7 @@ class NotifySpike(NotifyBase):
                 data=json.dumps(payload),
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if response.status_code != requests.codes.ok:
                 self.logger.warning(

--- a/apprise/plugins/splunk.py
+++ b/apprise/plugins/splunk.py
@@ -360,6 +360,7 @@ class NotifySplunk(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             # Sample Response
             # {

--- a/apprise/plugins/spugpush.py
+++ b/apprise/plugins/spugpush.py
@@ -123,6 +123,7 @@ class NotifySpugpush(NotifyBase):
                 data=json.dumps(payload),
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             if response.status_code != requests.codes.ok:

--- a/apprise/plugins/streamlabs.py
+++ b/apprise/plugins/streamlabs.py
@@ -296,6 +296,7 @@ class NotifyStreamlabs(NotifyBase):
                     data=data,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
                 if r.status_code != requests.codes.ok:
                     # We had a problem
@@ -344,6 +345,7 @@ class NotifyStreamlabs(NotifyBase):
                     data=data,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
                 if r.status_code != requests.codes.ok:
                     # We had a problem

--- a/apprise/plugins/synology.py
+++ b/apprise/plugins/synology.py
@@ -289,6 +289,7 @@ class NotifySynology(NotifyBase):
                 auth=auth,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code < 200 or r.status_code >= 300:
                 # We had a problem

--- a/apprise/plugins/techuluspush.py
+++ b/apprise/plugins/techuluspush.py
@@ -146,6 +146,7 @@ class NotifyTechulusPush(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code not in (
                 requests.codes.ok,

--- a/apprise/plugins/telegram.py
+++ b/apprise/plugins/telegram.py
@@ -621,6 +621,7 @@ class NotifyTelegram(NotifyBase):
                     data=payload,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 if r.status_code != requests.codes.ok:
@@ -687,6 +688,7 @@ class NotifyTelegram(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             if r.status_code != requests.codes.ok:
@@ -948,6 +950,7 @@ class NotifyTelegram(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 if r.status_code != requests.codes.ok:

--- a/apprise/plugins/threema.py
+++ b/apprise/plugins/threema.py
@@ -256,6 +256,7 @@ class NotifyThreema(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 if r.status_code != requests.codes.ok:

--- a/apprise/plugins/twilio.py
+++ b/apprise/plugins/twilio.py
@@ -442,6 +442,7 @@ class NotifyTwilio(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 if r.status_code not in (

--- a/apprise/plugins/twist.py
+++ b/apprise/plugins/twist.py
@@ -661,6 +661,7 @@ class NotifyTwist(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             # Get our JSON content if it's possible
@@ -703,6 +704,7 @@ class NotifyTwist(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 # Get our JSON content if it's possible

--- a/apprise/plugins/twitter.py
+++ b/apprise/plugins/twitter.py
@@ -786,6 +786,7 @@ class NotifyTwitter(NotifyBase):
                 auth=auth,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             try:

--- a/apprise/plugins/vapid/__init__.py
+++ b/apprise/plugins/vapid/__init__.py
@@ -425,6 +425,7 @@ class NotifyVapid(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
                 if r.status_code not in (
                     requests.codes.ok,

--- a/apprise/plugins/viber.py
+++ b/apprise/plugins/viber.py
@@ -235,6 +235,7 @@ class NotifyViber(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 # Viber returns the following on success:

--- a/apprise/plugins/voipms.py
+++ b/apprise/plugins/voipms.py
@@ -250,6 +250,7 @@ class NotifyVoipms(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 with contextlib.suppress(

--- a/apprise/plugins/vonage.py
+++ b/apprise/plugins/vonage.py
@@ -265,6 +265,7 @@ class NotifyVonage(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 if r.status_code != requests.codes.ok:

--- a/apprise/plugins/webexteams.py
+++ b/apprise/plugins/webexteams.py
@@ -325,6 +325,7 @@ class NotifyWebexTeams(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code not in (
                 requests.codes.ok,
@@ -416,6 +417,7 @@ class NotifyWebexTeams(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
                 if r.status_code != requests.codes.ok:
                     status_str = NotifyWebexTeams.http_response_code_lookup(
@@ -499,6 +501,7 @@ class NotifyWebexTeams(NotifyBase):
                         files=files,
                         verify=self.verify_certificate,
                         timeout=self.request_timeout,
+                        allow_redirects=self.redirects,
                     )
 
                 if r.status_code != requests.codes.ok:

--- a/apprise/plugins/wechat.py
+++ b/apprise/plugins/wechat.py
@@ -336,6 +336,7 @@ class NotifyWeChat(NotifyBase):
                 params=params,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             if r.status_code != requests.codes.ok:
@@ -479,6 +480,7 @@ class NotifyWeChat(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             if r.status_code != requests.codes.ok:

--- a/apprise/plugins/wecombot.py
+++ b/apprise/plugins/wecombot.py
@@ -187,6 +187,7 @@ class NotifyWeComBot(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code != requests.codes.ok:
                 # We had a problem

--- a/apprise/plugins/whatsapp.py
+++ b/apprise/plugins/whatsapp.py
@@ -490,6 +490,7 @@ class NotifyWhatsApp(NotifyBase):
                     headers=headers,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
                 if r.status_code not in (

--- a/apprise/plugins/workflows.py
+++ b/apprise/plugins/workflows.py
@@ -465,6 +465,7 @@ class NotifyWorkflows(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code not in (
                 requests.codes.ok,

--- a/apprise/plugins/wxpusher.py
+++ b/apprise/plugins/wxpusher.py
@@ -252,6 +252,7 @@ class NotifyWxPusher(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
 
             try:

--- a/apprise/plugins/zoom.py
+++ b/apprise/plugins/zoom.py
@@ -292,6 +292,7 @@ class NotifyZoom(NotifyBase):
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
+                allow_redirects=self.redirects,
             )
             if r.status_code not in (
                 requests.codes.ok,

--- a/apprise/plugins/zulip.py
+++ b/apprise/plugins/zulip.py
@@ -297,6 +297,7 @@ class NotifyZulip(NotifyBase):
                     auth=auth,
                     verify=self.verify_certificate,
                     timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
                 if r.status_code != requests.codes.ok:
                     # We had a problem

--- a/apprise/url.py
+++ b/apprise/url.py
@@ -898,9 +898,8 @@ class URLBase:
             # Pulled from YAML Configuration
             results["redirect"] = parse_bool(results.get("redirect", True))
 
-        else:
-            # HTTP redirects are enabled by default
-            results["redirect"] = True
+        # When redirect= is not specified, leave it absent so that URLBase
+        # __init__ falls back to asset.http_redirects as the global default.
 
         # Password overrides
         if "pass" in results:

--- a/apprise/url.py
+++ b/apprise/url.py
@@ -854,8 +854,10 @@ class URLBase:
         if self.verify_certificate != URLBase.verify_certificate:
             params["verify"] = "yes" if self.verify_certificate else "no"
 
-        # Redirect following
-        if self.redirects != URLBase.redirects:
+        # Redirect following -- compare against the asset default, not the
+        # class constant, so that a per-URL override is preserved when the
+        # asset global has been changed (round-trip idempotency).
+        if self.redirects != self.asset.http_redirects:
             params["redirect"] = "yes" if self.redirects else "no"
 
         return params

--- a/apprise/url.py
+++ b/apprise/url.py
@@ -228,8 +228,13 @@ class URLBase:
         )
 
         # Redirect support; default to disabled to prevent credential
-        # forwarding to unintended destinations via 3xx redirect chains
-        self.redirects = parse_bool(kwargs.get("redirect", URLBase.redirects))
+        # forwarding to unintended destinations via 3xx redirect chains.
+        # The asset-level http_redirects flag acts as the global default
+        # so operators can restore the historical behaviour without touching
+        # every individual URL.
+        self.redirects = parse_bool(
+            kwargs.get("redirect", self.asset.http_redirects)
+        )
 
         # Schema
         self.schema = kwargs.get("schema", "unknown").lower()

--- a/apprise/url.py
+++ b/apprise/url.py
@@ -120,6 +120,12 @@ class URLBase:
     # Secure sites should be verified against a Certificate Authority
     verify_certificate = True
 
+    # By default, HTTP redirects are not followed. Set to True to allow
+    # plugins to follow HTTP redirects when the remote server issues a 3xx
+    # response. Keeping this False prevents redirect-chain credential
+    # forwarding to destinations not explicitly configured by the operator.
+    redirects = False
+
     # Logging to our global logger
     logger = logger
 
@@ -147,6 +153,16 @@ class URLBase:
             # look up default using the following parent class value at
             # runtime.
             "_lookup_default": "verify_certificate",
+        },
+        "redirect": {
+            "name": _("Follow Redirects"),
+            # Whether to follow HTTP 3xx redirects
+            "type": "bool",
+            # Provide a default
+            "default": redirects,
+            # look up default using the following parent class value at
+            # runtime.
+            "_lookup_default": "redirects",
         },
         "rto": {
             "name": _("Socket Read Timeout"),
@@ -210,6 +226,10 @@ class URLBase:
         self.verify_certificate = parse_bool(
             kwargs.get("verify", URLBase.verify_certificate)
         )
+
+        # Redirect support; default to disabled to prevent credential
+        # forwarding to unintended destinations via 3xx redirect chains
+        self.redirects = parse_bool(kwargs.get("redirect", URLBase.redirects))
 
         # Schema
         self.schema = kwargs.get("schema", "unknown").lower()
@@ -830,6 +850,10 @@ class URLBase:
         if self.verify_certificate != URLBase.verify_certificate:
             params["verify"] = "yes" if self.verify_certificate else "no"
 
+        # Redirect following
+        if self.redirects != URLBase.redirects:
+            params["redirect"] = "yes" if self.redirects else "no"
+
         return params
 
     @staticmethod
@@ -859,6 +883,20 @@ class URLBase:
             # Support SSL Certificate 'verify' keyword. Default to being
             # enabled
             results["verify"] = True
+
+        if qsd_exists and "redirect" in results["qsd"]:
+            # Pulled from URL String
+            results["redirect"] = parse_bool(
+                results["qsd"].get("redirect", False)
+            )
+
+        elif "redirect" in results:
+            # Pulled from YAML Configuration
+            results["redirect"] = parse_bool(results.get("redirect", False))
+
+        else:
+            # HTTP redirects are disabled by default
+            results["redirect"] = False
 
         # Password overrides
         if "pass" in results:

--- a/apprise/url.py
+++ b/apprise/url.py
@@ -120,11 +120,11 @@ class URLBase:
     # Secure sites should be verified against a Certificate Authority
     verify_certificate = True
 
-    # By default, HTTP redirects are not followed. Set to True to allow
-    # plugins to follow HTTP redirects when the remote server issues a 3xx
-    # response. Keeping this False prevents redirect-chain credential
-    # forwarding to destinations not explicitly configured by the operator.
-    redirects = False
+    # By default, HTTP redirects are followed, matching the behaviour of the
+    # underlying requests library. Set to False to prevent redirect-chain
+    # credential forwarding to destinations not explicitly configured by the
+    # operator.
+    redirects = True
 
     # Logging to our global logger
     logger = logger
@@ -227,11 +227,10 @@ class URLBase:
             kwargs.get("verify", URLBase.verify_certificate)
         )
 
-        # Redirect support; default to disabled to prevent credential
-        # forwarding to unintended destinations via 3xx redirect chains.
-        # The asset-level http_redirects flag acts as the global default
-        # so operators can restore the historical behaviour without touching
-        # every individual URL.
+        # Redirect support; default to enabled to match the behaviour of the
+        # underlying requests library. The asset-level http_redirects flag
+        # acts as the global default so operators can disable redirect
+        # following across all plugins without touching every individual URL.
         self.redirects = parse_bool(
             kwargs.get("redirect", self.asset.http_redirects)
         )
@@ -892,16 +891,16 @@ class URLBase:
         if qsd_exists and "redirect" in results["qsd"]:
             # Pulled from URL String
             results["redirect"] = parse_bool(
-                results["qsd"].get("redirect", False)
+                results["qsd"].get("redirect", True)
             )
 
         elif "redirect" in results:
             # Pulled from YAML Configuration
-            results["redirect"] = parse_bool(results.get("redirect", False))
+            results["redirect"] = parse_bool(results.get("redirect", True))
 
         else:
-            # HTTP redirects are disabled by default
-            results["redirect"] = False
+            # HTTP redirects are enabled by default
+            results["redirect"] = True
 
         # Password overrides
         if "pass" in results:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -936,28 +936,28 @@ def test_apprise_urlbase_object():
     assert base.request_url == "http://127.0.0.1/path/"
     assert base.url().startswith("http://user@127.0.0.1/path/")
 
-    # redirect= defaults to False (disabled for security)
-    results = URLBase.parse_url("https://localhost/path/?redirect=no")
-    assert results.get("redirect") is False
-    base = URLBase(**results)
-    assert base.redirects is False
-    # redirect=no is the default, so it must not appear in url() output
-    assert "redirect" not in base.url()
-
-    # redirect=yes enables redirect following and round-trips in the URL
-    results = URLBase.parse_url(
-        "http://user:pass@localhost:34/path/here?redirect=yes"
-    )
+    # redirect= defaults to True (follows redirects, matching requests default)
+    results = URLBase.parse_url("https://localhost/path/?redirect=yes")
     assert results.get("redirect") is True
     base = URLBase(**results)
     assert base.redirects is True
-    assert "redirect=yes" in base.url()
+    # redirect=yes is the default, so it must not appear in url() output
+    assert "redirect" not in base.url()
 
-    # redirect is False when not specified at all
-    results = URLBase.parse_url("http://user@127.0.0.1/path/")
+    # redirect=no disables redirect following and round-trips in the URL
+    results = URLBase.parse_url(
+        "http://user:pass@localhost:34/path/here?redirect=no"
+    )
     assert results.get("redirect") is False
     base = URLBase(**results)
     assert base.redirects is False
+    assert "redirect=no" in base.url()
+
+    # redirect is True when not specified at all
+    results = URLBase.parse_url("http://user@127.0.0.1/path/")
+    assert results.get("redirect") is True
+    base = URLBase(**results)
+    assert base.redirects is True
     assert "redirect" not in base.url()
 
     # Generic initialization

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -956,7 +956,7 @@ def test_apprise_urlbase_object():
     # redirect is absent from results when not specified -- URLBase inherits
     # the global default from the asset (default asset has http_redirects=True)
     results = URLBase.parse_url("http://user@127.0.0.1/path/")
-    assert results.get("redirect") is None
+    assert "redirect" not in results
     base = URLBase(**results)
     assert base.redirects is True
     assert "redirect" not in base.url()
@@ -967,7 +967,7 @@ def test_apprise_urlbase_object():
 
     asset_no_redirect = AppriseAsset(http_redirects=False)
     results = URLBase.parse_url("http://user@127.0.0.1/path/")
-    assert results.get("redirect") is None
+    assert "redirect" not in results
     base = URLBase(**results, asset=asset_no_redirect)
     assert base.redirects is False  # inherited the asset global
     assert "redirect=no" in base.url()  # serialised as non-default

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -953,12 +953,31 @@ def test_apprise_urlbase_object():
     assert base.redirects is False
     assert "redirect=no" in base.url()
 
-    # redirect is True when not specified at all
+    # redirect is absent from results when not specified -- URLBase inherits
+    # the global default from the asset (default asset has http_redirects=True)
     results = URLBase.parse_url("http://user@127.0.0.1/path/")
-    assert results.get("redirect") is True
+    assert results.get("redirect") is None
     base = URLBase(**results)
     assert base.redirects is True
     assert "redirect" not in base.url()
+
+    # AppriseAsset(http_redirects=False) flows through to every plugin when the
+    # URL does not specify redirect=
+    from apprise import AppriseAsset
+
+    asset_no_redirect = AppriseAsset(http_redirects=False)
+    results = URLBase.parse_url("http://user@127.0.0.1/path/")
+    assert results.get("redirect") is None
+    base = URLBase(**results, asset=asset_no_redirect)
+    assert base.redirects is False  # inherited the asset global
+    assert "redirect=no" in base.url()  # serialised as non-default
+
+    # URL-level redirect=yes overrides asset http_redirects=False
+    results = URLBase.parse_url("http://user@127.0.0.1/path/?redirect=yes")
+    assert results.get("redirect") is True
+    base = URLBase(**results, asset=asset_no_redirect)
+    assert base.redirects is True  # URL wins over asset
+    assert "redirect" not in base.url()  # yes is the class default, omitted
 
     # Generic initialization
     base = URLBase(**{"schema": ""})

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -970,14 +970,16 @@ def test_apprise_urlbase_object():
     assert "redirect" not in results
     base = URLBase(**results, asset=asset_no_redirect)
     assert base.redirects is False  # inherited the asset global
-    assert "redirect=no" in base.url()  # serialised as non-default
+    # redirects matches the asset default -- no override to serialise
+    assert "redirect" not in base.url()
 
-    # URL-level redirect=yes overrides asset http_redirects=False
+    # URL-level redirect=yes overrides asset http_redirects=False; the
+    # override must be preserved in url() so the round-trip is idempotent
     results = URLBase.parse_url("http://user@127.0.0.1/path/?redirect=yes")
     assert results.get("redirect") is True
     base = URLBase(**results, asset=asset_no_redirect)
     assert base.redirects is True  # URL wins over asset
-    assert "redirect" not in base.url()  # yes is the class default, omitted
+    assert "redirect=yes" in base.url()  # differs from asset default, emitted
 
     # YAML config path: redirect= provided in the results dict directly
     # (not via qsd) -- exercises the elif "redirect" in results branch in

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -979,6 +979,19 @@ def test_apprise_urlbase_object():
     assert base.redirects is True  # URL wins over asset
     assert "redirect" not in base.url()  # yes is the class default, omitted
 
+    # YAML config path: redirect= provided in the results dict directly
+    # (not via qsd) -- exercises the elif "redirect" in results branch in
+    # post_process_parse_url_results()
+    results = URLBase.parse_url("http://user@127.0.0.1/path/")
+    assert "redirect" not in results
+    results["redirect"] = "no"
+    URLBase.post_process_parse_url_results(results)
+    assert results.get("redirect") is False
+
+    results["redirect"] = "yes"
+    URLBase.post_process_parse_url_results(results)
+    assert results.get("redirect") is True
+
     # Generic initialization
     base = URLBase(**{"schema": ""})
     assert base.request_timeout == (4.0, 4.0)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -936,6 +936,30 @@ def test_apprise_urlbase_object():
     assert base.request_url == "http://127.0.0.1/path/"
     assert base.url().startswith("http://user@127.0.0.1/path/")
 
+    # redirect= defaults to False (disabled for security)
+    results = URLBase.parse_url("https://localhost/path/?redirect=no")
+    assert results.get("redirect") is False
+    base = URLBase(**results)
+    assert base.redirects is False
+    # redirect=no is the default, so it must not appear in url() output
+    assert "redirect" not in base.url()
+
+    # redirect=yes enables redirect following and round-trips in the URL
+    results = URLBase.parse_url(
+        "http://user:pass@localhost:34/path/here?redirect=yes"
+    )
+    assert results.get("redirect") is True
+    base = URLBase(**results)
+    assert base.redirects is True
+    assert "redirect=yes" in base.url()
+
+    # redirect is False when not specified at all
+    results = URLBase.parse_url("http://user@127.0.0.1/path/")
+    assert results.get("redirect") is False
+    base = URLBase(**results)
+    assert base.redirects is False
+    assert "redirect" not in base.url()
+
     # Generic initialization
     base = URLBase(**{"schema": ""})
     assert base.request_timeout == (4.0, 4.0)
@@ -1796,6 +1820,7 @@ def test_apprise_details_plugin_verification():
         "optional",
         # URLBase parameters:
         "verify",
+        "redirect",
         "cto",
         "rto",
         "store",

--- a/tests/test_attach_http.py
+++ b/tests/test_attach_http.py
@@ -539,7 +539,6 @@ def test_attach_http(mock_get, mock_request):
         """Simulates a 301 response returned when allow_redirects=False."""
 
         status_code = requests.codes.moved_permanently
-        is_redirect = True
         headers: ClassVar[dict[str, str]] = {}
 
         def raise_for_status(self):

--- a/tests/test_attach_http.py
+++ b/tests/test_attach_http.py
@@ -533,6 +533,36 @@ def test_attach_http(mock_get, mock_request):
     # No encoding if we choose
     assert isinstance(obj.base64(encoding=None), bytes)
 
+    # Test that a 3xx redirect is rejected when redirect=no is set; the
+    # is_redirect guard catches responses that raise_for_status() misses.
+    class RedirectResponse:
+        """Simulates a 301 response returned when allow_redirects=False."""
+
+        status_code = requests.codes.moved_permanently
+        is_redirect = True
+        headers: ClassVar[dict[str, str]] = {}
+
+        def raise_for_status(self):
+            return
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args, **kwargs):
+            return
+
+    mock_get.return_value = RedirectResponse()
+    results = AttachHTTP.parse_url(
+        "http://user@localhost/filename.gif?redirect=no"
+    )
+    assert isinstance(results, dict)
+    obj_no_redir = AttachHTTP(**results)
+    assert obj_no_redir.redirects is False
+    # Download must fail -- streaming a redirect stub would be wrong
+    assert obj_no_redir.download() is False
+    # Restore for downstream tests
+    mock_get.return_value = dummy_response
+
     # Error cases:
     with mock.patch(
         "builtins.open",

--- a/tests/test_attach_http.py
+++ b/tests/test_attach_http.py
@@ -533,8 +533,8 @@ def test_attach_http(mock_get, mock_request):
     # No encoding if we choose
     assert isinstance(obj.base64(encoding=None), bytes)
 
-    # Test that a 3xx redirect is rejected when redirect=no is set; the
-    # is_redirect guard catches responses that raise_for_status() misses.
+    # Test that a 3xx redirect is rejected when redirect=no is set; a
+    # status-code range guard (300-399) catches what raise_for_status() misses.
     class RedirectResponse:
         """Simulates a 301 response returned when allow_redirects=False."""
 

--- a/tests/test_config_http.py
+++ b/tests/test_config_http.py
@@ -339,8 +339,8 @@ def test_config_http(mock_post):
     ch.max_error_buffer_size = 0
     assert ch.read() is None
 
-    # Test that a 3xx redirect is rejected when redirect=no is set; the
-    # is_redirect guard catches responses that raise_for_status() misses.
+    # Test that a 3xx redirect is rejected when redirect=no is set; a
+    # status-code range guard (300-399) catches what raise_for_status() misses.
     class RedirectResponse:
         """Simulates a 301 response returned when allow_redirects=False."""
 

--- a/tests/test_config_http.py
+++ b/tests/test_config_http.py
@@ -345,7 +345,6 @@ def test_config_http(mock_post):
         """Simulates a 301 response returned when allow_redirects=False."""
 
         status_code = requests.codes.moved_permanently
-        is_redirect = True
         headers: ClassVar[dict[str, str]] = {}
         text = ""
 

--- a/tests/test_config_http.py
+++ b/tests/test_config_http.py
@@ -339,6 +339,35 @@ def test_config_http(mock_post):
     ch.max_error_buffer_size = 0
     assert ch.read() is None
 
+    # Test that a 3xx redirect is rejected when redirect=no is set; the
+    # is_redirect guard catches responses that raise_for_status() misses.
+    class RedirectResponse:
+        """Simulates a 301 response returned when allow_redirects=False."""
+
+        status_code = requests.codes.moved_permanently
+        is_redirect = True
+        headers: ClassVar[dict[str, str]] = {}
+        text = ""
+
+        def raise_for_status(self):
+            return
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args, **kwargs):
+            return
+
+    mock_post.return_value = RedirectResponse()
+    results = ConfigHTTP.parse_url("http://localhost/?redirect=no")
+    assert isinstance(results, dict)
+    ch_no_redir = ConfigHTTP(**results)
+    assert ch_no_redir.redirects is False
+    # read() must return None -- returning redirect HTML as config is wrong
+    assert ch_no_redir.read() is None
+    # Restore for downstream tests
+    mock_post.return_value = dummy_response
+
     # Exception handling
     for exception in REQUEST_EXCEPTIONS:
         mock_post.side_effect = exception

--- a/tests/test_decorator_notify.py
+++ b/tests/test_decorator_notify.py
@@ -622,12 +622,13 @@ def test_notify_multi_instance_decoration(tmpdir):
     assert "tag" in meta
     assert isinstance(meta["tag"], set)
 
-    assert len(meta) == 8
+    assert len(meta) == 9
     # We carry all of our default arguments from the @notify's initialization
     assert meta["schema"] == "multi"
     assert meta["host"] == "hostname"
     assert meta["user"] == "user1"
     assert meta["verify"] is True
+    assert meta["redirect"] is True
     assert meta["password"] == "pass"
 
     # Verify our URL is correct
@@ -660,13 +661,14 @@ def test_notify_multi_instance_decoration(tmpdir):
     assert "tag" in meta
     assert isinstance(meta["tag"], set)
 
-    assert len(meta) == 9
+    assert len(meta) == 10
     # We carry all of our default arguments from the @notify's initialization
     assert meta["schema"] == "multi"
     assert meta["host"] == "hostname"
     assert meta["user"] == "user2"
     assert meta["password"] == "pass2"
     assert meta["verify"] is False
+    assert meta["redirect"] is True
     assert meta["qsd"]["verify"] == "no"
 
     # Verify our URL is correct

--- a/tests/test_decorator_notify.py
+++ b/tests/test_decorator_notify.py
@@ -622,13 +622,13 @@ def test_notify_multi_instance_decoration(tmpdir):
     assert "tag" in meta
     assert isinstance(meta["tag"], set)
 
-    assert len(meta) == 9
+    assert len(meta) == 8
     # We carry all of our default arguments from the @notify's initialization
     assert meta["schema"] == "multi"
     assert meta["host"] == "hostname"
     assert meta["user"] == "user1"
     assert meta["verify"] is True
-    assert meta["redirect"] is True
+    assert "redirect" not in meta  # absent -- URLBase inherits asset default
     assert meta["password"] == "pass"
 
     # Verify our URL is correct
@@ -661,14 +661,14 @@ def test_notify_multi_instance_decoration(tmpdir):
     assert "tag" in meta
     assert isinstance(meta["tag"], set)
 
-    assert len(meta) == 10
+    assert len(meta) == 9
     # We carry all of our default arguments from the @notify's initialization
     assert meta["schema"] == "multi"
     assert meta["host"] == "hostname"
     assert meta["user"] == "user2"
     assert meta["password"] == "pass2"
     assert meta["verify"] is False
-    assert meta["redirect"] is True
+    assert "redirect" not in meta  # absent -- URLBase inherits asset default
     assert meta["qsd"]["verify"] == "no"
 
     # Verify our URL is correct


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #<!-- apprise issue number goes here -->

Due to a security concern raised against Apprise, `url_redirects` can now be cofigured via the URL and AppriseAsset object.  By default redirections continue to take place to keep with backwards ompatbibility. They can be turned off  by just setting `?redirect=no` on the Apprise URL.

This applies to Attachents, Configuration, and all Plugins


<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/60](https://github.com/caronc/apprise-docs/pull/60)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@global-redirect-flag

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "schema://credentials/?redirect=yes"
```
