### PR TITLE
mqtt:// now depends on paho-mqtt v2.1.0+

### DIFF
--- a/all-plugin-requirements.txt
+++ b/all-plugin-requirements.txt
@@ -11,8 +11,7 @@ cryptography
 gntp
 
 # Provides mqtt:// support
-# use any version other than 2.0.x due to https://github.com/eclipse/paho.mqtt.python/issues/814
-paho-mqtt != 2.0.*
+paho-mqtt >= 2.1.0
 
 # Pretty Good Privacy (PGP) Provides mailto:// and deltachat:// support
 PGPy

--- a/apprise/plugins/mqtt.py
+++ b/apprise/plugins/mqtt.py
@@ -50,6 +50,7 @@ NOTIFY_MQTT_SUPPORT_ENABLED = False
 try:
     # 3rd party modules
     import paho.mqtt.client as mqtt
+    from paho.mqtt.client import CallbackAPIVersion as _MQTTCallbackAPI
 
     # We're good to go!
     NOTIFY_MQTT_SUPPORT_ENABLED = True
@@ -67,7 +68,8 @@ try:
 
 except ImportError:
     # No problem; we just simply can't support this plugin because we're
-    # either using Linux, or simply do not have pywin32 installed.
+    # missing the required paho-mqtt >= 2.1.0 library.
+    _MQTTCallbackAPI = None
     MQTT_PROTOCOL_MAP = {}
 
 # A lookup map for relaying version to user
@@ -86,7 +88,7 @@ class NotifyMQTT(NotifyBase):
 
     requirements = {
         # Define our required packaging in order to work
-        "packages_required": "paho-mqtt != 2.0.*"
+        "packages_required": "paho-mqtt >= 2.1.0"
     }
 
     # The default descriptive name associated with the Notification
@@ -313,6 +315,7 @@ class NotifyMQTT(NotifyBase):
 
         # Our MQTT Client Object
         self.client = mqtt.Client(
+            _MQTTCallbackAPI.VERSION2,
             client_id=self.client_id,
             clean_session=not self.session,
             userdata=None,
@@ -347,7 +350,10 @@ class NotifyMQTT(NotifyBase):
                     )
 
                 if self.secure:
-                    if self.ca_certs is None:
+                    if self.verify_certificate and self.ca_certs is None:
+                        # CA certificates are only required when verification
+                        # is enabled; skip this check when verify=False so
+                        # that self-signed certificates are accepted.
                         self.logger.error(
                             "MQTT secure communication can not be verified, "
                             "CA certificates file missing"
@@ -355,10 +361,21 @@ class NotifyMQTT(NotifyBase):
                         return False
 
                     self.client.tls_set(
-                        ca_certs=self.ca_certs,
+                        # Only supply CA certs when verification is enabled;
+                        # passing them with CERT_NONE has no effect but is
+                        # cleaner to omit.
+                        ca_certs=(
+                            self.ca_certs if self.verify_certificate else None
+                        ),
                         certfile=None,
                         keyfile=None,
-                        cert_reqs=ssl.CERT_REQUIRED,
+                        # CERT_NONE disables chain validation when verify=False
+                        # so that self-signed certificates are accepted.
+                        cert_reqs=(
+                            ssl.CERT_REQUIRED
+                            if self.verify_certificate
+                            else ssl.CERT_NONE
+                        ),
                         tls_version=ssl.PROTOCOL_TLS,
                         ciphers=None,
                     )

--- a/apprise/plugins/mqtt.py
+++ b/apprise/plugins/mqtt.py
@@ -475,15 +475,32 @@ class NotifyMQTT(NotifyBase):
                 # if we reach here; we're at the bottom of our loop
                 # we loop around and do the next topic now
 
+        except ssl.CertificateError as e:
+            # Hostname/certificate mismatch; most specific SSL error
+            self.logger.warning(
+                f"MQTT SSL Certificate Error received from {url}"
+            )
+            self.logger.debug(f"Socket Exception: {e!s}")
+            return False
+
+        except ssl.SSLError as e:
+            # TLS handshake failure, ALPN negotiation error, malformed CA file,
+            # or any other SSL-layer problem not covered by CertificateError
+            self.logger.warning(f"MQTT SSL Error received from {url}")
+            self.logger.debug(f"Socket Exception: {e!s}")
+            return False
+
         except ConnectionError as e:
+            # Refused, reset, or dropped connections (subclass of OSError)
             self.logger.warning(f"MQTT Connection Error received from {url}")
             self.logger.debug(f"Socket Exception: {e!s}")
             return False
 
-        except ssl.CertificateError as e:
-            self.logger.warning(
-                f"MQTT SSL Certificate Error received from {url}"
-            )
+        except OSError as e:
+            # Remaining socket/OS errors: TimeoutError, BrokenPipeError,
+            # PermissionError, etc. -- all subclasses of OSError not caught
+            # by the more specific handlers above
+            self.logger.warning(f"MQTT Socket Error received from {url}")
             self.logger.debug(f"Socket Exception: {e!s}")
             return False
 

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -145,7 +145,7 @@ Requires: python3dist(certifi)
 Requires: python3dist(pyyaml)
 
 Recommends: python3dist(hidapi)
-Recommends: python3dist(paho-mqtt)
+Recommends: python3dist(paho-mqtt) >= 2.1.0
 Recommends: python3dist(slixmpp)
 
 %if 0%{?legacy_python_build} == 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,9 +228,7 @@ all-plugins = [
     # provides growl:// support
     "gntp",
     # Provides mqtt:// support
-    # use any version other than 2.0.x due to:
-    #  - https://github.com/eclipse/paho.mqtt.python/issues/814
-    "paho-mqtt != 2.0.*",
+    "paho-mqtt >= 2.1.0",
 
      # Pretty Good Privacy (PGP) Provides mailto:// and deltachat:// support
     "PGPy",

--- a/tests/test_plugin_mqtt.py
+++ b/tests/test_plugin_mqtt.py
@@ -421,8 +421,15 @@ def test_plugin_mqtt_exception_failure(mqtt_client_mock):
     # Emulate a situation where `connect()` raises an exception.
     mqtt_client_mock.connect.return_value = None
 
-    # Verify notification fails.
-    for side_effect in (ValueError, ConnectionError, ssl.CertificateError):
+    # Verify notification fails for every exception type that connect() or
+    # the TLS setup can raise (most-specific to least-specific order).
+    for side_effect in (
+        ssl.CertificateError,
+        ssl.SSLError,
+        ConnectionError,
+        OSError,
+        ValueError,
+    ):
         mqtt_client_mock.connect.side_effect = side_effect
         assert obj.notify(body="test=test") is False
 

--- a/tests/test_plugin_mqtt.py
+++ b/tests/test_plugin_mqtt.py
@@ -291,10 +291,48 @@ def test_plugin_mqtt_tls_no_verify_success(mqtt_client_mock):
     assert isinstance(obj, NotifyMQTT)
     assert obj.notify(body="test=test") is True
 
-    # Verify the right calls have been made to the MQTT client object.
-    # Let's only validate the single call of interest is present.
-    # Everything else is identical with `test_plugin_mqtt_tls_connect_success`.
+    # Chain validation must be disabled via CERT_NONE (not just hostname
+    # skipping via tls_insecure_set) so self-signed certs are accepted.
+    assert (
+        call.tls_set(
+            ca_certs=None,
+            certfile=None,
+            keyfile=None,
+            cert_reqs=ssl.CERT_NONE,
+            tls_version=ssl.PROTOCOL_TLS,
+            ciphers=None,
+        )
+        in mqtt_client_mock.mock_calls
+    )
     assert call.tls_insecure_set(True) in mqtt_client_mock.mock_calls
+
+
+def test_plugin_mqtt_tls_no_verify_no_ca_success(mqtt_client_mock, mocker):
+    """Verify TLS with verify=False succeeds without CA certificates."""
+
+    # Clear CA certificates -- with verify=False this should not block us
+    mocker.patch.object(NotifyMQTT, "CA_CERTIFICATE_FILE_LOCATIONS", [])
+
+    obj = apprise.Apprise.instantiate(
+        "mqtts://user:pass@localhost/my/topic?verify=False",
+        suppress_exceptions=False,
+    )
+    assert isinstance(obj, NotifyMQTT)
+
+    # Should succeed without CA certificates when verify is disabled
+    assert obj.notify(body="test=test") is True
+
+    assert (
+        call.tls_set(
+            ca_certs=None,
+            certfile=None,
+            keyfile=None,
+            cert_reqs=ssl.CERT_NONE,
+            tls_version=ssl.PROTOCOL_TLS,
+            ciphers=None,
+        )
+        in mqtt_client_mock.mock_calls
+    )
 
 
 def test_plugin_mqtt_session_client_id_success(mqtt_client_mock):


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #802

This PR fixes two bugs in the MQTT plugin and brings it into full compatibility with paho-mqtt v2.x (>= 2.1.0). The version requirement is raised to `>= 2.1.0` to skip the initial 2.0.x release that had rough edges: 

- `verify=no` did not actually allow self-signed certificates; this was a limitation of `paho-mqtt` at the time the Issued was created (and not anymore allowing Apprise to adapt to it).
- CA certificate check blocked `verify=no` connections entirely.

## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/66](https://github.com/caronc/apprise-docs/pull/66)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing

Anyone can help test as follows:

```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@802-paho-mqtt-alignment

# Test insecure connection (plain MQTT)
apprise -vv -t "Test" -b "hello" "mqtt://localhost/my/topic"

# Test TLS with a valid certificate
apprise -vv -t "Test" -b "hello" "mqtts://user:pass@host/my/topic"

# Test TLS with a self-signed certificate (the fix)
apprise -vv -t "Test" -b "hello" "mqtts://user:pass@host/my/topic?verify=no"
```
