### PR TITLE
Support same-level yaml indented URL configuration entries

### DIFF
--- a/apprise/config/base.py
+++ b/apprise/config/base.py
@@ -1223,8 +1223,6 @@ class ConfigBase(URLBase):
 
                         # We are a url string with additional options
                         if isinstance(entries, dict):
-                            url_, tokens = next(iter(url.items()))
-
                             # Tags you just can't over-ride
                             if "schema" in entries:
                                 del entries["schema"]

--- a/apprise/config/base.py
+++ b/apprise/config/base.py
@@ -39,7 +39,7 @@ from ..logger import logging
 from ..manager_config import ConfigurationManager
 from ..manager_plugins import NotificationManager
 from ..tag import AppriseTag
-from ..url import URLBase
+from ..url import URL_TOKEN_ALIASES, URLBase
 from ..utils.cwe312 import cwe312_url
 from ..utils.parse import GET_SCHEMA_RE, parse_bool, parse_list, parse_urls
 from ..utils.time import zoneinfo
@@ -1162,7 +1162,14 @@ class ConfigBase(URLBase):
                     )
                     continue
 
-                # Collect any remaining items from the iterator.
+                # Collect sibling tokens from the entire mapping,
+                # excluding only the URL key itself.  Using the full
+                # url.items() dict (rather than the remaining iterator)
+                # ensures siblings that appear *before* the URL key in
+                # the YAML mapping are captured too.  YAML does not
+                # guarantee key order within a mapping, so order must
+                # not matter here.
+                #
                 # In YAML, keys at the same indentation level as
                 # the schema URL key become siblings in the same
                 # mapping dict rather than children of the URL key.
@@ -1181,7 +1188,7 @@ class ConfigBase(URLBase):
                 #   - mailtos://_:
                 #       smtp: smtp.example.com
                 #       from: no-reply@example.com
-                sibling_tokens = dict(it)
+                sibling_tokens = {k: v for k, v in url.items() if k != url_}
 
                 results_ = plugins.url_to_dict(
                     url_, secure_logging=asset.secure_logging
@@ -1484,6 +1491,20 @@ class ConfigBase(URLBase):
         """
         # Create a copy of our dictionary
         tokens = tokens.copy()
+
+        # Apply URL_TOKEN_ALIASES so shorthand keys (e.g. 'pass') are
+        # normalized to the canonical kwarg name ('password') before any
+        # plugin-specific template_args mapping runs.  YAML tokens bypass
+        # parse_url() / post_process_parse_url_results() entirely, so the
+        # same alias table must be applied here too.
+        for alias, canonical in URL_TOKEN_ALIASES.items():
+            if alias in tokens and canonical not in tokens:
+                tokens[canonical] = tokens.pop(alias)
+
+            elif alias in tokens:
+                # canonical key already set -- silently discard the alias so
+                # the explicitly-provided canonical value is not overwritten
+                del tokens[alias]
 
         for kw, meta in N_MGR[schema].template_kwargs.items():
             # Determine our prefix:

--- a/apprise/config/base.py
+++ b/apprise/config/base.py
@@ -1411,11 +1411,11 @@ class ConfigBase(URLBase):
                 # For the second post_process_parse_url_results call we
                 # need to distinguish two plugin families:
                 #
-                # URLBase-based plugins run post_process inside parse_url,
-                # which sets 'verify' (at minimum to its default True)
-                # before YAML tokens are merged.  The presence of 'verify'
-                # in results_ is therefore a reliable indicator that qsd
-                # was already applied once -- every field that
+                # URLBase-based plugins use the full-mode utils.parse.parse_url()
+                # (simple=False), which always creates qsd plus the extended qsd
+                # dicts (qsd+, qsd-, qsd:).  The presence of these keys is a
+                # reliable indicator that qsd was already applied once before
+                # YAML tokens were merged.
                 # post_process reads from qsd (verify, redirect, rto, cto,
                 # port, user, password, URL_TOKEN_ALIASES aliases, ...) is
                 # already reflected in results_.  YAML tokens then overrode

--- a/apprise/config/base.py
+++ b/apprise/config/base.py
@@ -1188,7 +1188,9 @@ class ConfigBase(URLBase):
                 #   - mailtos://_:
                 #       smtp: smtp.example.com
                 #       from: no-reply@example.com
-                sibling_tokens = {k: v for k, v in url.items() if k != url_}
+                sibling_tokens = {
+                    k: v for k, v in url.items() if k not in (url_, "schema")
+                }
 
                 results_ = plugins.url_to_dict(
                     url_, secure_logging=asset.secure_logging
@@ -1240,6 +1242,21 @@ class ConfigBase(URLBase):
                             results.append(r)
 
                 elif isinstance(tokens, dict):
+                    # Normalize sibling and child token dicts
+                    # independently before merging, so that an alias key
+                    # in sibling tokens (e.g. 'smtp' -> 'smtp_host') can
+                    # never overwrite a canonical key already set in the
+                    # higher-priority child tokens.
+                    if schema in N_MGR:
+                        if sibling_tokens:
+                            sibling_tokens = ConfigBase._special_token_handler(
+                                schema, sibling_tokens
+                            )
+
+                        tokens = ConfigBase._special_token_handler(
+                            schema, tokens
+                        )
+
                     # Merge sibling tokens as the lower-priority base
                     # and let the child token dict (the indented value
                     # of the URL key) override on a per-key basis.
@@ -1247,12 +1264,6 @@ class ConfigBase(URLBase):
                         merged = sibling_tokens.copy()
                         merged.update(tokens)
                         tokens = merged
-
-                    # support our special tokens (if they're present)
-                    if schema in N_MGR:
-                        tokens = ConfigBase._special_token_handler(
-                            schema, tokens
-                        )
 
                     # Copy ourselves a template of our parsed URL as
                     # a base to work with
@@ -1388,6 +1399,14 @@ class ConfigBase(URLBase):
                 # Prepare our Asset Object
                 results_["asset"] = asset
 
+                # Strip qsd before the second post_process_parse_url_results
+                # call.  YAML tokens were already merged into results_ at a
+                # higher priority than qsd.  Leaving qsd in place would cause
+                # post_process_parse_url_results to re-apply URL query-string
+                # parameters (e.g. ?pass=, ?user=) and silently overwrite the
+                # YAML-token values, breaking the documented 1>2>3 priority.
+                results_.pop("qsd", None)
+
                 # Handle post processing of result set
                 results_ = URLBase.post_process_parse_url_results(results_)
 
@@ -1493,8 +1512,8 @@ class ConfigBase(URLBase):
         # Apply URL_TOKEN_ALIASES so shorthand keys (e.g. 'pass') are
         # normalized to the canonical kwarg name ('password') before any
         # plugin-specific template_args mapping runs.  YAML tokens bypass
-        # parse_url() / post_process_parse_url_results() entirely, so the
-        # same alias table must be applied here too.
+        # parse_url() and its initial post_process_parse_url_results() call
+        # inside url_to_dict(), so the same alias table must be applied here.
         for alias, canonical in URL_TOKEN_ALIASES.items():
             if alias in tokens and canonical not in tokens:
                 tokens[canonical] = tokens.pop(alias)

--- a/apprise/config/base.py
+++ b/apprise/config/base.py
@@ -1195,9 +1195,8 @@ class ConfigBase(URLBase):
 
                 if isinstance(tokens, (list, tuple, set)):
                     # Pre-process sibling tokens once before the loop
-                    # so each per-entry copy already has mappings
-                    # resolved (smtp -> smtp_host, from -> from_addr,
-                    # pass -> password, etc.)
+                    # so each per-entry copy already has template
+                    # mappings resolved (smtp -> smtp_host, etc.)
                     if sibling_tokens and schema in N_MGR:
                         sibling_tokens = ConfigBase._special_token_handler(
                             schema, sibling_tokens

--- a/apprise/config/base.py
+++ b/apprise/config/base.py
@@ -1162,6 +1162,27 @@ class ConfigBase(URLBase):
                     )
                     continue
 
+                # Collect any remaining items from the iterator.
+                # In YAML, keys at the same indentation level as
+                # the schema URL key become siblings in the same
+                # mapping dict rather than children of the URL key.
+                # We treat these sibling keys as token overrides
+                # that sit above URL-parsed values (priority 3) and
+                # below explicitly-nested child tokens (priority 1).
+                #
+                # This means both YAML forms produce the same result:
+                #
+                #   # sibling form (same indentation)
+                #   - mailtos://_:
+                #     smtp: smtp.example.com
+                #     from: no-reply@example.com
+                #
+                #   # child form (indented one level deeper)
+                #   - mailtos://_:
+                #       smtp: smtp.example.com
+                #       from: no-reply@example.com
+                sibling_tokens = dict(it)
+
                 results_ = plugins.url_to_dict(
                     url_, secure_logging=asset.secure_logging
                 )
@@ -1173,14 +1194,28 @@ class ConfigBase(URLBase):
                     }
 
                 if isinstance(tokens, (list, tuple, set)):
-                    # populate and/or override any results populated by
-                    # parse_url()
+                    # Pre-process sibling tokens once before the loop
+                    # so each per-entry copy already has mappings
+                    # resolved (smtp -> smtp_host, from -> from_addr,
+                    # pass -> password, etc.)
+                    if sibling_tokens and schema in N_MGR:
+                        sibling_tokens = ConfigBase._special_token_handler(
+                            schema, sibling_tokens
+                        )
+
+                    # populate and/or override any results populated
+                    # by parse_url()
                     for entries in tokens:
-                        # Copy ourselves a template of our parsed URL as a base
-                        # to work with
+                        # Copy ourselves a template of our parsed URL
+                        # as a base to work with
                         r = results_.copy()
 
-                        # We are a url string with additional unescaped options
+                        # Apply sibling tokens as a shared base before
+                        # per-entry tokens (sibling < per-entry)
+                        if sibling_tokens:
+                            r.update(sibling_tokens)
+
+                        # We are a url string with additional options
                         if isinstance(entries, dict):
                             url_, tokens = next(iter(url.items()))
 
@@ -1188,7 +1223,7 @@ class ConfigBase(URLBase):
                             if "schema" in entries:
                                 del entries["schema"]
 
-                            # support our special tokens (if they're present)
+                            # support our special tokens
                             if schema in N_MGR:
                                 entries = ConfigBase._special_token_handler(
                                     schema, entries
@@ -1201,18 +1236,45 @@ class ConfigBase(URLBase):
                             results.append(r)
 
                 elif isinstance(tokens, dict):
+                    # Merge sibling tokens as the lower-priority base
+                    # and let the child token dict (the indented value
+                    # of the URL key) override on a per-key basis.
+                    if sibling_tokens:
+                        merged = sibling_tokens.copy()
+                        merged.update(tokens)
+                        tokens = merged
+
                     # support our special tokens (if they're present)
                     if schema in N_MGR:
                         tokens = ConfigBase._special_token_handler(
                             schema, tokens
                         )
 
-                    # Copy ourselves a template of our parsed URL as a base to
-                    # work with
+                    # Copy ourselves a template of our parsed URL as
+                    # a base to work with
                     r = results_.copy()
 
                     # add our result set
                     r.update(tokens)
+
+                    # add our results to our global set
+                    results.append(r)
+
+                elif sibling_tokens:
+                    # The URL key had a null child value, but sibling
+                    # keys supply token overrides. Process them the
+                    # same way as a child token dict.
+                    if schema in N_MGR:
+                        sibling_tokens = ConfigBase._special_token_handler(
+                            schema, sibling_tokens
+                        )
+
+                    # Copy ourselves a template of our parsed URL as
+                    # a base to work with
+                    r = results_.copy()
+
+                    # Apply the sibling token overrides
+                    r.update(sibling_tokens)
 
                     # add our results to our global set
                     results.append(r)

--- a/apprise/config/base.py
+++ b/apprise/config/base.py
@@ -53,6 +53,19 @@ from ..utils.time import zoneinfo
 # Test whether token is valid or not
 VALID_TOKEN = re.compile(r"(?P<token>[a-z0-9][a-z0-9_]+)", re.I)
 
+# Keys excluded from the YAML-token re-apply that happens after
+# post_process_parse_url_results() inside config_parse_yaml().
+#
+# 'tag'/'tags': assembled as a merged set (YAML tags + global_tags) by the
+# while loop before post_process runs; re-applying the raw YAML string would
+# replace the set with a string.  YAML accepts both spellings ('tag:' and
+# 'tags:'); both are excluded so neither overwrites the assembled set.
+#
+# 'asset': written programmatically from the Python asset parameter at
+# that point in the while loop; VALID_TOKEN does not strip it, so a
+# user-written YAML 'asset:' key would otherwise overwrite the object.
+_YAML_REAPPLY_SKIP = frozenset(("tag", "tags", "asset"))
+
 # Grant access to our Notification Manager Singleton
 N_MGR = NotificationManager()
 
@@ -1120,7 +1133,7 @@ class ConfigBase(URLBase):
                     continue
 
                 # add our results to our global set
-                results.append(results_)
+                results.append((results_, {}))
 
             elif isinstance(url, dict):
                 # We are a url string with additional unescaped options. In
@@ -1241,8 +1254,16 @@ class ConfigBase(URLBase):
                             # Extend our dictionary with our new entries
                             r.update(entries)
 
+                            # Record the YAML contributions for this entry
+                            # so post_process_parse_url_results() cannot
+                            # overwrite them (enforces YAML > qsd priority).
+                            yaml_ = {}
+                            if sibling_tokens:
+                                yaml_.update(sibling_tokens)
+                            yaml_.update(entries)
+
                             # add our results to our global set
-                            results.append(r)
+                            results.append((r, yaml_))
 
                 elif isinstance(tokens, dict):
                     # Strip 'schema' from child tokens -- it is determined
@@ -1282,7 +1303,7 @@ class ConfigBase(URLBase):
                     r.update(tokens)
 
                     # add our results to our global set
-                    results.append(r)
+                    results.append((r, dict(tokens)))
 
                 elif sibling_tokens:
                     # The URL key had a null child value, but sibling
@@ -1301,11 +1322,11 @@ class ConfigBase(URLBase):
                     r.update(sibling_tokens)
 
                     # add our results to our global set
-                    results.append(r)
+                    results.append((r, dict(sibling_tokens)))
 
                 else:
                     # add our results to our global set
-                    results.append(results_)
+                    results.append((results_, {}))
 
             else:
                 # Unsupported
@@ -1325,7 +1346,7 @@ class ConfigBase(URLBase):
                 entry += 1
 
                 # Grab our first item
-                results_ = results.popleft()
+                results_, yaml_tokens_ = results.popleft()
 
                 if results_["schema"] not in N_MGR:
                     # the arguments are invalid or can not be used.
@@ -1438,9 +1459,9 @@ class ConfigBase(URLBase):
                 # that callers (e.g. the @notify meta dict) can still
                 # inspect the raw query-string values.
                 orig_qsd = results_.get("qsd")
-                if QSD_FULL_MODE_KEYS.issubset(results_) and isinstance(
-                    orig_qsd, dict
-                ):
+                if all(
+                    k in results_ for k in QSD_FULL_MODE_KEYS
+                ) and isinstance(orig_qsd, dict):
                     # Full-mode parse_url() always creates all three extended
                     # qsd dicts (qsd+, qsd-, qsd:), even when the URL has no
                     # query params.  Simple-mode @notify parse_url() creates
@@ -1453,6 +1474,24 @@ class ConfigBase(URLBase):
 
                 # Handle post processing of result set
                 results_ = URLBase.post_process_parse_url_results(results_)
+
+                # Re-apply YAML tokens on top of post_process results.
+                # For URLBase plugins qsd was stripped above so this is
+                # idempotent.  For @notify plugins qsd was kept intact and
+                # post_process_parse_url_results() will have overwritten any
+                # YAML-token values with qsd values; re-applying here restores
+                # the correct YAML > qsd priority for those plugins too.
+                #
+                # Keys in _YAML_REAPPLY_SKIP are handled specially by the
+                # while loop above and must not be overwritten here.
+                if yaml_tokens_:
+                    results_.update(
+                        {
+                            k: v
+                            for k, v in yaml_tokens_.items()
+                            if k not in _YAML_REAPPLY_SKIP
+                        }
+                    )
 
                 # Restore the original qsd so the full meta dict is
                 # available downstream regardless of which branch above ran.

--- a/apprise/config/base.py
+++ b/apprise/config/base.py
@@ -1411,11 +1411,12 @@ class ConfigBase(URLBase):
                 # For the second post_process_parse_url_results call we
                 # need to distinguish two plugin families:
                 #
-                # URLBase-based plugins use the full-mode utils.parse.parse_url()
-                # (simple=False), which always creates qsd plus the extended qsd
-                # dicts (qsd+, qsd-, qsd:).  The presence of these keys is a
-                # reliable indicator that qsd was already applied once before
-                # YAML tokens were merged.
+                # URLBase-based plugins use the full-mode
+                # utils.parse.parse_url() (simple=False), which always creates
+                # qsd plus the extended qsd dicts (qsd+, qsd-, qsd:).  The
+                # presence of these keys is a reliable indicator that qsd was
+                # already applied once before YAML tokens were merged.
+                #
                 # post_process reads from qsd (verify, redirect, rto, cto,
                 # port, user, password, URL_TOKEN_ALIASES aliases, ...) is
                 # already reflected in results_.  YAML tokens then overrode

--- a/apprise/config/base.py
+++ b/apprise/config/base.py
@@ -41,7 +41,13 @@ from ..manager_plugins import NotificationManager
 from ..tag import AppriseTag
 from ..url import URL_TOKEN_ALIASES, URLBase
 from ..utils.cwe312 import cwe312_url
-from ..utils.parse import GET_SCHEMA_RE, parse_bool, parse_list, parse_urls
+from ..utils.parse import (
+    GET_SCHEMA_RE,
+    QSD_FULL_MODE_KEYS,
+    parse_bool,
+    parse_list,
+    parse_urls,
+)
 from ..utils.time import zoneinfo
 
 # Test whether token is valid or not
@@ -1134,13 +1140,10 @@ class ConfigBase(URLBase):
                     # Test our schema
                     schema_ = GET_SCHEMA_RE.match(key)
                     if schema_ is None:
-                        # Log invalid entries so that maintainer of config
-                        # config file at least has something to take action
-                        # with.
-                        ConfigBase.logger.warning(
-                            f"Ignored entry {key} found under urls, entry"
-                            f" #{no + 1}"
-                        )
+                        # Non-schema key -- may be a sibling token sitting
+                        # before the URL key in the YAML mapping.  Sibling
+                        # tokens are collected later via url.items(), so
+                        # nothing is "ignored" here.  Skip silently.
                         continue
 
                     # Store our schema
@@ -1242,6 +1245,12 @@ class ConfigBase(URLBase):
                             results.append(r)
 
                 elif isinstance(tokens, dict):
+                    # Strip 'schema' from child tokens -- it is determined
+                    # by the URL key's own schema and must not be overridden
+                    # by a child dict value (matching the list-expansion
+                    # branch that does the same via del entries["schema"]).
+                    tokens.pop("schema", None)
+
                     # Normalize sibling and child token dicts
                     # independently before merging, so that an alias key
                     # in sibling tokens (e.g. 'smtp' -> 'smtp_host') can
@@ -1399,16 +1408,58 @@ class ConfigBase(URLBase):
                 # Prepare our Asset Object
                 results_["asset"] = asset
 
-                # Strip qsd before the second post_process_parse_url_results
-                # call.  YAML tokens were already merged into results_ at a
-                # higher priority than qsd.  Leaving qsd in place would cause
-                # post_process_parse_url_results to re-apply URL query-string
-                # parameters (e.g. ?pass=, ?user=) and silently overwrite the
-                # YAML-token values, breaking the documented 1>2>3 priority.
-                results_.pop("qsd", None)
+                # For the second post_process_parse_url_results call we
+                # need to distinguish two plugin families:
+                #
+                # URLBase-based plugins run post_process inside parse_url,
+                # which sets 'verify' (at minimum to its default True)
+                # before YAML tokens are merged.  The presence of 'verify'
+                # in results_ is therefore a reliable indicator that qsd
+                # was already applied once -- every field that
+                # post_process reads from qsd (verify, redirect, rto, cto,
+                # port, user, password, URL_TOKEN_ALIASES aliases, ...) is
+                # already reflected in results_.  YAML tokens then overrode
+                # those values at higher priority.  Strip qsd entirely so
+                # the second call cannot re-apply any qsd field and undo
+                # the YAML-token values.  The second call will still
+                # normalise types (e.g. string -> bool for 'verify') from
+                # the already-merged results_.  There is intentionally no
+                # hardcoded list of fields to skip here; stripping the whole
+                # qsd is sufficient and avoids coupling this code to the
+                # internals of post_process_parse_url_results().
+                #
+                # @notify-style plugins use a minimal parse_url that does
+                # NOT call post_process, so 'verify' is absent.  Keep qsd
+                # intact for those so verify, redirect, and other fields
+                # still get processed on this second call.
+                #
+                # The original qsd is always restored after the call so
+                # that callers (e.g. the @notify meta dict) can still
+                # inspect the raw query-string values.
+                orig_qsd = results_.get("qsd")
+                if QSD_FULL_MODE_KEYS.issubset(results_) and isinstance(
+                    orig_qsd, dict
+                ):
+                    # Full-mode parse_url() always creates all three extended
+                    # qsd dicts (qsd+, qsd-, qsd:), even when the URL has no
+                    # query params.  Simple-mode @notify parse_url() creates
+                    # only qsd.  YAML sibling tokens never inject any of these
+                    # keys.  QSD_FULL_MODE_KEYS is the authoritative list from
+                    # utils/parse.py -- no duplication.
+                    # Strip the full qsd so it cannot overwrite YAML tokens
+                    # on this second post_process call.
+                    del results_["qsd"]
 
                 # Handle post processing of result set
                 results_ = URLBase.post_process_parse_url_results(results_)
+
+                # Restore the original qsd so the full meta dict is
+                # available downstream regardless of which branch above ran.
+                # post_process_parse_url_results() never adds a 'qsd' key, so
+                # the elif branch (orig_qsd is None but qsd appeared) cannot
+                # occur and is omitted intentionally.
+                if orig_qsd is not None:
+                    results_["qsd"] = orig_qsd
 
                 # Store our preloaded entries
                 preloaded.append(
@@ -1515,12 +1566,18 @@ class ConfigBase(URLBase):
         # parse_url() and its initial post_process_parse_url_results() call
         # inside url_to_dict(), so the same alias table must be applied here.
         for alias, canonical in URL_TOKEN_ALIASES.items():
-            if alias in tokens and canonical not in tokens:
+            if alias in tokens and (
+                canonical not in tokens or tokens[canonical] is None
+            ):
+                # Canonical absent or explicitly null -- promote alias.
+                # A null canonical (e.g. password: with no value) is treated
+                # as "not provided", consistent with how
+                # post_process_parse_url_results() handles None credentials.
                 tokens[canonical] = tokens.pop(alias)
 
             elif alias in tokens:
-                # canonical key already set -- silently discard the alias so
-                # the explicitly-provided canonical value is not overwritten
+                # canonical key already set to a non-None value -- discard
+                # the alias so the explicit canonical is not overwritten
                 del tokens[alias]
 
         for kw, meta in N_MGR[schema].template_kwargs.items():

--- a/apprise/url.py
+++ b/apprise/url.py
@@ -925,6 +925,19 @@ class URLBase:
                 if results.get(canonical) is None:
                     results[canonical] = results[alias]
 
+                else:
+                    # canonical already holds a value from the URL path or
+                    # a prior assignment; the alias is redundant and is
+                    # dropped.  Log at WARNING so the operator knows an
+                    # alias key was present but ignored.  No values are
+                    # logged to avoid leaking credentials.
+                    logger.warning(
+                        "URL token alias '%s' ignored; '%s' is already"
+                        " set -- alias was dropped",
+                        alias,
+                        canonical,
+                    )
+
                 del results[alias]
 
         if qsd_exists:

--- a/apprise/url.py
+++ b/apprise/url.py
@@ -227,6 +227,14 @@ class URLBase:
         will keep things consistent when working with the children that inherit
         this class."""
         # Prepare our Asset Object
+        if asset is not None and not isinstance(asset, AppriseAsset):
+            # A non-None value that is not an AppriseAsset object was passed;
+            # log at debug level so the caller knows the value was not used.
+            logger.debug(
+                "Invalid asset type (%s) ignored; using default AppriseAsset",
+                type(asset).__name__,
+            )
+
         self.asset = (
             asset if isinstance(asset, AppriseAsset) else AppriseAsset()
         )

--- a/apprise/url.py
+++ b/apprise/url.py
@@ -917,7 +917,15 @@ class URLBase:
         # as well as flat YAML-style token dicts passed directly).
         for alias, canonical in URL_TOKEN_ALIASES.items():
             if alias in results:
-                results[canonical] = results.pop(alias)
+                # Only populate the canonical key when it has not already
+                # been set to a real value (parse_url() always initialises
+                # 'password' to None, so a None value means it was not
+                # explicitly provided).  This avoids clobbering an actual
+                # password extracted from the URL path with a 'pass=' alias.
+                if results.get(canonical) is None:
+                    results[canonical] = results[alias]
+
+                del results[alias]
 
         if qsd_exists:
             if "password" in results["qsd"]:

--- a/apprise/url.py
+++ b/apprise/url.py
@@ -48,6 +48,15 @@ from .utils.parse import (
 # Used to break a path list into parts
 PATHSPLIT_LIST_DELIM = re.compile(r"[ \t\r\n,\\/]+")
 
+# Maps shorthand token keys to their canonical kwarg names.  Applied by
+# post_process_parse_url_results() for URL-parsed results, and imported by
+# the YAML config layer (config/base.py) to normalize YAML tokens that
+# bypass parse_url() entirely.  Add new aliases here to extend support.
+URL_TOKEN_ALIASES = {
+    # 'pass' is the conventional URL shorthand for 'password'
+    "pass": "password",
+}
+
 
 class PrivacyMode:
     # Defines different privacy modes strings can be printed as
@@ -903,16 +912,21 @@ class URLBase:
         # When redirect= is not specified, leave it absent so that URLBase
         # __init__ falls back to asset.http_redirects as the global default.
 
-        # Password overrides
-        if "pass" in results:
-            results["password"] = results["pass"]
-            del results["pass"]
+        # Apply URL token aliases (e.g. 'pass' -> 'password') to the
+        # top-level results dict (covers values from URL path segments
+        # as well as flat YAML-style token dicts passed directly).
+        for alias, canonical in URL_TOKEN_ALIASES.items():
+            if alias in results:
+                results[canonical] = results.pop(alias)
 
         if qsd_exists:
             if "password" in results["qsd"]:
                 results["password"] = results["qsd"]["password"]
-            if "pass" in results["qsd"]:
-                results["password"] = results["qsd"]["pass"]
+
+            # Apply URL token aliases from query-string parameters
+            for alias, canonical in URL_TOKEN_ALIASES.items():
+                if alias in results["qsd"]:
+                    results[canonical] = results["qsd"][alias]
 
             # User overrides
             if "user" in results["qsd"]:

--- a/apprise/utils/parse.py
+++ b/apprise/utils/parse.py
@@ -156,6 +156,12 @@ UUID4_RE = re.compile(
 # Validate if we're a loadable Python file or not
 VALID_PYTHON_FILE_RE = re.compile(r".+\.py(o|c)?$", re.IGNORECASE)
 
+# Keys created exclusively by full-mode (simple=False) parse_qsd() calls.
+# Simple-mode calls produce only 'qsd'; full-mode adds all three of these.
+# Used both internally by parse_qsd() and externally to detect whether a
+# result dict came from a full-mode parse without re-enumerating the names.
+QSD_FULL_MODE_KEYS = frozenset(("qsd+", "qsd-", "qsd:"))
+
 # validate_regex() utilizes this mapping to track and re-use pre-complied
 # regular expressions
 REGEX_VALIDATE_LOOKUP = {}
@@ -517,19 +523,10 @@ def parse_qsd(qs, simple=False, plus_to_space=False, sanitize=True):
 
     # Our return result set:
     result = (
-        {
-            # The arguments passed in (the parsed query). This is in a
-            # dictionary of {'key': 'val', etc }.  Keys are all made lowercase
-            # before storing to simplify access to them.
-            "qsd": {},
-            # Detected Entries that start with + or - are additionally stored
-            # in these values (un-touched).  The :,+,- however are stripped
-            # from their name before they are stored here.
-            "qsd+": {},
-            "qsd-": {},
-            "qsd:": {},
-        }
+        # Full mode: create the base qsd dict plus all extended qsd dicts.
+        {"qsd": {}, **{k: {} for k in QSD_FULL_MODE_KEYS}}
         if not simple
+        # Simple mode: only the base qsd dict.
         else {"qsd": {}}
     )
 

--- a/apprise/utils/parse.py
+++ b/apprise/utils/parse.py
@@ -160,7 +160,9 @@ VALID_PYTHON_FILE_RE = re.compile(r".+\.py(o|c)?$", re.IGNORECASE)
 # Simple-mode calls produce only 'qsd'; full-mode adds all three of these.
 # Used both internally by parse_qsd() and externally to detect whether a
 # result dict came from a full-mode parse without re-enumerating the names.
-QSD_FULL_MODE_KEYS = frozenset(("qsd+", "qsd-", "qsd:"))
+# Stored as a tuple (not frozenset) so that dict construction order is
+# deterministic across Python runs regardless of PYTHONHASHSEED.
+QSD_FULL_MODE_KEYS = ("qsd+", "qsd-", "qsd:")
 
 # validate_regex() utilizes this mapping to track and re-use pre-complied
 # regular expressions

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -994,6 +994,20 @@ def test_apprise_urlbase_object():
     URLBase.post_process_parse_url_results(results)
     assert results.get("redirect") is True
 
+    # URL_TOKEN_ALIASES: 'pass' in top-level results is normalized to
+    # 'password' by post_process_parse_url_results (covers the YAML config
+    # path where a flat dict is passed rather than a parsed URL string)
+    results = URLBase.parse_url("http://user@127.0.0.1/path/")
+    results["pass"] = "secret"
+    URLBase.post_process_parse_url_results(results)
+    assert results.get("password") == "secret"
+    assert "pass" not in results
+
+    # URL_TOKEN_ALIASES: 'pass' in qsd is also normalized to 'password'
+    results = URLBase.parse_url("http://user@127.0.0.1/path/?pass=qsecret")
+    URLBase.post_process_parse_url_results(results)
+    assert results.get("password") == "qsecret"
+
     # Generic initialization
     base = URLBase(**{"schema": ""})
     assert base.request_timeout == (4.0, 4.0)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1050,6 +1050,18 @@ def test_apprise_urlbase_object():
     # targets override this to return the actual count.
     assert len(base) == 1
 
+    # Invalid asset type -- a non-AppriseAsset value must be silently ignored
+    # and a debug log must tell the caller what happened.  The instance must
+    # still receive a valid default AppriseAsset so nothing downstream breaks.
+    with mock.patch("apprise.url.logger") as mock_log:
+        base = URLBase(asset="not-an-asset")
+        mock_log.debug.assert_called_once()
+        call_args = mock_log.debug.call_args[0]
+        # The type name appears in the message so the caller can identify it
+        assert "str" in call_args[1]
+
+    assert isinstance(base.asset, AppriseAsset)
+
 
 def test_apprise_unique_id():
     """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1005,10 +1005,17 @@ def test_apprise_urlbase_object():
 
     # URL_TOKEN_ALIASES: canonical 'password' wins when already set to a
     # real value -- 'pass' in top-level results must not overwrite an
-    # explicitly provided URL-path password
+    # explicitly provided URL-path password; a WARNING is logged so the
+    # operator knows the alias was present but dropped (no values logged)
     results = URLBase.parse_url("http://user:realpass@127.0.0.1/path/")
     results["pass"] = "shouldnotwin"
-    URLBase.post_process_parse_url_results(results)
+    with mock.patch("apprise.url.logger") as mock_log:
+        URLBase.post_process_parse_url_results(results)
+        mock_log.warning.assert_called_once()
+        call_args = mock_log.warning.call_args[0]
+        # alias and canonical key names appear; actual values must not
+        assert "pass" in call_args[1]
+        assert "password" in call_args[2]
     assert results.get("password") == "realpass"
     assert "pass" not in results
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1003,6 +1003,24 @@ def test_apprise_urlbase_object():
     assert results.get("password") == "secret"
     assert "pass" not in results
 
+    # URL_TOKEN_ALIASES: canonical 'password' wins when already set to a
+    # real value -- 'pass' in top-level results must not overwrite an
+    # explicitly provided URL-path password
+    results = URLBase.parse_url("http://user:realpass@127.0.0.1/path/")
+    results["pass"] = "shouldnotwin"
+    URLBase.post_process_parse_url_results(results)
+    assert results.get("password") == "realpass"
+    assert "pass" not in results
+
+    # URL_TOKEN_ALIASES: qsd 'pass=' overrides the URL-path password because
+    # query-string parameters always take the highest priority
+    results = URLBase.parse_url(
+        "http://user:shouldnotwin@127.0.0.1/path/?pass=realpass"
+    )
+    URLBase.post_process_parse_url_results(results)
+    assert results.get("password") == "realpass"
+    assert "pass" not in results
+
     # URL_TOKEN_ALIASES: 'pass' in qsd is also normalized to 'password'
     results = URLBase.parse_url("http://user@127.0.0.1/path/?pass=qsecret")
     URLBase.post_process_parse_url_results(results)

--- a/tests/test_config_base.py
+++ b/tests/test_config_base.py
@@ -2034,38 +2034,132 @@ urls:
     assert result[0].smtp_host == "child.smtp.example.com"
 
 
-def test_yaml_sibling_token_with_list_children():
+def test_yaml_sibling_token_with_multiple_targets():
     """
-    API: ConfigBase - sibling tokens apply to every list-child entry.
+    API: ConfigBase - multiple targets via sibling 'to:' token.
 
-    When a URL key has a LIST value (expanding to N plugin instances)
-    AND sibling tokens at the same indent level, the sibling tokens
-    are applied as a shared base to each expanded instance.
+    'to:' in YAML tokens is a kwarg equivalent to ?to= in a URL.
+    Multiple recipients must be expressed as a comma-separated string
+    or as a YAML list under the 'to:' key -- NOT as multiple YAML
+    entries each containing a separate 'to:' (that would create
+    multiple plugin instances rather than one plugin with many targets).
 
-    Note: if both the sibling dict and a per-entry dict define the
-    same key (e.g. 'tag'), the per-entry value takes precedence
-    (per-entry > sibling priority within the list case).
+    Both the comma-separated and YAML-list forms should resolve to a
+    single plugin instance whose 'targets' list contains all recipients.
+    """
+    # Comma-separated form: equivalent to ?to=user1,user2 in the URL
+    result_csv, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - mailtos://sender@example.com:
+    smtp: smtp.example.com
+    to: user1@example.com, user2@example.com
+    tag: shared
+""")
+
+    # YAML list form: same semantics, different syntax
+    result_list, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - mailtos://sender@example.com:
+    smtp: smtp.example.com
+    to:
+      - user1@example.com
+      - user2@example.com
+    tag: shared
+""")
+
+    # Each form must load exactly one plugin instance
+    assert len(result_csv) == 1
+    assert len(result_list) == 1
+
+    for obj in (result_csv[0], result_list[0]):
+        assert isinstance(obj, NotifyEmail)
+
+        # Sibling smtp: applies to the single instance
+        assert obj.smtp_host == "smtp.example.com"
+
+        # Both recipients must appear in targets
+        assert any(t[1] == "user1@example.com" for t in obj.targets)
+        assert any(t[1] == "user2@example.com" for t in obj.targets)
+
+        # Sibling tag: applies correctly
+        assert "shared" in obj.tags
+
+
+def test_yaml_sibling_token_shared_across_list_expansion():
+    """
+    API: ConfigBase - sibling tokens propagate to every list-expansion entry.
+
+    When the URL key has a YAML list as its child value (each list item
+    becomes a separate plugin instance) AND sibling keys supply shared
+    settings, the sibling tokens are applied as a base to every instance
+    before per-entry overrides are merged.
+
+    This is distinct from 'to: email1, email2' (multiple targets for one
+    instance) -- here each list entry is an independent plugin instance
+    with its own per-entry settings, all sharing the sibling tokens.
     """
     result, _ = ConfigBase.config_parse_yaml("""
 urls:
   - mailtos://sender@example.com:
-    - to: user1@example.com
-    - to: user2@example.com
+      - to: manager@example.com
+        tag: boss
+      - to: coworker@example.com
+        tag: team
     smtp: smtp.example.com
-    tag: shared
 """)
 
-    # One list entry per to: recipient
+    # One plugin instance per list entry
     assert len(result) == 2
     assert all(isinstance(r, NotifyEmail) for r in result)
 
-    # The sibling smtp: must be applied to both instances
+    # Sibling smtp: must be applied to every instance
     assert result[0].smtp_host == "smtp.example.com"
     assert result[1].smtp_host == "smtp.example.com"
 
-    # Sibling tag: applies to both instances (no per-entry tag conflict)
-    assert "shared" in result[0].tags
-    assert "shared" in result[1].tags
+    # Per-entry tags must be respected
+    assert "boss" in result[0].tags
+    assert "team" in result[1].tags
+
+
+def test_yaml_sibling_token_per_entry_overrides_sibling():
+    """
+    API: ConfigBase - per-entry tokens override sibling tokens for same key.
+
+    When a list-expansion entry defines the same key as a sibling token,
+    the per-entry value wins for that instance only.  Other instances with
+    no per-entry value for that key still receive the sibling fallback.
+
+    Scenario:
+      - sibling smtp: smtp1.example.com   (shared fallback for all entries)
+      - entry 1: to=manager, tag=boss     (no per-entry smtp -> uses sibling)
+      - entry 2: to=coworker, smtp=smtp2, tag=team  (overrides sibling smtp)
+
+    Expected result: 2 instances, each with correct smtp and tags.
+    """
+    result, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - mailtos://sender@example.com:
+      - to: manager@example.com
+        tag: boss
+      - to: coworker@example.com
+        smtp: smtp2.example.com
+        tag: team
+    smtp: smtp1.example.com
+""")
+
+    # One instance per list entry
+    assert len(result) == 2
+    assert all(isinstance(r, NotifyEmail) for r in result)
+
+    # Instance 0: no per-entry smtp, so sibling smtp1 is used
+    assert any(t[1] == "manager@example.com" for t in result[0].targets)
+    assert result[0].smtp_host == "smtp1.example.com"
+    assert "boss" in result[0].tags
+
+    # Instance 1: per-entry smtp2 overrides the sibling smtp1
+    assert any(t[1] == "coworker@example.com" for t in result[1].targets)
+    assert result[1].smtp_host == "smtp2.example.com"
+    assert "team" in result[1].tags
 
 
 def test_yaml_sibling_password_token():
@@ -2137,3 +2231,27 @@ urls:
     assert any(t[1] == "recipient@example.com" for t in obj.targets)
     assert "dev" in obj.tags
     assert "prod" in obj.tags
+
+
+def test_yaml_sibling_token_unknown_schema():
+    """
+    API: ConfigBase - sibling tokens with an unregistered schema.
+
+    When the schema is not in N_MGR the _special_token_handler call
+    inside the 'elif sibling_tokens' branch is skipped (the False arm
+    of 'if schema in N_MGR').  The branch still executes fully; it
+    just applies sibling tokens as-is.  Because the schema is unknown
+    no plugin is instantiated and the result list is empty.
+    """
+    # 'xyzunknown' is not a registered Apprise plugin, so the
+    # 'if schema in N_MGR' guard evaluates to False.
+    result, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - xyzunknown://placeholder:
+    mytoken: value
+    otherkey: data
+""")
+
+    # The sibling branch ran (no exception), but no plugin loaded
+    assert isinstance(result, list)
+    assert len(result) == 0

--- a/tests/test_config_base.py
+++ b/tests/test_config_base.py
@@ -2162,15 +2162,54 @@ urls:
     assert "team" in result[1].tags
 
 
+def test_yaml_sibling_token_order_independent():
+    """
+    API: ConfigBase - sibling tokens are captured regardless of YAML key order.
+
+    YAML does not guarantee mapping key order.  If a sibling token appears
+    before the URL key in the mapping dict (e.g. due to editor or template
+    quirks), it must still be captured.  The old dict(it) approach only
+    captured items *after* the URL key in the iterator; the fix uses the
+    full url.items() dict so all non-URL-key items are included.
+    """
+    # Construct a dict that places the sibling key BEFORE the URL key.
+    # We cannot express this reliably in YAML (PyYAML preserves input order)
+    # so we call config_parse_yaml with a hand-crafted dict equivalent.
+    import yaml as _yaml
+
+    from apprise.config.base import ConfigBase as _CB
+
+    # Build the raw YAML structure directly: smtp appears before the URL key
+    raw = {
+        "urls": [
+            {
+                "smtp": "smtp.example.com",
+                "mailtos://sender@example.com": None,
+                "to": "recipient@example.com",
+            }
+        ]
+    }
+    content = _yaml.dump(raw)
+
+    result, _ = _CB.config_parse_yaml(content)
+
+    # Both pre-URL (smtp) and post-URL (to) siblings must be applied
+    assert len(result) == 1
+    assert isinstance(result[0], NotifyEmail)
+    assert result[0].smtp_host == "smtp.example.com"
+    assert any(t[1] == "recipient@example.com" for t in result[0].targets)
+
+
 def test_yaml_sibling_password_token():
     """
-    API: ConfigBase - 'password' key in sibling/child tokens sets password.
+    API: ConfigBase - 'password' and 'pass' keys both set plugin password.
 
-    In YAML tokens use 'password:' (the actual plugin kwarg name).  The
-    URL-path shorthand 'pass' is handled by parse_url() when processing
-    the URL string itself, not by the YAML token layer.
+    YAML tokens bypass parse_url(), so the URL-path shorthand 'pass' must
+    be normalized to 'password' by YAML_TOKEN_ALIASES inside
+    _special_token_handler.  Verify that both spellings work in sibling
+    and child indentation forms.
     """
-    # Sibling form
+    # --- 'password:' sibling form ---
     result_sibling, _ = ConfigBase.config_parse_yaml("""
 urls:
   - json://testhost:
@@ -2179,7 +2218,7 @@ urls:
     tag: pw-test
 """)
 
-    # Child form
+    # --- 'password:' child form ---
     result_child, _ = ConfigBase.config_parse_yaml("""
 urls:
   - json://testhost:
@@ -2188,13 +2227,52 @@ urls:
       tag: pw-test
 """)
 
-    assert len(result_sibling) == 1
-    assert len(result_child) == 1
+    # --- 'pass:' sibling form (alias normalization) ---
+    result_pass_sibling, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - json://testhost:
+    user: alice
+    pass: s3cr3t
+    tag: pw-test
+""")
 
-    for obj in (result_sibling[0], result_child[0]):
+    # --- 'pass:' child form (alias normalization) ---
+    result_pass_child, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - json://testhost:
+      user: alice
+      pass: s3cr3t
+      tag: pw-test
+""")
+
+    for result in (
+        result_sibling,
+        result_child,
+        result_pass_sibling,
+        result_pass_child,
+    ):
+        assert len(result) == 1
+
+    for obj in (
+        result_sibling[0],
+        result_child[0],
+        result_pass_sibling[0],
+        result_pass_child[0],
+    ):
         assert obj.user == "alice"
         assert obj.password == "s3cr3t"
         assert "pw-test" in obj.tags
+
+    # When both 'pass:' and 'password:' appear, 'password:' (canonical) wins
+    result_both, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - json://testhost:
+      user: alice
+      password: canonical
+      pass: shorthand
+""")
+    assert len(result_both) == 1
+    assert result_both[0].password == "canonical"
 
 
 def test_yaml_sibling_no_silent_drop_on_null_child():

--- a/tests/test_config_base.py
+++ b/tests/test_config_base.py
@@ -2162,6 +2162,40 @@ urls:
     assert "team" in result[1].tags
 
 
+def test_yaml_sibling_alias_does_not_overwrite_child_canonical():
+    """
+    API: ConfigBase - child alias key wins over sibling canonical key.
+
+    When a sibling provides a canonical key ('password') and the child dict
+    provides the URL_TOKEN_ALIASES shorthand for the same key ('pass'), the
+    child value must win.
+
+    Before the fix, both dicts were merged raw before _special_token_handler()
+    ran the URL_TOKEN_ALIASES step.  The combined dict contained both 'pass'
+    and 'password', so the alias-conflict branch discarded 'pass' and kept
+    the sibling's 'password' -- the wrong winner.
+
+    The fix normalizes sibling and child token dicts separately first, so
+    each alias is resolved in the context of its own dict only.  After
+    normalization both dicts carry 'password', and the priority merge
+    (sibling as base, child overrides) produces the correct winner.
+    """
+    result, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - mailtos://sender@example.com:
+      pass: child_pass
+      to: recipient@example.com
+    password: sibling_pass
+""")
+
+    # One instance created
+    assert len(result) == 1
+    assert isinstance(result[0], NotifyEmail)
+
+    # Child 'pass' (alias) must win over sibling 'password' (canonical)
+    assert result[0].password == "child_pass"
+
+
 def test_yaml_sibling_token_order_independent():
     """
     API: ConfigBase - sibling tokens are captured regardless of YAML key order.
@@ -2172,26 +2206,17 @@ def test_yaml_sibling_token_order_independent():
     captured items *after* the URL key in the iterator; the fix uses the
     full url.items() dict so all non-URL-key items are included.
     """
-    # Construct a dict that places the sibling key BEFORE the URL key.
-    # We cannot express this reliably in YAML (PyYAML preserves input order)
-    # so we call config_parse_yaml with a hand-crafted dict equivalent.
-    import yaml as _yaml
+    # Write the YAML directly so the key order is explicit and no
+    # yaml.dump call is required.  smtp appears BEFORE the URL key,
+    # to appears AFTER -- both must be captured as sibling tokens.
+    content = """
+urls:
+  - smtp: smtp.example.com
+    mailtos://sender@example.com:
+    to: recipient@example.com
+"""
 
-    from apprise.config.base import ConfigBase as _CB
-
-    # Build the raw YAML structure directly: smtp appears before the URL key
-    raw = {
-        "urls": [
-            {
-                "smtp": "smtp.example.com",
-                "mailtos://sender@example.com": None,
-                "to": "recipient@example.com",
-            }
-        ]
-    }
-    content = _yaml.dump(raw, sort_keys=False)
-
-    result, _ = _CB.config_parse_yaml(content)
+    result, _ = ConfigBase.config_parse_yaml(content)
 
     # Both pre-URL (smtp) and post-URL (to) siblings must be applied
     assert len(result) == 1
@@ -2332,3 +2357,25 @@ urls:
     # The sibling branch ran (no exception), but no plugin loaded
     assert isinstance(result, list)
     assert len(result) == 0
+
+
+def test_yaml_token_priority_over_qsd():
+    """
+    API: ConfigBase - YAML tokens take priority over URL query-string params.
+
+    The documented priority is: YAML tokens > ?key=value qsd > URL path.
+    A second call to post_process_parse_url_results() runs after YAML tokens
+    are merged.  Without stripping qsd first, that call would re-apply qsd
+    overrides and silently overwrite YAML-token values, breaking the
+    documented priority.
+    """
+    # The URL embeds ?pass= in the query string; the YAML sibling token
+    # 'password:' should take priority and survive to the plugin.
+    result, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - json://user:urlpass@localhost?pass=qsdpass:
+    password: yamlpass
+""")
+    assert len(result) == 1
+    # YAML token must win over qsd ?pass= and URL-path password
+    assert result[0].password == "yamlpass"

--- a/tests/test_config_base.py
+++ b/tests/test_config_base.py
@@ -2189,7 +2189,7 @@ def test_yaml_sibling_token_order_independent():
             }
         ]
     }
-    content = _yaml.dump(raw)
+    content = _yaml.dump(raw, sort_keys=False)
 
     result, _ = _CB.config_parse_yaml(content)
 
@@ -2284,8 +2284,7 @@ def test_yaml_sibling_no_silent_drop_on_null_child():
     were silently ignored and the URL failed to instantiate.  Confirm
     that the failure mode described in issue #1635 no longer occurs.
     """
-    # Mirrors the bug-report YAML (correcting 'rom' typo to 'from'
-    # and using 'password' -- the YAML token layer kwarg name)
+    # Mirrors the bug-report YAML (correcting 'rom' typo to 'from')
     result, _ = ConfigBase.config_parse_yaml("""
 urls:
   - mailtos://_:

--- a/tests/test_config_base.py
+++ b/tests/test_config_base.py
@@ -2196,6 +2196,33 @@ urls:
     assert result[0].password == "child_pass"
 
 
+def test_yaml_alias_populates_null_canonical():
+    """
+    API: ConfigBase - alias populates canonical when canonical is null.
+
+    """
+    # canonical 'password:' is null (no value) + alias 'pass: secret'
+    # alias must win because null == not provided
+    result, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - json://user@localhost:
+      pass: secret
+      password:
+""")
+    assert len(result) == 1
+    assert result[0].password == "secret"
+
+    # Canonical with a real value still wins over the alias
+    result2, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - json://user@localhost:
+      pass: alias_val
+      password: real_val
+""")
+    assert len(result2) == 1
+    assert result2[0].password == "real_val"
+
+
 def test_yaml_sibling_token_order_independent():
     """
     API: ConfigBase - sibling tokens are captured regardless of YAML key order.
@@ -2230,7 +2257,7 @@ def test_yaml_sibling_password_token():
     API: ConfigBase - 'password' and 'pass' keys both set plugin password.
 
     YAML tokens bypass parse_url(), so the URL-path shorthand 'pass' must
-    be normalized to 'password' by YAML_TOKEN_ALIASES inside
+    be normalized to 'password' by URL_TOKEN_ALIASES inside
     _special_token_handler.  Verify that both spellings work in sibling
     and child indentation forms.
     """
@@ -2359,6 +2386,61 @@ urls:
     assert len(result) == 0
 
 
+def test_yaml_child_dict_schema_key_ignored():
+    """
+    API: ConfigBase - 'schema' key in a child dict token is stripped.
+
+    The schema that determines which plugin is instantiated comes from the
+    URL key itself.  Allowing a child dict to override 'schema' via a
+    token would cause the wrong plugin constructor to be called with
+    fields parsed for a different URL type, leading to silent failures.
+
+    The list-expansion branch explicitly strips 'schema' from each entry.
+    This test verifies the single-child-dict branch does the same.
+    """
+    result, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - mailtos://sender@example.com:
+      schema: json
+      to: recipient@example.com
+""")
+
+    # The email plugin must load; the child 'schema: json' must be ignored
+    assert len(result) == 1
+    assert isinstance(result[0], NotifyEmail)
+
+
+def test_yaml_sibling_before_url_no_spurious_warning():
+    """
+    API: ConfigBase - sibling tokens before the URL key emit no warning.
+
+    YAML mappings do not guarantee key order.  A sibling token (e.g.
+    'smtp:') may appear before the URL key in the serialised YAML.  The
+    scan loop that finds the URL key must skip non-schema keys silently;
+    it must NOT emit an 'Ignored entry' warning because those keys are
+    collected later as valid sibling tokens.
+    """
+    from unittest import mock as _mock
+
+    with _mock.patch("apprise.config.base.ConfigBase.logger") as mock_log:
+        result, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - smtp: smtp.example.com
+    mailtos://sender@example.com:
+    to: recipient@example.com
+""")
+
+    # Both siblings are applied; no spurious "Ignored entry" warning fired
+    assert len(result) == 1
+    assert isinstance(result[0], NotifyEmail)
+    assert result[0].smtp_host == "smtp.example.com"
+    assert any(t[1] == "recipient@example.com" for t in result[0].targets)
+
+    # Confirm no "Ignored entry" warning was logged
+    for call_args in mock_log.warning.call_args_list:
+        assert "Ignored entry" not in str(call_args)
+
+
 def test_yaml_token_priority_over_qsd():
     """
     API: ConfigBase - YAML tokens take priority over URL query-string params.
@@ -2379,3 +2461,110 @@ urls:
     assert len(result) == 1
     # YAML token must win over qsd ?pass= and URL-path password
     assert result[0].password == "yamlpass"
+
+
+def test_yaml_token_priority_over_qsd_non_credential_fields():
+    """
+    API: ConfigBase - YAML tokens take priority over qsd for non-credential
+    fields (verify, redirect, etc.).
+
+    post_process_parse_url_results() processes not only user/password but
+    also verify, redirect, rto, cto, and port from qsd.  All of these
+    must honour the same YAML > qsd > URL-path priority rule.
+
+    The fix strips ALL qsd (not just credential keys) before the second
+    post_process call for URLBase-based plugins, so qsd can never
+    overwrite any YAML-token value regardless of which field it sets.
+    """
+    # URL has ?verify=no but the YAML sibling says verify: yes --
+    # YAML token must win; the plugin should have verify_certificate=True
+    result, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - json://user:pass@localhost?verify=no:
+    verify: yes
+""")
+    assert len(result) == 1
+    assert result[0].verify_certificate is True
+
+
+def test_yaml_priority_all_urlbase_globals_via_plugin_details():
+    """
+    API: ConfigBase - YAML priority verified dynamically for every
+    URLBase-level global arg via plugin.details().
+
+    Verify that the priority sequence (YAML > qsd > URL path)
+    is respected for every global arg defined.
+    """
+    from apprise import plugins
+    from apprise.config.base import N_MGR
+    from apprise.url import URLBase
+
+    # Discover args via plugin.details() for a minimal URLBase plugin.
+    # json:// has no required service credentials and is always available.
+    details = plugins.details(N_MGR["json"])
+
+    # Type-driven conflict pairs: (qsd_str, yaml_str).
+    # YAML should win -- expected value is derived from yaml_str.
+    type_conflict = {
+        "bool": ("no", "yes"),
+        "float": ("5.0", "10.0"),
+        "int": ("5", "10"),
+    }
+
+    # Intersect plugin.details() args with URLBase.template_args to
+    # isolate the globals shared by every URLBase plugin.
+    # _lookup_default is the URLBase instance attribute name for the arg.
+    urlbase_meta = URLBase.template_args
+    test_cases = []
+    for name, arg_meta in details["args"].items():
+        if name not in urlbase_meta:
+            continue
+        arg_type = arg_meta.get("type", "string")
+        if arg_type not in type_conflict:
+            continue
+        attr_name = urlbase_meta[name].get("_lookup_default")
+        if not attr_name:
+            continue
+        qsd_val, yaml_val = type_conflict[arg_type]
+        test_cases.append((name, attr_name, arg_type, qsd_val, yaml_val))
+
+    # Guard: the 4 known URLBase globals must always be discovered.
+    # If URLBase.template_args loses an entry this fires immediately.
+    found = {t[0] for t in test_cases}
+    assert found >= {"cto", "redirect", "rto", "verify"}, (
+        "Expected URLBase globals cto/redirect/rto/verify in "
+        "plugin.details(); got: {}".format(sorted(found))
+    )
+
+    # Build a YAML config that sets every global in both qsd AND as a
+    # YAML sibling token with a conflicting value so the winner is
+    # unambiguous.
+    qsd_str = "&".join("{}={}".format(n, qv) for n, _, _, qv, _ in test_cases)
+    siblings = "\n    ".join(
+        "{}: {}".format(n, yv) for n, _, _, _, yv in test_cases
+    )
+    yaml_cfg = (
+        "urls:\n  - json://user:pass@localhost?{qsd}:\n    {siblings}\n"
+    ).format(qsd=qsd_str, siblings=siblings)
+
+    result, _ = ConfigBase.config_parse_yaml(yaml_cfg)
+    assert len(result) == 1
+    inst = result[0]
+
+    # Verify YAML wins for every global.
+    for name, attr_name, arg_type, qsd_val, yaml_val in test_cases:
+        actual = getattr(inst, attr_name)
+        if arg_type == "bool":
+            expected = True  # yaml_val is always "yes"
+        elif arg_type == "float":
+            expected = float(yaml_val)
+        elif arg_type == "int":
+            expected = int(yaml_val)
+        else:
+            expected = yaml_val
+        assert actual == expected, (
+            "YAML token '{}' should override qsd "
+            "(YAML={!r}, qsd={!r}) but got {!r} for '{}'".format(
+                name, yaml_val, qsd_val, actual, attr_name
+            )
+        )

--- a/tests/test_config_base.py
+++ b/tests/test_config_base.py
@@ -1917,3 +1917,223 @@ def test_config_base_parse_yaml_file07_tag_priority_over_tags(tmpdir):
     # Tag priority check
     assert sum(1 for _ in a.find("primary")) == 1
     assert sum(1 for _ in a.find("secondary")) == 0
+
+
+def test_yaml_sibling_token_overrides_basic():
+    """
+    API: ConfigBase - YAML sibling-key token overrides (basic cases).
+
+    Keys at the same indentation level as the schema URL key
+    (sibling form) must behave identically to child-indented tokens.
+    Both of these forms must load the same plugin with the same attrs:
+
+      # sibling form (same indentation)
+      - mailtos://_:
+        smtp: smtp.example.com
+        from: sender@example.com
+
+      # child form (one level deeper)
+      - mailtos://_:
+          smtp: smtp.example.com
+          from: sender@example.com
+    """
+    # --- sibling form (the historically broken form) ---
+    result_sibling, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - mailtos://_:
+    user: sender@example.com
+    password: secret
+    smtp: smtp.example.com
+    from: sender@example.com
+    to: recipient@example.com
+    tag: myteam
+""")
+
+    # --- child form (always worked) ---
+    result_child, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - mailtos://_:
+      user: sender@example.com
+      password: secret
+      smtp: smtp.example.com
+      from: sender@example.com
+      to: recipient@example.com
+      tag: myteam
+""")
+
+    # Both forms must load exactly one plugin instance
+    assert len(result_sibling) == 1
+    assert len(result_child) == 1
+
+    # Both results must be NotifyEmail instances
+    assert isinstance(result_sibling[0], NotifyEmail)
+    assert isinstance(result_child[0], NotifyEmail)
+
+    for obj in (result_sibling[0], result_child[0]):
+        # SMTP server from sibling/child token
+        assert obj.smtp_host == "smtp.example.com"
+
+        # from: maps to from_addr via template_args
+        assert obj.from_addr[1] == "sender@example.com"
+
+        # to: maps to targets
+        assert any(t[1] == "recipient@example.com" for t in obj.targets)
+
+        # password: sets the credential directly
+        assert obj.password == "secret"
+
+        # tag: applies correctly
+        assert "myteam" in obj.tags
+
+
+def test_yaml_sibling_token_priority_over_url():
+    """
+    API: ConfigBase - sibling tokens override URL-embedded values.
+
+    Priority order (lowest to highest):
+      3 - URL path (user:pass@host:port)
+      2 - URL query string (?smtp=...)
+      1 - YAML sibling/child tokens (highest)
+    """
+    # URL embeds one smtp server; sibling token overrides it
+    result, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - mailtos://sender@example.com?smtp=old.smtp.example.com:
+    smtp: new.smtp.example.com
+    to: recipient@example.com
+    tag: priority-test
+""")
+
+    assert len(result) == 1
+    assert isinstance(result[0], NotifyEmail)
+
+    # Sibling token must win over the URL query-string value
+    assert result[0].smtp_host == "new.smtp.example.com"
+    assert "priority-test" in result[0].tags
+
+
+def test_yaml_child_token_priority_over_sibling():
+    """
+    API: ConfigBase - child tokens (indented) override sibling tokens.
+
+    When a URL entry has BOTH a child value (indented under the key)
+    AND sibling keys, child tokens take priority on a per-key basis.
+    """
+    result, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - mailtos://sender@example.com:
+      smtp: child.smtp.example.com
+    smtp: sibling.smtp.example.com
+    to: recipient@example.com
+""")
+
+    assert len(result) == 1
+    assert isinstance(result[0], NotifyEmail)
+
+    # Child token (child.smtp.example.com) must beat sibling token
+    assert result[0].smtp_host == "child.smtp.example.com"
+
+
+def test_yaml_sibling_token_with_list_children():
+    """
+    API: ConfigBase - sibling tokens apply to every list-child entry.
+
+    When a URL key has a LIST value (expanding to N plugin instances)
+    AND sibling tokens at the same indent level, the sibling tokens
+    are applied as a shared base to each expanded instance.
+
+    Note: if both the sibling dict and a per-entry dict define the
+    same key (e.g. 'tag'), the per-entry value takes precedence
+    (per-entry > sibling priority within the list case).
+    """
+    result, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - mailtos://sender@example.com:
+    - to: user1@example.com
+    - to: user2@example.com
+    smtp: smtp.example.com
+    tag: shared
+""")
+
+    # One list entry per to: recipient
+    assert len(result) == 2
+    assert all(isinstance(r, NotifyEmail) for r in result)
+
+    # The sibling smtp: must be applied to both instances
+    assert result[0].smtp_host == "smtp.example.com"
+    assert result[1].smtp_host == "smtp.example.com"
+
+    # Sibling tag: applies to both instances (no per-entry tag conflict)
+    assert "shared" in result[0].tags
+    assert "shared" in result[1].tags
+
+
+def test_yaml_sibling_password_token():
+    """
+    API: ConfigBase - 'password' key in sibling/child tokens sets password.
+
+    In YAML tokens use 'password:' (the actual plugin kwarg name).  The
+    URL-path shorthand 'pass' is handled by parse_url() when processing
+    the URL string itself, not by the YAML token layer.
+    """
+    # Sibling form
+    result_sibling, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - json://testhost:
+    user: alice
+    password: s3cr3t
+    tag: pw-test
+""")
+
+    # Child form
+    result_child, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - json://testhost:
+      user: alice
+      password: s3cr3t
+      tag: pw-test
+""")
+
+    assert len(result_sibling) == 1
+    assert len(result_child) == 1
+
+    for obj in (result_sibling[0], result_child[0]):
+        assert obj.user == "alice"
+        assert obj.password == "s3cr3t"
+        assert "pw-test" in obj.tags
+
+
+def test_yaml_sibling_no_silent_drop_on_null_child():
+    """
+    API: ConfigBase - sibling tokens are never silently discarded.
+
+    Previously, when the URL key had a null child value (the common
+    case when users used same-level indentation), all sibling keys
+    were silently ignored and the URL failed to instantiate.  Confirm
+    that the failure mode described in issue #1635 no longer occurs.
+    """
+    # Mirrors the bug-report YAML (correcting 'rom' typo to 'from'
+    # and using 'password' -- the YAML token layer kwarg name)
+    result, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - mailtos://_:
+    user: sender@example.com
+    password: secret
+    smtp: smtp.example.com
+    from: sender@example.com
+    to: recipient@example.com
+    tag:
+      - dev
+      - prod
+""")
+
+    # Must load successfully (previously raised TypeError and returned [])
+    assert len(result) == 1
+    assert isinstance(result[0], NotifyEmail)
+
+    obj = result[0]
+    assert obj.smtp_host == "smtp.example.com"
+    assert obj.from_addr[1] == "sender@example.com"
+    assert any(t[1] == "recipient@example.com" for t in obj.targets)
+    assert "dev" in obj.tags
+    assert "prod" in obj.tags

--- a/tests/test_decorator_notify.py
+++ b/tests/test_decorator_notify.py
@@ -678,6 +678,45 @@ def test_notify_multi_instance_decoration(tmpdir):
     N_MGR.remove("multi")
 
 
+def test_notify_yaml_verify_sibling_does_not_strip_qsd():
+    """
+    decorators: YAML sibling 'verify' must not strip qsd for @notify.
+    """
+    from apprise.config import ConfigBase
+
+    assert "notifyverify" not in N_MGR
+
+    @notify(on="notifyverify", name="Test verify sibling @notify")
+    def _handler(body, title, notify_type, attach, meta, *args, **kwargs):
+        pass
+
+    assert "notifyverify" in N_MGR
+
+    # URL has ?verify=no in qsd; YAML sibling says verify: yes.
+    # For a @notify plugin qsd must survive to the second post_process
+    # call -- it must NOT be stripped by a spurious 'verify in results_'
+    # hit from the YAML merge.
+    result, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - notifyverify://user:pass@hostname?verify=no:
+    verify: yes
+""")
+
+    assert len(result) == 1
+    meta = result[0]._default_args
+
+    # qsd must be intact -- not stripped by the wrong discriminator
+    assert isinstance(meta.get("qsd"), dict)
+    assert meta["qsd"].get("verify") == "no"
+
+    # post_process_parse_url_results() processed verify from qsd;
+    # qsd must win over the YAML sibling for @notify plugins
+    assert meta["verify"] is False
+
+    # Tidy
+    N_MGR.remove("notifyverify")
+
+
 def test_custom_notify_plugin_decoration():
     """decorators: CustomNotifyPlugin testing"""
 

--- a/tests/test_decorator_notify.py
+++ b/tests/test_decorator_notify.py
@@ -678,40 +678,61 @@ def test_notify_multi_instance_decoration(tmpdir):
     N_MGR.remove("multi")
 
 
-def test_notify_yaml_verify_sibling_does_not_strip_qsd():
+def test_notify_yaml_priority_over_qsd():
     """
-    decorators: YAML sibling 'verify' must not strip qsd for @notify.
+    decorators: YAML tokens take priority over qsd for @notify plugins.
+
+    YAML > qsd > URL path must hold for ALL plugin types, including
+    @notify decorator plugins.  Previously, @notify plugins kept qsd
+    intact for the second post_process_parse_url_results() call, which
+    allowed qsd to silently overwrite YAML-token values.  The fix
+    re-applies YAML tokens after post_process to restore priority.
+
+    Also verifies qsd is still preserved in the meta dict (for raw
+    inspection) and that qsd still wins over URL-path when no YAML
+    token is present for a field.
     """
     from apprise.config import ConfigBase
 
     assert "notifyverify" not in N_MGR
 
-    @notify(on="notifyverify", name="Test verify sibling @notify")
+    @notify(on="notifyverify", name="Test YAML priority @notify")
     def _handler(body, title, notify_type, attach, meta, *args, **kwargs):
         pass
 
     assert "notifyverify" in N_MGR
 
-    # URL has ?verify=no in qsd; YAML sibling says verify: yes.
-    # For a @notify plugin qsd must survive to the second post_process
-    # call -- it must NOT be stripped by a spurious 'verify in results_'
-    # hit from the YAML merge.
+    # URL has ?verify=no&user=qsduser; YAML sibling says verify: yes
+    # and user: yamluser.  YAML must win for both.
     result, _ = ConfigBase.config_parse_yaml("""
 urls:
-  - notifyverify://user:pass@hostname?verify=no:
+  - notifyverify://urluser:urlpass@hostname?verify=no&user=qsduser:
     verify: yes
+    user: yamluser
 """)
 
     assert len(result) == 1
     meta = result[0]._default_args
 
-    # qsd must be intact -- not stripped by the wrong discriminator
+    # qsd must be preserved intact for downstream meta inspection
     assert isinstance(meta.get("qsd"), dict)
     assert meta["qsd"].get("verify") == "no"
+    assert meta["qsd"].get("user") == "qsduser"
 
-    # post_process_parse_url_results() processed verify from qsd;
-    # qsd must win over the YAML sibling for @notify plugins
-    assert meta["verify"] is False
+    # YAML tokens must win over qsd
+    assert meta["verify"] is True
+    assert meta["user"] == "yamluser"
+
+    # When no YAML token is present for a field, qsd still wins over
+    # the URL-path value (qsd > URL path).
+    result2, _ = ConfigBase.config_parse_yaml("""
+urls:
+  - notifyverify://urluser:urlpass@hostname?verify=no:
+""")
+    assert len(result2) == 1
+    meta2 = result2[0]._default_args
+    assert meta2["verify"] is False  # qsd wins over URLBase default
+    assert meta2["user"] == "urluser"  # URL-path value (no qsd for user)
 
     # Tidy
     N_MGR.remove("notifyverify")

--- a/tests/test_plugin_email.py
+++ b/tests/test_plugin_email.py
@@ -2221,7 +2221,7 @@ def test_plugin_email_variables_1087():
     result, _ = ConfigBase.config_parse(
         cleandoc("""
     #
-    # Test Email Parsing where qsd over-rides all
+    # Test Email Parsing where YAML tokens over-ride qsd
     #
     urls:
       - mailtos://alt.lan/?pass=abcd&user=joe@alt.lan:
@@ -2236,12 +2236,14 @@ def test_plugin_email_variables_1087():
     assert isinstance(result, list)
     assert len(result) == 1
 
+    # YAML child tokens are higher priority than URL query-string
+    # parameters -- testuser and xxxxXXXxxx win over joe and abcd.
     email_ = result[0]
-    assert email_.from_addr == ["Apprise", "joe@alt.lan"]
-    assert email_.user == "joe@alt.lan"
+    assert email_.from_addr == ["Apprise", "testuser@alt.lan"]
+    assert email_.user == "testuser@alt.lan"
     assert email_.smtp_host == "smtp.alt.lan"
     assert email_.targets == [(False, "alteriks@alt.lan")]
-    assert email_.password == "abcd"
+    assert email_.password == "xxxxXXXxxx"
 
 
 @mock.patch("smtplib.SMTP_SSL")


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1635

YAML configuration entries that supply token overrides at the same indentation level as the schema URL key (the "sibling" form) were silently ignored. Because PyYAML parses same-level keys as siblings in the mapping rather than children of the URL key, the URL's token value was `null` and all the user's overrides -- `smtp:`, `from:`, `to:`, `user:`, `pass:`, `tag:` -- were never seen by the parser.

This PR makes both YAML forms produce identical results:

```yaml
# sibling form (same indentation -- now works)
urls:
  - mailtos://_:
    smtp: smtp.example.com
    from: sender@example.com
    to: recipient@example.com

# child form (indented one level deeper -- always worked)
urls:
  - mailtos://_:
      smtp: smtp.example.com
      from: sender@example.com
      to: recipient@example.com
```

The three-level priority the user expected is now correctly enforced:

1. YAML sibling/child tokens (highest -- override everything)
2. URL query-string parameters (`?smtp=...`)
3. URL path-embedded values (`user:pass@host:port`) (lowest)

`pass:` in YAML tokens is also now normalized to `password:` in `_special_token_handler`, matching the same conversion that `parse_url()` performs for URL-embedded credentials.

## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/80](https://github.com/caronc/apprise-docs/pull/80)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1635-yaml-config-improvements

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    mailtos://_?smtp=smtp.example.com
```
