### PR TITLE
fix(telegram): render Markdown with Telegram formatting

### DIFF
--- a/apprise/apprise.py
+++ b/apprise/apprise.py
@@ -1019,6 +1019,10 @@ class Apprise:
                 # pulled out of the notification
                 key += "-emojis"
 
+            conversion = getattr(server, "convert_between", convert_between)
+            if conversion != convert_between:
+                key += f"-{server.__class__.__name__}-convert"
+
             if key not in conversion_title_map:
                 # Prepare our title
                 conversion_title_map[key] = title if title else ""
@@ -1026,14 +1030,14 @@ class Apprise:
                 # Conversion of title only occurs for services where the title
                 # is blended with the body (title_maxlen <= 0)
                 if conversion_title_map[key] and server.title_maxlen <= 0:
-                    conversion_title_map[key] = convert_between(
+                    conversion_title_map[key] = conversion(
                         body_format,
                         server.notify_format,
                         content=conversion_title_map[key],
                     )
 
                 # Our body is always converted no matter what
-                conversion_body_map[key] = convert_between(
+                conversion_body_map[key] = conversion(
                     body_format, server.notify_format, content=body
                 )
 

--- a/apprise/plugins/telegram.py
+++ b/apprise/plugins/telegram.py
@@ -211,7 +211,7 @@ def _escape_telegram_markdown_text(value, markdown_ver):
     if markdown_ver == TelegramMarkdownVersion.TWO:
         return re.sub(r"([\\_*[\]()~`>#+\-=|{}.!])", r"\\\1", value)
 
-    return re.sub(r"([\\*_`\[])", r"\\\1", value)
+    return re.sub(r"([\\*_`])", r"\\\1", value)
 
 
 class TelegramMarkdownHTMLConverter(HTMLParser):

--- a/apprise/plugins/telegram.py
+++ b/apprise/plugins/telegram.py
@@ -51,10 +51,12 @@
 #
 # Development API Reference::
 #  - https://core.telegram.org/bots/api
+from html.parser import HTMLParser
 from json import dumps, loads
 import os
 import re
 
+from markdown import markdown
 import requests
 
 from ..attachment.base import AttachBase
@@ -64,6 +66,7 @@ from ..common import (
     NotifyType,
     PersistentStoreMode,
 )
+from ..conversion import convert_between
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_bool, parse_list, validate_regex
 from .base import NotifyBase
@@ -123,6 +126,246 @@ TELEGRAM_CONTENT_PLACEMENT = (
     TelegramContentPlacement.AFTER,
 )
 
+TELEGRAM_HTML_BLOCK_TAGS = frozenset((
+    "blockquote",
+    "div",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "li",
+    "p",
+    "pre",
+))
+
+TELEGRAM_HTML_PARAGRAPH_TAGS = frozenset((
+    "blockquote",
+    "div",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "p",
+))
+
+
+def _telegram_markdown_html(content):
+    """Convert standard Markdown to HTML suitable for Telegram rendering."""
+    content = re.sub(r"~~(.+?)~~", r"<del>\1</del>", content, flags=re.S)
+    return markdown(
+        content,
+        extensions=[
+            "markdown.extensions.fenced_code",
+            "markdown.extensions.nl2br",
+            "markdown.extensions.tables",
+        ],
+    )
+
+
+def _ensure_line_break(result):
+    """Ensure the token list ends in one newline."""
+    if not result:
+        return
+
+    value = "".join(result)
+    if not value.endswith("\n"):
+        result.append("\n")
+
+
+def _ensure_paragraph_break(result):
+    """Ensure the token list ends in one paragraph break."""
+    if not result:
+        return
+
+    value = "".join(result)
+    if value.endswith("\n\n"):
+        return
+    if value.endswith("\n"):
+        result.append("\n")
+    else:
+        result.append("\n\n")
+
+
+def _escape_telegram_markdown_code_text(value, markdown_ver):
+    """Escape text inside Telegram Markdown code/pre sections."""
+    if markdown_ver != TelegramMarkdownVersion.TWO:
+        return value
+
+    return value.replace("\\", "\\\\").replace("`", "\\`")
+
+
+def _escape_telegram_markdown_link(value, markdown_ver):
+    """Escape Telegram Markdown link destinations."""
+    if markdown_ver != TelegramMarkdownVersion.TWO:
+        return value
+
+    return value.replace("\\", "\\\\").replace(")", "\\)")
+
+
+def _escape_telegram_markdown_text(value, markdown_ver):
+    """Escape regular Telegram Markdown text."""
+    if markdown_ver == TelegramMarkdownVersion.TWO:
+        return re.sub(r"([\\_*[\]()~`>#+\-=|{}.!])", r"\\\1", value)
+
+    return re.sub(r"([\\*_`\[])", r"\\\1", value)
+
+
+class TelegramMarkdownHTMLConverter(HTMLParser):
+    """Render a small HTML subset into Telegram Markdown."""
+
+    def __init__(self, markdown_ver):
+        super().__init__(convert_charrefs=True)
+        self.markdown_ver = markdown_ver
+        self.result = []
+        self.stack = []
+        self.trim_leading_newline = False
+
+    @property
+    def converted(self):
+        return "".join(self.result).strip("\n")
+
+    @property
+    def in_code(self):
+        return any(entry["tag"] in ("code", "pre") for entry in self.stack)
+
+    def handle_starttag(self, tag, attrs):
+        tag = tag.lower()
+        attrs = dict(attrs)
+        parent_is_pre = self._current_is("pre")
+
+        if self.result:
+            if tag in TELEGRAM_HTML_PARAGRAPH_TAGS:
+                _ensure_paragraph_break(self.result)
+            elif tag in TELEGRAM_HTML_BLOCK_TAGS:
+                _ensure_line_break(self.result)
+
+        entry = {
+            "tag": tag,
+            "href": attrs.get("href"),
+            "parent_is_pre": parent_is_pre,
+        }
+        self.stack.append(entry)
+
+        if tag == "a" and entry["href"]:
+            self.result.append("[")
+
+        elif tag in ("b", "strong", "h1", "h2", "h3", "h4", "h5", "h6"):
+            self.result.append("*")
+
+        elif tag in ("em", "i"):
+            self.result.append("_")
+
+        elif tag in ("del", "s", "strike"):
+            if self.markdown_ver == TelegramMarkdownVersion.TWO:
+                self.result.append("~")
+
+        elif tag == "br":
+            _ensure_line_break(self.result)
+            self.trim_leading_newline = True
+
+        elif tag == "code" and not parent_is_pre:
+            self.result.append("`")
+
+        elif tag == "li":
+            self.result.append(
+                "\\- " if self.markdown_ver == TelegramMarkdownVersion.TWO
+                else "- "
+            )
+
+        elif tag == "pre":
+            self.result.append("```\n")
+
+    def handle_startendtag(self, tag, attrs):
+        if tag.lower() == "br":
+            _ensure_line_break(self.result)
+            self.trim_leading_newline = True
+            return
+
+        self.handle_starttag(tag, attrs)
+        self.handle_endtag(tag)
+
+    def handle_endtag(self, tag):
+        tag = tag.lower()
+        entry = self._pop_tag(tag)
+
+        if tag == "a" and entry and entry["href"]:
+            self.result.append("](")
+            self.result.append(
+                _escape_telegram_markdown_link(
+                    entry["href"], self.markdown_ver
+                )
+            )
+            self.result.append(")")
+
+        elif tag in ("b", "strong", "h1", "h2", "h3", "h4", "h5", "h6"):
+            self.result.append("*")
+
+        elif tag in ("em", "i"):
+            self.result.append("_")
+
+        elif tag in ("del", "s", "strike"):
+            if self.markdown_ver == TelegramMarkdownVersion.TWO:
+                self.result.append("~")
+
+        elif tag == "code" and entry and not entry["parent_is_pre"]:
+            self.result.append("`")
+
+        elif tag == "pre":
+            self.result.append("```")
+
+        if tag in TELEGRAM_HTML_PARAGRAPH_TAGS:
+            _ensure_paragraph_break(self.result)
+        elif tag in TELEGRAM_HTML_BLOCK_TAGS:
+            _ensure_line_break(self.result)
+
+    def handle_data(self, data):
+        if self.trim_leading_newline:
+            data = data.lstrip("\r\n")
+            self.trim_leading_newline = False
+
+        if self.in_code:
+            self.result.append(
+                _escape_telegram_markdown_code_text(
+                    data, self.markdown_ver
+                )
+            )
+            return
+
+        if not data.strip() and "\n" in data:
+            return
+
+        self.result.append(
+            _escape_telegram_markdown_text(data, self.markdown_ver)
+        )
+
+    def _current_is(self, tag):
+        return bool(self.stack) and self.stack[-1]["tag"] == tag
+
+    def _pop_tag(self, tag):
+        for index in range(len(self.stack) - 1, -1, -1):
+            if self.stack[index]["tag"] == tag:
+                return self.stack.pop(index)
+        return None
+
+
+def _telegram_markdown_from_html(content, markdown_ver):
+    """Convert HTML content into Telegram Markdown."""
+    parser = TelegramMarkdownHTMLConverter(markdown_ver)
+    parser.feed(content)
+    parser.close()
+    return parser.converted
+
+
+def _telegram_markdown_from_standard_markdown(content, markdown_ver):
+    """Convert standard Markdown content into Telegram Markdown."""
+    return _telegram_markdown_from_html(
+        _telegram_markdown_html(content), markdown_ver
+    )
+
 
 class NotifyTelegram(NotifyBase):
     """A wrapper for Telegram Notifications."""
@@ -168,6 +411,13 @@ class NotifyTelegram(NotifyBase):
     # Our default is to no not use persistent storage beyond in-memory
     # reference
     storage_mode = PersistentStoreMode.AUTO
+
+    def convert_between(self, from_format, to_format, content):
+        """Let Telegram perform its own Markdown target conversion."""
+        if to_format == NotifyFormat.MARKDOWN:
+            return content
+
+        return convert_between(from_format, to_format, content)
 
     # Define object templates
     templates = (
@@ -857,16 +1107,21 @@ class NotifyTelegram(NotifyBase):
 
         # Prepare Message Body
         if self.notify_format == NotifyFormat.MARKDOWN:
-            if (
-                body_format not in (None, NotifyFormat.MARKDOWN)
+            if body_format == NotifyFormat.MARKDOWN:
+                body = _telegram_markdown_from_standard_markdown(
+                    body, self.markdown_ver
+                )
+
+            elif body_format == NotifyFormat.HTML:
+                body = _telegram_markdown_from_html(body, self.markdown_ver)
+
+            elif (
+                body_format is not None
                 and self.markdown_ver == TelegramMarkdownVersion.TWO
             ):
-                # Telegram Markdown v2 is not very accomodating to some
-                # characters such as the hashtag (#) which is fine in v1.
-                # To try and be accomodating we escape them in advance
-                # See: https://stackoverflow.com/a/69892704/355584
-                # Also: https://core.telegram.org/bots/api#markdownv2-style
-                body = re.sub(r"(?<!\\)([_*[\]()~`>#+=|{}.!-])", r"\\\1", body)
+                body = _escape_telegram_markdown_text(
+                    body, self.markdown_ver
+                )
 
             payload_["parse_mode"] = self.markdown_ver
             payload_["text"] = body

--- a/apprise/plugins/telegram.py
+++ b/apprise/plugins/telegram.py
@@ -317,7 +317,26 @@ class NotifyTelegram(NotifyBase):
         ),
         (
             re.compile(
-                r"\s*<\s*/\s*(br|p|hr|li|div)([^a-z0-9>][^>]*)?>\s*",
+                r"\s*<\s*/\s*p([^a-z0-9>][^>]*)?>\s*(?=</b>)",
+                (re.I | re.M | re.S),
+            ),
+            "\r\n",
+            {},
+        ),
+        (
+            re.compile(
+                r"\s*<\s*/\s*p([^a-z0-9>][^>]*)?>\s*",
+                (re.I | re.M | re.S),
+            ),
+            "{}",
+            {
+                "markdown": "\r\n\r\n",
+                "default": "\r\n",
+            },
+        ),
+        (
+            re.compile(
+                r"\s*<\s*/\s*(br|hr|li|div)([^a-z0-9>][^>]*)?>\s*",
                 (re.I | re.M | re.S),
             ),
             "\r\n",
@@ -333,7 +352,14 @@ class NotifyTelegram(NotifyBase):
         (re.compile(r"\&apos;?", re.I), "'", {}),
         (re.compile(r"\&quot;?", re.I), '"', {}),
         # New line cleanup
-        (re.compile(r"\r*\n[\r\n]+", re.I), "\r\n", {}),
+        (
+            re.compile(r"(?:\r?\n){2,}", re.I),
+            "{}",
+            {
+                "markdown": "\r\n\r\n",
+                "default": "\r\n",
+            },
+        ),
     )
 
     # Define our template tokens
@@ -849,7 +875,18 @@ class NotifyTelegram(NotifyBase):
             # Use Telegram's HTML mode
             payload_["parse_mode"] = "HTML"
             for r, v, m in self.__telegram_escape_html_entries:
-                if "html" in m:
+                if "default" in m:
+                    # Handle format-sensitive line-break normalization. For
+                    # Markdown-origin content, preserve paragraph breaks while
+                    # keeping the legacy single-line cleanup for HTML/text.
+                    body_format_key = (
+                        body_format.value
+                        if isinstance(body_format, NotifyFormat)
+                        else body_format
+                    )
+                    v = v.format(m.get(body_format_key, m["default"]))
+
+                elif "html" in m:
                     # Handle special cases where we need to alter new lines
                     # for presentation purposes
                     v = v.format(
@@ -860,6 +897,11 @@ class NotifyTelegram(NotifyBase):
                     )
 
                 body = r.sub(v, body)
+
+            if body_format == NotifyFormat.MARKDOWN and body.endswith(
+                "\r\n\r\n"
+            ):
+                body = body[:-2]
 
             # Prepare our payload based on HTML or TEXT
             payload_["text"] = body

--- a/apprise/plugins/telegram.py
+++ b/apprise/plugins/telegram.py
@@ -126,31 +126,35 @@ TELEGRAM_CONTENT_PLACEMENT = (
     TelegramContentPlacement.AFTER,
 )
 
-TELEGRAM_HTML_BLOCK_TAGS = frozenset((
-    "blockquote",
-    "div",
-    "h1",
-    "h2",
-    "h3",
-    "h4",
-    "h5",
-    "h6",
-    "li",
-    "p",
-    "pre",
-))
+TELEGRAM_HTML_BLOCK_TAGS = frozenset(
+    (
+        "blockquote",
+        "div",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "li",
+        "p",
+        "pre",
+    )
+)
 
-TELEGRAM_HTML_PARAGRAPH_TAGS = frozenset((
-    "blockquote",
-    "div",
-    "h1",
-    "h2",
-    "h3",
-    "h4",
-    "h5",
-    "h6",
-    "p",
-))
+TELEGRAM_HTML_PARAGRAPH_TAGS = frozenset(
+    (
+        "blockquote",
+        "div",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "p",
+    )
+)
 
 
 def _telegram_markdown_html(content):
@@ -215,7 +219,12 @@ def _escape_telegram_markdown_text(value, markdown_ver):
 
 
 class TelegramMarkdownHTMLConverter(HTMLParser):
-    """Render a small HTML subset into Telegram Markdown."""
+    """Render a small HTML subset into Telegram Markdown.
+
+    This is intentionally scoped to Telegram's restrictive Markdown parse
+    modes. It is not a general HTML-to-Markdown converter; it preserves only
+    the tags and escaping rules Telegram accepts before sending the payload.
+    """
 
     def __init__(self, markdown_ver):
         super().__init__(convert_charrefs=True)
@@ -272,7 +281,8 @@ class TelegramMarkdownHTMLConverter(HTMLParser):
 
         elif tag == "li":
             self.result.append(
-                "\\- " if self.markdown_ver == TelegramMarkdownVersion.TWO
+                "\\- "
+                if self.markdown_ver == TelegramMarkdownVersion.TWO
                 else "- "
             )
 
@@ -329,9 +339,7 @@ class TelegramMarkdownHTMLConverter(HTMLParser):
 
         if self.in_code:
             self.result.append(
-                _escape_telegram_markdown_code_text(
-                    data, self.markdown_ver
-                )
+                _escape_telegram_markdown_code_text(data, self.markdown_ver)
             )
             return
 
@@ -413,7 +421,12 @@ class NotifyTelegram(NotifyBase):
     storage_mode = PersistentStoreMode.AUTO
 
     def convert_between(self, from_format, to_format, content):
-        """Let Telegram perform its own Markdown target conversion."""
+        """Keep Markdown target conversion inside the Telegram plugin.
+
+        Apprise's global HTML-to-Markdown path currently falls back to plain
+        text. Telegram needs the original body plus the original body_format
+        so send() can apply Telegram-specific parse-mode escaping.
+        """
         if to_format == NotifyFormat.MARKDOWN:
             return content
 
@@ -1119,9 +1132,7 @@ class NotifyTelegram(NotifyBase):
                 body_format is not None
                 and self.markdown_ver == TelegramMarkdownVersion.TWO
             ):
-                body = _escape_telegram_markdown_text(
-                    body, self.markdown_ver
-                )
+                body = _escape_telegram_markdown_text(body, self.markdown_ver)
 
             payload_["parse_mode"] = self.markdown_ver
             payload_["text"] = body

--- a/tests/test_plugin_telegram.py
+++ b/tests/test_plugin_telegram.py
@@ -1031,15 +1031,17 @@ def test_plugin_telegram_formatting(mock_post):
 
     # Markdown paragraphs converted to Telegram HTML should preserve paragraph
     # spacing without turning hard line breaks into blank lines.
-    body = "\n".join((
-        "**--- Header ---**",
-        "",
-        "Hostname: **server**",
-        "Date/Time: **Today**",
-        "Uptime: **TESTER**",
-        "",
-        "_Beware of a tall blond man with one black shoe._",
-    ))
+    body = "\n".join(
+        (
+            "**--- Header ---**",
+            "",
+            "Hostname: **server**",
+            "Date/Time: **Today**",
+            "Uptime: **TESTER**",
+            "",
+            "_Beware of a tall blond man with one black shoe._",
+        )
+    )
 
     assert aobj.notify(body=body, body_format=NotifyFormat.MARKDOWN)
 
@@ -1048,8 +1050,7 @@ def test_plugin_telegram_formatting(mock_post):
     payload = loads(mock_post.call_args_list[0][1]["data"])
 
     assert (
-        payload["text"]
-        == "<b>--- Header ---</b>\r\n\r\n"
+        payload["text"] == "<b>--- Header ---</b>\r\n\r\n"
         "Hostname: <b>server</b>\r\n"
         "Date/Time: <b>Today</b>\r\n"
         "Uptime: <b>TESTER</b>\r\n\r\n"
@@ -1363,26 +1364,22 @@ def test_plugin_telegram_markdown_conversion(mock_post):
         return loads(mock_post.call_args_list[0][1]["data"])
 
     payload = send_payload(
-        "tgram://123456789:abcdefg_hijklmnop/12345"
-        "?format=markdown&mdv=1",
+        "tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=1",
         "~~Strike~~ **Bold** _Italics_ Text",
     )
     assert payload["parse_mode"] == "MARKDOWN"
     assert payload["text"] == "Strike *Bold* _Italics_ Text"
 
     payload = send_payload(
-        "tgram://123456789:abcdefg_hijklmnop/12345"
-        "?format=markdown&mdv=2",
+        "tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=2",
         "~~Strike~~ **Bold** _Italics_ Text",
     )
     assert payload["parse_mode"] == "MarkdownV2"
     assert payload["text"] == "~Strike~ *Bold* _Italics_ Text"
 
     payload = send_payload(
-        "tgram://123456789:abcdefg_hijklmnop/12345"
-        "?format=markdown&mdv=1",
-        "**Bold**\n_Italics_\n"
-        "```go\nif x > 0 { return `tick` }\\path\n```",
+        "tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=1",
+        "**Bold**\n_Italics_\n```go\nif x > 0 { return `tick` }\\path\n```",
     )
     assert "````" not in payload["text"]
     assert "```\nif x > 0 { return `tick` }\\path\n```" in payload["text"]
@@ -1390,8 +1387,7 @@ def test_plugin_telegram_markdown_conversion(mock_post):
     assert "\\\\path" not in payload["text"]
 
     payload = send_payload(
-        "tgram://123456789:abcdefg_hijklmnop/12345"
-        "?format=markdown&mdv=2",
+        "tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=2",
         "```go\nif x > 0 { return `tick` }\\path\n```",
     )
     assert payload["text"] == (
@@ -1399,8 +1395,7 @@ def test_plugin_telegram_markdown_conversion(mock_post):
     )
 
     payload = send_payload(
-        "tgram://123456789:abcdefg_hijklmnop/12345"
-        "?format=markdown&mdv=2",
+        "tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=2",
         "`if x > 0 { return path\\name }`",
     )
     assert payload["text"] == "`if x > 0 { return path\\\\name }`"
@@ -1409,34 +1404,33 @@ def test_plugin_telegram_markdown_conversion(mock_post):
     assert "\\}" not in payload["text"]
 
     payload = send_payload(
-        "tgram://123456789:abcdefg_hijklmnop/12345"
-        "?format=markdown&mdv=2",
+        "tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=2",
         '<a href="https://example.com/a)b\\c">Docs</a>',
         body_format=NotifyFormat.HTML,
     )
     assert payload["text"] == "[Docs](https://example.com/a\\)b\\\\c)"
 
     payload = send_payload(
-        "tgram://123456789:abcdefg_hijklmnop/12345"
-        "?format=markdown&mdv=2",
+        "tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=2",
         "<b>Bold</b> <i>Italics</i> Text",
         body_format=NotifyFormat.HTML,
     )
     assert payload["text"] == "*Bold* _Italics_ Text"
 
-    body = "\n".join((
-        "**--- Header ---**",
-        "",
-        "Hostname: **server**",
-        "Date/Time: **Today**",
-        "Uptime: **TESTER**",
-        "",
-        "_Beware of a tall blond man with one black shoe._",
-    ))
+    body = "\n".join(
+        (
+            "**--- Header ---**",
+            "",
+            "Hostname: **server**",
+            "Date/Time: **Today**",
+            "Uptime: **TESTER**",
+            "",
+            "_Beware of a tall blond man with one black shoe._",
+        )
+    )
 
     payload = send_payload(
-        "tgram://123456789:abcdefg_hijklmnop/12345"
-        "?format=markdown&mdv=1",
+        "tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=1",
         body,
     )
     assert payload["text"] == (
@@ -1448,8 +1442,7 @@ def test_plugin_telegram_markdown_conversion(mock_post):
     )
 
     payload = send_payload(
-        "tgram://123456789:abcdefg_hijklmnop/12345"
-        "?format=markdown&mdv=2",
+        "tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=2",
         body,
     )
     assert payload["text"] == (

--- a/tests/test_plugin_telegram.py
+++ b/tests/test_plugin_telegram.py
@@ -43,6 +43,7 @@ from apprise import (
     NotifyFormat,
     NotifyType,
 )
+from apprise.plugins import telegram as telegram_plugin
 from apprise.plugins.telegram import NotifyTelegram
 
 logging.disable(logging.CRITICAL)
@@ -1457,6 +1458,57 @@ def test_plugin_telegram_markdown_conversion(mock_post):
         "Date/Time: *Today*\n"
         "Uptime: *TESTER*\n\n"
         "_Beware of a tall blond man with one black shoe\\._"
+    )
+
+
+def test_plugin_telegram_markdown_converter_edges():
+    """NotifyTelegram() covers Telegram Markdown renderer edge cases."""
+
+    result = []
+    telegram_plugin._ensure_line_break(result)
+    assert result == []
+
+    result = []
+    telegram_plugin._ensure_paragraph_break(result)
+    assert result == []
+
+    result = ["line\n"]
+    telegram_plugin._ensure_paragraph_break(result)
+    assert result == ["line\n", "\n"]
+
+    assert (
+        telegram_plugin._telegram_markdown_from_html(
+            "<br>after", telegram_plugin.TelegramMarkdownVersion.TWO
+        )
+        == "after"
+    )
+
+    assert (
+        telegram_plugin._telegram_markdown_from_html(
+            "<li>Item</li>", telegram_plugin.TelegramMarkdownVersion.TWO
+        )
+        == "\\- Item"
+    )
+
+    assert (
+        telegram_plugin._telegram_markdown_from_html(
+            "<img />after", telegram_plugin.TelegramMarkdownVersion.TWO
+        )
+        == "after"
+    )
+
+    assert (
+        telegram_plugin._telegram_markdown_from_html(
+            "</i>after", telegram_plugin.TelegramMarkdownVersion.TWO
+        )
+        == "_after"
+    )
+
+    assert (
+        telegram_plugin._telegram_markdown_from_html(
+            "<b>bold</i></b>", telegram_plugin.TelegramMarkdownVersion.TWO
+        )
+        == "*bold_*"
     )
 
 

--- a/tests/test_plugin_telegram.py
+++ b/tests/test_plugin_telegram.py
@@ -936,9 +936,9 @@ def test_plugin_telegram_formatting(mock_post):
 
     payload = loads(mock_post.call_args_list[1][1]["data"])
 
-    # Test that everything is escaped properly in a HTML mode
+    # Test that standard Markdown is converted to Telegram MarkdownV2.
     assert (
-        payload["text"] == "# 🚨 Change detected for _Apprise Test Title_\r\n"
+        payload["text"] == "*🚨 Change detected for _Apprise Test Title_*\n\n"
         "_[Apprise Body Title](http://localhost)_ had "
         "[a change](http://127.0.0.1)"
     )
@@ -975,9 +975,9 @@ def test_plugin_telegram_formatting(mock_post):
 
     payload = loads(mock_post.call_args_list[1][1]["data"])
 
-    # Test that everything is escaped properly in a HTML mode
+    # Test that standard Markdown is converted to Telegram Markdown v1.
     assert (
-        payload["text"] == "# 🚨 Change detected for _Apprise Test Title_\r\n"
+        payload["text"] == "*🚨 Change detected for _Apprise Test Title_*\n\n"
         "_[Apprise Body Title](http://localhost)_ had "
         "[a change](http://127.0.0.1)"
     )
@@ -1220,9 +1220,9 @@ def test_plugin_telegram_formatting(mock_post):
 
     payload = loads(mock_post.call_args_list[0][1]["data"])
 
-    # No escaping in this circumstance
+    # Standard Markdown is converted to Telegram MarkdownV2.
     assert (
-        payload["text"] == "# A Great Title\r\n"
+        payload["text"] == "*A Great Title*\n\n"
         "_[Apprise Body Title](http://localhost)_ had "
         "[a change](http://127.0.0.2)"
     )
@@ -1341,6 +1341,122 @@ def test_plugin_telegram_formatting(mock_post):
     assert (
         payload["text"]
         == "<b>Test Message Title</b>\r\nTest Message Body\r\nok\r\n"
+    )
+
+
+@mock.patch("requests.post")
+def test_plugin_telegram_markdown_conversion(mock_post):
+    """NotifyTelegram() converts standard Markdown to Telegram Markdown."""
+
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+    mock_post.return_value.content = dumps({"ok": True, "result": True})
+
+    def send_payload(url, body, body_format=NotifyFormat.MARKDOWN):
+        mock_post.reset_mock()
+
+        aobj = Apprise()
+        aobj.add(url)
+        assert aobj.notify(body=body, body_format=body_format)
+        assert mock_post.call_count == 1
+        return loads(mock_post.call_args_list[0][1]["data"])
+
+    payload = send_payload(
+        "tgram://123456789:abcdefg_hijklmnop/12345"
+        "?format=markdown&mdv=1",
+        "~~Strike~~ **Bold** _Italics_ Text",
+    )
+    assert payload["parse_mode"] == "MARKDOWN"
+    assert payload["text"] == "Strike *Bold* _Italics_ Text"
+
+    payload = send_payload(
+        "tgram://123456789:abcdefg_hijklmnop/12345"
+        "?format=markdown&mdv=2",
+        "~~Strike~~ **Bold** _Italics_ Text",
+    )
+    assert payload["parse_mode"] == "MarkdownV2"
+    assert payload["text"] == "~Strike~ *Bold* _Italics_ Text"
+
+    payload = send_payload(
+        "tgram://123456789:abcdefg_hijklmnop/12345"
+        "?format=markdown&mdv=1",
+        "**Bold**\n_Italics_\n"
+        "```go\nif x > 0 { return `tick` }\\path\n```",
+    )
+    assert "````" not in payload["text"]
+    assert "```\nif x > 0 { return `tick` }\\path\n```" in payload["text"]
+    assert "\\`" not in payload["text"]
+    assert "\\\\path" not in payload["text"]
+
+    payload = send_payload(
+        "tgram://123456789:abcdefg_hijklmnop/12345"
+        "?format=markdown&mdv=2",
+        "```go\nif x > 0 { return `tick` }\\path\n```",
+    )
+    assert payload["text"] == (
+        "```\nif x > 0 { return \\`tick\\` }\\\\path\n```"
+    )
+
+    payload = send_payload(
+        "tgram://123456789:abcdefg_hijklmnop/12345"
+        "?format=markdown&mdv=2",
+        "`if x > 0 { return path\\name }`",
+    )
+    assert payload["text"] == "`if x > 0 { return path\\\\name }`"
+    assert "\\>" not in payload["text"]
+    assert "\\{" not in payload["text"]
+    assert "\\}" not in payload["text"]
+
+    payload = send_payload(
+        "tgram://123456789:abcdefg_hijklmnop/12345"
+        "?format=markdown&mdv=2",
+        '<a href="https://example.com/a)b\\c">Docs</a>',
+        body_format=NotifyFormat.HTML,
+    )
+    assert payload["text"] == "[Docs](https://example.com/a\\)b\\\\c)"
+
+    payload = send_payload(
+        "tgram://123456789:abcdefg_hijklmnop/12345"
+        "?format=markdown&mdv=2",
+        "<b>Bold</b> <i>Italics</i> Text",
+        body_format=NotifyFormat.HTML,
+    )
+    assert payload["text"] == "*Bold* _Italics_ Text"
+
+    body = "\n".join((
+        "**--- Header ---**",
+        "",
+        "Hostname: **server**",
+        "Date/Time: **Today**",
+        "Uptime: **TESTER**",
+        "",
+        "_Beware of a tall blond man with one black shoe._",
+    ))
+
+    payload = send_payload(
+        "tgram://123456789:abcdefg_hijklmnop/12345"
+        "?format=markdown&mdv=1",
+        body,
+    )
+    assert payload["text"] == (
+        "*--- Header ---*\n\n"
+        "Hostname: *server*\n"
+        "Date/Time: *Today*\n"
+        "Uptime: *TESTER*\n\n"
+        "_Beware of a tall blond man with one black shoe._"
+    )
+
+    payload = send_payload(
+        "tgram://123456789:abcdefg_hijklmnop/12345"
+        "?format=markdown&mdv=2",
+        body,
+    )
+    assert payload["text"] == (
+        "*\\-\\-\\- Header \\-\\-\\-*\n\n"
+        "Hostname: *server*\n"
+        "Date/Time: *Today*\n"
+        "Uptime: *TESTER*\n\n"
+        "_Beware of a tall blond man with one black shoe\\._"
     )
 
 
@@ -1625,10 +1741,10 @@ def test_plugin_telegram_markdown_v2(mock_post):
     assert mock_post.call_count == 2
     payload = loads(mock_post.call_args_list[1][1]["data"])
 
-    # Our content is escapped properly
+    # Our content is escaped properly, including literal backslashes.
     assert (
         payload["text"] == "\\# my message\r\n"
-        "\\#\\# more content\r\n\\# already escaped hashtag"
+        "\\#\\# more content\r\n\\\\\\# already escaped hashtag"
     )
 
     mock_post.reset_mock()
@@ -1663,10 +1779,10 @@ def test_plugin_telegram_markdown_v2(mock_post):
         assert mock_post.call_count == 1
         payload = loads(mock_post.call_args_list[0][1]["data"])
 
-        # Our content is escapped properly
+        # Our content is escaped properly, including literal backslashes.
         assert (
             payload["text"]
-            == f"bad character: \\{c}, and already escapped \\{c}"
+            == rf"bad character: \{c}, and already escapped \\\{c}"
         )
 
         mock_post.reset_mock()

--- a/tests/test_plugin_telegram.py
+++ b/tests/test_plugin_telegram.py
@@ -1025,6 +1025,36 @@ def test_plugin_telegram_formatting(mock_post):
         '</i> had <a href="http://127.0.0.2">a change</a>\r\n'
     )
 
+    # Reset our values
+    mock_post.reset_mock()
+
+    # Markdown paragraphs converted to Telegram HTML should preserve paragraph
+    # spacing without turning hard line breaks into blank lines.
+    body = "\n".join((
+        "**--- Header ---**",
+        "",
+        "Hostname: **server**",
+        "Date/Time: **Today**",
+        "Uptime: **TESTER**",
+        "",
+        "_Beware of a tall blond man with one black shoe._",
+    ))
+
+    assert aobj.notify(body=body, body_format=NotifyFormat.MARKDOWN)
+
+    assert mock_post.call_count == 1
+
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+
+    assert (
+        payload["text"]
+        == "<b>--- Header ---</b>\r\n\r\n"
+        "Hostname: <b>server</b>\r\n"
+        "Date/Time: <b>Today</b>\r\n"
+        "Uptime: <b>TESTER</b>\r\n\r\n"
+        "<i>Beware of a tall blond man with one black shoe.</i>\r\n"
+    )
+
     # Now we'll test an edge case where a title was defined, but after
     # processing it, it was determiend there really wasn't anything there
     # at all at the end of the day.


### PR DESCRIPTION
## Summary
- Preserves paragraph breaks when Markdown input is converted to Telegram HTML payloads.
- Converts standard Markdown/HTML into Telegram Markdown v1 or MarkdownV2 for Telegram Markdown targets.
- Adds Telegram-specific MarkdownV2 escaping for regular text, link destinations, and code/pre blocks.
- Adds regression coverage for Markdown paragraphs, strikethrough, emphasis, HTML links, fenced code, inline code, HTML input, and renderer edge cases.

## Root Cause
Telegram's Markdown modes are not generic Markdown. The previous path either passed standard Markdown through mostly unchanged for Telegram Markdown targets, or relied on generic HTML cleanup for Telegram HTML targets. That collapsed intentional paragraph breaks, lost Telegram-supported formatting in some HTML-to-Markdown cases, and escaped MarkdownV2 content without enough context for links and code blocks. Live Telegram client testing also showed that escaping literal `[` in Markdown v1 text can display a visible backslash, so Markdown v1 text escaping is kept narrower than MarkdownV2.

## Implementation Notes
- Adds a small Telegram-specific `HTMLParser` renderer that emits Telegram Markdown v1/MarkdownV2.
- Documents that the renderer is intentionally scoped to Telegram parse-mode rules and is not a replacement for a future global `html_to_markdown()` converter.
- Uses Python Markdown with fenced-code support as the standard Markdown input path, with `~~strike~~` normalized for Telegram rendering.
- Adds a per-plugin conversion hook so Telegram can receive original Markdown/HTML and perform target-specific conversion without changing generic conversion behavior for other plugins.
- Keeps the paragraph-spacing fix from the original draft PR, now as part of the broader Telegram formatting backport from the Go port investigation in unraid/apprise-go#48.

## Validation
- `uv run --with ruff ruff check .`
- `uv run --with ruff ruff format --check .`
- `uv run --with pytest --with pytest-mock pytest tests/test_plugin_telegram.py tests/test_api.py -q`
- Focused diff coverage for changed production code: 100.0% line coverage, 100.0% branch coverage, 100.0% combined line+branch coverage.
- Live Telegram Bot API/client smoke test sent HTML paragraph spacing, Markdown v1, MarkdownV2, HTML-to-MarkdownV2 link, and text-to-MarkdownV2 escaping messages. Follow-up live test verified the Markdown v1 bracket escape fix and a clean docs link.

## Additional Check
- `uv run --with pytest --with pytest-mock pytest -q` reported `1349 passed, 265 skipped, 14 warnings` before I interrupted a hanging teardown/keyboard-interrupt cleanup path; the focused suites above completed normally.