### PR TITLE
Pushover E2EE Support

### DIFF
--- a/apprise/plugins/pushover.py
+++ b/apprise/plugins/pushover.py
@@ -25,16 +25,41 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import base64
 import contextlib
+import gzip
+import os as _os
 import re
 
 import requests
+
+# Optional dependency for E2EE field encryption.
+# When absent, encryption is silently skipped with a warning if the user
+# explicitly configured a key + e2ee=yes.
+try:
+    from cryptography.hazmat.primitives import (
+        hashes as _crypto_hashes,
+        hmac as _crypto_hmac,
+        padding as _crypto_pad,
+    )
+    from cryptography.hazmat.primitives.ciphers import (
+        Cipher as _Cipher,
+        algorithms as _crypto_algos,
+        modes as _crypto_modes,
+    )
+
+    # E2EE support is available
+    PUSHOVER_E2EE_SUPPORT = True
+
+except ImportError:
+    # E2EE support unavailable; `pip install cryptography` to enable
+    PUSHOVER_E2EE_SUPPORT = False
 
 from ..attachment.base import AttachBase
 from ..common import NotifyFormat, NotifyType
 from ..conversion import convert_between
 from ..locale import gettext_lazy as _
-from ..utils.parse import parse_list, validate_regex
+from ..utils.parse import parse_bool, parse_list, validate_regex
 from .base import NotifyBase
 
 # Flag used as a placeholder to sending to all devices
@@ -141,12 +166,24 @@ PUSHOVER_HTTP_ERROR_MAP = {
     401: "Unauthorized - Invalid Token.",
 }
 
+# Validate the E2EE encryption key: exactly 64 hexadecimal characters
+# representing a 256-bit AES key, matching the format required by the
+# Pushover E2EE API: https://pushover.net/api#e2ee
+VALIDATE_ENCRYPTION_KEY = re.compile(r"^[0-9a-f]{64}$", re.I)
+
 
 class NotifyPushover(NotifyBase):
     """A wrapper for Pushover Notifications."""
 
     # The default descriptive name associated with the Notification
     service_name = "Pushover"
+
+    # Optional dependency: cryptography is only needed for E2EE field
+    # encryption.  The plugin works without it; encryption is skipped
+    # with a warning when the package is absent.
+    requirements = {
+        "packages_recommended": "cryptography",
+    }
 
     # The services URL
     service_url = "https://pushover.net/"
@@ -260,6 +297,20 @@ class NotifyPushover(NotifyBase):
             "to": {
                 "alias_of": "targets",
             },
+            "key": {
+                "name": _("Encryption Key"),
+                "type": "string",
+                "private": True,
+                # Maps to the encryption_key __init__ parameter
+                "map_to": "encryption_key",
+            },
+            "e2ee": {
+                "name": _("E2EE"),
+                "type": "bool",
+                # Enabled by default when an encryption_key is provided;
+                # set to no to force plaintext even when a key is set
+                "default": True,
+            },
         },
     )
 
@@ -274,6 +325,8 @@ class NotifyPushover(NotifyBase):
         expire=None,
         supplemental_url=None,
         supplemental_url_title=None,
+        encryption_key=None,
+        e2ee=None,
         **kwargs,
     ):
         """Initialize Pushover Object."""
@@ -377,7 +430,84 @@ class NotifyPushover(NotifyBase):
                 )
                 self.logger.warning(msg)
                 raise TypeError(msg)
+
+        # End-to-end encryption: validate and store the encryption key.
+        # The key must be exactly 64 hex characters (256-bit AES key).
+        if encryption_key:
+            # Normalise to lower-case hex string
+            _key = str(encryption_key).strip().lower()
+            if not VALIDATE_ENCRYPTION_KEY.match(_key):
+                msg = (
+                    "Pushover encryption_key must be exactly 64 hex "
+                    "characters (256-bit AES key); got: "
+                    "{}".format(encryption_key)
+                )
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
+            self.encryption_key = _key
+        else:
+            # No key -- E2EE is not possible
+            self.encryption_key = None
+
+        # e2ee flag: defaults to True (encrypt when a key is available).
+        # Set to False/no to force plaintext even when a key is configured.
+        self.e2ee = (
+            self.template_args["e2ee"]["default"]
+            if e2ee is None
+            else parse_bool(e2ee)
+        )
         return
+
+    def _encrypt_field(self, plaintext, key_bytes):
+        """Encrypt a single Pushover message field for E2EE.
+
+        Implements the field-level encryption scheme from
+        https://pushover.net/api#e2ee -- per field:
+
+        1. gzip-compress the plaintext string (UTF-8)
+        2. AES-256-CBC-encrypt the compressed data (random 16-byte IV,
+           PKCS7 padding) using the caller-supplied 256-bit key
+        3. Compute HMAC-SHA256 over (IV || ciphertext) with the same key
+        4. Return base64(IV || ciphertext || HMAC)
+
+        Returns the encrypted base64 string, or the original plaintext
+        on any error (the caller will fall back to unencrypted in that
+        case).
+        """
+
+        try:
+            # Compress the UTF-8 encoded plaintext
+            compressed = gzip.compress(plaintext.encode("utf-8"))
+
+            # Generate a random 16-byte initialisation vector
+            iv = _os.urandom(16)
+
+            # Pad the compressed data to a multiple of the AES block size
+            padder = _crypto_pad.PKCS7(128).padder()
+            padded = padder.update(compressed) + padder.finalize()
+
+            # AES-256-CBC encryption
+            cipher = _Cipher(
+                _crypto_algos.AES(key_bytes),
+                _crypto_modes.CBC(iv),
+            )
+            encryptor = cipher.encryptor()
+            ciphertext = encryptor.update(padded) + encryptor.finalize()
+
+            # HMAC-SHA256 over IV || ciphertext for integrity
+            h = _crypto_hmac.HMAC(key_bytes, _crypto_hashes.SHA256())
+            h.update(iv + ciphertext)
+            mac = h.finalize()
+
+            # Base64-encode the concatenated IV || ciphertext || HMAC
+            return base64.b64encode(iv + ciphertext + mac).decode("ascii")
+
+        except Exception as err:
+            self.logger.debug(
+                "Pushover E2EE field encryption failed: {}".format(err)
+            )
+            raise
 
     def send(
         self,
@@ -393,6 +523,20 @@ class NotifyPushover(NotifyBase):
             # There were no services to notify
             self.logger.warning("There were no Pushover targets to notify.")
             return False
+
+        # Determine whether E2EE field encryption should be applied.
+        # Conditions: user supplied a key, e2ee flag is True, and the
+        # cryptography package is installed.
+        do_encrypt = bool(self.encryption_key and self.e2ee)
+        if do_encrypt and not PUSHOVER_E2EE_SUPPORT:
+            # Encryption was explicitly requested but the library is absent;
+            # fall back to plaintext with a clear warning
+            self.logger.warning(
+                "Pushover E2EE requested but the 'cryptography' package "
+                "is not installed; sending message unencrypted. "
+                "Install it with: pip install cryptography"
+            )
+            do_encrypt = False
 
         # Build the base payload shared across all sends
         base_payload = {
@@ -426,6 +570,42 @@ class NotifyPushover(NotifyBase):
                     "expire": self.expire,
                 }
             )
+
+        # Apply field-level E2EE encryption when conditions are met.
+        # Encrypted fields: message, title, url, url_title.
+        # Reference: https://pushover.net/api#e2ee
+        if do_encrypt:
+            # Decode the hex key once for all fields in this send call
+            key_bytes = bytes.fromhex(self.encryption_key)
+
+            try:
+                # Encrypt each present field individually
+                base_payload["message"] = self._encrypt_field(
+                    base_payload["message"], key_bytes
+                )
+                base_payload["title"] = self._encrypt_field(
+                    base_payload["title"], key_bytes
+                )
+                if "url" in base_payload:
+                    base_payload["url"] = self._encrypt_field(
+                        base_payload["url"], key_bytes
+                    )
+                if "url_title" in base_payload:
+                    base_payload["url_title"] = self._encrypt_field(
+                        base_payload["url_title"], key_bytes
+                    )
+
+                # Signal to the Pushover API that fields are encrypted
+                base_payload["encrypted"] = 1
+
+            except Exception:
+                # Any failure in the crypto path is fatal -- do not send
+                # silently degraded (unencrypted) content when the caller
+                # expected encryption.
+                self.logger.warning(
+                    "Pushover E2EE encryption failed; notification not sent."
+                )
+                return False
 
         # Build per-target payloads:
         #  - devices: one call with user=user_key, device=dev1,dev2,...
@@ -630,7 +810,12 @@ class NotifyPushover(NotifyBase):
 
         Targets or end points should never be identified here.
         """
-        return (self.secure_protocol, self.user_key, self.token)
+        return (
+            self.secure_protocol,
+            self.user_key,
+            self.token,
+            self.encryption_key,
+        )
 
     def __len__(self):
         """Returns the number of HTTP requests this instance will make.
@@ -663,6 +848,19 @@ class NotifyPushover(NotifyBase):
         # Pushover ignores them for all other priorities
         if self.priority == PushoverPriority.EMERGENCY:
             params.update({"expire": self.expire, "interval": self.interval})
+
+        # Include E2EE parameters when a key is set.
+        # Use the short ?key= URL parameter for brevity.
+        if self.encryption_key:
+            params["key"] = (
+                self.pprint(self.encryption_key, privacy, safe="")
+                if privacy
+                else self.encryption_key
+            )
+            # Only emit e2ee=no when the user explicitly disabled it;
+            # the default (True) is implied when a key is present
+            if not self.e2ee:
+                params["e2ee"] = "no"
 
         # Extend our parameters
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
@@ -744,7 +942,26 @@ class NotifyPushover(NotifyBase):
                 results["qsd"]["to"]
             )
 
+        # E2EE encryption key (64-char hex string); URL param is ?key= for
+        # brevity, mapped to the encryption_key __init__ parameter
+        if "key" in results["qsd"] and results["qsd"]["key"]:
+            results["encryption_key"] = NotifyPushover.unquote(
+                results["qsd"]["key"]
+            )
+
+        # E2EE flag -- only parse when present; absence preserves default
+        if "e2ee" in results["qsd"] and results["qsd"]["e2ee"]:
+            results["e2ee"] = results["qsd"]["e2ee"]
+
         # Token
         results["token"] = NotifyPushover.unquote(results["host"])
 
         return results
+
+    @staticmethod
+    def runtime_deps():
+        """Return optional runtime dependency package names.
+
+        E2EE support requires the ``cryptography`` package.
+        """
+        return ("cryptography",)

--- a/apprise/plugins/pushover.py
+++ b/apprise/plugins/pushover.py
@@ -439,8 +439,8 @@ class NotifyPushover(NotifyBase):
             if not VALIDATE_ENCRYPTION_KEY.match(_key):
                 msg = (
                     "Pushover encryption_key must be exactly 64 hex "
-                    "characters (256-bit AES key); got: "
-                    "{}".format(encryption_key)
+                    "characters (256-bit AES key); "
+                    "got {} chars".format(len(_key))
                 )
                 self.logger.warning(msg)
                 raise TypeError(msg)
@@ -471,9 +471,8 @@ class NotifyPushover(NotifyBase):
         3. Compute HMAC-SHA256 over (IV || ciphertext) with the same key
         4. Return base64(IV || ciphertext || HMAC)
 
-        Returns the encrypted base64 string, or the original plaintext
-        on any error (the caller will fall back to unencrypted in that
-        case).
+        Raises on any crypto error; the caller must not silently fall
+        back to sending plaintext when encryption fails.
         """
 
         try:
@@ -810,12 +809,7 @@ class NotifyPushover(NotifyBase):
 
         Targets or end points should never be identified here.
         """
-        return (
-            self.secure_protocol,
-            self.user_key,
-            self.token,
-            self.encryption_key,
-        )
+        return (self.secure_protocol, self.user_key, self.token)
 
     def __len__(self):
         """Returns the number of HTTP requests this instance will make.

--- a/tests/test_plugin_pushover.py
+++ b/tests/test_plugin_pushover.py
@@ -323,6 +323,47 @@ apprise_url_tests = (
             "test_requests_exceptions": True,
         },
     ),
+    # E2EE: valid 64-char hex encryption key
+    (
+        "pover://{}@{}?key={}".format("u" * 30, "a" * 30, "b" * 64),
+        {
+            "instance": NotifyPushover,
+            "privacy_url": "pover://u...u@a...a",
+        },
+    ),
+    # E2EE: explicit e2ee=yes with key
+    (
+        "pover://{}@{}?key={}&e2ee=yes".format("u" * 30, "a" * 30, "c" * 64),
+        {
+            "instance": NotifyPushover,
+        },
+    ),
+    # E2EE: key present but e2ee=no (plaintext send)
+    (
+        "pover://{}@{}?key={}&e2ee=no".format("u" * 30, "a" * 30, "d" * 64),
+        {
+            "instance": NotifyPushover,
+        },
+    ),
+    # E2EE: invalid key (not 64 hex chars)
+    (
+        "pover://{}@{}?key=tooshort".format("u" * 30, "a" * 30),
+        {
+            "instance": TypeError,
+        },
+    ),
+    # E2EE: invalid key (correct length but non-hex)
+    (
+        "pover://{}@{}?key={}".format(
+            "u" * 30,
+            "a" * 30,
+            # 64 chars but contains 'z' which is not valid hex
+            "z" * 64,
+        ),
+        {
+            "instance": TypeError,
+        },
+    ),
 )
 
 
@@ -754,3 +795,199 @@ def test_plugin_pushover_attach_memory(mock_post):
 
     assert obj.notify(body="Test", attach=mem) is True
     assert mock_post.call_count == 1
+
+
+@mock.patch("requests.post")
+def test_plugin_pushover_e2ee(mock_post):
+    """NotifyPushover() E2EE encryption support."""
+    import apprise.plugins.pushover as _pover_mod
+
+    user_key = "u" * 30
+    token = "a" * 30
+    # A valid 256-bit AES key expressed as 64 hex characters
+    valid_key = "ab" * 32  # 64 chars
+
+    response = mock.Mock()
+    response.content = dumps(
+        {"status": 1, "request": "647d2300-702c-4b38-8b2f-d56326ae460b"}
+    )
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    # --- Invalid key: too short ---
+    with pytest.raises(TypeError):
+        NotifyPushover(user_key=user_key, token=token, encryption_key="abc")
+
+    # --- Invalid key: 64 chars but non-hex ---
+    with pytest.raises(TypeError):
+        NotifyPushover(user_key=user_key, token=token, encryption_key="z" * 64)
+
+    # --- Valid key: object instantiates correctly ---
+    obj = NotifyPushover(
+        user_key=user_key, token=token, encryption_key=valid_key
+    )
+    assert isinstance(obj, NotifyPushover)
+    assert obj.encryption_key == valid_key
+    # e2ee defaults to True
+    assert obj.e2ee is True
+
+    # --- e2ee=False: encryption disabled even when key present ---
+    obj_no_e2ee = NotifyPushover(
+        user_key=user_key, token=token, encryption_key=valid_key, e2ee=False
+    )
+    assert obj_no_e2ee.e2ee is False
+
+    # --- No key: e2ee flag is still stored but encryption is skipped ---
+    obj_nokey = NotifyPushover(user_key=user_key, token=token)
+    assert obj_nokey.encryption_key is None
+    # Send without key succeeds normally (no encryption path taken)
+    assert obj_nokey.send(body="test") is True
+    assert mock_post.call_count == 1
+    mock_post.reset_mock()
+
+    # --- URL round-trip with key: key and e2ee survive parse/reconstruct ---
+    generated = obj.url()
+    assert "key=" in generated
+    # e2ee=no is NOT emitted because the default is True
+    assert "e2ee=" not in generated
+
+    parsed = NotifyPushover.parse_url(generated)
+    assert parsed is not None
+    assert parsed["encryption_key"] == valid_key
+    obj2 = NotifyPushover(**parsed)
+    assert obj2.encryption_key == valid_key
+    assert obj2.e2ee is True
+    assert obj.url_identifier == obj2.url_identifier
+
+    # --- URL round-trip with key + e2ee=no ---
+    generated_no = obj_no_e2ee.url()
+    assert "e2ee=no" in generated_no
+
+    parsed_no = NotifyPushover.parse_url(generated_no)
+    assert parsed_no is not None
+    obj3 = NotifyPushover(**parsed_no)
+    assert obj3.e2ee is False
+    assert obj3.encryption_key == valid_key
+
+    # --- Privacy URL hides the key ---
+    priv = obj.url(privacy=True)
+    assert valid_key not in priv
+    assert "key=" in priv
+
+    # --- Successful encrypted send (patch support flag + _encrypt_field so
+    #     the test works in both minimal and qa tox environments) ---
+    _fake_enc = "FAKE_ENC_BASE64VALUE=="
+    mock_post.reset_mock()
+    with (
+        mock.patch.object(_pover_mod, "PUSHOVER_E2EE_SUPPORT", True),
+        mock.patch.object(obj, "_encrypt_field", return_value=_fake_enc),
+    ):
+        assert obj.send(body="Hello", title="World") is True
+        assert mock_post.call_count == 1
+        call_data = mock_post.call_args[1]["data"]
+        # The API must receive encrypted=1
+        assert call_data.get("encrypted") == 1
+        # message and title must be the fake-encrypted string
+        assert call_data["message"] == _fake_enc
+        assert call_data["title"] == _fake_enc
+
+    # --- Encrypted send with url and url_title fields ---
+    mock_post.reset_mock()
+    obj_url = NotifyPushover(
+        user_key=user_key,
+        token=token,
+        encryption_key=valid_key,
+        supplemental_url="https://example.com",
+        supplemental_url_title="Click",
+    )
+    with (
+        mock.patch.object(_pover_mod, "PUSHOVER_E2EE_SUPPORT", True),
+        mock.patch.object(obj_url, "_encrypt_field", return_value=_fake_enc),
+    ):
+        assert obj_url.send(body="body", title="title") is True
+        call_data = mock_post.call_args[1]["data"]
+        assert call_data.get("encrypted") == 1
+        assert call_data["url"] == _fake_enc
+        assert call_data["url_title"] == _fake_enc
+
+    # --- e2ee=False: plaintext send despite key being set ---
+    mock_post.reset_mock()
+    assert obj_no_e2ee.send(body="plaintext", title="ptitle") is True
+    call_data = mock_post.call_args[1]["data"]
+    assert "encrypted" not in call_data
+    assert call_data["message"] == "plaintext"
+    assert call_data["title"] == "ptitle"
+
+    # --- Fallback: PUSHOVER_E2EE_SUPPORT patched to False ---
+    mock_post.reset_mock()
+    orig_support = _pover_mod.PUSHOVER_E2EE_SUPPORT
+    _pover_mod.PUSHOVER_E2EE_SUPPORT = False
+    try:
+        # Should warn and fall back to sending unencrypted
+        result = obj.send(body="unenc body", title="unenc title")
+        assert result is True
+        assert mock_post.call_count == 1
+        call_data = mock_post.call_args[1]["data"]
+        # encrypted flag must NOT be set when we fell back
+        assert "encrypted" not in call_data
+        assert call_data["message"] == "unenc body"
+    finally:
+        _pover_mod.PUSHOVER_E2EE_SUPPORT = orig_support
+
+    # --- Crypto failure in _encrypt_field causes send() to return False ---
+    mock_post.reset_mock()
+    with (
+        mock.patch.object(_pover_mod, "PUSHOVER_E2EE_SUPPORT", True),
+        mock.patch.object(
+            obj, "_encrypt_field", side_effect=ValueError("boom")
+        ),
+    ):
+        result = obj.send(body="fail body", title="fail title")
+        assert result is False
+        assert mock_post.call_count == 0
+
+    # --- runtime_deps returns tuple containing 'cryptography' ---
+    deps = NotifyPushover.runtime_deps()
+    assert isinstance(deps, tuple)
+    assert "cryptography" in deps
+
+
+def test_plugin_pushover_e2ee_field_encrypt():
+    """Exercise _encrypt_field directly; skipped when cryptography absent."""
+    import apprise.plugins.pushover as _pover_mod
+
+    pytest.importorskip("cryptography")
+
+    user_key = "u" * 30
+    token = "a" * 30
+    valid_key = "ab" * 32  # 64 hex chars = 32-byte AES-256 key
+
+    obj = NotifyPushover(
+        user_key=user_key, token=token, encryption_key=valid_key
+    )
+    key_bytes = bytes.fromhex(valid_key)
+
+    # Happy path: should return a non-empty ASCII base64 string
+    result = obj._encrypt_field("hello world", key_bytes)
+    assert isinstance(result, str)
+    assert len(result) > 0
+    # Verify the blob decodes to IV (16 B) + ciphertext + HMAC (32 B)
+    import base64 as _b64
+
+    decoded = _b64.b64decode(result)
+    # Minimum: 16-byte IV + 16-byte ciphertext block + 32-byte HMAC = 64 B
+    assert len(decoded) >= 64
+
+    # Empty string is also a valid input (compressed + encrypted)
+    result_empty = obj._encrypt_field("", key_bytes)
+    assert isinstance(result_empty, str)
+    assert len(result_empty) > 0
+
+    # Exception path: patch urandom to trigger the except/raise branch
+    with (
+        mock.patch.object(
+            _pover_mod._os, "urandom", side_effect=OSError("rng failure")
+        ),
+        pytest.raises(OSError, match="rng failure"),
+    ):
+        obj._encrypt_field("boom", key_bytes)

--- a/tests/test_plugin_pushover.py
+++ b/tests/test_plugin_pushover.py
@@ -968,20 +968,63 @@ def test_plugin_pushover_e2ee_field_encrypt():
     key_bytes = bytes.fromhex(valid_key)
 
     # Happy path: should return a non-empty ASCII base64 string
-    result = obj._encrypt_field("hello world", key_bytes)
+    plaintext = "hello world"
+    result = obj._encrypt_field(plaintext, key_bytes)
     assert isinstance(result, str)
     assert len(result) > 0
-    # Verify the blob decodes to IV (16 B) + ciphertext + HMAC (32 B)
-    import base64 as _b64
 
-    decoded = _b64.b64decode(result)
-    # Minimum: 16-byte IV + 16-byte ciphertext block + 32-byte HMAC = 64 B
-    assert len(decoded) >= 64
+    # Self-decryption round-trip: verify the blob layout and that
+    # decrypting it reproduces the original plaintext.
+    # This validates our AES + HMAC + gzip implementation matches
+    # the Pushover spec (IV || ciphertext || HMAC, all base64 encoded).
+    import base64 as _b64
+    import gzip as _gzip
+    import hmac as _hmac_std
+
+    from cryptography.hazmat.primitives import (
+        hashes as _h,
+        hmac as _hmac_crypt,
+        padding as _pad,
+    )
+    from cryptography.hazmat.primitives.ciphers import (
+        Cipher as _C,
+        algorithms as _alg,
+        modes as _mode,
+    )
+
+    blob = _b64.b64decode(result)
+    # Minimum: 16-byte IV + 16-byte AES block + 32-byte HMAC = 64 B
+    assert len(blob) >= 64
+
+    iv = blob[:16]
+    mac_from_blob = blob[-32:]
+    ct = blob[16:-32]
+
+    # Verify HMAC-SHA256 over IV || ciphertext
+    h = _hmac_crypt.HMAC(key_bytes, _h.SHA256())
+    h.update(iv + ct)
+    expected_mac = h.finalize()
+    assert _hmac_std.compare_digest(mac_from_blob, expected_mac)
+
+    # AES-256-CBC decrypt
+    cipher = _C(_alg.AES(key_bytes), _mode.CBC(iv))
+    decryptor = cipher.decryptor()
+    padded_plain = decryptor.update(ct) + decryptor.finalize()
+
+    # Remove PKCS7 padding
+    unpadder = _pad.PKCS7(128).unpadder()
+    compressed = unpadder.update(padded_plain) + unpadder.finalize()
+
+    # Gzip decompress and compare to original plaintext
+    recovered = _gzip.decompress(compressed).decode("utf-8")
+    assert recovered == plaintext
 
     # Empty string is also a valid input (compressed + encrypted)
     result_empty = obj._encrypt_field("", key_bytes)
     assert isinstance(result_empty, str)
     assert len(result_empty) > 0
+    blob_empty = _b64.b64decode(result_empty)
+    assert len(blob_empty) >= 64
 
     # Exception path: patch urandom to trigger the except/raise branch
     with (


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1597

Adds Pushover end-to-end encryption (E2EE) support as described in https://pushover.net/api#e2ee.

When an encryption key is configured, the `message`, `title`, `url`, and `url_title` fields are each encrypted client-side using **AES-256-CBC** (PKCS7 padding) with **HMAC-SHA256** integrity before being sent to the Pushover API.

### URL format

```text
pover://{user_key}@{token}?key={64-char-hex}
pover://{user_key}@{token}?key={64-char-hex}&e2ee=no
```

### Encryption key format

A 64-character lowercase hexadecimal string (256-bit AES key). Generate one with:

```bash
python3 -c "import secrets; print(secrets.token_hex(32))"
```

You must configure the same key in the Pushover app on every device that should receive decryptable notifications.

## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/62](https://github.com/caronc/apprise-docs/pull/62)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing

Anyone can help test as follows:

```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1597-pushover-e2ee-support

# Install E2EE dependency
pip install cryptography

# Generate a key (save this -- you'll configure it in the Pushover app too)
python3 -c "import secrets; print(secrets.token_hex(32))"

# Send an encrypted notification
apprise -vv -t "Test Title" -b "Test Message" \
    "pover://{user_key}@{token}?key={your-64-char-key}"

# If you have cloned the branch and have tox available to you:
tox -e qa -- -k pushover
```
