### PR TITLE
Added Keybase support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The table below identifies the services this tool supports and some example serv
 | [Jellyfin](https://appriseit.com/services/jellyfin/)  | jellyfin:// or jellyfins:// | (TCP) 8096 | jellyfin://user@hostname/<br />jellyfins://user:password@hostname
 | [Jira](https://appriseit.com/services/jira/) | jira:// | (TCP) 443 | jira://APIKey<br/>jira://APIKey/@UserID<br/>jira://APIKey/#Team<br/>jira://APIKey/\*Schedule<br/>jira://APIKey/^Escalation
 | [Join](https://appriseit.com/services/join/) | join://   | (TCP) 443    | join://apikey/device<br />join://apikey/device1/device2/deviceN/<br />join://apikey/group<br />join://apikey/groupA/groupB/groupN<br />join://apikey/DeviceA/groupA/groupN/DeviceN/
+| [Keybase](https://appriseit.com/services/keybase/) | keybase:// | n/a | keybase://_/@username<br />keybase://_/teamname<br />keybase://_/teamname#channel
 | [KODI](https://appriseit.com/services/kodi/) | kodi:// or kodis://    | (TCP) 8080 or 443   | kodi://hostname<br />kodi://user@hostname<br />kodi://user:password@hostname:port
 | [Kumulos](https://appriseit.com/services/kumulos/) | kumulos:// | (TCP) 443 | kumulos://apikey/serverkey
 | [LaMetric Time](https://appriseit.com/services/lametric/) | lametric:// | (TCP) 443 | lametric://apikey@device_ipaddr<br/>lametric://apikey@hostname:port<br/>lametric://client_id@client_secret

--- a/all-plugin-requirements.txt
+++ b/all-plugin-requirements.txt
@@ -24,3 +24,7 @@ smpplib
 
 # For xmpp:// support
 slixmpp >= 1.10.0
+
+# Provides Saltpack v2.0 signing and NaCl box encryption for keybase://
+# and the apprise.utils.saltpack utility (Threema E2EE also uses this)
+PyNaCl

--- a/apprise/plugins/keybase/__init__.py
+++ b/apprise/plugins/keybase/__init__.py
@@ -1,0 +1,50 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Keybase Chat Notifications."""
+
+from .base import NotifyKeybase
+from .common import (
+    KEYBASE_DEFAULT_CHANNEL,
+    KEYBASE_DEFAULT_HOST,
+    KEYBASE_DEFAULT_MODE,
+    KEYBASE_DEFAULT_PORT,
+    KEYBASE_MODES,
+    KeybaseMode,
+    keybase_default_socket,
+)
+
+__all__ = [
+    "KEYBASE_DEFAULT_CHANNEL",
+    "KEYBASE_DEFAULT_HOST",
+    "KEYBASE_DEFAULT_MODE",
+    "KEYBASE_DEFAULT_PORT",
+    "KEYBASE_MODES",
+    "KeybaseMode",
+    "NotifyKeybase",
+    "keybase_default_socket",
+]

--- a/apprise/plugins/keybase/base.py
+++ b/apprise/plugins/keybase/base.py
@@ -1,0 +1,679 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Keybase Chat Notifications
+#
+# Keybase is an end-to-end encrypted messaging platform. Apprise sends
+# notifications by connecting directly to the locally running Keybase
+# service -- no binary wrapper is required.
+#
+# Two connection modes are supported:
+#
+#   socket (default)
+#     Apprise connects to the Keybase service via its Unix domain socket.
+#     The socket path is auto-detected for the current platform; you may
+#     override it with the ?socket= query parameter.
+#
+#     Linux default:  $XDG_RUNTIME_DIR/keybase/keybased.sock
+#     macOS default:  ~/Library/Group Containers/keybase/Library/keybased.sock
+#     Windows:        \\.\pipe\keybase.service
+#
+#   tcp
+#     Apprise connects over HTTP to a local Keybase service endpoint.
+#     The service port must be provided either in the URL authority or
+#     via ?port=.  The host defaults to localhost.
+#
+# Two target types are supported:
+#
+#   @username          -- direct message (1-on-1 with a Keybase user)
+#   teamname           -- post to a team channel (default: #general)
+#   teamname#channel   -- post to a specific team channel
+#
+# Apprise URL forms:
+#
+#   Socket mode (default):
+#     keybase://_/@alice
+#     keybase://_/myteam
+#     keybase://_/myteam%23dev
+#     keybase://_/@alice?socket=/run/user/1000/keybase/keybased.sock
+#
+#   TCP mode:
+#     keybase://localhost:3000/@alice
+#     keybase://localhost:3000/myteam%23dev
+#
+#   Optional Saltpack signing (requires PyNaCl):
+#     keybase://_/@alice?sigkey=aabb...64hexchars
+#
+# The keybase service must be running and the logged-in user must have
+# permission to send messages to the specified targets.
+#
+# API reference:
+#   https://keybase.io/docs/api/1.0/call/chat/send
+#   https://book.keybase.io/docs/bots
+#   https://saltpack.org/signing-crypto-format
+
+import json
+import os
+import socket as _socket
+import stat
+
+import requests
+
+from ...common import NotifyType
+from ...locale import gettext_lazy as _
+from ...url import PrivacyMode
+from ...utils.parse import parse_list
+from ...utils.saltpack import (
+    NACL_SUPPORT,
+    AppriseSaltpackController,
+    AppriseSaltpackException,
+)
+from ..base import NotifyBase
+from .common import (
+    IS_TEAM_TARGET,
+    IS_USER_TARGET,
+    IS_VALID_SIGKEY,
+    KEYBASE_DEFAULT_CHANNEL,
+    KEYBASE_DEFAULT_HOST,
+    KEYBASE_DEFAULT_MODE,
+    KEYBASE_DEFAULT_PORT,
+    KEYBASE_MODES,
+    KeybaseMode,
+    keybase_default_socket,
+)
+
+
+class NotifyKeybase(NotifyBase):
+    """A wrapper for Keybase Chat Notifications."""
+
+    # The default descriptive name associated with the Notification
+    service_name = "Keybase"
+
+    # The services URL
+    service_url = "https://keybase.io/"
+
+    # The default protocol
+    protocol = "keybase"
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = "https://appriseit.com/services/keybase/"
+
+    # PyNaCl is recommended for Saltpack signing mode
+    requirements = {
+        "packages_recommended": "PyNaCl",
+    }
+
+    # Keybase messages are plain text
+    body_maxlen = 10000
+
+    # No title concept in Keybase chat
+    title_maxlen = 0
+
+    # No remote rate limit; local service call
+    request_rate_per_sec = 0
+
+    # No URL identifier -- this is a local service, not a remote endpoint
+    url_identifier = False
+
+    # Define object URL templates
+    # First template: socket mode (no host/port in authority)
+    # Second template: TCP mode (host:port in authority)
+    templates = (
+        "{schema}://{targets}",
+        "{schema}://{host}:{port}/{targets}",
+    )
+
+    # Define our template tokens
+    template_tokens = dict(
+        NotifyBase.template_tokens,
+        **{
+            # @username -- direct message to a Keybase user
+            "target_user": {
+                "name": _("Target User"),
+                "type": "string",
+                "prefix": "@",
+                "map_to": "targets",
+            },
+            # teamname -- message to a team's default channel
+            "target_team": {
+                "name": _("Target Team"),
+                "type": "string",
+                "map_to": "targets",
+            },
+            # teamname#channel -- message to a specific team channel
+            "target_team_channel": {
+                "name": _("Target Team Channel"),
+                "type": "string",
+                "map_to": "targets",
+            },
+            "targets": {
+                "name": _("Targets"),
+                "type": "list:string",
+            },
+            "host": {
+                "name": _("Hostname"),
+                "type": "string",
+            },
+            "port": {
+                "name": _("Port"),
+                "type": "int",
+                "min": 1,
+                "max": 65535,
+            },
+        },
+    )
+
+    # Define our template arguments
+    template_args = dict(
+        NotifyBase.template_args,
+        **{
+            # Comma-separated alias for targets in the path
+            "to": {
+                "alias_of": "targets",
+            },
+            # Optional Ed25519 signing-key seed (64 hex chars)
+            "sigkey": {
+                "name": _("Signing Key"),
+                "type": "string",
+                "private": True,
+            },
+            # Connection mode: socket (default) or tcp
+            "mode": {
+                "name": _("Mode"),
+                "type": "choice:string",
+                "values": KEYBASE_MODES,
+                "default": KEYBASE_DEFAULT_MODE,
+            },
+            # Override socket path for socket mode
+            "socket": {
+                "name": _("Socket Path"),
+                "type": "string",
+            },
+        },
+    )
+
+    def __init__(
+        self,
+        targets=None,
+        sigkey=None,
+        mode=None,
+        socket_path=None,
+        **kwargs,
+    ):
+        """Initialize Keybase Object."""
+        super().__init__(**kwargs)
+
+        # Parsed and validated target list.
+        # Each entry is a tuple: ("user", username) or
+        # ("team", team_name, channel_name)
+        self.targets = []
+
+        # Track invalid targets for URL round-tripping
+        self._invalid_targets = []
+
+        # Parse each raw target string
+        for raw in parse_list(targets):
+            # Try user DM (@username)
+            match = IS_USER_TARGET.match(raw)
+            if match:
+                self.targets.append(("user", match.group("name")))
+                continue
+
+            # Try team (teamname or teamname#channel)
+            match = IS_TEAM_TARGET.match(raw)
+            if match:
+                team = match.group("team")
+                channel = match.group("channel") or KEYBASE_DEFAULT_CHANNEL
+                self.targets.append(("team", team, channel))
+                continue
+
+            # Drop the target and record it for URL round-trip
+            self.logger.warning(
+                "Dropping invalid Keybase target: %s",
+                raw,
+            )
+            self._invalid_targets.append(raw)
+
+        # Require at least one valid target
+        if not self.targets:
+            msg = "No valid Keybase targets were specified."
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # Validate and store the optional Saltpack signing key seed
+        self.sigkey = None
+        if sigkey:
+            if not IS_VALID_SIGKEY.match(sigkey):
+                msg = "Keybase signing key must be exactly 64 hex characters."
+                self.logger.warning(msg)
+                raise TypeError(msg)
+            # Store normalised to lowercase
+            self.sigkey = sigkey.lower()
+
+        # Determine connection mode:
+        #   1. Explicit mode= kwarg (highest priority)
+        #   2. Port present in URL -> implies TCP
+        #   3. Default to socket
+        if mode and mode.lower() in KEYBASE_MODES:
+            self.mode = mode.lower()
+
+        elif self.port is not None:
+            # A port in the URL authority always signals TCP mode
+            self.mode = KeybaseMode.TCP
+
+        else:
+            # No port, no explicit mode -> use Unix socket
+            self.mode = KEYBASE_DEFAULT_MODE
+
+        # Store the socket path (socket mode only); auto-detect if absent
+        self.socket_path = (
+            socket_path if socket_path else keybase_default_socket()
+        )
+
+        # Validate the socket path when it refers to a user-provided value
+        # and the path already exists on disk.  Reject anything that is not
+        # a Unix domain socket -- this prevents socket= from being pointed
+        # at regular files (/etc/shadow, /dev/sda, ...) or other non-socket
+        # filesystem objects.
+        if socket_path and self.mode == KeybaseMode.SOCKET:
+            try:
+                path_stat = os.stat(self.socket_path)
+
+            except OSError:
+                # Path does not exist yet; the service may not be running.
+                # Accept it now; the connect() call will fail if needed.
+                path_stat = None
+
+            if path_stat is not None and not stat.S_ISSOCK(path_stat.st_mode):
+                msg = (
+                    "Keybase socket path does not point to a"
+                    " socket: {}".format(self.socket_path)
+                )
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
+        # For TCP mode: apply defaults for missing host / port
+        if self.mode == KeybaseMode.TCP:
+            if not self.host or self.host == "_":
+                # Fall back to localhost when no real host was given
+                self.host = KEYBASE_DEFAULT_HOST
+
+            if self.port is None:
+                # Use the well-known keybase service port default
+                self.port = KEYBASE_DEFAULT_PORT
+
+    def _stat_socket_path(self):
+        """Raise OSError if socket_path does not point to a Unix socket."""
+
+        # Check whether the path exists and is actually a socket file
+        try:
+            path_stat = os.stat(self.socket_path)
+            if not stat.S_ISSOCK(path_stat.st_mode):
+                # Path exists but is not a socket (e.g. a regular file)
+                raise OSError(
+                    "Path is not a Unix socket: {}".format(self.socket_path)
+                )
+
+        except FileNotFoundError as exc:
+            # Socket file missing -- service is likely not running
+            raise OSError(
+                "Keybase socket not found: {}. "
+                "Is the Keybase service running?".format(self.socket_path)
+            ) from exc
+
+    def _send_socket(self, payload):
+        """Send payload over a Unix domain socket; return response dict."""
+
+        # AF_UNIX is required for socket mode
+        if not hasattr(_socket, "AF_UNIX"):
+            raise OSError(
+                "Unix domain sockets are unavailable on this "
+                "platform; configure mode=tcp instead."
+            )
+
+        # Safety: verify the path is a Unix socket before connecting.
+        self._stat_socket_path()
+
+        # Open a stream socket for the Unix domain transport
+        sock = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+        sock.settimeout(self.socket_read_timeout)
+
+        try:
+            # Connect to the keybase service socket file
+            sock.connect(self.socket_path)
+
+            # Encode and send the JSON payload terminated by a newline
+            data = json.dumps(payload).encode("utf-8") + b"\n"
+            sock.sendall(data)
+
+            # Read until the newline-terminated response arrives
+            buf = b""
+            while True:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    # Connection closed before full response
+                    break
+
+                buf += chunk
+                if b"\n" in buf:
+                    # Complete response received
+                    break
+
+        finally:
+            # Always close the socket regardless of outcome
+            sock.close()
+
+        # Parse the first newline-delimited JSON object in the buffer
+        try:
+            return json.loads(buf.split(b"\n")[0])
+
+        except (ValueError, IndexError):
+            # Non-JSON or empty response -- treat as success (no error key)
+            return {}
+
+    def _send_tcp(self, payload):
+        """Send payload via HTTP to the local keybase service."""
+
+        # Construct the keybase HTTP API endpoint
+        url = "http://{}:{}/v1".format(self.host, self.port)
+
+        # Attempt the HTTP POST
+        try:
+            r = requests.post(
+                url,
+                json=payload,
+                headers={"Content-Type": "application/json"},
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+            )
+
+            # Non-OK HTTP status is returned as an API-level error dict
+            if r.status_code != requests.codes.ok:
+                return {
+                    "error": {
+                        "code": r.status_code,
+                        "message": r.text[:200],
+                    }
+                }
+
+            # Parse and return the JSON response body
+            try:
+                return r.json()
+
+            except ValueError:
+                # Empty or non-JSON body
+                return {}
+
+        except requests.RequestException as exc:
+            # Re-raise as OSError so send() handles it uniformly
+            raise OSError(str(exc)) from exc
+
+    def send(
+        self,
+        body,
+        title="",
+        notify_type=NotifyType.INFO,
+        **kwargs,
+    ):
+        """Perform Keybase Chat Notification."""
+
+        # Apply Saltpack signing when a signing key is configured
+        if self.sigkey:
+            if not NACL_SUPPORT:
+                self.logger.warning(
+                    "Keybase Saltpack signing requires PyNaCl;"
+                    " install with: pip install PyNaCl"
+                )
+                return False
+
+            # Sign the message body with Saltpack v2.0
+            controller = AppriseSaltpackController()
+            try:
+                body = controller.sign(body, self.sigkey)
+
+            except AppriseSaltpackException as exc:
+                self.logger.warning("Keybase Saltpack signing failed: %s", exc)
+                return False
+
+        # Track overall delivery status across all targets
+        has_error = False
+
+        # Iterate over all targets and send one message per target
+        for target in self.targets:
+            kind = target[0]
+
+            if kind == "user":
+                # Direct-message channel descriptor
+                _, username = target
+                channel = {"name": username}
+
+            else:
+                # Team channel descriptor
+                _, team, ch_name = target
+                channel = {
+                    "name": team,
+                    "topic_name": ch_name,
+                    "members_type": "team",
+                }
+
+            # Build the keybase chat API JSON payload
+            payload = {
+                "method": "send",
+                "params": {
+                    "options": {
+                        "channel": channel,
+                        "message": {"body": body},
+                    },
+                },
+            }
+
+            self.logger.debug("Keybase target: %s", channel)
+            self.logger.debug("Keybase payload: %s", payload)
+
+            # Throttle before each service call
+            self.throttle()
+
+            # Dispatch to the appropriate transport
+            try:
+                response = (
+                    self._send_socket(payload)
+                    if self.mode == KeybaseMode.SOCKET
+                    else self._send_tcp(payload)
+                )
+
+            except OSError as exc:
+                self.logger.warning(
+                    "Keybase %s connection error for %s: %s",
+                    self.mode,
+                    channel.get("name"),
+                    exc,
+                )
+                has_error = True
+                continue
+
+            # Check for API-level errors in the JSON response
+            if "error" in response:
+                err = response["error"]
+                self.logger.warning(
+                    "Keybase API error for %s: %s",
+                    channel.get("name"),
+                    err.get("message", "unknown")
+                    if isinstance(err, dict)
+                    else str(err),
+                )
+                has_error = True
+                continue
+
+            self.logger.info(
+                "Sent Keybase notification to %s.",
+                channel.get("name"),
+            )
+
+        return not has_error
+
+    def url(self, privacy=False, *args, **kwargs):
+        """Returns the URL built dynamically based on specified arguments."""
+
+        # Collect any extra URL parameters
+        params = self.url_parameters(privacy=privacy, *args, **kwargs)
+
+        # Include the signing key when set
+        if self.sigkey:
+            params["sigkey"] = self.pprint(
+                self.sigkey,
+                privacy=privacy,
+                mode=PrivacyMode.Secret,
+                safe="",
+            )
+
+        # Always emit the mode so generated URLs are self-documenting
+        params["mode"] = self.mode
+
+        # Include the socket path only when it differs from the
+        # auto-detected platform default (socket mode only)
+        if (
+            self.mode == KeybaseMode.SOCKET
+            and self.socket_path != keybase_default_socket()
+        ):
+            params["socket"] = self.socket_path
+
+        # Build the ordered target path segments
+        parts = []
+        for target in self.targets:
+            kind = target[0]
+            if kind == "user":
+                _, username = target
+                # Re-add the @ prefix; safe-quote for URL path
+                parts.append("@" + NotifyKeybase.quote(username, safe=""))
+            else:
+                _, team, channel = target
+                if channel == KEYBASE_DEFAULT_CHANNEL:
+                    parts.append(NotifyKeybase.quote(team, safe=""))
+
+                else:
+                    # Encode # as %23 so it survives URL round-trip
+                    parts.append(
+                        NotifyKeybase.quote(team, safe="")
+                        + "%23"
+                        + NotifyKeybase.quote(channel, safe="")
+                    )
+
+        # Append any invalid targets unchanged for round-trip preservation
+        for raw in self._invalid_targets:
+            parts.append(NotifyKeybase.quote(raw, safe=""))
+
+        # TCP mode: emit real host:port in the URL authority
+        if self.mode == KeybaseMode.TCP:
+            return "{schema}://{host}:{port}/{targets}?{params}".format(
+                schema=self.protocol,
+                host=self.host,
+                port=self.port,
+                targets="/".join(parts),
+                params=NotifyKeybase.urlencode(params),
+            )
+
+        # Socket mode: use _ as a placeholder host
+        return "{schema}://_/{targets}?{params}".format(
+            schema=self.protocol,
+            targets="/".join(parts),
+            params=NotifyKeybase.urlencode(params),
+        )
+
+    @staticmethod
+    def parse_url(url):
+        """Parses the URL and returns enough arguments that can allow
+        us to re-instantiate this object."""
+
+        # Pre-encode any bare '#' in the URL path to '%23' so that
+        # 'teamname#channel' is treated identically to
+        # 'teamname%23channel'.  A literal '#' in a URL is the fragment
+        # separator; without this step the channel name would be silently
+        # discarded by the underlying URL parser.  Only the path portion
+        # is affected -- split on '?' first so query-string values are
+        # left untouched.
+        _q = url.find("?")
+        if _q >= 0:
+            url = url[:_q].replace("#", "%23") + url[_q:]
+
+        else:
+            url = url.replace("#", "%23")
+
+        results = NotifyBase.parse_url(url, verify_host=False)
+        if not results:
+            return results
+
+        # Collect all target strings
+        targets = []
+
+        # Extract the host field and port
+        host = NotifyKeybase.unquote(results.get("host") or "")
+        port = results.get("port")
+
+        # The host is a notification target only when no port is present.
+        # A port in the authority signals TCP mode; the host is then a
+        # connection endpoint, not a chat target.
+        if host and host != "_" and port is None:
+            if results.get("user") == "":
+                # @ prefix was present -> direct-message target
+                targets.append("@" + host)
+
+            else:
+                # Team or bare username -> chat target
+                targets.append(host)
+
+        # Path segments carry the remaining targets
+        targets += NotifyKeybase.split_path(results["fullpath"])
+
+        # ?to= query param is an alias for targets
+        if "to" in results["qsd"] and results["qsd"]["to"]:
+            targets += NotifyKeybase.parse_list(results["qsd"]["to"])
+
+        results["targets"] = targets
+
+        # Extract the optional Saltpack signing key
+        if "sigkey" in results["qsd"] and results["qsd"]["sigkey"]:
+            results["sigkey"] = NotifyKeybase.unquote(results["qsd"]["sigkey"])
+
+        # Extract the connection mode; explicit mode= wins over auto-detect
+        if "mode" in results["qsd"] and results["qsd"]["mode"]:
+            results["mode"] = NotifyKeybase.unquote(
+                results["qsd"]["mode"]
+            ).lower()
+
+        # Extract an optional custom socket path
+        if "socket" in results["qsd"] and results["qsd"]["socket"]:
+            results["socket_path"] = NotifyKeybase.unquote(
+                results["qsd"]["socket"]
+            )
+
+        return results
+
+    @staticmethod
+    def runtime_deps():
+        """Return a tuple of top-level Python package names that this
+        plugin imported as optional runtime dependencies."""
+        return ("nacl",)

--- a/apprise/plugins/keybase/base.py
+++ b/apprise/plugins/keybase/base.py
@@ -38,6 +38,11 @@
 #     The socket path is auto-detected for the current platform; you may
 #     override it with the ?socket= query parameter.
 #
+#     Security: any custom socket path must contain the word "keybase"
+#     (case-insensitive).  This guards against ?socket= being aimed at
+#     unrelated system sockets (e.g. /var/run/docker.sock).  The default
+#     auto-detected paths always satisfy this requirement.
+#
 #     Linux default:  $XDG_RUNTIME_DIR/keybase/keybased.sock
 #     macOS default:  ~/Library/Group Containers/keybase/Library/keybased.sock
 #     Windows:        \\.\pipe\keybase.service
@@ -94,6 +99,7 @@ from ...utils.saltpack import (
 )
 from ..base import NotifyBase
 from .common import (
+    IS_KEYBASE_SOCKET_PATH,
     IS_TEAM_TARGET,
     IS_USER_TARGET,
     IS_VALID_SIGKEY,
@@ -211,7 +217,9 @@ class NotifyKeybase(NotifyBase):
                 "values": KEYBASE_MODES,
                 "default": KEYBASE_DEFAULT_MODE,
             },
-            # Override socket path for socket mode
+            # Override socket path for socket mode.
+            # The path must contain the word "keybase" (case-insensitive)
+            # to prevent accidental use of unrelated system sockets.
             "socket": {
                 "name": _("Socket Path"),
                 "type": "string",
@@ -298,11 +306,26 @@ class NotifyKeybase(NotifyBase):
         )
 
         # Validate the socket path when it refers to a user-provided value
-        # and the path already exists on disk.  Reject anything that is not
-        # a Unix domain socket -- this prevents socket= from being pointed
-        # at regular files (/etc/shadow, /dev/sda, ...) or other non-socket
-        # filesystem objects.
+        # and the path already exists on disk.
         if socket_path and self.mode == KeybaseMode.SOCKET:
+            # Security guard: reject paths that do not reference keybase.
+            # This prevents ?socket= from being aimed at unrelated system
+            # sockets (e.g. /var/run/docker.sock,
+            # /run/containerd/containerd.sock).  Every legitimate Keybase
+            # socket path -- platform defaults and custom installs alike --
+            # contains the word "keybase".
+            if not IS_KEYBASE_SOCKET_PATH.search(socket_path):
+                msg = (
+                    "Keybase socket path must contain 'keybase' to"
+                    " prevent misuse of unrelated system"
+                    " sockets: {}".format(socket_path)
+                )
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
+            # Reject anything that is not a Unix domain socket -- this
+            # prevents socket= from being pointed at regular files
+            # (/etc/shadow, /dev/sda, ...) or other non-socket objects.
             try:
                 path_stat = os.stat(self.socket_path)
 

--- a/apprise/plugins/keybase/base.py
+++ b/apprise/plugins/keybase/base.py
@@ -133,6 +133,9 @@ class NotifyKeybase(NotifyBase):
     # No title concept in Keybase chat
     title_maxlen = 0
 
+    # Keybase supports file attachments via the 'attach' API method
+    attachment_support = True
+
     # No remote rate limit; local service call
     request_rate_per_sec = 0
 
@@ -437,6 +440,7 @@ class NotifyKeybase(NotifyBase):
         body,
         title="",
         notify_type=NotifyType.INFO,
+        attach=None,
         **kwargs,
     ):
         """Perform Keybase Chat Notification."""
@@ -532,6 +536,75 @@ class NotifyKeybase(NotifyBase):
                 "Sent Keybase notification to %s.",
                 channel.get("name"),
             )
+
+            # Send any file attachments to the same target
+            if attach and self.attachment_support:
+                for attachment in attach:
+                    # Verify the attachment file is accessible
+                    if not attachment:
+                        self.logger.warning(
+                            "Could not access Keybase attachment: %s.",
+                            attachment.url(privacy=True),
+                        )
+                        has_error = True
+                        continue
+
+                    # Build the keybase file attach API payload
+                    attach_payload = {
+                        "method": "attach",
+                        "params": {
+                            "options": {
+                                "channel": channel,
+                                "filename": attachment.path,
+                                "title": attachment.name,
+                            },
+                        },
+                    }
+
+                    self.logger.debug(
+                        "Keybase attachment: %s",
+                        attachment.url(privacy=True),
+                    )
+
+                    # Throttle before each service call
+                    self.throttle()
+
+                    # Dispatch to the appropriate transport
+                    try:
+                        response = (
+                            self._send_socket(attach_payload)
+                            if self.mode == KeybaseMode.SOCKET
+                            else self._send_tcp(attach_payload)
+                        )
+
+                    except OSError as exc:
+                        self.logger.warning(
+                            "Keybase %s attachment error for %s: %s",
+                            self.mode,
+                            channel.get("name"),
+                            exc,
+                        )
+                        has_error = True
+                        continue
+
+                    # Check for API-level errors in the response
+                    if "error" in response:
+                        err = response["error"]
+                        self.logger.warning(
+                            "Keybase API attachment error for %s: %s",
+                            channel.get("name"),
+                            err.get("message", "unknown")
+                            if isinstance(err, dict)
+                            else str(err),
+                        )
+                        has_error = True
+                        continue
+
+                    self.logger.info(
+                        "Sent Keybase attachment (%s) to %s.",
+                        attachment.name,
+                        channel.get("name"),
+                    )
 
         return not has_error
 

--- a/apprise/plugins/keybase/base.py
+++ b/apprise/plugins/keybase/base.py
@@ -91,7 +91,7 @@ import requests
 from ...common import NotifyType
 from ...locale import gettext_lazy as _
 from ...url import PrivacyMode
-from ...utils.parse import parse_list
+from ...utils.parse import is_hostname, parse_list
 from ...utils.saltpack import (
     NACL_SUPPORT,
     AppriseSaltpackController,
@@ -111,6 +111,11 @@ from .common import (
     KeybaseMode,
     keybase_default_socket,
 )
+
+# AF_UNIX is absent on some Windows Python builds.  Store it at module
+# level so both _stat_socket_path and _send_socket reference the same
+# patchable name rather than reaching into the live socket module.
+_AF_UNIX = getattr(_socket, "AF_UNIX", None)
 
 
 class NotifyKeybase(NotifyBase):
@@ -232,7 +237,7 @@ class NotifyKeybase(NotifyBase):
         targets=None,
         sigkey=None,
         mode=None,
-        socket_path=None,
+        socket=None,
         **kwargs,
     ):
         """Initialize Keybase Object."""
@@ -288,7 +293,8 @@ class NotifyKeybase(NotifyBase):
         # Determine connection mode:
         #   1. Explicit mode= kwarg (highest priority)
         #   2. Port present in URL -> implies TCP
-        #   3. Default to socket
+        #   3. Host is localhost or an IPv4 address -> implies TCP
+        #   4. Default to socket
         if mode and mode.lower() in KEYBASE_MODES:
             self.mode = mode.lower()
 
@@ -296,29 +302,32 @@ class NotifyKeybase(NotifyBase):
             # A port in the URL authority always signals TCP mode
             self.mode = KeybaseMode.TCP
 
+        elif self.host and is_hostname(self.host):
+            # Any valid hostname or IP address (v4/v6) in the URL
+            # authority signals TCP mode even without a port
+            self.mode = KeybaseMode.TCP
+
         else:
             # No port, no explicit mode -> use Unix socket
             self.mode = KEYBASE_DEFAULT_MODE
 
         # Store the socket path (socket mode only); auto-detect if absent
-        self.socket_path = (
-            socket_path if socket_path else keybase_default_socket()
-        )
+        self.socket = socket if socket else keybase_default_socket()
 
         # Validate the socket path when it refers to a user-provided value
         # and the path already exists on disk.
-        if socket_path and self.mode == KeybaseMode.SOCKET:
+        if socket and self.mode == KeybaseMode.SOCKET:
             # Security guard: reject paths that do not reference keybase.
             # This prevents ?socket= from being aimed at unrelated system
             # sockets (e.g. /var/run/docker.sock,
             # /run/containerd/containerd.sock).  Every legitimate Keybase
             # socket path -- platform defaults and custom installs alike --
             # contains the word "keybase".
-            if not IS_KEYBASE_SOCKET_PATH.search(socket_path):
+            if not IS_KEYBASE_SOCKET_PATH.search(socket):
                 msg = (
                     "Keybase socket path must contain 'keybase' to"
                     " prevent misuse of unrelated system"
-                    " sockets: {}".format(socket_path)
+                    " sockets: {}".format(socket)
                 )
                 self.logger.warning(msg)
                 raise TypeError(msg)
@@ -327,7 +336,7 @@ class NotifyKeybase(NotifyBase):
             # prevents socket= from being pointed at regular files
             # (/etc/shadow, /dev/sda, ...) or other non-socket objects.
             try:
-                path_stat = os.stat(self.socket_path)
+                path_stat = os.stat(self.socket)
 
             except OSError:
                 # Path does not exist yet; the service may not be running.
@@ -337,7 +346,7 @@ class NotifyKeybase(NotifyBase):
             if path_stat is not None and not stat.S_ISSOCK(path_stat.st_mode):
                 msg = (
                     "Keybase socket path does not point to a"
-                    " socket: {}".format(self.socket_path)
+                    " socket: {}".format(self.socket)
                 )
                 self.logger.warning(msg)
                 raise TypeError(msg)
@@ -353,44 +362,57 @@ class NotifyKeybase(NotifyBase):
                 self.port = KEYBASE_DEFAULT_PORT
 
     def _stat_socket_path(self):
-        """Raise OSError if socket_path does not point to a Unix socket."""
+        """Raise OSError if AF_UNIX is unavailable or socket path is invalid.
 
-        # Check whether the path exists and is actually a socket file
-        try:
-            path_stat = os.stat(self.socket_path)
-            if not stat.S_ISSOCK(path_stat.st_mode):
-                # Path exists but is not a socket (e.g. a regular file)
-                raise OSError(
-                    "Path is not a Unix socket: {}".format(self.socket_path)
-                )
+        This method is the single preflight gate for socket mode.  All
+        platform capability and path validity checks live here so that
+        tests can mock this one method and bypass the whole preflight.
+        """
 
-        except FileNotFoundError as exc:
-            # Socket file missing -- service is likely not running
-            raise OSError(
-                "Keybase socket not found: {}. "
-                "Is the Keybase service running?".format(self.socket_path)
-            ) from exc
-
-    def _send_socket(self, payload):
-        """Send payload over a Unix domain socket; return response dict."""
-
-        # AF_UNIX is required for socket mode
-        if not hasattr(_socket, "AF_UNIX"):
+        # AF_UNIX is required for socket mode; not present on all platforms
+        if _AF_UNIX is None:
             raise OSError(
                 "Unix domain sockets are unavailable on this "
                 "platform; configure mode=tcp instead."
             )
 
-        # Safety: verify the path is a Unix socket before connecting.
+        # Probe the socket path -- keep stat() in its own try block so
+        # the handlers below do not accidentally catch the OSError we
+        # raise for the S_ISSOCK check immediately after.
+        try:
+            path_stat = os.stat(self.socket)
+
+        except FileNotFoundError as exc:
+            # Socket file missing -- service is likely not running
+            raise OSError(
+                "Keybase socket not found: {}. "
+                "Is the Keybase service running?".format(self.socket)
+            ) from exc
+
+        except OSError as exc:
+            # Permission denied, not-a-directory, or other stat failure
+            raise OSError(
+                "Keybase socket inaccessible {}: {}".format(self.socket, exc)
+            ) from exc
+
+        # Verify the path points to an actual socket, not a regular file
+        if not stat.S_ISSOCK(path_stat.st_mode):
+            raise OSError("Path is not a Unix socket: {}".format(self.socket))
+
+    def _send_socket(self, payload):
+        """Send payload over a Unix domain socket; return response dict."""
+
+        # Preflight: verify AF_UNIX is available and the path is valid.
+        # Raises OSError on any failure; also mocked in unit tests.
         self._stat_socket_path()
 
         # Open a stream socket for the Unix domain transport
-        sock = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+        sock = _socket.socket(_AF_UNIX, _socket.SOCK_STREAM)
         sock.settimeout(self.socket_read_timeout)
 
         try:
             # Connect to the keybase service socket file
-            sock.connect(self.socket_path)
+            sock.connect(self.socket)
 
             # Encode and send the JSON payload terminated by a newline
             data = json.dumps(payload).encode("utf-8") + b"\n"
@@ -653,9 +675,9 @@ class NotifyKeybase(NotifyBase):
         # auto-detected platform default (socket mode only)
         if (
             self.mode == KeybaseMode.SOCKET
-            and self.socket_path != keybase_default_socket()
+            and self.socket != keybase_default_socket()
         ):
-            params["socket"] = self.socket_path
+            params["socket"] = self.socket
 
         # Build the ordered target path segments
         parts = []
@@ -729,10 +751,13 @@ class NotifyKeybase(NotifyBase):
         host = NotifyKeybase.unquote(results.get("host") or "")
         port = results.get("port")
 
-        # The host is a notification target only when no port is present.
-        # A port in the authority signals TCP mode; the host is then a
-        # connection endpoint, not a chat target.
-        if host and host != "_" and port is None:
+        # The host is a notification target only when:
+        #   - it is not the "_" placeholder, AND
+        #   - no port is present (port implies TCP mode), AND
+        #   - it is not a valid hostname or IP address.
+        # Any valid hostname/IP in the URL authority is a TCP endpoint;
+        # is_hostname() covers IPv4, IPv6, and named hosts.
+        if host and host != "_" and port is None and not is_hostname(host):
             if results.get("user") == "":
                 # @ prefix was present -> direct-message target
                 targets.append("@" + host)
@@ -762,9 +787,7 @@ class NotifyKeybase(NotifyBase):
 
         # Extract an optional custom socket path
         if "socket" in results["qsd"] and results["qsd"]["socket"]:
-            results["socket_path"] = NotifyKeybase.unquote(
-                results["qsd"]["socket"]
-            )
+            results["socket"] = NotifyKeybase.unquote(results["qsd"]["socket"])
 
         return results
 

--- a/apprise/plugins/keybase/common.py
+++ b/apprise/plugins/keybase/common.py
@@ -28,6 +28,7 @@
 """Shared constants and validation patterns for the Keybase plugin."""
 
 import os
+import posixpath
 import re
 import sys
 
@@ -103,10 +104,12 @@ def keybase_default_socket():
             "keybased.sock",
         )
 
-    # Linux / other Unix: honour XDG_RUNTIME_DIR; fall back to /run/user
+    # Linux / other Unix: honour XDG_RUNTIME_DIR; fall back to /run/user.
+    # posixpath.join is used so that cross-platform test runs (e.g. Windows
+    # CI testing the Linux branch) always produce forward-slash paths.
     uid = os.getuid() if hasattr(os, "getuid") else 1000
     runtime_dir = os.environ.get(
         "XDG_RUNTIME_DIR",
         "/run/user/{}".format(uid),
     )
-    return os.path.join(runtime_dir, "keybase", "keybased.sock")
+    return posixpath.join(runtime_dir, "keybase", "keybased.sock")

--- a/apprise/plugins/keybase/common.py
+++ b/apprise/plugins/keybase/common.py
@@ -1,0 +1,104 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Shared constants and validation patterns for the Keybase plugin."""
+
+import os
+import re
+import sys
+
+
+class KeybaseMode:
+    """Tracks the operating mode for the Keybase plugin."""
+
+    # Connect via Unix domain socket (auto-detected path).
+    # This is the default mode and requires no port number.
+    SOCKET = "socket"
+
+    # Connect via HTTP to a locally running keybase service.
+    # Requires host and port (e.g. localhost:3000).
+    TCP = "tcp"
+
+
+# All supported connection modes
+KEYBASE_MODES = (
+    KeybaseMode.SOCKET,
+    KeybaseMode.TCP,
+)
+
+# Default connection mode
+KEYBASE_DEFAULT_MODE = KeybaseMode.SOCKET
+
+# Default host and port used when TCP mode is active
+KEYBASE_DEFAULT_HOST = "localhost"
+KEYBASE_DEFAULT_PORT = 3000
+
+# Default team channel when none is specified in the target
+KEYBASE_DEFAULT_CHANNEL = "general"
+
+# Valid Keybase username:
+#   lowercase letters, digits, underscores; 2-16 characters total.
+#   Leading @ is stripped by the caller before matching.
+IS_USER_TARGET = re.compile(r"^@(?P<name>[a-z0-9][a-z0-9_]{0,14}[a-z0-9])$")
+
+# Valid Keybase team name (optionally followed by #channel_name):
+#   - Team:    lowercase letters, digits, dots, underscores; 2-40 chars
+#   - Channel: lowercase letters, digits, underscores; 2-20 chars
+IS_TEAM_TARGET = re.compile(
+    r"^(?P<team>[a-z0-9][a-z0-9_.]{0,38}[a-z0-9])"
+    r"(?:#(?P<channel>[a-z0-9][a-z0-9_]{0,18}[a-z0-9]))?$"
+)
+
+# Ed25519 signing key seed: exactly 64 lowercase or uppercase hex characters
+IS_VALID_SIGKEY = re.compile(r"^[0-9a-fA-F]{64}$")
+
+
+def keybase_default_socket():
+    """Return the platform-default keybase service socket path."""
+
+    # Windows: keybase exposes a named pipe
+    if sys.platform == "win32":
+        return r"\\.\pipe\keybase.service"
+
+    # macOS: socket lives inside Library/Group Containers
+    if sys.platform == "darwin":
+        return os.path.join(
+            os.path.expanduser("~"),
+            "Library",
+            "Group Containers",
+            "keybase",
+            "Library",
+            "keybased.sock",
+        )
+
+    # Linux / other Unix: honour XDG_RUNTIME_DIR; fall back to /run/user
+    uid = os.getuid() if hasattr(os, "getuid") else 1000
+    runtime_dir = os.environ.get(
+        "XDG_RUNTIME_DIR",
+        "/run/user/{}".format(uid),
+    )
+    return os.path.join(runtime_dir, "keybase", "keybased.sock")

--- a/apprise/plugins/keybase/common.py
+++ b/apprise/plugins/keybase/common.py
@@ -76,6 +76,14 @@ IS_TEAM_TARGET = re.compile(
 # Ed25519 signing key seed: exactly 64 lowercase or uppercase hex characters
 IS_VALID_SIGKEY = re.compile(r"^[0-9a-fA-F]{64}$")
 
+# Socket path safety guard: the path must contain the word "keybase"
+# (case-insensitive).  This prevents ?socket= from being aimed at
+# unrelated system sockets such as /var/run/docker.sock or
+# /run/containerd/containerd.sock.  All legitimate Keybase socket
+# paths -- platform defaults and custom installs alike -- contain
+# the word "keybase".
+IS_KEYBASE_SOCKET_PATH = re.compile(r"(?i)keybase")
+
 
 def keybase_default_socket():
     """Return the platform-default keybase service socket path."""

--- a/apprise/utils/saltpack.py
+++ b/apprise/utils/saltpack.py
@@ -1,0 +1,550 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# NaCl signing and encryption utilities for Apprise.
+#
+# This module implements:
+#
+#  - Saltpack v2.0 attached signing (Ed25519).  Output is compatible
+#    with `keybase verify` and any Saltpack-aware client.
+#
+#  - NaCl box encryption (Curve25519 + XSalsa20-Poly1305), the same
+#    primitive used by Threema E2EE and other Apprise plugins.
+#
+#  - Convenience helpers for Keybase public key lookup via the
+#    public HTTPS API.
+#
+# Saltpack v2.0 signing format references:
+#   https://saltpack.org/signing-crypto-format
+#   https://saltpack.org/armoring
+#
+# Keybase key lookup API:
+#   https://keybase.io/docs/api/1.0/call/user/lookup
+
+import hashlib
+import math
+import struct
+
+import requests
+
+from ..exception import ApprisePluginException
+from ..logger import logger
+
+try:
+    from nacl.public import (
+        Box as _NaclBox,
+        PrivateKey as _NaclPrivateKey,
+        PublicKey as _NaclPublicKey,
+    )
+    from nacl.signing import SigningKey as _NaclSigningKey
+    from nacl.utils import random as _nacl_random
+
+    # PyNaCl is available
+    NACL_SUPPORT = True
+
+except ImportError:
+    _NaclBox = None
+    _NaclPrivateKey = None
+    _NaclPublicKey = None
+    _NaclSigningKey = None
+    _nacl_random = None
+
+    # PyNaCl is not installed
+    NACL_SUPPORT = False
+
+
+# Armor header and footer markers
+_SP_BEGIN_SIGNED = "BEGIN KEYBASE SALTPACK SIGNED MESSAGE."
+_SP_END_SIGNED = "END KEYBASE SALTPACK SIGNED MESSAGE."
+
+# Base62 alphabet used by Saltpack (digits, then upper, then lower)
+_BASE62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+# Saltpack armor chunking: 32 raw bytes -> 43 base62 characters
+# (62^43 > 2^256, so 43 chars can represent any 32-byte value)
+_ARMOR_CHUNK_BYTES = 32
+_ARMOR_CHUNK_CHARS = 43
+
+# Armor line width (characters per line)
+_ARMOR_LINE_WIDTH = 70
+
+# Saltpack signing payload chunk size (per spec: 1 MB)
+_PAYLOAD_CHUNK = 1_000_000
+
+
+# ---------------------------------------------------------------------------
+# Inline msgpack encoder
+#
+# Only the subset of types needed for Saltpack v2.0 headers and packets
+# is implemented here, so no external msgpack library is required.
+# ---------------------------------------------------------------------------
+
+
+def _mp_fixstr(s):
+    """Encode a short ASCII string as msgpack fixstr (length <= 31)."""
+    b = s.encode("ascii")
+    if len(b) > 31:
+        raise ValueError("fixstr too long ({} bytes)".format(len(b)))
+    # fixstr: 0xa0 | length, then the UTF-8 bytes
+    return bytes([0xA0 | len(b)]) + b
+
+
+def _mp_uint(n):
+    """Encode a small non-negative integer as msgpack positive fixint."""
+    if 0 <= n <= 127:
+        return bytes([n])
+    raise ValueError("uint out of positive fixint range: {}".format(n))
+
+
+def _mp_bool(v):
+    """Encode a boolean as msgpack bool."""
+    # 0xc3 = true, 0xc2 = false
+    return b"\xc3" if v else b"\xc2"
+
+
+def _mp_bytes(data):
+    """Encode a bytes object as msgpack bin8, bin16, or bin32."""
+    n = len(data)
+    if n <= 255:
+        # bin8: 0xc4, length (1 byte), data
+        return b"\xc4" + bytes([n]) + data
+    if n <= 65535:
+        # bin16: 0xc5, length (2 bytes big-endian), data
+        return b"\xc5" + struct.pack(">H", n) + data
+    # bin32: 0xc6, length (4 bytes big-endian), data
+    return b"\xc6" + struct.pack(">I", n) + data
+
+
+def _mp_array(items):
+    """Encode a list of pre-encoded msgpack items as a msgpack array."""
+    n = len(items)
+    body = b"".join(items)
+    if n <= 15:
+        # fixarray: 0x90 | count
+        return bytes([0x90 | n]) + body
+    if n <= 65535:
+        # array16: 0xdc, count (2 bytes big-endian)
+        return b"\xdc" + struct.pack(">H", n) + body
+    # array32: 0xdd, count (4 bytes big-endian)
+    return b"\xdd" + struct.pack(">I", n) + body
+
+
+# ---------------------------------------------------------------------------
+# Base62 codec (Saltpack armoring)
+# ---------------------------------------------------------------------------
+
+
+def _b62_encode(data):
+    """Encode a byte string using Saltpack base62 armor.
+
+    Processes 32-byte chunks at a time, mapping each chunk to exactly
+    43 base62 characters.  The final partial chunk uses the minimum
+    number of chars that can represent its value.  Returns the encoded
+    characters as a single string (without armor headers or line-breaks).
+    """
+    parts = []
+    for i in range(0, len(data), _ARMOR_CHUNK_BYTES):
+        chunk = data[i : i + _ARMOR_CHUNK_BYTES]
+        # Number of output chars for this chunk
+        if len(chunk) == _ARMOR_CHUNK_BYTES:
+            n_chars = _ARMOR_CHUNK_CHARS
+        else:
+            # ceil(k * 8 / log2(62)) for a k-byte partial chunk
+            n_chars = math.ceil(len(chunk) * 8 / math.log2(62))
+
+        # Convert chunk to a big-endian integer and base62-encode it
+        n = int.from_bytes(chunk, "big")
+        chars = []
+        for _ in range(n_chars):
+            n, r = divmod(n, 62)
+            chars.append(_BASE62[r])
+        # Reverse because we built the digits least-significant first
+        parts.extend(reversed(chars))
+
+    return "".join(parts)
+
+
+def _b62_decode(text):
+    """Decode a Saltpack base62 armor string to bytes.
+
+    Processes 43-char chunks at a time, each mapping back to exactly
+    32 bytes.  The final partial chunk infers its byte count from the
+    number of remaining characters.
+    """
+    # Strip all whitespace first
+    text = "".join(text.split())
+
+    parts = []
+    pos = 0
+    while pos < len(text):
+        remaining = len(text) - pos
+        if remaining >= _ARMOR_CHUNK_CHARS:
+            # Full 43-char chunk -> 32 bytes
+            chunk_text = text[pos : pos + _ARMOR_CHUNK_CHARS]
+            pos += _ARMOR_CHUNK_CHARS
+            n_bytes = _ARMOR_CHUNK_BYTES
+        else:
+            # Partial last chunk: infer byte count
+            chunk_text = text[pos:]
+            pos = len(text)
+            # floor(n_chars * log2(62) / 8)
+            n_bytes = int(remaining * math.log2(62) / 8)
+
+        # Decode base62 chars to integer then to bytes
+        n = 0
+        for ch in chunk_text:
+            n = n * 62 + _BASE62.index(ch)
+        parts.append(n.to_bytes(n_bytes, "big"))
+
+    return b"".join(parts)
+
+
+class AppriseSaltpackException(ApprisePluginException):
+    """Thrown when a Saltpack or NaCl operation fails."""
+
+    def __init__(self, message, error_code=610):
+        super().__init__(message, error_code=error_code)
+
+
+class AppriseSaltpackController:
+    """Saltpack signing and NaCl encryption controller for Apprise.
+
+    Provides:
+      - Saltpack v2.0 attached signing (Ed25519) via sign().
+      - NaCl box encryption (Curve25519 + XSalsa20-Poly1305)
+        via box_encrypt(), matching the primitive used by
+        Threema E2EE and other plugins.
+      - Ed25519 and Curve25519 key generation helpers.
+      - Keybase public-key lookup via the HTTPS API.
+
+    Requires: pip install PyNaCl
+    """
+
+    def sign(self, message, signing_key_hex):
+        """Create a Saltpack v2.0 armored signed message.
+
+        Output is compatible with any Saltpack client (including
+        ``keybase verify``).
+
+        Args:
+            message:
+                Text or bytes to sign.
+            signing_key_hex:
+                64-character hex string of the 32-byte Ed25519
+                signing-key seed.
+
+        Returns the full armored signed-message string.
+        Raises AppriseSaltpackException on any error.
+        """
+        if not NACL_SUPPORT:
+            raise AppriseSaltpackException(
+                "PyNaCl is required for Saltpack signing;"
+                " install with: pip install PyNaCl"
+            )
+
+        # Parse and validate the signing key seed
+        try:
+            seed = bytes.fromhex(signing_key_hex)
+        except (ValueError, TypeError) as exc:
+            raise AppriseSaltpackException(
+                "Invalid signing key: expected 64 hex characters"
+            ) from exc
+
+        if len(seed) != 32:
+            raise AppriseSaltpackException(
+                "Invalid signing key length: expected 32 bytes, got {}".format(
+                    len(seed)
+                )
+            )
+
+        # Build the Ed25519 signing key and extract the verify key
+        signing_key = _NaclSigningKey(seed)
+        verify_key_bytes = bytes(signing_key.verify_key)
+
+        # Normalize message to bytes
+        if isinstance(message, str):
+            message = message.encode("utf-8")
+
+        # Generate a random 32-byte nonce for the header
+        nonce = _nacl_random(32)
+
+        # Build and hash the Saltpack v2.0 signing header
+        header = self._build_header(verify_key_bytes, nonce)
+        header_hash = hashlib.sha512(header).digest()
+
+        # Build payload packets (split into 1 MB chunks per spec)
+        packets = [header]
+        chunks = [
+            message[i : i + _PAYLOAD_CHUNK]
+            for i in range(0, len(message), _PAYLOAD_CHUNK)
+        ]
+        # An empty message still produces one payload packet
+        if not chunks:
+            chunks = [b""]
+
+        for idx, chunk in enumerate(chunks):
+            # Mark the final packet
+            is_final = idx == len(chunks) - 1
+            # Build the packet and append it to the stream
+            pkt = self._build_payload_packet(
+                header_hash, chunk, is_final, signing_key
+            )
+            packets.append(pkt)
+
+        # Concatenate all msgpack-encoded packets into one binary stream
+        stream = b"".join(packets)
+
+        # Base62-encode the stream
+        encoded = _b62_encode(stream)
+
+        # Wrap encoded output at the armor line width
+        lines = [
+            encoded[i : i + _ARMOR_LINE_WIDTH]
+            for i in range(0, len(encoded), _ARMOR_LINE_WIDTH)
+        ]
+
+        # Assemble the final armored message
+        body = "\n".join(lines)
+        return ". {begin}\n{body}\n. {end}".format(
+            begin=_SP_BEGIN_SIGNED,
+            body=body,
+            end=_SP_END_SIGNED,
+        )
+
+    @staticmethod
+    def _build_header(verify_key_bytes, nonce):
+        """Return the msgpack-encoded Saltpack v2.0 signing header.
+
+        Header structure (from the Saltpack spec):
+          ["saltpack", [2, 0], 1, sender_public_key, nonce]
+        """
+        return _mp_array(
+            [
+                _mp_fixstr("saltpack"),
+                _mp_array([_mp_uint(2), _mp_uint(0)]),
+                _mp_uint(1),  # mode 1 = attached signing
+                _mp_bytes(verify_key_bytes),
+                _mp_bytes(nonce),
+            ]
+        )
+
+    @staticmethod
+    def _build_payload_packet(header_hash, chunk, is_final, signing_key):
+        """Build and msgpack-encode one Saltpack v2.0 payload packet.
+
+        The signature covers (per spec):
+          "saltpack\\0" + "attached signing\\0" +
+          final_byte + header_hash + sha512(chunk)
+        """
+        # Construct the byte string to sign
+        final_byte = b"\x01" if is_final else b"\x00"
+        to_sign = (
+            b"saltpack\x00"
+            + b"attached signing\x00"
+            + final_byte
+            + header_hash
+            + hashlib.sha512(chunk).digest()
+        )
+
+        # Sign and extract the 64-byte Ed25519 signature
+        sig = signing_key.sign(to_sign).signature
+
+        # Encode as [is_final, signature, payload_chunk]
+        return _mp_array(
+            [
+                _mp_bool(is_final),
+                _mp_bytes(sig),
+                _mp_bytes(chunk),
+            ]
+        )
+
+    @staticmethod
+    def keygen_signing():
+        """Generate a new Ed25519 key pair for Saltpack signing.
+
+        Returns a (signing_key_hex, verify_key_hex) tuple where each
+        element is a 64-character lowercase hex string representing a
+        32-byte key.  Raises AppriseSaltpackException when PyNaCl is
+        not available.
+        """
+        if not NACL_SUPPORT:
+            raise AppriseSaltpackException(
+                "PyNaCl is required for key generation;"
+                " install with: pip install PyNaCl"
+            )
+
+        # Generate a random 32-byte seed
+        sk = _NaclSigningKey(_nacl_random(32))
+        signing_key_hex = bytes(sk).hex()
+        verify_key_hex = bytes(sk.verify_key).hex()
+        return signing_key_hex, verify_key_hex
+
+    @staticmethod
+    def keygen_box():
+        """Generate a new Curve25519 key pair for NaCl box encryption.
+
+        Returns a (private_key_hex, public_key_hex) tuple where each
+        element is a 64-character lowercase hex string.  Raises
+        AppriseSaltpackException when PyNaCl is not available.
+        """
+        if not NACL_SUPPORT:
+            raise AppriseSaltpackException(
+                "PyNaCl is required for key generation;"
+                " install with: pip install PyNaCl"
+            )
+
+        # Generate a new Curve25519 private key
+        priv = _NaclPrivateKey(_nacl_random(32))
+        private_key_hex = bytes(priv).hex()
+        public_key_hex = bytes(priv.public_key).hex()
+        return private_key_hex, public_key_hex
+
+    @staticmethod
+    def box_encrypt(plaintext, sender_privkey_hex, recipient_pubkey_bytes):
+        """Encrypt plaintext using NaCl Box (Curve25519 + XSalsa20-Poly1305).
+
+        Note: This is the same primitive used by Threema E2EE.
+
+        Args:
+            plaintext:
+                Message to encrypt (str or bytes).
+            sender_privkey_hex:
+                64-character hex string of the sender's 32-byte
+                Curve25519 private key.
+            recipient_pubkey_bytes:
+                32-byte Curve25519 public key of the recipient.
+
+        Returns a (nonce_bytes, ciphertext_bytes) tuple.
+        Raises AppriseSaltpackException on error.
+        """
+        if not NACL_SUPPORT:
+            raise AppriseSaltpackException(
+                "PyNaCl is required for NaCl box encryption;"
+                " install with: pip install PyNaCl"
+            )
+
+        # Parse the sender private key
+        try:
+            privkey_bytes = bytes.fromhex(sender_privkey_hex)
+        except (ValueError, TypeError) as exc:
+            raise AppriseSaltpackException(
+                "Invalid private key: expected 64 hex characters"
+            ) from exc
+
+        # Normalize plaintext to bytes
+        if isinstance(plaintext, str):
+            plaintext = plaintext.encode("utf-8")
+
+        # Construct the NaCl Box and encrypt
+        sender_key = _NaclPrivateKey(privkey_bytes)
+        recipient_key = _NaclPublicKey(recipient_pubkey_bytes)
+        box = _NaclBox(sender_key, recipient_key)
+
+        nonce = _nacl_random(_NaclBox.NONCE_SIZE)
+        encrypted = box.encrypt(plaintext, nonce)
+        return encrypted.nonce, encrypted.ciphertext
+
+    @staticmethod
+    def fetch_keybase_keys(username):
+        """Fetch the NaCl public keys for a Keybase user.
+
+        Uses the public Keybase HTTPS API to look up the user's
+        Curve25519 (DH) and Ed25519 (signing) public keys.
+
+        Returns a dict:
+          {
+            'dh':    bytes  -- 32-byte Curve25519 public key
+            'eddsa': bytes  -- 32-byte Ed25519 verify key
+          }
+        or None on any error (user not found, network failure, etc.).
+        """
+        # Build the Keybase user lookup URL
+        url = (
+            "https://keybase.io/_/api/1.0/user/lookup.json"
+            "?username={}&fields=public_keys".format(username)
+        )
+
+        logger.debug("Fetching Keybase public keys for user: %s", username)
+
+        try:
+            # Perform the HTTPS GET request
+            r = requests.get(url, timeout=10)
+            if r.status_code != requests.codes.ok:
+                logger.warning(
+                    "Keybase key lookup failed for %s: HTTP %d",
+                    username,
+                    r.status_code,
+                )
+                return None
+
+            data = r.json()
+
+        except requests.RequestException as exc:
+            logger.warning(
+                "Network error fetching Keybase keys for %s",
+                username,
+            )
+            logger.debug("RequestException: %s", exc)
+            return None
+
+        except (ValueError, TypeError) as exc:
+            logger.warning(
+                "Invalid JSON in Keybase key response for %s",
+                username,
+            )
+            logger.debug("JSONDecodeError: %s", exc)
+            return None
+
+        # Extract the NaCl key fields from the response
+        try:
+            them = data.get("them") or []
+            user_data = them[0] if isinstance(them, list) else them
+            nacl = user_data["public_keys"]["nacl"]
+
+            # Parse the hex-encoded keys
+            dh_hex = nacl.get("dh", "")
+            eddsa_hex = nacl.get("eddsa", "")
+
+            if not dh_hex or not eddsa_hex:
+                logger.warning(
+                    "Keybase user %s has no NaCl keys in profile",
+                    username,
+                )
+                return None
+
+            return {
+                "dh": bytes.fromhex(dh_hex),
+                "eddsa": bytes.fromhex(eddsa_hex),
+            }
+
+        except (KeyError, IndexError, TypeError, ValueError) as exc:
+            logger.warning(
+                "Could not parse NaCl keys for Keybase user %s",
+                username,
+            )
+            logger.debug("Key parse error: %s", exc)
+            return None

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -65,7 +65,7 @@ notification services. It supports sending alerts to platforms such as: \
 `Dot. (Quote/0)`, `E-Mail`, `Emby`, `Evolution API`, `Exotel`, \
 `FCM`, `Feishu`, `Flock`, `Fluxer`, `Free Mobile`, `Google Chat`, \
 `Gotify`, `Growl`, `Guilded`, `Home Assistant`, `httpSMS`, `HumHub`, \
-`IFTTT`, `IRC`, `Jellyfin`, `Jira`, `Join`, `Kavenegar`, `KODI`, \
+`IFTTT`, `IRC`, `Jellyfin`, `Jira`, `Join`, `Kavenegar`, `Keybase`, `KODI`, \
 `Kumulos`, `LaMetric`, `Lark`, `Line`, `MacOSX`, `Mailgun`, `Mastodon`, \
 `Mattermost`, `Matrix`, `MessageBird`, `Microsoft Windows`, \
 `Microsoft Teams`, `Misskey`, \

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -149,6 +149,7 @@ Requires: python3dist(pyyaml)
 
 Recommends: python3dist(hidapi)
 Recommends: python3dist(paho-mqtt) >= 2.1.0
+Recommends: python3dist(pynacl)
 Recommends: python3dist(slixmpp)
 
 %if 0%{?legacy_python_build} == 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ keywords = [
     "Join",
     "JSON",
     "Kavenegar",
+    "Keybase",
     "KODI",
     "Kumulos",
     "LaMetric",
@@ -244,6 +245,11 @@ all-plugins = [
 
     # For xmpp:// support
     "slixmpp >= 1.10.0",
+
+    # Provides Saltpack v2.0 signing and NaCl box encryption for
+    # keybase:// and the apprise.utils.saltpack utility
+    # (Threema E2EE also uses this)
+    "PyNaCl",
 ]
 windows = [
     "pywin32",

--- a/tests/test_plugin_keybase.py
+++ b/tests/test_plugin_keybase.py
@@ -27,6 +27,7 @@
 
 import json
 import logging
+import os
 import socket as _real_socket
 from unittest import mock
 
@@ -34,6 +35,7 @@ import pytest
 import requests as _requests
 
 import apprise
+from apprise import AppriseAttachment
 from apprise.plugins.keybase import (
     KEYBASE_DEFAULT_CHANNEL,
     KEYBASE_DEFAULT_HOST,
@@ -48,6 +50,9 @@ from apprise.utils.saltpack import (
 )
 
 logging.disable(logging.CRITICAL)
+
+# Directory containing test fixture files (GIF, PNG, etc.)
+TEST_VAR_DIR = os.path.join(os.path.dirname(__file__), "var")
 
 
 # ---------------------------------------------------------------------------
@@ -449,9 +454,7 @@ def test_plugin_keybase_parse_url_hash_channel_literal():
 
 def test_plugin_keybase_parse_url_hash_channel_multiple_targets():
     """Multiple targets with literal '#' all parse correctly."""
-    r = NotifyKeybase.parse_url(
-        "keybase://_/@alice/@bob/myteam#general"
-    )
+    r = NotifyKeybase.parse_url("keybase://_/@alice/@bob/myteam#general")
     obj = NotifyKeybase(**r)
     assert ("user", "alice") in obj.targets
     assert ("user", "bob") in obj.targets
@@ -1013,3 +1016,126 @@ def test_stat_socket_path_missing_raises():
         pytest.raises(OSError, match="socket not found"),
     ):
         obj._stat_socket_path()
+
+
+# ---------------------------------------------------------------------------
+# send() -- attachment paths
+# ---------------------------------------------------------------------------
+
+
+@mock.patch.object(NotifyKeybase, "_stat_socket_path")
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+def test_plugin_keybase_send_attachment_socket_success(
+    mock_sock_cls, mock_stat_sp
+):
+    """Attachment is dispatched after the text message via socket."""
+    mock_sock_cls.return_value = _socket_ok()
+
+    path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
+    attach = AppriseAttachment(path)
+
+    obj = NotifyKeybase(targets=["@alice"])
+    assert obj.notify(body="Hello", attach=attach) is True
+
+    conn = mock_sock_cls.return_value
+    # One send for text, one for the attachment
+    assert conn.sendall.call_count == 2
+
+    # Verify the attach payload structure
+    raw = conn.sendall.call_args_list[1][0][0]
+    payload = json.loads(raw.rstrip(b"\n"))
+    assert payload["method"] == "attach"
+    opts = payload["params"]["options"]
+    assert opts["channel"]["name"] == "alice"
+    assert opts["filename"] == path
+    assert opts["title"] == "apprise-test.gif"
+
+
+@mock.patch("apprise.plugins.keybase.base.requests.post")
+def test_plugin_keybase_send_attachment_tcp_success(mock_post):
+    """Attachment is dispatched after the text message via TCP."""
+    mock_post.return_value = _http_ok()
+
+    path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
+    attach = AppriseAttachment(path)
+
+    obj = NotifyKeybase(targets=["@alice"], host="localhost", port=3000)
+    assert obj.notify(body="Hello", attach=attach) is True
+
+    # One HTTP POST for text, one for the attachment
+    assert mock_post.call_count == 2
+
+    attach_payload = mock_post.call_args_list[1][1]["json"]
+    assert attach_payload["method"] == "attach"
+    opts = attach_payload["params"]["options"]
+    assert opts["channel"]["name"] == "alice"
+    assert opts["filename"] == path
+
+
+@mock.patch.object(NotifyKeybase, "_stat_socket_path")
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+def test_plugin_keybase_send_attachment_multiple(mock_sock_cls, mock_stat_sp):
+    """Multiple attachments are each dispatched in order."""
+    mock_sock_cls.return_value = _socket_ok()
+
+    path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
+    attach = AppriseAttachment((path, path, path))
+
+    obj = NotifyKeybase(targets=["@alice"])
+    assert obj.notify(body="Hello", attach=attach) is True
+
+    # 1 text + 3 attachments = 4 total sendall calls
+    assert mock_sock_cls.return_value.sendall.call_count == 4
+
+
+@mock.patch.object(NotifyKeybase, "_stat_socket_path")
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+def test_plugin_keybase_send_attachment_inaccessible(
+    mock_sock_cls, mock_stat_sp
+):
+    """Inaccessible attachment is skipped and send() returns False."""
+    mock_sock_cls.return_value = _socket_ok()
+
+    # Non-existent file -> attachment is inaccessible
+    attach = AppriseAttachment("/path/does/not/exist/apprise-test.gif")
+
+    obj = NotifyKeybase(targets=["@alice"])
+    assert obj.notify(body="Hello", attach=attach) is False
+
+    # Text message was still sent; no attachment sendall
+    assert mock_sock_cls.return_value.sendall.call_count == 1
+
+
+@mock.patch.object(NotifyKeybase, "_stat_socket_path")
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+def test_plugin_keybase_send_attachment_api_error(mock_sock_cls, mock_stat_sp):
+    """API error during attachment dispatch causes send() to return False."""
+    # First socket (text) succeeds; second (attach) returns an API error
+    mock_sock_cls.side_effect = [
+        _socket_ok(),
+        _socket_api_error("attachment failed"),
+    ]
+
+    path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
+    attach = AppriseAttachment(path)
+
+    obj = NotifyKeybase(targets=["@alice"])
+    assert obj.notify(body="Hello", attach=attach) is False
+
+
+@mock.patch.object(NotifyKeybase, "_stat_socket_path")
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+def test_plugin_keybase_send_attachment_connection_error(
+    mock_sock_cls, mock_stat_sp
+):
+    """OSError during attachment socket connect is handled gracefully."""
+    err_conn = mock.MagicMock()
+    err_conn.connect.side_effect = OSError("connection refused")
+    # First socket (text) succeeds; second (attach) raises on connect
+    mock_sock_cls.side_effect = [_socket_ok(), err_conn]
+
+    path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
+    attach = AppriseAttachment(path)
+
+    obj = NotifyKeybase(targets=["@alice"])
+    assert obj.notify(body="Hello", attach=attach) is False

--- a/tests/test_plugin_keybase.py
+++ b/tests/test_plugin_keybase.py
@@ -192,13 +192,13 @@ def test_plugin_keybase_mode_tcp_defaults_host_and_port():
 def test_plugin_keybase_mode_socket_path_default():
     """Socket mode uses the platform default socket path."""
     obj = NotifyKeybase(targets=["@alice"])
-    assert obj.socket_path == keybase_default_socket()
+    assert obj.socket == keybase_default_socket()
 
 
 def test_plugin_keybase_mode_socket_path_custom():
-    """A custom socket_path overrides the platform default."""
-    obj = NotifyKeybase(targets=["@alice"], socket_path="/tmp/keybase.sock")
-    assert obj.socket_path == "/tmp/keybase.sock"
+    """A custom socket overrides the platform default."""
+    obj = NotifyKeybase(targets=["@alice"], socket="/tmp/keybase.sock")
+    assert obj.socket == "/tmp/keybase.sock"
 
 
 # ---------------------------------------------------------------------------
@@ -304,14 +304,12 @@ def test_plugin_keybase_url_socket_mode_contains_mode_param():
 
 def test_plugin_keybase_url_custom_socket_path_included():
     """Custom socket path is included in the URL."""
-    obj = NotifyKeybase(
-        targets=["@alice"], socket_path="/tmp/custom-keybase.sock"
-    )
+    obj = NotifyKeybase(targets=["@alice"], socket="/tmp/custom-keybase.sock")
     url = obj.url()
     assert "socket=" in url
     r = NotifyKeybase.parse_url(url)
     obj2 = NotifyKeybase(**r)
-    assert obj2.socket_path == "/tmp/custom-keybase.sock"
+    assert obj2.socket == "/tmp/custom-keybase.sock"
 
 
 def test_plugin_keybase_url_default_socket_path_omitted():
@@ -376,22 +374,22 @@ def test_plugin_keybase_url_sigkey_hidden_in_privacy_mode():
 
 
 def test_plugin_keybase_parse_url_at_in_authority():
-    """keybase://@alice is parsed as a user DM."""
-    r = NotifyKeybase.parse_url("keybase://@alice")
+    """keybase://_/@alice is parsed as a user DM (canonical form)."""
+    r = NotifyKeybase.parse_url("keybase://_/@alice")
     obj = NotifyKeybase(**r)
     assert obj.targets == [("user", "alice")]
 
 
 def test_plugin_keybase_parse_url_team_host():
-    """keybase://myteam is parsed as a team message."""
-    r = NotifyKeybase.parse_url("keybase://myteam")
+    """keybase://_/myteam is parsed as a team message (canonical form)."""
+    r = NotifyKeybase.parse_url("keybase://_/myteam")
     obj = NotifyKeybase(**r)
     assert obj.targets == [("team", "myteam", KEYBASE_DEFAULT_CHANNEL)]
 
 
 def test_plugin_keybase_parse_url_team_channel_host():
-    """keybase://myteam%23dev is parsed as team + channel."""
-    r = NotifyKeybase.parse_url("keybase://myteam%23dev")
+    """keybase://_/myteam%23dev is parsed as team + channel."""
+    r = NotifyKeybase.parse_url("keybase://_/myteam%23dev")
     obj = NotifyKeybase(**r)
     assert obj.targets == [("team", "myteam", "dev")]
 
@@ -439,12 +437,44 @@ def test_plugin_keybase_parse_url_tcp_authority():
     assert obj.targets == [("user", "alice")]
 
 
+def test_plugin_keybase_parse_url_tcp_localhost_no_port():
+    """keybase://localhost/@alice auto-detects TCP mode without a port."""
+    r = NotifyKeybase.parse_url("keybase://localhost/@alice")
+    obj = NotifyKeybase(**r)
+    assert obj.mode == KeybaseMode.TCP
+    assert obj.host == "localhost"
+    assert obj.port == KEYBASE_DEFAULT_PORT
+    # "localhost" must NOT be treated as a target
+    assert obj.targets == [("user", "alice")]
+
+
+def test_plugin_keybase_parse_url_tcp_ipv4_no_port():
+    """keybase://192.168.1.5/@alice auto-detects TCP mode without a port."""
+    r = NotifyKeybase.parse_url("keybase://192.168.1.5/@alice")
+    obj = NotifyKeybase(**r)
+    assert obj.mode == KeybaseMode.TCP
+    assert obj.host == "192.168.1.5"
+    assert obj.port == KEYBASE_DEFAULT_PORT
+    # IPv4 address must NOT be treated as a target
+    assert obj.targets == [("user", "alice")]
+
+
+def test_plugin_keybase_parse_url_tcp_fqdn_no_port():
+    """keybase://keybase.home.lan/@alice auto-detects TCP via is_hostname."""
+    r = NotifyKeybase.parse_url("keybase://keybase.home.lan/@alice")
+    obj = NotifyKeybase(**r)
+    assert obj.mode == KeybaseMode.TCP
+    assert obj.host == "keybase.home.lan"
+    assert obj.port == KEYBASE_DEFAULT_PORT
+    assert obj.targets == [("user", "alice")]
+
+
 def test_plugin_keybase_parse_url_custom_socket():
-    """?socket= is mapped to socket_path."""
+    """?socket= is mapped to the socket attribute."""
     url = "keybase://_/@alice?socket=/tmp/keybase.sock"
     r = NotifyKeybase.parse_url(url)
     obj = NotifyKeybase(**r)
-    assert obj.socket_path == "/tmp/keybase.sock"
+    assert obj.socket == "/tmp/keybase.sock"
 
 
 def test_plugin_keybase_parse_url_hash_channel_literal():
@@ -492,7 +522,7 @@ def test_plugin_keybase_send_user_dm_socket(mock_sock_cls, mock_stat_sp):
 
     # Verify the socket was connected to the expected path
     conn = mock_sock_cls.return_value
-    conn.connect.assert_called_once_with(obj.socket_path)
+    conn.connect.assert_called_once_with(obj.socket)
 
     # Verify the payload structure
     sent_raw = conn.sendall.call_args[0][0]
@@ -879,31 +909,31 @@ def test_plugin_keybase_socket_path_no_keybase_in_path_raises():
     with pytest.raises(TypeError, match=r"[Kk]eybase"):
         NotifyKeybase(
             targets=["@alice"],
-            socket_path="/var/run/docker.sock",
+            socket="/var/run/docker.sock",
         )
 
 
 def test_plugin_keybase_socket_path_non_socket_file_raises():
-    """socket_path pointing at a regular file raises TypeError at init."""
+    """socket= pointing at a regular file raises TypeError at init."""
     with mock.patch("os.stat") as mock_stat:
         # Simulate a regular file (S_IFREG, mode 0o100644)
         mock_stat.return_value.st_mode = 0o100644
         with pytest.raises(TypeError, match=r"not.*socket"):
             NotifyKeybase(
                 targets=["@alice"],
-                socket_path="/run/keybase/not-a-socket",
+                socket="/run/keybase/not-a-socket",
             )
 
 
 def test_plugin_keybase_socket_path_nonexistent_accepted_at_init():
-    """Non-existent socket_path is accepted at init (service may be down)."""
+    """Non-existent socket= is accepted at init (service may be down)."""
     with mock.patch("os.stat", side_effect=OSError("no such file")):
         # Should not raise -- service is just not running yet
         obj = NotifyKeybase(
             targets=["@alice"],
-            socket_path="/tmp/not_there-keybase.sock",
+            socket="/tmp/not_there-keybase.sock",
         )
-    assert obj.socket_path == "/tmp/not_there-keybase.sock"
+    assert obj.socket == "/tmp/not_there-keybase.sock"
 
 
 @mock.patch.object(
@@ -999,6 +1029,7 @@ def test_plugin_keybase_send_socket_chunked_response(
 # ---------------------------------------------------------------------------
 
 
+@mock.patch("apprise.plugins.keybase.base._AF_UNIX", new=1)
 def test_stat_socket_path_valid_socket():
     """_stat_socket_path does not raise for a genuine socket file."""
     obj = NotifyKeybase(targets=["@alice"])
@@ -1009,6 +1040,7 @@ def test_stat_socket_path_valid_socket():
         obj._stat_socket_path()
 
 
+@mock.patch("apprise.plugins.keybase.base._AF_UNIX", new=1)
 def test_stat_socket_path_regular_file_raises():
     """_stat_socket_path raises OSError when path is a regular file."""
     obj = NotifyKeybase(targets=["@alice"])
@@ -1019,12 +1051,26 @@ def test_stat_socket_path_regular_file_raises():
             obj._stat_socket_path()
 
 
+@mock.patch("apprise.plugins.keybase.base._AF_UNIX", new=1)
 def test_stat_socket_path_missing_raises():
     """_stat_socket_path raises OSError when path does not exist."""
     obj = NotifyKeybase(targets=["@alice"])
     with (
         mock.patch("os.stat", side_effect=FileNotFoundError("no such file")),
         pytest.raises(OSError, match="socket not found"),
+    ):
+        obj._stat_socket_path()
+
+
+@mock.patch("apprise.plugins.keybase.base._AF_UNIX", new=1)
+def test_stat_socket_path_permission_error_raises():
+    """_stat_socket_path raises OSError for PermissionError from os.stat."""
+    obj = NotifyKeybase(targets=["@alice"])
+    with (
+        mock.patch(
+            "os.stat", side_effect=PermissionError("permission denied")
+        ),
+        pytest.raises(OSError, match="inaccessible"),
     ):
         obj._stat_socket_path()
 

--- a/tests/test_plugin_keybase.py
+++ b/tests/test_plugin_keybase.py
@@ -197,8 +197,8 @@ def test_plugin_keybase_mode_socket_path_default():
 
 def test_plugin_keybase_mode_socket_path_custom():
     """A custom socket_path overrides the platform default."""
-    obj = NotifyKeybase(targets=["@alice"], socket_path="/tmp/kb.sock")
-    assert obj.socket_path == "/tmp/kb.sock"
+    obj = NotifyKeybase(targets=["@alice"], socket_path="/tmp/keybase.sock")
+    assert obj.socket_path == "/tmp/keybase.sock"
 
 
 # ---------------------------------------------------------------------------
@@ -304,12 +304,14 @@ def test_plugin_keybase_url_socket_mode_contains_mode_param():
 
 def test_plugin_keybase_url_custom_socket_path_included():
     """Custom socket path is included in the URL."""
-    obj = NotifyKeybase(targets=["@alice"], socket_path="/tmp/custom.sock")
+    obj = NotifyKeybase(
+        targets=["@alice"], socket_path="/tmp/custom-keybase.sock"
+    )
     url = obj.url()
     assert "socket=" in url
     r = NotifyKeybase.parse_url(url)
     obj2 = NotifyKeybase(**r)
-    assert obj2.socket_path == "/tmp/custom.sock"
+    assert obj2.socket_path == "/tmp/custom-keybase.sock"
 
 
 def test_plugin_keybase_url_default_socket_path_omitted():
@@ -439,10 +441,10 @@ def test_plugin_keybase_parse_url_tcp_authority():
 
 def test_plugin_keybase_parse_url_custom_socket():
     """?socket= is mapped to socket_path."""
-    url = "keybase://_/@alice?socket=/tmp/kb.sock"
+    url = "keybase://_/@alice?socket=/tmp/keybase.sock"
     r = NotifyKeybase.parse_url(url)
     obj = NotifyKeybase(**r)
-    assert obj.socket_path == "/tmp/kb.sock"
+    assert obj.socket_path == "/tmp/keybase.sock"
 
 
 def test_plugin_keybase_parse_url_hash_channel_literal():
@@ -872,6 +874,15 @@ def test_plugin_keybase_apprise_integration(mock_sock_cls, mock_stat_sp):
 # ---------------------------------------------------------------------------
 
 
+def test_plugin_keybase_socket_path_no_keybase_in_path_raises():
+    """socket= without 'keybase' in the path is rejected at init."""
+    with pytest.raises(TypeError, match=r"[Kk]eybase"):
+        NotifyKeybase(
+            targets=["@alice"],
+            socket_path="/var/run/docker.sock",
+        )
+
+
 def test_plugin_keybase_socket_path_non_socket_file_raises():
     """socket_path pointing at a regular file raises TypeError at init."""
     with mock.patch("os.stat") as mock_stat:
@@ -880,7 +891,7 @@ def test_plugin_keybase_socket_path_non_socket_file_raises():
         with pytest.raises(TypeError, match=r"not.*socket"):
             NotifyKeybase(
                 targets=["@alice"],
-                socket_path="/etc/shadow",
+                socket_path="/run/keybase/not-a-socket",
             )
 
 
@@ -890,9 +901,9 @@ def test_plugin_keybase_socket_path_nonexistent_accepted_at_init():
         # Should not raise -- service is just not running yet
         obj = NotifyKeybase(
             targets=["@alice"],
-            socket_path="/tmp/not_there.sock",
+            socket_path="/tmp/not_there-keybase.sock",
         )
-    assert obj.socket_path == "/tmp/not_there.sock"
+    assert obj.socket_path == "/tmp/not_there-keybase.sock"
 
 
 @mock.patch.object(

--- a/tests/test_plugin_keybase.py
+++ b/tests/test_plugin_keybase.py
@@ -1,0 +1,1015 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import json
+import logging
+import socket as _real_socket
+from unittest import mock
+
+import pytest
+import requests as _requests
+
+import apprise
+from apprise.plugins.keybase import (
+    KEYBASE_DEFAULT_CHANNEL,
+    KEYBASE_DEFAULT_HOST,
+    KEYBASE_DEFAULT_PORT,
+    KeybaseMode,
+    NotifyKeybase,
+    keybase_default_socket,
+)
+from apprise.plugins.keybase.common import keybase_default_socket as _kds
+from apprise.utils.saltpack import (
+    AppriseSaltpackException,
+)
+
+logging.disable(logging.CRITICAL)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _socket_ok(response=None):
+    """Return a mock socket connection that yields a success response."""
+    if response is None:
+        response = {"result": {"message": "chat send", "id": 1}}
+    conn = mock.MagicMock()
+    conn.recv.return_value = json.dumps(response).encode("utf-8") + b"\n"
+    return conn
+
+
+def _socket_api_error(message="bad request"):
+    """Return a mock socket connection that yields an API-level error."""
+    response = {"error": {"code": 400, "message": message}}
+    conn = mock.MagicMock()
+    conn.recv.return_value = json.dumps(response).encode("utf-8") + b"\n"
+    return conn
+
+
+def _http_ok(response=None):
+    """Return a mock requests.Response indicating HTTP 200 + success JSON."""
+    if response is None:
+        response = {"result": {"message": "chat send", "id": 1}}
+    r = mock.MagicMock()
+    r.status_code = 200
+    r.json.return_value = response
+    r.text = json.dumps(response)
+    return r
+
+
+def _http_error(status=500, message="internal error"):
+    """Return a mock requests.Response indicating an HTTP error."""
+    r = mock.MagicMock()
+    r.status_code = status
+    r.json.side_effect = ValueError("no json")
+    r.text = message
+    return r
+
+
+# ---------------------------------------------------------------------------
+# Instantiation and validation
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_keybase_init_user():
+    """Valid user DM target."""
+    obj = NotifyKeybase(targets=["@alice"])
+    assert obj.targets == [("user", "alice")]
+
+
+def test_plugin_keybase_init_team_default_channel():
+    """Valid team target defaults to 'general' channel."""
+    obj = NotifyKeybase(targets=["myteam"])
+    assert obj.targets == [("team", "myteam", KEYBASE_DEFAULT_CHANNEL)]
+
+
+def test_plugin_keybase_init_team_explicit_channel():
+    """Valid team target with explicit channel."""
+    obj = NotifyKeybase(targets=["myteam#dev"])
+    assert obj.targets == [("team", "myteam", "dev")]
+
+
+def test_plugin_keybase_init_mixed_targets():
+    """Multiple mixed targets are all parsed."""
+    obj = NotifyKeybase(targets=["@alice", "myteam#general", "@bob"])
+    assert ("user", "alice") in obj.targets
+    assert ("team", "myteam", "general") in obj.targets
+    assert ("user", "bob") in obj.targets
+    assert len(obj.targets) == 3
+
+
+def test_plugin_keybase_init_invalid_target_dropped():
+    """Invalid targets are dropped and preserved in _invalid_targets."""
+    obj = NotifyKeybase(targets=["@alice", "!!bad!!"])
+    assert len(obj.targets) == 1
+    assert obj.targets[0] == ("user", "alice")
+    assert "!!bad!!" in obj._invalid_targets
+    # url() preserves invalid targets for round-trip inspection
+    url = obj.url()
+    assert "alice" in url
+
+
+def test_plugin_keybase_init_no_targets_raises():
+    """No targets at all raises TypeError."""
+    with pytest.raises(TypeError):
+        NotifyKeybase(targets=[])
+
+
+def test_plugin_keybase_init_only_invalid_targets_raises():
+    """Only invalid targets raises TypeError."""
+    with pytest.raises(TypeError):
+        NotifyKeybase(targets=["!!!"])
+
+
+# ---------------------------------------------------------------------------
+# Mode detection
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_keybase_default_mode_is_socket():
+    """Default connection mode is socket."""
+    obj = NotifyKeybase(targets=["@alice"])
+    assert obj.mode == KeybaseMode.SOCKET
+
+
+def test_plugin_keybase_mode_socket_explicit():
+    """Explicit mode=socket sets socket mode."""
+    obj = NotifyKeybase(targets=["@alice"], mode="socket")
+    assert obj.mode == KeybaseMode.SOCKET
+
+
+def test_plugin_keybase_mode_tcp_explicit():
+    """Explicit mode=tcp sets TCP mode."""
+    obj = NotifyKeybase(targets=["@alice"], mode="tcp")
+    assert obj.mode == KeybaseMode.TCP
+
+
+def test_plugin_keybase_mode_tcp_from_port():
+    """Providing a port auto-selects TCP mode."""
+    obj = NotifyKeybase(targets=["@alice"], port=3000)
+    assert obj.mode == KeybaseMode.TCP
+    assert obj.port == 3000
+
+
+def test_plugin_keybase_mode_tcp_defaults_host_and_port():
+    """TCP mode fills in default host and port when absent."""
+    obj = NotifyKeybase(targets=["@alice"], mode="tcp")
+    assert obj.host == KEYBASE_DEFAULT_HOST
+    assert obj.port == KEYBASE_DEFAULT_PORT
+
+
+def test_plugin_keybase_mode_socket_path_default():
+    """Socket mode uses the platform default socket path."""
+    obj = NotifyKeybase(targets=["@alice"])
+    assert obj.socket_path == keybase_default_socket()
+
+
+def test_plugin_keybase_mode_socket_path_custom():
+    """A custom socket_path overrides the platform default."""
+    obj = NotifyKeybase(targets=["@alice"], socket_path="/tmp/kb.sock")
+    assert obj.socket_path == "/tmp/kb.sock"
+
+
+# ---------------------------------------------------------------------------
+# Signing-key validation
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_keybase_init_sigkey_valid():
+    """A valid 64-char hex signing key is accepted."""
+    sigkey = "aa" * 32
+    obj = NotifyKeybase(targets=["@alice"], sigkey=sigkey)
+    assert obj.sigkey == sigkey.lower()
+
+
+def test_plugin_keybase_init_sigkey_uppercase_normalised():
+    """Uppercase hex in sigkey is normalised to lowercase."""
+    sigkey = "AB" * 32
+    obj = NotifyKeybase(targets=["@alice"], sigkey=sigkey)
+    assert obj.sigkey == sigkey.lower()
+
+
+def test_plugin_keybase_init_sigkey_too_short_raises():
+    """A sigkey that is too short raises TypeError."""
+    with pytest.raises(TypeError):
+        NotifyKeybase(targets=["@alice"], sigkey="aabb")
+
+
+def test_plugin_keybase_init_sigkey_invalid_chars_raises():
+    """A sigkey with non-hex characters raises TypeError."""
+    with pytest.raises(TypeError):
+        NotifyKeybase(targets=["@alice"], sigkey="zz" * 32)
+
+
+def test_plugin_keybase_init_sigkey_none_accepted():
+    """No signing key produces a plugin without Saltpack signing."""
+    obj = NotifyKeybase(targets=["@alice"])
+    assert obj.sigkey is None
+
+
+# ---------------------------------------------------------------------------
+# URL round-trip (socket mode)
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_keybase_url_user():
+    """User DM URL round-trips correctly."""
+    obj = NotifyKeybase(targets=["@alice"])
+    url = obj.url()
+    assert "@alice" in url
+    r = NotifyKeybase.parse_url(url)
+    obj2 = NotifyKeybase(**r)
+    assert obj2.targets == obj.targets
+
+
+def test_plugin_keybase_url_team():
+    """Team URL round-trips correctly."""
+    obj = NotifyKeybase(targets=["myteam"])
+    url = obj.url()
+    assert "myteam" in url
+    r = NotifyKeybase.parse_url(url)
+    obj2 = NotifyKeybase(**r)
+    assert obj2.targets == obj.targets
+
+
+def test_plugin_keybase_url_team_channel():
+    """Team+channel URL round-trips correctly."""
+    obj = NotifyKeybase(targets=["myteam#dev"])
+    url = obj.url()
+    # # must be percent-encoded in the generated URL
+    assert "%23" in url
+    r = NotifyKeybase.parse_url(url)
+    obj2 = NotifyKeybase(**r)
+    assert obj2.targets == obj.targets
+
+
+def test_plugin_keybase_url_mixed():
+    """Mixed targets round-trip correctly."""
+    obj = NotifyKeybase(targets=["@alice", "myteam#dev"])
+    url = obj.url()
+    r = NotifyKeybase.parse_url(url)
+    obj2 = NotifyKeybase(**r)
+    assert obj2.targets == obj.targets
+
+
+def test_plugin_keybase_url_privacy():
+    """Privacy URL returns a non-empty string."""
+    obj = NotifyKeybase(targets=["@alice"])
+    assert isinstance(obj.url(privacy=True), str)
+    assert len(obj.url(privacy=True)) > 0
+
+
+def test_plugin_keybase_url_identifier_is_false():
+    """url_id() returns None (url_identifier = False)."""
+    obj = NotifyKeybase(targets=["@alice"])
+    assert obj.url_id() is None
+
+
+def test_plugin_keybase_url_socket_mode_contains_mode_param():
+    """Socket mode URL always contains mode=socket."""
+    obj = NotifyKeybase(targets=["@alice"])
+    assert "mode=socket" in obj.url()
+
+
+def test_plugin_keybase_url_custom_socket_path_included():
+    """Custom socket path is included in the URL."""
+    obj = NotifyKeybase(targets=["@alice"], socket_path="/tmp/custom.sock")
+    url = obj.url()
+    assert "socket=" in url
+    r = NotifyKeybase.parse_url(url)
+    obj2 = NotifyKeybase(**r)
+    assert obj2.socket_path == "/tmp/custom.sock"
+
+
+def test_plugin_keybase_url_default_socket_path_omitted():
+    """Default socket path is omitted from the URL."""
+    obj = NotifyKeybase(targets=["@alice"])
+    assert "socket=" not in obj.url()
+
+
+# ---------------------------------------------------------------------------
+# URL round-trip (TCP mode)
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_keybase_url_tcp_mode():
+    """TCP mode URL contains host, port, and mode=tcp."""
+    obj = NotifyKeybase(targets=["@alice"], host="localhost", port=4000)
+    url = obj.url()
+    assert "localhost" in url
+    assert "4000" in url
+    assert "mode=tcp" in url
+
+
+def test_plugin_keybase_url_tcp_roundtrip():
+    """TCP mode URL round-trips preserving host, port, mode."""
+    obj = NotifyKeybase(targets=["@alice"], host="localhost", port=3000)
+    url = obj.url()
+    r = NotifyKeybase.parse_url(url)
+    obj2 = NotifyKeybase(**r)
+    assert obj2.mode == KeybaseMode.TCP
+    assert obj2.host == "localhost"
+    assert obj2.port == 3000
+    assert obj2.targets == obj.targets
+
+
+# ---------------------------------------------------------------------------
+# URL with sigkey
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_keybase_url_with_sigkey():
+    """A sigkey appears in the URL and round-trips."""
+    sigkey = "ab" * 32
+    obj = NotifyKeybase(targets=["@alice"], sigkey=sigkey)
+    url = obj.url()
+    assert sigkey in url
+    r = NotifyKeybase.parse_url(url)
+    obj2 = NotifyKeybase(**r)
+    assert obj2.sigkey == sigkey
+
+
+def test_plugin_keybase_url_sigkey_hidden_in_privacy_mode():
+    """The sigkey is masked when privacy=True."""
+    sigkey = "ab" * 32
+    obj = NotifyKeybase(targets=["@alice"], sigkey=sigkey)
+    priv_url = obj.url(privacy=True)
+    assert sigkey not in priv_url
+
+
+# ---------------------------------------------------------------------------
+# parse_url edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_keybase_parse_url_at_in_authority():
+    """keybase://@alice is parsed as a user DM."""
+    r = NotifyKeybase.parse_url("keybase://@alice")
+    obj = NotifyKeybase(**r)
+    assert obj.targets == [("user", "alice")]
+
+
+def test_plugin_keybase_parse_url_team_host():
+    """keybase://myteam is parsed as a team message."""
+    r = NotifyKeybase.parse_url("keybase://myteam")
+    obj = NotifyKeybase(**r)
+    assert obj.targets == [("team", "myteam", KEYBASE_DEFAULT_CHANNEL)]
+
+
+def test_plugin_keybase_parse_url_team_channel_host():
+    """keybase://myteam%23dev is parsed as team + channel."""
+    r = NotifyKeybase.parse_url("keybase://myteam%23dev")
+    obj = NotifyKeybase(**r)
+    assert obj.targets == [("team", "myteam", "dev")]
+
+
+def test_plugin_keybase_parse_url_to_param():
+    """?to= query param populates targets."""
+    r = NotifyKeybase.parse_url("keybase://_/?to=@alice")
+    obj = NotifyKeybase(**r)
+    assert ("user", "alice") in obj.targets
+
+
+def test_plugin_keybase_parse_url_sigkey_param():
+    """?sigkey= query param is extracted and stored."""
+    sigkey = "cd" * 32
+    url = "keybase://_/@alice?sigkey={}".format(sigkey)
+    r = NotifyKeybase.parse_url(url)
+    obj = NotifyKeybase(**r)
+    assert obj.sigkey == sigkey
+
+
+def test_plugin_keybase_parse_url_mode_socket():
+    """?mode=socket is parsed correctly."""
+    r = NotifyKeybase.parse_url("keybase://_/@alice?mode=socket")
+    obj = NotifyKeybase(**r)
+    assert obj.mode == KeybaseMode.SOCKET
+
+
+def test_plugin_keybase_parse_url_mode_tcp():
+    """?mode=tcp is parsed correctly and host/port defaults applied."""
+    r = NotifyKeybase.parse_url("keybase://_/@alice?mode=tcp")
+    obj = NotifyKeybase(**r)
+    assert obj.mode == KeybaseMode.TCP
+    assert obj.host == KEYBASE_DEFAULT_HOST
+    assert obj.port == KEYBASE_DEFAULT_PORT
+
+
+def test_plugin_keybase_parse_url_tcp_authority():
+    """keybase://localhost:3000/@alice sets TCP mode via port."""
+    r = NotifyKeybase.parse_url("keybase://localhost:3000/@alice")
+    obj = NotifyKeybase(**r)
+    assert obj.mode == KeybaseMode.TCP
+    assert obj.host == "localhost"
+    assert obj.port == 3000
+    # "localhost" must NOT be treated as a target
+    assert obj.targets == [("user", "alice")]
+
+
+def test_plugin_keybase_parse_url_custom_socket():
+    """?socket= is mapped to socket_path."""
+    url = "keybase://_/@alice?socket=/tmp/kb.sock"
+    r = NotifyKeybase.parse_url(url)
+    obj = NotifyKeybase(**r)
+    assert obj.socket_path == "/tmp/kb.sock"
+
+
+def test_plugin_keybase_parse_url_hash_channel_literal():
+    """Literal '#' in URL is treated as '%23' -- channel is preserved."""
+    r = NotifyKeybase.parse_url("keybase://_/myteam#dev")
+    obj = NotifyKeybase(**r)
+    assert obj.targets == [("team", "myteam", "dev")]
+
+
+def test_plugin_keybase_parse_url_hash_channel_multiple_targets():
+    """Multiple targets with literal '#' all parse correctly."""
+    r = NotifyKeybase.parse_url(
+        "keybase://_/@alice/@bob/myteam#general"
+    )
+    obj = NotifyKeybase(**r)
+    assert ("user", "alice") in obj.targets
+    assert ("user", "bob") in obj.targets
+    assert ("team", "myteam", "general") in obj.targets
+
+
+def test_plugin_keybase_parse_url_invalid_returns_none():
+    """parse_url returns None for unparseable input."""
+    result = NotifyKeybase.parse_url("not-a-url")
+    assert result is None or isinstance(result, dict)
+
+
+def test_plugin_keybase_parse_url_no_targets():
+    """parse_url with no actual targets yields a TypeError on init."""
+    r = NotifyKeybase.parse_url("keybase://_/?")
+    with pytest.raises(TypeError):
+        NotifyKeybase(**r)
+
+
+# ---------------------------------------------------------------------------
+# send() via socket mode -- success paths
+# ---------------------------------------------------------------------------
+
+
+@mock.patch.object(NotifyKeybase, "_stat_socket_path")
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+def test_plugin_keybase_send_user_dm_socket(mock_sock_cls, mock_stat_sp):
+    """Successful DM send via Unix socket."""
+    mock_sock_cls.return_value = _socket_ok()
+
+    obj = NotifyKeybase(targets=["@alice"])
+    assert obj.notify(title="Hi", body="Hello") is True
+
+    # Verify the socket was connected to the expected path
+    conn = mock_sock_cls.return_value
+    conn.connect.assert_called_once_with(obj.socket_path)
+
+    # Verify the payload structure
+    sent_raw = conn.sendall.call_args[0][0]
+    payload = json.loads(sent_raw.rstrip(b"\n"))
+    assert payload["method"] == "send"
+    ch = payload["params"]["options"]["channel"]
+    assert ch["name"] == "alice"
+    assert "topic_name" not in ch
+
+
+@mock.patch.object(NotifyKeybase, "_stat_socket_path")
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+def test_plugin_keybase_send_team_socket(mock_sock_cls, mock_stat_sp):
+    """Successful team channel send via socket."""
+    mock_sock_cls.return_value = _socket_ok()
+
+    obj = NotifyKeybase(targets=["myteam"])
+    assert obj.notify(body="Hello") is True
+
+    sent_raw = mock_sock_cls.return_value.sendall.call_args[0][0]
+    payload = json.loads(sent_raw.rstrip(b"\n"))
+    ch = payload["params"]["options"]["channel"]
+    assert ch["name"] == "myteam"
+    assert ch["topic_name"] == "general"
+    assert ch["members_type"] == "team"
+
+
+@mock.patch.object(NotifyKeybase, "_stat_socket_path")
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+def test_plugin_keybase_send_team_channel_socket(mock_sock_cls, mock_stat_sp):
+    """Successful team+channel send via socket."""
+    mock_sock_cls.return_value = _socket_ok()
+
+    obj = NotifyKeybase(targets=["myteam#dev"])
+    assert obj.notify(body="Hello") is True
+
+    sent_raw = mock_sock_cls.return_value.sendall.call_args[0][0]
+    payload = json.loads(sent_raw.rstrip(b"\n"))
+    ch = payload["params"]["options"]["channel"]
+    assert ch["name"] == "myteam"
+    assert ch["topic_name"] == "dev"
+
+
+@mock.patch.object(NotifyKeybase, "_stat_socket_path")
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+def test_plugin_keybase_send_multiple_targets_socket(
+    mock_sock_cls, mock_stat_sp
+):
+    """Send to multiple targets via socket; all succeed."""
+    mock_sock_cls.return_value = _socket_ok()
+
+    obj = NotifyKeybase(targets=["@alice", "myteam"])
+    assert obj.notify(body="Hello") is True
+
+    # One socket.sendall call per target
+    assert mock_sock_cls.return_value.sendall.call_count == 2
+
+
+@mock.patch.object(NotifyKeybase, "_stat_socket_path")
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+def test_plugin_keybase_send_partial_failure_socket(
+    mock_sock_cls, mock_stat_sp
+):
+    """If one of two socket sends fails, send() returns False."""
+    # First call succeeds; second raises OSError
+    first_conn = _socket_ok()
+    second_conn = mock.MagicMock()
+    second_conn.connect.side_effect = OSError("connection refused")
+    mock_sock_cls.side_effect = [first_conn, second_conn]
+
+    obj = NotifyKeybase(targets=["@alice", "myteam"])
+    assert obj.notify(body="Hello") is False
+
+
+# ---------------------------------------------------------------------------
+# send() via socket mode -- error paths
+# ---------------------------------------------------------------------------
+
+
+@mock.patch.object(NotifyKeybase, "_stat_socket_path")
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+def test_plugin_keybase_send_socket_connection_refused(
+    mock_sock_cls, mock_stat_sp
+):
+    """ConnectionRefusedError from socket is handled gracefully."""
+    conn = mock.MagicMock()
+    conn.connect.side_effect = OSError("connection refused")
+    mock_sock_cls.return_value = conn
+
+    obj = NotifyKeybase(targets=["@alice"])
+    assert obj.notify(body="Hello") is False
+
+
+@mock.patch.object(NotifyKeybase, "_stat_socket_path")
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+def test_plugin_keybase_send_socket_file_not_found(
+    mock_sock_cls, mock_stat_sp
+):
+    """FileNotFoundError (missing socket file) is handled gracefully."""
+    conn = mock.MagicMock()
+    conn.connect.side_effect = FileNotFoundError("no such file")
+    mock_sock_cls.return_value = conn
+
+    obj = NotifyKeybase(targets=["@alice"])
+    assert obj.notify(body="Hello") is False
+
+
+@mock.patch.object(NotifyKeybase, "_stat_socket_path")
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+def test_plugin_keybase_send_socket_timeout(mock_sock_cls, mock_stat_sp):
+    """Socket timeout is handled gracefully."""
+    conn = mock.MagicMock()
+    conn.recv.side_effect = _real_socket.timeout("timed out")
+    mock_sock_cls.return_value = conn
+
+    obj = NotifyKeybase(targets=["@alice"])
+    assert obj.notify(body="Hello") is False
+
+
+@mock.patch.object(NotifyKeybase, "_stat_socket_path")
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+def test_plugin_keybase_send_socket_api_error(mock_sock_cls, mock_stat_sp):
+    """API-level error in socket response returns False."""
+    mock_sock_cls.return_value = _socket_api_error("user not found")
+
+    obj = NotifyKeybase(targets=["@alice"])
+    assert obj.notify(body="Hello") is False
+
+
+@mock.patch.object(NotifyKeybase, "_stat_socket_path")
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+def test_plugin_keybase_send_socket_api_error_non_dict(
+    mock_sock_cls, mock_stat_sp
+):
+    """API error when 'error' value is not a dict."""
+    conn = mock.MagicMock()
+    conn.recv.return_value = (
+        json.dumps({"error": "string error"}).encode() + b"\n"
+    )
+    mock_sock_cls.return_value = conn
+
+    obj = NotifyKeybase(targets=["@alice"])
+    assert obj.notify(body="Hello") is False
+
+
+@mock.patch.object(NotifyKeybase, "_stat_socket_path")
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+def test_plugin_keybase_send_socket_bad_json(mock_sock_cls, mock_stat_sp):
+    """Non-JSON socket response is treated as success (no error key)."""
+    conn = mock.MagicMock()
+    conn.recv.return_value = b"not json\n"
+    mock_sock_cls.return_value = conn
+
+    obj = NotifyKeybase(targets=["@alice"])
+    assert obj.notify(body="Hello") is True
+
+
+@mock.patch.object(NotifyKeybase, "_stat_socket_path")
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+def test_plugin_keybase_send_socket_empty_response(
+    mock_sock_cls, mock_stat_sp
+):
+    """Empty socket response is treated as success."""
+    conn = mock.MagicMock()
+    # recv returns empty bytes -> connection closed mid-response
+    conn.recv.return_value = b""
+    mock_sock_cls.return_value = conn
+
+    obj = NotifyKeybase(targets=["@alice"])
+    assert obj.notify(body="Hello") is True
+
+
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+def test_plugin_keybase_send_socket_no_af_unix(mock_sock_cls):
+    """OSError raised when AF_UNIX is unavailable (e.g. old Windows)."""
+    with mock.patch(
+        "apprise.plugins.keybase.base._socket",
+        spec=[],  # spec=[] removes all attributes including AF_UNIX
+    ):
+        obj = NotifyKeybase(targets=["@alice"])
+        assert obj.notify(body="Hello") is False
+
+
+# ---------------------------------------------------------------------------
+# send() via TCP mode -- success paths
+# ---------------------------------------------------------------------------
+
+
+@mock.patch("apprise.plugins.keybase.base.requests.post")
+def test_plugin_keybase_send_user_dm_tcp(mock_post):
+    """Successful DM send via TCP mode."""
+    mock_post.return_value = _http_ok()
+
+    obj = NotifyKeybase(targets=["@alice"], host="localhost", port=3000)
+    assert obj.notify(body="Hello") is True
+
+    # Verify the HTTP call was made to the correct endpoint
+    call_url = mock_post.call_args[0][0]
+    assert "localhost:3000" in call_url
+
+    # Verify the payload structure
+    payload = mock_post.call_args[1]["json"]
+    assert payload["method"] == "send"
+    ch = payload["params"]["options"]["channel"]
+    assert ch["name"] == "alice"
+
+
+@mock.patch("apprise.plugins.keybase.base.requests.post")
+def test_plugin_keybase_send_team_tcp(mock_post):
+    """Successful team channel send via TCP."""
+    mock_post.return_value = _http_ok()
+
+    obj = NotifyKeybase(targets=["myteam"], host="localhost", port=3000)
+    assert obj.notify(body="Hello") is True
+
+    payload = mock_post.call_args[1]["json"]
+    ch = payload["params"]["options"]["channel"]
+    assert ch["name"] == "myteam"
+    assert ch["topic_name"] == "general"
+    assert ch["members_type"] == "team"
+
+
+@mock.patch("apprise.plugins.keybase.base.requests.post")
+def test_plugin_keybase_send_multiple_targets_tcp(mock_post):
+    """Send to multiple targets via TCP; all succeed."""
+    mock_post.return_value = _http_ok()
+
+    obj = NotifyKeybase(
+        targets=["@alice", "myteam"], host="localhost", port=3000
+    )
+    assert obj.notify(body="Hello") is True
+
+    # One HTTP POST per target
+    assert mock_post.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# send() via TCP mode -- error paths
+# ---------------------------------------------------------------------------
+
+
+@mock.patch("apprise.plugins.keybase.base.requests.post")
+def test_plugin_keybase_send_tcp_http_error(mock_post):
+    """Non-200 HTTP response returns False."""
+    mock_post.return_value = _http_error(status=500)
+
+    obj = NotifyKeybase(targets=["@alice"], host="localhost", port=3000)
+    assert obj.notify(body="Hello") is False
+
+
+@mock.patch("apprise.plugins.keybase.base.requests.post")
+def test_plugin_keybase_send_tcp_api_error(mock_post):
+    """API-level error in the TCP JSON response returns False."""
+    r = mock.MagicMock()
+    r.status_code = 200
+    r.json.return_value = {"error": {"code": 400, "message": "user not found"}}
+    mock_post.return_value = r
+
+    obj = NotifyKeybase(targets=["@alice"], host="localhost", port=3000)
+    assert obj.notify(body="Hello") is False
+
+
+@mock.patch("apprise.plugins.keybase.base.requests.post")
+def test_plugin_keybase_send_tcp_request_exception(mock_post):
+    """requests.RequestException is handled gracefully."""
+    mock_post.side_effect = _requests.RequestException("timeout")
+
+    obj = NotifyKeybase(targets=["@alice"], host="localhost", port=3000)
+    assert obj.notify(body="Hello") is False
+
+
+@mock.patch("apprise.plugins.keybase.base.requests.post")
+def test_plugin_keybase_send_tcp_bad_json_response(mock_post):
+    """Non-JSON HTTP response body is treated as success (no error key)."""
+    r = mock.MagicMock()
+    r.status_code = 200
+    r.json.side_effect = ValueError("no json")
+    mock_post.return_value = r
+
+    obj = NotifyKeybase(targets=["@alice"], host="localhost", port=3000)
+    assert obj.notify(body="Hello") is True
+
+
+@mock.patch("apprise.plugins.keybase.base.requests.post")
+def test_plugin_keybase_send_tcp_partial_failure(mock_post):
+    """Partial failure across multiple targets returns False."""
+    mock_post.side_effect = [
+        _http_ok(),
+        _requests.RequestException("connection refused"),
+    ]
+
+    obj = NotifyKeybase(
+        targets=["@alice", "myteam"], host="localhost", port=3000
+    )
+    assert obj.notify(body="Hello") is False
+
+
+# ---------------------------------------------------------------------------
+# send() -- Saltpack signing paths
+# ---------------------------------------------------------------------------
+
+
+@mock.patch.object(NotifyKeybase, "_stat_socket_path")
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+@mock.patch(
+    "apprise.plugins.keybase.base.AppriseSaltpackController.sign",
+    return_value=(
+        ". BEGIN KEYBASE SALTPACK SIGNED MESSAGE.\nabc\n"
+        ". END KEYBASE SALTPACK SIGNED MESSAGE."
+    ),
+)
+def test_plugin_keybase_send_with_sigkey_calls_sign(
+    mock_sign, mock_sock_cls, mock_stat_sp
+):
+    """When sigkey is set and NACL is available, sign() is called."""
+    mock_sock_cls.return_value = _socket_ok()
+    sigkey = "ab" * 32
+
+    with mock.patch("apprise.plugins.keybase.base.NACL_SUPPORT", True):
+        obj = NotifyKeybase(targets=["@alice"], sigkey=sigkey)
+        assert obj.notify(body="Hello") is True
+
+    # sign() must have been called with the original body and key
+    assert mock_sign.called
+    assert mock_sign.call_args[0][0] == "Hello"
+    assert mock_sign.call_args[0][1] == sigkey
+
+    # The signed message must appear in the socket payload
+    sent_raw = mock_sock_cls.return_value.sendall.call_args[0][0]
+    payload = json.loads(sent_raw.rstrip(b"\n"))
+    body = payload["params"]["options"]["message"]["body"]
+    assert "SALTPACK SIGNED MESSAGE" in body
+
+
+def test_plugin_keybase_send_sigkey_no_nacl():
+    """When sigkey is set but NACL_SUPPORT is False, send() fails."""
+    sigkey = "ab" * 32
+    obj = NotifyKeybase(targets=["@alice"], sigkey=sigkey)
+    with mock.patch("apprise.plugins.keybase.base.NACL_SUPPORT", False):
+        assert obj.notify(body="Hello") is False
+
+
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+@mock.patch(
+    "apprise.plugins.keybase.base.AppriseSaltpackController.sign",
+    side_effect=AppriseSaltpackException("key error"),
+)
+def test_plugin_keybase_send_sigkey_sign_exception(mock_sign, mock_sock_cls):
+    """AppriseSaltpackException from sign() causes send() to return False."""
+    mock_sock_cls.return_value = _socket_ok()
+    sigkey = "ab" * 32
+
+    with mock.patch("apprise.plugins.keybase.base.NACL_SUPPORT", True):
+        obj = NotifyKeybase(targets=["@alice"], sigkey=sigkey)
+        assert obj.notify(body="Hello") is False
+
+    # Socket must NOT have been called since signing failed first
+    assert not mock_sock_cls.return_value.sendall.called
+
+
+# ---------------------------------------------------------------------------
+# Apprise integration
+# ---------------------------------------------------------------------------
+
+
+@mock.patch.object(NotifyKeybase, "_stat_socket_path")
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+def test_plugin_keybase_apprise_integration(mock_sock_cls, mock_stat_sp):
+    """Apprise.add() and notify() work end-to-end via socket mode."""
+    mock_sock_cls.return_value = _socket_ok()
+
+    a = apprise.Apprise()
+    assert a.add("keybase://_/@alice/myteam%23general") is True
+    assert a.notify(title="Title", body="Body") is True
+
+
+# ---------------------------------------------------------------------------
+# socket path security validation
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_keybase_socket_path_non_socket_file_raises():
+    """socket_path pointing at a regular file raises TypeError at init."""
+    with mock.patch("os.stat") as mock_stat:
+        # Simulate a regular file (S_IFREG, mode 0o100644)
+        mock_stat.return_value.st_mode = 0o100644
+        with pytest.raises(TypeError, match=r"not.*socket"):
+            NotifyKeybase(
+                targets=["@alice"],
+                socket_path="/etc/shadow",
+            )
+
+
+def test_plugin_keybase_socket_path_nonexistent_accepted_at_init():
+    """Non-existent socket_path is accepted at init (service may be down)."""
+    with mock.patch("os.stat", side_effect=OSError("no such file")):
+        # Should not raise -- service is just not running yet
+        obj = NotifyKeybase(
+            targets=["@alice"],
+            socket_path="/tmp/not_there.sock",
+        )
+    assert obj.socket_path == "/tmp/not_there.sock"
+
+
+@mock.patch.object(
+    NotifyKeybase,
+    "_stat_socket_path",
+    side_effect=OSError("Path is not a Unix socket: /fake"),
+)
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+def test_plugin_keybase_send_socket_path_not_socket_at_send(
+    mock_sock_cls, mock_stat_sp
+):
+    """send() returns False when socket_path exists but is not a socket."""
+    obj = NotifyKeybase(targets=["@alice"])
+    assert obj.notify(body="Hello") is False
+
+    # socket.socket() must never be called on a non-socket path
+    assert not mock_sock_cls.called
+
+
+@mock.patch.object(
+    NotifyKeybase,
+    "_stat_socket_path",
+    side_effect=OSError("Keybase socket not found: /fake"),
+)
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+def test_plugin_keybase_send_socket_path_missing_at_send(
+    mock_sock_cls, mock_stat_sp
+):
+    """send() returns False when socket_path is missing at send time."""
+    obj = NotifyKeybase(targets=["@alice"])
+    assert obj.notify(body="Hello") is False
+
+    assert not mock_sock_cls.called
+
+
+# ---------------------------------------------------------------------------
+# keybase_default_socket() -- platform branches
+# ---------------------------------------------------------------------------
+
+
+def test_keybase_default_socket_windows():
+    """Windows path returns the named pipe."""
+    with mock.patch("apprise.plugins.keybase.common.sys.platform", "win32"):
+        path = _kds()
+    assert path == r"\\.\pipe\keybase.service"
+
+
+def test_keybase_default_socket_macos():
+    """macOS path returns a Library/Group Containers path."""
+    with mock.patch("apprise.plugins.keybase.common.sys.platform", "darwin"):
+        path = _kds()
+    assert "Library" in path
+    assert "keybased.sock" in path
+
+
+def test_keybase_default_socket_linux():
+    """Linux path uses XDG_RUNTIME_DIR when set."""
+    with (
+        mock.patch("apprise.plugins.keybase.common.sys.platform", "linux"),
+        mock.patch.dict(
+            "os.environ",
+            {"XDG_RUNTIME_DIR": "/run/user/1234"},
+            clear=False,
+        ),
+    ):
+        path = _kds()
+    assert path == "/run/user/1234/keybase/keybased.sock"
+
+
+# ---------------------------------------------------------------------------
+# _send_socket() -- multi-chunk response
+# ---------------------------------------------------------------------------
+
+
+@mock.patch.object(NotifyKeybase, "_stat_socket_path")
+@mock.patch("apprise.plugins.keybase.base._socket.socket")
+def test_plugin_keybase_send_socket_chunked_response(
+    mock_sock_cls, mock_stat_sp
+):
+    """Socket response arriving in two chunks is reassembled correctly."""
+    response = json.dumps({"result": {"id": 1}}).encode() + b"\n"
+    # Split so the first chunk has no newline; second chunk completes it
+    conn = mock.MagicMock()
+    conn.recv.side_effect = [response[:10], response[10:]]
+    mock_sock_cls.return_value = conn
+
+    obj = NotifyKeybase(targets=["@alice"])
+    assert obj.notify(body="Hello") is True
+
+
+# ---------------------------------------------------------------------------
+# _stat_socket_path() -- unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_stat_socket_path_valid_socket():
+    """_stat_socket_path does not raise for a genuine socket file."""
+    obj = NotifyKeybase(targets=["@alice"])
+    with mock.patch("os.stat") as mock_stat:
+        # Simulate a Unix socket (S_IFSOCK = 0o140000, mode 0o140777)
+        mock_stat.return_value.st_mode = 0o140777
+        # Should not raise
+        obj._stat_socket_path()
+
+
+def test_stat_socket_path_regular_file_raises():
+    """_stat_socket_path raises OSError when path is a regular file."""
+    obj = NotifyKeybase(targets=["@alice"])
+    with mock.patch("os.stat") as mock_stat:
+        # Simulate a regular file (S_IFREG = 0o100000, mode 0o100644)
+        mock_stat.return_value.st_mode = 0o100644
+        with pytest.raises(OSError, match="not a Unix socket"):
+            obj._stat_socket_path()
+
+
+def test_stat_socket_path_missing_raises():
+    """_stat_socket_path raises OSError when path does not exist."""
+    obj = NotifyKeybase(targets=["@alice"])
+    with (
+        mock.patch("os.stat", side_effect=FileNotFoundError("no such file")),
+        pytest.raises(OSError, match="socket not found"),
+    ):
+        obj._stat_socket_path()

--- a/tests/utils/test_saltpack.py
+++ b/tests/utils/test_saltpack.py
@@ -1,0 +1,459 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import logging
+from unittest import mock
+
+import pytest
+
+from apprise.utils.saltpack import (
+    NACL_SUPPORT,
+    AppriseSaltpackController,
+    AppriseSaltpackException,
+    _b62_decode,
+    _b62_encode,
+    _mp_array,
+    _mp_bool,
+    _mp_bytes,
+    _mp_fixstr,
+    _mp_uint,
+)
+
+logging.disable(logging.CRITICAL)
+
+
+# ---------------------------------------------------------------------------
+# Inline msgpack encoder
+# ---------------------------------------------------------------------------
+
+
+def test_saltpack_mp_fixstr_basic():
+    """Short ASCII strings are encoded as msgpack fixstr."""
+    # "saltpack" is 8 chars -> 0xa8 + b"saltpack"
+    encoded = _mp_fixstr("saltpack")
+    assert encoded == b"\xa8saltpack"
+
+
+def test_saltpack_mp_fixstr_too_long():
+    """Strings > 31 bytes raise ValueError."""
+    with pytest.raises(ValueError):
+        _mp_fixstr("x" * 32)
+
+
+def test_saltpack_mp_uint_small():
+    """Small integers use msgpack positive fixint."""
+    assert _mp_uint(0) == b"\x00"
+    assert _mp_uint(1) == b"\x01"
+    assert _mp_uint(127) == b"\x7f"
+
+
+def test_saltpack_mp_uint_out_of_range():
+    """Values outside 0-127 raise ValueError."""
+    with pytest.raises(ValueError):
+        _mp_uint(128)
+    with pytest.raises(ValueError):
+        _mp_uint(-1)
+
+
+def test_saltpack_mp_bool():
+    """Booleans are encoded as msgpack bool."""
+    assert _mp_bool(True) == b"\xc3"
+    assert _mp_bool(False) == b"\xc2"
+
+
+def test_saltpack_mp_bytes_bin8():
+    """Bytes up to 255 use msgpack bin8."""
+    data = b"\x01\x02\x03"
+    encoded = _mp_bytes(data)
+    # 0xc4 = bin8 marker, then length byte, then data
+    assert encoded == b"\xc4\x03\x01\x02\x03"
+
+
+def test_saltpack_mp_bytes_bin16():
+    """Bytes 256-65535 use msgpack bin16."""
+    data = b"\xff" * 256
+    encoded = _mp_bytes(data)
+    assert encoded[0:1] == b"\xc5"
+    assert int.from_bytes(encoded[1:3], "big") == 256
+
+
+def test_saltpack_mp_bytes_bin32():
+    """Bytes > 65535 use msgpack bin32."""
+    data = b"\xaa" * 65536
+    encoded = _mp_bytes(data)
+    assert encoded[0:1] == b"\xc6"
+    assert int.from_bytes(encoded[1:5], "big") == 65536
+
+
+def test_saltpack_mp_array_fixarray():
+    """Arrays up to 15 elements use msgpack fixarray."""
+    items = [_mp_uint(i) for i in range(5)]
+    encoded = _mp_array(items)
+    # fixarray(5) = 0x90 | 5 = 0x95
+    assert encoded[0:1] == b"\x95"
+
+
+def test_saltpack_mp_array_array16():
+    """Arrays of 16-65535 elements use msgpack array16."""
+    items = [_mp_uint(0)] * 16
+    encoded = _mp_array(items)
+    # array16 marker
+    assert encoded[0:1] == b"\xdc"
+
+
+def test_saltpack_mp_array_array32():
+    """Arrays of >65535 elements use msgpack array32."""
+    items = [_mp_uint(0)] * 65536
+    encoded = _mp_array(items)
+    # array32 marker
+    assert encoded[0:1] == b"\xdd"
+
+
+# ---------------------------------------------------------------------------
+# Base62 codec
+# ---------------------------------------------------------------------------
+
+
+def test_saltpack_b62_encode_roundtrip_full_chunk():
+    """A 32-byte value round-trips through base62 encode/decode."""
+    data = bytes(range(32))
+    encoded = _b62_encode(data)
+    # Full chunk should produce exactly 43 chars
+    assert len(encoded) == 43
+    decoded = _b62_decode(encoded)
+    assert decoded == data
+
+
+def test_saltpack_b62_encode_roundtrip_partial_chunk():
+    """A partial chunk round-trips correctly."""
+    for n in range(1, 32):
+        data = bytes(range(n))
+        encoded = _b62_encode(data)
+        decoded = _b62_decode(encoded)
+        assert decoded == data, f"Failed for {n} bytes"
+
+
+def test_saltpack_b62_encode_roundtrip_multi_chunk():
+    """Multiple full chunks plus a partial chunk round-trip."""
+    data = bytes(range(70))  # 2 full chunks (64 bytes) + 6 bytes
+    encoded = _b62_encode(data)
+    decoded = _b62_decode(encoded)
+    assert decoded == data
+
+
+def test_saltpack_b62_encode_leading_zero_bytes():
+    """Leading zero bytes in a chunk are preserved after round-trip."""
+    data = b"\x00\x00\x01" + bytes(29)  # starts with 2 zero bytes
+    encoded = _b62_encode(data)
+    decoded = _b62_decode(encoded)
+    assert decoded == data
+
+
+def test_saltpack_b62_decode_ignores_whitespace():
+    """Whitespace (spaces and newlines) in encoded text is ignored."""
+    data = bytes(range(32))
+    encoded = _b62_encode(data)
+    # Insert spaces and newlines
+    spaced = " ".join(encoded[i : i + 10] for i in range(0, len(encoded), 10))
+    newlined = "\n".join(spaced.split())
+    decoded = _b62_decode(newlined)
+    assert decoded == data
+
+
+# ---------------------------------------------------------------------------
+# AppriseSaltpackController -- no-PyNaCl paths
+# ---------------------------------------------------------------------------
+
+
+def test_saltpack_sign_no_nacl_raises():
+    """sign() raises AppriseSaltpackException when PyNaCl is absent."""
+    ctrl = AppriseSaltpackController()
+    with (
+        mock.patch("apprise.utils.saltpack.NACL_SUPPORT", False),
+        pytest.raises(AppriseSaltpackException),
+    ):
+        ctrl.sign("hello", "ab" * 32)
+
+
+def test_saltpack_keygen_signing_no_nacl_raises():
+    """keygen_signing() raises when PyNaCl is absent."""
+    with (
+        mock.patch("apprise.utils.saltpack.NACL_SUPPORT", False),
+        pytest.raises(AppriseSaltpackException),
+    ):
+        AppriseSaltpackController.keygen_signing()
+
+
+def test_saltpack_keygen_box_no_nacl_raises():
+    """keygen_box() raises when PyNaCl is absent."""
+    with (
+        mock.patch("apprise.utils.saltpack.NACL_SUPPORT", False),
+        pytest.raises(AppriseSaltpackException),
+    ):
+        AppriseSaltpackController.keygen_box()
+
+
+def test_saltpack_box_encrypt_no_nacl_raises():
+    """box_encrypt() raises when PyNaCl is absent."""
+    with (
+        mock.patch("apprise.utils.saltpack.NACL_SUPPORT", False),
+        pytest.raises(AppriseSaltpackException),
+    ):
+        AppriseSaltpackController.box_encrypt("msg", "ab" * 32, b"\x00" * 32)
+
+
+# ---------------------------------------------------------------------------
+# AppriseSaltpackController -- sign() input validation
+# ---------------------------------------------------------------------------
+
+
+def test_saltpack_sign_invalid_key_non_hex():
+    """sign() raises when the signing key contains non-hex chars."""
+    ctrl = AppriseSaltpackController()
+    with (
+        mock.patch("apprise.utils.saltpack.NACL_SUPPORT", True),
+        pytest.raises(AppriseSaltpackException),
+    ):
+        ctrl.sign("hello", "zz" * 32)
+
+
+def test_saltpack_sign_invalid_key_wrong_length():
+    """sign() raises when the signing key is not 32 bytes (64 hex chars)."""
+    ctrl = AppriseSaltpackController()
+    with (
+        mock.patch("apprise.utils.saltpack.NACL_SUPPORT", True),
+        pytest.raises(AppriseSaltpackException),
+    ):
+        ctrl.sign("hello", "ab" * 16)  # only 16 bytes
+
+
+# ---------------------------------------------------------------------------
+# AppriseSaltpackController -- with PyNaCl (skip if not installed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+def test_saltpack_keygen_signing_returns_hex_pair():
+    """keygen_signing() returns two 64-char hex strings."""
+    sk_hex, vk_hex = AppriseSaltpackController.keygen_signing()
+    assert len(sk_hex) == 64
+    assert len(vk_hex) == 64
+    # Verify both strings are valid hex
+    bytes.fromhex(sk_hex)
+    bytes.fromhex(vk_hex)
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+def test_saltpack_keygen_box_returns_hex_pair():
+    """keygen_box() returns two 64-char hex strings."""
+    priv_hex, pub_hex = AppriseSaltpackController.keygen_box()
+    assert len(priv_hex) == 64
+    assert len(pub_hex) == 64
+    bytes.fromhex(priv_hex)
+    bytes.fromhex(pub_hex)
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+def test_saltpack_sign_produces_armored_output():
+    """sign() produces a properly armored Saltpack message."""
+    sk_hex, _ = AppriseSaltpackController.keygen_signing()
+    ctrl = AppriseSaltpackController()
+    result = ctrl.sign("Hello, Keybase!", sk_hex)
+
+    assert "BEGIN KEYBASE SALTPACK SIGNED MESSAGE" in result
+    assert "END KEYBASE SALTPACK SIGNED MESSAGE" in result
+    # Verify the armor block is non-empty between the markers
+    lines = result.splitlines()
+    assert len(lines) >= 3
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+def test_saltpack_sign_bytes_message():
+    """sign() accepts a bytes message as well as str."""
+    sk_hex, _ = AppriseSaltpackController.keygen_signing()
+    ctrl = AppriseSaltpackController()
+    result = ctrl.sign(b"bytes message", sk_hex)
+    assert "BEGIN KEYBASE SALTPACK SIGNED MESSAGE" in result
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+def test_saltpack_sign_empty_message():
+    """sign() handles an empty message without error."""
+    sk_hex, _ = AppriseSaltpackController.keygen_signing()
+    ctrl = AppriseSaltpackController()
+    result = ctrl.sign("", sk_hex)
+    assert "BEGIN KEYBASE SALTPACK SIGNED MESSAGE" in result
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+def test_saltpack_sign_long_message():
+    """sign() splits messages > 1 MB into multiple payload packets."""
+    sk_hex, _ = AppriseSaltpackController.keygen_signing()
+    ctrl = AppriseSaltpackController()
+    # 1.5 MB message produces two payload packets
+    big = "A" * (1_000_000 + 500_000)
+    result = ctrl.sign(big, sk_hex)
+    assert "BEGIN KEYBASE SALTPACK SIGNED MESSAGE" in result
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+def test_saltpack_box_encrypt_returns_nonce_and_ciphertext():
+    """box_encrypt() returns a (nonce, ciphertext) tuple."""
+    priv_hex, pub_hex = AppriseSaltpackController.keygen_box()
+    pub_bytes = bytes.fromhex(pub_hex)
+    nonce, ct = AppriseSaltpackController.box_encrypt(
+        "secret", priv_hex, pub_bytes
+    )
+    # NaCl Box nonce is 24 bytes
+    assert len(nonce) == 24
+    assert len(ct) > 0
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+def test_saltpack_box_encrypt_bytes_plaintext():
+    """box_encrypt() accepts a bytes plaintext (not just str)."""
+    priv_hex, pub_hex = AppriseSaltpackController.keygen_box()
+    pub_bytes = bytes.fromhex(pub_hex)
+    nonce, ct = AppriseSaltpackController.box_encrypt(
+        b"bytes secret", priv_hex, pub_bytes
+    )
+    assert len(nonce) == 24
+    assert len(ct) > 0
+
+
+@pytest.mark.skipif(not NACL_SUPPORT, reason="PyNaCl not installed")
+def test_saltpack_box_encrypt_bad_privkey_raises():
+    """box_encrypt() raises when the private key is not valid hex."""
+    with pytest.raises(AppriseSaltpackException):
+        AppriseSaltpackController.box_encrypt("msg", "zz" * 32, b"\x00" * 32)
+
+
+# ---------------------------------------------------------------------------
+# AppriseSaltpackController -- fetch_keybase_keys()
+# ---------------------------------------------------------------------------
+
+
+def test_saltpack_fetch_keybase_keys_success():
+    """fetch_keybase_keys() parses a successful API response."""
+    dh_hex = "aa" * 32
+    eddsa_hex = "bb" * 32
+    response_json = {
+        "them": [
+            {
+                "public_keys": {
+                    "nacl": {
+                        "dh": dh_hex,
+                        "eddsa": eddsa_hex,
+                    }
+                }
+            }
+        ]
+    }
+
+    mock_resp = mock.MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = response_json
+
+    with mock.patch("requests.get", return_value=mock_resp):
+        result = AppriseSaltpackController.fetch_keybase_keys("alice")
+
+    assert result is not None
+    assert result["dh"] == bytes.fromhex(dh_hex)
+    assert result["eddsa"] == bytes.fromhex(eddsa_hex)
+
+
+def test_saltpack_fetch_keybase_keys_http_error():
+    """fetch_keybase_keys() returns None on HTTP error status."""
+    mock_resp = mock.MagicMock()
+    mock_resp.status_code = 404
+
+    with mock.patch("requests.get", return_value=mock_resp):
+        result = AppriseSaltpackController.fetch_keybase_keys("nosuchuser")
+
+    assert result is None
+
+
+def test_saltpack_fetch_keybase_keys_network_error():
+    """fetch_keybase_keys() returns None on network failure."""
+    import requests as _requests
+
+    with mock.patch(
+        "requests.get",
+        side_effect=_requests.RequestException("timeout"),
+    ):
+        result = AppriseSaltpackController.fetch_keybase_keys("alice")
+
+    assert result is None
+
+
+def test_saltpack_fetch_keybase_keys_bad_json():
+    """fetch_keybase_keys() returns None when response is not valid JSON."""
+    mock_resp = mock.MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.side_effect = ValueError("not json")
+
+    with mock.patch("requests.get", return_value=mock_resp):
+        result = AppriseSaltpackController.fetch_keybase_keys("alice")
+
+    assert result is None
+
+
+def test_saltpack_fetch_keybase_keys_missing_nacl_fields():
+    """fetch_keybase_keys() returns None when nacl keys are absent."""
+    response_json = {
+        "them": [
+            {
+                "public_keys": {
+                    "nacl": {
+                        "dh": "",
+                        "eddsa": "",
+                    }
+                }
+            }
+        ]
+    }
+
+    mock_resp = mock.MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = response_json
+
+    with mock.patch("requests.get", return_value=mock_resp):
+        result = AppriseSaltpackController.fetch_keybase_keys("alice")
+
+    assert result is None
+
+
+def test_saltpack_fetch_keybase_keys_unexpected_structure():
+    """fetch_keybase_keys() returns None for unexpected JSON structure."""
+    mock_resp = mock.MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"unexpected": "structure"}
+
+    with mock.patch("requests.get", return_value=mock_resp):
+        result = AppriseSaltpackController.fetch_keybase_keys("alice")
+
+    assert result is None


### PR DESCRIPTION
## Description
**Related issue (if applicable):** N/A

## Keybase Notifications
* **Source**: https://keybase.io/
* **Image Support**: No
* **Attachment Support**: Yes
* **Message Format**: Plain Text
* **Message Limit**: 10,000 characters

Adds a new Keybase Chat notification plugin that communicates directly with the locally running Keybase service over a Unix domain socket (default) or a local HTTP endpoint (TCP mode).

Two target types are supported in any combination within a single URL: `@username` for direct messages and `teamname#channel` for team channels (default channel `general` when no channel is specified). Multiple targets are packed into the URL path: `keybase://_/@alice/@bob/myteam#dev`.

An optional Saltpack v2.0 message-signing feature is available via `?sigkey=` when the PyNaCl package is installed. Signed messages can be verified with `keybase verify` or any Saltpack client.

## Account Setup
1. Download and install Keybase from https://keybase.io/download.
2. Log in with `keybase login` or through the Keybase desktop application.
3. Keep the Keybase service running in the background when sending notifications (the desktop app or `keybase service` keeps it alive automatically).

## Syntax

Valid syntax is as follows:
- `keybase://_/@{username}` -- direct message (socket mode)
- `keybase://_/{teamname}` -- team message, default channel `general`
- `keybase://_/{teamname}#{channel}` -- specific team channel
- `keybase://_/@{user1}/@{user2}/{teamname}#{channel}` -- multiple targets
- `keybase://localhost:{port}/@{username}` -- TCP mode

## Parameter Breakdown

| Variable    | Required                    | Description |
| ----------- | --------------------------- | ----------- |
| `@username` | \*Yes (at least one target) | Keybase username for a direct message. Prefix with `@`. |
| `teamname`  | \*Yes (at least one target) | Keybase team name. Append `#channel` for a specific channel. |
| `channel`   | No                          | Team channel. Defaults to `general`. |
| `mode`      | No                          | Connection mode: `socket` (default) or `tcp`. |
| `socket`    | No                          | Override the Unix domain socket path (must contain `keybase`). |
| `port`      | No                          | Port for the local Keybase HTTP service (TCP mode). |
| `sigkey`    | No                          | 64-char hex Ed25519 seed for Saltpack signing (requires PyNaCl). |

## Examples

Send a direct message (socket mode):
```bash
apprise -vv -t "Title" -b "Message" \
    keybase://_/@alice
```

Send to a team channel:
```bash
apprise -vv -t "Title" -b "Message" \
    "keybase://_/myteam#dev"
```

Send via TCP mode:
```bash
apprise -vv -t "Title" -b "Message" \
    keybase://localhost:3000/@alice
```

Send a Saltpack-signed message:
```bash
apprise -vv -t "Title" -b "Message" \
    "keybase://_/@alice?sigkey=aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344"
```

## New Service Completion Status
* [x] `apprise/plugins/keybase/`
* [x] `pyproject.toml` 
* [x] `README.md`
* [x] `packaging/redhat/python-apprise.spec`

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/77](https://github.com/caronc/apprise-docs/pull/77)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@keybase-support

# Socket mode -- direct message
tox -e apprise -- -t "Test Title" -b "Test Message" \
    keybase://_/@yourusername

# TCP mode
tox -e apprise -- -t "Test Title" -b "Test Message" \
    keybase://localhost:3000/@yourusername

# With attachment
tox -e apprise -- -t "Test Title" -b "Test Message" \
    --attach=/path/to/file.png \
    "keybase://_/yourteam#general"

# With Saltpack signing (requires PyNaCl)
pip install PyNaCl
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "keybase://_/@yourusername?sigkey=<64-char-hex-seed>"
```
