### PR TITLE
Amazon SNS/SES Improvements

### DIFF
--- a/apprise/plugins/ses.py
+++ b/apprise/plugins/ses.py
@@ -150,6 +150,15 @@ class NotifySES(NotifyBase):
     template_tokens = dict(
         NotifyBase.template_tokens,
         **{
+            "token": {
+                # Session token for temporary/IAM credentials (optional).
+                # SES uses sender@domain in the URL host slot, so the token
+                # is provided via ?token= rather than the userinfo position.
+                "name": _("Session Token"),
+                "type": "string",
+                "private": True,
+                "map_to": "session_token",
+            },
             "from_email": {
                 "name": _("From Email"),
                 "type": "string",
@@ -186,6 +195,9 @@ class NotifySES(NotifyBase):
     template_args = dict(
         NotifyBase.template_args,
         **{
+            "to": {
+                "alias_of": "targets",
+            },
             "from": {
                 "alias_of": "from_email",
             },
@@ -199,7 +211,15 @@ class NotifySES(NotifyBase):
                 "type": "string",
                 "map_to": "from_name",
             },
+            "token": {
+                # ?token= kwarg mirrors the token template token
+                "alias_of": "token",
+            },
             "access": {
+                "alias_of": "access_key_id",
+            },
+            "key": {
+                # Intuitive alias for access_key_id
                 "alias_of": "access_key_id",
             },
             "secret": {
@@ -207,9 +227,6 @@ class NotifySES(NotifyBase):
             },
             "region": {
                 "alias_of": "region",
-            },
-            "to": {
-                "alias_of": "targets",
             },
             "cc": {
                 "name": _("Carbon Copy"),
@@ -233,10 +250,14 @@ class NotifySES(NotifyBase):
         targets=None,
         cc=None,
         bcc=None,
+        session_token=None,
         **kwargs,
     ):
         """Initialize Notify AWS SES Object."""
         super().__init__(**kwargs)
+
+        # Store optional session token for temporary/IAM credentials
+        self.aws_session_token = session_token if session_token else None
 
         # Store our AWS API Access Key
         self.aws_access_key_id = validate_regex(access_key_id)
@@ -668,6 +689,13 @@ class NotifySES(NotifyBase):
             ]
         )
 
+        # Include session token in signed headers for temporary credentials;
+        # x-amz-security-token sorts after x-amz-date alphabetically and
+        # must appear after it to keep the canonical request valid.
+        if self.aws_session_token:
+            headers["X-Amz-Security-Token"] = self.aws_session_token
+            signed_headers["x-amz-security-token"] = self.aws_session_token
+
         #
         # Build Canonical Request Object
         #
@@ -868,6 +896,14 @@ class NotifySES(NotifyBase):
                 else self.reply_to[1]
             )
 
+        # Include session token in query params for temporary credentials
+        if self.aws_session_token:
+            params["token"] = (
+                self.pprint(self.aws_session_token, privacy, safe="")
+                if privacy
+                else self.aws_session_token
+            )
+
         # a simple boolean check as to whether we display our target emails
         # or not
         has_targets = not (
@@ -1005,8 +1041,11 @@ class NotifySES(NotifyBase):
         else:
             results["secret_access_key"] = secret_access_key
 
-        # Handle access key id over-ride
-        if "access" in results["qsd"] and len(results["qsd"]["access"]):
+        # Handle access key id override; ?key= is the preferred alias,
+        # ?access= is retained for backwards compatibility
+        if "key" in results["qsd"] and len(results["qsd"]["key"]):
+            results["access_key_id"] = NotifySES.unquote(results["qsd"]["key"])
+        elif "access" in results["qsd"] and len(results["qsd"]["access"]):
             results["access_key_id"] = NotifySES.unquote(
                 results["qsd"]["access"]
             )
@@ -1020,6 +1059,14 @@ class NotifySES(NotifyBase):
             )
         else:
             results["region_name"] = region_name
+
+        # Session token via ?token= (SES uses sender@domain in the URL host
+        # slot, so there is no userinfo position available for the token)
+        results["session_token"] = None
+        if "token" in results["qsd"] and len(results["qsd"]["token"]):
+            results["session_token"] = NotifySES.unquote(
+                results["qsd"]["token"]
+            )
 
         # Return our result set
         return results

--- a/apprise/plugins/ses.py
+++ b/apprise/plugins/ses.py
@@ -152,8 +152,8 @@ class NotifySES(NotifyBase):
         **{
             "token": {
                 # Session token for temporary/IAM credentials (optional).
-                # SES uses sender@domain in the URL host slot, so the token
-                # is provided via ?token= rather than the userinfo position.
+                # May be supplied in the URL password field
+                # (ses://user:{token}@host/...) or via ?token=.
                 "name": _("Session Token"),
                 "type": "string",
                 "private": True,
@@ -896,25 +896,34 @@ class NotifySES(NotifyBase):
                 else self.reply_to[1]
             )
 
-        # Include session token in query params for temporary credentials
-        if self.aws_session_token:
-            params["token"] = (
-                self.pprint(self.aws_session_token, privacy, safe="")
-                if privacy
-                else self.aws_session_token
-            )
-
         # a simple boolean check as to whether we display our target emails
         # or not
         has_targets = not (
             len(self.targets) == 1 and self.targets[0][1] == self.from_addr
         )
 
+        # Build the from-address URL segment; include the session token in
+        # the password position when present:
+        # ses://sender:{token}@example.com/...
+        if self.aws_session_token:
+            # Split from_addr into local and domain parts;
+            # from_addr always contains @ (enforced by __init__ validation)
+            fa_local, fa_domain = self.from_addr.split("@", 1)
+            from_url_part = "{}:{}@{}".format(
+                NotifySES.quote(fa_local, safe=""),
+                self.pprint(self.aws_session_token, privacy, safe="+=")
+                if privacy
+                else NotifySES.quote(self.aws_session_token, safe="+="),
+                NotifySES.quote(fa_domain, safe=""),
+            )
+        else:
+            from_url_part = NotifySES.quote(self.from_addr, safe="@")
+
         return (
             "{schema}://{from_addr}/{key_id}/{key_secret}/{region}/"
             "{targets}/?{params}".format(
                 schema=self.secure_protocol,
-                from_addr=NotifySES.quote(self.from_addr, safe="@"),
+                from_addr=from_url_part,
                 key_id=self.pprint(self.aws_access_key_id, privacy, safe=""),
                 key_secret=self.pprint(
                     self.aws_secret_access_key,
@@ -1060,9 +1069,12 @@ class NotifySES(NotifyBase):
         else:
             results["region_name"] = region_name
 
-        # Session token via ?token= (SES uses sender@domain in the URL host
-        # slot, so there is no userinfo position available for the token)
+        # Session token may come from the URL password field or the
+        # ?token= query parameter; ?token= takes priority when both
+        # are present.
         results["session_token"] = None
+        if results.get("password"):
+            results["session_token"] = NotifySES.unquote(results["password"])
         if "token" in results["qsd"] and len(results["qsd"]["token"]):
             results["session_token"] = NotifySES.unquote(
                 results["qsd"]["token"]

--- a/apprise/plugins/sns.py
+++ b/apprise/plugins/sns.py
@@ -95,6 +95,10 @@ class NotifySNS(NotifyBase):
 
     # Define object templates
     templates = (
+        # With session token (for temporary/IAM credentials)
+        "{schema}://{token}@{access_key_id}"
+        "/{secret_access_key}/{region}/{targets}",
+        # Without session token (standard long-term credentials)
         "{schema}://{access_key_id}/{secret_access_key}/{region}/{targets}",
     )
 
@@ -102,6 +106,13 @@ class NotifySNS(NotifyBase):
     template_tokens = dict(
         NotifyBase.template_tokens,
         **{
+            "token": {
+                # Session token for temporary/IAM credentials (optional)
+                "name": _("Session Token"),
+                "type": "string",
+                "private": True,
+                "map_to": "session_token",
+            },
             "access_key_id": {
                 "name": _("Access Key ID"),
                 "type": "string",
@@ -146,7 +157,18 @@ class NotifySNS(NotifyBase):
     template_args = dict(
         NotifyBase.template_args,
         **{
+            "to": {
+                "alias_of": "targets",
+            },
+            "token": {
+                # ?token= kwarg mirrors the {token} URL path entry
+                "alias_of": "token",
+            },
             "access": {
+                "alias_of": "access_key_id",
+            },
+            "key": {
+                # Intuitive alias for access_key_id
                 "alias_of": "access_key_id",
             },
             "secret": {
@@ -154,9 +176,6 @@ class NotifySNS(NotifyBase):
             },
             "region": {
                 "alias_of": "region",
-            },
-            "to": {
-                "alias_of": "targets",
             },
         },
     )
@@ -167,10 +186,14 @@ class NotifySNS(NotifyBase):
         secret_access_key,
         region_name,
         targets=None,
+        session_token=None,
         **kwargs,
     ):
         """Initialize Notify AWS SNS Object."""
         super().__init__(**kwargs)
+
+        # Store optional session token for temporary/IAM credentials
+        self.aws_session_token = session_token if session_token else None
 
         # Store our AWS API Access Key
         self.aws_access_key_id = validate_regex(access_key_id)
@@ -428,6 +451,13 @@ class NotifySNS(NotifyBase):
             ]
         )
 
+        # Include session token in signed headers for temporary credentials;
+        # x-amz-security-token sorts after x-amz-date alphabetically and
+        # must appear after it to keep the canonical request valid.
+        if self.aws_session_token:
+            headers["X-Amz-Security-Token"] = self.aws_session_token
+            signed_headers["x-amz-security-token"] = self.aws_session_token
+
         #
         # Build Canonical Request Object
         #
@@ -595,10 +625,20 @@ class NotifySNS(NotifyBase):
         # Our URL parameters
         params = self.url_parameters(privacy=privacy, *args, **kwargs)
 
+        # Prepare session token prefix when using temporary credentials
+        token_prefix = (
+            "{token}@".format(
+                token=self.pprint(self.aws_session_token, privacy, safe=""),
+            )
+            if self.aws_session_token
+            else ""
+        )
+
         return (
-            "{schema}://{key_id}/{key_secret}/{region}/{targets}/"
-            "?{params}".format(
+            "{schema}://{token_prefix}{key_id}/{key_secret}"
+            "/{region}/{targets}/?{params}".format(
                 schema=self.secure_protocol,
+                token_prefix=token_prefix,
                 key_id=self.pprint(self.aws_access_key_id, privacy, safe=""),
                 key_secret=self.pprint(
                     self.aws_secret_access_key,
@@ -696,8 +736,11 @@ class NotifySNS(NotifyBase):
         else:
             results["secret_access_key"] = secret_access_key
 
-        # Handle access key id over-ride
-        if "access" in results["qsd"] and len(results["qsd"]["access"]):
+        # Handle access key id override; ?key= is the preferred alias,
+        # ?access= is retained for backwards compatibility
+        if "key" in results["qsd"] and len(results["qsd"]["key"]):
+            results["access_key_id"] = NotifySNS.unquote(results["qsd"]["key"])
+        elif "access" in results["qsd"] and len(results["qsd"]["access"]):
             results["access_key_id"] = NotifySNS.unquote(
                 results["qsd"]["access"]
             )
@@ -711,6 +754,16 @@ class NotifySNS(NotifyBase):
             )
         else:
             results["region_name"] = region_name
+
+        # Session token: userinfo position ({token}@{host}) takes first pass;
+        # ?token= kwarg overrides it when both appear
+        results["session_token"] = None
+        if results.get("user"):
+            results["session_token"] = NotifySNS.unquote(results["user"])
+        if "token" in results["qsd"] and len(results["qsd"]["token"]):
+            results["session_token"] = NotifySNS.unquote(
+                results["qsd"]["token"]
+            )
 
         # Return our result set
         return results

--- a/apprise/plugins/sns.py
+++ b/apprise/plugins/sns.py
@@ -706,10 +706,13 @@ class NotifySNS(NotifyBase):
         # Always include mode so the round-trip preserves the setting
         params["mode"] = self.mode
 
-        # Prepare session token prefix when using temporary credentials
+        # Prepare session token prefix when using temporary credentials;
+        # + and = are RFC 3986 sub-delimiters safe in the userinfo position
+        # and look nicer unencoded; / must stay encoded (%2F) because an
+        # unencoded slash terminates the URL authority and breaks parsing
         token_prefix = (
             "{token}@".format(
-                token=self.pprint(self.aws_session_token, privacy, safe=""),
+                token=self.pprint(self.aws_session_token, privacy, safe="+="),
             )
             if self.aws_session_token
             else ""

--- a/apprise/plugins/sns.py
+++ b/apprise/plugins/sns.py
@@ -66,6 +66,27 @@ AWS_HTTP_ERROR_MAP = {
 }
 
 
+class SNSMode:
+    """Tracks the mode of operation for SNS Notifications."""
+
+    # SMS mode: the title is merged into the message body and the
+    # body is limited to 160 characters. This is the safe default
+    # and applies to phone targets and any mix of phones + topics.
+    SMS = "sms"
+
+    # Topic mode: the title is sent as the SNS Subject field for
+    # topic targets; the body limit is 256 KB. Auto-selected when
+    # all targets are SNS topics (no phone numbers present).
+    TOPIC = "topic"
+
+
+# All valid SNS operating modes
+SNS_MODES = (
+    SNSMode.SMS,
+    SNSMode.TOPIC,
+)
+
+
 class NotifySNS(NotifyBase):
     """A wrapper for AWS SNS (Amazon Simple Notification)"""
 
@@ -85,13 +106,13 @@ class NotifySNS(NotifyBase):
     # can occur in much shorter bursts
     request_rate_per_sec = 2.5
 
-    # The maximum length of the body
+    # body_maxlen and title_maxlen are defined as @property methods below
+    # since the limits differ by mode: SMS mode caps the body at 160
+    # characters and has no title field (title_maxlen = 0 causes the
+    # framework to fold the title into the body automatically); Topic
+    # mode allows up to 256 KB and passes the title as the SNS Subject
+    # field (title_maxlen = 100).
     # Source: https://docs.aws.amazon.com/sns/latest/api/API_Publish.html
-    body_maxlen = 160
-
-    # A title can not be used for SMS Messages.  Setting this to zero will
-    # cause any title (if defined) to get placed into the message body.
-    title_maxlen = 0
 
     # Define object templates
     templates = (
@@ -177,6 +198,12 @@ class NotifySNS(NotifyBase):
             "region": {
                 "alias_of": "region",
             },
+            "mode": {
+                "name": _("Mode"),
+                "type": "choice:string",
+                "values": SNS_MODES,
+                "default": SNSMode.SMS,
+            },
         },
     )
 
@@ -187,6 +214,7 @@ class NotifySNS(NotifyBase):
         region_name,
         targets=None,
         session_token=None,
+        mode=None,
         **kwargs,
     ):
         """Initialize Notify AWS SNS Object."""
@@ -258,6 +286,28 @@ class NotifySNS(NotifyBase):
                 f"Dropped invalid phone/topic ({target}) specified.",
             )
 
+        # Determine operating mode: explicit override wins, otherwise
+        # auto-detect from target composition
+        if mode and isinstance(mode, str):
+            # Resolve via prefix match (e.g. "t" -> "topic")
+            self.mode = next(
+                (m for m in SNS_MODES if m.startswith(mode.lower())),
+                None,
+            )
+            if self.mode not in SNS_MODES:
+                msg = f"The AWS SNS mode specified ({mode}) is invalid."
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
+        else:
+            # Auto-detect: topic mode when all targets are SNS topics
+            # (no phone numbers); SMS mode for phones or mixed sets
+            self.mode = (
+                SNSMode.TOPIC
+                if self.topics and not self.phone
+                else SNSMode.SMS
+            )
+
         return
 
     def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
@@ -280,10 +330,18 @@ class NotifySNS(NotifyBase):
             # Get Phone No
             no = phone.pop(0)
 
+            # In topic mode the framework passes the title through
+            # separately; SMS has no Subject field so the title is
+            # prepended to the body manually when present
+            if self.mode == SNSMode.TOPIC and title:
+                sms_body = "{}\r\n{}".format(title, body)
+            else:
+                sms_body = body
+
             # Prepare SNS Message Payload
             payload = {
                 "Action": "Publish",
-                "Message": body,
+                "Message": sms_body,
                 "Version": "2010-03-31",
                 "PhoneNumber": no,
             }
@@ -323,6 +381,12 @@ class NotifySNS(NotifyBase):
                 "TopicArn": topic_arn,
                 "Message": body,
             }
+
+            # In topic mode, use the title as the SNS Subject field
+            # when a title was provided; email subscribers will see
+            # it as the message subject line
+            if self.mode == SNSMode.TOPIC and title:
+                payload["Subject"] = title
 
             # Send our payload to AWS
             (result, _) = self._post(payload=payload, to=topic)
@@ -619,11 +683,28 @@ class NotifySNS(NotifyBase):
             self.aws_region_name,
         )
 
+    @property
+    def title_maxlen(self):
+        """Maximum title length: 100 for topic mode, 0 for SMS."""
+        # Return 100 in topic mode so the framework passes the title
+        # to send() separately; return 0 for SMS so the framework
+        # folds the title into the body automatically before send()
+        return 100 if self.mode == SNSMode.TOPIC else 0
+
+    @property
+    def body_maxlen(self):
+        """Maximum body length: 256 KB for topic mode, 160 for SMS."""
+        # Topic publishes support up to 256 KB; SMS is capped at 160
+        return 256000 if self.mode == SNSMode.TOPIC else 160
+
     def url(self, privacy=False, *args, **kwargs):
         """Returns the URL built dynamically based on specified arguments."""
 
         # Our URL parameters
         params = self.url_parameters(privacy=privacy, *args, **kwargs)
+
+        # Always include mode so the round-trip preserves the setting
+        params["mode"] = self.mode
 
         # Prepare session token prefix when using temporary credentials
         token_prefix = (
@@ -764,6 +845,12 @@ class NotifySNS(NotifyBase):
             results["session_token"] = NotifySNS.unquote(
                 results["qsd"]["token"]
             )
+
+        # Read mode parameter if supplied; None triggers auto-detection
+        # in __init__ based on target composition
+        results["mode"] = None
+        if "mode" in results["qsd"] and results["qsd"]["mode"]:
+            results["mode"] = NotifySNS.unquote(results["qsd"]["mode"])
 
         # Return our result set
         return results

--- a/tests/test_plugin_ses.py
+++ b/tests/test_plugin_ses.py
@@ -66,6 +66,7 @@ AWS_SES_GOOD_RESPONSE = """
 TEST_ACCESS_KEY_ID = "AHIAJGNT76XIMXDBIJYA"
 TEST_ACCESS_KEY_SECRET = "bu1dHSdO22pfaaVy/wmNsdljF4C07D3bndi9PQJ9"
 TEST_REGION = "us-east-2"
+TEST_SESSION_TOKEN = "FwoGZXIvYXdzSESSIONTOKENABCDEFGHIJKLMNOPQRS"
 
 # Our Testing URLs
 apprise_url_tests = (
@@ -240,6 +241,46 @@ apprise_url_tests = (
             "requests_response_text": AWS_SES_GOOD_RESPONSE,
             # Throws a series of connection and transfer exceptions when this
             # flag is set and tests that we gracefully handle them
+            "test_requests_exceptions": True,
+        },
+    ),
+    (
+        # Session token via ?token= query parameter
+        "ses://user@example.com/T1JJ3T3L2/A1BRTD4JD/TIiacevi7FQ/us-west-2/"
+        "user2@example.com?token=SESSIONTOKEN",
+        {
+            "instance": NotifySES,
+            "requests_response_text": AWS_SES_GOOD_RESPONSE,
+        },
+    ),
+    (
+        # Access key via ?key= alias
+        "ses://user@example.com/?key=T1JJ3T3L2"
+        "&secret=A1BRTD4JD/TIiacevi7FQ&region=us-west-2"
+        "&to=user2@example.com",
+        {
+            "instance": NotifySES,
+            "requests_response_text": AWS_SES_GOOD_RESPONSE,
+        },
+    ),
+    (
+        # Session token + HTTP error
+        "ses://user@example.com/T1JJ3T3L2/A1BRTD4JD/TIiacevi7FQ/us-west-2/"
+        "user2@example.com?token=SESSIONTOKEN",
+        {
+            "instance": NotifySES,
+            "requests_response_text": AWS_SES_GOOD_RESPONSE,
+            "response": False,
+            "requests_response_code": 999,
+        },
+    ),
+    (
+        # Session token + request exceptions
+        "ses://user@example.com/T1JJ3T3L2/A1BRTD4JD/TIiacevi7FQ/us-west-2/"
+        "user2@example.com?token=SESSIONTOKEN",
+        {
+            "instance": NotifySES,
+            "requests_response_text": AWS_SES_GOOD_RESPONSE,
             "test_requests_exceptions": True,
         },
     ),
@@ -471,3 +512,114 @@ def test_plugin_ses_attachments(mock_post):
     path = os.path.join(TEST_VAR_DIR, "/invalid/path/to/an/invalid/file.jpg")
     attach = AppriseAttachment(path)
     assert obj.notify(body="test", attach=attach) is False
+
+
+@mock.patch("requests.post")
+def test_plugin_ses_session_token(mock_post):
+    """NotifySES() session token for temporary/IAM credentials."""
+
+    response = mock.MagicMock()
+    response.status_code = requests.codes.ok
+    response.content = AWS_SES_GOOD_RESPONSE
+    mock_post.return_value = response
+
+    # Init with session token
+    obj = NotifySES(
+        access_key_id=TEST_ACCESS_KEY_ID,
+        secret_access_key=TEST_ACCESS_KEY_SECRET,
+        region_name=TEST_REGION,
+        from_addr="sender@example.com",
+        targets=["recipient@example.com"],
+        session_token=TEST_SESSION_TOKEN,
+    )
+    assert obj.aws_session_token == TEST_SESSION_TOKEN
+
+    # send() must include X-Amz-Security-Token in request headers
+    assert obj.notify(body="test") is True
+    call_kwargs = mock_post.call_args[1]
+    assert "X-Amz-Security-Token" in call_kwargs["headers"]
+    assert call_kwargs["headers"]["X-Amz-Security-Token"] == TEST_SESSION_TOKEN
+
+    # x-amz-security-token must appear in the Authorization SignedHeaders
+    auth = call_kwargs["headers"]["Authorization"]
+    assert "x-amz-security-token" in auth
+
+    # URL round-trip: token appears in query params
+    url = obj.url()
+    assert "token=" in url
+    assert TEST_SESSION_TOKEN in url
+
+    results = NotifySES.parse_url(url)
+    assert results["session_token"] == TEST_SESSION_TOKEN
+    assert results["access_key_id"] == TEST_ACCESS_KEY_ID
+
+    obj2 = NotifySES(**results)
+    assert obj2.aws_session_token == TEST_SESSION_TOKEN
+    assert obj2.url_identifier == obj.url_identifier
+
+    # Privacy URL must mask the token value
+    priv_url = obj.url(privacy=True)
+    assert TEST_SESSION_TOKEN not in priv_url
+    assert "token=" in priv_url
+
+    # Without a session token no X-Amz-Security-Token header is sent
+    mock_post.reset_mock()
+    obj_plain = NotifySES(
+        access_key_id=TEST_ACCESS_KEY_ID,
+        secret_access_key=TEST_ACCESS_KEY_SECRET,
+        region_name=TEST_REGION,
+        from_addr="sender@example.com",
+        targets=["recipient@example.com"],
+    )
+    assert obj_plain.aws_session_token is None
+    assert obj_plain.notify(body="test") is True
+    call_kwargs = mock_post.call_args[1]
+    assert "X-Amz-Security-Token" not in call_kwargs["headers"]
+
+    # url() without token has no token= param
+    plain_url = obj_plain.url()
+    assert "token=" not in plain_url
+
+
+def test_plugin_ses_session_token_via_kwarg():
+    """NotifySES() session token parsed from ?token= kwarg."""
+
+    url = (
+        f"ses://sender@example.com/{TEST_ACCESS_KEY_ID}"
+        f"/{TEST_ACCESS_KEY_SECRET}/{TEST_REGION}"
+        f"/recipient@example.com?token={TEST_SESSION_TOKEN}"
+    )
+    results = NotifySES.parse_url(url)
+    assert results["session_token"] == TEST_SESSION_TOKEN
+    assert results["access_key_id"] == TEST_ACCESS_KEY_ID
+
+    obj = NotifySES(**results)
+    assert obj.aws_session_token == TEST_SESSION_TOKEN
+
+
+def test_plugin_ses_key_alias():
+    """NotifySES() ?key= alias for access_key_id."""
+
+    url = (
+        "ses://sender@example.com/"
+        f"?key={TEST_ACCESS_KEY_ID}"
+        f"&secret={TEST_ACCESS_KEY_SECRET}"
+        f"&region={TEST_REGION}"
+        "&to=recipient@example.com"
+    )
+    results = NotifySES.parse_url(url)
+    assert results["access_key_id"] == TEST_ACCESS_KEY_ID
+
+    obj = NotifySES(**results)
+    assert obj.aws_access_key_id == TEST_ACCESS_KEY_ID
+
+    # ?key= takes priority over ?access= when both appear
+    url_both = (
+        "ses://sender@example.com/"
+        f"?key={TEST_ACCESS_KEY_ID}&access=OTHERID"
+        f"&secret={TEST_ACCESS_KEY_SECRET}"
+        f"&region={TEST_REGION}"
+        "&to=recipient@example.com"
+    )
+    results2 = NotifySES.parse_url(url_both)
+    assert results2["access_key_id"] == TEST_ACCESS_KEY_ID

--- a/tests/test_plugin_ses.py
+++ b/tests/test_plugin_ses.py
@@ -284,6 +284,15 @@ apprise_url_tests = (
             "test_requests_exceptions": True,
         },
     ),
+    (
+        # Session token in the URL password field
+        "ses://user:SESSIONTOKEN@example.com/T1JJ3T3L2/A1BRTD4JD/"
+        "TIiacevi7FQ/us-west-2/user2@example.com",
+        {
+            "instance": NotifySES,
+            "requests_response_text": AWS_SES_GOOD_RESPONSE,
+        },
+    ),
 )
 
 
@@ -544,10 +553,10 @@ def test_plugin_ses_session_token(mock_post):
     auth = call_kwargs["headers"]["Authorization"]
     assert "x-amz-security-token" in auth
 
-    # URL round-trip: token appears in query params
+    # URL round-trip: token appears in the password field, not ?token=
     url = obj.url()
-    assert "token=" in url
-    assert TEST_SESSION_TOKEN in url
+    assert f":{TEST_SESSION_TOKEN}@" in url
+    assert "token=" not in url
 
     results = NotifySES.parse_url(url)
     assert results["session_token"] == TEST_SESSION_TOKEN
@@ -557,10 +566,10 @@ def test_plugin_ses_session_token(mock_post):
     assert obj2.aws_session_token == TEST_SESSION_TOKEN
     assert obj2.url_identifier == obj.url_identifier
 
-    # Privacy URL must mask the token value
+    # Privacy URL must mask the token value (in the password position)
     priv_url = obj.url(privacy=True)
     assert TEST_SESSION_TOKEN not in priv_url
-    assert "token=" in priv_url
+    assert "token=" not in priv_url
 
     # Without a session token no X-Amz-Security-Token header is sent
     mock_post.reset_mock()
@@ -623,3 +632,47 @@ def test_plugin_ses_key_alias():
     )
     results2 = NotifySES.parse_url(url_both)
     assert results2["access_key_id"] == TEST_ACCESS_KEY_ID
+
+
+def test_plugin_ses_session_token_via_password_field():
+    """NotifySES() session token parsed from URL password position."""
+
+    # Token in the password field:
+    # ses://sender:{token}@example.com/{access_key_id}/...
+    url = (
+        f"ses://sender:{TEST_SESSION_TOKEN}@example.com"
+        f"/{TEST_ACCESS_KEY_ID}/{TEST_ACCESS_KEY_SECRET}"
+        f"/{TEST_REGION}/recipient@example.com"
+    )
+    results = NotifySES.parse_url(url)
+    assert results["session_token"] == TEST_SESSION_TOKEN
+    assert results["access_key_id"] == TEST_ACCESS_KEY_ID
+
+    obj = NotifySES(**results)
+    assert obj.aws_session_token == TEST_SESSION_TOKEN
+    assert obj.from_addr == "sender@example.com"
+
+    # Round-trip: url() emits password-field form, which re-parses correctly
+    regenerated = obj.url()
+    assert f":{TEST_SESSION_TOKEN}@" in regenerated
+    assert "token=" not in regenerated
+
+    results2 = NotifySES.parse_url(regenerated)
+    assert results2["session_token"] == TEST_SESSION_TOKEN
+
+    obj2 = NotifySES(**results2)
+    assert obj2.aws_session_token == TEST_SESSION_TOKEN
+    assert obj2.from_addr == obj.from_addr
+
+    # ?token= takes priority over the password field when both are present
+    url_both = (
+        f"ses://sender:WRONGTOKEN@example.com"
+        f"/{TEST_ACCESS_KEY_ID}/{TEST_ACCESS_KEY_SECRET}"
+        f"/{TEST_REGION}/recipient@example.com"
+        f"?token={TEST_SESSION_TOKEN}"
+    )
+    results3 = NotifySES.parse_url(url_both)
+    assert results3["session_token"] == TEST_SESSION_TOKEN
+
+    obj3 = NotifySES(**results3)
+    assert obj3.aws_session_token == TEST_SESSION_TOKEN

--- a/tests/test_plugin_sns.py
+++ b/tests/test_plugin_sns.py
@@ -43,6 +43,9 @@ TEST_ACCESS_KEY_ID = "AHIAJGNT76XIMXDBIJYA"
 TEST_ACCESS_KEY_SECRET = "bu1dHSdO22pfaaVy/wmNsdljF4C07D3bndi9PQJ9"
 TEST_REGION = "us-east-2"
 
+# A realistic-looking (but fake) AWS session token
+TEST_SESSION_TOKEN = "FwoGZXIvYXdzSESSIONTOKENABCDEFGHIJKLMNOPQRS"
+
 # Our Testing URLs
 apprise_url_tests = (
     (
@@ -122,6 +125,49 @@ apprise_url_tests = (
             "instance": NotifySNS,
             # Throws a series of i/o exceptions with this flag
             # is set and tests that we gracefully handle them
+            "test_requests_exceptions": True,
+        },
+    ),
+    (
+        # Session token in userinfo position (temporary/IAM credentials)
+        "sns://SESSIONTOKEN@T1JJ3T3L2"
+        "/A1BRTD4JD/TIiajkdnlazkcevi7FQ/us-west-2/12223334444",
+        {
+            "instance": NotifySNS,
+        },
+    ),
+    (
+        # Session token via ?token= query parameter
+        "sns://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcevi7FQ"
+        "/us-west-2/12223334444?token=SESSIONTOKEN",
+        {
+            "instance": NotifySNS,
+        },
+    ),
+    (
+        # Access key via ?key= alias
+        "sns://?key=T1JJ3T3L2&secret=A1BRTD4JD/TIiajkdnlazkcevi7FQ"
+        "&region=us-west-2&to=12223334444",
+        {
+            "instance": NotifySNS,
+        },
+    ),
+    (
+        # Session token + HTTP error
+        "sns://SESSIONTOKEN@T1JJ3T3L2"
+        "/A1BRTD4JD/TIiajkdnlazkcevi7FQ/us-west-2/12223334444",
+        {
+            "instance": NotifySNS,
+            "response": False,
+            "requests_response_code": 999,
+        },
+    ),
+    (
+        # Session token + request exceptions
+        "sns://SESSIONTOKEN@T1JJ3T3L2"
+        "/A1BRTD4JD/TIiajkdnlazkcevi7FQ/us-west-2/15556667777",
+        {
+            "instance": NotifySNS,
             "test_requests_exceptions": True,
         },
     ),
@@ -445,6 +491,129 @@ def test_plugin_sns_aws_topic_handling(mock_post):
     mock_post.return_value = robj
     # We would have failed to make Post
     assert a.notify(title="", body="test") is True
+
+
+@mock.patch("requests.post")
+def test_plugin_sns_session_token(mock_post):
+    """NotifySNS() session token for temporary/IAM credentials."""
+
+    response = mock.MagicMock()
+    response.status_code = requests.codes.ok
+    response.text = ""
+    mock_post.return_value = response
+
+    # Init with session token
+    obj = NotifySNS(
+        access_key_id=TEST_ACCESS_KEY_ID,
+        secret_access_key=TEST_ACCESS_KEY_SECRET,
+        region_name=TEST_REGION,
+        targets="+18001234567",
+        session_token=TEST_SESSION_TOKEN,
+    )
+    assert obj.aws_session_token == TEST_SESSION_TOKEN
+
+    # send() must include X-Amz-Security-Token in request headers
+    assert obj.notify(body="test") is True
+    call_kwargs = mock_post.call_args[1]
+    assert "X-Amz-Security-Token" in call_kwargs["headers"]
+    assert call_kwargs["headers"]["X-Amz-Security-Token"] == TEST_SESSION_TOKEN
+
+    # x-amz-security-token must also appear in the Authorization header
+    # (it is listed in SignedHeaders)
+    auth = call_kwargs["headers"]["Authorization"]
+    assert "x-amz-security-token" in auth
+
+    # URL round-trip via userinfo position
+    url = obj.url()
+    assert "@" in url
+    assert TEST_SESSION_TOKEN in url
+
+    results = NotifySNS.parse_url(url)
+    assert results["session_token"] == TEST_SESSION_TOKEN
+    assert results["access_key_id"] == TEST_ACCESS_KEY_ID
+
+    obj2 = NotifySNS(**results)
+    assert obj2.aws_session_token == TEST_SESSION_TOKEN
+    assert obj2.url_identifier == obj.url_identifier
+
+    # Privacy URL must mask the token but keep the @ separator
+    priv_url = obj.url(privacy=True)
+    assert TEST_SESSION_TOKEN not in priv_url
+    assert "@" in priv_url
+
+    # Without a session token no X-Amz-Security-Token header is sent
+    mock_post.reset_mock()
+    obj_plain = NotifySNS(
+        access_key_id=TEST_ACCESS_KEY_ID,
+        secret_access_key=TEST_ACCESS_KEY_SECRET,
+        region_name=TEST_REGION,
+        targets="+18001234567",
+    )
+    assert obj_plain.aws_session_token is None
+    assert obj_plain.notify(body="test") is True
+    call_kwargs = mock_post.call_args[1]
+    assert "X-Amz-Security-Token" not in call_kwargs["headers"]
+
+    # url() without token has no @ separator
+    plain_url = obj_plain.url()
+    assert "@" not in plain_url
+
+
+@mock.patch("requests.post")
+def test_plugin_sns_session_token_via_kwarg(mock_post):
+    """NotifySNS() session token parsed from ?token= kwarg."""
+
+    response = mock.MagicMock()
+    response.status_code = requests.codes.ok
+    response.text = ""
+    mock_post.return_value = response
+
+    url = (
+        f"sns://{TEST_ACCESS_KEY_ID}/{TEST_ACCESS_KEY_SECRET}"
+        f"/{TEST_REGION}/+18001234567?token={TEST_SESSION_TOKEN}"
+    )
+    results = NotifySNS.parse_url(url)
+    assert results["session_token"] == TEST_SESSION_TOKEN
+
+    obj = NotifySNS(**results)
+    assert obj.aws_session_token == TEST_SESSION_TOKEN
+    assert obj.notify(body="test") is True
+
+    call_kwargs = mock_post.call_args[1]
+    assert call_kwargs["headers"]["X-Amz-Security-Token"] == TEST_SESSION_TOKEN
+
+    # ?token= overrides userinfo when both are present
+    url_both = (
+        f"sns://OTHERTOKEN@{TEST_ACCESS_KEY_ID}/{TEST_ACCESS_KEY_SECRET}"
+        f"/{TEST_REGION}/+18001234567?token={TEST_SESSION_TOKEN}"
+    )
+    results2 = NotifySNS.parse_url(url_both)
+    assert results2["session_token"] == TEST_SESSION_TOKEN
+
+
+def test_plugin_sns_key_alias():
+    """NotifySNS() ?key= alias for access_key_id."""
+
+    # ?key= resolves to access_key_id
+    url = (
+        f"sns://?key={TEST_ACCESS_KEY_ID}"
+        f"&secret={TEST_ACCESS_KEY_SECRET}"
+        f"&region={TEST_REGION}&to=+18001234567"
+    )
+    results = NotifySNS.parse_url(url)
+    assert results["access_key_id"] == TEST_ACCESS_KEY_ID
+
+    obj = NotifySNS(**results)
+    assert obj.aws_access_key_id == TEST_ACCESS_KEY_ID
+
+    # ?key= takes priority over ?access= when both appear
+    url_both = (
+        f"sns://?key={TEST_ACCESS_KEY_ID}&access=OTHERID"
+        f"&secret={TEST_ACCESS_KEY_SECRET}"
+        f"&region={TEST_REGION}&to=+18001234567"
+    )
+    results2 = NotifySNS.parse_url(url_both)
+    assert results2["access_key_id"] == TEST_ACCESS_KEY_ID
 
 
 def test_plugin_sns_detailed_failures(mocker):

--- a/tests/test_plugin_sns.py
+++ b/tests/test_plugin_sns.py
@@ -44,7 +44,7 @@ TEST_ACCESS_KEY_SECRET = "bu1dHSdO22pfaaVy/wmNsdljF4C07D3bndi9PQJ9"
 TEST_REGION = "us-east-2"
 
 # A realistic-looking (but fake) AWS session token
-TEST_SESSION_TOKEN = "FwoGZXIvYXdzSESSIONTOKENABCDEFGHIJKLMNOPQRS"
+TEST_SESSION_TOKEN = "FwoGZXIvYXdz+SESSION/TOKENABCDEFGHIJKLMNOPQRS="
 
 # Our Testing URLs
 apprise_url_tests = (

--- a/tests/test_plugin_sns.py
+++ b/tests/test_plugin_sns.py
@@ -34,7 +34,7 @@ import pytest
 import requests
 
 from apprise import Apprise
-from apprise.plugins.sns import NotifySNS
+from apprise.plugins.sns import NotifySNS, SNSMode
 
 logging.disable(logging.CRITICAL)
 
@@ -169,6 +169,30 @@ apprise_url_tests = (
         {
             "instance": NotifySNS,
             "test_requests_exceptions": True,
+        },
+    ),
+    (
+        # Explicit SMS mode
+        "sns://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcevi7FQ"
+        "/us-west-2/12223334444?mode=sms",
+        {
+            "instance": NotifySNS,
+        },
+    ),
+    (
+        # Forced topic mode on a phone target
+        "sns://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcevi7FQ"
+        "/us-west-2/12223334444?mode=topic",
+        {
+            "instance": NotifySNS,
+        },
+    ),
+    (
+        # Invalid mode raises TypeError
+        "sns://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcevi7FQ"
+        "/us-west-2/12223334444?mode=invalid",
+        {
+            "instance": TypeError,
         },
     ),
 )
@@ -688,3 +712,223 @@ def test_plugin_sns_detailed_failures(mocker):
 
     # Should return False because Publish failed
     assert obj_topic.notify(body="test") is False
+
+
+def test_plugin_sns_mode_detection():
+    """NotifySNS() auto-detects and validates operating mode."""
+
+    # Topic-only targets -> TOPIC mode auto-detected
+    obj = NotifySNS(
+        access_key_id=TEST_ACCESS_KEY_ID,
+        secret_access_key=TEST_ACCESS_KEY_SECRET,
+        region_name=TEST_REGION,
+        targets=["#MyTopic"],
+    )
+    assert obj.mode == SNSMode.TOPIC
+    assert obj.title_maxlen == 100
+    assert obj.body_maxlen == 256000
+
+    # Phone targets -> SMS mode auto-detected
+    obj = NotifySNS(
+        access_key_id=TEST_ACCESS_KEY_ID,
+        secret_access_key=TEST_ACCESS_KEY_SECRET,
+        region_name=TEST_REGION,
+        targets=["+18001234567"],
+    )
+    assert obj.mode == SNSMode.SMS
+    assert obj.title_maxlen == 0
+    assert obj.body_maxlen == 160
+
+    # Mixed targets -> SMS mode (safe default)
+    obj = NotifySNS(
+        access_key_id=TEST_ACCESS_KEY_ID,
+        secret_access_key=TEST_ACCESS_KEY_SECRET,
+        region_name=TEST_REGION,
+        targets=["+18001234567", "#MyTopic"],
+    )
+    assert obj.mode == SNSMode.SMS
+
+    # No targets -> SMS mode (safe default)
+    obj = NotifySNS(
+        access_key_id=TEST_ACCESS_KEY_ID,
+        secret_access_key=TEST_ACCESS_KEY_SECRET,
+        region_name=TEST_REGION,
+        targets=[],
+    )
+    assert obj.mode == SNSMode.SMS
+
+    # Explicit mode=topic overrides auto-detection for phone-only URL
+    obj = NotifySNS(
+        access_key_id=TEST_ACCESS_KEY_ID,
+        secret_access_key=TEST_ACCESS_KEY_SECRET,
+        region_name=TEST_REGION,
+        targets=["+18001234567"],
+        mode=SNSMode.TOPIC,
+    )
+    assert obj.mode == SNSMode.TOPIC
+
+    # Explicit mode=sms overrides auto-detection for topic-only URL
+    obj = NotifySNS(
+        access_key_id=TEST_ACCESS_KEY_ID,
+        secret_access_key=TEST_ACCESS_KEY_SECRET,
+        region_name=TEST_REGION,
+        targets=["#MyTopic"],
+        mode=SNSMode.SMS,
+    )
+    assert obj.mode == SNSMode.SMS
+
+    # Prefix matching: "to" -> "topic"
+    obj = NotifySNS(
+        access_key_id=TEST_ACCESS_KEY_ID,
+        secret_access_key=TEST_ACCESS_KEY_SECRET,
+        region_name=TEST_REGION,
+        targets=["#MyTopic"],
+        mode="to",
+    )
+    assert obj.mode == SNSMode.TOPIC
+
+    # Invalid mode raises TypeError
+    with pytest.raises(TypeError):
+        NotifySNS(
+            access_key_id=TEST_ACCESS_KEY_ID,
+            secret_access_key=TEST_ACCESS_KEY_SECRET,
+            region_name=TEST_REGION,
+            targets=["#MyTopic"],
+            mode="invalid",
+        )
+
+
+@mock.patch("requests.post")
+def test_plugin_sns_topic_mode_send(mock_post):
+    """NotifySNS() TOPIC mode sets Subject field on topic payloads."""
+
+    arn_response = (
+        "<CreateTopicResponse>"
+        "<CreateTopicResult>"
+        "<TopicArn>"
+        "arn:aws:sns:us-east-2:000000000000:MyTopic"
+        "</TopicArn>"
+        "</CreateTopicResult>"
+        "</CreateTopicResponse>"
+    )
+
+    # Capture the most recent Publish payload for inspection
+    publish_data = {}
+
+    def side_effect(url, data, **kwargs):
+        """Return ARN on CreateTopic; record payload on Publish."""
+        robj = mock.Mock()
+        robj.status_code = requests.codes.ok
+        if "Action=CreateTopic" in data:
+            robj.text = arn_response
+        elif "Action=Publish" in data:
+            publish_data["data"] = data
+            robj.text = ""
+        else:
+            robj.text = ""
+        return robj
+
+    mock_post.side_effect = side_effect
+
+    # Topic-only -> TOPIC mode auto-detected; title goes to Subject
+    obj = NotifySNS(
+        access_key_id=TEST_ACCESS_KEY_ID,
+        secret_access_key=TEST_ACCESS_KEY_SECRET,
+        region_name=TEST_REGION,
+        targets=["#MyTopic"],
+    )
+    assert obj.mode == SNSMode.TOPIC
+
+    # With title: Subject must appear in the Publish payload
+    assert obj.notify(title="My Title", body="My Body") is True
+    # urlencode() uses %20 for spaces
+    assert "Subject=My%20Title" in publish_data["data"]
+    assert "Message=My%20Body" in publish_data["data"]
+
+    # With no title: Subject must not appear in the Publish payload
+    publish_data.clear()
+    assert obj.notify(title="", body="My Body") is True
+    assert "Subject=" not in publish_data.get("data", "")
+
+
+@mock.patch("requests.post")
+def test_plugin_sns_topic_mode_phone_forced(mock_post):
+    """NotifySNS() TOPIC mode forced on phone target prepends title."""
+
+    response = mock.MagicMock()
+    response.status_code = requests.codes.ok
+    response.text = ""
+    mock_post.return_value = response
+
+    # Force TOPIC mode on a phone target
+    obj = NotifySNS(
+        access_key_id=TEST_ACCESS_KEY_ID,
+        secret_access_key=TEST_ACCESS_KEY_SECRET,
+        region_name=TEST_REGION,
+        targets=["+18001234567"],
+        mode=SNSMode.TOPIC,
+    )
+    assert obj.mode == SNSMode.TOPIC
+
+    # With a title: it must be prepended to the body in the SMS payload
+    assert obj.notify(title="My Title", body="My Body") is True
+    data = mock_post.call_args[1]["data"]
+    # urlencode() uses %20 for spaces; \r\n becomes %0D%0A
+    assert "My%20Title" in data
+    assert "My%20Body" in data
+
+    # With no title: body is sent as-is without modification
+    mock_post.reset_mock()
+    assert obj.notify(title="", body="My Body") is True
+    data = mock_post.call_args[1]["data"]
+    assert "My%20Body" in data
+
+
+def test_plugin_sns_mode_url_round_trip():
+    """NotifySNS() mode is preserved through url() and parse_url()."""
+
+    # TOPIC mode round-trip
+    obj = NotifySNS(
+        access_key_id=TEST_ACCESS_KEY_ID,
+        secret_access_key=TEST_ACCESS_KEY_SECRET,
+        region_name=TEST_REGION,
+        targets=["#MyTopic"],
+        mode=SNSMode.TOPIC,
+    )
+    url = obj.url()
+    assert "mode=topic" in url
+
+    results = NotifySNS.parse_url(url)
+    assert results["mode"] == SNSMode.TOPIC
+
+    obj2 = NotifySNS(**results)
+    assert obj2.mode == SNSMode.TOPIC
+    assert obj2.url_identifier == obj.url_identifier
+
+    # SMS mode round-trip
+    obj = NotifySNS(
+        access_key_id=TEST_ACCESS_KEY_ID,
+        secret_access_key=TEST_ACCESS_KEY_SECRET,
+        region_name=TEST_REGION,
+        targets=["+18001234567"],
+        mode=SNSMode.SMS,
+    )
+    url = obj.url()
+    assert "mode=sms" in url
+
+    results = NotifySNS.parse_url(url)
+    assert results["mode"] == SNSMode.SMS
+
+    obj2 = NotifySNS(**results)
+    assert obj2.mode == SNSMode.SMS
+
+    # No mode in URL -> auto-detection runs on re-instantiation
+    url_no_mode = (
+        f"sns://{TEST_ACCESS_KEY_ID}/{TEST_ACCESS_KEY_SECRET}"
+        f"/{TEST_REGION}/+18001234567"
+    )
+    results = NotifySNS.parse_url(url_no_mode)
+    assert results["mode"] is None
+    obj3 = NotifySNS(**results)
+    # Auto-detected from phone target
+    assert obj3.mode == SNSMode.SMS

--- a/tests/test_plugin_sns.py
+++ b/tests/test_plugin_sns.py
@@ -547,10 +547,11 @@ def test_plugin_sns_session_token(mock_post):
     auth = call_kwargs["headers"]["Authorization"]
     assert "x-amz-security-token" in auth
 
-    # URL round-trip via userinfo position
+    # URL round-trip via userinfo position; + and = stay unencoded
+    # (safe in userinfo); / is encoded since it terminates the netloc
     url = obj.url()
     assert "@" in url
-    assert TEST_SESSION_TOKEN in url
+    assert NotifySNS.quote(TEST_SESSION_TOKEN, safe="+=") in url
 
     results = NotifySNS.parse_url(url)
     assert results["session_token"] == TEST_SESSION_TOKEN


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #979, #1157 and PR  #797

**SNS** support for session_token
```text
sns://{SessionToken}@{AccessKeyID}/{SecretKey}/{Region}/+{PhoneNo}
sns://{AccessKeyID}/{SecretKey}/{Region}/+{PhoneNo}?token={SessionToken}
```

**SES** -- support for session_token as well.
```text
ses://user:{SessionToken}@example.com/{AccessKeyID}/{SecretKey}/{Region}
ses://user@example.com/{AccessKeyID}/{SecretKey}/{Region}?token={SessionToken}
```

Both plugins also gain `?key=` as a more intuitive alias for `access_key_id` (alongside the existing `?access=`), and `?token=` / `?secret=` aliases for YAML config use.

SNS topics now support a `Subject` field (up to 100 characters) that maps naturally to Apprise's title. SMS messages have no such field. Previously, the title was always folded into the body for all target types (`title_maxlen = 0`).

**Auto-detection**: mode is determined at `__init__` time from target composition -- topic-only URLs get `topic` mode; any URL with a phone number stays on `sms` mode. Users can override with `?mode=sms` or `?mode=topic`.

## Checklist
* [x] Documentation ticket created (if applicable): [apprise-doc/72](https://github.com/caronc/apprise-docs/pull/72)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing

```bash
# Create a virtual environment
python3 -m venv apprise
cd apprise
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@979-sns-improvements

# SMS with session token (Lambda/IAM role credentials)
apprise -vv -b "Lambda alert" \
  "sns://MySessionToken@AKIAIOSFODNN7EXAMPLE/wJalrXUtnFEMI/us-east-1/+18005551234"

# Topic mode (title becomes SNS Subject)
apprise -vv -t "Alert Subject" -b "Alert Body" \
  "sns://AKIAIOSFODNN7EXAMPLE/wJalrXUtnFEMI/us-east-1/#MyTopic"

# Force SMS mode on a topic URL
apprise -vv -t "My Title" -b "My Body" \
  "sns://AKIAIOSFODNN7EXAMPLE/wJalrXUtnFEMI/us-east-1/#MyTopic?mode=sms"

# SES with session token
apprise -vv -b "Test" \
  "ses://sender@example.com/AKIAIOSFODNN7EXAMPLE/wJalrXUtnFEMI/us-east-1?token=MySessionToken&to=recipient@example.com"
```
