### PR TITLE
Added Amazon Chime Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The table below identifies the services this tool supports and some example serv
 | [BlueSky](https://appriseit.com/services/bluesky/) | bluesky://  | (TCP) 443   | bluesky://Handle:AppPw<br />bluesky://Handle:AppPw/TargetHandle<br />bluesky://Handle:AppPw/TargetHandle1/TargetHandle2/TargetHandleN
 | [Brevo](https://appriseit.com/services/brevo/) | brevo://  | (TCP) 443   | brevo://APIToken:FromEmail/<br />brevo://APIToken:FromEmail/ToEmail<br />brevo://APIToken:FromEmail/ToEmail1/ToEmail2/ToEmailN/
 | [Chanify](https://appriseit.com/services/chanify/) | chantify://    | (TCP) 443    | chantify://token
+| [Amazon Chime](https://appriseit.com/services/chime/) | chime://   | (TCP) 443   | chime://WebhookID/Token
 | [Discord](https://appriseit.com/services/discord/)  | discord://   | (TCP) 443   | discord://webhook_id/webhook_token<br />discord://avatar@webhook_id/webhook_token
 | [Dot.](https://appriseit.com/services/dot/)  | dot:// | (TCP) 443 | dot://apikey@device_id/text/<br />dot://apikey@device_id/image/<br />**Note**: `device_id` is the Quote/0 hardware serial
 | [Emby](https://appriseit.com/services/emby/)  | emby:// or embys:// | (TCP) 8096 | emby://user@hostname/<br />emby://user:password@hostname

--- a/apprise/plugins/chime.py
+++ b/apprise/plugins/chime.py
@@ -1,0 +1,342 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Amazon Chime Incoming Webhooks
+#
+# To create an incoming webhook for an Amazon Chime chat room:
+#  1. Open Amazon Chime and navigate to the chat room you want to
+#     send notifications to.
+#  2. Choose the gear icon in the top-right corner of the chat room.
+#  3. Choose "Manage webhooks and bots".
+#  4. Choose "Add webhook", give it a name, then choose "Create".
+#  5. To copy the webhook URL, choose "Copy URL" next to your new
+#     webhook in the list.
+#
+# The webhook URL will look something like:
+#   https://hooks.chime.aws/incomingwebhooks/
+#       xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx?token=AaBbCcDd%3D%3D
+#
+# Where the path segment after /incomingwebhooks/ is the Webhook ID
+# and the ?token= query parameter is the authentication token.
+#
+# Your Apprise URL would be assembled as:
+#   chime://{WebhookID}/{Token}
+#
+# For example:
+#   chime://xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/AaBbCcDd%3D%3D
+#
+# The token value may include base64 padding characters (=). Apprise
+# handles encoding automatically; you can paste the token exactly as
+# it appears in the Chime webhook URL (already URL-decoded form) or
+# as-is from the ?token= query parameter.
+#
+# References:
+# - https://docs.aws.amazon.com/chime/latest/ug/webhooks.html
+# - https://docs.aws.amazon.com/chime/latest/APIReference/\
+#       API_CreateIncomingWebhook.html
+
+from json import dumps
+import re
+
+import requests
+
+from ..common import NotifyFormat, NotifyType
+from ..locale import gettext_lazy as _
+from ..utils.parse import validate_regex
+from .base import NotifyBase
+
+# Extend HTTP Error Messages
+CHIME_HTTP_ERROR_MAP = {
+    401: "Unauthorized - Invalid Webhook Token.",
+    403: "Forbidden - Webhook has been disabled or revoked.",
+    404: "Not Found - Invalid Webhook ID.",
+    429: "Too many requests; rate-limit exceeded.",
+}
+
+# Amazon Chime Incoming Webhook base URL
+CHIME_WEBHOOK_URL = (
+    "https://hooks.chime.aws/incomingwebhooks/{webhook_id}?token={token}"
+)
+
+# Validates a Chime webhook ID (UUID-like hex string with hyphens,
+# but we keep this flexible to handle any future format changes)
+IS_WEBHOOK_ID = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", re.I)
+
+
+class NotifyChime(NotifyBase):
+    """A wrapper for Amazon Chime Notifications."""
+
+    # The default descriptive name associated with the Notification
+    service_name = "Amazon Chime"
+
+    # The services URL
+    service_url = "https://aws.amazon.com/chime/"
+
+    # The default secure protocol
+    secure_protocol = "chime"
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = "https://appriseit.com/services/chime/"
+
+    # Amazon Chime Webhook URL (used in send())
+    notify_url = CHIME_WEBHOOK_URL
+
+    # Amazon Chime webhooks support Markdown in the Content field
+    notify_format = NotifyFormat.MARKDOWN
+
+    # Chime webhooks have no native title field; title_maxlen = 0
+    # causes the framework to prepend the title to the body automatically
+    title_maxlen = 0
+
+    # Maximum allowed characters in the Content field
+    body_maxlen = 4096
+
+    # Chime incoming webhooks do not support file attachments;
+    # attachments can only be sent through the Chime SDK/API
+    attachment_support = False
+
+    # Define object URL templates
+    templates = ("{schema}://{webhook_id}/{token}",)
+
+    # Define our template tokens
+    template_tokens = dict(
+        NotifyBase.template_tokens,
+        **{
+            "webhook_id": {
+                "name": _("Webhook ID"),
+                "type": "string",
+                "private": True,
+                "required": True,
+            },
+            "token": {
+                "name": _("Webhook Token"),
+                "type": "string",
+                "private": True,
+                "required": True,
+            },
+        },
+    )
+
+    # Define our template arguments
+    template_args = dict(
+        NotifyBase.template_args,
+        **{
+            "webhook_id": {
+                "alias_of": "webhook_id",
+            },
+            "token": {
+                "alias_of": "token",
+            },
+        },
+    )
+
+    def __init__(self, webhook_id, token, **kwargs):
+        """Initialize Amazon Chime Object."""
+        super().__init__(**kwargs)
+
+        # Validate the Webhook ID (any non-empty, non-whitespace string)
+        self.webhook_id = validate_regex(webhook_id)
+        if not self.webhook_id:
+            msg = (
+                "An invalid Amazon Chime Webhook ID "
+                "({}) was specified.".format(webhook_id)
+            )
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # Validate the Webhook Token
+        self.token = validate_regex(token)
+        if not self.token:
+            msg = (
+                "An invalid Amazon Chime Webhook Token "
+                "({}) was specified.".format(token)
+            )
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        return
+
+    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+        """Perform Amazon Chime Notification."""
+
+        # Prepare our headers
+        headers = {
+            "User-Agent": self.app_id,
+            "Content-Type": "application/json; charset=utf-8",
+        }
+
+        # Prepare our payload; Chime webhooks accept a single Content field
+        payload = {
+            "Content": body,
+        }
+
+        # Construct the full webhook URL; the token must be URL-encoded
+        # because it may contain base64 padding characters (=, +, /)
+        notify_url = self.notify_url.format(
+            webhook_id=self.webhook_id,
+            token=NotifyChime.quote(self.token, safe=""),
+        )
+
+        self.logger.debug(
+            "Amazon Chime POST URL: %s (cert_verify=%s)",
+            notify_url,
+            self.verify_certificate,
+        )
+        self.logger.debug("Amazon Chime Payload: %s", str(payload))
+
+        # Always call throttle before any remote server i/o is made
+        self.throttle()
+
+        try:
+            r = requests.post(
+                notify_url,
+                data=dumps(payload),
+                headers=headers,
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+                allow_redirects=self.redirects,
+            )
+
+            if r.status_code != requests.codes.ok:
+                # We had a problem
+                status_str = NotifyChime.http_response_code_lookup(
+                    r.status_code, CHIME_HTTP_ERROR_MAP
+                )
+
+                self.logger.warning(
+                    "Failed to send Amazon Chime notification: "
+                    "{}{}error={}.".format(
+                        status_str,
+                        ", " if status_str else "",
+                        r.status_code,
+                    )
+                )
+
+                self.logger.debug(
+                    "Response Details:\r\n%r", (r.content or b"")[:2000]
+                )
+
+                # Return; we're done
+                return False
+
+            else:
+                self.logger.info("Sent Amazon Chime notification.")
+
+        except requests.RequestException as e:
+            self.logger.warning(
+                "A Connection error occurred posting to Amazon Chime."
+            )
+            self.logger.debug("Socket Exception: %s", str(e))
+            return False
+
+        return True
+
+    @property
+    def url_identifier(self):
+        """Returns all of the identifiers that make this URL unique from
+        another simliar one.
+
+        Targets or end points should never be identified here.
+        """
+        return (
+            self.secure_protocol,
+            self.webhook_id,
+            self.token,
+        )
+
+    def url(self, privacy=False, *args, **kwargs):
+        """Returns the URL built dynamically based on specified arguments."""
+
+        # Acquire any global URL parameters
+        params = self.url_parameters(privacy=privacy, *args, **kwargs)
+
+        return "{schema}://{webhook_id}/{token}/?{params}".format(
+            schema=self.secure_protocol,
+            webhook_id=self.pprint(self.webhook_id, privacy, safe=""),
+            token=self.pprint(self.token, privacy, safe=""),
+            params=NotifyChime.urlencode(params),
+        )
+
+    @staticmethod
+    def parse_url(url):
+        """Parses the URL and returns enough arguments that can allow
+        us to re-instantiate this object."""
+        results = NotifyBase.parse_url(url, verify_host=False)
+        if not results:
+            # We're done early as we couldn't load the results
+            return results
+
+        # Webhook ID is in the host position
+        results["webhook_id"] = NotifyChime.unquote(results["host"])
+
+        # The token is the first entry in the URL path
+        tokens = NotifyChime.split_path(results["fullpath"])
+        results["token"] = tokens.pop(0) if tokens else None
+
+        # Allow ?token= to override the path-supplied token
+        if "token" in results["qsd"] and results["qsd"]["token"]:
+            results["token"] = NotifyChime.unquote(results["qsd"]["token"])
+
+        # Allow ?webhook_id= to override the host-supplied webhook ID
+        if "webhook_id" in results["qsd"] and results["qsd"]["webhook_id"]:
+            results["webhook_id"] = NotifyChime.unquote(
+                results["qsd"]["webhook_id"]
+            )
+
+        return results
+
+    @staticmethod
+    def parse_native_url(url):
+        """Support native Amazon Chime webhook URLs.
+
+        For example:
+          https://hooks.chime.aws/incomingwebhooks/
+              xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx?token=AaBbCcDd%3D%3D
+        """
+        result = re.match(
+            r"^https?://hooks\.chime\.aws/incomingwebhooks/"
+            r"(?P<webhook_id>[a-z0-9][a-z0-9-]*[a-z0-9])/?"
+            r"(\?.*token=(?P<token>[^&#]+).*)?$",
+            url,
+            re.I,
+        )
+        if result:
+            # Unquote the token from the native URL's query string so
+            # parse_url() receives the decoded form and can store it
+            token = result.group("token") or ""
+            return NotifyChime.parse_url(
+                "{schema}://{webhook_id}/{token}".format(
+                    schema=NotifyChime.secure_protocol,
+                    webhook_id=result.group("webhook_id"),
+                    # Re-encode so parse_url / split_path decode it once
+                    token=NotifyChime.quote(
+                        NotifyChime.unquote(token), safe=""
+                    ),
+                )
+            )
+
+        return None

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -58,8 +58,9 @@
 Apprise is a Python package that simplifies access to many popular \
 notification services. It supports sending alerts to platforms such as: \
 \
-`46elks`, `AfricasTalking`, `Apprise API`, `APRS`, `AWS SES`, `AWS SNS`, \
-`Bark`, `Blink(1)`, `BlueSky`, `Brevo`, `Burst SMS`, `BulkSMS`, `BulkVS`, \
+`46elks`, `AfricasTalking`, `Amazon Chime`, `Apprise API`, `APRS`, \
+`AWS SES`, `AWS SNS`, `Bark`, `Blink(1)`, `BlueSky`, `Brevo`, \
+`Burst SMS`, `BulkSMS`, `BulkVS`, \
 `Chanify`, `Clickatell`, `ClickSend`, `DAPNET`, `DingTalk`, `Discord`, \
 `Dot. (Quote/0)`, `E-Mail`, `Emby`, `Evolution API`, `Exotel`, \
 `FCM`, `Feishu`, `Flock`, `Fluxer`, `Free Mobile`, `Google Chat`, \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ keywords = [
     "Alerts",
     "Apprise API",
     "Automated Packet Reporting System",
+    "Amazon Chime",
     "AWS",
     "Bark",
     "Blink(1)",

--- a/tests/test_plugin_chime.py
+++ b/tests/test_plugin_chime.py
@@ -1,0 +1,445 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Disable logging for a cleaner testing output
+import logging
+from unittest import mock
+
+from helpers import AppriseURLTester
+import pytest
+import requests
+
+from apprise import Apprise
+from apprise.plugins.chime import NotifyChime
+
+logging.disable(logging.CRITICAL)
+
+# Fake but realistic-looking credentials
+TEST_WEBHOOK_ID = "aabbccdd-1234-5678-abcd-ef1234567890"
+TEST_TOKEN = "AaBbCcDdEeFf1234567890=="
+
+
+# Our Testing URLs
+apprise_url_tests = (
+    (
+        # No webhook_id or token
+        "chime://",
+        {
+            "instance": TypeError,
+        },
+    ),
+    (
+        # Empty URL
+        "chime://:@/",
+        {
+            "instance": TypeError,
+        },
+    ),
+    (
+        # Webhook ID supplied but no token
+        "chime://aabbccdd-1234-5678-abcd-ef1234567890",
+        {
+            "instance": TypeError,
+        },
+    ),
+    (
+        # Valid webhook_id + token in path (token has base64 padding)
+        "chime://aabbccdd-1234-5678-abcd-ef1234567890/AaBbCcDd1234%3D%3D",
+        {
+            "instance": NotifyChime,
+            # Expected privacy URL prefix; pprint shows the decoded token
+            # character, so the trailing = of AaBbCcDd1234== appears as =
+            "privacy_url": "chime://a...0/A...=/",
+        },
+    ),
+    (
+        # Webhook token supplied via query string
+        "chime://aabbccdd-1234-5678-abcd-ef1234567890"
+        "?token=AaBbCcDd1234%3D%3D",
+        {
+            "instance": NotifyChime,
+        },
+    ),
+    (
+        # Webhook ID supplied via query string
+        "chime://?webhook_id=aabbccdd-1234-5678-abcd-ef1234567890"
+        "&token=AaBbCcDd1234%3D%3D",
+        {
+            "instance": NotifyChime,
+        },
+    ),
+    (
+        # Valid credentials; HTTP 500 response
+        "chime://aabbccdd-1234-5678-abcd-ef1234567890/AaBbCcDd1234%3D%3D",
+        {
+            "instance": NotifyChime,
+            "response": False,
+            "requests_response_code": (requests.codes.internal_server_error),
+        },
+    ),
+    (
+        # Valid credentials; unknown response code
+        "chime://aabbccdd-1234-5678-abcd-ef1234567890/AaBbCcDd1234%3D%3D",
+        {
+            "instance": NotifyChime,
+            # throw a bizarre code forcing us to fail to look it up
+            "response": False,
+            "requests_response_code": 999,
+        },
+    ),
+    (
+        # Valid credentials; request exceptions
+        "chime://aabbccdd-1234-5678-abcd-ef1234567890/AaBbCcDd1234%3D%3D",
+        {
+            "instance": NotifyChime,
+            # Throws a series of i/o exceptions with this flag set
+            # and tests that we gracefully handle them
+            "test_requests_exceptions": True,
+        },
+    ),
+    (
+        # Native Chime webhook URL
+        "https://hooks.chime.aws/incomingwebhooks/"
+        "aabbccdd-1234-5678-abcd-ef1234567890"
+        "?token=AaBbCcDd1234%3D%3D",
+        {
+            "instance": NotifyChime,
+        },
+    ),
+)
+
+
+def test_plugin_chime_urls():
+    """NotifyChime() Apprise URLs."""
+
+    # Run our general tests
+    AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+@mock.patch("requests.post")
+def test_plugin_chime_init(mock_post):
+    """NotifyChime() Initialization Checks."""
+
+    # Prepare a valid mock response
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    # Missing webhook_id raises TypeError
+    with pytest.raises(TypeError):
+        NotifyChime(webhook_id=None, token=TEST_TOKEN)
+
+    # Blank webhook_id raises TypeError
+    with pytest.raises(TypeError):
+        NotifyChime(webhook_id="  ", token=TEST_TOKEN)
+
+    # Missing token raises TypeError
+    with pytest.raises(TypeError):
+        NotifyChime(webhook_id=TEST_WEBHOOK_ID, token=None)
+
+    # Blank token raises TypeError
+    with pytest.raises(TypeError):
+        NotifyChime(webhook_id=TEST_WEBHOOK_ID, token="  ")
+
+    # Valid object instantiates without error
+    obj = NotifyChime(webhook_id=TEST_WEBHOOK_ID, token=TEST_TOKEN)
+    assert isinstance(obj, NotifyChime)
+
+    # Confirm the webhook_id and token are stored correctly
+    assert obj.webhook_id == TEST_WEBHOOK_ID
+    assert obj.token == TEST_TOKEN
+
+
+@mock.patch("requests.post")
+def test_plugin_chime_send(mock_post):
+    """NotifyChime() Send Checks."""
+
+    def _mk_resp(code):
+        """Build a minimal mock response with the given status code."""
+        resp = requests.Request()
+        resp.status_code = code
+        # content is accessed in error-path debug logging
+        resp.content = b""
+        return resp
+
+    # Prepare a successful mock response
+    mock_post.return_value = _mk_resp(requests.codes.ok)
+
+    # Instantiate a valid object
+    obj = NotifyChime(webhook_id=TEST_WEBHOOK_ID, token=TEST_TOKEN)
+    assert isinstance(obj, NotifyChime)
+
+    # Perform a successful send
+    assert obj.notify(body="Test body", title="Test title") is True
+
+    # Verify the POST was made exactly once
+    assert mock_post.call_count == 1
+
+    # Confirm the URL used matches the expected Chime webhook URL pattern
+    call_url = mock_post.call_args_list[0][0][0]
+    assert "hooks.chime.aws/incomingwebhooks/" in call_url
+    assert TEST_WEBHOOK_ID in call_url
+    # The token is URL-encoded in the query string
+    assert "token=" in call_url
+
+    mock_post.reset_mock()
+
+    # A 401 response returns False
+    mock_post.return_value = _mk_resp(requests.codes.unauthorized)
+    assert obj.notify(body="Test body") is False
+
+    mock_post.reset_mock()
+
+    # A 403 response returns False
+    mock_post.return_value = _mk_resp(requests.codes.forbidden)
+    assert obj.notify(body="Test body") is False
+
+    mock_post.reset_mock()
+
+    # A 404 response returns False
+    mock_post.return_value = _mk_resp(requests.codes.not_found)
+    assert obj.notify(body="Test body") is False
+
+    mock_post.reset_mock()
+
+    # A 429 too-many-requests response returns False
+    mock_post.return_value = _mk_resp(429)
+    assert obj.notify(body="Test body") is False
+
+    mock_post.reset_mock()
+
+    # A 500 response returns False
+    mock_post.return_value = _mk_resp(requests.codes.internal_server_error)
+    assert obj.notify(body="Test body") is False
+
+    mock_post.reset_mock()
+
+    # An unknown response code returns False
+    mock_post.return_value = _mk_resp(999)
+    assert obj.notify(body="Test body") is False
+
+    mock_post.reset_mock()
+
+    # A RequestException returns False
+    mock_post.side_effect = requests.RequestException("Network error")
+    assert obj.notify(body="Test body") is False
+
+
+@mock.patch("requests.post")
+def test_plugin_chime_url_roundtrip(mock_post):
+    """NotifyChime() URL round-trip invariant."""
+
+    # Prepare our mock response
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    # Build a simple token that contains base64 padding (=)
+    token_with_padding = "AaBbCcDd1234=="
+
+    obj = NotifyChime(
+        webhook_id=TEST_WEBHOOK_ID,
+        token=token_with_padding,
+    )
+    assert isinstance(obj, NotifyChime)
+
+    # Generate a URL and parse it back
+    generated_url = obj.url()
+    results = NotifyChime.parse_url(generated_url)
+    assert results is not None
+
+    # Reconstruct from parsed results
+    obj2 = NotifyChime(**results)
+    assert isinstance(obj2, NotifyChime)
+
+    # The connection identity must be identical
+    assert obj.url_identifier == obj2.url_identifier
+
+    # Token must survive the round-trip (including = padding)
+    assert obj.token == obj2.token
+    assert obj.webhook_id == obj2.webhook_id
+
+
+@mock.patch("requests.post")
+def test_plugin_chime_url_parsing(mock_post):
+    """NotifyChime() URL Parsing Checks."""
+
+    # Prepare our mock response
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    # Parse a standard Apprise URL
+    results = NotifyChime.parse_url(
+        "chime://{}/{}".format(TEST_WEBHOOK_ID, TEST_TOKEN)
+    )
+    assert results is not None
+    assert results["webhook_id"] == TEST_WEBHOOK_ID
+    assert results["token"] == TEST_TOKEN
+
+    # ?token= query parameter overrides path-supplied token
+    results = NotifyChime.parse_url(
+        "chime://{}/ignored-token?token={}".format(TEST_WEBHOOK_ID, TEST_TOKEN)
+    )
+    assert results is not None
+    assert results["token"] == TEST_TOKEN
+
+    # ?webhook_id= query parameter overrides host-supplied ID
+    results = NotifyChime.parse_url(
+        "chime://ignored-id/{}?webhook_id={}".format(
+            TEST_TOKEN, TEST_WEBHOOK_ID
+        )
+    )
+    assert results is not None
+    assert results["webhook_id"] == TEST_WEBHOOK_ID
+
+    # None is returned for an invalid URL
+    assert NotifyChime.parse_url(None) is None
+
+    # Missing token returns a result dict with no token
+    results = NotifyChime.parse_url("chime://{}".format(TEST_WEBHOOK_ID))
+    # split_path on an empty fullpath returns no entries
+    assert results is not None
+    assert not results.get("token")
+
+
+@mock.patch("requests.post")
+def test_plugin_chime_native_url(mock_post):
+    """NotifyChime() Native URL Parsing."""
+
+    # Prepare our mock response
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    # A native URL with a URL-encoded token
+    native_url = (
+        "https://hooks.chime.aws/incomingwebhooks/"
+        "{webhook_id}?token={token}".format(
+            webhook_id=TEST_WEBHOOK_ID,
+            # URL-encode the token as it would appear in a real Chime URL
+            token=NotifyChime.quote(TEST_TOKEN, safe=""),
+        )
+    )
+
+    results = NotifyChime.parse_native_url(native_url)
+    assert results is not None
+    assert results["webhook_id"] == TEST_WEBHOOK_ID
+    assert results["token"] == TEST_TOKEN
+
+    # The constructed object must be functional
+    obj = NotifyChime(**results)
+    assert isinstance(obj, NotifyChime)
+    assert obj.notify(body="Native URL test") is True
+
+    # A non-matching URL returns None
+    assert (
+        NotifyChime.parse_native_url("https://example.com/not-a-chime-url")
+        is None
+    )
+
+
+@mock.patch("requests.post")
+def test_plugin_chime_privacy_url(mock_post):
+    """NotifyChime() Privacy URL."""
+
+    # Prepare our mock response
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    obj = NotifyChime(webhook_id=TEST_WEBHOOK_ID, token=TEST_TOKEN)
+    assert isinstance(obj, NotifyChime)
+
+    # Privacy URL must mask credentials
+    privacy = obj.url(privacy=True)
+    assert TEST_TOKEN not in privacy
+    assert TEST_WEBHOOK_ID not in privacy
+    # Scheme must still be present
+    assert privacy.startswith("chime://")
+
+
+@mock.patch("requests.post")
+def test_plugin_chime_apprise_integration(mock_post):
+    """NotifyChime() Apprise integration."""
+
+    # Prepare a valid mock response
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    # Test loading via Apprise URL
+    a = Apprise()
+    url = "chime://{}/{}".format(TEST_WEBHOOK_ID, TEST_TOKEN)
+    assert a.add(url) is True
+    assert len(a) == 1
+    assert isinstance(a[0], NotifyChime)
+
+    # Notify succeeds
+    assert a.notify(body="Test", title="Title") is True
+    assert mock_post.call_count == 1
+
+    mock_post.reset_mock()
+
+    # Test failure response
+    mock_post.return_value.status_code = requests.codes.internal_server_error
+    assert a.notify(body="Test", title="Title") is False
+
+    mock_post.reset_mock()
+
+    # Test with native URL
+    a2 = Apprise()
+    native = (
+        "https://hooks.chime.aws/incomingwebhooks/"
+        "{webhook_id}?token={token}".format(
+            webhook_id=TEST_WEBHOOK_ID,
+            token=NotifyChime.quote(TEST_TOKEN, safe=""),
+        )
+    )
+    assert a2.add(native) is True
+    assert len(a2) == 1
+    assert isinstance(a2[0], NotifyChime)
+
+    mock_post.return_value.status_code = requests.codes.ok
+    assert a2.notify(body="Native test", title="Title") is True
+
+
+@mock.patch("requests.post")
+def test_plugin_chime_url_identifier(mock_post):
+    """NotifyChime() url_identifier uniqueness."""
+
+    # Two objects with the same credentials share an identifier
+    obj1 = NotifyChime(webhook_id=TEST_WEBHOOK_ID, token=TEST_TOKEN)
+    obj2 = NotifyChime(webhook_id=TEST_WEBHOOK_ID, token=TEST_TOKEN)
+    assert obj1.url_identifier == obj2.url_identifier
+
+    # Different webhook_id produces a different identifier
+    obj3 = NotifyChime(webhook_id="different-id-abcd", token=TEST_TOKEN)
+    assert obj1.url_identifier != obj3.url_identifier
+
+    # Different token produces a different identifier
+    obj4 = NotifyChime(webhook_id=TEST_WEBHOOK_ID, token="DifferentToken123")
+    assert obj1.url_identifier != obj4.url_identifier
+
+    # Targets must not affect the identifier (no targets for Chime)
+    assert obj1.url_identifier[0] == NotifyChime.secure_protocol
+    assert obj1.url_identifier[1] == TEST_WEBHOOK_ID
+    assert obj1.url_identifier[2] == TEST_TOKEN


### PR DESCRIPTION
## Description
**Related issue (if applicable):** n/a
## Amazon Chime Notifications
* **Source**: https://aws.amazon.com/chime/
* **Image Support**: No
* **Message Format**: Markdown
* **Message Limit**: 4096 characters

Amazon Chime is a communications service from AWS.
## Account Setup
1. Open Amazon Chime and navigate to the chat room you want to receive notifications.
2. Choose the gear icon in the top-right corner of the chat room.
3. Choose **Manage webhooks and bots**, then **Add webhook**.
4. Give it a name (e.g. `Apprise`) and choose **Create**.
5. Choose **Copy URL** next to your new webhook.

The URL looks like:
```text
https://hooks.chime.aws/incomingwebhooks/{WebhookID}?token={Token}
```

## Syntax

Valid syntax is as follows:
- `chime://{WebhookID}/{Token}`
- `https://hooks.chime.aws/incomingwebhooks/{WebhookID}?token={Token}` (native URL, auto-parsed)

## Parameter Breakdown

| Variable  | Required | Description                                                                                         |
|-----------|----------|-----------------------------------------------------------------------------------------------------|
| WebhookID | Yes      | The UUID-like path segment after `/incomingwebhooks/` in your Chime webhook URL                     |
| Token     | Yes      | The value of the `?token=` query parameter from your Chime webhook URL (may contain `=` padding)   |

## Examples

Sends a notification to an Amazon Chime chat room:
```bash
apprise -vv -t "Alert" -b "Deployment completed." \
    "chime://xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/AaBbCcDd%3D%3D"
```

## New Service Completion Status
* [x] apprise/plugins/chime.py
* [x] pyproject.toml
* [x] README.md
    - Added entry for Amazon Chime (alphabetically between Chanify and Discord).
* [x] packaging/redhat/python-apprise.spec
    - Added `Amazon Chime` to the `%global common_description` block.

## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/76](https://github.com/caronc/apprise-docs/pull/76)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1254-notifico-standalone-support

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "chime://xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/YourTokenHere"
```
