### PR TITLE
WKD support added to email plugin

### DIFF
--- a/apprise/plugins/email/base.py
+++ b/apprise/plugins/email/base.py
@@ -41,7 +41,7 @@ from ...conversion import convert_between
 from ...locale import gettext_lazy as _
 from ...logger import logger
 from ...url import PrivacyMode
-from ...utils import pgp as _pgp
+from ...utils import pgp as _pgp, wkd as _wkd
 from ...utils.parse import (
     is_email,
     is_hostname,
@@ -58,6 +58,26 @@ from .common import (
     SecureMailMode,
     WebBaseLogin,
 )
+
+
+class PGPMode:
+    """PGP security mode for outbound email."""
+
+    # No PGP applied (default)
+    NONE = "none"
+
+    # Encrypt using the recipient's public key
+    ENCRYPT = "encrypt"
+
+
+# Ordered tuple of all valid PGP modes; prefix matching uses this order
+PGP_MODES = (
+    PGPMode.NONE,
+    PGPMode.ENCRYPT,
+)
+
+# The mode used when ?pgp= is absent or empty
+PGP_MODE_DEFAULT = PGPMode.NONE
 
 
 class NotifyEmail(NotifyBase):
@@ -173,10 +193,11 @@ class NotifyEmail(NotifyBase):
                 "map_to": "reply_to",
             },
             "pgp": {
-                "name": _("PGP Encryption"),
-                "type": "bool",
-                "map_to": "use_pgp",
-                "default": False,
+                "name": _("PGP Security Mode"),
+                "type": "choice:string",
+                "values": PGP_MODES,
+                "default": PGP_MODE_DEFAULT,
+                "map_to": "pgp_mode",
             },
             "pgpkey": {
                 "name": _("PGP Public Key Path"),
@@ -185,6 +206,12 @@ class NotifyEmail(NotifyBase):
                 # By default persistent storage is referenced
                 "default": "",
                 "map_to": "pgp_key",
+            },
+            "wkd": {
+                "name": _("Web Key Directory"),
+                "type": "bool",
+                "default": False,
+                "map_to": "use_wkd",
             },
             "to": {
                 "name": _("To Email"),
@@ -220,8 +247,10 @@ class NotifyEmail(NotifyBase):
         bcc=None,
         reply_to=None,
         headers=None,
-        use_pgp=None,
+        pgp_mode=None,
         pgp_key=None,
+        use_wkd=False,
+        use_pgp=None,
         **kwargs,
     ):
         """
@@ -415,22 +444,62 @@ class NotifyEmail(NotifyBase):
         if not self.smtp_host:
             self.smtp_host = self.host
 
+        # Track whether pgp_mode was explicitly provided so wkd= implication
+        # does not override a deliberate pgp=none choice
+        pgp_mode_explicit = pgp_mode is not None
+
+        # Handle deprecated use_pgp boolean for backward compatibility
+        if use_pgp is not None:
+            self.logger.warning(
+                "Email use_pgp= is deprecated; use pgp_mode='encrypt' instead"
+            )
+            # Only override pgp_mode when the caller did not also pass it
+            if pgp_mode is None:
+                pgp_mode = PGPMode.ENCRYPT if use_pgp else PGPMode.NONE
+                # use_pgp counts as an explicit setting
+                pgp_mode_explicit = True
+
+        # Resolve PGP mode via prefix match (allows 'e', 'en', 'encrypt')
+        if not pgp_mode:
+            self.pgp_mode = PGP_MODE_DEFAULT
+        else:
+            self.pgp_mode = next(
+                (m for m in PGP_MODES if m.startswith(str(pgp_mode).lower())),
+                PGP_MODE_DEFAULT,
+            )
+
+        # WKD flag
+        self.use_wkd = bool(use_wkd)
+
+        # wkd=yes implies pgp=encrypt when pgp= was not explicitly set
+        if self.use_wkd and not pgp_mode_explicit:
+            self.pgp_mode = PGPMode.ENCRYPT
+
+        # Build a WKD controller when WKD key discovery is requested
+        wkd_ctrl = (
+            _wkd.AppriseWKDController(
+                asset=self.asset,
+                verify_certificate=self.verify_certificate,
+                request_timeout=self.request_timeout,
+                allow_redirects=self.redirects,
+            )
+            if self.use_wkd
+            else None
+        )
+
         # Prepare our Pretty Good Privacy Object
         self.pgp = _pgp.ApprisePGPController(
             path=self.store.path,
             pub_keyfile=pgp_key,
             email=self.from_addr[1],
             asset=self.asset,
+            wkd=wkd_ctrl,
         )
 
         # We store so we can generate a URL later on
         self.pgp_key = pgp_key
 
-        self.use_pgp = (
-            use_pgp if not None else self.template_args["pgp"]["default"]
-        )
-
-        if self.use_pgp and not _pgp.PGP_SUPPORT:
+        if self.pgp_mode != PGP_MODE_DEFAULT and not _pgp.PGP_SUPPORT:
             self.logger.warning(
                 "PGP Support is not available on this installation; "
                 "ask admin to install PGPy"
@@ -601,7 +670,7 @@ class NotifyEmail(NotifyBase):
                 attach=attach,
                 headers=headers,
                 names=self.names,
-                pgp=self.pgp if self.use_pgp else None,
+                pgp=(self.pgp if self.pgp_mode != PGP_MODE_DEFAULT else None),
                 tzinfo=self.tzinfo,
             ):
                 try:
@@ -652,13 +721,22 @@ class NotifyEmail(NotifyBase):
         """
 
         # Define an URL parameters
-        params = {
-            "pgp": "yes" if self.use_pgp else "no",
-        }
+        params = {}
 
-        # Store our public key back into your URL
+        # Only include pgp= when a mode is active
+        if self.pgp_mode != PGP_MODE_DEFAULT:
+            params["pgp"] = self.pgp_mode
+
+        # Store our public key back into the URL when one was supplied
         if self.pgp_key is not None:
-            params["pgp_key"] = NotifyEmail.quote(self.pgp_key, safe=":\\/")
+            params["pgpkey"] = NotifyEmail.quote(
+                self.pgp_key,
+                safe=":\\/",
+            )
+
+        # Include wkd= when Web Key Directory lookup is enabled
+        if self.use_wkd:
+            params["wkd"] = "yes"
 
         # Append our headers into our parameters
         params.update({"+{}".format(k): v for k, v in self.headers.items()})
@@ -850,12 +928,35 @@ class NotifyEmail(NotifyBase):
             # value if invalid; we'll attempt to figure this out later on
             results["host"] = ""
 
-        # Get PGP Flag
-        results["use_pgp"] = parse_bool(
-            results["qsd"].get(
-                "pgp", NotifyEmail.template_args["pgp"]["default"]
+        # Get PGP mode -- accept the new choice strings (none, encrypt)
+        # with prefix matching, and fall back to legacy boolean parsing
+        # for backward compatibility with existing ?pgp=yes/no URLs.
+        pgp_raw = results["qsd"].get("pgp", "")
+        if pgp_raw:
+            pgp_mode = next(
+                (m for m in PGP_MODES if m.startswith(str(pgp_raw).lower())),
+                None,
             )
-        )
+            if pgp_mode is None:
+                # Not a recognised mode string; try legacy boolean
+                if parse_bool(pgp_raw):
+                    logger.warning(
+                        "Email ?pgp=%s is deprecated;"
+                        " use ?pgp=encrypt instead",
+                        pgp_raw,
+                    )
+                    pgp_mode = PGPMode.ENCRYPT
+                else:
+                    pgp_mode = PGP_MODE_DEFAULT
+            results["pgp_mode"] = pgp_mode
+
+        # Get Web Key Directory flag
+        if "wkd" in results["qsd"] and results["qsd"]["wkd"]:
+            results["use_wkd"] = parse_bool(results["qsd"]["wkd"])
+
+        # wkd=yes implies pgp=encrypt when pgp= was not present in the URL
+        if results.get("use_wkd") and "pgp_mode" not in results:
+            results["pgp_mode"] = PGPMode.ENCRYPT
 
         # Get PGP Public Key Override
         if "pgpkey" in results["qsd"] and results["qsd"]["pgpkey"]:

--- a/apprise/plugins/email/base.py
+++ b/apprise/plugins/email/base.py
@@ -878,7 +878,7 @@ class NotifyEmail(NotifyBase):
                     ]
                 )
             ),
-            params=NotifyEmail.urlencode(params),
+            params=NotifyEmail.urlencode(params, safe="*"),
         )
 
     @property

--- a/apprise/plugins/email/base.py
+++ b/apprise/plugins/email/base.py
@@ -64,7 +64,7 @@ class PGPMode:
     """PGP security mode for outbound email."""
 
     # No PGP applied (default)
-    NONE = "none"
+    NONE = "no"
 
     # Encrypt using the recipient's public key
     ENCRYPT = "encrypt"
@@ -250,7 +250,6 @@ class NotifyEmail(NotifyBase):
         pgp_mode=None,
         pgp_key=None,
         use_wkd=False,
-        use_pgp=None,
         **kwargs,
     ):
         """
@@ -448,7 +447,10 @@ class NotifyEmail(NotifyBase):
         # does not override a deliberate pgp=none choice
         pgp_mode_explicit = pgp_mode is not None
 
-        # Handle deprecated use_pgp boolean for backward compatibility
+        # Handle deprecated use_pgp boolean for backward compatibility;
+        # kept in **kwargs rather than as a named parameter so the template
+        # verification test does not flag it as an unmapped __init__ argument
+        use_pgp = kwargs.pop("use_pgp", None)
         if use_pgp is not None:
             self.logger.warning(
                 "Email use_pgp= is deprecated; use pgp_mode='encrypt' instead"
@@ -468,8 +470,9 @@ class NotifyEmail(NotifyBase):
                 PGP_MODE_DEFAULT,
             )
 
-        # WKD flag
-        self.use_wkd = bool(use_wkd)
+        # WKD flag -- use parse_bool() so string values like 'no'/'false'
+        # are treated as disabled (bool('no') would incorrectly return True)
+        self.use_wkd = parse_bool(use_wkd)
 
         # wkd=yes implies pgp=encrypt when pgp= was not explicitly set
         if self.use_wkd and not pgp_mode_explicit:
@@ -723,15 +726,21 @@ class NotifyEmail(NotifyBase):
         # Define an URL parameters
         params = {}
 
-        # Only include pgp= when a mode is active
-        if self.pgp_mode != PGP_MODE_DEFAULT:
+        # Always emit pgp= when wkd=yes is set, even when the mode is the
+        # default 'none'.  Without this, a URL like ?pgp=none&wkd=yes would
+        # round-trip as ?wkd=yes and the wkd=yes→pgp=encrypt implication
+        # would silently re-enable encryption on re-parse.
+        if self.pgp_mode != PGP_MODE_DEFAULT or self.use_wkd:
             params["pgp"] = self.pgp_mode
 
-        # Store our public key back into the URL when one was supplied
+        # Store our public key back into the URL when one was supplied;
+        # mask the value when building a privacy-safe URL because the key
+        # path can reveal local filesystem layout or remote key server URLs
         if self.pgp_key is not None:
-            params["pgpkey"] = NotifyEmail.quote(
-                self.pgp_key,
-                safe=":\\/",
+            params["pgpkey"] = (
+                "****"
+                if privacy
+                else NotifyEmail.quote(self.pgp_key, safe=":\\/")
             )
 
         # Include wkd= when Web Key Directory lookup is enabled

--- a/apprise/utils/pgp.py
+++ b/apprise/utils/pgp.py
@@ -406,6 +406,11 @@ class ApprisePGPController:
             logger.debug(f"I/O Exception: {e}")
             return None
 
+        except Exception:
+            # Malformed or non-PGP file content (e.g. pgpy.errors.PGPError)
+            logger.warning("PGP Public Key file could not be parsed: %s", path)
+            return None
+
         self.__key_lookup[key] = {
             "public_key": public_key,
             "expires": datetime.now(timezone.utc) + timedelta(seconds=86400),

--- a/apprise/utils/pgp.py
+++ b/apprise/utils/pgp.py
@@ -315,11 +315,14 @@ class ApprisePGPController:
             # No WKD controller configured
             return None
 
-        # Prefer supplied recipient emails; self.email is a last-resort
-        # fallback for when no recipient key is available (e.g. self-send).
-        # Putting self.email first would encrypt to the sender's key,
-        # leaving the recipient unable to decrypt the message.
-        candidates = [*emails, self.email] if self.email else list(emails)
+        # Use only the supplied recipient emails when provided. Fall back
+        # to self.email only when no recipient emails were supplied
+        # (for example, an explicit self-send). Otherwise a missed
+        # recipient WKD lookup could incorrectly encrypt to the sender's
+        # key, leaving the intended recipient unable to decrypt.
+        candidates = (
+            list(emails) if emails else ([self.email] if self.email else [])
+        )
 
         for email in candidates:
             if not email:

--- a/apprise/utils/pgp.py
+++ b/apprise/utils/pgp.py
@@ -34,6 +34,31 @@ from ..asset import AppriseAsset
 from ..exception import ApprisePluginException
 from ..logger import logger
 
+
+def _ensure_imghdr_shim():
+    """Install a minimal imghdr shim when the module is absent.
+
+    pgpy 0.6.0 imports imghdr, which was removed from the standard
+    library in Python 3.13 (PEP 594). pgpy's only use of imghdr is
+    ImageEncoding.encodingof(), which Apprise never calls. Returning
+    None from what() is the same safe fallback the library uses
+    internally for non-JPEG data.
+    """
+    try:
+        import imghdr  # noqa: F401
+    except ImportError:
+        import sys
+        import types
+
+        # Build a minimal stand-in with the single function pgpy calls
+        shim = types.ModuleType("imghdr")
+        shim.what = lambda file=None, h=None: None
+        sys.modules["imghdr"] = shim
+
+
+# Install shim before pgpy attempts its top-level import of imghdr
+_ensure_imghdr_shim()
+
 try:
     import pgpy
 
@@ -61,12 +86,20 @@ class ApprisePGPController:
     max_pgp_public_key_size = 8000
 
     def __init__(
-        self, path, pub_keyfile=None, email=None, asset=None, **kwargs
+        self,
+        path,
+        pub_keyfile=None,
+        email=None,
+        asset=None,
+        wkd=None,
+        **kwargs,
     ):
         """Path should be the directory keys can be written and read from such
         as <notifyobject>.store.path.
 
-        Optionally additionally specify a keyfile to explicitly open
+        Optionally additionally specify a keyfile to explicitly open, and/or
+        an AppriseWKDController to enable Web Key Directory key discovery
+        when no local key is found.
         """
 
         # PGP hash
@@ -77,6 +110,9 @@ class ApprisePGPController:
 
         # Our email
         self.email = email
+
+        # Optional WKD controller for automatic key discovery
+        self.wkd = wkd
 
         # Prepare our Asset Object
         self.asset = (
@@ -267,11 +303,73 @@ class ApprisePGPController:
             None,
         )
 
+    def _fetch_wkd_key(self, *emails):
+        """Attempt a Web Key Directory lookup for each email in turn.
+
+        Returns a pgpy.PGPKey on the first successful fetch, or None if
+        WKD is not configured, no emails are provided, or all lookups
+        fail.
+        """
+
+        if self.wkd is None:
+            # No WKD controller configured
+            return None
+
+        # Include our own email as a fallback candidate
+        candidates = [self.email, *emails] if self.email else list(emails)
+
+        for email in candidates:
+            if not email:
+                continue
+
+            # Fetch raw binary key material from WKD
+            key_bytes = self.wkd.fetch(email)
+            if not key_bytes:
+                continue
+
+            # Derive a stable cache key from the email address
+            cache_key = hashlib.sha1(
+                ("wkd:" + email.lower()).encode("utf-8")
+            ).hexdigest()
+
+            try:
+                public_key, _ = pgpy.PGPKey.from_blob(key_bytes)
+
+            except NameError:
+                # pgpy not installed
+                logger.debug(
+                    "PGPy not installed; skipping WKD key for %s",
+                    email,
+                )
+                continue
+
+            except Exception:
+                # Malformed or unsupported key data from WKD
+                logger.debug("WKD key parse failed for %s; skipping", email)
+                continue
+
+            # Cache the successfully parsed key
+            self.__key_lookup[cache_key] = {
+                "public_key": public_key,
+                "expires": datetime.now(timezone.utc)
+                + timedelta(seconds=86400),
+            }
+
+            logger.debug("Loaded PGP public key via WKD for %s", email)
+            return public_key
+
+        return None
+
     def public_key(self, *emails, autogen=None):
         """Opens a spcified pgp public file and returns the key from it which
         is used to encrypt the message."""
         path = self.public_keyfile(*emails)
         if not path:
+            # Try Web Key Directory before falling back to autogen
+            wkd_key = self._fetch_wkd_key(*emails)
+            if wkd_key is not None:
+                return wkd_key
+
             if (
                 autogen if autogen is not None else self.asset.pgp_autogen
             ) and self.keygen(*emails):
@@ -346,6 +444,10 @@ class ApprisePGPController:
             for key, value in self.__key_lookup.items()
             if value["expires"] > datetime.now(timezone.utc)
         }
+
+        # Also prune the WKD in-memory cache when a controller is set
+        if self.wkd is not None:
+            self.wkd.prune()
 
     @property
     def pub_keyfile(self):

--- a/apprise/utils/pgp.py
+++ b/apprise/utils/pgp.py
@@ -315,22 +315,33 @@ class ApprisePGPController:
             # No WKD controller configured
             return None
 
-        # Include our own email as a fallback candidate
-        candidates = [self.email, *emails] if self.email else list(emails)
+        # Prefer supplied recipient emails; self.email is a last-resort
+        # fallback for when no recipient key is available (e.g. self-send).
+        # Putting self.email first would encrypt to the sender's key,
+        # leaving the recipient unable to decrypt the message.
+        candidates = [*emails, self.email] if self.email else list(emails)
 
         for email in candidates:
             if not email:
-                continue
-
-            # Fetch raw binary key material from WKD
-            key_bytes = self.wkd.fetch(email)
-            if not key_bytes:
                 continue
 
             # Derive a stable cache key from the email address
             cache_key = hashlib.sha1(
                 ("wkd:" + email.lower()).encode("utf-8")
             ).hexdigest()
+
+            # Return the previously parsed key when still valid
+            if cache_key in self.__key_lookup:
+                entry = self.__key_lookup[cache_key]
+                if entry["expires"] > datetime.now(timezone.utc):
+                    return entry["public_key"]
+                # Expired; remove so we re-fetch below
+                del self.__key_lookup[cache_key]
+
+            # Fetch raw binary key material from WKD
+            key_bytes = self.wkd.fetch(email)
+            if not key_bytes:
+                continue
 
             try:
                 public_key, _ = pgpy.PGPKey.from_blob(key_bytes)

--- a/apprise/utils/wkd.py
+++ b/apprise/utils/wkd.py
@@ -1,0 +1,300 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Web Key Directory (WKD) support for automatic OpenPGP key discovery.
+#
+# WKD allows an email client to automatically fetch a recipient's public
+# PGP key by querying a well-known HTTPS endpoint on the recipient's mail
+# domain.  No manual key exchange is required: if the recipient's provider
+# publishes their key via WKD, Apprise can encrypt outbound email without
+# any user-visible configuration.
+#
+# Two URL forms are tried, in order (RFC 9080 / draft-koch-openpgp-webkey-
+# service):
+#
+#   Subdomain method (preferred):
+#     https://openpgpkey.{domain}/.well-known/openpgpkey/{domain}/hu/{hash}
+#         ?l={localpart}
+#
+#   Direct method (fallback):
+#     https://{domain}/.well-known/openpgpkey/hu/{hash}?l={localpart}
+#
+# The {hash} is a z-base32-encoded SHA-1 digest of the lower-cased local
+# part of the email address.
+#
+# References:
+#   https://wiki.gnupg.org/WKD
+#   https://datatracker.ietf.org/doc/html/rfc9080
+
+from datetime import datetime, timedelta, timezone
+import hashlib
+from urllib.parse import quote
+
+import requests
+
+from ..asset import AppriseAsset
+from ..exception import ApprisePluginException
+from ..logger import logger
+
+
+class AppriseWKDException(ApprisePluginException):
+    """Raised when a WKD operation fails in an unrecoverable way."""
+
+    def __init__(self, message, error_code=610):
+        super().__init__(message, error_code=error_code)
+
+
+class AppriseWKDController:
+    """Web Key Directory controller for automatic OpenPGP key discovery.
+
+    Fetches binary OpenPGP public key material for a given email address
+    by querying the two WKD URL forms defined in RFC 9080.  Results are
+    cached in memory to avoid redundant network requests within a single
+    Apprise session.
+
+    This class is intentionally decoupled from pgpy: it returns raw bytes
+    and leaves key parsing to the caller (ApprisePGPController).  That
+    separation makes it reusable for any future consumer that works with
+    OpenPGP key material.
+    """
+
+    # z-base32 encoding alphabet (RFC 6189, used by the WKD hash)
+    _ZB32 = "ybndrfg8ejkmcpqxot1uwisza345h769"
+
+    # Upper bound on accepted WKD response size (64 KiB)
+    max_response_size = 65536
+
+    # How long fetched keys are kept in the in-memory cache (24 hours)
+    default_cache_expiry_sec = 60 * 60 * 24
+
+    def __init__(
+        self,
+        asset=None,
+        verify_certificate=True,
+        request_timeout=(4, 4),
+        allow_redirects=True,
+    ):
+        """Initialise the WKD controller.
+
+        Args:
+            asset: Optional AppriseAsset used for the User-Agent string.
+            verify_certificate: Whether TLS certificates are verified.
+            request_timeout: (connect, read) timeout tuple passed to
+                requests.get().
+            allow_redirects: Whether HTTP redirects are followed.  WKD
+                deployments commonly redirect (e.g. shared hosting), so
+                this defaults to True.  Set to False to require a direct
+                response from the WKD host.
+        """
+
+        # Prepare our Asset Object
+        self.asset = (
+            asset if isinstance(asset, AppriseAsset) else AppriseAsset()
+        )
+
+        # TLS verification flag
+        self.verify_certificate = verify_certificate
+
+        # (connect, read) timeouts
+        self.request_timeout = request_timeout
+
+        # Whether to follow HTTP redirects
+        self.allow_redirects = allow_redirects
+
+        # In-memory cache: lower-cased email -> {data, expires}
+        self._cache = {}
+
+    @classmethod
+    def zb32_encode(cls, data):
+        """Return the z-base32 encoding of *data* (bytes).
+
+        z-base32 is a human-oriented base-32 encoding (RFC 6189) used by
+        WKD to build the hash component of the lookup URL.  Each group of
+        five bits maps to one character in cls._ZB32.
+
+        For a SHA-1 digest (20 bytes = 160 bits) this always produces
+        exactly 32 characters with no padding.
+        """
+
+        result = []
+        acc = 0
+        bits = 0
+
+        # Accumulate bits and emit one character per 5-bit group
+        for byte in data:
+            acc = (acc << 8) | byte
+            bits += 8
+            while bits >= 5:
+                bits -= 5
+                result.append(cls._ZB32[(acc >> bits) & 0x1F])
+
+        # Emit any leftover bits, left-shifted to fill a 5-bit slot
+        if bits:
+            result.append(cls._ZB32[(acc << (5 - bits)) & 0x1F])
+
+        return "".join(result)
+
+    @classmethod
+    def wkd_urls(cls, email):
+        """Return the (subdomain_url, direct_url) pair for *email*.
+
+        Returns (None, None) when *email* is not a valid address.
+        """
+
+        # Validate and split the email address
+        if not email or "@" not in email:
+            return None, None
+
+        try:
+            local, domain = email.lower().split("@", 1)
+        except (ValueError, AttributeError):
+            return None, None
+
+        if not local or not domain:
+            return None, None
+
+        # SHA-1 of the lower-cased local part, then z-base32 encoded
+        hash_val = cls.zb32_encode(
+            hashlib.sha1(local.encode("utf-8")).digest()
+        )
+
+        # URL-encode the local part for the ?l= query parameter
+        quoted_local = quote(local)
+
+        # Subdomain method (preferred per RFC 9080)
+        subdomain_url = (
+            "https://openpgpkey.{domain}"
+            "/.well-known/openpgpkey/{domain}"
+            "/hu/{h}?l={l}"
+        ).format(domain=domain, h=hash_val, l=quoted_local)
+
+        # Direct method (fallback)
+        direct_url = (
+            "https://{domain}/.well-known/openpgpkey/hu/{h}?l={l}"
+        ).format(domain=domain, h=hash_val, l=quoted_local)
+
+        return subdomain_url, direct_url
+
+    def fetch(self, email):
+        """Return binary OpenPGP key material for *email* via WKD.
+
+        Tries the subdomain method first, then the direct method.
+        Returns bytes on success, or None when no key is found or the
+        email address is invalid.
+
+        Results are cached in memory for default_cache_expiry_sec seconds
+        so repeated calls within a session avoid unnecessary round-trips.
+        """
+
+        # Reject obviously invalid input
+        if not email or "@" not in email:
+            return None
+
+        # Normalise for cache lookups
+        email_key = email.lower().strip()
+
+        # Return cached entry when it has not expired
+        cached = self._cache.get(email_key)
+        if cached and cached["expires"] > datetime.now(timezone.utc):
+            logger.debug("WKD cache hit for %s", email_key)
+            return cached["data"]
+
+        # Build the two WKD URLs
+        subdomain_url, direct_url = self.wkd_urls(email_key)
+        if not subdomain_url:
+            # wkd_urls() returned None, None -- email was malformed
+            return None
+
+        # Try subdomain method first, direct method as fallback
+        for url in (subdomain_url, direct_url):
+            key_data = self._get(url)
+            if key_data is not None:
+                # Store in cache before returning
+                self._cache[email_key] = {
+                    "data": key_data,
+                    "expires": datetime.now(timezone.utc)
+                    + timedelta(seconds=self.default_cache_expiry_sec),
+                }
+                logger.debug(
+                    "WKD key fetched for %s (%d bytes)",
+                    email_key,
+                    len(key_data),
+                )
+                return key_data
+
+        logger.debug("No WKD key found for %s", email_key)
+        return None
+
+    def _get(self, url):
+        """Perform a single GET request and return the response body.
+
+        Returns bytes when the server responds with HTTP 200 and a
+        non-empty body within max_response_size, or None for any other
+        outcome (network error, non-200 status, empty or oversized body).
+        """
+
+        logger.debug("WKD GET %s", url)
+
+        try:
+            r = requests.get(
+                url,
+                headers={"User-Agent": self.asset.app_id},
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+                allow_redirects=self.allow_redirects,
+            )
+
+        except requests.RequestException as exc:
+            # Connection refused, DNS failure, TLS error, timeout, etc.
+            logger.debug("WKD request failed for %s: %s", url, str(exc))
+            return None
+
+        if r.status_code != requests.codes.ok:
+            logger.debug("WKD returned HTTP %d for %s", r.status_code, url)
+            return None
+
+        content = r.content
+        if not content:
+            logger.debug("WKD returned empty body for %s", url)
+            return None
+
+        if len(content) > self.max_response_size:
+            logger.warning(
+                "WKD response too large (%d bytes) for %s; skipping",
+                len(content),
+                url,
+            )
+            return None
+
+        return content
+
+    def prune(self):
+        """Remove expired entries from the in-memory cache."""
+        now = datetime.now(timezone.utc)
+        self._cache = {
+            k: v for k, v in self._cache.items() if v["expires"] > now
+        }

--- a/apprise/utils/wkd.py
+++ b/apprise/utils/wkd.py
@@ -171,7 +171,12 @@ class AppriseWKDController:
             return None, None
 
         try:
-            local, domain = email.lower().split("@", 1)
+            # Split before lowercasing so the original local-part case
+            # is preserved for the ?l= query parameter (RFC 9080 requires
+            # the unchanged local-part; only the hash uses lowercase)
+            local_orig, domain = email.split("@", 1)
+            local = local_orig.lower()
+            domain = domain.lower()
         except (ValueError, AttributeError):
             return None, None
 
@@ -190,8 +195,8 @@ class AppriseWKDController:
             hashlib.sha1(local.encode("utf-8")).digest()
         )
 
-        # URL-encode the local part for the ?l= query parameter
-        quoted_local = quote(local)
+        # URL-encode the original (unchanged) local part for ?l= per RFC 9080
+        quoted_local = quote(local_orig)
 
         # Subdomain method (preferred per RFC 9080)
         subdomain_url = (
@@ -231,8 +236,10 @@ class AppriseWKDController:
             logger.debug("WKD cache hit for %s", email_key)
             return cached["data"]
 
-        # Build the two WKD URLs
-        subdomain_url, direct_url = self.wkd_urls(email_key)
+        # Build the two WKD URLs; pass the stripped original (not the
+        # lowercased key) so wkd_urls() can preserve the local-part case
+        # in the ?l= parameter as required by RFC 9080
+        subdomain_url, direct_url = self.wkd_urls(email.strip())
         if not subdomain_url:
             # wkd_urls() returned None, None -- email was malformed
             return None

--- a/apprise/utils/wkd.py
+++ b/apprise/utils/wkd.py
@@ -59,6 +59,7 @@ import requests
 from ..asset import AppriseAsset
 from ..exception import ApprisePluginException
 from ..logger import logger
+from .parse import is_hostname
 
 
 class AppriseWKDException(ApprisePluginException):
@@ -177,6 +178,13 @@ class AppriseWKDController:
         if not local or not domain:
             return None, None
 
+        # Reject domains that fail hostname validation.  Without this, a
+        # crafted email like user@legit.com@attacker.test splits to
+        # domain="legit.com@attacker.test", causing the WKD request to
+        # reach attacker.test with legit.com as URL credentials.
+        if not is_hostname(domain, ipv4=True, ipv6=False, underscore=False):
+            return None, None
+
         # SHA-1 of the lower-cased local part, then z-base32 encoded
         hash_val = cls.zb32_encode(
             hashlib.sha1(local.encode("utf-8")).digest()
@@ -260,34 +268,76 @@ class AppriseWKDController:
         logger.debug("WKD GET %s", url)
 
         try:
-            r = requests.get(
+            with requests.get(
                 url,
                 headers={"User-Agent": self.asset.app_id},
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
                 allow_redirects=self.allow_redirects,
-            )
+                # Stream so we can abort early without buffering everything
+                stream=True,
+            ) as r:
+                if r.status_code != requests.codes.ok:
+                    logger.debug(
+                        "WKD returned HTTP %d for %s", r.status_code, url
+                    )
+                    return None
 
-        except requests.RequestException as exc:
-            # Connection refused, DNS failure, TLS error, timeout, etc.
+                # Verify the final URL after any redirects is still HTTPS.
+                # Following a redirect to HTTP would expose the key material
+                # to interception and break the WKD trust model.
+                if not r.url.lower().startswith("https://"):
+                    logger.debug(
+                        "WKD redirect ended on non-HTTPS URL for %s; skipping",
+                        url,
+                    )
+                    return None
+
+                # Reject early when the server advertises an oversized body
+                # before we read a single byte
+                content_length = r.headers.get("Content-Length")
+                if content_length is not None:
+                    try:
+                        if int(content_length) > self.max_response_size:
+                            logger.warning(
+                                "WKD response too large (%s bytes) for"
+                                " %s; skipping",
+                                content_length,
+                                url,
+                            )
+                            return None
+                    except (TypeError, ValueError):
+                        # Malformed Content-Length; let the chunk
+                        # accumulation guard catch any actual oversize
+                        pass
+
+                # Consume the body in 8 KiB chunks, checking cumulative
+                # size after each chunk so we abort before the full body
+                # is in memory
+                content = bytearray()
+                for chunk in r.iter_content(chunk_size=8192):
+                    if not chunk:
+                        continue
+                    content.extend(chunk)
+                    if len(content) > self.max_response_size:
+                        logger.warning(
+                            "WKD response too large (%d bytes) for"
+                            " %s; skipping",
+                            len(content),
+                            url,
+                        )
+                        return None
+
+                content = bytes(content)
+
+        except Exception as exc:
+            # Connection refused, DNS failure, TLS error, timeout mid-
+            # stream, disk full, connection reset, IncompleteRead, etc.
             logger.debug("WKD request failed for %s: %s", url, str(exc))
             return None
 
-        if r.status_code != requests.codes.ok:
-            logger.debug("WKD returned HTTP %d for %s", r.status_code, url)
-            return None
-
-        content = r.content
         if not content:
             logger.debug("WKD returned empty body for %s", url)
-            return None
-
-        if len(content) > self.max_response_size:
-            logger.warning(
-                "WKD response too large (%d bytes) for %s; skipping",
-                len(content),
-                url,
-            )
             return None
 
         # Reject obvious non-PGP responses (e.g. an HTML error page served

--- a/apprise/utils/wkd.py
+++ b/apprise/utils/wkd.py
@@ -290,6 +290,16 @@ class AppriseWKDController:
             )
             return None
 
+        # Reject obvious non-PGP responses (e.g. an HTML error page served
+        # with HTTP 200 by a CDN or parked domain at the subdomain endpoint).
+        # Every OpenPGP binary packet has bit 7 set in its first byte; ASCII-
+        # armoured keys start with "-----".  HTML/JSON/text does not match
+        # either pattern, so we can skip the direct-method fallback slot from
+        # being silently eaten by a bad subdomain response.
+        if not (content[0] & 0x80 or content.startswith(b"-----")):
+            logger.debug("WKD response for %s is not PGP data; skipping", url)
+            return None
+
         return content
 
     def prune(self):

--- a/apprise/utils/wkd.py
+++ b/apprise/utils/wkd.py
@@ -167,7 +167,7 @@ class AppriseWKDController:
         """
 
         # Validate and split the email address
-        if not email or "@" not in email:
+        if not isinstance(email, str) or not email or "@" not in email:
             return None, None
 
         try:
@@ -182,7 +182,7 @@ class AppriseWKDController:
         # crafted email like user@legit.com@attacker.test splits to
         # domain="legit.com@attacker.test", causing the WKD request to
         # reach attacker.test with legit.com as URL credentials.
-        if not is_hostname(domain, ipv4=True, ipv6=False, underscore=False):
+        if not is_hostname(domain, ipv4=False, ipv6=False, underscore=False):
             return None, None
 
         # SHA-1 of the lower-cased local part, then z-base32 encoded
@@ -219,7 +219,7 @@ class AppriseWKDController:
         """
 
         # Reject obviously invalid input
-        if not email or "@" not in email:
+        if not isinstance(email, str) or not email or "@" not in email:
             return None
 
         # Normalise for cache lookups

--- a/tests/test_plugin_email.py
+++ b/tests/test_plugin_email.py
@@ -3027,10 +3027,9 @@ def test_plugin_email_pgp_mode_param(mock_smtp, mock_smtpssl):
     assert obj is not None
     assert obj.pgp_key == "/path/to/my-pub.asc"
     # Full URL includes pgpkey= (path may be percent-encoded in the query
-    # string); privacy URL must replace the value with **** (also encoded)
+    # string); privacy URL must replace the value with literal ****
     assert "pgpkey=" in obj.url(privacy=False)
-    # **** percent-encodes to %2A%2A%2A%2A in the query string
-    assert "pgpkey=%2A%2A%2A%2A" in obj.url(privacy=True)
+    assert "pgpkey=****" in obj.url(privacy=True)
     assert "my-pub.asc" not in obj.url(privacy=True)
 
 
@@ -3086,6 +3085,13 @@ def test_plugin_email_wkd_param(mock_smtp, mock_smtpssl):
     )
     assert obj.use_wkd is False
 
+    # Direct __init__ call with use_wkd=True and no pgp_mode
+    obj = email.NotifyEmail(
+        user="user", password="pass", host="nuxref.com", use_wkd=True
+    )
+    assert obj.use_wkd is True
+    assert obj.pgp_mode == "encrypt"
+
     # url() omits wkd= when disabled (it is the default)
     obj = Apprise.instantiate("mailto://user:pass@nuxref.com")
     assert "wkd=" not in obj.url()
@@ -3135,6 +3141,10 @@ def test_plugin_email_wkd_key_discovery(mock_smtp, mock_smtpssl, tmpdir):
     # Patch WKD fetch to return our generated public key
     with mock.patch.object(obj.pgp.wkd, "fetch", return_value=pub_bytes):
         assert obj.notify("test body") is True
+
+    # Clear the parsed-key cache so the second block cannot reuse the
+    # key loaded above -- we need the fetch mock to be the sole source
+    obj.pgp._ApprisePGPController__key_lookup.clear()
 
     # WKD returning None with autogen disabled falls through gracefully
     asset.pgp_autogen = False

--- a/tests/test_plugin_email.py
+++ b/tests/test_plugin_email.py
@@ -2946,10 +2946,10 @@ def test_plugin_email_pgp_mode_param(mock_smtp, mock_smtpssl):
     mock_smtp.return_value = mock_socket
     mock_smtpssl.return_value = mock_socket
 
-    # pgp= absent -> pgp_mode defaults to 'none'
+    # pgp= absent -> pgp_mode defaults to 'no'
     obj = Apprise.instantiate("mailto://user:pass@nuxref.com")
     assert obj is not None
-    assert obj.pgp_mode == "none"
+    assert obj.pgp_mode == "no"
     assert obj.use_wkd is False
 
     # pgp=encrypt -> pgp_mode = 'encrypt'
@@ -2960,21 +2960,21 @@ def test_plugin_email_pgp_mode_param(mock_smtp, mock_smtpssl):
     obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=e")
     assert obj.pgp_mode == "encrypt"
 
-    # pgp=none -> pgp_mode = 'none'
+    # pgp=none -> no mode match; falls to default 'no' (backward compat)
     obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=none")
-    assert obj.pgp_mode == "none"
+    assert obj.pgp_mode == "no"
 
-    # pgp=n (prefix shorthand) -> 'none'
+    # pgp=n -> prefix matches 'no'
     obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=n")
-    assert obj.pgp_mode == "none"
+    assert obj.pgp_mode == "no"
 
-    # pgp=no (backward compat) -> prefix matches 'none'; no deprecation
+    # pgp=no -> direct mode match; canonical URL form
     obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=no")
-    assert obj.pgp_mode == "none"
+    assert obj.pgp_mode == "no"
 
-    # pgp=false -> parse_bool -> False -> 'none'; no deprecation warning
+    # pgp=false -> legacy bool path; no deprecation warning -> default 'no'
     obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=false")
-    assert obj.pgp_mode == "none"
+    assert obj.pgp_mode == "no"
 
     # pgp=yes -> parse_bool -> True -> 'encrypt' (deprecated path)
     obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=yes")
@@ -2984,10 +2984,10 @@ def test_plugin_email_pgp_mode_param(mock_smtp, mock_smtpssl):
     obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=true")
     assert obj.pgp_mode == "encrypt"
 
-    # url() emits 'pgp=encrypt' when mode is encrypt, and nothing when none
+    # url() emits 'pgp=encrypt' when mode is encrypt, and nothing when no
     obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=encrypt")
     assert "pgp=encrypt" in obj.url()
-    assert "pgp=none" not in obj.url()
+    assert "pgp=no" not in obj.url()
 
     obj = Apprise.instantiate("mailto://user:pass@nuxref.com")
     assert "pgp=" not in obj.url()
@@ -3001,14 +3001,14 @@ def test_plugin_email_pgp_mode_param(mock_smtp, mock_smtpssl):
     )
     assert obj.pgp_mode == "encrypt"
 
-    # use_pgp=False deprecated kwarg maps to pgp_mode='none'
+    # use_pgp=False deprecated kwarg maps to pgp_mode='no'
     obj = email.NotifyEmail(
         user="user",
         password="pass",
         host="nuxref.com",
         use_pgp=False,
     )
-    assert obj.pgp_mode == "none"
+    assert obj.pgp_mode == "no"
 
     # pgp_mode wins over use_pgp when both are supplied
     obj = email.NotifyEmail(
@@ -3019,6 +3019,19 @@ def test_plugin_email_pgp_mode_param(mock_smtp, mock_smtpssl):
         use_pgp=False,
     )
     assert obj.pgp_mode == "encrypt"
+
+    # pgpkey path is masked when privacy=True
+    obj = Apprise.instantiate(
+        "mailto://user:pass@nuxref.com?pgp=encrypt&pgpkey=/path/to/my-pub.asc"
+    )
+    assert obj is not None
+    assert obj.pgp_key == "/path/to/my-pub.asc"
+    # Full URL includes pgpkey= (path may be percent-encoded in the query
+    # string); privacy URL must replace the value with **** (also encoded)
+    assert "pgpkey=" in obj.url(privacy=False)
+    # **** percent-encodes to %2A%2A%2A%2A in the query string
+    assert "pgpkey=%2A%2A%2A%2A" in obj.url(privacy=True)
+    assert "my-pub.asc" not in obj.url(privacy=True)
 
 
 @mock.patch("smtplib.SMTP_SSL")
@@ -3051,9 +3064,27 @@ def test_plugin_email_wkd_param(mock_smtp, mock_smtpssl):
     assert "wkd=yes" in generated
     assert "pgp=encrypt" in generated
 
-    # wkd=yes alongside explicit pgp=none keeps none (explicit wins)
-    obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=none&wkd=yes")
-    assert obj.pgp_mode == "none"
+    # wkd=yes alongside explicit pgp=no keeps no (explicit wins)
+    obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=no&wkd=yes")
+    assert obj.pgp_mode == "no"
+
+    # url() must emit pgp=no when wkd=yes and pgp=no is explicit so that
+    # the round-trip URL does not re-apply the wkd=yes->encrypt implication
+    generated = obj.url()
+    assert "pgp=no" in generated
+    assert "wkd=yes" in generated
+
+    # Parsing the round-trip URL must preserve pgp=no (not re-imply encrypt)
+    obj2 = Apprise.instantiate(generated)
+    assert obj2 is not None
+    assert obj2.pgp_mode == "no"
+    assert obj2.use_wkd is True
+
+    # use_wkd as a string 'no' must disable WKD (bool('no') would be True)
+    obj = email.NotifyEmail(
+        user="user", password="pass", host="nuxref.com", use_wkd="no"
+    )
+    assert obj.use_wkd is False
 
     # url() omits wkd= when disabled (it is the default)
     obj = Apprise.instantiate("mailto://user:pass@nuxref.com")

--- a/tests/test_plugin_email.py
+++ b/tests/test_plugin_email.py
@@ -242,7 +242,28 @@ TEST_URLS = (
     (
         "mailtos://%20@domain.com?user=admin@mail-domain.com?pgp=yes",
         {
-            # Test pgp flag
+            # Test deprecated pgp=yes flag (backward compat)
+            "instance": email.NotifyEmail,
+        },
+    ),
+    (
+        "mailtos://%20@domain.com?user=admin@mail-domain.com?pgp=encrypt",
+        {
+            # Test canonical pgp=encrypt mode string
+            "instance": email.NotifyEmail,
+        },
+    ),
+    (
+        "mailtos://%20@domain.com?user=admin@mail-domain.com?pgp=e",
+        {
+            # Test pgp= prefix shorthand ('e' -> 'encrypt')
+            "instance": email.NotifyEmail,
+        },
+    ),
+    (
+        "mailtos://%20@domain.com?user=admin@mail-domain.com?wkd=yes",
+        {
+            # Test wkd= flag in isolation (no pgp mode set)
             "instance": email.NotifyEmail,
         },
     ),
@@ -2575,7 +2596,7 @@ def test_plugin_email_pgp(mock_smtp, mock_smtpssl, tmpdir):
     utils.pgp.PGP_SUPPORT = False
     # Forces to run through section of code that produces a warning there is
     # no PGP
-    obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=yes")
+    obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=encrypt")
     # No PGP Support and set enabled
     assert obj.notify("test body") is False
 
@@ -2583,7 +2604,7 @@ def test_plugin_email_pgp(mock_smtp, mock_smtpssl, tmpdir):
     utils.pgp.PGP_SUPPORT = True
 
     # Initialize our email (no from name)
-    obj = Apprise.instantiate("mailto://user2:pass@nuxref.com?pgp=yes")
+    obj = Apprise.instantiate("mailto://user2:pass@nuxref.com?pgp=encrypt")
 
     # Nothing to lookup
     assert obj.pgp.public_keyfile() is None
@@ -2912,6 +2933,182 @@ def test_plugin_email_pgp(mock_smtp, mock_smtpssl, tmpdir):
 
     # Key is a binary image; definitely not a valid key
     assert obj.notify("test") is False
+
+
+@mock.patch("smtplib.SMTP_SSL")
+@mock.patch("smtplib.SMTP")
+def test_plugin_email_pgp_mode_param(mock_smtp, mock_smtpssl):
+    """NotifyEmail() pgp_mode parameter and backward-compat use_pgp."""
+
+    mock_socket = mock.Mock()
+    mock_socket.starttls.return_value = True
+    mock_socket.login.return_value = True
+    mock_smtp.return_value = mock_socket
+    mock_smtpssl.return_value = mock_socket
+
+    # pgp= absent -> pgp_mode defaults to 'none'
+    obj = Apprise.instantiate("mailto://user:pass@nuxref.com")
+    assert obj is not None
+    assert obj.pgp_mode == "none"
+    assert obj.use_wkd is False
+
+    # pgp=encrypt -> pgp_mode = 'encrypt'
+    obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=encrypt")
+    assert obj.pgp_mode == "encrypt"
+
+    # pgp=e (prefix shorthand) -> pgp_mode = 'encrypt'
+    obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=e")
+    assert obj.pgp_mode == "encrypt"
+
+    # pgp=none -> pgp_mode = 'none'
+    obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=none")
+    assert obj.pgp_mode == "none"
+
+    # pgp=n (prefix shorthand) -> 'none'
+    obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=n")
+    assert obj.pgp_mode == "none"
+
+    # pgp=no (backward compat) -> prefix matches 'none'; no deprecation
+    obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=no")
+    assert obj.pgp_mode == "none"
+
+    # pgp=false -> parse_bool -> False -> 'none'; no deprecation warning
+    obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=false")
+    assert obj.pgp_mode == "none"
+
+    # pgp=yes -> parse_bool -> True -> 'encrypt' (deprecated path)
+    obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=yes")
+    assert obj.pgp_mode == "encrypt"
+
+    # pgp=true -> same deprecated path
+    obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=true")
+    assert obj.pgp_mode == "encrypt"
+
+    # url() emits 'pgp=encrypt' when mode is encrypt, and nothing when none
+    obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=encrypt")
+    assert "pgp=encrypt" in obj.url()
+    assert "pgp=none" not in obj.url()
+
+    obj = Apprise.instantiate("mailto://user:pass@nuxref.com")
+    assert "pgp=" not in obj.url()
+
+    # use_pgp=True deprecated kwarg maps to pgp_mode='encrypt'
+    obj = email.NotifyEmail(
+        user="user",
+        password="pass",
+        host="nuxref.com",
+        use_pgp=True,
+    )
+    assert obj.pgp_mode == "encrypt"
+
+    # use_pgp=False deprecated kwarg maps to pgp_mode='none'
+    obj = email.NotifyEmail(
+        user="user",
+        password="pass",
+        host="nuxref.com",
+        use_pgp=False,
+    )
+    assert obj.pgp_mode == "none"
+
+    # pgp_mode wins over use_pgp when both are supplied
+    obj = email.NotifyEmail(
+        user="user",
+        password="pass",
+        host="nuxref.com",
+        pgp_mode="encrypt",
+        use_pgp=False,
+    )
+    assert obj.pgp_mode == "encrypt"
+
+
+@mock.patch("smtplib.SMTP_SSL")
+@mock.patch("smtplib.SMTP")
+def test_plugin_email_wkd_param(mock_smtp, mock_smtpssl):
+    """NotifyEmail() wkd= URL parameter and url() round-trip."""
+
+    mock_socket = mock.Mock()
+    mock_socket.starttls.return_value = True
+    mock_socket.login.return_value = True
+    mock_smtp.return_value = mock_socket
+    mock_smtpssl.return_value = mock_socket
+
+    # wkd=yes -> use_wkd=True; a WKD controller is wired into pgp
+    obj = Apprise.instantiate("mailto://user:pass@nuxref.com?wkd=yes")
+    assert obj.use_wkd is True
+    assert obj.pgp.wkd is not None
+
+    # wkd=yes without pgp= implies pgp=encrypt
+    assert obj.pgp_mode == "encrypt"
+
+    # wkd=no -> use_wkd=False
+    obj = Apprise.instantiate("mailto://user:pass@nuxref.com?wkd=no")
+    assert obj.use_wkd is False
+    assert obj.pgp.wkd is None
+
+    # url() includes wkd=yes when enabled; pgp=encrypt is implied
+    obj = Apprise.instantiate("mailto://user:pass@nuxref.com?wkd=yes")
+    generated = obj.url()
+    assert "wkd=yes" in generated
+    assert "pgp=encrypt" in generated
+
+    # wkd=yes alongside explicit pgp=none keeps none (explicit wins)
+    obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=none&wkd=yes")
+    assert obj.pgp_mode == "none"
+
+    # url() omits wkd= when disabled (it is the default)
+    obj = Apprise.instantiate("mailto://user:pass@nuxref.com")
+    assert "wkd=" not in obj.url()
+
+
+@pytest.mark.skipif("pgpy" not in sys.modules, reason="Requires PGPy")
+@mock.patch("smtplib.SMTP_SSL")
+@mock.patch("smtplib.SMTP")
+def test_plugin_email_wkd_key_discovery(mock_smtp, mock_smtpssl, tmpdir):
+    """Email send uses the WKD-fetched key when no local key exists."""
+    import pgpy
+
+    mock_socket = mock.Mock()
+    mock_socket.starttls.return_value = True
+    mock_socket.login.return_value = True
+    mock_smtp.return_value = mock_socket
+    mock_smtpssl.return_value = mock_socket
+
+    # Generate a real key pair to serve as the WKD response
+    key = pgpy.PGPKey.new(
+        pgpy.constants.PubKeyAlgorithm.RSAEncryptOrSign, 2048
+    )
+    uid = pgpy.PGPUID.new("Chris", email="chris@nuxref.com")
+    key.add_uid(
+        uid,
+        usage={
+            pgpy.constants.KeyFlags.Sign,
+            pgpy.constants.KeyFlags.EncryptCommunications,
+        },
+        hashes=[pgpy.constants.HashAlgorithm.SHA256],
+        ciphers=[pgpy.constants.SymmetricKeyAlgorithm.AES256],
+        compression=[pgpy.constants.CompressionAlgorithm.ZLIB],
+    )
+    pub_bytes = str(key.pubkey).encode()
+
+    asset = AppriseAsset(
+        storage_mode=PersistentStoreMode.FLUSH,
+        storage_path=str(tmpdir),
+    )
+
+    obj = Apprise.instantiate(
+        "mailto://chris:pass@nuxref.com?pgp=encrypt&wkd=yes",
+        asset=asset,
+    )
+    assert obj.use_wkd is True
+
+    # Patch WKD fetch to return our generated public key
+    with mock.patch.object(obj.pgp.wkd, "fetch", return_value=pub_bytes):
+        assert obj.notify("test body") is True
+
+    # WKD returning None with autogen disabled falls through gracefully
+    asset.pgp_autogen = False
+    with mock.patch.object(obj.pgp.wkd, "fetch", return_value=None):
+        assert obj.notify("test body") is False
 
 
 @pytest.mark.skipif("pgpy" not in sys.modules, reason="Requires PGPy")

--- a/tests/test_utils_pgp.py
+++ b/tests/test_utils_pgp.py
@@ -1,0 +1,312 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Disable logging for a cleaner testing output
+import logging
+import sys
+from unittest import mock
+
+import pytest
+
+from apprise.utils import pgp as pgp_module
+from apprise.utils.pgp import ApprisePGPController, _ensure_imghdr_shim
+
+logging.disable(logging.CRITICAL)
+
+
+# ---------------------------------------------------------------------------
+# imghdr shim
+# ---------------------------------------------------------------------------
+
+
+def test_imghdr_shim_when_present():
+    """_ensure_imghdr_shim() leaves sys.modules intact when imghdr imports."""
+
+    # Guarantee imghdr is importable for this test
+    real_imghdr = sys.modules.get("imghdr")
+    try:
+        import imghdr as _real
+
+        # If we got here, imghdr is available on this Python version
+        _ensure_imghdr_shim()
+
+        # sys.modules entry must not have been replaced by our shim
+        assert sys.modules.get("imghdr") is _real
+
+    except ImportError:
+        # Python 3.13+ -- imghdr is gone; skip this branch
+        pytest.skip("imghdr not present on this Python version")
+
+    finally:
+        # Restore whatever was there before
+        if real_imghdr is None:
+            sys.modules.pop("imghdr", None)
+        else:
+            sys.modules["imghdr"] = real_imghdr
+
+
+def test_imghdr_shim_when_absent():
+    """_ensure_imghdr_shim() installs a working shim when imghdr is missing."""
+
+    # Remove any real imghdr from sys.modules and make import fail
+    saved = sys.modules.pop("imghdr", None)
+    try:
+        # Setting the key to None causes 'import imghdr' to raise ImportError
+        sys.modules["imghdr"] = None
+
+        _ensure_imghdr_shim()
+
+        shim = sys.modules.get("imghdr")
+        assert shim is not None
+        assert callable(shim.what)
+
+        # The shim must return None (safe fallback for all inputs)
+        assert shim.what() is None
+        assert shim.what(file=None, h=b"\xff\xd8\xff") is None
+        assert shim.what(None, h=b"some data") is None
+
+    finally:
+        # Restore original state
+        if saved is None:
+            sys.modules.pop("imghdr", None)
+        else:
+            sys.modules["imghdr"] = saved
+
+
+# ---------------------------------------------------------------------------
+# ApprisePGPController -- WKD integration
+# ---------------------------------------------------------------------------
+
+
+def test_pgp_controller_wkd_none_by_default(tmpdir):
+    """ApprisePGPController has wkd=None unless explicitly provided."""
+    ctrl = ApprisePGPController(path=str(tmpdir))
+    assert ctrl.wkd is None
+
+
+def test_pgp_controller_accepts_wkd(tmpdir):
+    """ApprisePGPController stores the WKD controller it is given."""
+    mock_wkd = mock.Mock()
+    ctrl = ApprisePGPController(path=str(tmpdir), wkd=mock_wkd)
+    assert ctrl.wkd is mock_wkd
+
+
+def test_fetch_wkd_key_no_controller(tmpdir):
+    """_fetch_wkd_key() returns None when no WKD controller is set."""
+    ctrl = ApprisePGPController(path=str(tmpdir))
+    result = ctrl._fetch_wkd_key("user@example.com")
+    assert result is None
+
+
+def test_fetch_wkd_key_empty_emails(tmpdir):
+    """_fetch_wkd_key() returns None when no email candidates exist."""
+    mock_wkd = mock.Mock()
+    ctrl = ApprisePGPController(path=str(tmpdir), wkd=mock_wkd)
+    # No self.email set and no positional emails
+    result = ctrl._fetch_wkd_key()
+    assert result is None
+    mock_wkd.fetch.assert_not_called()
+
+
+def test_fetch_wkd_key_skips_none_in_candidate_list(tmpdir):
+    """_fetch_wkd_key() skips None/empty entries in the email candidates."""
+    mock_wkd = mock.Mock()
+    mock_wkd.fetch.return_value = None
+    ctrl = ApprisePGPController(path=str(tmpdir), wkd=mock_wkd)
+    # None is a valid positional argument; it must be skipped, not crash
+    result = ctrl._fetch_wkd_key(None, "user@example.com")
+    assert result is None
+    # fetch must only be called for the valid address, not for None
+    mock_wkd.fetch.assert_called_once_with("user@example.com")
+
+
+def test_fetch_wkd_key_wkd_returns_none(tmpdir):
+    """_fetch_wkd_key() returns None when WKD fetch yields nothing."""
+    mock_wkd = mock.Mock()
+    mock_wkd.fetch.return_value = None
+    ctrl = ApprisePGPController(path=str(tmpdir), wkd=mock_wkd)
+    result = ctrl._fetch_wkd_key("user@example.com")
+    assert result is None
+
+
+@pytest.mark.skipif("pgpy" not in sys.modules, reason="Requires PGPy")
+def test_fetch_wkd_key_success(tmpdir):
+    """_fetch_wkd_key() parses and caches a key returned by WKD."""
+    import pgpy
+
+    # Generate a fresh key pair to use as our fake WKD payload
+    key = pgpy.PGPKey.new(
+        pgpy.constants.PubKeyAlgorithm.RSAEncryptOrSign, 2048
+    )
+    uid = pgpy.PGPUID.new("Test", email="user@example.com")
+    key.add_uid(
+        uid,
+        usage={
+            pgpy.constants.KeyFlags.Sign,
+            pgpy.constants.KeyFlags.EncryptCommunications,
+        },
+        hashes=[pgpy.constants.HashAlgorithm.SHA256],
+        ciphers=[pgpy.constants.SymmetricKeyAlgorithm.AES256],
+        compression=[pgpy.constants.CompressionAlgorithm.ZLIB],
+    )
+    pub_bytes = str(key.pubkey).encode()
+
+    mock_wkd = mock.Mock()
+    mock_wkd.fetch.return_value = pub_bytes
+    ctrl = ApprisePGPController(path=str(tmpdir), wkd=mock_wkd)
+
+    result = ctrl._fetch_wkd_key("user@example.com")
+    assert result is not None
+    assert isinstance(result, pgpy.PGPKey)
+    mock_wkd.fetch.assert_called_once_with("user@example.com")
+
+    # Second call returns the cached key without hitting WKD again
+    mock_wkd.fetch.reset_mock()
+    result2 = ctrl._fetch_wkd_key("user@example.com")
+    # Cache stores it in __key_lookup; second fetch still calls wkd.fetch
+    # because the cache is keyed by path and WKD keys have no path --
+    # verify WKD is called again (no local file path cache hit)
+    assert result2 is not None
+
+
+@pytest.mark.skipif(
+    pgp_module.PGP_SUPPORT, reason="Tests behavior when pgpy is absent"
+)
+def test_fetch_wkd_key_pgpy_not_installed(tmpdir):
+    """_fetch_wkd_key() skips silently when pgpy raises NameError."""
+    mock_wkd = mock.Mock()
+    mock_wkd.fetch.return_value = b"fake-key-bytes"
+    ctrl = ApprisePGPController(path=str(tmpdir), wkd=mock_wkd)
+    # In a minimal env pgpy is not installed, so pgpy.PGPKey.from_blob
+    # raises NameError naturally -- no mock needed.
+    result = ctrl._fetch_wkd_key("user@example.com")
+    assert result is None
+
+
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+def test_fetch_wkd_key_corrupt_data(tmpdir):
+    """_fetch_wkd_key() skips and tries next candidate on parse failure."""
+    mock_wkd = mock.Mock()
+    mock_wkd.fetch.return_value = b"this-is-not-a-pgp-key"
+    ctrl = ApprisePGPController(path=str(tmpdir), wkd=mock_wkd)
+
+    # Patch the canonical pgpy module directly (not the pgp module's copy)
+    # so the mock works whether pgpy was imported by name or attribute.
+    with mock.patch(
+        "pgpy.PGPKey.from_blob",
+        side_effect=Exception("bad key"),
+    ):
+        result = ctrl._fetch_wkd_key("user@example.com")
+
+    assert result is None
+
+
+def test_fetch_wkd_key_uses_self_email_as_candidate(tmpdir):
+    """_fetch_wkd_key() includes self.email in the candidate list."""
+    mock_wkd = mock.Mock()
+    mock_wkd.fetch.return_value = None
+    ctrl = ApprisePGPController(
+        path=str(tmpdir), email="sender@example.com", wkd=mock_wkd
+    )
+
+    ctrl._fetch_wkd_key()
+
+    # self.email must have been tried
+    mock_wkd.fetch.assert_called_with("sender@example.com")
+
+
+@pytest.mark.skipif("pgpy" not in sys.modules, reason="Requires PGPy")
+def test_public_key_falls_through_to_wkd(tmpdir):
+    """public_key() uses WKD when no local key file exists."""
+    import pgpy
+
+    # Generate a minimal key for the mock WKD response
+    key = pgpy.PGPKey.new(
+        pgpy.constants.PubKeyAlgorithm.RSAEncryptOrSign, 2048
+    )
+    uid = pgpy.PGPUID.new("WKD User", email="wkd@example.com")
+    key.add_uid(
+        uid,
+        usage={
+            pgpy.constants.KeyFlags.Sign,
+            pgpy.constants.KeyFlags.EncryptCommunications,
+        },
+        hashes=[pgpy.constants.HashAlgorithm.SHA256],
+        ciphers=[pgpy.constants.SymmetricKeyAlgorithm.AES256],
+        compression=[pgpy.constants.CompressionAlgorithm.ZLIB],
+    )
+    pub_bytes = str(key.pubkey).encode()
+
+    mock_wkd = mock.Mock()
+    mock_wkd.fetch.return_value = pub_bytes
+    ctrl = ApprisePGPController(path=str(tmpdir), wkd=mock_wkd)
+
+    # No local key file exists, so WKD must be tried
+    result = ctrl.public_key("wkd@example.com", autogen=False)
+    assert result is not None
+    mock_wkd.fetch.assert_called()
+
+
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+def test_public_key_wkd_fails_falls_through_to_autogen(tmpdir):
+    """public_key() falls through to autogen when WKD also returns None."""
+    mock_wkd = mock.Mock()
+    mock_wkd.fetch.return_value = None
+    ctrl = ApprisePGPController(path=str(tmpdir), wkd=mock_wkd)
+    # No local key file exists; WKD fails; autogen=False => None returned
+    result = ctrl.public_key("nobody@example.com", autogen=False)
+    assert result is None
+    mock_wkd.fetch.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# prune() -- WKD delegation
+# ---------------------------------------------------------------------------
+
+
+def test_prune_delegates_to_wkd(tmpdir):
+    """prune() calls prune() on the WKD controller when one is set."""
+    mock_wkd = mock.Mock()
+    ctrl = ApprisePGPController(path=str(tmpdir), wkd=mock_wkd)
+    ctrl.prune()
+    mock_wkd.prune.assert_called_once()
+
+
+def test_prune_without_wkd(tmpdir):
+    """prune() runs without error when no WKD controller is set."""
+    ctrl = ApprisePGPController(path=str(tmpdir))
+    ctrl.prune()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# PGP_SUPPORT flag consistency
+# ---------------------------------------------------------------------------
+
+
+def test_pgp_support_flag_present():
+    """PGP_SUPPORT is a boolean exported from the pgp module."""
+    assert isinstance(pgp_module.PGP_SUPPORT, bool)

--- a/tests/test_utils_pgp.py
+++ b/tests/test_utils_pgp.py
@@ -184,13 +184,102 @@ def test_fetch_wkd_key_success(tmpdir):
     assert isinstance(result, pgpy.PGPKey)
     mock_wkd.fetch.assert_called_once_with("user@example.com")
 
-    # Second call returns the cached key without hitting WKD again
+    # Second call must use the parsed-key cache -- wkd.fetch must NOT be
+    # called again (the cache check now happens before wkd.fetch())
     mock_wkd.fetch.reset_mock()
     result2 = ctrl._fetch_wkd_key("user@example.com")
-    # Cache stores it in __key_lookup; second fetch still calls wkd.fetch
-    # because the cache is keyed by path and WKD keys have no path --
-    # verify WKD is called again (no local file path cache hit)
     assert result2 is not None
+    mock_wkd.fetch.assert_not_called()
+
+
+@pytest.mark.skipif("pgpy" not in sys.modules, reason="Requires PGPy")
+def test_fetch_wkd_key_expired_cache_refetches(tmpdir):
+    """_fetch_wkd_key() drops an expired parsed-key cache entry and
+    re-fetches from WKD rather than returning the stale key."""
+    from datetime import datetime, timedelta, timezone
+    import hashlib
+
+    import pgpy
+
+    # Generate a key to serve as the fresh WKD result
+    key = pgpy.PGPKey.new(
+        pgpy.constants.PubKeyAlgorithm.RSAEncryptOrSign, 2048
+    )
+    uid = pgpy.PGPUID.new("Fresh", email="user@example.com")
+    key.add_uid(
+        uid,
+        usage={
+            pgpy.constants.KeyFlags.Sign,
+            pgpy.constants.KeyFlags.EncryptCommunications,
+        },
+        hashes=[pgpy.constants.HashAlgorithm.SHA256],
+        ciphers=[pgpy.constants.SymmetricKeyAlgorithm.AES256],
+        compression=[pgpy.constants.CompressionAlgorithm.ZLIB],
+    )
+    pub_bytes = str(key.pubkey).encode()
+
+    mock_wkd = mock.Mock()
+    mock_wkd.fetch.return_value = pub_bytes
+    ctrl = ApprisePGPController(path=str(tmpdir), wkd=mock_wkd)
+
+    # Seed the parsed-key cache with an already-expired entry
+    cache_key = hashlib.sha1(b"wkd:user@example.com").hexdigest()
+    # Use the private name-mangled attribute
+    ctrl._ApprisePGPController__key_lookup[cache_key] = {
+        "public_key": None,
+        "expires": datetime.now(timezone.utc) - timedelta(seconds=1),
+    }
+
+    # The expired entry is discarded; WKD is fetched and result returned
+    result = ctrl._fetch_wkd_key("user@example.com")
+    assert result is not None
+    mock_wkd.fetch.assert_called_once_with("user@example.com")
+
+
+@pytest.mark.skipif("pgpy" not in sys.modules, reason="Requires PGPy")
+def test_fetch_wkd_key_prefers_recipient_over_sender(tmpdir):
+    """_fetch_wkd_key() tries recipient emails before self.email so that
+    the recipient's public key (not the sender's) is used for encryption."""
+    import pgpy
+
+    # Generate a key to represent the recipient's WKD result
+    key = pgpy.PGPKey.new(
+        pgpy.constants.PubKeyAlgorithm.RSAEncryptOrSign, 2048
+    )
+    uid = pgpy.PGPUID.new("Recipient", email="recipient@example.com")
+    key.add_uid(
+        uid,
+        usage={
+            pgpy.constants.KeyFlags.Sign,
+            pgpy.constants.KeyFlags.EncryptCommunications,
+        },
+        hashes=[pgpy.constants.HashAlgorithm.SHA256],
+        ciphers=[pgpy.constants.SymmetricKeyAlgorithm.AES256],
+        compression=[pgpy.constants.CompressionAlgorithm.ZLIB],
+    )
+    pub_bytes = str(key.pubkey).encode()
+
+    # WKD returns a key only for the recipient address
+    def fake_fetch(email):
+        if email == "recipient@example.com":
+            return pub_bytes
+        return None
+
+    mock_wkd = mock.Mock(side_effect=fake_fetch)
+    mock_wkd.fetch.side_effect = fake_fetch
+    ctrl = ApprisePGPController(
+        path=str(tmpdir),
+        email="sender@example.com",
+        wkd=mock_wkd,
+    )
+
+    # The recipient's email is passed as a positional argument
+    result = ctrl._fetch_wkd_key("recipient@example.com")
+    assert result is not None
+    # sender@example.com must NOT have been tried before the recipient hit
+    calls = [call.args[0] for call in mock_wkd.fetch.call_args_list]
+    assert calls[0] == "recipient@example.com"
+    assert "sender@example.com" not in calls
 
 
 @pytest.mark.skipif(

--- a/tests/test_utils_pgp.py
+++ b/tests/test_utils_pgp.py
@@ -283,6 +283,21 @@ def test_public_key_wkd_fails_falls_through_to_autogen(tmpdir):
     mock_wkd.fetch.assert_called()
 
 
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+def test_public_key_malformed_local_file_returns_none(tmpdir):
+    """public_key() returns None gracefully when the local .asc file is
+    not valid PGP data (pgpy raises during parse)."""
+    # Write a file with non-PGP content under a name that public_keyfile()
+    # will discover automatically
+    bad_key_path = tmpdir.join("pub.asc")
+    bad_key_path.write("this is not a pgp key\n")
+
+    ctrl = ApprisePGPController(path=str(tmpdir))
+    # No autogen so the only candidate is the malformed file above
+    result = ctrl.public_key(autogen=False)
+    assert result is None
+
+
 # ---------------------------------------------------------------------------
 # prune() -- WKD delegation
 # ---------------------------------------------------------------------------

--- a/tests/test_utils_wkd.py
+++ b/tests/test_utils_wkd.py
@@ -90,18 +90,28 @@ def test_zb32_encode_single_byte():
 
 
 def test_zb32_encode_known_vector():
-    """Verify encoding of the 20-byte SHA-1 of 'test' local part.
+    """Verify z-base32 encoding against independently computed single-byte
+    reference values.
 
-    The expected value is produced by the same algorithm implemented here;
-    this guards against accidental alphabet or bit-shift regressions.
+    These expected strings are derived from first principles: each 5-bit
+    group maps directly to _ZB32[value], and leftover bits are
+    left-aligned.  They do NOT call zb32_encode() to generate the
+    expected string, so a regression in the alphabet or bit-shifting
+    logic will cause at least one assertion to fail.
+
+    0xf8 = 11111000:
+      group1 (bits 0-4): 11111 = 31 -> '9'
+      leftover (bits 5-7) << 2: 00000 = 0 -> 'y'
+    0xa8 = 10101000:
+      group1 (bits 0-4): 10101 = 21 -> 'i'
+      leftover (bits 5-7) << 2: 00000 = 0 -> 'y'
+    0x08 = 00001000:
+      group1 (bits 0-4): 00001 = 1 -> 'b'
+      leftover (bits 5-7) << 2: 00000 = 0 -> 'y'
     """
-    import hashlib
-
-    digest = hashlib.sha1(b"test").digest()
-    expected = AppriseWKDController.zb32_encode(digest)
-
-    # Re-encode to confirm idempotency
-    assert AppriseWKDController.zb32_encode(digest) == expected
+    assert AppriseWKDController.zb32_encode(b"\xf8") == "9y"
+    assert AppriseWKDController.zb32_encode(b"\xa8") == "iy"
+    assert AppriseWKDController.zb32_encode(b"\x08") == "by"
 
 
 # ---------------------------------------------------------------------------
@@ -188,9 +198,53 @@ def test_wkd_urls_lower_raises_attribute_error():
     assert direct is None
 
 
+def test_wkd_urls_domain_injection_rejected():
+    """wkd_urls() returns (None, None) for emails whose domain contains
+    characters that would rewrite the URL host.
+
+    user@legit.com@attacker.test splits to domain='legit.com@attacker.test'
+    which, when embedded in an HTTPS URL, sends the request to attacker.test
+    with legit.com as URL credentials.  The is_hostname() guard rejects it.
+    """
+    for bad_email in (
+        "user@example.com@attacker.test",
+        "user@example.com/path",
+        "user@example.com:8080",
+        "user@example.com space",
+    ):
+        sub, direct = AppriseWKDController.wkd_urls(bad_email)
+        assert sub is None, f"Expected None for domain injection: {bad_email}"
+        assert direct is None, (
+            f"Expected None for domain injection: {bad_email}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # AppriseWKDController.fetch -- happy path
 # ---------------------------------------------------------------------------
+
+
+def _make_resp(status_code, chunks=None, url=None):
+    """Build a context-manager-compatible requests.Response mock.
+
+    ``chunks`` is a list of byte strings that iter_content() will yield.
+    Pass an empty list for an empty body.  Leave as None when the status
+    code is non-200 and the body will never be consumed.
+    ``url`` sets r.url (the final URL after any redirects).  When omitted
+    the attribute is a MagicMock, which passes the HTTPS check because
+    MagicMock().lower().startswith() is truthy.
+    """
+    resp = mock.MagicMock(status_code=status_code)
+    resp.__enter__ = mock.Mock(return_value=resp)
+    resp.__exit__ = mock.Mock(return_value=False)
+    # Default to an empty headers dict so r.headers.get("Content-Length")
+    # returns None; tests that need a specific header override this
+    resp.headers = {}
+    if url is not None:
+        resp.url = url
+    if chunks is not None:
+        resp.iter_content.return_value = iter(chunks)
+    return resp
 
 
 @mock.patch("requests.get")
@@ -199,11 +253,8 @@ def test_fetch_subdomain_success(mock_get):
     # 0x99 is a valid old-format OpenPGP packet header byte (bit 7 set)
     key_bytes = b"\x99fake-openpgp-key-data"
 
-    # Subdomain call succeeds
-    mock_get.return_value = mock.Mock(
-        status_code=requests.codes.ok,
-        content=key_bytes,
-    )
+    # Subdomain call succeeds; iter_content yields the key in one chunk
+    mock_get.return_value = _make_resp(requests.codes.ok, chunks=[key_bytes])
 
     ctrl = AppriseWKDController()
     result = ctrl.fetch("user@example.com")
@@ -217,10 +268,10 @@ def test_fetch_direct_fallback(mock_get):
     """fetch() tries the direct URL when the subdomain URL fails."""
     key_bytes = b"\x99another-fake-key"
 
-    # Subdomain -> 404, direct -> 200
+    # Subdomain -> 404 (body never consumed), direct -> 200 with key bytes
     mock_get.side_effect = [
-        mock.Mock(status_code=404, content=b""),
-        mock.Mock(status_code=requests.codes.ok, content=key_bytes),
+        _make_resp(404),
+        _make_resp(requests.codes.ok, chunks=[key_bytes]),
     ]
 
     ctrl = AppriseWKDController()
@@ -233,7 +284,7 @@ def test_fetch_direct_fallback(mock_get):
 @mock.patch("requests.get")
 def test_fetch_both_fail(mock_get):
     """fetch() returns None when both WKD URLs fail."""
-    mock_get.return_value = mock.Mock(status_code=404, content=b"")
+    mock_get.return_value = _make_resp(404)
 
     ctrl = AppriseWKDController()
     result = ctrl.fetch("user@example.com")
@@ -251,10 +302,7 @@ def test_fetch_both_fail(mock_get):
 def test_fetch_caches_result(mock_get):
     """A successful fetch is cached; subsequent calls skip the network."""
     key_bytes = b"\x99cached-key"
-    mock_get.return_value = mock.Mock(
-        status_code=requests.codes.ok,
-        content=key_bytes,
-    )
+    mock_get.return_value = _make_resp(requests.codes.ok, chunks=[key_bytes])
 
     ctrl = AppriseWKDController()
     result1 = ctrl.fetch("user@example.com")
@@ -270,10 +318,7 @@ def test_fetch_caches_result(mock_get):
 def test_fetch_cache_case_insensitive(mock_get):
     """Cache lookup normalises the email address."""
     key_bytes = b"\x99normalised-key"
-    mock_get.return_value = mock.Mock(
-        status_code=requests.codes.ok,
-        content=key_bytes,
-    )
+    mock_get.return_value = _make_resp(requests.codes.ok, chunks=[key_bytes])
 
     ctrl = AppriseWKDController()
     ctrl.fetch("User@Example.COM")
@@ -287,10 +332,7 @@ def test_fetch_cache_case_insensitive(mock_get):
 def test_fetch_expired_cache_refetches(mock_get):
     """An expired cache entry triggers a new network request."""
     key_bytes = b"\x99refreshed-key"
-    mock_get.return_value = mock.Mock(
-        status_code=requests.codes.ok,
-        content=key_bytes,
-    )
+    mock_get.return_value = _make_resp(requests.codes.ok, chunks=[key_bytes])
 
     ctrl = AppriseWKDController()
 
@@ -349,7 +391,7 @@ def test_fetch_at_only():
 def test_get_non_200_returns_none(mock_get):
     """_get() returns None for any non-200 HTTP status."""
     for code in (301, 400, 403, 404, 500):
-        mock_get.return_value = mock.Mock(status_code=code, content=b"body")
+        mock_get.return_value = _make_resp(code)
         ctrl = AppriseWKDController()
         assert ctrl._get("https://example.com/key") is None
 
@@ -357,21 +399,78 @@ def test_get_non_200_returns_none(mock_get):
 @mock.patch("requests.get")
 def test_get_empty_body_returns_none(mock_get):
     """_get() returns None when the response body is empty."""
-    mock_get.return_value = mock.Mock(
-        status_code=requests.codes.ok, content=b""
-    )
+    mock_get.return_value = _make_resp(requests.codes.ok, chunks=[])
     ctrl = AppriseWKDController()
     assert ctrl._get("https://example.com/key") is None
 
 
 @mock.patch("requests.get")
-def test_get_oversized_body_returns_none(mock_get):
-    """_get() returns None when the response exceeds max_response_size."""
-    ctrl = AppriseWKDController()
-    oversized = b"x" * (ctrl.max_response_size + 1)
-    mock_get.return_value = mock.Mock(
-        status_code=requests.codes.ok, content=oversized
+def test_get_empty_chunk_is_skipped(mock_get):
+    """_get() skips empty bytestrings yielded by iter_content().
+
+    Some HTTP adapters yield b"" sentinel chunks between real chunks;
+    the in-loop ``if not chunk: continue`` guard must skip them so they
+    do not corrupt the accumulated content or trigger a false empty-body
+    result.
+    """
+    # Interleave an empty sentinel before a valid PGP binary chunk
+    key_bytes = b"\x99" + b"\x00" * 8
+    mock_get.return_value = _make_resp(
+        requests.codes.ok, chunks=[b"", key_bytes]
     )
+    ctrl = AppriseWKDController()
+    result = ctrl._get("https://example.com/key")
+    assert result == key_bytes
+
+
+@mock.patch("requests.get")
+def test_get_oversized_via_content_length_returns_none(mock_get):
+    """_get() rejects early when Content-Length already exceeds the limit.
+
+    iter_content() must not be called at all -- we detect the oversize
+    from the header before reading any bytes.
+    """
+    ctrl = AppriseWKDController()
+    resp = _make_resp(requests.codes.ok)
+    resp.headers = {"Content-Length": str(ctrl.max_response_size + 1)}
+    mock_get.return_value = resp
+    assert ctrl._get("https://example.com/key") is None
+    resp.iter_content.assert_not_called()
+
+
+@mock.patch("requests.get")
+def test_get_valid_content_length_within_limit_proceeds(mock_get):
+    """_get() proceeds to read chunks when Content-Length is within the limit.
+
+    This exercises the branch where content_length is not None and the
+    parsed value does not exceed max_response_size.
+    """
+    key_bytes = b"\x99valid-key"
+    resp = _make_resp(requests.codes.ok, chunks=[key_bytes])
+    resp.headers = {"Content-Length": str(len(key_bytes))}
+    mock_get.return_value = resp
+    ctrl = AppriseWKDController()
+    assert ctrl._get("https://example.com/key") == key_bytes
+
+
+@mock.patch("requests.get")
+def test_get_malformed_content_length_proceeds(mock_get):
+    """_get() ignores a malformed Content-Length and reads chunks normally."""
+    key_bytes = b"\x99valid-key"
+    resp = _make_resp(requests.codes.ok, chunks=[key_bytes])
+    resp.headers = {"Content-Length": "not-a-number"}
+    mock_get.return_value = resp
+    ctrl = AppriseWKDController()
+    assert ctrl._get("https://example.com/key") == key_bytes
+
+
+@mock.patch("requests.get")
+def test_get_oversized_body_returns_none(mock_get):
+    """_get() returns None when accumulated chunks exceed max_response_size."""
+    ctrl = AppriseWKDController()
+    # Single chunk one byte over the limit triggers the in-loop guard
+    oversized = b"\x99" + b"x" * ctrl.max_response_size
+    mock_get.return_value = _make_resp(requests.codes.ok, chunks=[oversized])
     assert ctrl._get("https://example.com/key") is None
 
 
@@ -389,9 +488,7 @@ def test_get_non_pgp_body_returns_none(mock_get):
         b"{}",
         b"Not PGP data",
     ):
-        mock_get.return_value = mock.Mock(
-            status_code=requests.codes.ok, content=non_pgp
-        )
+        mock_get.return_value = _make_resp(requests.codes.ok, chunks=[non_pgp])
         ctrl = AppriseWKDController()
         assert ctrl._get("https://example.com/key") is None, (
             f"Expected None for non-PGP content: {non_pgp[:20]}"
@@ -404,9 +501,7 @@ def test_get_binary_pgp_packet_accepted(mock_get):
     binary packet format)."""
     # 0x99 is the old-format public-key packet header
     pgp_binary = b"\x99\x01\xd6" + b"\x00" * 100
-    mock_get.return_value = mock.Mock(
-        status_code=requests.codes.ok, content=pgp_binary
-    )
+    mock_get.return_value = _make_resp(requests.codes.ok, chunks=[pgp_binary])
     ctrl = AppriseWKDController()
     assert ctrl._get("https://example.com/key") == pgp_binary
 
@@ -415,9 +510,7 @@ def test_get_binary_pgp_packet_accepted(mock_get):
 def test_get_ascii_armoured_key_accepted(mock_get):
     """_get() accepts ASCII-armoured PGP key material (starts with '-----')."""
     armoured = b"-----BEGIN PGP PUBLIC KEY BLOCK-----\n..."
-    mock_get.return_value = mock.Mock(
-        status_code=requests.codes.ok, content=armoured
-    )
+    mock_get.return_value = _make_resp(requests.codes.ok, chunks=[armoured])
     ctrl = AppriseWKDController()
     assert ctrl._get("https://example.com/key") == armoured
 
@@ -430,12 +523,55 @@ def test_get_request_exception_returns_none(mock_get):
 
 
 @mock.patch("requests.get")
+def test_get_stream_oserror_returns_none(mock_get):
+    """_get() returns None when iter_content() raises OSError mid-stream.
+
+    Covers disk-full, connection-reset, and other IO-level failures that
+    surface after the HTTP headers have been received successfully.
+    """
+    resp = _make_resp(requests.codes.ok)
+    resp.iter_content.side_effect = OSError("connection reset by peer")
+    mock_get.return_value = resp
+    ctrl = AppriseWKDController()
+    assert ctrl._get("https://example.com/key") is None
+
+
+@mock.patch("requests.get")
+def test_get_stream_generic_exception_returns_none(mock_get):
+    """_get() returns None when iter_content() raises an unexpected exception.
+
+    Covers urllib3 IncompleteRead, read-timeout mid-stream, and any other
+    exception not otherwise categorised.
+    """
+    resp = _make_resp(requests.codes.ok)
+    resp.iter_content.side_effect = Exception("unexpected streaming error")
+    mock_get.return_value = resp
+    ctrl = AppriseWKDController()
+    assert ctrl._get("https://example.com/key") is None
+
+
+@mock.patch("requests.get")
+def test_get_http_redirect_rejected(mock_get):
+    """_get() returns None when a redirect lands on a non-HTTPS URL.
+
+    A redirect from HTTPS to HTTP would expose key material to interception
+    and break the WKD trust model.
+    """
+    resp = _make_resp(
+        requests.codes.ok,
+        chunks=[b"\x99key"],
+        url="http://attacker.example.com/hu/abc",
+    )
+    mock_get.return_value = resp
+    ctrl = AppriseWKDController()
+    assert ctrl._get("https://example.com/key") is None
+
+
+@mock.patch("requests.get")
 def test_get_success_returns_bytes(mock_get):
     """_get() returns the response bytes on HTTP 200 with content."""
     payload = b"\x99\xaa\xbb\xcc"
-    mock_get.return_value = mock.Mock(
-        status_code=requests.codes.ok, content=payload
-    )
+    mock_get.return_value = _make_resp(requests.codes.ok, chunks=[payload])
     ctrl = AppriseWKDController()
     assert ctrl._get("https://example.com/key") == payload
 
@@ -503,11 +639,9 @@ def test_custom_allow_redirects():
 
 @mock.patch("requests.get")
 def test_get_passes_verify_and_timeout(mock_get):
-    """_get() forwards verify_certificate, request_timeout, and
-    allow_redirects to requests."""
-    mock_get.return_value = mock.Mock(
-        status_code=requests.codes.ok, content=b"\x99key"
-    )
+    """_get() forwards verify_certificate, request_timeout, allow_redirects,
+    and stream=True to requests."""
+    mock_get.return_value = _make_resp(requests.codes.ok, chunks=[b"\x99key"])
     ctrl = AppriseWKDController(
         verify_certificate=False, request_timeout=(1, 5), allow_redirects=False
     )
@@ -517,3 +651,4 @@ def test_get_passes_verify_and_timeout(mock_get):
     assert kwargs["verify"] is False
     assert kwargs["timeout"] == (1, 5)
     assert kwargs["allow_redirects"] is False
+    assert kwargs["stream"] is True

--- a/tests/test_utils_wkd.py
+++ b/tests/test_utils_wkd.py
@@ -155,7 +155,7 @@ def test_wkd_urls_case_normalised():
     assert "?l=user" in sub_lower
 
     # Domain is always lower-cased regardless of input
-    assert "example.com" in sub_lower
+    assert urlparse(sub_lower).hostname == "openpgpkey.example.com"
 
 
 def test_wkd_urls_l_param_preserves_original_case():

--- a/tests/test_utils_wkd.py
+++ b/tests/test_utils_wkd.py
@@ -29,6 +29,7 @@
 from datetime import datetime, timedelta, timezone
 import logging
 from unittest import mock
+from urllib.parse import urlparse
 
 import requests
 
@@ -168,9 +169,9 @@ def test_wkd_urls_l_param_preserves_original_case():
     sub, direct = AppriseWKDController.wkd_urls("Joe.Doe@Example.ORG")
     assert "?l=Joe.Doe" in sub
     assert "?l=Joe.Doe" in direct
-    # Domain part is always lowercased in the URL path
-    assert "example.org" in sub
-    assert "example.org" in direct
+    # Domain part is always lowercased in the URL host
+    assert urlparse(sub).hostname == "openpgpkey.example.org"
+    assert urlparse(direct).hostname == "example.org"
 
 
 def test_wkd_urls_local_part_encoded():

--- a/tests/test_utils_wkd.py
+++ b/tests/test_utils_wkd.py
@@ -143,8 +143,8 @@ def test_wkd_urls_case_normalised():
 def test_wkd_urls_local_part_encoded():
     """wkd_urls() percent-encodes special characters in the local part."""
     sub, direct = AppriseWKDController.wkd_urls("first+last@example.com")
-    assert "first%2Blast" in sub or "first+last" in sub
-    assert "first%2Blast" in direct or "first+last" in direct
+    assert "first%2Blast" in sub
+    assert "first%2Blast" in direct
 
 
 def test_wkd_urls_no_at_sign():
@@ -180,6 +180,35 @@ def test_wkd_urls_none_input():
     sub, direct = AppriseWKDController.wkd_urls(None)
     assert sub is None
     assert direct is None
+
+
+def test_wkd_urls_non_string_input():
+    """wkd_urls() returns (None, None) for non-string truthy inputs.
+
+    Without the isinstance guard, ``"@" not in 123`` raises TypeError
+    before the try/except block can handle it.
+    """
+    for bad in (123, 12.5, object(), ["user@example.com"]):
+        sub, direct = AppriseWKDController.wkd_urls(bad)
+        assert sub is None
+        assert direct is None
+
+
+def test_wkd_urls_ipv4_domain_rejected():
+    """wkd_urls() returns (None, None) for emails with an IPv4 domain.
+
+    WKD is defined for DNS hostnames only (RFC 9080).  Allowing IP
+    literals as the domain creates an SSRF vector because WKD discovery
+    turns recipient domains into outbound HTTPS requests.
+    """
+    for addr in (
+        "user@127.0.0.1",
+        "user@192.168.1.1",
+        "user@10.0.0.1",
+    ):
+        sub, direct = AppriseWKDController.wkd_urls(addr)
+        assert sub is None, f"Expected None for IP domain: {addr}"
+        assert direct is None, f"Expected None for IP domain: {addr}"
 
 
 def test_wkd_urls_lower_raises_attribute_error():
@@ -369,6 +398,17 @@ def test_fetch_none():
     """fetch() returns None when called with None."""
     ctrl = AppriseWKDController()
     assert ctrl.fetch(None) is None
+
+
+def test_fetch_non_string_input():
+    """fetch() returns None for non-string truthy inputs.
+
+    Without the isinstance guard, ``"@" not in 123`` raises TypeError
+    before the method can return None for invalid input.
+    """
+    ctrl = AppriseWKDController()
+    for bad in (123, 12.5, object(), ["user@example.com"]):
+        assert ctrl.fetch(bad) is None
 
 
 def test_fetch_at_only():

--- a/tests/test_utils_wkd.py
+++ b/tests/test_utils_wkd.py
@@ -1,0 +1,471 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Disable logging for a cleaner testing output
+from datetime import datetime, timedelta, timezone
+import logging
+from unittest import mock
+
+import requests
+
+from apprise.utils.wkd import AppriseWKDController, AppriseWKDException
+
+logging.disable(logging.CRITICAL)
+
+
+# ---------------------------------------------------------------------------
+# AppriseWKDException
+# ---------------------------------------------------------------------------
+
+
+def test_wkd_exception_default_error_code():
+    """AppriseWKDException uses error_code 610 by default."""
+    exc = AppriseWKDException("something went wrong")
+    assert exc.error_code == 610
+
+
+# ---------------------------------------------------------------------------
+# zb32_encode
+# ---------------------------------------------------------------------------
+
+
+def test_zb32_encode_all_zeros():
+    """20 zero bytes encode to 32 'y' characters (index 0 of the alphabet)."""
+    result = AppriseWKDController.zb32_encode(b"\x00" * 20)
+    assert result == "y" * 32
+
+
+def test_zb32_encode_all_ones():
+    """20 0xFF bytes encode to 32 '9' characters (index 31 of the alphabet)."""
+    result = AppriseWKDController.zb32_encode(b"\xff" * 20)
+    assert result == "9" * 32
+
+
+def test_zb32_encode_sha1_length():
+    """SHA-1 digest (20 bytes) always produces exactly 32 z-base32 chars."""
+    import hashlib
+
+    digest = hashlib.sha1(b"test@example.com").digest()
+    result = AppriseWKDController.zb32_encode(digest)
+    assert len(result) == 32
+    # All characters must belong to the z-base32 alphabet
+    assert all(c in AppriseWKDController._ZB32 for c in result)
+
+
+def test_zb32_encode_empty():
+    """Empty input produces an empty string."""
+    assert AppriseWKDController.zb32_encode(b"") == ""
+
+
+def test_zb32_encode_single_byte():
+    """Single byte (5 bits + 3 leftover bits) produces 2 characters."""
+    # 0x00 = 00000 000  -> 'y' then 0x00 << 2 = 00000 -> 'y'
+    result = AppriseWKDController.zb32_encode(b"\x00")
+    assert len(result) == 2
+    assert result[0] == "y"
+
+
+def test_zb32_encode_known_vector():
+    """Verify encoding of the 20-byte SHA-1 of 'test' local part.
+
+    The expected value is produced by the same algorithm implemented here;
+    this guards against accidental alphabet or bit-shift regressions.
+    """
+    import hashlib
+
+    digest = hashlib.sha1(b"test").digest()
+    expected = AppriseWKDController.zb32_encode(digest)
+
+    # Re-encode to confirm idempotency
+    assert AppriseWKDController.zb32_encode(digest) == expected
+
+
+# ---------------------------------------------------------------------------
+# wkd_urls
+# ---------------------------------------------------------------------------
+
+
+def test_wkd_urls_structure():
+    """wkd_urls() returns properly formed subdomain and direct URLs."""
+    sub, direct = AppriseWKDController.wkd_urls("user@example.com")
+
+    assert sub.startswith("https://openpgpkey.example.com/")
+    assert "/.well-known/openpgpkey/example.com/hu/" in sub
+    assert "?l=user" in sub
+
+    assert direct.startswith("https://example.com/")
+    assert "/.well-known/openpgpkey/hu/" in direct
+    assert "?l=user" in direct
+
+
+def test_wkd_urls_case_normalised():
+    """wkd_urls() lower-cases the email before building URLs."""
+    sub1, dir1 = AppriseWKDController.wkd_urls("User@Example.COM")
+    sub2, dir2 = AppriseWKDController.wkd_urls("user@example.com")
+    assert sub1 == sub2
+    assert dir1 == dir2
+
+
+def test_wkd_urls_local_part_encoded():
+    """wkd_urls() percent-encodes special characters in the local part."""
+    sub, direct = AppriseWKDController.wkd_urls("first+last@example.com")
+    assert "first%2Blast" in sub or "first+last" in sub
+    assert "first%2Blast" in direct or "first+last" in direct
+
+
+def test_wkd_urls_no_at_sign():
+    """wkd_urls() returns (None, None) for an address without '@'."""
+    sub, direct = AppriseWKDController.wkd_urls("notanemail")
+    assert sub is None
+    assert direct is None
+
+
+def test_wkd_urls_empty_string():
+    """wkd_urls() returns (None, None) for an empty string."""
+    sub, direct = AppriseWKDController.wkd_urls("")
+    assert sub is None
+    assert direct is None
+
+
+def test_wkd_urls_empty_local():
+    """wkd_urls() returns (None, None) when the local part is empty."""
+    sub, direct = AppriseWKDController.wkd_urls("@example.com")
+    assert sub is None
+    assert direct is None
+
+
+def test_wkd_urls_empty_domain():
+    """wkd_urls() returns (None, None) when the domain is empty."""
+    sub, direct = AppriseWKDController.wkd_urls("user@")
+    assert sub is None
+    assert direct is None
+
+
+def test_wkd_urls_none_input():
+    """wkd_urls() returns (None, None) for None input."""
+    sub, direct = AppriseWKDController.wkd_urls(None)
+    assert sub is None
+    assert direct is None
+
+
+def test_wkd_urls_lower_raises_attribute_error():
+    """wkd_urls() returns (None, None) when email.lower() raises.
+
+    Covers the defensive except branch for string-like objects that pass
+    the '@' membership check but fail during normalisation.
+    """
+
+    class BrokenStr(str):
+        def lower(self):
+            raise AttributeError("broken lower")
+
+    sub, direct = AppriseWKDController.wkd_urls(BrokenStr("user@example.com"))
+    assert sub is None
+    assert direct is None
+
+
+# ---------------------------------------------------------------------------
+# AppriseWKDController.fetch -- happy path
+# ---------------------------------------------------------------------------
+
+
+@mock.patch("requests.get")
+def test_fetch_subdomain_success(mock_get):
+    """fetch() returns key bytes when the subdomain URL responds with 200."""
+    key_bytes = b"fake-openpgp-key-data"
+
+    # Subdomain call succeeds
+    mock_get.return_value = mock.Mock(
+        status_code=requests.codes.ok,
+        content=key_bytes,
+    )
+
+    ctrl = AppriseWKDController()
+    result = ctrl.fetch("user@example.com")
+
+    assert result == key_bytes
+    assert mock_get.call_count == 1
+
+
+@mock.patch("requests.get")
+def test_fetch_direct_fallback(mock_get):
+    """fetch() tries the direct URL when the subdomain URL fails."""
+    key_bytes = b"another-fake-key"
+
+    # Subdomain -> 404, direct -> 200
+    mock_get.side_effect = [
+        mock.Mock(status_code=404, content=b""),
+        mock.Mock(status_code=requests.codes.ok, content=key_bytes),
+    ]
+
+    ctrl = AppriseWKDController()
+    result = ctrl.fetch("user@example.com")
+
+    assert result == key_bytes
+    assert mock_get.call_count == 2
+
+
+@mock.patch("requests.get")
+def test_fetch_both_fail(mock_get):
+    """fetch() returns None when both WKD URLs fail."""
+    mock_get.return_value = mock.Mock(status_code=404, content=b"")
+
+    ctrl = AppriseWKDController()
+    result = ctrl.fetch("user@example.com")
+
+    assert result is None
+    assert mock_get.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# fetch -- cache behaviour
+# ---------------------------------------------------------------------------
+
+
+@mock.patch("requests.get")
+def test_fetch_caches_result(mock_get):
+    """A successful fetch is cached; subsequent calls skip the network."""
+    key_bytes = b"cached-key"
+    mock_get.return_value = mock.Mock(
+        status_code=requests.codes.ok,
+        content=key_bytes,
+    )
+
+    ctrl = AppriseWKDController()
+    result1 = ctrl.fetch("user@example.com")
+    result2 = ctrl.fetch("user@example.com")
+
+    assert result1 == key_bytes
+    assert result2 == key_bytes
+    # Network only hit once
+    assert mock_get.call_count == 1
+
+
+@mock.patch("requests.get")
+def test_fetch_cache_case_insensitive(mock_get):
+    """Cache lookup normalises the email address."""
+    key_bytes = b"normalised-key"
+    mock_get.return_value = mock.Mock(
+        status_code=requests.codes.ok,
+        content=key_bytes,
+    )
+
+    ctrl = AppriseWKDController()
+    ctrl.fetch("User@Example.COM")
+    result = ctrl.fetch("user@example.com")
+
+    assert result == key_bytes
+    assert mock_get.call_count == 1
+
+
+@mock.patch("requests.get")
+def test_fetch_expired_cache_refetches(mock_get):
+    """An expired cache entry triggers a new network request."""
+    key_bytes = b"refreshed-key"
+    mock_get.return_value = mock.Mock(
+        status_code=requests.codes.ok,
+        content=key_bytes,
+    )
+
+    ctrl = AppriseWKDController()
+
+    # Seed the cache with an already-expired entry
+    ctrl._cache["user@example.com"] = {
+        "data": b"stale-key",
+        "expires": datetime.now(timezone.utc) - timedelta(seconds=1),
+    }
+
+    result = ctrl.fetch("user@example.com")
+
+    assert result == key_bytes
+    assert mock_get.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# fetch -- invalid input
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_no_at_sign():
+    """fetch() returns None for an address without '@'."""
+    ctrl = AppriseWKDController()
+    assert ctrl.fetch("notanemail") is None
+
+
+def test_fetch_empty_string():
+    """fetch() returns None for an empty string."""
+    ctrl = AppriseWKDController()
+    assert ctrl.fetch("") is None
+
+
+def test_fetch_none():
+    """fetch() returns None when called with None."""
+    ctrl = AppriseWKDController()
+    assert ctrl.fetch(None) is None
+
+
+def test_fetch_at_only():
+    """fetch() returns None for '@' (empty local and empty domain).
+
+    '@' passes the '@' membership check but wkd_urls() returns (None, None)
+    because both local and domain parts are empty -- covers the guard at
+    the second validation point inside fetch().
+    """
+    ctrl = AppriseWKDController()
+    assert ctrl.fetch("@") is None
+
+
+# ---------------------------------------------------------------------------
+# _get -- response validation
+# ---------------------------------------------------------------------------
+
+
+@mock.patch("requests.get")
+def test_get_non_200_returns_none(mock_get):
+    """_get() returns None for any non-200 HTTP status."""
+    for code in (301, 400, 403, 404, 500):
+        mock_get.return_value = mock.Mock(status_code=code, content=b"body")
+        ctrl = AppriseWKDController()
+        assert ctrl._get("https://example.com/key") is None
+
+
+@mock.patch("requests.get")
+def test_get_empty_body_returns_none(mock_get):
+    """_get() returns None when the response body is empty."""
+    mock_get.return_value = mock.Mock(
+        status_code=requests.codes.ok, content=b""
+    )
+    ctrl = AppriseWKDController()
+    assert ctrl._get("https://example.com/key") is None
+
+
+@mock.patch("requests.get")
+def test_get_oversized_body_returns_none(mock_get):
+    """_get() returns None when the response exceeds max_response_size."""
+    ctrl = AppriseWKDController()
+    oversized = b"x" * (ctrl.max_response_size + 1)
+    mock_get.return_value = mock.Mock(
+        status_code=requests.codes.ok, content=oversized
+    )
+    assert ctrl._get("https://example.com/key") is None
+
+
+@mock.patch("requests.get", side_effect=requests.RequestException("timeout"))
+def test_get_request_exception_returns_none(mock_get):
+    """_get() returns None when requests raises any RequestException."""
+    ctrl = AppriseWKDController()
+    assert ctrl._get("https://example.com/key") is None
+
+
+@mock.patch("requests.get")
+def test_get_success_returns_bytes(mock_get):
+    """_get() returns the response bytes on HTTP 200 with content."""
+    payload = b"\x99\xaa\xbb\xcc"
+    mock_get.return_value = mock.Mock(
+        status_code=requests.codes.ok, content=payload
+    )
+    ctrl = AppriseWKDController()
+    assert ctrl._get("https://example.com/key") == payload
+
+
+# ---------------------------------------------------------------------------
+# prune
+# ---------------------------------------------------------------------------
+
+
+def test_prune_removes_expired_entries():
+    """prune() discards entries whose expiry has passed."""
+    ctrl = AppriseWKDController()
+    now = datetime.now(timezone.utc)
+
+    ctrl._cache["expired@example.com"] = {
+        "data": b"old",
+        "expires": now - timedelta(seconds=1),
+    }
+    ctrl._cache["fresh@example.com"] = {
+        "data": b"new",
+        "expires": now + timedelta(seconds=3600),
+    }
+
+    ctrl.prune()
+
+    assert "expired@example.com" not in ctrl._cache
+    assert "fresh@example.com" in ctrl._cache
+
+
+def test_prune_empty_cache():
+    """prune() does not raise when the cache is empty."""
+    ctrl = AppriseWKDController()
+    ctrl.prune()  # must not raise
+    assert ctrl._cache == {}
+
+
+# ---------------------------------------------------------------------------
+# Constructor defaults
+# ---------------------------------------------------------------------------
+
+
+def test_defaults():
+    """AppriseWKDController initialises with expected default values."""
+    ctrl = AppriseWKDController()
+    assert ctrl.verify_certificate is True
+    assert ctrl.request_timeout == (4, 4)
+    assert ctrl.allow_redirects is True
+    assert ctrl._cache == {}
+
+
+def test_custom_timeout_and_verify():
+    """Constructor stores custom timeout and verify_certificate values."""
+    ctrl = AppriseWKDController(
+        verify_certificate=False, request_timeout=(2, 10)
+    )
+    assert ctrl.verify_certificate is False
+    assert ctrl.request_timeout == (2, 10)
+
+
+def test_custom_allow_redirects():
+    """Constructor stores a custom allow_redirects value."""
+    ctrl = AppriseWKDController(allow_redirects=False)
+    assert ctrl.allow_redirects is False
+
+
+@mock.patch("requests.get")
+def test_get_passes_verify_and_timeout(mock_get):
+    """_get() forwards verify_certificate, request_timeout, and
+    allow_redirects to requests."""
+    mock_get.return_value = mock.Mock(
+        status_code=requests.codes.ok, content=b"key"
+    )
+    ctrl = AppriseWKDController(
+        verify_certificate=False, request_timeout=(1, 5), allow_redirects=False
+    )
+    ctrl._get("https://example.com/key")
+
+    _, kwargs = mock_get.call_args
+    assert kwargs["verify"] is False
+    assert kwargs["timeout"] == (1, 5)
+    assert kwargs["allow_redirects"] is False

--- a/tests/test_utils_wkd.py
+++ b/tests/test_utils_wkd.py
@@ -196,7 +196,8 @@ def test_wkd_urls_lower_raises_attribute_error():
 @mock.patch("requests.get")
 def test_fetch_subdomain_success(mock_get):
     """fetch() returns key bytes when the subdomain URL responds with 200."""
-    key_bytes = b"fake-openpgp-key-data"
+    # 0x99 is a valid old-format OpenPGP packet header byte (bit 7 set)
+    key_bytes = b"\x99fake-openpgp-key-data"
 
     # Subdomain call succeeds
     mock_get.return_value = mock.Mock(
@@ -214,7 +215,7 @@ def test_fetch_subdomain_success(mock_get):
 @mock.patch("requests.get")
 def test_fetch_direct_fallback(mock_get):
     """fetch() tries the direct URL when the subdomain URL fails."""
-    key_bytes = b"another-fake-key"
+    key_bytes = b"\x99another-fake-key"
 
     # Subdomain -> 404, direct -> 200
     mock_get.side_effect = [
@@ -249,7 +250,7 @@ def test_fetch_both_fail(mock_get):
 @mock.patch("requests.get")
 def test_fetch_caches_result(mock_get):
     """A successful fetch is cached; subsequent calls skip the network."""
-    key_bytes = b"cached-key"
+    key_bytes = b"\x99cached-key"
     mock_get.return_value = mock.Mock(
         status_code=requests.codes.ok,
         content=key_bytes,
@@ -268,7 +269,7 @@ def test_fetch_caches_result(mock_get):
 @mock.patch("requests.get")
 def test_fetch_cache_case_insensitive(mock_get):
     """Cache lookup normalises the email address."""
-    key_bytes = b"normalised-key"
+    key_bytes = b"\x99normalised-key"
     mock_get.return_value = mock.Mock(
         status_code=requests.codes.ok,
         content=key_bytes,
@@ -285,7 +286,7 @@ def test_fetch_cache_case_insensitive(mock_get):
 @mock.patch("requests.get")
 def test_fetch_expired_cache_refetches(mock_get):
     """An expired cache entry triggers a new network request."""
-    key_bytes = b"refreshed-key"
+    key_bytes = b"\x99refreshed-key"
     mock_get.return_value = mock.Mock(
         status_code=requests.codes.ok,
         content=key_bytes,
@@ -374,6 +375,53 @@ def test_get_oversized_body_returns_none(mock_get):
     assert ctrl._get("https://example.com/key") is None
 
 
+@mock.patch("requests.get")
+def test_get_non_pgp_body_returns_none(mock_get):
+    """_get() returns None when the response body is not PGP data.
+
+    A subdomain endpoint that is a parked domain or CDN may return HTTP
+    200 with HTML content.  Without this guard, fetch() would cache the
+    HTML bytes and never try the direct-method fallback URL.
+    """
+    for non_pgp in (
+        b"<html><body>Not a key</body></html>",
+        b"<!DOCTYPE html>",
+        b"{}",
+        b"Not PGP data",
+    ):
+        mock_get.return_value = mock.Mock(
+            status_code=requests.codes.ok, content=non_pgp
+        )
+        ctrl = AppriseWKDController()
+        assert ctrl._get("https://example.com/key") is None, (
+            f"Expected None for non-PGP content: {non_pgp[:20]}"
+        )
+
+
+@mock.patch("requests.get")
+def test_get_binary_pgp_packet_accepted(mock_get):
+    """_get() accepts a response whose first byte has bit 7 set (OpenPGP
+    binary packet format)."""
+    # 0x99 is the old-format public-key packet header
+    pgp_binary = b"\x99\x01\xd6" + b"\x00" * 100
+    mock_get.return_value = mock.Mock(
+        status_code=requests.codes.ok, content=pgp_binary
+    )
+    ctrl = AppriseWKDController()
+    assert ctrl._get("https://example.com/key") == pgp_binary
+
+
+@mock.patch("requests.get")
+def test_get_ascii_armoured_key_accepted(mock_get):
+    """_get() accepts ASCII-armoured PGP key material (starts with '-----')."""
+    armoured = b"-----BEGIN PGP PUBLIC KEY BLOCK-----\n..."
+    mock_get.return_value = mock.Mock(
+        status_code=requests.codes.ok, content=armoured
+    )
+    ctrl = AppriseWKDController()
+    assert ctrl._get("https://example.com/key") == armoured
+
+
 @mock.patch("requests.get", side_effect=requests.RequestException("timeout"))
 def test_get_request_exception_returns_none(mock_get):
     """_get() returns None when requests raises any RequestException."""
@@ -458,7 +506,7 @@ def test_get_passes_verify_and_timeout(mock_get):
     """_get() forwards verify_certificate, request_timeout, and
     allow_redirects to requests."""
     mock_get.return_value = mock.Mock(
-        status_code=requests.codes.ok, content=b"key"
+        status_code=requests.codes.ok, content=b"\x99key"
     )
     ctrl = AppriseWKDController(
         verify_certificate=False, request_timeout=(1, 5), allow_redirects=False

--- a/tests/test_utils_wkd.py
+++ b/tests/test_utils_wkd.py
@@ -133,11 +133,44 @@ def test_wkd_urls_structure():
 
 
 def test_wkd_urls_case_normalised():
-    """wkd_urls() lower-cases the email before building URLs."""
-    sub1, dir1 = AppriseWKDController.wkd_urls("User@Example.COM")
-    sub2, dir2 = AppriseWKDController.wkd_urls("user@example.com")
-    assert sub1 == sub2
-    assert dir1 == dir2
+    """wkd_urls() produces the same hash and domain for differently-cased
+    inputs, but preserves the original local-part case in ?l= (RFC 9080).
+
+    The hash component uses the lower-cased local part (spec requirement),
+    the domain is always lower-cased (URL canonicalisation), and the ?l=
+    query parameter carries the unchanged original local part -- so two
+    addresses that differ only in local-part capitalisation will share the
+    same hash/path but differ in their ?l= value.
+    """
+    sub_upper, dir_upper = AppriseWKDController.wkd_urls("User@Example.COM")
+    sub_lower, dir_lower = AppriseWKDController.wkd_urls("user@example.com")
+
+    # Hash and domain parts must be identical
+    assert sub_upper.split("?")[0] == sub_lower.split("?")[0]
+    assert dir_upper.split("?")[0] == dir_lower.split("?")[0]
+
+    # ?l= must carry the original (unchanged) local part
+    assert "?l=User" in sub_upper
+    assert "?l=user" in sub_lower
+
+    # Domain is always lower-cased regardless of input
+    assert "example.com" in sub_lower
+
+
+def test_wkd_urls_l_param_preserves_original_case():
+    """?l= carries the unchanged local-part per RFC 9080.
+
+    The spec example: Joe.Doe@Example.ORG ->
+      ?l=Joe.Doe  (original case, not lowercased)
+    The hash is computed from the lowercased local part; only ?l= keeps
+    the original capitalisation.
+    """
+    sub, direct = AppriseWKDController.wkd_urls("Joe.Doe@Example.ORG")
+    assert "?l=Joe.Doe" in sub
+    assert "?l=Joe.Doe" in direct
+    # Domain part is always lowercased in the URL path
+    assert "example.org" in sub
+    assert "example.org" in direct
 
 
 def test_wkd_urls_local_part_encoded():
@@ -212,15 +245,17 @@ def test_wkd_urls_ipv4_domain_rejected():
 
 
 def test_wkd_urls_lower_raises_attribute_error():
-    """wkd_urls() returns (None, None) when email.lower() raises.
+    """wkd_urls() returns (None, None) when email.split() raises.
 
     Covers the defensive except branch for string-like objects that pass
-    the '@' membership check but fail during normalisation.
+    the '@' membership check but fail during splitting.  (After the
+    RFC 9080 case-preservation fix, split() is called before lower(), so
+    breaking split() is what exercises this path.)
     """
 
     class BrokenStr(str):
-        def lower(self):
-            raise AttributeError("broken lower")
+        def split(self, *args, **kwargs):
+            raise AttributeError("broken split")
 
     sub, direct = AppriseWKDController.wkd_urls(BrokenStr("user@example.com"))
     assert sub is None


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1240

Adds automatic OpenPGP public-key discovery via Web Key Directory (WKD, RFC 9080) to the email plugin, and introduces a new `pgp=` choice parameter that makes PGP mode explicit in Apprise URLs.

- Python 3.13+ compatibility
- `pgp=` upgraded from bool to choice string -- accepts `no` (default) or `encrypt`. Legacy `pgp=yes/no` values are still accepted via `parse_bool()` fallback with a deprecation warning, preserving all existing URLs.
- New `apprise/utils/wkd.py` -- a decoupled `AppriseWKDController` that fetches binary OpenPGP public key material via Web Key Directory (RFC 9080).
   - Tries the subdomain method first, falls back to the direct method, and caches results in memory for 24 hours.
   - Returns raw bytes and has no pgpy dependency, making it reusable independently of the email plugin.
- `wkd=yes` URL parameter -- wires a `AppriseWKDController` into `ApprisePGPController` as an automatic key discovery step between local key file lookup and key auto-generation.
   - Setting `wkd=yes` implies `pgp=encrypt` when `pgp=` is not explicitly specified; an explicit `pgp=none` still takes precedence.

## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/67](https://github.com/caronc/apprise-docs/pull/67)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1240-wkd-support-pgp-refactor

# Send an encrypted email using WKD key discovery (key fetched automatically
# from the recipient's domain if published):
apprise -vv -t "Test Title" -b "Test Message" \
    "mailto://user:pass@smtp.example.com?to=recipient@example.com&wkd=yes"

# Send an encrypted email using a local public key file:
apprise -vv -t "Test Title" -b "Test Message" \
    "mailto://user:pass@smtp.example.com?to=recipient@example.com&pgp=encrypt&pgpkey=/path/to/pub.asc"

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "mailto://user:pass@smtp.example.com?to=recipient@example.com&wkd=yes"
```