### PR TITLE
XMPP SASL improvments and CLI Debug output added

### DIFF
--- a/all-plugin-requirements.txt
+++ b/all-plugin-requirements.txt
@@ -23,4 +23,4 @@ hidapi
 smpplib
 
 # For xmpp:// support
-slixmpp >= 1.10.0
+slixmpp >= 1.16.0

--- a/apprise/cli.py
+++ b/apprise/cli.py
@@ -40,6 +40,7 @@ from . import (
     Apprise,
     AppriseAsset,
     AppriseConfig,
+    NotificationManager,
     PersistentStore,
     __copyright__,
     __license__,
@@ -243,6 +244,86 @@ PERSISTENT_STORAGE_MODES = (
 if os.environ.get("APPRISE_STORAGE_PATH", "").strip():
     # Override Default Storage Path
     DEFAULT_STORAGE_PATH = os.environ.get("APPRISE_STORAGE_PATH")
+
+
+def _log_runtime_env():
+    """Log Python, OS, encoding, and optional-dependency versions.
+
+    Only runs when the logger is at DEBUG level or below.
+    """
+    # Skip all work when DEBUG output is not enabled
+    if not logger.isEnabledFor(logging.DEBUG):
+        return
+
+    import contextlib
+    import locale
+
+    # One-line environment summary
+    logger.debug("Apprise: %s", __version__)
+    logger.debug("Python: %s", platform.python_version())
+    logger.debug("Platform: %s", platform.platform())
+    logger.debug("Encoding: %s", locale.getpreferredencoding(False))
+
+    # Collect unique runtime-dep import names from all enabled plugins
+    dep_names = set()
+    for module in NotificationManager():
+        for plugin in module.get("plugin", ()):
+            # Skip disabled plugins
+            if not getattr(plugin, "enabled", True):
+                continue
+
+            fn = getattr(plugin, "runtime_deps", None)
+            if not callable(fn):
+                continue
+
+            with contextlib.suppress(Exception):
+                dep_names.update(fn())
+
+    # Nothing to report
+    if not dep_names:
+        return
+
+    # packages_distributions() was added in Python 3.11; on older
+    # Python we skip the dep listing but the env summary above is
+    # still emitted.
+    try:
+        from importlib.metadata import (
+            PackageNotFoundError,
+            packages_distributions,
+            version as pkg_version,
+        )
+
+    except ImportError:
+        return
+
+    # Resolve import names -> pip distribution names, then fetch
+    # versions.  packages_distributions() returns:
+    #   {import_name: [dist_name, ...]}
+    try:
+        dist_map = packages_distributions()
+
+    except Exception:
+        return
+
+    # Build a sorted list of "name=version" pairs for resolved packages
+    resolved = []
+    for name in sorted(dep_names):
+        dist_names = dist_map.get(name, [])
+        if not dist_names:
+            # Import name not mapped to any installed distribution
+            continue
+
+        try:
+            ver = pkg_version(dist_names[0])
+
+        except (PackageNotFoundError, Exception):
+            # Package listed but not actually installed; skip silently
+            continue
+
+        resolved.append("{}={}".format(dist_names[0], ver))
+
+    if resolved:
+        logger.debug("Runtime deps: %s", ", ".join(resolved))
 
 
 def print_version_msg():
@@ -674,6 +755,9 @@ def main(
     for handler in logger.handlers:
         asyncio_logger.addHandler(handler)
     asyncio_logger.setLevel(logger.level)
+
+    # Log environment and runtime-dependency versions when debugging
+    _log_runtime_env()
 
     if version:
         print_version_msg()

--- a/apprise/plugins/xmpp/adapter.py
+++ b/apprise/plugins/xmpp/adapter.py
@@ -390,7 +390,7 @@ class SlixmppAdapter:
 
     # Define a Slixmpp reference version to prevent this tool from working
     # under non-supported versions
-    _supported_version = (1, 10, 0)
+    _supported_version = (1, 16, 0)
 
     # Flag to control if we are enabled or not
     # effectively.. .is the dependent slixmpp library available to us

--- a/apprise/plugins/xmpp/base.py
+++ b/apprise/plugins/xmpp/base.py
@@ -452,13 +452,23 @@ class NotifyXMPP(NotifyBase):
 
         except XMPPChannelBindingError:
             # The server rejected SASL SCRAM-PLUS channel binding.
-            # Log a targeted hint so the user knows what to fix.
-            self.logger.warning(
-                "XMPP authentication failed: the server rejected "
-                "SASL SCRAM-PLUS channel binding. Add "
-                "?scramplus=no to your Apprise URL to disable "
-                "SCRAM-PLUS mechanism negotiation."
-            )
+            # Only suggest ?scramplus=no when it has not already been set.
+            if self.scramplus:
+                self.logger.warning(
+                    "XMPP authentication failed: the server rejected "
+                    "SASL SCRAM-PLUS channel binding. Add "
+                    "?scramplus=no to your Apprise URL to disable "
+                    "SCRAM-PLUS mechanism negotiation."
+                )
+
+            else:
+                self.logger.warning(
+                    "XMPP authentication failed: the server rejected "
+                    "channel binding despite ?scramplus=no being set. "
+                    "This may be a Slixmpp or server compatibility "
+                    "issue."
+                )
+
             return False
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,7 +244,7 @@ all-plugins = [
     "smpplib",
 
     # For xmpp:// support
-    "slixmpp >= 1.10.0",
+    "slixmpp >= 1.16.0",
 ]
 windows = [
     "pywin32",

--- a/tests/test_apprise_cli.py
+++ b/tests/test_apprise_cli.py
@@ -2675,7 +2675,7 @@ def test_apprise_cli_windows_env(mock_system):
 
 
 @mock.patch("apprise.cli.NotificationManager")
-@mock.patch("importlib.metadata.packages_distributions")
+@mock.patch("importlib.metadata.packages_distributions", create=True)
 @mock.patch("importlib.metadata.version")
 @mock.patch("apprise.cli.logger")
 def test_apprise_cli_runtime_env_skip_when_not_debug(
@@ -2697,7 +2697,7 @@ def test_apprise_cli_runtime_env_skip_when_not_debug(
 
 
 @mock.patch("apprise.cli.NotificationManager")
-@mock.patch("importlib.metadata.packages_distributions")
+@mock.patch("importlib.metadata.packages_distributions", create=True)
 @mock.patch("importlib.metadata.version")
 @mock.patch("apprise.cli.logger")
 def test_apprise_cli_runtime_env_logging(
@@ -2763,7 +2763,7 @@ def test_apprise_cli_runtime_env_logging(
 
 
 @mock.patch("apprise.cli.NotificationManager")
-@mock.patch("importlib.metadata.packages_distributions")
+@mock.patch("importlib.metadata.packages_distributions", create=True)
 @mock.patch("importlib.metadata.version")
 @mock.patch("apprise.cli.logger")
 def test_apprise_cli_runtime_env_no_runtime_deps(
@@ -2799,7 +2799,7 @@ def test_apprise_cli_runtime_env_no_runtime_deps(
 
 
 @mock.patch("apprise.cli.NotificationManager")
-@mock.patch("importlib.metadata.packages_distributions")
+@mock.patch("importlib.metadata.packages_distributions", create=True)
 @mock.patch("importlib.metadata.version")
 @mock.patch("apprise.cli.logger")
 def test_apprise_cli_runtime_env_dist_map_exception(
@@ -2832,7 +2832,7 @@ def test_apprise_cli_runtime_env_dist_map_exception(
 
 
 @mock.patch("apprise.cli.NotificationManager")
-@mock.patch("importlib.metadata.packages_distributions")
+@mock.patch("importlib.metadata.packages_distributions", create=True)
 @mock.patch("importlib.metadata.version")
 @mock.patch("apprise.cli.logger")
 def test_apprise_cli_runtime_env_lookup_errors(
@@ -2886,4 +2886,84 @@ def test_apprise_cli_runtime_env_lookup_errors(
 
     # None of the error paths should produce a "  pkg: ver" line
     calls = [a for a, _ in mock_logger.debug.call_args_list]
+    assert not any(a[0] == "Runtime deps: %s" for a in calls)
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="packages_distributions requires Python 3.11+",
+)
+@mock.patch("apprise.cli.NotificationManager")
+@mock.patch("apprise.cli.logger")
+def test_apprise_cli_runtime_env_no_packages_distributions(
+    mock_logger, mock_mgr
+):
+    """
+    CLI: _log_runtime_env() gracefully skips dep listing when
+    packages_distributions() is missing (ImportError path).
+    Simulates the Python < 3.11 scenario on Python 3.11+ by temporarily
+    removing packages_distributions from importlib.metadata.
+    """
+    import importlib.metadata as _meta
+
+    mock_logger.isEnabledFor.return_value = True
+
+    class DepPlugin:
+        enabled = True
+
+        @staticmethod
+        def runtime_deps():
+            return ("somepkg",)
+
+    mock_mgr.return_value = [{"plugin": {DepPlugin}}]
+
+    # Temporarily hide packages_distributions to trigger the ImportError
+    _pd = _meta.packages_distributions
+    del _meta.packages_distributions
+    try:
+        cli._log_runtime_env()
+    finally:
+        _meta.packages_distributions = _pd
+
+    # Env summary was still logged despite the missing function
+    calls = [a for a, _ in mock_logger.debug.call_args_list]
+    assert any(a[0] == "Apprise: %s" for a in calls)
+
+    # No dep listing -- packages_distributions was unavailable
+    assert not any(a[0] == "Runtime deps: %s" for a in calls)
+
+
+# Remove this test when Python 3.9 support is dropped.
+@pytest.mark.skipif(
+    sys.version_info >= (3, 11),
+    reason="packages_distributions exists on Python 3.11+",
+)
+@mock.patch("apprise.cli.NotificationManager")
+@mock.patch("apprise.cli.logger")
+def test_apprise_cli_runtime_env_py39_no_packages_distributions(
+    mock_logger, mock_mgr
+):
+    """
+    CLI: _log_runtime_env() gracefully skips dep listing on Python < 3.11
+    where packages_distributions() is genuinely absent.
+    """
+    mock_logger.isEnabledFor.return_value = True
+
+    class DepPlugin:
+        enabled = True
+
+        @staticmethod
+        def runtime_deps():
+            return ("somepkg",)
+
+    mock_mgr.return_value = [{"plugin": {DepPlugin}}]
+
+    # packages_distributions() absent natively -- no manipulation needed
+    cli._log_runtime_env()
+
+    # Env summary was still logged despite the missing function
+    calls = [a for a, _ in mock_logger.debug.call_args_list]
+    assert any(a[0] == "Apprise: %s" for a in calls)
+
+    # No dep listing -- packages_distributions unavailable on Python < 3.11
     assert not any(a[0] == "Runtime deps: %s" for a in calls)

--- a/tests/test_apprise_cli.py
+++ b/tests/test_apprise_cli.py
@@ -26,6 +26,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from importlib import reload
+from importlib.metadata import PackageNotFoundError
 from inspect import cleandoc
 import json
 
@@ -2671,3 +2672,218 @@ def test_apprise_cli_windows_env(mock_system):
 
     # Reload our module
     reload(cli)
+
+
+@mock.patch("apprise.cli.NotificationManager")
+@mock.patch("importlib.metadata.packages_distributions")
+@mock.patch("importlib.metadata.version")
+@mock.patch("apprise.cli.logger")
+def test_apprise_cli_runtime_env_skip_when_not_debug(
+    mock_logger, mock_ver, mock_dist, mock_mgr
+):
+    """
+    CLI: _log_runtime_env() exits immediately when not at DEBUG level.
+    """
+    # Simulate a logger that is not at DEBUG level
+    mock_logger.isEnabledFor.return_value = False
+
+    cli._log_runtime_env()
+
+    # Nothing should be computed or logged
+    mock_logger.debug.assert_not_called()
+    mock_mgr.assert_not_called()
+    mock_dist.assert_not_called()
+    mock_ver.assert_not_called()
+
+
+@mock.patch("apprise.cli.NotificationManager")
+@mock.patch("importlib.metadata.packages_distributions")
+@mock.patch("importlib.metadata.version")
+@mock.patch("apprise.cli.logger")
+def test_apprise_cli_runtime_env_logging(
+    mock_logger, mock_ver, mock_dist, mock_mgr
+):
+    """
+    CLI: _log_runtime_env() summary
+    """
+    # Simulate a DEBUG-level logger
+    mock_logger.isEnabledFor.return_value = True
+
+    # Plugin whose dep should appear in output
+    class EnabledPlugin:
+        enabled = True
+
+        @staticmethod
+        def runtime_deps():
+            return ("testpkg",)
+
+    # Disabled plugin -- its dep must NOT appear in output
+    class DisabledPlugin:
+        enabled = False
+
+        @staticmethod
+        def runtime_deps():
+            return ("disabled-dep",)
+
+    # Plugin with no runtime_deps attribute -- silently skipped
+    class NoRuntimeDepsPlugin:
+        enabled = True
+
+    mock_mgr.return_value = [
+        {
+            "plugin": {
+                EnabledPlugin,
+                DisabledPlugin,
+                NoRuntimeDepsPlugin,
+            },
+        },
+    ]
+    mock_dist.return_value = {"testpkg": ["test-package"]}
+    mock_ver.return_value = "9.9.9"
+
+    cli._log_runtime_env()
+
+    # Collect positional-arg tuples from each debug() call
+    calls = [a for a, _ in mock_logger.debug.call_args_list]
+
+    # Environment summary lines must be present
+    assert any(a[0] == "Apprise: %s" for a in calls)
+    assert any(a[0] == "Python: %s" for a in calls)
+    assert any(a[0] == "Platform: %s" for a in calls)
+    assert any(a[0] == "Encoding: %s" for a in calls)
+
+    # Resolved deps emitted as a single inline line
+    assert any(
+        a[0] == "Runtime deps: %s" and a[1] == "test-package=9.9.9"
+        for a in calls
+    )
+
+    # Disabled plugin dep must not be logged
+    assert not any("disabled-dep" in str(a) for a in calls)
+
+
+@mock.patch("apprise.cli.NotificationManager")
+@mock.patch("importlib.metadata.packages_distributions")
+@mock.patch("importlib.metadata.version")
+@mock.patch("apprise.cli.logger")
+def test_apprise_cli_runtime_env_no_runtime_deps(
+    mock_logger, mock_ver, mock_dist, mock_mgr
+):
+    """
+    CLI: _log_runtime_env()
+    """
+    mock_logger.isEnabledFor.return_value = True
+
+    # Plugin that declares no deps
+    class NoDepsPlugin:
+        enabled = True
+
+        @staticmethod
+        def runtime_deps():
+            return ()
+
+    mock_mgr.return_value = [{"plugin": {NoDepsPlugin}}]
+
+    cli._log_runtime_env()
+
+    # Environment header was still logged
+    calls = [a for a, _ in mock_logger.debug.call_args_list]
+    assert any(a[0] == "Apprise: %s" for a in calls)
+
+    # Package-metadata scan must not have been attempted
+    mock_dist.assert_not_called()
+    mock_ver.assert_not_called()
+
+    # No "  pkg: ver" lines
+    assert not any(a[0] == "Runtime deps: %s" for a in calls)
+
+
+@mock.patch("apprise.cli.NotificationManager")
+@mock.patch("importlib.metadata.packages_distributions")
+@mock.patch("importlib.metadata.version")
+@mock.patch("apprise.cli.logger")
+def test_apprise_cli_runtime_env_dist_map_exception(
+    mock_logger, mock_ver, mock_dist, mock_mgr
+):
+    """
+    CLI: _log_runtime_env() handles packages_distributions() failures.
+    """
+    mock_logger.isEnabledFor.return_value = True
+
+    class DepPlugin:
+        enabled = True
+
+        @staticmethod
+        def runtime_deps():
+            return ("somepkg",)
+
+    mock_mgr.return_value = [{"plugin": {DepPlugin}}]
+    mock_dist.side_effect = Exception("metadata unavailable")
+
+    # Must not raise
+    cli._log_runtime_env()
+
+    # pkg_version should never be reached
+    mock_ver.assert_not_called()
+
+    # No "  pkg: ver" lines
+    calls = [a for a, _ in mock_logger.debug.call_args_list]
+    assert not any(a[0] == "Runtime deps: %s" for a in calls)
+
+
+@mock.patch("apprise.cli.NotificationManager")
+@mock.patch("importlib.metadata.packages_distributions")
+@mock.patch("importlib.metadata.version")
+@mock.patch("apprise.cli.logger")
+def test_apprise_cli_runtime_env_lookup_errors(
+    mock_logger, mock_ver, mock_dist, mock_mgr
+):
+    """
+    CLI: _log_runtime_env() silently skips packages exception raised.
+    """
+    mock_logger.isEnabledFor.return_value = True
+
+    # Plugin whose runtime_deps() raises
+    class BrokenPlugin:
+        enabled = True
+
+        @staticmethod
+        def runtime_deps():
+            raise RuntimeError("plugin error")
+
+    # Plugin whose dep import name is not in the dist map
+    class UnmappedPlugin:
+        enabled = True
+
+        @staticmethod
+        def runtime_deps():
+            return ("notmapped",)
+
+    # Plugin whose dep maps to a dist but the version lookup fails
+    class VersionlessPlugin:
+        enabled = True
+
+        @staticmethod
+        def runtime_deps():
+            return ("verpkg",)
+
+    mock_mgr.return_value = [
+        {
+            "plugin": {
+                BrokenPlugin,
+                UnmappedPlugin,
+                VersionlessPlugin,
+            },
+        },
+    ]
+
+    # "notmapped" absent from map; "verpkg" present but ver raises
+    mock_dist.return_value = {"verpkg": ["ver-package"]}
+    mock_ver.side_effect = PackageNotFoundError("ver-package")
+
+    # Must not raise
+    cli._log_runtime_env()
+
+    # None of the error paths should produce a "  pkg: ver" line
+    calls = [a for a, _ in mock_logger.debug.call_args_list]
+    assert not any(a[0] == "Runtime deps: %s" for a in calls)

--- a/tests/test_plugin_xmpp.py
+++ b/tests/test_plugin_xmpp.py
@@ -88,7 +88,7 @@ class FakeClientXMPP:
         self.handlers: dict[str, Any] = {}
         self.auto_reconnect = True
 
-        # Slixmpp >= 1.10.0: adapter waits on this Future
+        # Slixmpp >= 1.16.0: adapter waits on this Future
         self.disconnected: Optional[asyncio.Future[bool]] = None
 
         # Slixmpp toggles used by adapter
@@ -123,7 +123,7 @@ class FakeClientXMPP:
 
     def connect(self, **kwargs: Any) -> asyncio.Future[bool]:
         """
-        Slixmpp >= 1.10.0 connect() returns a Future. Our adapter awaits it.
+        Slixmpp >= 1.16.0 connect() returns a Future. Our adapter awaits it.
 
         This fake schedules session_start on the assigned loop so the adapter's
         loop.run_until_complete() drives it, and ensures disconnected resolves.
@@ -1538,15 +1538,19 @@ def test_xmpp_slixmpp_versioning(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     # Garbage in... garbage out
     assert xmpp_adapter.SlixmppAdapter.supported_version("garbage") is False
-    # This version is too old
+    # These versions are too old
     assert xmpp_adapter.SlixmppAdapter.supported_version("1.0.0") is False
+    assert xmpp_adapter.SlixmppAdapter.supported_version("1.10.0") is False
+    assert xmpp_adapter.SlixmppAdapter.supported_version("1.14.1") is False
+    assert xmpp_adapter.SlixmppAdapter.supported_version("1.15.0") is False
+    assert xmpp_adapter.SlixmppAdapter.supported_version("1.15.1") is False
 
     # Good version checks
-    assert xmpp_adapter.SlixmppAdapter.supported_version("1.10.0") is True
-    assert xmpp_adapter.SlixmppAdapter.supported_version("1.10") is True
-    assert xmpp_adapter.SlixmppAdapter.supported_version("1.10.1") is True
-    assert xmpp_adapter.SlixmppAdapter.supported_version("1.10.100") is True
-    assert xmpp_adapter.SlixmppAdapter.supported_version("1.11.0") is True
+    assert xmpp_adapter.SlixmppAdapter.supported_version("1.16.0") is True
+    assert xmpp_adapter.SlixmppAdapter.supported_version("1.16") is True
+    assert xmpp_adapter.SlixmppAdapter.supported_version("1.16.1") is True
+    assert xmpp_adapter.SlixmppAdapter.supported_version("1.16.100") is True
+    assert xmpp_adapter.SlixmppAdapter.supported_version("1.17.0") is True
 
     # This version is too old
     assert xmpp_adapter.SlixmppAdapter.supported_version("1") is False
@@ -5326,6 +5330,41 @@ def test_xmpp_send_catches_channel_binding_error_and_logs(
 
     assert result is False
     assert "scramplus=no" in caplog.text
+
+
+@pytest.mark.skipif(not SLIXMPP_AVAILABLE, reason="Requires slixmpp")
+def test_xmpp_send_channel_binding_error_scramplus_already_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No ?scramplus=no hint when scramplus is already False."""
+
+    class _RaisingAdapter:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        def process(self) -> bool:
+            raise xmpp_adapter.XMPPChannelBindingError()
+
+    monkeypatch.setattr(xmpp_base, "SlixmppAdapter", _RaisingAdapter)
+    monkeypatch.setattr(
+        xmpp_base, "SLIXMPP_SUPPORT_AVAILABLE", True, raising=False
+    )
+    monkeypatch.setattr(xmpp_base.NotifyXMPP, "enabled", True, raising=False)
+
+    # scramplus explicitly disabled -- the hint must NOT repeat the advice
+    n = NotifyXMPP(
+        host="example.com", user="me", password="x", scramplus=False
+    )
+
+    with caplog.at_level(logging.WARNING, logger="apprise"):
+        result = n.send(body="hi")
+
+    assert result is False
+    # The "Add ?scramplus=no" suggestion must not appear when already set
+    assert "Add ?scramplus=no" not in caplog.text
+    # A compatibility-oriented message must appear instead
+    assert "compatibility" in caplog.text
 
 
 @pytest.mark.skipif(not SLIXMPP_AVAILABLE, reason="Requires slixmpp")


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1558

Further XMPP  cleanup based on ongoing discussion. 
- includes cleaning up an unnessisary log entry to set scramplus=no when it already is
- increased slixmpp dependency version to the latest.

Also added debug logging to assist with future troubleshooting... if debug mode is set (via cli), additional log entries are set:
```
# e.g
Apprise: 1.11.0
Python: 3.12.4
Platform: Linux-6.19.11-x86_64
Encoding: UTF-8
Runtime deps: cryptography=46.0.6, slixmpp=1.15.0
```

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/81](https://github.com/caronc/apprise-docs/pull/81)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@<this.branch-name>

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    xmpp://credentials/
```
