### PR TITLE
fixed mastodon error: AttributeError -  'list' object has no attribute 'union'

### DIFF
--- a/apprise/plugins/mastodon.py
+++ b/apprise/plugins/mastodon.py
@@ -351,7 +351,7 @@ class NotifyMastodon(NotifyBase):
 
         # Our target users
         self.targets = []
-        self.tags = []
+        self.hashtags = []
         tag_seen = set()
 
         # Track any errors
@@ -369,7 +369,7 @@ class NotifyMastodon(NotifyBase):
                 key = normalized.casefold()
                 if key not in tag_seen:
                     tag_seen.add(key)
-                    self.tags.append(normalized)
+                    self.hashtags.append(normalized)
                 continue
 
             has_error = True
@@ -377,7 +377,7 @@ class NotifyMastodon(NotifyBase):
                 f"Dropped invalid Mastodon target ({target}) specified.",
             )
 
-        if has_error and not (self.targets or self.tags):
+        if has_error and not (self.targets or self.hashtags):
             # We have specified that we want to notify one or more individual
             # and we failed to load any of them.  Since it's also valid to
             # notify no one at all (which means we notify ourselves), it's
@@ -420,7 +420,7 @@ class NotifyMastodon(NotifyBase):
         """Return the body space available after configured status tokens."""
 
         tokens = self.ping_tokens(
-            " ".join(self.targets + self.tags + self.ping),
+            " ".join(self.targets + self.hashtags + self.ping),
             normalize=True,
         )
         return max(
@@ -473,7 +473,7 @@ class NotifyMastodon(NotifyBase):
             targets="/".join(
                 [
                     NotifyMastodon.quote(x, safe="@")
-                    for x in self.targets + self.tags
+                    for x in self.targets + self.hashtags
                 ]
             ),
             params=NotifyMastodon.urlencode(params),
@@ -631,20 +631,20 @@ class NotifyMastodon(NotifyBase):
         # Other formats only append explicitly configured ping values.
         if self.notify_format == NotifyFormat.MARKDOWN:
             ping_tokens.extend(self.ping_tokens(body, seen=seen))
-            if self.targets or self.tags or self.ping:
+            if self.targets or self.hashtags or self.ping:
                 ping_tokens.extend(
                     self.ping_tokens(
-                        " ".join(self.targets + self.tags + self.ping),
+                        " ".join(self.targets + self.hashtags + self.ping),
                         normalize=True,
                         seen=seen,
                     )
                 )
 
         # Non-markdown content is not scanned for mention or hashtag tokens.
-        elif self.targets or self.tags or self.ping:
+        elif self.targets or self.hashtags or self.ping:
             ping_tokens.extend(
                 self.ping_tokens(
-                    " ".join(self.targets + self.tags + self.ping),
+                    " ".join(self.targets + self.hashtags + self.ping),
                     normalize=True,
                     seen=seen,
                 )

--- a/tests/test_plugin_mastodon.py
+++ b/tests/test_plugin_mastodon.py
@@ -459,7 +459,7 @@ def test_plugin_mastodon_pings(mock_post):
         targets="#Apprise,#apprise",
         ping="#Media,#media",
     )
-    assert obj.tags == ["#Apprise"]
+    assert obj.hashtags == ["#Apprise"]
     assert obj.ping == ["#Media"]
 
     mock_post.reset_mock()
@@ -1130,3 +1130,56 @@ def test_plugin_mastodon_attachments(mock_get, mock_post):
     assert (
         mock_post.call_args_list[1][0][0] == "https://nuxref.com/api/v1/media"
     )
+
+
+@mock.patch("requests.post")
+def test_plugin_mastodon_apprise_tags(mock_post):
+    """NotifyMastodon() - Apprise tag filter must not corrupt URLBase.tags.
+
+    Regression test for a bug where self.hashtags = [] in __init__ was
+    mistakenly named self.tags, overwriting the set() that URLBase stores for
+    Apprise's own notification-tag system.  Any call to Apprise.find() or a
+    tag-filtered Apprise.notify() would crash with:
+        AttributeError: 'list' object has no attribute 'union'
+    """
+    akey = "access_key"
+    host = "mastodon.social"
+
+    # Prepare a good response
+    good_response = mock.Mock()
+    good_response.content = b"{}"
+    good_response.status_code = requests.codes.ok
+
+    mock_post.return_value = good_response
+
+    # Load a Mastodon URL that carries Mastodon hashtag targets into an Apprise
+    # instance that also has Apprise notification tags assigned.  The Mastodon
+    # #hashtag and the Apprise tag are distinct concepts and must not collide.
+    a = Apprise()
+    assert (
+        a.add(
+            f"mastodon://{akey}@{host}/%23apprise",
+            tag="prod",
+        )
+        is True
+    )
+
+    # Confirm the plugin loaded and its Apprise tag set is a proper set (not a
+    # list), which is what caused the AttributeError before the fix.
+    plugins = list(a)
+    assert len(plugins) == 1
+    assert isinstance(plugins[0].tags, set)
+    assert "prod" in plugins[0].tags
+
+    # Confirm the Mastodon hashtag target was stored under hashtags, not tags
+    assert plugins[0].hashtags == ["#apprise"]
+
+    # Exercising Apprise.find() is the exact path that crashed before the fix;
+    # it calls is_exclusive_match(data=notification.tags, ...) which requires
+    # notification.tags to support .union().
+    found = list(a.find("prod"))
+    assert len(found) == 1
+
+    # A tag-filtered notify() follows the same code path
+    assert a.notify(body="test", tag="prod") is True
+    assert mock_post.call_count == 1


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1630

Fixes issue:
```bash
Traceback (most recent call last):
  File "/opt/apprise/webapp/api/views.py", line 2493, in get
    for notification in a_obj.find(tag):
                        ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/apprise/apprise.py", line 385, in find
    if is_exclusive_match(
       ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/apprise/utils/logic.py", line 93, in is_exclusive_match
    if len(entries.intersection(data.union({match_all}))) == len(entries):
                                ^^^^^^^^^^
AttributeError: 'list' object has no attribute 'union'
```

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [ ] Documentation ticket created (if applicable): n/a
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1630-mastodon-tags-bugfix

# run tests (as a new one was created to verify this bug can't happen again)
tox -e qa
```
