### PR TITLE
TRACE logging during apprise init cleaned up

### DIFF
--- a/apprise/manager_config.py
+++ b/apprise/manager_config.py
@@ -52,5 +52,5 @@ class ConfigurationManager(PluginManager):
 
     # For filtering our result set
     module_filter_re = re.compile(
-        r"^(?P<name>" + fname_prefix + r"(?!Base)[A-Za-z0-9]+)$"
+        r"^(?P<name>" + fname_prefix + r"(?!Base|Format)[A-Za-z0-9]+)$"
     )

--- a/apprise/manager_plugins.py
+++ b/apprise/manager_plugins.py
@@ -52,5 +52,7 @@ class NotificationManager(PluginManager):
 
     # For filtering our result set
     module_filter_re = re.compile(
-        r"^(?P<name>" + fname_prefix + r"(?!Base|ImageSize|Type)[A-Za-z0-9]+)$"
+        r"^(?P<name>"
+        + fname_prefix
+        + r"(?!Base|Format|ImageSize|Type)[A-Za-z0-9]+)$"
     )

--- a/tests/test_apprise_attachments.py
+++ b/tests/test_apprise_attachments.py
@@ -40,6 +40,7 @@ from apprise import Apprise, AppriseAsset, AttachmentManager
 from apprise.apprise_attachment import AppriseAttachment
 from apprise.attachment import AttachBase
 from apprise.common import ContentLocation
+from apprise.logger import LogCapture
 
 logging.disable(logging.CRITICAL)
 
@@ -456,3 +457,37 @@ def test_attachment_matrix_dynamic_importing(tmpdir):
     )
 
     A_MGR.load_modules(path=str(base), name=module_name)
+
+
+def test_attachment_manager_no_import_failures():
+    """Verify all native attach plugins load without TRACE import errors."""
+
+    # Remove the global test-suite log suppression so TRACE records
+    # are visible during the scan below
+    logging.disable(logging.NOTSET)
+
+    # Force a clean reload of the native attachment plugin directory
+    A_MGR.unload_modules()
+
+    with LogCapture(level=logging.TRACE) as stream:
+        # Trigger load_modules() via the lazy-load path
+        len(A_MGR)
+
+        # Grab the captured log content before the handler is removed
+        content = stream.getvalue()
+
+    # Restore log suppression for the remainder of the test suite
+    logging.disable(logging.CRITICAL)
+
+    # Any "import failed" line means a plugin directory was found but
+    # contained no loadable Attach* class (e.g. a stale __pycache__
+    # directory left behind after a rename).
+    failures = [
+        line for line in content.splitlines() if "import failed" in line
+    ]
+    assert not failures, (
+        "Attachment plugin import failures detected:\n" + "\n".join(failures)
+    )
+
+    # Leave the manager in a clean state for subsequent tests
+    A_MGR.unload_modules()

--- a/tests/test_apprise_config.py
+++ b/tests/test_apprise_config.py
@@ -45,6 +45,7 @@ from apprise import (
 )
 from apprise.config import ConfigBase
 from apprise.config.file import ConfigFile
+from apprise.logger import LogCapture
 from apprise.plugins import NotifyBase
 
 logging.disable(logging.CRITICAL)
@@ -1533,3 +1534,37 @@ def test_config_base_expired_with_int_cache(monkeypatch):
     # Beyond cache window
     monkeypatch.setattr(time, "time", lambda: 1031.0)
     assert cb.expired() is True
+
+
+def test_configuration_manager_no_import_failures():
+    """Verify all native config plugins load without TRACE import errors."""
+
+    # Remove the global test-suite log suppression so TRACE records
+    # are visible during the scan below
+    logging.disable(logging.NOTSET)
+
+    # Force a clean reload of the native config plugin directory
+    C_MGR.unload_modules()
+
+    with LogCapture(level=logging.TRACE) as stream:
+        # Trigger load_modules() via the lazy-load path
+        len(C_MGR)
+
+        # Grab the captured log content before the handler is removed
+        content = stream.getvalue()
+
+    # Restore log suppression for the remainder of the test suite
+    logging.disable(logging.CRITICAL)
+
+    # Any "import failed" line means a plugin directory was found but
+    # contained no loadable Config* class (e.g. a stale __pycache__
+    # directory left behind after a rename).
+    failures = [
+        line for line in content.splitlines() if "import failed" in line
+    ]
+    assert not failures, (
+        "Config plugin import failures detected:\n" + "\n".join(failures)
+    )
+
+    # Leave the manager in a clean state for subsequent tests
+    C_MGR.unload_modules()

--- a/tests/test_notification_manager.py
+++ b/tests/test_notification_manager.py
@@ -37,6 +37,7 @@ import types
 import pytest
 
 from apprise import Apprise, NotificationManager
+from apprise.logger import LogCapture
 from apprise.plugins import NotifyBase
 
 logging.disable(logging.CRITICAL)
@@ -1023,4 +1024,38 @@ def test_load_modules_schema_conflict(tmpdir):
     # fallback loads the file; NotifyConflict.schemas() = {"json"};
     # "json" already in _schema_map -> conflict logged, skipped
     N_MGR.load_modules(path=str(tmpdir))
+    N_MGR.unload_modules()
+
+
+def test_notification_manager_no_import_failures():
+    """Verify all native plugins load without TRACE import errors."""
+
+    # Remove the global test-suite log suppression so TRACE records
+    # are visible during the scan below
+    logging.disable(logging.NOTSET)
+
+    # Force a clean reload of the native plugin directory
+    N_MGR.unload_modules()
+
+    with LogCapture(level=logging.TRACE) as stream:
+        # Trigger load_modules() via the lazy-load path
+        len(N_MGR)
+
+        # Grab the captured log content before the handler is removed
+        content = stream.getvalue()
+
+    # Restore log suppression for the remainder of the test suite
+    logging.disable(logging.CRITICAL)
+
+    # Any "import failed" line means a plugin directory was found but
+    # contained no loadable Notify* class (e.g. a stale __pycache__
+    # directory left behind after a rename).
+    failures = [
+        line for line in content.splitlines() if "import failed" in line
+    ]
+    assert not failures, "Plugin import failures detected:\n" + "\n".join(
+        failures
+    )
+
+    # Leave the manager in a clean state for subsequent tests
     N_MGR.unload_modules()


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1621

`TRACE` Logging cleaned up during Apprise initialization.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [ ] Documentation ticket created (if applicable) n/a
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1621-trace-log-noise-cleanup

# If you have cloned the branch and have tox available to you:
tox -e qa
```
