### PR TITLE
HTML to Markdown support

### DIFF
--- a/apprise/conversion.py
+++ b/apprise/conversion.py
@@ -41,6 +41,10 @@ LIST_DEPTH_MAX = 4
 # Apply the same depth cap to blockquote prefixes.
 BLOCKQUOTE_DEPTH_MAX = 4
 
+# Bound the context-stack depth so adversarially nested HTML cannot
+# exhaust memory.  Frames beyond this limit are silently dropped.
+MAX_FRAME_DEPTH = 200
+
 
 class _Marker(str):
     """Identify converter-generated structure."""
@@ -88,7 +92,7 @@ def convert_between(from_format, to_format, content):
         (NotifyFormat.HTML, NotifyFormat.MARKDOWN): html_to_markdown,
     }
 
-    # Fetch the requested converter
+    # Fetch the converter registered for this format pair.
     convert = converters.get((from_format, to_format))
 
     # Preserve the original content when no conversion is available
@@ -98,7 +102,7 @@ def convert_between(from_format, to_format, content):
 def markdown_to_html(content):
     """Converts specified content from markdown to HTML."""
 
-    # Enable line-break and table extensions used by notification content
+    # Enable notification-friendly line-break and table extensions.
     return markdown(
         content,
         extensions=["markdown.extensions.nl2br", "markdown.extensions.tables"],
@@ -115,28 +119,28 @@ def text_to_html(content):
 def html_to_text(content):
     """Converts a content from HTML to plain text."""
 
-    # Initialize our plain-text parser
+    # Initialize the plain-text parser.
     parser = HTMLConverter()
 
     # Feed and finalize the HTML document
     parser.feed(content)
     parser.close()
 
-    # Return the converted content
+    # Return the finalized parser output.
     return parser.converted
 
 
 def html_to_markdown(content):
     """Converts a content from HTML to Markdown."""
 
-    # Initialize our Markdown parser
+    # Initialize the Markdown parser.
     parser = HTMLMarkdownConverter()
 
     # Feed and finalize the HTML document
     parser.feed(content)
     parser.close()
 
-    # Return the converted content
+    # Return the finalized parser output.
     return parser.converted
 
 
@@ -188,7 +192,7 @@ class HTMLConverter(HTMLParser):
     def __init__(self, **kwargs):
         """Initialize the HTML converter."""
 
-        # Initialize the base HTML parser
+        # Initialize the standard-library HTML parser.
         super().__init__(**kwargs)
 
         # Shoudl we store the text content or not?
@@ -204,10 +208,10 @@ class HTMLConverter(HTMLParser):
     def close(self):
         """Finalize the converted content."""
 
-        # Combine all buffered content
+        # Combine buffered fragments into one string.
         string = "".join(self._finalize(self._result))
 
-        # Store the normalized result
+        # Publish the normalized result.
         self.converted = string.strip()
 
     def _finalize(self, result):
@@ -245,41 +249,136 @@ class HTMLConverter(HTMLParser):
     def handle_data(self, data, *args, **kwargs):
         """Store our data if it is not on the ignore list."""
 
-        # initialize our previous flag
+        # Ignore data while an ignored container is active.
         if self._do_store:
-            # Tidy our whitespace
+            # Collapse whitespace before buffering visible text.
             content = self.WS_TRIM.sub(" ", data)
+
+            # Preserve the normalized fragment for final assembly.
             self._result.append(content)
 
     def handle_starttag(self, tag, attrs):
         """Process our starting HTML Tag."""
-        # Toggle initial states
+
+        # Toggle storage according to the newly opened container.
         self._do_store = tag not in self.IGNORE_TAGS
 
+        # Start block elements on a fresh output line.
         if tag in self.BLOCK_TAGS:
             self._result.append(self.BLOCK_END)
 
+        # Prefix each list item with a plain-text bullet.
         if tag == "li":
             self._result.append("- ")
 
+        # Preserve explicit HTML line breaks.
         elif tag == "br":
             self._result.append("\n")
 
+        # Render horizontal rules on their own line.
         elif tag == "hr":
+            # Remove spacing that would precede the rule.
             if self._result and isinstance(self._result[-1], str):
                 self._result[-1] = self._result[-1].rstrip(" ")
 
             self._result.append("\n---\n")
 
+        # Mark the start of quoted plain text.
         elif tag == "blockquote":
             self._result.append(" >")
 
     def handle_endtag(self, tag):
         """Edge case handling of open/close tags."""
+
+        # Resume storage after leaving an ignored container.
         self._do_store = True
 
+        # Close block elements with a line boundary.
         if tag in self.BLOCK_TAGS:
             self._result.append(self.BLOCK_END)
+
+
+def build_backtick_run_index(text):
+    """Index unescaped backtick positions by run length in one pass."""
+
+    # Maps run-length -> [start, ...] in ascending position order.
+    index = {}
+
+    # Track the current scanner position and input length.
+    i = 0
+    n = len(text)
+
+    # Visit each character at most once.
+    while i < n:
+        ch = text[i]
+        # Consume escape pairs so a backslash-escaped backtick is not
+        # mistaken for the start or end of a code span.
+        if ch == "\\" and i + 1 < n:
+            i += 2
+            continue
+        if ch == "`":
+            # Measure the run by advancing until the first non-backtick.
+            j = i
+            while j < n and text[j] == "`":
+                j += 1
+            # Store this run's starting position under its length key.
+            # setdefault ensures the list exists before appending.
+            index.setdefault(j - i, []).append(i)
+            # Jump past the entire run to avoid double-counting.
+            i = j
+            continue
+
+        # Advance past ordinary text.
+        i += 1
+
+    # Return positions grouped by delimiter width.
+    return index
+
+
+def find_unescaped_run(index, start, run):
+    """Find the next indexed backtick run of the requested length."""
+
+    # Nothing to search if no run of this exact length was indexed.
+    positions = index.get(run)
+    if not positions:
+        return None
+    # Binary-search for the first position that is >= start.
+    pos = bisect_left(positions, start)
+    # Return the found position, or None if we went past the end of the list.
+    return positions[pos] if pos < len(positions) else None
+
+
+def commonmark_escape_link_url(url):
+    """Adapt a CommonMark URL for ``<url|label>`` dialects."""
+
+    # Step 1: strip CommonMark backslash escapes so we recover the raw URL
+    # characters before re-applying any encoding the target dialect needs.
+    out = []
+
+    # Scan the URL without allocating intermediate match objects.
+    i = 0
+    n = len(url)
+    while i < n:
+        ch = url[i]
+        if ch == "\\" and i + 1 < n:
+            # Discard the backslash and keep only the escaped character.
+            out.append(url[i + 1])
+            i += 2
+            continue
+        out.append(ch)
+        i += 1
+
+    # Reassemble the decoded CommonMark destination.
+    url = "".join(out)
+
+    # Step 2: re-encode the characters that the <url|label> delimiter syntax
+    # would mis-parse if left bare in the URL string.
+    # "&" must come first to avoid double-encoding the entities below.
+    url = url.replace("&", "&amp;").replace("<", "&lt;")
+    url = url.replace(">", "&gt;")
+    # "|" is the separator between the URL and label inside <url|label>;
+    # percent-encode it so it cannot be mistaken for the delimiter.
+    return url.replace("|", "%7C")
 
 
 class HTMLMarkdownConverter(HTMLConverter):
@@ -323,7 +422,9 @@ class HTMLMarkdownConverter(HTMLConverter):
     _BULLET_MARKER_RE = re.compile(r"^[-+](?=[ \t]|$)")
 
     # Match thematic breaks and setext heading underlines.
-    _THEMATIC_BREAK_RE = re.compile(r"^([-=])(?:[ \t]*\1){2,}$")
+    # Uses separate alternates (no backreference) to avoid ReDoS on
+    # inputs like "- - - - - - - - ... -x".
+    _THEMATIC_BREAK_RE = re.compile(r"^(?:-[ \t]*){3,}$|^(?:=[ \t]*){3,}$")
 
     # Collapse ASCII whitespace when flattening table cells.
     _CELL_WHITESPACE_RUN = re.compile(r"[ \t\r\f\v]+")
@@ -331,15 +432,20 @@ class HTMLMarkdownConverter(HTMLConverter):
     # Escape angle-bracket link destinations.
     HREF_ESCAPE = re.compile(r"([\\<>])")
 
-    # Remove control characters that invalidate link destinations.
-    _HREF_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+    # Remove ASCII controls and Unicode format/zero-width characters that
+    # browsers silently strip during URL parsing but that would bypass the
+    # scheme check (e.g. U+200B zero-width space prepended to "javascript:").
+    _HREF_CONTROL_CHARS = re.compile(
+        "[\x00-\x1f\x7f\u00ad\u200b-\u200f\u2028\u2029\ufeff]"
+    )
 
     # Detect URI schemes before sanitizing links.
     _HREF_SCHEME = re.compile(r"^([a-zA-Z][a-zA-Z0-9+.-]*):")
 
     # Block executable and local URI schemes while allowing app links.
+    # "blob" is included because blob: URLs can carry arbitrary payloads.
     _UNSAFE_HREF_SCHEMES = frozenset(
-        {"javascript", "vbscript", "data", "file"}
+        {"javascript", "vbscript", "data", "file", "blob"}
     )
 
     # Trim ASCII whitespace without removing deliberate non-breaking spaces.
@@ -446,6 +552,8 @@ class HTMLMarkdownConverter(HTMLConverter):
                 "list_indent_base": "",
             }
         )
+        # Build the new frame by inheriting all context keys from the parent.
+        # Callers pass **overrides to replace only the keys they need changed.
         frame = {
             "tag": tag,
             "do_store": parent["do_store"],
@@ -459,66 +567,65 @@ class HTMLMarkdownConverter(HTMLConverter):
             "list_indent_base": parent["list_indent_base"],
         }
 
-        # Apply tag-specific frame state.
+        # Apply caller-supplied overrides on top of the inherited defaults.
         frame.update(overrides)
         return frame
 
     def _indent(self, depth):
         """Return cached indentation for a list depth."""
 
-        # Convert the one-based depth into a cache index
+        # Depth 1 is the outermost level and needs no indentation,
+        # so shift by one: depth 1 -> index 0 (empty string).
         idx = max(depth - 1, 0)
 
-        # Reference the cache locally for repeated access
+        # Work against the shared per-instance indentation cache.
         cache = self._indent_cache
 
-        # Populate any missing indentation levels
+        # Extend the cache on demand -- each level adds two spaces.
         while len(cache) <= idx:
             cache.append(cache[-1] + "  ")
 
-        # Return the requested indentation
         return cache[idx]
 
     def _quote_prefix(self, depth):
         """Return the prefix for a quote depth."""
 
-        # Normalize the requested quote depth
+        # Clamp negative depths to zero (should not occur in practice).
         idx = max(depth, 0)
 
-        # Reference the cache locally for repeated access
+        # Work against the shared per-instance quote-prefix cache.
         cache = self._quote_prefix_cache
 
-        # Populate any missing quote levels
+        # Extend the cache on demand -- each nesting level prepends "> ".
         while len(cache) <= idx:
             cache.append(_QuoteMarker(cache[-1] + "> "))
 
-        # Return the requested quote prefix
         return cache[idx]
 
     def _continuation_prefix(self, ctx):
-        """Return the prefix for a continuation line."""
+        """Return the prefix that any continuation line must carry."""
 
-        # Start with the active list indentation
+        # Start with whatever list indentation this context inherited.
         prefix = ctx["list_indent"]
 
-        # Add any active blockquote prefix
+        # If we are inside a blockquote, append its ">" leader as well.
         if ctx["quote_depth"]:
             prefix += self._quote_prefix(ctx["quote_depth"])
 
-        # Return the combined continuation prefix
         return prefix
 
     def _write_boundary(self, ctx, strong=False):
-        """Append a line or paragraph boundary."""
+        """Append a line break or a nesting-aware paragraph break."""
 
-        # Resolve the prefix needed by the next line
+        # Compute the prefix that any following line must carry.
         prefix = self._continuation_prefix(ctx)
 
-        # Write an ordinary line boundary
         if not strong:
+            # Weak boundary -- a single line break in the output.
             self._result.append(self.BLOCK_END)
 
-            # Restate any active quote or list prefix
+            # Restate any active quote or list prefix so the next
+            # content line opens inside the correct nesting context.
             if prefix:
                 self._result.append(
                     _QuoteMarker(prefix)
@@ -526,45 +633,54 @@ class HTMLMarkdownConverter(HTMLConverter):
                     else _ListIndent(prefix)
                 )
 
-            # The ordinary boundary is complete
+            # The ordinary boundary is complete; nothing more to do.
             return
 
-        # Preserve nesting across a paragraph boundary
+        # Strong boundary -- blank-line paragraph separation.
         if prefix:
+            # Carry nesting context into the paragraph break so _finalize()
+            # can restate it on the first line of the next paragraph.
             self._result.append(
                 _ParaBreak(prefix, in_quote=bool(ctx["quote_depth"]))
             )
 
-        # Use the shared top-level paragraph boundary
         else:
+            # No active nesting -- use the cached bare paragraph break.
             self._result.append(self.PARA_BREAK)
 
     def _open_line_boundary(self, ctx, strong=False):
-        """Start a block unless it can join a marker."""
+        """Start a block unless a structural marker owns the line."""
 
-        # Keep pending list and quote markers on the same line
         if self._result and isinstance(self._result[-1], _Marker):
-            return  # suppress; marker and content stay on one line
+            # A structural marker is already on the line -- suppress the
+            # boundary so the block content follows it directly.
+            return
 
-        # Start a new line or paragraph
         self._write_boundary(ctx, strong=strong)
 
     def _emit(self, text):
-        """Append content and update the content sequence."""
+        """Append content and advance the empty-span sequence counter."""
 
-        # Append real content to the output buffer
         self._result.append(text)
 
-        # Record that the active frames produced content
+        # Each emission is a unique sequence point; comparing the counter
+        # value at open-time vs. close-time reveals whether the frame was
+        # empty without scanning the result buffer.
         self._content_seq += 1
 
     def _push_frame(self, frame):
-        """Push a frame and track its tag."""
+        """Push a new context frame and update the open-tag counter."""
 
-        # Push the new parsing context
+        # Silently discard frames beyond the depth cap so adversarially
+        # nested HTML cannot exhaust memory.
+        if len(self._stack) >= MAX_FRAME_DEPTH:
+            return
+
+        # Add the frame to the context stack.
         self._stack.append(frame)
 
-        # Track the number of open frames for this tag
+        # Maintain a per-tag count of currently open frames so that
+        # _pop_to() can reject unmatched closing tags in O(1).
         tag = frame["tag"]
         self._tag_open_counts[tag] = self._tag_open_counts.get(tag, 0) + 1
 
@@ -582,65 +698,75 @@ class HTMLMarkdownConverter(HTMLConverter):
                 for frame in self._stack[i:]:
                     self._tag_open_counts[frame["tag"]] -= 1
 
-                # Remove the matching frame and its descendants
                 del self._stack[i:]
                 return True
 
         return False
 
     def _close_emphasis_frame(self, frame):
-        """Close an emphasis frame with content."""
+        """Close an emphasis frame, dropping it if it collected no content."""
 
-        # Determine whether the span emitted real content
+        # Compare the global emission counter now vs. when the frame opened;
+        # any difference means at least one _emit() was called inside the span.
         has_content = self._content_seq != frame.get(
             "content_seq_at_open", self._content_seq
         )
 
         if not has_content:
-            # Remove the opening delimiter and any empty nested tokens.
+            # The span opened but collected nothing -- erase from the opening
+            # delimiter onward so we do not emit an empty ** or * pair.
             del self._result[frame["emphasis_result_start"] :]
             return
 
-        # Collect whitespace that belongs outside the closing delimiter
+        # CommonMark requires that the closing delimiter not be preceded by
+        # whitespace.  Relocate any trailing whitespace to after the delimiter.
         trailing = ""
         while self._result and type(self._result[-1]) is str:
             last = self._result[-1]
             rstripped = last.rstrip(self._ASCII_WHITESPACE)
 
-            # Stop once the fragment has no trailing whitespace
+            # This fragment has no trailing whitespace -- stop scanning.
             if rstripped == last:
                 break
 
-            # Prepend whitespace gathered from this fragment
+            # Accumulate trailing whitespace in front-to-back order.
             trailing = last[len(rstripped) :] + trailing
 
-            # Keep any non-whitespace portion in place
             if rstripped:
+                # Replace the fragment with its trimmed version and stop.
                 self._result[-1] = rstripped
                 break
 
-            # Drop fragments containing only whitespace
+            # The entire fragment was whitespace -- remove it and keep going.
             self._result.pop()
 
-        # Emit the closing emphasis delimiter
+        # Emit the closing delimiter (e.g. "**" or "*").
         self._emit(frame["emphasis_delim"])
 
-        # Restore trailing whitespace outside the span
+        # Re-append any whitespace that was after the span content so it
+        # falls outside the closed delimiter.
         if trailing:
             self._result.append(trailing)
 
-    @classmethod
-    def _escape_cell_pipes(cls, text):
+    @staticmethod
+    def _escape_cell_pipes(text):
         """Escape cell delimiters outside CommonMark code spans."""
 
+        # Accumulate escaped fragments without rebuilding the output string.
         out = []
+
+        # Initialize the single-pass scanner.
         i = 0
         n = len(text)
-        backtick_runs = cls._build_backtick_run_index(text)
+
+        # Index code delimiters before inspecting table separators.
+        backtick_runs = build_backtick_run_index(text)
 
         while i < n:
             ch = text[i]
 
+            # Keep escape pairs intact so a backslash-escaped "|" does not
+            # trigger an extra escape on the next pass.
             if ch == "\\" and i + 1 < n:
                 out.append(text[i : i + 2])
                 i += 2
@@ -648,48 +774,58 @@ class HTMLMarkdownConverter(HTMLConverter):
 
             if ch == "`":
                 j = i
+                # Measure the backtick run length.
                 while j < n and text[j] == "`":
                     j += 1
                 run = j - i
 
-                close = cls._find_unescaped_run(backtick_runs, j, run)
+                # Find the matching closing run of the same length.
+                close = find_unescaped_run(backtick_runs, j, run)
                 if close is not None:
-                    # Pipes are already literal inside code spans.
+                    # Inside a code span, "|" is a literal character --
+                    # copy the entire span verbatim without escaping.
                     out.append(text[i : close + run])
                     i = close + run
                     continue
 
-                # Preserve unmatched backticks as literal text.
+                # No matching close -- not a code span; preserve the
+                # raw backticks and let the outer Markdown renderer see them.
                 out.append(text[i:j])
                 i = j
                 continue
 
             if ch == "|":
+                # Outside code spans, "|" is a Markdown table delimiter --
+                # escape it so it does not break the table structure.
                 out.append("\\|")
                 i += 1
                 continue
 
+            # All other characters are safe to pass through unchanged.
             out.append(ch)
             i += 1
 
+        # Publish the escaped cell content.
         return "".join(out)
 
     def _close_cell_frame(self, frame):
-        """Capture a completed table cell."""
+        """Capture a completed table cell and store its text."""
 
-        # Extract tokens written since this cell opened
+        # Splice out all result tokens written since this cell was opened.
         start = frame["cell_result_start"]
         chunk = self._result[start:]
         del self._result[start:]
 
         if not frame["do_store"]:
-            # Suppressed tables must not emit empty cells.
+            # This cell belongs to a suppressed or nested table -- discard it
+            # so we do not emit empty cells or corrupt the outer table.
             return
 
-        # Finalize the cell into a single Markdown fragment
+        # Finalize the buffered tokens into a plain string and strip edges.
         text = "".join(self._finalize(chunk)).strip(self._ASCII_WHITESPACE)
 
-        # Table cells must remain on one Markdown source line.
+        # CommonMark table cells must live on a single source line.
+        # Collapse embedded newlines to spaces and then normalize runs.
         if "\n" in text:
             text = " ".join(text.split("\n"))
             text = self._CELL_WHITESPACE_RUN.sub(" ", text).strip(
@@ -700,7 +836,7 @@ class HTMLMarkdownConverter(HTMLConverter):
         if "|" in text:
             text = self._escape_cell_pipes(text)
 
-        # Add the completed cell to its row
+        # Add the completed value to its enclosing row.
         self._stack[-1]["cells"].append(text)
 
     def _close_pre_frame(self, ctx, tag):
@@ -713,6 +849,7 @@ class HTMLMarkdownConverter(HTMLConverter):
         run = self._longest_backtick_run(content)
 
         if tag == "code":
+            # Inline code uses a delimiter wider than its content.
             # CommonMark requires padding around edge backticks.
             delim = "`" * (run + 1)
             pad = (
@@ -721,7 +858,6 @@ class HTMLMarkdownConverter(HTMLConverter):
                 else ""
             )
 
-            # Emit the complete inline code span
             self._emit(delim + pad + content + pad + delim)
             return
 
@@ -741,7 +877,7 @@ class HTMLMarkdownConverter(HTMLConverter):
             )
             content = ("\n" + prefix).join(content.split("\n"))
 
-        # Emit the opening fence
+        # Emit the opening fence and terminate its line.
         self._emit(fence)
         self._result.append(self.BLOCK_END)
 
@@ -749,7 +885,7 @@ class HTMLMarkdownConverter(HTMLConverter):
         if prefix:
             self._result.append(marker)
 
-        # Emit the literal block content
+        # Emit the literal code body and terminate its final line.
         self._emit(content)
         self._result.append(self.BLOCK_END)
 
@@ -757,113 +893,155 @@ class HTMLMarkdownConverter(HTMLConverter):
         if prefix:
             self._result.append(marker)
 
-        # Emit the closing fence and boundary
+        # Emit the closing fence and restore a block boundary.
         self._emit(fence)
         self._result.append(self.BLOCK_END)
 
     def _close_row_frame(self, frame):
-        """Render a completed table row."""
+        """Render a completed table row as a Markdown pipe-table line."""
 
-        # Fetch all cells collected for this row
+        # Retrieve the cells collected while the row was open.
         cells = frame["cells"]
 
-        # Drop rows that never opened a cell
         if not cells:
-            return  # an entirely empty row (no cells at all) is dropped
+            # An entirely empty row (no cells at all) is not useful -- drop it.
+            return
 
-        # Identify whether this is the table's header row
+        # Retrieve the enclosing table frame, if one exists.
         table = frame.get("table_frame")
+
+        # The first row of a table is treated as the header row; CommonMark
+        # requires a separator line of dashes ("---") immediately after it.
         is_header = table is None or table["table_rows"] == 0
 
-        # Advance the enclosing table's row count
         if table is not None:
+            # Count this row so that subsequent rows know they are not headers.
             table["table_rows"] += 1
 
-        # Emit the completed row in the parent context
+        # Use the restored parent context for row boundaries and prefixes.
         ctx = self._stack[-1]
+        # Ensure the row starts on its own line within any active nesting.
         self._open_line_boundary(ctx, strong=False)
+        # Emit the pipe-delimited cell values.
         self._emit("| " + " | ".join(cells) + " |")
 
-        # Add the required separator after the header row
         if is_header:
-            # Preserve list or quote prefixes on the separator line.
+            # Emit the mandatory separator line beneath the header row.
+            # Restate list or quote prefixes so it stays inside any nesting.
             self._write_boundary(ctx, strong=False)
             self._emit("| " + " | ".join(["---"] * len(cells)) + " |")
 
         if table is None:
-            # A standalone row needs the same trailing boundary as a table.
+            # A standalone row has no enclosing table to supply the trailing
+            # paragraph boundary, so we must emit it here.
             self._write_boundary(ctx, strong=True)
 
-    def _close_table_frame(self):
-        """Finish a table boundary."""
+    def _close_table_frame(self, table_frame=None):
+        """Emit the paragraph boundary that follows a completed table."""
 
-        # Restore the context surrounding the table
         parent = self._stack[-1]
 
-        # Separate any following content from the table
+        # Skip the trailing boundary only for visible top-level tables that
+        # emitted no rows.  The leading paragraph break added before the
+        # table is sufficient; adding a trailing one too would produce a
+        # spurious blank line with no table content in between.
+        # Nested tables (table_do_store=False) are exempt: their boundary
+        # is absorbed into the enclosing cell and provides the whitespace
+        # that separates surrounding inline content from the table's slot.
+        if (
+            table_frame is not None
+            and not table_frame.get("table_rows")
+            and table_frame.get("table_do_store")
+        ):
+            return
+
         if parent["do_store"]:
+            # Separate the table from any following content with a blank line.
             self._write_boundary(parent, strong=True)
 
     def _close_stale_cell(self):
-        """Close an implicitly terminated cell."""
+        """Close a stale cell hidden beneath malformed inline frames."""
 
-        # Inspect the current frame for an unclosed cell
-        top = self._stack[-1]
+        # Walk backward until a cell or its structural boundary is found.
+        for i in range(len(self._stack) - 1, 0, -1):
+            frame = self._stack[i]
+            tag = frame["tag"]
+            # A row or table boundary means no stale cell exists here.
+            if tag in ("tr", "table"):
+                return
+            if tag in ("td", "th"):
+                # Silently drop any interleaved inline frames above the cell.
+                while len(self._stack) > i + 1:
+                    # Remove the nearest orphaned inline frame.
+                    orphan = self._stack[-1]
 
-        # Finalize the cell before its sibling begins
-        if top["tag"] in ("td", "th"):
-            self._pop_to(top["tag"])
-            self._close_cell_frame(top)
+                    # Keep its open-tag counter synchronized.
+                    self._tag_open_counts[orphan["tag"]] = max(
+                        0,
+                        self._tag_open_counts.get(orphan["tag"], 0) - 1,
+                    )
+                    self._stack.pop()
+                # Finalize the cell before its sibling begins.
+                self._pop_to(tag)
+                self._close_cell_frame(frame)
+                return
 
     def _close_stale_row(self):
-        """Close an implicitly terminated row."""
+        """Finalize an unterminated row before its table advances."""
 
-        # Close any cell still open in the row
+        # A stale row always has a stale cell inside it -- close that first.
         self._close_stale_cell()
 
-        # Inspect the remaining top-level frame
+        # Inspect the frame exposed after closing any stale cell.
         top = self._stack[-1]
 
-        # Finalize the row before its sibling begins
+        # If the top of the stack is now a row frame, close it too.
         if top["tag"] == "tr":
             self._pop_to("tr")
             self._close_row_frame(top)
 
     def close(self):
-        """Close malformed frames before finalizing output."""
+        """Recover any frames left open at end-of-document, then finalize."""
 
-        # Recover frames left open at the end of the document
+        # HTML does not require all tags to be closed, so we walk the stack
+        # top-down and synthesize the missing close events for each open frame.
+        # Only frames that emit Markdown structure need explicit finalization;
+        # list and blockquote frames just restore context silently via _pop_to.
         while len(self._stack) > 1:
             top = self._stack[-1]
             tag = top["tag"]
 
-            # Remove the current frame from the active stack
+            # Remove the frame from the stack (and update open-tag counts).
             self._pop_to(tag)
 
-            # Finalize content captured by special frames
             if top.get("emphasis_delim"):
+                # Emphasis frame -- emit or drop the closing delimiter.
                 self._close_emphasis_frame(top)
 
             elif tag in ("td", "th"):
+                # Cell frame -- finalize and store its content.
                 self._close_cell_frame(top)
 
             elif tag == "tr":
+                # Row frame -- emit the pipe-table line.
                 self._close_row_frame(top)
 
             elif tag == "table":
-                self._close_table_frame()
+                # Table frame -- emit the trailing paragraph boundary.
+                self._close_table_frame(top)
 
             elif tag in ("code", "pre", "samp") and top["do_store"]:
+                # Preformatted frame -- emit the fenced code block.
                 self._close_pre_frame(top, tag)
 
-        # Let the base converter assemble the final output
+        # Hand off to the base converter to assemble the final output string.
         super().close()
 
     @staticmethod
     def _longest_backtick_run(text):
         """Return the longest consecutive backtick run."""
 
-        # Track both the active and longest runs
+        # Track both the active run and the maximum observed width.
         longest = current = 0
 
         # Scan the content one character at a time
@@ -876,47 +1054,12 @@ class HTMLMarkdownConverter(HTMLConverter):
             else:
                 current = 0
 
-        # Return the delimiter width already present in the content
+        # Use the maximum to size a collision-free delimiter.
         return longest
 
-    @classmethod
-    def _build_backtick_run_index(cls, text):
-        """Index unescaped backtick runs by width in one pass."""
-
-        index = {}
-        i = 0
-        n = len(text)
-
-        while i < n:
-            ch = text[i]
-
-            # Consume escapes as pairs so escaped delimiters cannot match.
-            if ch == "\\" and i + 1 < n:
-                i += 2
-                continue
-
-            if ch == "`":
-                j = i
-                while j < n and text[j] == "`":
-                    j += 1
-                index.setdefault(j - i, []).append(i)
-                i = j
-                continue
-
-            i += 1
-
-        return index
-
-    @staticmethod
-    def _find_unescaped_run(index, start, run):
-        """Find the next indexed backtick run of the requested width."""
-
-        positions = index.get(run)
-        if not positions:
-            return None
-
-        pos = bisect_left(positions, start)
-        return positions[pos] if pos < len(positions) else None
+    # Expose shared helpers without binding them as instance methods.
+    build_backtick_run_index = staticmethod(build_backtick_run_index)
+    find_unescaped_run = staticmethod(find_unescaped_run)
 
     def _finalize(self, result):
         """Combine tokens into normalized Markdown lines."""
@@ -947,19 +1090,16 @@ class HTMLMarkdownConverter(HTMLConverter):
         # -- i.e. anything beyond the single boundary that did the terminating.
         boundary_after_terminate = False
 
-        # Process each buffered content or boundary token
         for item in result:
+            # Boundaries update state but do not immediately emit text.
             # Collect boundary state before flushing the current line
             if item == self.BLOCK_END or isinstance(item, _ParaBreak):
-                # Record the strongest paragraph boundary in this run
                 if isinstance(item, _ParaBreak):
                     # The latest break carries the current nesting context.
                     if item.prefix:
-                        # Keep the prefix required by the next line
                         para_break_prefix = item.prefix
                         para_break_in_quote = item.in_quote
 
-                    # Record a top-level paragraph boundary
                     else:
                         para_break_seen = True
                         para_break_prefix = None
@@ -983,7 +1123,6 @@ class HTMLMarkdownConverter(HTMLConverter):
 
             # Flush the previous line before adding new content.
             if terminated:
-                # Resolve the separator for a prefixed paragraph
                 if para_break_prefix is not None:
                     # Keep blank lines inside an active quote
                     if para_break_in_quote:
@@ -996,7 +1135,6 @@ class HTMLMarkdownConverter(HTMLConverter):
                     else:
                         sep = "\n\n"
 
-                # Use a blank line for a top-level paragraph break
                 elif para_break_seen:
                     sep = "\n\n"
 
@@ -1004,7 +1142,7 @@ class HTMLMarkdownConverter(HTMLConverter):
                 else:
                     sep = "\n"
 
-                # Emit the completed line and separator
+                # Emit the completed line with its chosen separator.
                 yield accum.rstrip(self._ASCII_WHITESPACE) + sep
 
                 # Seed the next line with any active list or quote prefix.
@@ -1017,7 +1155,6 @@ class HTMLMarkdownConverter(HTMLConverter):
                     accum_is_marker = True
                     marker_boundary_passed = boundary_after_terminate
 
-                # Start without a structural prefix
                 else:
                     accum = None
                     accum_is_marker = False
@@ -1030,8 +1167,8 @@ class HTMLMarkdownConverter(HTMLConverter):
                 para_break_in_quote = False
                 boundary_after_terminate = False
 
-            # Append this token to the active line
             if accum is not None:
+                # Determine whether this token is generated structure.
                 item_is_marker = isinstance(item, _Marker)
                 if (
                     marker_boundary_passed
@@ -1044,13 +1181,12 @@ class HTMLMarkdownConverter(HTMLConverter):
                     accum_is_marker = True
 
                 else:
-                    # Combine consecutive string fragments
+                    # Append ordinary content to the pending line.
                     accum += item
                     accum_is_marker = accum_is_marker and item_is_marker
 
                 marker_boundary_passed = False
 
-            # Start a new string accumulation.
             else:
                 # Seed a new line with this token
                 accum = item
@@ -1059,7 +1195,7 @@ class HTMLMarkdownConverter(HTMLConverter):
                 para_break_prefix = None
                 para_break_in_quote = False
 
-        # Emit the final non-marker content without a trailing newline.
+        # Flush the final content line without adding another newline.
         if accum is not None and not accum_is_marker:
             yield accum.rstrip(self._ASCII_WHITESPACE)
 
@@ -1085,13 +1221,13 @@ class HTMLMarkdownConverter(HTMLConverter):
             idx = content.index(trimmed[0])
             return content[:idx] + "\\" + content[idx:]
 
-        # Return ordinary text unchanged
+        # Leave ordinary line starts unchanged.
         return content
 
     def handle_data(self, data, *args, **kwargs):
         """Store escaped text for the current context."""
 
-        # Read formatting state from the current frame.
+        # Read all text-handling flags from the active frame.
         ctx = self._stack[-1]
 
         # Ignore text inside suppressed containers.
@@ -1140,7 +1276,6 @@ class HTMLMarkdownConverter(HTMLConverter):
 
         # Keep leading whitespace outside an emphasis delimiter.
         if ctx.get("emphasis_delim") and not ctx["emphasis_started"]:
-            # Separate leading whitespace from the emphasized content
             stripped = content.lstrip(self._ASCII_WHITESPACE)
 
             # Move leading whitespace before the opening delimiter
@@ -1151,7 +1286,6 @@ class HTMLMarkdownConverter(HTMLConverter):
                 self._result.append(delim)
                 content = stripped
 
-            # Drop an emphasis span that still has no real content
             if not content:
                 # The close handler removes an empty span.
                 return
@@ -1159,13 +1293,13 @@ class HTMLMarkdownConverter(HTMLConverter):
             # Mark the emphasis span as started
             ctx["emphasis_started"] = True
 
-        # Store the escaped text fragment
+        # Append the final escaped fragment to the output stream.
         self._emit(content)
 
     def handle_starttag(self, tag, attrs):
         """Handle an opening HTML tag."""
 
-        # Capture the parent context before pushing a new frame.
+        # Capture the parent context before opening another frame.
         ctx = self._stack[-1]
 
         # Treat nested tags inside preformatted content as literal text.
@@ -1178,8 +1312,8 @@ class HTMLMarkdownConverter(HTMLConverter):
             # CommonMark ordered lists default to one.
             counter = 1
 
-            # Read an explicit starting number for ordered lists
             if tag == "ol":
+                # Read an optional starting number from ordered lists.
                 start_attr = next((v for k, v in attrs if k == "start"), None)
                 if start_attr is not None:
                     with contextlib.suppress(TypeError, ValueError):
@@ -1187,7 +1321,7 @@ class HTMLMarkdownConverter(HTMLConverter):
                         # values.
                         counter = max(0, int(start_attr))
 
-            # Prepare the new list context
+            # Prepare the list-specific state inherited by its items.
             overrides = {
                 "do_store": False,
                 "list_type": tag,
@@ -1208,7 +1342,7 @@ class HTMLMarkdownConverter(HTMLConverter):
             if ctx["do_store"] and ctx["tag"] != "li":
                 self._open_line_boundary(ctx, strong=True)
 
-            # Activate the list context
+            # Open the list frame and suppress whitespace-only text nodes.
             self._push_frame(self._make_frame(tag, **overrides))
             return
 
@@ -1217,7 +1351,7 @@ class HTMLMarkdownConverter(HTMLConverter):
         if tag == "li":
             # An item value resets numbering for it and following siblings.
             if ctx["list_type"] == "ol" and ctx["counter"] is not None:
-                # Read an item-specific number override
+                # Read an optional per-item numbering override.
                 value_attr = next((v for k, v in attrs if k == "value"), None)
                 if value_attr is not None:
                     with contextlib.suppress(TypeError, ValueError):
@@ -1228,11 +1362,12 @@ class HTMLMarkdownConverter(HTMLConverter):
             # LIST_DEPTH_MAX
             indent = self._indent(ctx["depth"])
 
-            # Build the marker for the active list type
             if ctx["list_type"] == "ol" and ctx["counter"] is not None:
+                # Render the current ordered-list number.
                 marker_text = "{}{}. ".format(indent, ctx["counter"])
 
             else:
+                # Render a bullet for unordered or malformed list items.
                 marker_text = "{}- ".format(indent)
 
             # Tag the marker as converter-generated structure
@@ -1259,7 +1394,6 @@ class HTMLMarkdownConverter(HTMLConverter):
                 if not (
                     self._result and isinstance(self._result[-1], _Marker)
                 ):
-                    # Start a fresh line for this list item
                     self._result.append(self.BLOCK_END)
 
                     # Restate an enclosing quote prefix
@@ -1268,7 +1402,6 @@ class HTMLMarkdownConverter(HTMLConverter):
                             self._quote_prefix(ctx["quote_depth"])
                         )
 
-                # Append the item marker before its content
                 self._result.append(marker)
             return
 
@@ -1278,13 +1411,11 @@ class HTMLMarkdownConverter(HTMLConverter):
             # Clamp quote depth to keep generated prefixes bounded
             depth = min(ctx["quote_depth"] + 1, BLOCKQUOTE_DEPTH_MAX)
 
-            # Activate the new quote context
+            # Open a frame carrying the increased quote depth.
             new_frame = self._make_frame(tag, quote_depth=depth)
             self._push_frame(new_frame)
 
-            # Emit a prefix only when this context stores content
             if ctx["do_store"]:
-                # Inspect the token preceding this quote
                 last = self._result[-1] if self._result else None
 
                 # Extend an existing quote prefix
@@ -1294,13 +1425,11 @@ class HTMLMarkdownConverter(HTMLConverter):
                     if depth > ctx["quote_depth"]:
                         self._result.append(_QuoteMarker("> "))
 
-                # Add the quote prefix after another structural marker
                 elif isinstance(last, _Marker):
                     self._result.append(self._quote_prefix(depth))
 
                 # Separate a quote from preceding text.
                 elif isinstance(last, str):
-                    # Write the boundary using ctx's own (pre-nesting) depth.
                     self._write_boundary(ctx, strong=True)
 
                     if depth > ctx["quote_depth"]:
@@ -1324,11 +1453,10 @@ class HTMLMarkdownConverter(HTMLConverter):
                 or self._tag_open_counts.get("th")
             )
 
-            # Separate the table from preceding content
+            # Separate a representable table from preceding content.
             if ctx["do_store"] and not nested_in_cell:
                 self._open_line_boundary(ctx, strong=True)
 
-            # Activate a table context and suppress formatting whitespace
             self._push_frame(
                 self._make_frame(
                     tag,
@@ -1346,13 +1474,12 @@ class HTMLMarkdownConverter(HTMLConverter):
             # Finalize a malformed, unterminated previous row first.
             self._close_stale_row()
 
-            # Inspect the context containing this row
+            # Capture the table or container that owns the new row.
             row_ctx = self._stack[-1]
 
-            # Track whether the row belongs to a table
+            # Remember whether this row belongs to a real table frame.
             is_table = row_ctx["tag"] == "table"
 
-            # Activate a row context and collect its cells
             self._push_frame(
                 self._make_frame(
                     tag,
@@ -1373,11 +1500,11 @@ class HTMLMarkdownConverter(HTMLConverter):
             # Finalize an unterminated previous cell first.
             self._close_stale_cell()
 
-            # Inspect the context containing this cell
+            # Capture the row expected to own the new cell.
             cell_ctx = self._stack[-1]
 
-            # Capture cell content only inside a row
             if cell_ctx["tag"] == "tr":
+                # Record where this cell's buffered output begins.
                 self._push_frame(
                     self._make_frame(
                         tag,
@@ -1392,6 +1519,7 @@ class HTMLMarkdownConverter(HTMLConverter):
         # Buffer preformatted content until its closing tag.
 
         if tag in ("code", "pre", "samp"):
+            # Preserve raw whitespace until the matching closing tag.
             self._push_frame(
                 self._make_frame(tag, preserve_cr=True, buffer=[])
             )
@@ -1399,11 +1527,13 @@ class HTMLMarkdownConverter(HTMLConverter):
         # Resume text capture inside the document body.
 
         elif tag == "body":
+            # The document body always resumes visible text capture.
             self._push_frame(self._make_frame(tag, do_store=True))
 
         # Suppress content inside ignored containers.
 
         elif tag in self.IGNORE_TAGS:
+            # Ignored containers inherit context but disable text storage.
             self._push_frame(self._make_frame(tag, do_store=False))
 
         # Do not emit Markdown markers for suppressed content.
@@ -1428,23 +1558,28 @@ class HTMLMarkdownConverter(HTMLConverter):
             self._emit("---")
             self._result.append(self.BLOCK_END)
 
-        # Emit ATX heading markers
         elif tag == "h1":
+            # Render a level-one ATX heading marker.
             self._emit("# ")
 
         elif tag == "h2":
+            # Render a level-two ATX heading marker.
             self._emit("## ")
 
         elif tag == "h3":
+            # Render a level-three ATX heading marker.
             self._emit("### ")
 
         elif tag == "h4":
+            # Render a level-four ATX heading marker.
             self._emit("#### ")
 
         elif tag == "h5":
+            # Render a level-five ATX heading marker.
             self._emit("##### ")
 
         elif tag == "h6":
+            # Render a level-six ATX heading marker.
             self._emit("###### ")
 
         # Open an emphasis frame for bold or italic content
@@ -1452,7 +1587,6 @@ class HTMLMarkdownConverter(HTMLConverter):
             # A frame validates closing tags and relocates edge whitespace.
             delim = "**" if tag in ("strong", "b") else "*"
 
-            # Track the delimiter and output position for this span
             self._push_frame(
                 self._make_frame(
                     tag,
@@ -1464,7 +1598,7 @@ class HTMLMarkdownConverter(HTMLConverter):
                 )
             )
 
-            # Emit the opening emphasis delimiter
+            # Buffer the opening emphasis delimiter immediately.
             self._result.append(delim)
 
         # Open a Markdown link when an href is available
@@ -1477,13 +1611,14 @@ class HTMLMarkdownConverter(HTMLConverter):
 
             # Sanitize the destination before emitting Markdown
             if href is not None:
-                # Remove controls that invalidate angle-bracket destinations
+                # Remove controls that browsers ignore during URL parsing.
                 href = self._HREF_CONTROL_CHARS.sub("", href)
 
-                # Match browser URL parsing by trimming ASCII whitespace.
-                href = href.strip(self._ASCII_WHITESPACE)
+                # Strip all leading/trailing whitespace, including Unicode
+                # space characters that would otherwise bypass scheme checks.
+                href = href.strip()
 
-                # Identify any explicit URI scheme
+                # Extract an explicit URI scheme when one is present.
                 scheme = self._HREF_SCHEME.match(href)
 
                 # Neutralize schemes that can execute or expose local content
@@ -1499,10 +1634,10 @@ class HTMLMarkdownConverter(HTMLConverter):
                 safe_href = self.HREF_ESCAPE.sub(r"\\\1", href)
                 target = "<{}>".format(safe_href)
 
-                # Track the destination until the closing anchor
+                # Store the destination until all nested label text closes.
                 self._push_frame(self._make_frame(tag, href=target))
 
-                # Emit the opening link-label delimiter
+                # Begin the CommonMark link label.
                 self._emit("[")
 
     def handle_endtag(self, tag):
@@ -1512,7 +1647,6 @@ class HTMLMarkdownConverter(HTMLConverter):
         # content can still be read for this closing tag
         ctx = self._stack[-1]
 
-        # Close the nearest open link frame.
         if tag == "a":
             # Find the href stored in the nearest <a> frame
             href = None
@@ -1523,7 +1657,6 @@ class HTMLMarkdownConverter(HTMLConverter):
                     href = frame.get("href")
                     break
 
-            # Remove the anchor and any malformed child frames
             self._pop_to(tag)
 
             # Bare or suppressed anchors do not create link frames.
@@ -1536,12 +1669,13 @@ class HTMLMarkdownConverter(HTMLConverter):
         # Track list type, depth, and numbering.
 
         if tag in ("ul", "ol"):
-            # Restore the list's parent context.
+            # Ignore a list closer that has no corresponding open frame.
             if not self._pop_to(tag):
                 return
+
+            # Continue rendering in the restored parent context.
             parent = self._stack[-1]
 
-            # Separate following content when storage is active
             if parent["do_store"]:
                 self._write_boundary(parent, strong=parent["tag"] != "li")
             return
@@ -1554,21 +1688,30 @@ class HTMLMarkdownConverter(HTMLConverter):
             if not self._tag_open_counts.get(tag):
                 return
 
+            # Locate the actual li frame -- the top frame may be an unclosed
+            # child (e.g. <em> inside <li>text<em>bold</li>).
+            li_frame = next(
+                (f for f in reversed(self._stack) if f["tag"] == "li"),
+                ctx,
+            )
+
             # Empty items are dropped and do not advance ordered-list
             # numbering.
-            has_content = ctx["do_store"] and self._content_seq != ctx.get(
+            has_content = li_frame[
+                "do_store"
+            ] and self._content_seq != li_frame.get(
                 "content_seq_at_open", self._content_seq
             )
 
             # Block boundary closes the item content -- only if the item
-            # actually emitted a marker when it opened
-            if ctx["do_store"]:
+            # actually emitted a marker when it opened.
+            if li_frame["do_store"]:
                 self._result.append(self.BLOCK_END)
 
-            # Pop the li frame; parent ul/ol frame is now on top
+            # Pop the li frame (and any unclosed children above it).
             self._pop_to(tag)
 
-            # Advance the ordered-list counter in the parent frame
+            # The enclosing list is exposed after the item frame is removed.
             parent = self._stack[-1]
 
             # Increment numbering only for items that emitted content
@@ -1583,9 +1726,9 @@ class HTMLMarkdownConverter(HTMLConverter):
             # no open <blockquote> anywhere on the stack is a no-op.
             if not self._pop_to(tag):
                 return
+            # Continue rendering in the restored outer context.
             parent = self._stack[-1]
 
-            # Separate following content from the completed quote
             if parent["do_store"]:
                 self._write_boundary(parent, strong=True)
             return
@@ -1595,6 +1738,7 @@ class HTMLMarkdownConverter(HTMLConverter):
         if tag in ("td", "th"):
             # Ignore stray cell closers instead of emitting a block boundary.
             if ctx["tag"] == tag:
+                # Remove the frame before storing its value on the row.
                 self._pop_to(tag)
                 self._close_cell_frame(ctx)
             return
@@ -1604,8 +1748,8 @@ class HTMLMarkdownConverter(HTMLConverter):
             self._close_stale_cell()
             row_ctx = self._stack[-1]
 
-            # Finalize the matching row
             if row_ctx["tag"] == "tr":
+                # Remove the row before rendering it in the parent context.
                 self._pop_to(tag)
                 self._close_row_frame(row_ctx)
             return
@@ -1615,10 +1759,10 @@ class HTMLMarkdownConverter(HTMLConverter):
             self._close_stale_row()
             table_ctx = self._stack[-1]
 
-            # Finalize the matching table
             if table_ctx["tag"] == "table":
+                # Remove the table before emitting its trailing boundary.
                 self._pop_to(tag)
-                self._close_table_frame()
+                self._close_table_frame(table_ctx)
             return
 
         # Buffer preformatted content until its closing tag.
@@ -1628,7 +1772,7 @@ class HTMLMarkdownConverter(HTMLConverter):
             if ctx["do_store"] and ctx["tag"] == tag:
                 self._close_pre_frame(ctx, tag)
 
-            # Restore the context surrounding the code block
+            # Restore the context that preceded the preformatted element.
             self._pop_to(tag)
             return
 
@@ -1653,4 +1797,5 @@ class HTMLMarkdownConverter(HTMLConverter):
         # Pop frames created by container tags.
 
         if tag == "body" or tag in self.IGNORE_TAGS:
+            # Restore storage flags inherited from the enclosing frame.
             self._pop_to(tag)

--- a/apprise/conversion.py
+++ b/apprise/conversion.py
@@ -220,7 +220,7 @@ class HTMLConverter(HTMLParser):
 
 
 class HTMLMarkdownConverter(HTMLConverter):
-    """An HTML to Markdown converter tuned for email messages."""
+    """An HTML to Markdown converter tuned for notification messages."""
 
     # Override BLOCK_TAGS to exclude 'code' (handled inline with backticks)
     # and include 'samp' (treated as a fenced pre block like 'pre').
@@ -244,58 +244,294 @@ class HTMLMarkdownConverter(HTMLConverter):
     # Escape content characters that carry special meaning in Markdown
     MARKDOWN_ESCAPE = re.compile(r"([`*#])", re.DOTALL | re.MULTILINE)
 
+    # Matches the exact strings that <li> writes as bullet/number markers.
+    # Used to detect when a BLOCK_END would separate a marker from its
+    # first child element (e.g. <li><p>text</p></li>).
+    # Pattern: optional leading spaces, then "- " or "N. "
+    _LIST_MARKER_RE = re.compile(r"^\s*(?:\d+\.|-) $")
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        # href value of the current <a> tag; empty string means no link
-        self._link = ""
+        # Context stack.  The sentinel root frame at index 0 is never
+        # popped and represents top-level content outside every tag.
+        # Each frame is a dict with these keys:
+        #   tag         -- str|None  tag that opened this frame
+        #   do_store    -- bool      store text nodes encountered here?
+        #   preserve_cr -- bool      keep whitespace literally (pre/code)?
+        #   list_type   -- str|None  'ul', 'ol', or None
+        #   depth       -- int       list nesting depth (1 = outermost)
+        #   counter     -- int|None  next item number for 'ol' lists
+        #   href        -- str|None  href of an enclosing <a> tag; set
+        #                            only on frames pushed by <a>
+        #   buffer      -- list[str] raw text accumulated inside a
+        #                            code/pre/samp frame; only present
+        #                            on frames pushed by those tags --
+        #                            the matching close tag needs the
+        #                            full text up front to size a
+        #                            delimiter that cannot collide with
+        #                            backticks already in the content
+        self._stack = [
+            {
+                "tag": None,
+                "do_store": True,
+                "preserve_cr": False,
+                "list_type": None,
+                "depth": 0,
+                "counter": None,
+            }
+        ]
 
-        # True while inside a <code>, <pre>, or <samp> block so that
-        # carriage returns in the content are preserved rather than
-        # collapsed by WS_TRIM
-        self._preserve_cr = False
+    def _make_frame(self, tag, **overrides):
+        """Return a new frame inheriting all fields from the current top."""
+
+        # Copy every field from the parent frame as the default.
+        # The root sentinel is never popped, so self._stack[-1] should
+        # always succeed; the fallback guards against subclass misuse.
+        parent = (
+            self._stack[-1]
+            if self._stack
+            else {
+                "tag": None,
+                "do_store": True,
+                "preserve_cr": False,
+                "list_type": None,
+                "depth": 0,
+                "counter": None,
+            }
+        )
+        frame = {
+            "tag": tag,
+            "do_store": parent["do_store"],
+            "preserve_cr": parent["preserve_cr"],
+            "list_type": parent["list_type"],
+            "depth": parent["depth"],
+            "counter": parent["counter"],
+        }
+
+        # Apply tag-specific overrides on top of the inherited defaults
+        frame.update(overrides)
+        return frame
+
+    def _pop_to(self, tag):
+        """Pop frames until the one opened by *tag* is removed.
+
+        Scans from the top of the stack toward the root sentinel; if a
+        matching frame is found it and all frames above it are removed.
+        If no frame matches (unmatched close tag in malformed HTML) the
+        call is silently a no-op -- the root sentinel is never popped.
+        """
+        for i in range(len(self._stack) - 1, 0, -1):
+            if self._stack[i]["tag"] == tag:
+                # Remove the matched frame and everything above it
+                del self._stack[i:]
+                return
+
+    @staticmethod
+    def _longest_backtick_run(text):
+        """Return the length of the longest run of consecutive backticks
+        in *text*, used to size a delimiter that cannot be closed early
+        by backticks already present in code/pre content."""
+
+        longest = current = 0
+        for ch in text:
+            if ch == "`":
+                current += 1
+                longest = max(longest, current)
+            else:
+                current = 0
+
+        return longest
+
+    def _finalize(self, result):
+        """Like the parent but uses rstrip() to preserve leading indent
+        on list markers that come from items without a closing </li>."""
+
+        # None means the last item was a block boundary
+        accum = None
+
+        for item in result:
+            if item == self.BLOCK_END:
+                # Multiple consecutive boundaries -- absorb silently
+                if accum is None:
+                    continue
+
+                # Emit the current line, stripping only trailing space
+                yield accum.rstrip() + "\n"
+                accum = None
+
+            # Combine consecutive string fragments
+            elif accum is not None:
+                accum += item
+
+            # Start a new string accumulation
+            else:
+                accum = item
+
+        # Emit any remaining content without a trailing newline.
+        # rstrip() (not strip()) preserves leading indent from list
+        # markers whose </li> was omitted.
+        if accum is not None:
+            yield accum.rstrip()
 
     def handle_data(self, data, *args, **kwargs):
         """Store data, escaping Markdown special characters."""
 
-        if not self._do_store:
+        # Read current context from the stack top
+        ctx = self._stack[-1]
+
+        # Discard text when the current context suppresses content
+        if not ctx["do_store"]:
             return
 
-        # Preserve whitespace literally inside code/pre blocks;
-        # collapse whitespace runs to a single space everywhere else
-        content = data if self._preserve_cr else self.WS_TRIM.sub(" ", data)
+        if ctx["preserve_cr"]:
+            # Buffer raw text instead of writing straight to _result --
+            # the matching close tag needs the full content up front to
+            # size a delimiter that cannot collide with backticks
+            # already present in the text.  Nested tags never push
+            # their own frame while preserve_cr is set (handle_starttag
+            # treats them as inert), so ctx is always the frame that
+            # owns this buffer.
+            ctx["buffer"].append(data)
+            return
 
-        # Escape Markdown special characters only outside code/pre blocks --
-        # content inside backtick/fence delimiters is already treated as
-        # literal by all Markdown parsers; escaping there produces wrong output
-        if not self._preserve_cr:
-            content = self.MARKDOWN_ESCAPE.sub(r"\\\1", content)
+        # Collapse whitespace runs to a single space outside code/pre
+        content = self.WS_TRIM.sub(" ", data)
 
-        # Wrap in link syntax when we are inside an <a href="..."> tag
-        if self._link:
-            self._result.append("[" + content + "]" + self._link)
+        # Drop whitespace-only nodes that sit right after a block
+        # boundary or right after a list marker -- both are HTML
+        # indentation artifacts that must not appear as leading spaces
+        if not content.strip() and (
+            not self._result
+            or self._result[-1] == self.BLOCK_END
+            or (
+                isinstance(self._result[-1], str)
+                and self._LIST_MARKER_RE.match(self._result[-1])
+            )
+        ):
+            return
 
-        else:
-            self._result.append(content)
+        # Escape special Markdown characters -- code/pre content was
+        # already buffered above and never reaches this point
+        content = self.MARKDOWN_ESCAPE.sub(r"\\\1", content)
+
+        self._result.append(content)
 
     def handle_starttag(self, tag, attrs):
         """Process a starting HTML tag."""
 
-        # Determine whether text content inside this tag should be kept
-        self._do_store = tag not in self.IGNORE_TAGS
-        self._link = ""
+        # Capture the context before any push so list markers read
+        # the parent's depth and counter
+        ctx = self._stack[-1]
 
-        # Block-level elements force a line break before their content
-        if tag in self.BLOCK_TAGS:
-            self._result.append(self.BLOCK_END)
+        # Inside a code/pre/samp block, nested tags carry no special
+        # meaning -- only their literal text (handled by handle_data,
+        # unaffected since no frame is pushed here) joins the buffered
+        # content.  This also avoids markers from a nested tag (e.g.
+        # <a>) landing in _result out of order relative to the
+        # buffered text, which is only flushed once the enclosing
+        # code/pre/samp tag closes.
+        if ctx["preserve_cr"]:
+            return
+
+        # List containers: suppress direct text, track list kind
+
+        if tag in ("ul", "ol"):
+            self._stack.append(
+                self._make_frame(
+                    tag,
+                    do_store=False,
+                    list_type=tag,
+                    depth=ctx["depth"] + 1,
+                    counter=(1 if tag == "ol" else None),
+                )
+            )
+            return
+
+        # List items: re-enable text storage and emit a marker
 
         if tag == "li":
-            self._result.append("- ")
+            # Indent scales with nesting depth (depth 1 = no indent)
+            indent = "  " * (ctx["depth"] - 1)
+            if ctx["list_type"] == "ol" and ctx["counter"] is not None:
+                marker = "{}{}. ".format(indent, ctx["counter"])
+            else:
+                marker = "{}- ".format(indent)
 
-        elif tag == "br":
+            # Re-enable storage for this item's own content, but only
+            # if no ancestor OUTSIDE the list itself (e.g. <head> or
+            # <script>) is suppressing -- walk past list frames to find
+            # that ancestor's actual do_store state.  The root sentinel
+            # always matches, so this never falls back to the default.
+            do_store = next(
+                (
+                    f["do_store"]
+                    for f in reversed(self._stack)
+                    if f["tag"] not in ("ul", "ol", "li")
+                ),
+                True,
+            )
+
+            self._stack.append(self._make_frame(tag, do_store=do_store))
+
+            if do_store:
+                # Block boundary before the marker so it starts its own line
+                self._result.append(self.BLOCK_END)
+                self._result.append(marker)
+            return
+
+        # Literal-whitespace blocks: buffer raw content so the matching
+        # close tag can size a delimiter that avoids colliding with any
+        # backticks already present in the text
+
+        if tag in ("code", "pre", "samp"):
+            self._stack.append(
+                self._make_frame(tag, preserve_cr=True, buffer=[])
+            )
+
+        # <body> re-enables storage after a suppressing <html> frame
+
+        elif tag == "body":
+            self._stack.append(self._make_frame(tag, do_store=True))
+
+        # All other IGNORE_TAGS: suppress enclosed text
+
+        elif tag in self.IGNORE_TAGS:
+            self._stack.append(self._make_frame(tag, do_store=False))
+
+        # Suppressed containers (e.g. anything inside <head>/<script>)
+        # must not emit ANY Markdown syntax -- not just text.  Without
+        # this guard, tags like <b> or <h1> would still write "**"/"#"
+        # markers into the result even though their text is dropped.
+
+        if not ctx["do_store"]:
+            return
+
+        # Block boundary before block-level content.
+        # Exception: when a block element is the first child of a <li>,
+        # the marker ("- " or "N. ") is already in _result[-1] and a
+        # BLOCK_END would put them on separate lines.  Suppress it so
+        # the marker and the first block child share the same line.
+
+        if tag in self.BLOCK_TAGS:
+            if (
+                self._result
+                and isinstance(self._result[-1], str)
+                and self._LIST_MARKER_RE.match(self._result[-1])
+            ):
+                pass  # suppress; marker and content stay on one line
+
+            else:
+                self._result.append(self.BLOCK_END)
+
+        # Tag-specific Markdown output
+
+        if tag == "br":
             self._result.append("\n")
 
         elif tag == "hr":
+            # Strip trailing space from the previous token so the rule
+            # renders flush against the surrounding content
             if self._result and isinstance(self._result[-1], str):
                 self._result[-1] = self._result[-1].rstrip(" ")
 
@@ -328,35 +564,123 @@ class HTMLMarkdownConverter(HTMLConverter):
         elif tag in ("em", "i"):
             self._result.append("*")
 
-        elif tag == "code":
-            # Inline code -- no block boundary, just wrap in backticks
-            self._result.append("`")
-            self._preserve_cr = True
-
-        elif tag in ("pre", "samp"):
-            # Fenced code block -- the BLOCK_END above separates it from
-            # preceding content; a second BLOCK_END after the fence
-            # marker ensures the content starts on its own line
-            self._result.append("```")
-            self._result.append(self.BLOCK_END)
-            self._preserve_cr = True
-
         elif tag == "a":
-            # Build the link target from the href attribute
+            # Push a frame that carries the href so ALL content between
+            # <a> and </a> -- including nested bold/italic -- is wrapped
+            # in Markdown link syntax by handle_endtag("a")
             href = next(
                 (v for k, v in attrs if k == "href"),
                 None,
             )
             if href is not None:
-                self._link = "(" + href + ")"
+                # A bare link destination cannot contain whitespace;
+                # wrap it in angle brackets when it does
+                target = "<{}>".format(href) if " " in href else href
+                self._stack.append(self._make_frame(tag, href=target))
+                self._result.append("[")
 
     def handle_endtag(self, tag):
         """Edge case handling of close tags."""
 
-        self._do_store = True
-        self._link = ""
+        # Capture context before any pop so do_store and any buffered
+        # code/pre content can still be read for this closing tag
+        ctx = self._stack[-1]
 
-        # Block-level elements force a line break after their content
+        # Links: retrieve the href from the <a> frame, pop it, then
+        # close the Markdown link -- all content written between <a>
+        # and </a> (bold, italic, raw text) is now inside the brackets
+        if tag == "a":
+            # Find the href stored in the nearest <a> frame
+            href = None
+            for frame in reversed(self._stack):
+                if frame["tag"] == "a":
+                    href = frame.get("href")
+                    break
+
+            self._pop_to(tag)
+
+            # Only emit the closing if there was an href; a bare <a>
+            # without href, or one suppressed entirely by an ignored
+            # ancestor, never pushed a frame -- this is then a no-op
+            if href is not None:
+                self._result.append("](" + href + ")")
+
+            return
+
+        # List containers: pop the frame and return
+
+        if tag in ("ul", "ol"):
+            self._pop_to(tag)
+            return
+
+        # List items: emit boundary, pop, then advance ol counter
+
+        if tag == "li":
+            # Block boundary closes the item content -- only if the
+            # item actually emitted a marker when it opened
+            if ctx["do_store"]:
+                self._result.append(self.BLOCK_END)
+
+            # Pop the li frame; parent ul/ol frame is now on top
+            self._pop_to(tag)
+
+            # Advance the ordered-list counter in the parent frame
+            parent = self._stack[-1]
+            if parent["list_type"] == "ol":
+                parent["counter"] += 1
+
+            return
+
+        # Literal-whitespace blocks: emit the buffered content now that
+        # its full length is known, sizing the delimiter so it cannot
+        # collide with any backticks already present in the text
+
+        if tag in ("code", "pre", "samp"):
+            if ctx["do_store"] and ctx["tag"] == tag:
+                content = "".join(ctx.get("buffer", ()))
+                run = self._longest_backtick_run(content)
+
+                if tag == "code":
+                    # Inline code -- pad with a space when the content
+                    # starts or ends with a backtick (CommonMark's code
+                    # span disambiguation rule)
+                    delim = "`" * (run + 1)
+                    pad = (
+                        " "
+                        if not content
+                        or content[0] == "`"
+                        or content[-1] == "`"
+                        else ""
+                    )
+                    self._result.append(delim + pad + content + pad + delim)
+
+                else:
+                    # Fenced block -- widen the fence past the longest
+                    # run of backticks already present in the content
+                    fence = "`" * max(3, run + 1)
+                    self._result.append(fence)
+                    self._result.append(self.BLOCK_END)
+                    self._result.append(content)
+                    self._result.append(self.BLOCK_END)
+                    self._result.append(fence)
+                    self._result.append(self.BLOCK_END)
+
+            self._pop_to(tag)
+            return
+
+        # Suppressed containers emit no markers at all; only pop frames
+        # for tags that pushed one.  This also covers any tag nested
+        # inside a code/pre/samp block -- its opening was treated as
+        # inert above, so this closing must be a no-op too (the
+        # code/pre/samp tag's own matching close already returned out
+        # of the branch above and never reaches this point).
+
+        if not ctx["do_store"] or ctx["preserve_cr"]:
+            if tag == "body" or tag in self.IGNORE_TAGS:
+                self._pop_to(tag)
+            return
+
+        # Block boundary after block-level content
         if tag in self.BLOCK_TAGS:
             self._result.append(self.BLOCK_END)
 
@@ -366,13 +690,7 @@ class HTMLMarkdownConverter(HTMLConverter):
         elif tag in ("em", "i"):
             self._result.append("*")
 
-        elif tag == "code":
-            self._result.append("`")
-            self._preserve_cr = False
+        # Pop frames for all tags that pushed them
 
-        elif tag in ("pre", "samp"):
-            # The BLOCK_END from BLOCK_TAGS above ends the content line;
-            # the closing fence and a second BLOCK_END close the block
-            self._result.append("```")
-            self._result.append(self.BLOCK_END)
-            self._preserve_cr = False
+        if tag == "body" or tag in self.IGNORE_TAGS:
+            self._pop_to(tag)

--- a/apprise/conversion.py
+++ b/apprise/conversion.py
@@ -669,12 +669,24 @@ class HTMLMarkdownConverter(HTMLConverter):
         self._content_seq += 1
 
     def _push_frame(self, frame):
-        """Push a new context frame and update the open-tag counter."""
+        """Push a new context frame and update the open-tag counter.
+
+        Returns True when the frame was accepted, False when it was
+        silently discarded because MAX_FRAME_DEPTH was reached.
+
+        Callers that emit Markdown delimiters (emphasis, anchor) MUST
+        check this return value before appending the opening delimiter.
+        Emitting a delimiter without a matching frame leaves it unclosed
+        and produces malformed Markdown when the input is adversarially
+        deep.
+        """
 
         # Silently discard frames beyond the depth cap so adversarially
-        # nested HTML cannot exhaust memory.
+        # nested HTML cannot exhaust memory.  Return False so callers that
+        # emit inline Markdown delimiters can gate that emission on the
+        # result and avoid producing unmatched delimiters in the output.
         if len(self._stack) >= MAX_FRAME_DEPTH:
-            return
+            return False
 
         # Add the frame to the context stack.
         self._stack.append(frame)
@@ -683,6 +695,8 @@ class HTMLMarkdownConverter(HTMLConverter):
         # _pop_to() can reject unmatched closing tags in O(1).
         tag = frame["tag"]
         self._tag_open_counts[tag] = self._tag_open_counts.get(tag, 0) + 1
+
+        return True
 
     def _pop_to(self, tag):
         """Pop through the nearest match and report whether one existed."""
@@ -1378,7 +1392,10 @@ class HTMLMarkdownConverter(HTMLConverter):
             do_store = ctx["list_do_store"]
 
             # Snapshot content state for constant-time empty-item detection.
-            self._push_frame(
+            # Gate marker emission on the return value: at MAX_FRAME_DEPTH
+            # the frame is discarded and we must not append the marker,
+            # otherwise there is nothing to pop it on </li>.
+            if not self._push_frame(
                 self._make_frame(
                     tag,
                     do_store=do_store,
@@ -1387,7 +1404,8 @@ class HTMLMarkdownConverter(HTMLConverter):
                         ctx["list_indent_base"] + " " * len(marker_text)
                     ),
                 )
-            )
+            ):
+                return
 
             if do_store:
                 # Reuse a pending quote or list marker on this line.
@@ -1412,8 +1430,12 @@ class HTMLMarkdownConverter(HTMLConverter):
             depth = min(ctx["quote_depth"] + 1, BLOCKQUOTE_DEPTH_MAX)
 
             # Open a frame carrying the increased quote depth.
+            # Gate marker emission on the return value: at MAX_FRAME_DEPTH
+            # the frame is discarded and we must not append a _QuoteMarker,
+            # otherwise there is nothing to pop it on </blockquote>.
             new_frame = self._make_frame(tag, quote_depth=depth)
-            self._push_frame(new_frame)
+            if not self._push_frame(new_frame):
+                return
 
             if ctx["do_store"]:
                 last = self._result[-1] if self._result else None
@@ -1587,7 +1609,12 @@ class HTMLMarkdownConverter(HTMLConverter):
             # A frame validates closing tags and relocates edge whitespace.
             delim = "**" if tag in ("strong", "b") else "*"
 
-            self._push_frame(
+            # Only emit the opening delimiter when the frame was accepted.
+            # If the depth cap was hit, _push_frame returns False and we
+            # skip both the frame and its delimiter -- an unmatched "**"
+            # or "*" in the output would be worse than silently dropping
+            # the emphasis on text that is already deeply nested.
+            if self._push_frame(
                 self._make_frame(
                     tag,
                     emphasis_delim=delim,
@@ -1596,10 +1623,10 @@ class HTMLMarkdownConverter(HTMLConverter):
                     # Exact delimiter index used when removing an empty span.
                     emphasis_result_start=len(self._result),
                 )
-            )
-
-            # Buffer the opening emphasis delimiter immediately.
-            self._result.append(delim)
+            ):
+                # Frame accepted: buffer the opening delimiter immediately
+                # so the matching closing tag can emit the close delimiter.
+                self._result.append(delim)
 
         # Open a Markdown link when an href is available
         elif tag == "a":
@@ -1635,10 +1662,14 @@ class HTMLMarkdownConverter(HTMLConverter):
                 target = "<{}>".format(safe_href)
 
                 # Store the destination until all nested label text closes.
-                self._push_frame(self._make_frame(tag, href=target))
-
-                # Begin the CommonMark link label.
-                self._emit("[")
+                # Only emit "[" when the frame was accepted -- skipping it
+                # when the depth cap is hit prevents an unmatched "[" from
+                # reaching the output (which would produce "[label" with no
+                # closing "](url)" when the closing </a> fires and finds no
+                # frame to pop).
+                if self._push_frame(self._make_frame(tag, href=target)):
+                    # Frame accepted: begin the CommonMark link label.
+                    self._emit("[")
 
     def handle_endtag(self, tag):
         """Handle a closing HTML tag."""

--- a/apprise/conversion.py
+++ b/apprise/conversion.py
@@ -25,6 +25,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import contextlib
 from html.parser import HTMLParser
 import re
 
@@ -32,6 +33,43 @@ from markdown import markdown
 
 from .common import NotifyFormat
 from .url import URLBase
+
+# Cap list indentation so deeply nested input stays linear.
+LIST_DEPTH_MAX = 4
+
+# Apply the same depth cap to blockquote prefixes.
+BLOCKQUOTE_DEPTH_MAX = 4
+
+
+class _Marker(str):
+    """Identify converter-generated structure."""
+
+
+class _ListMarker(_Marker):
+    """Identify a generated list marker."""
+
+
+class _QuoteMarker(_Marker):
+    """Identify a generated quote prefix."""
+
+
+class _ListIndent(_Marker):
+    """Identify list continuation indentation."""
+
+
+class _ParaBreak:
+    """Represent a paragraph boundary and its prefix."""
+
+    __slots__ = ("in_quote", "prefix")
+
+    def __init__(self, prefix="", in_quote=False):
+        """Initialize a paragraph boundary."""
+
+        # Store the continuation prefix
+        self.prefix = prefix
+
+        # Track whether the boundary remains inside a quote
+        self.in_quote = in_quote
 
 
 def convert_between(from_format, to_format, content):
@@ -41,6 +79,7 @@ def convert_between(from_format, to_format, content):
     This function returns the content translated (if required)
     """
 
+    # Map each supported format pair to its converter
     converters = {
         (NotifyFormat.MARKDOWN, NotifyFormat.HTML): markdown_to_html,
         (NotifyFormat.TEXT, NotifyFormat.HTML): text_to_html,
@@ -48,12 +87,17 @@ def convert_between(from_format, to_format, content):
         (NotifyFormat.HTML, NotifyFormat.MARKDOWN): html_to_markdown,
     }
 
+    # Fetch the requested converter
     convert = converters.get((from_format, to_format))
+
+    # Preserve the original content when no conversion is available
     return convert(content) if convert else content
 
 
 def markdown_to_html(content):
     """Converts specified content from markdown to HTML."""
+
+    # Enable line-break and table extensions used by notification content
     return markdown(
         content,
         extensions=["markdown.extensions.nl2br", "markdown.extensions.tables"],
@@ -70,18 +114,28 @@ def text_to_html(content):
 def html_to_text(content):
     """Converts a content from HTML to plain text."""
 
+    # Initialize our plain-text parser
     parser = HTMLConverter()
+
+    # Feed and finalize the HTML document
     parser.feed(content)
     parser.close()
+
+    # Return the converted content
     return parser.converted
 
 
 def html_to_markdown(content):
     """Converts a content from HTML to Markdown."""
 
+    # Initialize our Markdown parser
     parser = HTMLMarkdownConverter()
+
+    # Feed and finalize the HTML document
     parser.feed(content)
     parser.close()
+
+    # Return the converted content
     return parser.converted
 
 
@@ -131,6 +185,9 @@ class HTMLConverter(HTMLParser):
     BLOCK_END = {}
 
     def __init__(self, **kwargs):
+        """Initialize the HTML converter."""
+
+        # Initialize the base HTML parser
         super().__init__(**kwargs)
 
         # Shoudl we store the text content or not?
@@ -144,7 +201,12 @@ class HTMLConverter(HTMLParser):
         self.converted = ""
 
     def close(self):
+        """Finalize the converted content."""
+
+        # Combine all buffered content
         string = "".join(self._finalize(self._result))
+
+        # Store the normalized result
         self.converted = string.strip()
 
     def _finalize(self, result):
@@ -222,36 +284,85 @@ class HTMLConverter(HTMLParser):
 class HTMLMarkdownConverter(HTMLConverter):
     """An HTML to Markdown converter tuned for notification messages."""
 
-    # Override BLOCK_TAGS to exclude 'code' (handled inline with backticks)
-    # and include 'samp' (treated as a fenced pre block like 'pre').
-    BLOCK_TAGS = (
-        "p",
-        "h1",
-        "h2",
-        "h3",
-        "h4",
-        "h5",
-        "h6",
-        "div",
-        "td",
-        "th",
-        "pre",
-        "samp",
-        "label",
-        "li",
+    # Define tags that create Markdown block boundaries.
+    BLOCK_TAGS = frozenset(
+        {
+            "p",
+            "h1",
+            "h2",
+            "h3",
+            "h4",
+            "h5",
+            "h6",
+            "div",
+            "td",
+            "th",
+            "pre",
+            "samp",
+            "label",
+            "li",
+        }
     )
 
-    # Escape content characters that carry special meaning in Markdown
-    MARKDOWN_ESCAPE = re.compile(r"([`*#])", re.DOTALL | re.MULTILINE)
+    # Paragraph-like blocks need blank-line separation in CommonMark.
+    _PARA_LIKE_TAGS = frozenset({"p", "div", "td", "th", "label"})
 
-    # Matches the exact strings that <li> writes as bullet/number markers.
-    # Used to detect when a BLOCK_END would separate a marker from its
-    # first child element (e.g. <li><p>text</p></li>).
-    # Pattern: optional leading spaces, then "- " or "N. "
-    _LIST_MARKER_RE = re.compile(r"^\s*(?:\d+\.|-) $")
+    # Reuse a plain paragraph boundary outside blockquotes.
+    PARA_BREAK = _ParaBreak()
+
+    # Escape characters that could become inline Markdown.
+    MARKDOWN_ESCAPE = re.compile(
+        r"([\\`*_~#\[\]()!<>])", re.DOTALL | re.MULTILINE
+    )
+
+    # Escape block syntax only when it appears at the start of a line.
+    #
+    # Match ordered-list markers at the start of a line.
+    _ORDERED_MARKER_RE = re.compile(r"^\d+\.(?=[ \t]|$)")
+
+    # Match bullet markers at the start of a line.
+    _BULLET_MARKER_RE = re.compile(r"^[-+](?=[ \t]|$)")
+
+    # Match thematic breaks and setext heading underlines.
+    _THEMATIC_BREAK_RE = re.compile(r"^([-=])(?:[ \t]*\1){2,}$")
+
+    # Collapse ASCII whitespace when flattening table cells.
+    _CELL_WHITESPACE_RUN = re.compile(r"[ \t\r\f\v]+")
+
+    # Escape angle-bracket link destinations.
+    HREF_ESCAPE = re.compile(r"([\\<>])")
+
+    # Remove control characters that invalidate link destinations.
+    _HREF_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+
+    # Detect URI schemes before sanitizing links.
+    _HREF_SCHEME = re.compile(r"^([a-zA-Z][a-zA-Z0-9+.-]*):")
+
+    # Block executable and local URI schemes while allowing app links.
+    _UNSAFE_HREF_SCHEMES = frozenset(
+        {"javascript", "vbscript", "data", "file"}
+    )
+
+    # Trim ASCII whitespace without removing deliberate non-breaking spaces.
+    _ASCII_WHITESPACE = " \t\n\r\x0b\x0c"
 
     def __init__(self, **kwargs):
+        """Initialize the HTML-to-Markdown converter."""
+
+        # Initialize the base converter
         super().__init__(**kwargs)
+
+        # Cache indentation by list depth.
+        self._indent_cache = [""]
+
+        # Cache prefixes by blockquote depth.
+        self._quote_prefix_cache = [""]
+
+        # Track open tags for constant-time unmatched-close checks.
+        self._tag_open_counts = {}
+
+        # Track whether the current frame emitted real content.
+        self._content_seq = 0
 
         # Context stack.  The sentinel root frame at index 0 is never
         # popped and represents top-level content outside every tag.
@@ -260,8 +371,38 @@ class HTMLMarkdownConverter(HTMLConverter):
         #   do_store    -- bool      store text nodes encountered here?
         #   preserve_cr -- bool      keep whitespace literally (pre/code)?
         #   list_type   -- str|None  'ul', 'ol', or None
-        #   depth       -- int       list nesting depth (1 = outermost)
+        #   depth       -- int       list nesting depth (1 = outermost),
+        #                            clamped to LIST_DEPTH_MAX
         #   counter     -- int|None  next item number for 'ol' lists
+        #   list_do_store -- bool    do_store of the list's own parent
+        #                            (the nearest non-ul/ol/li ancestor),
+        #                            saved here when the ul/ol is pushed
+        #                            so <li> can read it directly instead
+        #                            of walking back up the stack
+        #   quote_depth -- int       blockquote nesting depth (1 = outermost),
+        #                            clamped to BLOCKQUOTE_DEPTH_MAX; 0
+        #                            means "not inside a blockquote"
+        #   list_indent -- str       spaces a continuation line needs to
+        #                            stay part of the current <li> --
+        #                            "" outside any list. Combined with
+        #                            quote_depth's "> " (in whichever
+        #                            order they were actually nested)
+        #                            by _write_boundary() for any line
+        #                            that needs to restate it.
+        #   list_indent_base -- str  list_indent from *outside* the
+        #                            entire list-nesting chain (e.g.
+        #                            from an enclosing <blockquote>) --
+        #                            captured once where that chain
+        #                            starts (depth 0 -> 1) and inherited
+        #                            unchanged by every level nested
+        #                            inside it after that. <li> adds
+        #                            only its own marker's width on top
+        #                            of *this*, not the immediately
+        #                            enclosing list's full list_indent,
+        #                            since that would double-count: a
+        #                            nested marker's own leading spaces
+        #                            (from _indent(depth)) already cover
+        #                            every outer list level's width.
         #   href        -- str|None  href of an enclosing <a> tag; set
         #                            only on frames pushed by <a>
         #   buffer      -- list[str] raw text accumulated inside a
@@ -279,15 +420,17 @@ class HTMLMarkdownConverter(HTMLConverter):
                 "list_type": None,
                 "depth": 0,
                 "counter": None,
+                "list_do_store": True,
+                "quote_depth": 0,
+                "list_indent": "",
+                "list_indent_base": "",
             }
         ]
 
     def _make_frame(self, tag, **overrides):
-        """Return a new frame inheriting all fields from the current top."""
+        """Create a frame from the current context."""
 
-        # Copy every field from the parent frame as the default.
-        # The root sentinel is never popped, so self._stack[-1] should
-        # always succeed; the fallback guards against subclass misuse.
+        # Inherit frame defaults from the parent context.
         parent = (
             self._stack[-1]
             if self._stack
@@ -298,6 +441,10 @@ class HTMLMarkdownConverter(HTMLConverter):
                 "list_type": None,
                 "depth": 0,
                 "counter": None,
+                "list_do_store": True,
+                "quote_depth": 0,
+                "list_indent": "",
+                "list_indent_base": "",
             }
         )
         frame = {
@@ -307,317 +454,1011 @@ class HTMLMarkdownConverter(HTMLConverter):
             "list_type": parent["list_type"],
             "depth": parent["depth"],
             "counter": parent["counter"],
+            "list_do_store": parent["list_do_store"],
+            "quote_depth": parent["quote_depth"],
+            "list_indent": parent["list_indent"],
+            "list_indent_base": parent["list_indent_base"],
         }
 
-        # Apply tag-specific overrides on top of the inherited defaults
+        # Apply tag-specific frame state.
         frame.update(overrides)
         return frame
 
-    def _pop_to(self, tag):
-        """Pop frames until the one opened by *tag* is removed.
+    def _indent(self, depth):
+        """Return cached indentation for a list depth."""
 
-        Scans from the top of the stack toward the root sentinel; if a
-        matching frame is found it and all frames above it are removed.
-        If no frame matches (unmatched close tag in malformed HTML) the
-        call is silently a no-op -- the root sentinel is never popped.
-        """
+        # Convert the one-based depth into a cache index
+        idx = max(depth - 1, 0)
+
+        # Reference the cache locally for repeated access
+        cache = self._indent_cache
+
+        # Populate any missing indentation levels
+        while len(cache) <= idx:
+            cache.append(cache[-1] + "  ")
+
+        # Return the requested indentation
+        return cache[idx]
+
+    def _quote_prefix(self, depth):
+        """Return the prefix for a quote depth."""
+
+        # Normalize the requested quote depth
+        idx = max(depth, 0)
+
+        # Reference the cache locally for repeated access
+        cache = self._quote_prefix_cache
+
+        # Populate any missing quote levels
+        while len(cache) <= idx:
+            cache.append(_QuoteMarker(cache[-1] + "> "))
+
+        # Return the requested quote prefix
+        return cache[idx]
+
+    def _continuation_prefix(self, ctx):
+        """Return the prefix for a continuation line."""
+
+        # Start with the active list indentation
+        prefix = ctx["list_indent"]
+
+        # Add any active blockquote prefix
+        if ctx["quote_depth"]:
+            prefix += self._quote_prefix(ctx["quote_depth"])
+
+        # Return the combined continuation prefix
+        return prefix
+
+    def _write_boundary(self, ctx, strong=False):
+        """Append a line or paragraph boundary."""
+
+        # Resolve the prefix needed by the next line
+        prefix = self._continuation_prefix(ctx)
+
+        # Write an ordinary line boundary
+        if not strong:
+            self._result.append(self.BLOCK_END)
+
+            # Restate any active quote or list prefix
+            if prefix:
+                self._result.append(
+                    _QuoteMarker(prefix)
+                    if ctx["quote_depth"]
+                    else _ListIndent(prefix)
+                )
+
+            # The ordinary boundary is complete
+            return
+
+        # Preserve nesting across a paragraph boundary
+        if prefix:
+            self._result.append(
+                _ParaBreak(prefix, in_quote=bool(ctx["quote_depth"]))
+            )
+
+        # Use the shared top-level paragraph boundary
+        else:
+            self._result.append(self.PARA_BREAK)
+
+    def _open_line_boundary(self, ctx, strong=False):
+        """Start a block unless it can join a marker."""
+
+        # Keep pending list and quote markers on the same line
+        if self._result and isinstance(self._result[-1], _Marker):
+            return  # suppress; marker and content stay on one line
+
+        # Start a new line or paragraph
+        self._write_boundary(ctx, strong=strong)
+
+    def _emit(self, text):
+        """Append content and update the content sequence."""
+
+        # Append real content to the output buffer
+        self._result.append(text)
+
+        # Record that the active frames produced content
+        self._content_seq += 1
+
+    def _push_frame(self, frame):
+        """Push a frame and track its tag."""
+
+        # Push the new parsing context
+        self._stack.append(frame)
+
+        # Track the number of open frames for this tag
+        tag = frame["tag"]
+        self._tag_open_counts[tag] = self._tag_open_counts.get(tag, 0) + 1
+
+    def _pop_to(self, tag):
+        """Pop through the nearest matching frame."""
+
+        # Reject unmatched closing tags without scanning the stack
+        if not self._tag_open_counts.get(tag):
+            return
+
+        # Search backward for the nearest matching frame
         for i in range(len(self._stack) - 1, 0, -1):
             if self._stack[i]["tag"] == tag:
-                # Remove the matched frame and everything above it
+                # Remove the matched frame and everything above it, discounting
+                # each one from _tag_open_counts so it stays accurate for
+                # whatever's left on the stack
+                for frame in self._stack[i:]:
+                    self._tag_open_counts[frame["tag"]] -= 1
+
+                # Remove the matching frame and its descendants
                 del self._stack[i:]
                 return
 
+    def _close_emphasis_frame(self, frame):
+        """Close an emphasis frame with content."""
+
+        # Determine whether the span emitted real content
+        has_content = self._content_seq != frame.get(
+            "content_seq_at_open", self._content_seq
+        )
+
+        if not has_content:
+            # Remove the opening delimiter and any empty nested tokens.
+            del self._result[frame["emphasis_result_start"] :]
+            return
+
+        # Collect whitespace that belongs outside the closing delimiter
+        trailing = ""
+        while self._result and type(self._result[-1]) is str:
+            last = self._result[-1]
+            rstripped = last.rstrip(self._ASCII_WHITESPACE)
+
+            # Stop once the fragment has no trailing whitespace
+            if rstripped == last:
+                break
+
+            # Prepend whitespace gathered from this fragment
+            trailing = last[len(rstripped) :] + trailing
+
+            # Keep any non-whitespace portion in place
+            if rstripped:
+                self._result[-1] = rstripped
+                break
+
+            # Drop fragments containing only whitespace
+            self._result.pop()
+
+        # Emit the closing emphasis delimiter
+        self._emit(frame["emphasis_delim"])
+
+        # Restore trailing whitespace outside the span
+        if trailing:
+            self._result.append(trailing)
+
+    def _close_cell_frame(self, frame):
+        """Capture a completed table cell."""
+
+        # Extract tokens written since this cell opened
+        start = frame["cell_result_start"]
+        chunk = self._result[start:]
+        del self._result[start:]
+
+        if not frame["do_store"]:
+            # Suppressed tables must not emit empty cells.
+            return
+
+        # Finalize the cell into a single Markdown fragment
+        text = "".join(self._finalize(chunk)).strip(self._ASCII_WHITESPACE)
+
+        # A Markdown table row is exactly one line -- any newline the cell's
+        # own content produced (a <br>, a nested block) is flattened to a
+        # single space rather than corrupting the row.
+        if "\n" in text:
+            text = " ".join(text.split("\n"))
+            text = self._CELL_WHITESPACE_RUN.sub(" ", text).strip(
+                self._ASCII_WHITESPACE
+            )
+
+        # '|' is the cell delimiter itself; escape any literal one in the
+        # content so it can't be misread as starting a new column.
+        if "|" in text:
+            text = text.replace("|", "\\|")
+
+        # Add the completed cell to its row
+        self._stack[-1]["cells"].append(text)
+
+    def _close_row_frame(self, frame):
+        """Render a completed table row."""
+
+        # Fetch all cells collected for this row
+        cells = frame["cells"]
+
+        # Drop rows that never opened a cell
+        if not cells:
+            return  # an entirely empty row (no cells at all) is dropped
+
+        # Identify whether this is the table's header row
+        table = frame.get("table_frame")
+        is_header = table is None or table["table_rows"] == 0
+
+        # Advance the enclosing table's row count
+        if table is not None:
+            table["table_rows"] += 1
+
+        # Emit the completed row in the parent context
+        ctx = self._stack[-1]
+        self._open_line_boundary(ctx, strong=False)
+        self._emit("| " + " | ".join(cells) + " |")
+
+        # Add the required separator after the header row
+        if is_header:
+            # _write_boundary() (not a bare BLOCK_END) so a list item's
+            # indentation or an enclosing blockquote's "> " is restated in
+            # front of the separator line too, the same as it would be for any
+            # other continuation line of this table.
+            self._write_boundary(ctx, strong=False)
+            self._emit("| " + " | ".join(["---"] * len(cells)) + " |")
+
+    def _close_table_frame(self):
+        """Finish a table boundary."""
+
+        # Restore the context surrounding the table
+        parent = self._stack[-1]
+
+        # Separate any following content from the table
+        if parent["do_store"]:
+            self._write_boundary(parent, strong=True)
+
+    def _close_stale_cell(self):
+        """Close an implicitly terminated cell."""
+
+        # Inspect the current frame for an unclosed cell
+        top = self._stack[-1]
+
+        # Finalize the cell before its sibling begins
+        if top["tag"] in ("td", "th"):
+            self._pop_to(top["tag"])
+            self._close_cell_frame(top)
+
+    def _close_stale_row(self):
+        """Close an implicitly terminated row."""
+
+        # Close any cell still open in the row
+        self._close_stale_cell()
+
+        # Inspect the remaining top-level frame
+        top = self._stack[-1]
+
+        # Finalize the row before its sibling begins
+        if top["tag"] == "tr":
+            self._pop_to("tr")
+            self._close_row_frame(top)
+
+    def close(self):
+        """Close malformed frames before finalizing output."""
+
+        # Recover frames left open at the end of the document
+        while len(self._stack) > 1:
+            top = self._stack[-1]
+            tag = top["tag"]
+
+            # Remove the current frame from the active stack
+            self._pop_to(tag)
+
+            # Finalize content captured by special frames
+            if top.get("emphasis_delim"):
+                self._close_emphasis_frame(top)
+            elif tag in ("td", "th"):
+                self._close_cell_frame(top)
+            elif tag == "tr":
+                self._close_row_frame(top)
+            elif tag == "table":
+                self._close_table_frame()
+
+        # Let the base converter assemble the final output
+        super().close()
+
     @staticmethod
     def _longest_backtick_run(text):
-        """Return the length of the longest run of consecutive backticks
-        in *text*, used to size a delimiter that cannot be closed early
-        by backticks already present in code/pre content."""
+        """Return the longest consecutive backtick run."""
 
+        # Track both the active and longest runs
         longest = current = 0
+
+        # Scan the content one character at a time
         for ch in text:
             if ch == "`":
                 current += 1
                 longest = max(longest, current)
+
+            # Reset the active run on non-backtick content
             else:
                 current = 0
 
+        # Return the delimiter width already present in the content
         return longest
 
     def _finalize(self, result):
-        """Like the parent but uses rstrip() to preserve leading indent
-        on list markers that come from items without a closing </li>."""
+        """Combine tokens into normalized Markdown lines."""
 
-        # None means the last item was a block boundary
+        # Track whether a line is waiting after a boundary.
         accum = None
 
+        # Whether accum, so far, is composed only of marker fragments
+        accum_is_marker = False
+
+        # Set when a boundary was absorbed while accum was marker-only -- see
+        # the docstring above
+        marker_boundary_passed = False
+
+        # Set once accum holds real content and at least one boundary has been
+        # seen since -- the line is done, but not yet flushed (see the
+        # docstring above)
+        terminated = False
+
+        # Set when a plain (no prefix at all) _ParaBreak has been seen since
+        # accum was last extended with real content
+        para_break_seen = False
+
+        # The prefix of a _ParaBreak seen since accum was last extended with
+        # real content, if it had one (list indent and/or a blockquote's "> ")
+        # -- takes priority over para_break_seen when both are set
+        para_break_prefix = None
+
+        # Whether para_break_prefix came from a _ParaBreak with in_quote set --
+        # see _ParaBreak
+        para_break_in_quote = False
+
+        # Set when a boundary arrives *after* the line was already terminated
+        # -- i.e. anything beyond the single boundary that did the terminating.
+        boundary_after_terminate = False
+
+        # Process each buffered content or boundary token
         for item in result:
-            if item == self.BLOCK_END:
-                # Multiple consecutive boundaries -- absorb silently
+            # Collect boundary state before flushing the current line
+            if item == self.BLOCK_END or isinstance(item, _ParaBreak):
+                # Record the strongest paragraph boundary in this run
+                if isinstance(item, _ParaBreak):
+                    # The most recent _ParaBreak in a run reflects the current
+                    # context (e.g. a blockquote that closed partway through
+                    # the run) -- always overwrite rather than keeping an
+                    # earlier, now-stale prefix from before that exit.
+                    if item.prefix:
+                        # Keep the prefix required by the next line
+                        para_break_prefix = item.prefix
+                        para_break_in_quote = item.in_quote
+
+                    # Record a top-level paragraph boundary
+                    else:
+                        para_break_seen = True
+                        para_break_prefix = None
+                        para_break_in_quote = False
+
+                # Absorb boundaries until real content arrives.
                 if accum is None:
                     continue
 
-                # Emit the current line, stripping only trailing space
-                yield accum.rstrip() + "\n"
-                accum = None
+                # Keep an unused structural marker pending
+                if accum_is_marker:
+                    marker_boundary_passed = True
+                    continue
 
-            # Combine consecutive string fragments
-            elif accum is not None:
-                accum += item
+                # Remember boundaries beyond the one ending this line
+                if terminated:
+                    boundary_after_terminate = True
 
-            # Start a new string accumulation
+                terminated = True
+                continue
+
+            # Flush the previous line before adding new content.
+            if terminated:
+                # Resolve the separator for a prefixed paragraph
+                if para_break_prefix is not None:
+                    # Keep blank lines inside an active quote
+                    if para_break_in_quote:
+                        blank = para_break_prefix.rstrip(
+                            self._ASCII_WHITESPACE
+                        )
+                        sep = "\n" + blank + "\n"
+
+                    # Lists use an ordinary blank paragraph line
+                    else:
+                        sep = "\n\n"
+
+                # Use a blank line for a top-level paragraph break
+                elif para_break_seen:
+                    sep = "\n\n"
+
+                # Fall back to a single line break
+                else:
+                    sep = "\n"
+
+                # Emit the completed line and separator
+                yield accum.rstrip(self._ASCII_WHITESPACE) + sep
+
+                # Seed the next line with any active list or quote prefix.
+                if para_break_prefix is not None:
+                    accum = (
+                        _QuoteMarker(para_break_prefix)
+                        if para_break_in_quote
+                        else _ListIndent(para_break_prefix)
+                    )
+                    accum_is_marker = True
+                    marker_boundary_passed = boundary_after_terminate
+
+                # Start without a structural prefix
+                else:
+                    accum = None
+                    accum_is_marker = False
+                    marker_boundary_passed = False
+
+                # Reset state gathered for the completed line
+                terminated = False
+                para_break_seen = False
+                para_break_prefix = None
+                para_break_in_quote = False
+                boundary_after_terminate = False
+
+            # Append this token to the active line
+            if accum is not None:
+                item_is_marker = isinstance(item, _Marker)
+                if (
+                    marker_boundary_passed
+                    and accum_is_marker
+                    and item_is_marker
+                ):
+                    # A new marker after the old one sat through a boundary
+                    # unused -- start over with this one
+                    accum = item
+                    accum_is_marker = True
+
+                else:
+                    # Combine consecutive string fragments
+                    accum += item
+                    accum_is_marker = accum_is_marker and item_is_marker
+
+                marker_boundary_passed = False
+
+            # Start a new string accumulation.
             else:
+                # Seed a new line with this token
                 accum = item
+                accum_is_marker = isinstance(item, _Marker)
+                para_break_seen = False
+                para_break_prefix = None
+                para_break_in_quote = False
 
-        # Emit any remaining content without a trailing newline.
-        # rstrip() (not strip()) preserves leading indent from list
-        # markers whose </li> was omitted.
-        if accum is not None:
-            yield accum.rstrip()
+        # Emit the final non-marker content without a trailing newline.
+        if accum is not None and not accum_is_marker:
+            yield accum.rstrip(self._ASCII_WHITESPACE)
+
+    def _escape_line_start(self, content):
+        """Escape text that could become block syntax."""
+
+        # Look for an ordered-list marker
+        ordered = self._ORDERED_MARKER_RE.match(content)
+        if ordered:
+            # Escape just the '.', not the digits themselves
+            dot = ordered.end() - 1
+            return content[:dot] + "\\" + content[dot:]
+
+        # Escape an unordered-list marker
+        if self._BULLET_MARKER_RE.match(content):
+            return "\\" + content
+
+        # Ignore surrounding whitespace while checking the full line
+        trimmed = content.strip(self._ASCII_WHITESPACE)
+
+        # Escape thematic breaks and setext underlines
+        if trimmed and self._THEMATIC_BREAK_RE.match(trimmed):
+            idx = content.index(trimmed[0])
+            return content[:idx] + "\\" + content[idx:]
+
+        # Return ordinary text unchanged
+        return content
 
     def handle_data(self, data, *args, **kwargs):
-        """Store data, escaping Markdown special characters."""
+        """Store escaped text for the current context."""
 
-        # Read current context from the stack top
+        # Read formatting state from the current frame.
         ctx = self._stack[-1]
 
-        # Discard text when the current context suppresses content
+        # Ignore text inside suppressed containers.
         if not ctx["do_store"]:
             return
 
+        # Preserve literal whitespace inside code blocks
         if ctx["preserve_cr"]:
-            # Buffer raw text instead of writing straight to _result --
-            # the matching close tag needs the full content up front to
-            # size a delimiter that cannot collide with backticks
-            # already present in the text.  Nested tags never push
-            # their own frame while preserve_cr is set (handle_starttag
-            # treats them as inert), so ctx is always the frame that
-            # owns this buffer.
+            # Buffer raw text instead of writing straight to _result -- the
+            # matching close tag needs the full content up front to size a
+            # delimiter that cannot collide with backticks already present in
+            # the text.
             ctx["buffer"].append(data)
             return
 
-        # Collapse whitespace runs to a single space outside code/pre
+        # A &nbsp; (decoded by the parser to U+00A0) on its own, with nothing
+        # but ordinary whitespace around it, is a deliberate space -- unlike
+        # plain whitespace it's kept no matter where it falls.
+        if not data.strip() and "\xa0" in data:
+            self._emit("\xa0")
+            return
+
+        # Collapse ordinary whitespace outside preformatted content.
         content = self.WS_TRIM.sub(" ", data)
 
-        # Drop whitespace-only nodes that sit right after a block
-        # boundary or right after a list marker -- both are HTML
-        # indentation artifacts that must not appear as leading spaces
+        # Drop indentation-only text around block boundaries.
         if not content.strip() and (
             not self._result
             or self._result[-1] == self.BLOCK_END
-            or (
-                isinstance(self._result[-1], str)
-                and self._LIST_MARKER_RE.match(self._result[-1])
-            )
+            or isinstance(self._result[-1], (_Marker, _ParaBreak))
         ):
             return
 
-        # Escape special Markdown characters -- code/pre content was
-        # already buffered above and never reaches this point
+        # Detect text that begins a fresh Markdown source line.
+        is_line_start = (
+            not self._result
+            or self._result[-1] == self.BLOCK_END
+            or isinstance(self._result[-1], (_Marker, _ParaBreak))
+            or (
+                type(self._result[-1]) is str
+                and self._result[-1].endswith("\n")
+            )
+        )
+
+        # Escape Markdown punctuation in ordinary text.
         content = self.MARKDOWN_ESCAPE.sub(r"\\\1", content)
 
-        self._result.append(content)
+        if is_line_start:
+            # Prevent plain text from becoming a Markdown block
+            content = self._escape_line_start(content)
+
+        # The first real content directly inside an <em>/<i>/<strong>/ <b>
+        # span: relocate any leading whitespace to sit before the opening
+        # delimiter instead of after it.
+        if ctx.get("emphasis_delim") and not ctx["emphasis_started"]:
+            # Separate leading whitespace from the emphasized content
+            stripped = content.lstrip(self._ASCII_WHITESPACE)
+
+            # Move leading whitespace before the opening delimiter
+            if stripped != content:
+                leading = content[: len(content) - len(stripped)]
+                delim = self._result.pop()
+                self._result.append(leading)
+                self._result.append(delim)
+                content = stripped
+
+            # Drop an emphasis span that still has no real content
+            if not content:
+                # Nothing real left after trimming -- handle_endtag() (or
+                # close(), for a span left open at end of document) will see
+                # the delimiter is still the last thing written and drop it as
+                # an empty span.
+                return
+
+            # Mark the emphasis span as started
+            ctx["emphasis_started"] = True
+
+        # Store the escaped text fragment
+        self._emit(content)
 
     def handle_starttag(self, tag, attrs):
-        """Process a starting HTML tag."""
+        """Handle an opening HTML tag."""
 
-        # Capture the context before any push so list markers read
-        # the parent's depth and counter
+        # Capture the parent context before pushing a new frame.
         ctx = self._stack[-1]
 
-        # Inside a code/pre/samp block, nested tags carry no special
-        # meaning -- only their literal text (handled by handle_data,
-        # unaffected since no frame is pushed here) joins the buffered
-        # content.  This also avoids markers from a nested tag (e.g.
-        # <a>) landing in _result out of order relative to the
-        # buffered text, which is only flushed once the enclosing
-        # code/pre/samp tag closes.
+        # Treat nested tags inside preformatted content as literal text.
         if ctx["preserve_cr"]:
             return
 
-        # List containers: suppress direct text, track list kind
+        # Track list type, depth, and numbering.
 
         if tag in ("ul", "ol"):
-            self._stack.append(
+            # Honor a "start" attribute on <ol> -- defaults to 1, same as the
+            # value CommonMark itself assumes when an ordered list's Markdown
+            # source has no leading number override.
+            counter = 1
+
+            # Read an explicit starting number for ordered lists
+            if tag == "ol":
+                start_attr = next((v for k, v in attrs if k == "start"), None)
+                if start_attr is not None:
+                    with contextlib.suppress(TypeError, ValueError):
+                        # Markdown list markers cannot represent negative
+                        # values.
+                        counter = max(0, int(start_attr))
+
+            # Prepare the new list context
+            overrides = {
+                "do_store": False,
+                "list_type": tag,
+                "depth": min(ctx["depth"] + 1, LIST_DEPTH_MAX),
+                "counter": (counter if tag == "ol" else None),
+            }
+
+            # Only refresh list_do_store when this is the outermost list (its
+            # parent isn't itself a ul/ol).
+            if ctx["tag"] not in ("ul", "ol"):
+                overrides["list_do_store"] = ctx["do_store"]
+
+            # Capture indentation once at the start of a nested list chain.
+            if ctx["depth"] == 0:
+                overrides["list_indent_base"] = ctx["list_indent"]
+
+            # A boundary before the list -- strong, unless it's a sublist
+            # directly continuing a <li>'s own content, in which case no
+            # boundary is added here at all.
+            if ctx["do_store"] and ctx["tag"] != "li":
+                self._open_line_boundary(ctx, strong=True)
+
+            # Activate the list context
+            self._push_frame(self._make_frame(tag, **overrides))
+            return
+
+        # Emit a list marker and enable item content.
+
+        if tag == "li":
+            # A "value" attribute resets the ordered-list counter for this item
+            # (and, since ctx is the live parent ul/ol frame, every sibling
+            # after it too) -- same as it would in an actual rendered <ol>.
+            if ctx["list_type"] == "ol" and ctx["counter"] is not None:
+                # Read an item-specific number override
+                value_attr = next((v for k, v in attrs if k == "value"), None)
+                if value_attr is not None:
+                    with contextlib.suppress(TypeError, ValueError):
+                        # Same clamp as <ol start=> -- see its comment
+                        ctx["counter"] = max(0, int(value_attr))
+
+            # Indent scales with nesting depth (depth 1 = no indent), capped at
+            # LIST_DEPTH_MAX
+            indent = self._indent(ctx["depth"])
+
+            # Build the marker for the active list type
+            if ctx["list_type"] == "ol" and ctx["counter"] is not None:
+                marker_text = "{}{}. ".format(indent, ctx["counter"])
+
+            else:
+                marker_text = "{}- ".format(indent)
+
+            # Tag the marker as converter-generated structure
+            marker = _ListMarker(marker_text)
+
+            # Re-enable storage, unless something outside the list itself (e.g.
+            # <head>) is suppressing content
+            do_store = ctx["list_do_store"]
+
+            # Snapshot _content_seq so the closing tag can tell in O(1) whether
+            # anything real was written for this item -- see _emit() and
+            # handle_endtag("li").
+            self._push_frame(
+                self._make_frame(
+                    tag,
+                    do_store=do_store,
+                    content_seq_at_open=self._content_seq,
+                    list_indent=(
+                        ctx["list_indent_base"] + " " * len(marker_text)
+                    ),
+                )
+            )
+
+            if do_store:
+                # Glue directly onto whatever marker is already pending on this
+                # same line (e.g. an enclosing <blockquote>'s "> ", when this
+                # <li> is its first child) instead of forcing a fresh boundary
+                # that would lose it.
+                if not (
+                    self._result and isinstance(self._result[-1], _Marker)
+                ):
+                    # Start a fresh line for this list item
+                    self._result.append(self.BLOCK_END)
+
+                    # Restate an enclosing quote prefix
+                    if ctx["quote_depth"]:
+                        self._result.append(
+                            self._quote_prefix(ctx["quote_depth"])
+                        )
+
+                # Append the item marker before its content
+                self._result.append(marker)
+            return
+
+        # Extend a pending quote/list marker, or begin a fresh quoted line.
+
+        if tag == "blockquote":
+            # Clamp quote depth to keep generated prefixes bounded
+            depth = min(ctx["quote_depth"] + 1, BLOCKQUOTE_DEPTH_MAX)
+
+            # Activate the new quote context
+            self._push_frame(self._make_frame(tag, quote_depth=depth))
+
+            # Emit a prefix only when this context stores content
+            if ctx["do_store"]:
+                # Inspect the token preceding this quote
+                last = self._result[-1] if self._result else None
+
+                # Extend an existing quote prefix
+                if isinstance(last, _QuoteMarker) or (
+                    isinstance(last, _ParaBreak) and last.in_quote
+                ):
+                    if depth > ctx["quote_depth"]:
+                        self._result.append(_QuoteMarker("> "))
+
+                # Add the quote prefix after another structural marker
+                elif isinstance(last, _Marker):
+                    self._result.append(self._quote_prefix(depth))
+
+                # Start a new quoted line
+                else:
+                    if isinstance(last, str):
+                        # Real text content (not a marker, not a boundary --
+                        # the elif/if above already ruled those out) is
+                        # directly preceding this blockquote with nothing
+                        # separating them yet.
+                        self._write_boundary(ctx, strong=True)
+                    self._result.append(
+                        _QuoteMarker(
+                            ctx["list_indent"] + self._quote_prefix(depth)
+                        )
+                    )
+            return
+
+        # Tables: <thead>/<tbody>/<tfoot> are intentionally not handled here at
+        # all -- they push no frame of their own and so are fully transparent
+        # to everything below.
+
+        if tag == "table":
+            # Separate the table from preceding content
+            if ctx["do_store"]:
+                self._open_line_boundary(ctx, strong=True)
+
+            # Activate a table context and suppress formatting whitespace
+            self._push_frame(
                 self._make_frame(
                     tag,
                     do_store=False,
-                    list_type=tag,
-                    depth=ctx["depth"] + 1,
-                    counter=(1 if tag == "ol" else None),
+                    # Cells restore the table parent's storage state.
+                    table_do_store=ctx["do_store"],
+                    table_rows=0,
                 )
             )
             return
 
-        # List items: re-enable text storage and emit a marker
+        if tag == "tr":
+            # A previous row (and/or its own last cell) left open with no
+            # closing tag at all is finalized first -- same reasoning as <li>
+            # below, just one level up.
+            self._close_stale_row()
 
-        if tag == "li":
-            # Indent scales with nesting depth (depth 1 = no indent)
-            indent = "  " * (ctx["depth"] - 1)
-            if ctx["list_type"] == "ol" and ctx["counter"] is not None:
-                marker = "{}{}. ".format(indent, ctx["counter"])
-            else:
-                marker = "{}- ".format(indent)
+            # Inspect the context containing this row
+            row_ctx = self._stack[-1]
 
-            # Re-enable storage for this item's own content, but only
-            # if no ancestor OUTSIDE the list itself (e.g. <head> or
-            # <script>) is suppressing -- walk past list frames to find
-            # that ancestor's actual do_store state.  The root sentinel
-            # always matches, so this never falls back to the default.
-            do_store = next(
-                (
-                    f["do_store"]
-                    for f in reversed(self._stack)
-                    if f["tag"] not in ("ul", "ol", "li")
-                ),
-                True,
+            # Track whether the row belongs to a table
+            is_table = row_ctx["tag"] == "table"
+
+            # Activate a row context and collect its cells
+            self._push_frame(
+                self._make_frame(
+                    tag,
+                    do_store=False,
+                    cells=[],
+                    # None when there's no enclosing <table> (a stray <tr>) --
+                    # _close_row_frame() then treats this row as a one-row
+                    # table of its own.
+                    table_frame=(row_ctx if is_table else None),
+                    table_do_store=(
+                        row_ctx["table_do_store"]
+                        if is_table
+                        else row_ctx["do_store"]
+                    ),
+                )
             )
-
-            self._stack.append(self._make_frame(tag, do_store=do_store))
-
-            if do_store:
-                # Block boundary before the marker so it starts its own line
-                self._result.append(self.BLOCK_END)
-                self._result.append(marker)
             return
 
-        # Literal-whitespace blocks: buffer raw content so the matching
-        # close tag can size a delimiter that avoids colliding with any
-        # backticks already present in the text
+        if tag in ("td", "th"):
+            # A previous cell in this same row left open with no closing tag at
+            # all is finalized first.
+            self._close_stale_cell()
+
+            # Inspect the context containing this cell
+            cell_ctx = self._stack[-1]
+
+            # Capture cell content only inside a row
+            if cell_ctx["tag"] == "tr":
+                self._push_frame(
+                    self._make_frame(
+                        tag,
+                        do_store=cell_ctx["table_do_store"],
+                        cell_result_start=len(self._result),
+                    )
+                )
+                return
+            # No enclosing <tr> -- this isn't really a table cell (e.g. a stray
+            # <td> with no surrounding table structure at all).
+
+        # Buffer preformatted content until its closing tag.
 
         if tag in ("code", "pre", "samp"):
-            self._stack.append(
+            self._push_frame(
                 self._make_frame(tag, preserve_cr=True, buffer=[])
             )
 
-        # <body> re-enables storage after a suppressing <html> frame
+        # Resume text capture inside the document body.
 
         elif tag == "body":
-            self._stack.append(self._make_frame(tag, do_store=True))
+            self._push_frame(self._make_frame(tag, do_store=True))
 
-        # All other IGNORE_TAGS: suppress enclosed text
+        # Suppress content inside ignored containers.
 
         elif tag in self.IGNORE_TAGS:
-            self._stack.append(self._make_frame(tag, do_store=False))
+            self._push_frame(self._make_frame(tag, do_store=False))
 
-        # Suppressed containers (e.g. anything inside <head>/<script>)
-        # must not emit ANY Markdown syntax -- not just text.  Without
-        # this guard, tags like <b> or <h1> would still write "**"/"#"
-        # markers into the result even though their text is dropped.
+        # Do not emit Markdown markers for suppressed content.
 
         if not ctx["do_store"]:
             return
 
-        # Block boundary before block-level content.
-        # Exception: when a block element is the first child of a <li>,
-        # the marker ("- " or "N. ") is already in _result[-1] and a
-        # BLOCK_END would put them on separate lines.  Suppress it so
-        # the marker and the first block child share the same line.
-
+        # Start block-level content on the correct boundary.
         if tag in self.BLOCK_TAGS:
-            if (
-                self._result
-                and isinstance(self._result[-1], str)
-                and self._LIST_MARKER_RE.match(self._result[-1])
-            ):
-                pass  # suppress; marker and content stay on one line
+            self._open_line_boundary(ctx, strong=tag in self._PARA_LIKE_TAGS)
 
-            else:
-                self._result.append(self.BLOCK_END)
-
-        # Tag-specific Markdown output
+        # Emit Markdown syntax for the current tag.
 
         if tag == "br":
-            self._result.append("\n")
+            # CommonMark needs two trailing spaces for a visible hard break.
+            self._emit("  \n" + self._continuation_prefix(ctx))
 
         elif tag == "hr":
-            # Strip trailing space from the previous token so the rule
-            # renders flush against the surrounding content
-            if self._result and isinstance(self._result[-1], str):
-                self._result[-1] = self._result[-1].rstrip(" ")
+            # <hr> is a void element, so unlike other block tags it can't lean
+            # on handle_endtag for its closing boundary -- that may never fire
+            # (a bare "<hr>" has no closing tag for the parser to call it on).
+            #
+            # Keep a blank line before "---" so it cannot become a setext
+            # heading.
+            self._open_line_boundary(ctx, strong=True)
+            self._emit("---")
+            self._result.append(self.BLOCK_END)
 
-            self._result.append("\n---\n")
-
-        elif tag == "blockquote":
-            self._result.append("> ")
-
+        # Emit ATX heading markers
         elif tag == "h1":
-            self._result.append("# ")
+            self._emit("# ")
 
         elif tag == "h2":
-            self._result.append("## ")
+            self._emit("## ")
 
         elif tag == "h3":
-            self._result.append("### ")
+            self._emit("### ")
 
         elif tag == "h4":
-            self._result.append("#### ")
+            self._emit("#### ")
 
         elif tag == "h5":
-            self._result.append("##### ")
+            self._emit("##### ")
 
         elif tag == "h6":
-            self._result.append("###### ")
+            self._emit("###### ")
 
-        elif tag in ("strong", "b"):
-            self._result.append("**")
+        # Open an emphasis frame for bold or italic content
+        elif tag in ("strong", "b", "em", "i"):
+            # Pushed as a frame (rather than just emitting the delimiter
+            # outright, as every other inline tag here does) so handle_endtag()
+            # can tell a genuine close from a stray one with no matching open,
+            # and handle_data() can relocate leading whitespace.
+            delim = "**" if tag in ("strong", "b") else "*"
 
-        elif tag in ("em", "i"):
-            self._result.append("*")
+            # Track the delimiter and output position for this span
+            self._push_frame(
+                self._make_frame(
+                    tag,
+                    emphasis_delim=delim,
+                    emphasis_started=False,
+                    content_seq_at_open=self._content_seq,
+                    # Index of the delim about to be appended below -- see
+                    # _close_emphasis_frame()'s "not has_content" case for why
+                    # this needs to be the exact index rather than just
+                    # checking self._result[-1].
+                    emphasis_result_start=len(self._result),
+                )
+            )
 
+            # Emit the opening emphasis delimiter
+            self._result.append(delim)
+
+        # Open a Markdown link when an href is available
         elif tag == "a":
-            # Push a frame that carries the href so ALL content between
-            # <a> and </a> -- including nested bold/italic -- is wrapped
-            # in Markdown link syntax by handle_endtag("a")
+            # Push a frame that carries the href so ALL content between <a> and
+            # </a> -- including nested bold/italic -- is wrapped in Markdown
+            # link syntax by handle_endtag("a")
             href = next(
                 (v for k, v in attrs if k == "href"),
                 None,
             )
+
+            # Sanitize the destination before emitting Markdown
             if href is not None:
-                # A bare link destination cannot contain whitespace;
-                # wrap it in angle brackets when it does
-                target = "<{}>".format(href) if " " in href else href
-                self._stack.append(self._make_frame(tag, href=target))
-                self._result.append("[")
+                # Remove controls that invalidate angle-bracket destinations
+                href = self._HREF_CONTROL_CHARS.sub("", href)
+
+                # Browsers trim leading/trailing space before parsing a
+                # URL's scheme, so an unstripped href (e.g. "  javascript:
+                # ...") would otherwise slip past the scheme check below
+                # while still executing once rendered.
+                href = href.strip(self._ASCII_WHITESPACE)
+
+                # Identify any explicit URI scheme
+                scheme = self._HREF_SCHEME.match(href)
+
+                # Neutralize schemes that can execute or expose local content
+                if (
+                    scheme
+                    and scheme.group(1).lower() in self._UNSAFE_HREF_SCHEMES
+                ):
+                    # Neutralize rather than drop -- this keeps the link link-
+                    # shaped (matching whatever surrounding text described it)
+                    # instead of silently losing the fact that a link was even
+                    # there.
+                    href = "#"
+
+            if href is not None:
+                # Always use the angle-bracket destination form so the href
+                # cannot break out of the link early via an unescaped ')';
+                # escape the characters that are meaningful within that form.
+                safe_href = self.HREF_ESCAPE.sub(r"\\\1", href)
+                target = "<{}>".format(safe_href)
+
+                # Track the destination until the closing anchor
+                self._push_frame(self._make_frame(tag, href=target))
+
+                # Emit the opening link-label delimiter
+                self._emit("[")
 
     def handle_endtag(self, tag):
-        """Edge case handling of close tags."""
+        """Handle a closing HTML tag."""
 
-        # Capture context before any pop so do_store and any buffered
-        # code/pre content can still be read for this closing tag
+        # Capture context before any pop so do_store and any buffered code/pre
+        # content can still be read for this closing tag
         ctx = self._stack[-1]
 
-        # Links: retrieve the href from the <a> frame, pop it, then
-        # close the Markdown link -- all content written between <a>
-        # and </a> (bold, italic, raw text) is now inside the brackets
+        # Close the nearest open link frame.
         if tag == "a":
             # Find the href stored in the nearest <a> frame
             href = None
+
+            # Search backward for the matching anchor
             for frame in reversed(self._stack):
                 if frame["tag"] == "a":
                     href = frame.get("href")
                     break
 
+            # Remove the anchor and any malformed child frames
             self._pop_to(tag)
 
-            # Only emit the closing if there was an href; a bare <a>
-            # without href, or one suppressed entirely by an ignored
-            # ancestor, never pushed a frame -- this is then a no-op
+            # Only emit the closing if there was an href; a bare <a> without
+            # href, or one suppressed entirely by an ignored ancestor, never
+            # pushed a frame -- this is then a no-op
             if href is not None:
-                self._result.append("](" + href + ")")
+                # Complete the Markdown link
+                self._emit("](" + href + ")")
 
             return
 
-        # List containers: pop the frame and return
+        # Track list type, depth, and numbering.
 
         if tag in ("ul", "ol"):
+            # Restore the list's parent context
             self._pop_to(tag)
+            parent = self._stack[-1]
+
+            # Separate following content when storage is active
+            if parent["do_store"]:
+                self._write_boundary(parent, strong=parent["tag"] != "li")
             return
 
-        # List items: emit boundary, pop, then advance ol counter
+        # Emit a list marker and enable item content.
 
         if tag == "li":
-            # Block boundary closes the item content -- only if the
-            # item actually emitted a marker when it opened
+            # Empty items are dropped and do not advance ordered-list
+            # numbering.
+            has_content = ctx["do_store"] and self._content_seq != ctx.get(
+                "content_seq_at_open", self._content_seq
+            )
+
+            # Block boundary closes the item content -- only if the item
+            # actually emitted a marker when it opened
             if ctx["do_store"]:
                 self._result.append(self.BLOCK_END)
 
@@ -626,24 +1467,71 @@ class HTMLMarkdownConverter(HTMLConverter):
 
             # Advance the ordered-list counter in the parent frame
             parent = self._stack[-1]
-            if parent["list_type"] == "ol":
+
+            # Increment numbering only for items that emitted content
+            if parent["list_type"] == "ol" and has_content:
                 parent["counter"] += 1
 
             return
 
-        # Literal-whitespace blocks: emit the buffered content now that
-        # its full length is known, sizing the delimiter so it cannot
-        # collide with any backticks already present in the text
+        # Track blockquote depth and emit its prefix.
+        if tag == "blockquote":
+            # Restore the quote's parent context
+            self._pop_to(tag)
+            parent = self._stack[-1]
+
+            # Separate following content from the completed quote
+            if parent["do_store"]:
+                self._write_boundary(parent, strong=True)
+            return
+
+        # Close only matching table frames; ignore stray closing tags.
+
+        if tag in ("td", "th"):
+            # Finalize only the matching active cell
+            if ctx["tag"] == tag:
+                self._pop_to(tag)
+                self._close_cell_frame(ctx)
+                return
+            # else: falls through to BLOCK_TAGS treatment below
+
+        elif tag == "tr":
+            # Recover any cell left open by malformed HTML
+            self._close_stale_cell()
+            row_ctx = self._stack[-1]
+
+            # Finalize the matching row
+            if row_ctx["tag"] == "tr":
+                self._pop_to(tag)
+                self._close_row_frame(row_ctx)
+            return
+
+        elif tag == "table":
+            # Recover any row left open by malformed HTML
+            self._close_stale_row()
+            table_ctx = self._stack[-1]
+
+            # Finalize the matching table
+            if table_ctx["tag"] == "table":
+                self._pop_to(tag)
+                self._close_table_frame()
+            return
+
+        # Buffer preformatted content until its closing tag.
 
         if tag in ("code", "pre", "samp"):
+            # Render only the matching preformatted frame
             if ctx["do_store"] and ctx["tag"] == tag:
+                # Join the buffered literal content
                 content = "".join(ctx.get("buffer", ()))
+
+                # Size the delimiter beyond any embedded backtick run
                 run = self._longest_backtick_run(content)
 
                 if tag == "code":
-                    # Inline code -- pad with a space when the content
-                    # starts or ends with a backtick (CommonMark's code
-                    # span disambiguation rule)
+                    # Inline code -- pad with a space when the content starts
+                    # or ends with a backtick (CommonMark's code span
+                    # disambiguation rule)
                     delim = "`" * (run + 1)
                     pad = (
                         " "
@@ -652,45 +1540,76 @@ class HTMLMarkdownConverter(HTMLConverter):
                         or content[-1] == "`"
                         else ""
                     )
-                    self._result.append(delim + pad + content + pad + delim)
+
+                    # Emit the complete inline code span
+                    self._emit(delim + pad + content + pad + delim)
 
                 else:
-                    # Fenced block -- widen the fence past the longest
-                    # run of backticks already present in the content
+                    # Fenced block -- widen the fence past the longest run of
+                    # backticks already present in the content
                     fence = "`" * max(3, run + 1)
-                    self._result.append(fence)
-                    self._result.append(self.BLOCK_END)
-                    self._result.append(content)
-                    self._result.append(self.BLOCK_END)
-                    self._result.append(fence)
+
+                    # Every line of the block -- both fences and every line of
+                    # the content between them -- needs a list item's
+                    # indentation and/or an enclosing blockquote's "> "
+                    # restated to stay part of it, the same as any other
+                    # continuation line would.
+                    prefix = self._continuation_prefix(ctx)
+
+                    # Prefix every fenced line inside a list or quote
+                    if prefix:
+                        marker = (
+                            _QuoteMarker(prefix)
+                            if ctx["quote_depth"]
+                            else _ListIndent(prefix)
+                        )
+                        content = ("\n" + prefix).join(content.split("\n"))
+
+                    # Emit the opening fence
+                    self._emit(fence)
                     self._result.append(self.BLOCK_END)
 
+                    # Restate nesting before the code content
+                    if prefix:
+                        self._result.append(marker)
+
+                    # Emit the literal block content
+                    self._emit(content)
+                    self._result.append(self.BLOCK_END)
+
+                    # Restate nesting before the closing fence
+                    if prefix:
+                        self._result.append(marker)
+
+                    # Emit the closing fence and boundary
+                    self._emit(fence)
+                    self._result.append(self.BLOCK_END)
+
+            # Restore the context surrounding the code block
             self._pop_to(tag)
             return
 
-        # Suppressed containers emit no markers at all; only pop frames
-        # for tags that pushed one.  This also covers any tag nested
-        # inside a code/pre/samp block -- its opening was treated as
-        # inert above, so this closing must be a no-op too (the
-        # code/pre/samp tag's own matching close already returned out
-        # of the branch above and never reaches this point).
+        # Do not emit Markdown markers for suppressed content.
 
         if not ctx["do_store"] or ctx["preserve_cr"]:
             if tag == "body" or tag in self.IGNORE_TAGS:
                 self._pop_to(tag)
             return
 
-        # Block boundary after block-level content
+        # Close block-level content on the correct boundary.
+        #
+        # Paragraph-like tags use strong boundaries for following bare text.
         if tag in self.BLOCK_TAGS:
-            self._result.append(self.BLOCK_END)
+            self._write_boundary(ctx, strong=tag in self._PARA_LIKE_TAGS)
 
-        if tag in ("strong", "b"):
-            self._result.append("**")
+        if tag in ("strong", "b", "em", "i"):
+            # Only a matching emphasis frame emits a closing delimiter.
+            if ctx["tag"] == tag and ctx.get("emphasis_delim"):
+                self._pop_to(tag)
+                self._close_emphasis_frame(ctx)
+            return
 
-        elif tag in ("em", "i"):
-            self._result.append("*")
-
-        # Pop frames for all tags that pushed them
+        # Pop frames created by container tags.
 
         if tag == "body" or tag in self.IGNORE_TAGS:
             self._pop_to(tag)

--- a/apprise/conversion.py
+++ b/apprise/conversion.py
@@ -131,7 +131,7 @@ def html_to_text(content):
 
 
 def html_to_markdown(content):
-    """Converts a content from HTML to Markdown."""
+    """Convert HTML content to CommonMark."""
 
     # Initialize the Markdown parser.
     parser = HTMLMarkdownConverter()
@@ -195,7 +195,7 @@ class HTMLConverter(HTMLParser):
         # Initialize the standard-library HTML parser.
         super().__init__(**kwargs)
 
-        # Shoudl we store the text content or not?
+        # Should we store the text content or not?
         self._do_store = True
 
         # Initialize internal result list
@@ -381,8 +381,112 @@ def commonmark_escape_link_url(url):
     return url.replace("|", "%7C")
 
 
+def commonmark_scan_angle_dest(body, i, n):
+    """Find the closing ``>`` of a ``](<url>)`` destination.
+
+    ``i`` points at ``](<`` and ``n`` bounds the scan. Escaped ``>)`` pairs
+    are skipped; the closing index or ``None`` is returned.
+    """
+
+    # Start immediately after the opening ``](<`` sequence.
+    k = i + 3
+
+    # Scan until a complete two-character terminator can no longer fit.
+    while k < n - 1:
+        if body[k] == "\\" and k + 1 < n:
+            # Skip escape sequences -- they cannot be the terminator.
+            k += 2
+            continue
+        if body[k] == ">" and body[k + 1] == ")":
+            return k
+        k += 1
+    return None
+
+
+def commonmark_emphasis_run(body, i, n, stack, out):
+    """Map one CommonMark asterisk run to target emphasis delimiters.
+
+    ``stack`` tracks nested bold/italic spans while ``out`` receives their
+    delimiters. The returned index points immediately after the run.
+    """
+    # Measure the full asterisk run starting at i.
+    j = i
+    while j < n and body[j] == "*":
+        j += 1
+    run = j - i
+
+    # Consume the run one span at a time.  Each iteration either closes
+    # the top-of-stack span (if the remaining run width satisfies it) or
+    # opens a new span.
+    while run > 0:
+        if stack and (
+            (stack[-1][0] == "*" and run >= 2)
+            or (stack[-1][0] == "_" and run >= 1)
+        ):
+            # Close the innermost open span.
+            delim, open_index = stack.pop()
+            if open_index == len(out) - 1:
+                # Span opened but collected no content -- drop the orphan.
+                out.pop()
+            else:
+                # Emit the matching close delimiter.
+                out.append(delim)
+            # Bold ("*") consumes 2 asterisks; italic ("_") consumes 1.
+            run -= 2 if delim == "*" else 1
+
+        elif run >= 2:
+            # No closeable bold on stack; open a new bold span.
+            out.append("*")
+            stack.append(("*", len(out) - 1))
+            run -= 2
+
+        else:
+            # run == 1: open a new italic span.
+            out.append("_")
+            stack.append(("_", len(out) - 1))
+            run -= 1
+
+    # Return the position after the full asterisk run.
+    return j
+
+
+def commonmark_force_close_spans(out, stack):
+    """Close remaining LIFO emphasis spans and discard empty ones.
+
+    Both ``out`` and ``stack`` are updated in place.
+    """
+
+    # Close innermost spans first to preserve valid nesting.
+    while stack:
+        delim, open_index = stack.pop()
+        if open_index == len(out) - 1:
+            # Span opened but collected no content -- remove the orphan.
+            out.pop()
+        else:
+            # Emit the close delimiter.
+            out.append(delim)
+
+
+def commonmark_prepend_title(body, title):
+    """Prepend a clean CommonMark H1 title above the body.
+
+    Returns ``(body, "")`` so callers can clear their separate title field.
+    """
+
+    # Remove whitespace and structural prefixes before adding our heading.
+    title_text = title.lstrip("\r\n \t\v\f#-")
+
+    # Add the heading only when meaningful title text remains.
+    if title_text:
+        body = f"# {title_text}\n{body}" if body else f"# {title_text}"
+    return body, ""
+
+
 class HTMLMarkdownConverter(HTMLConverter):
-    """An HTML to Markdown converter tuned for notification messages."""
+    """Convert HTML to notification-friendly CommonMark.
+
+    Plugins may adapt this output to their own Markdown dialects.
+    """
 
     # Define tags that create Markdown block boundaries.
     BLOCK_TAGS = frozenset(
@@ -432,11 +536,14 @@ class HTMLMarkdownConverter(HTMLConverter):
     # Escape angle-bracket link destinations.
     HREF_ESCAPE = re.compile(r"([\\<>])")
 
-    # Remove ASCII controls and Unicode format/zero-width characters that
-    # browsers silently strip during URL parsing but that would bypass the
-    # scheme check (e.g. U+200B zero-width space prepended to "javascript:").
+    # Remove ASCII controls, Unicode format/zero-width characters, and
+    # BiDi override/embedding controls that browsers silently discard during
+    # URL parsing.  These characters can be prepended to a dangerous scheme
+    # (e.g. U+200B before "javascript:") or used to visually reverse a URL
+    # (e.g. U+202E before "javascript:") so they appear safe on screen while
+    # containing an exploitable scheme once the override is decoded.
     _HREF_CONTROL_CHARS = re.compile(
-        "[\x00-\x1f\x7f\u00ad\u200b-\u200f\u2028\u2029\ufeff]"
+        "[\x00-\x1f\x7f\u00ad\u200b-\u200f\u2028-\u202e\u2066-\u2069\ufeff]"
     )
 
     # Detect URI schemes before sanitizing links.
@@ -669,22 +776,14 @@ class HTMLMarkdownConverter(HTMLConverter):
         self._content_seq += 1
 
     def _push_frame(self, frame):
-        """Push a new context frame and update the open-tag counter.
+        """Push a frame, returning whether the depth limit accepted it.
 
-        Returns True when the frame was accepted, False when it was
-        silently discarded because MAX_FRAME_DEPTH was reached.
-
-        Callers that emit Markdown delimiters (emphasis, anchor) MUST
-        check this return value before appending the opening delimiter.
-        Emitting a delimiter without a matching frame leaves it unclosed
-        and produces malformed Markdown when the input is adversarially
-        deep.
+        ``True`` means the frame and tag counter were stored. ``False`` means
+        the depth cap rejected it. Delimiter-producing callers must emit only
+        after a successful push or their Markdown would remain unmatched.
         """
 
-        # Silently discard frames beyond the depth cap so adversarially
-        # nested HTML cannot exhaust memory.  Return False so callers that
-        # emit inline Markdown delimiters can gate that emission on the
-        # result and avoid producing unmatched delimiters in the output.
+        # Reject excessive nesting without emitting unmatched delimiters.
         if len(self._stack) >= MAX_FRAME_DEPTH:
             return False
 
@@ -955,13 +1054,8 @@ class HTMLMarkdownConverter(HTMLConverter):
 
         parent = self._stack[-1]
 
-        # Skip the trailing boundary only for visible top-level tables that
-        # emitted no rows.  The leading paragraph break added before the
-        # table is sufficient; adding a trailing one too would produce a
-        # spurious blank line with no table content in between.
-        # Nested tables (table_do_store=False) are exempt: their boundary
-        # is absorbed into the enclosing cell and provides the whitespace
-        # that separates surrounding inline content from the table's slot.
+        # Empty visible tables already received their only needed boundary.
+        # Suppressed nested tables still need spacing inside their cell.
         if (
             table_frame is not None
             and not table_frame.get("table_rows")
@@ -1070,10 +1164,6 @@ class HTMLMarkdownConverter(HTMLConverter):
 
         # Use the maximum to size a collision-free delimiter.
         return longest
-
-    # Expose shared helpers without binding them as instance methods.
-    build_backtick_run_index = staticmethod(build_backtick_run_index)
-    find_unescaped_run = staticmethod(find_unescaped_run)
 
     def _finalize(self, result):
         """Combine tokens into normalized Markdown lines."""
@@ -1609,11 +1699,7 @@ class HTMLMarkdownConverter(HTMLConverter):
             # A frame validates closing tags and relocates edge whitespace.
             delim = "**" if tag in ("strong", "b") else "*"
 
-            # Only emit the opening delimiter when the frame was accepted.
-            # If the depth cap was hit, _push_frame returns False and we
-            # skip both the frame and its delimiter -- an unmatched "**"
-            # or "*" in the output would be worse than silently dropping
-            # the emphasis on text that is already deeply nested.
+            # Emit a delimiter only when its frame passed the depth limit.
             if self._push_frame(
                 self._make_frame(
                     tag,
@@ -1624,8 +1710,7 @@ class HTMLMarkdownConverter(HTMLConverter):
                     emphasis_result_start=len(self._result),
                 )
             ):
-                # Frame accepted: buffer the opening delimiter immediately
-                # so the matching closing tag can emit the close delimiter.
+                # Buffer the opening delimiter for the matching close tag.
                 self._result.append(delim)
 
         # Open a Markdown link when an href is available
@@ -1661,12 +1746,7 @@ class HTMLMarkdownConverter(HTMLConverter):
                 safe_href = self.HREF_ESCAPE.sub(r"\\\1", href)
                 target = "<{}>".format(safe_href)
 
-                # Store the destination until all nested label text closes.
-                # Only emit "[" when the frame was accepted -- skipping it
-                # when the depth cap is hit prevents an unmatched "[" from
-                # reaching the output (which would produce "[label" with no
-                # closing "](url)" when the closing </a> fires and finds no
-                # frame to pop).
+                # Store the target only when its frame passes the depth limit.
                 if self._push_frame(self._make_frame(tag, href=target)):
                     # Frame accepted: begin the CommonMark link label.
                     self._emit("[")

--- a/apprise/conversion.py
+++ b/apprise/conversion.py
@@ -45,8 +45,7 @@ def convert_between(from_format, to_format, content):
         (NotifyFormat.MARKDOWN, NotifyFormat.HTML): markdown_to_html,
         (NotifyFormat.TEXT, NotifyFormat.HTML): text_to_html,
         (NotifyFormat.HTML, NotifyFormat.TEXT): html_to_text,
-        # For now; use same converter for Markdown support
-        (NotifyFormat.HTML, NotifyFormat.MARKDOWN): html_to_text,
+        (NotifyFormat.HTML, NotifyFormat.MARKDOWN): html_to_markdown,
     }
 
     convert = converters.get((from_format, to_format))
@@ -72,6 +71,15 @@ def html_to_text(content):
     """Converts a content from HTML to plain text."""
 
     parser = HTMLConverter()
+    parser.feed(content)
+    parser.close()
+    return parser.converted
+
+
+def html_to_markdown(content):
+    """Converts a content from HTML to Markdown."""
+
+    parser = HTMLMarkdownConverter()
     parser.feed(content)
     parser.close()
     return parser.converted
@@ -209,3 +217,162 @@ class HTMLConverter(HTMLParser):
 
         if tag in self.BLOCK_TAGS:
             self._result.append(self.BLOCK_END)
+
+
+class HTMLMarkdownConverter(HTMLConverter):
+    """An HTML to Markdown converter tuned for email messages."""
+
+    # Override BLOCK_TAGS to exclude 'code' (handled inline with backticks)
+    # and include 'samp' (treated as a fenced pre block like 'pre').
+    BLOCK_TAGS = (
+        "p",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "div",
+        "td",
+        "th",
+        "pre",
+        "samp",
+        "label",
+        "li",
+    )
+
+    # Escape content characters that carry special meaning in Markdown
+    MARKDOWN_ESCAPE = re.compile(r"([`*#])", re.DOTALL | re.MULTILINE)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        # href value of the current <a> tag; empty string means no link
+        self._link = ""
+
+        # True while inside a <code>, <pre>, or <samp> block so that
+        # carriage returns in the content are preserved rather than
+        # collapsed by WS_TRIM
+        self._preserve_cr = False
+
+    def handle_data(self, data, *args, **kwargs):
+        """Store data, escaping Markdown special characters."""
+
+        if not self._do_store:
+            return
+
+        # Preserve whitespace literally inside code/pre blocks;
+        # collapse whitespace runs to a single space everywhere else
+        content = data if self._preserve_cr else self.WS_TRIM.sub(" ", data)
+
+        # Escape Markdown special characters only outside code/pre blocks --
+        # content inside backtick/fence delimiters is already treated as
+        # literal by all Markdown parsers; escaping there produces wrong output
+        if not self._preserve_cr:
+            content = self.MARKDOWN_ESCAPE.sub(r"\\\1", content)
+
+        # Wrap in link syntax when we are inside an <a href="..."> tag
+        if self._link:
+            self._result.append("[" + content + "]" + self._link)
+
+        else:
+            self._result.append(content)
+
+    def handle_starttag(self, tag, attrs):
+        """Process a starting HTML tag."""
+
+        # Determine whether text content inside this tag should be kept
+        self._do_store = tag not in self.IGNORE_TAGS
+        self._link = ""
+
+        # Block-level elements force a line break before their content
+        if tag in self.BLOCK_TAGS:
+            self._result.append(self.BLOCK_END)
+
+        if tag == "li":
+            self._result.append("- ")
+
+        elif tag == "br":
+            self._result.append("\n")
+
+        elif tag == "hr":
+            if self._result and isinstance(self._result[-1], str):
+                self._result[-1] = self._result[-1].rstrip(" ")
+
+            self._result.append("\n---\n")
+
+        elif tag == "blockquote":
+            self._result.append("> ")
+
+        elif tag == "h1":
+            self._result.append("# ")
+
+        elif tag == "h2":
+            self._result.append("## ")
+
+        elif tag == "h3":
+            self._result.append("### ")
+
+        elif tag == "h4":
+            self._result.append("#### ")
+
+        elif tag == "h5":
+            self._result.append("##### ")
+
+        elif tag == "h6":
+            self._result.append("###### ")
+
+        elif tag in ("strong", "b"):
+            self._result.append("**")
+
+        elif tag in ("em", "i"):
+            self._result.append("*")
+
+        elif tag == "code":
+            # Inline code -- no block boundary, just wrap in backticks
+            self._result.append("`")
+            self._preserve_cr = True
+
+        elif tag in ("pre", "samp"):
+            # Fenced code block -- the BLOCK_END above separates it from
+            # preceding content; a second BLOCK_END after the fence
+            # marker ensures the content starts on its own line
+            self._result.append("```")
+            self._result.append(self.BLOCK_END)
+            self._preserve_cr = True
+
+        elif tag == "a":
+            # Build the link target from the href attribute
+            href = next(
+                (v for k, v in attrs if k == "href"),
+                None,
+            )
+            if href is not None:
+                self._link = "(" + href + ")"
+
+    def handle_endtag(self, tag):
+        """Edge case handling of close tags."""
+
+        self._do_store = True
+        self._link = ""
+
+        # Block-level elements force a line break after their content
+        if tag in self.BLOCK_TAGS:
+            self._result.append(self.BLOCK_END)
+
+        if tag in ("strong", "b"):
+            self._result.append("**")
+
+        elif tag in ("em", "i"):
+            self._result.append("*")
+
+        elif tag == "code":
+            self._result.append("`")
+            self._preserve_cr = False
+
+        elif tag in ("pre", "samp"):
+            # The BLOCK_END from BLOCK_TAGS above ends the content line;
+            # the closing fence and a second BLOCK_END close the block
+            self._result.append("```")
+            self._result.append(self.BLOCK_END)
+            self._preserve_cr = False

--- a/apprise/conversion.py
+++ b/apprise/conversion.py
@@ -25,6 +25,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from bisect import bisect_left
 import contextlib
 from html.parser import HTMLParser
 import re
@@ -315,9 +316,7 @@ class HTMLMarkdownConverter(HTMLConverter):
         r"([\\`*_~#\[\]()!<>])", re.DOTALL | re.MULTILINE
     )
 
-    # Escape block syntax only when it appears at the start of a line.
-    #
-    # Match ordered-list markers at the start of a line.
+    # Block syntax only needs escaping at the start of a line.
     _ORDERED_MARKER_RE = re.compile(r"^\d+\.(?=[ \t]|$)")
 
     # Match bullet markers at the start of a line.
@@ -570,24 +569,24 @@ class HTMLMarkdownConverter(HTMLConverter):
         self._tag_open_counts[tag] = self._tag_open_counts.get(tag, 0) + 1
 
     def _pop_to(self, tag):
-        """Pop through the nearest matching frame."""
+        """Pop through the nearest match and report whether one existed."""
 
         # Reject unmatched closing tags without scanning the stack
         if not self._tag_open_counts.get(tag):
-            return
+            return False
 
         # Search backward for the nearest matching frame
         for i in range(len(self._stack) - 1, 0, -1):
             if self._stack[i]["tag"] == tag:
-                # Remove the matched frame and everything above it, discounting
-                # each one from _tag_open_counts so it stays accurate for
-                # whatever's left on the stack
+                # Keep tag counts synchronized with removed frames.
                 for frame in self._stack[i:]:
                     self._tag_open_counts[frame["tag"]] -= 1
 
                 # Remove the matching frame and its descendants
                 del self._stack[i:]
-                return
+                return True
+
+        return False
 
     def _close_emphasis_frame(self, frame):
         """Close an emphasis frame with content."""
@@ -630,6 +629,51 @@ class HTMLMarkdownConverter(HTMLConverter):
         if trailing:
             self._result.append(trailing)
 
+    @classmethod
+    def _escape_cell_pipes(cls, text):
+        """Escape cell delimiters outside CommonMark code spans."""
+
+        out = []
+        i = 0
+        n = len(text)
+        backtick_runs = cls._build_backtick_run_index(text)
+
+        while i < n:
+            ch = text[i]
+
+            if ch == "\\" and i + 1 < n:
+                out.append(text[i : i + 2])
+                i += 2
+                continue
+
+            if ch == "`":
+                j = i
+                while j < n and text[j] == "`":
+                    j += 1
+                run = j - i
+
+                close = cls._find_unescaped_run(backtick_runs, j, run)
+                if close is not None:
+                    # Pipes are already literal inside code spans.
+                    out.append(text[i : close + run])
+                    i = close + run
+                    continue
+
+                # Preserve unmatched backticks as literal text.
+                out.append(text[i:j])
+                i = j
+                continue
+
+            if ch == "|":
+                out.append("\\|")
+                i += 1
+                continue
+
+            out.append(ch)
+            i += 1
+
+        return "".join(out)
+
     def _close_cell_frame(self, frame):
         """Capture a completed table cell."""
 
@@ -645,22 +689,77 @@ class HTMLMarkdownConverter(HTMLConverter):
         # Finalize the cell into a single Markdown fragment
         text = "".join(self._finalize(chunk)).strip(self._ASCII_WHITESPACE)
 
-        # A Markdown table row is exactly one line -- any newline the cell's
-        # own content produced (a <br>, a nested block) is flattened to a
-        # single space rather than corrupting the row.
+        # Table cells must remain on one Markdown source line.
         if "\n" in text:
             text = " ".join(text.split("\n"))
             text = self._CELL_WHITESPACE_RUN.sub(" ", text).strip(
                 self._ASCII_WHITESPACE
             )
 
-        # '|' is the cell delimiter itself; escape any literal one in the
-        # content so it can't be misread as starting a new column.
+        # Escape cell delimiters except where code spans make them literal.
         if "|" in text:
-            text = text.replace("|", "\\|")
+            text = self._escape_cell_pipes(text)
 
         # Add the completed cell to its row
         self._stack[-1]["cells"].append(text)
+
+    def _close_pre_frame(self, ctx, tag):
+        """Render a completed code/pre/samp frame's buffered content."""
+
+        # Join the buffered literal content
+        content = "".join(ctx.get("buffer", ()))
+
+        # Size the delimiter beyond any embedded backtick run
+        run = self._longest_backtick_run(content)
+
+        if tag == "code":
+            # CommonMark requires padding around edge backticks.
+            delim = "`" * (run + 1)
+            pad = (
+                " "
+                if not content or content[0] == "`" or content[-1] == "`"
+                else ""
+            )
+
+            # Emit the complete inline code span
+            self._emit(delim + pad + content + pad + delim)
+            return
+
+        # Fenced block -- widen the fence past the longest run of
+        # backticks already present in the content
+        fence = "`" * max(3, run + 1)
+
+        # Restate list and quote prefixes on every fenced-block line.
+        prefix = self._continuation_prefix(ctx)
+
+        # Prefix every fenced line inside a list or quote
+        if prefix:
+            marker = (
+                _QuoteMarker(prefix)
+                if ctx["quote_depth"]
+                else _ListIndent(prefix)
+            )
+            content = ("\n" + prefix).join(content.split("\n"))
+
+        # Emit the opening fence
+        self._emit(fence)
+        self._result.append(self.BLOCK_END)
+
+        # Restate nesting before the code content
+        if prefix:
+            self._result.append(marker)
+
+        # Emit the literal block content
+        self._emit(content)
+        self._result.append(self.BLOCK_END)
+
+        # Restate nesting before the closing fence
+        if prefix:
+            self._result.append(marker)
+
+        # Emit the closing fence and boundary
+        self._emit(fence)
+        self._result.append(self.BLOCK_END)
 
     def _close_row_frame(self, frame):
         """Render a completed table row."""
@@ -687,12 +786,13 @@ class HTMLMarkdownConverter(HTMLConverter):
 
         # Add the required separator after the header row
         if is_header:
-            # _write_boundary() (not a bare BLOCK_END) so a list item's
-            # indentation or an enclosing blockquote's "> " is restated in
-            # front of the separator line too, the same as it would be for any
-            # other continuation line of this table.
+            # Preserve list or quote prefixes on the separator line.
             self._write_boundary(ctx, strong=False)
             self._emit("| " + " | ".join(["---"] * len(cells)) + " |")
+
+        if table is None:
+            # A standalone row needs the same trailing boundary as a table.
+            self._write_boundary(ctx, strong=True)
 
     def _close_table_frame(self):
         """Finish a table boundary."""
@@ -743,12 +843,18 @@ class HTMLMarkdownConverter(HTMLConverter):
             # Finalize content captured by special frames
             if top.get("emphasis_delim"):
                 self._close_emphasis_frame(top)
+
             elif tag in ("td", "th"):
                 self._close_cell_frame(top)
+
             elif tag == "tr":
                 self._close_row_frame(top)
+
             elif tag == "table":
                 self._close_table_frame()
+
+            elif tag in ("code", "pre", "samp") and top["do_store"]:
+                self._close_pre_frame(top, tag)
 
         # Let the base converter assemble the final output
         super().close()
@@ -773,6 +879,45 @@ class HTMLMarkdownConverter(HTMLConverter):
         # Return the delimiter width already present in the content
         return longest
 
+    @classmethod
+    def _build_backtick_run_index(cls, text):
+        """Index unescaped backtick runs by width in one pass."""
+
+        index = {}
+        i = 0
+        n = len(text)
+
+        while i < n:
+            ch = text[i]
+
+            # Consume escapes as pairs so escaped delimiters cannot match.
+            if ch == "\\" and i + 1 < n:
+                i += 2
+                continue
+
+            if ch == "`":
+                j = i
+                while j < n and text[j] == "`":
+                    j += 1
+                index.setdefault(j - i, []).append(i)
+                i = j
+                continue
+
+            i += 1
+
+        return index
+
+    @staticmethod
+    def _find_unescaped_run(index, start, run):
+        """Find the next indexed backtick run of the requested width."""
+
+        positions = index.get(run)
+        if not positions:
+            return None
+
+        pos = bisect_left(positions, start)
+        return positions[pos] if pos < len(positions) else None
+
     def _finalize(self, result):
         """Combine tokens into normalized Markdown lines."""
 
@@ -782,26 +927,20 @@ class HTMLMarkdownConverter(HTMLConverter):
         # Whether accum, so far, is composed only of marker fragments
         accum_is_marker = False
 
-        # Set when a boundary was absorbed while accum was marker-only -- see
-        # the docstring above
+        # True when a marker absorbed a boundary without content.
         marker_boundary_passed = False
 
-        # Set once accum holds real content and at least one boundary has been
-        # seen since -- the line is done, but not yet flushed (see the
-        # docstring above)
+        # True when a complete line is waiting to be flushed.
         terminated = False
 
         # Set when a plain (no prefix at all) _ParaBreak has been seen since
         # accum was last extended with real content
         para_break_seen = False
 
-        # The prefix of a _ParaBreak seen since accum was last extended with
-        # real content, if it had one (list indent and/or a blockquote's "> ")
-        # -- takes priority over para_break_seen when both are set
+        # Active list or quote prefix for the next paragraph line.
         para_break_prefix = None
 
-        # Whether para_break_prefix came from a _ParaBreak with in_quote set --
-        # see _ParaBreak
+        # Whether the active paragraph prefix belongs to a quote.
         para_break_in_quote = False
 
         # Set when a boundary arrives *after* the line was already terminated
@@ -814,10 +953,7 @@ class HTMLMarkdownConverter(HTMLConverter):
             if item == self.BLOCK_END or isinstance(item, _ParaBreak):
                 # Record the strongest paragraph boundary in this run
                 if isinstance(item, _ParaBreak):
-                    # The most recent _ParaBreak in a run reflects the current
-                    # context (e.g. a blockquote that closed partway through
-                    # the run) -- always overwrite rather than keeping an
-                    # earlier, now-stale prefix from before that exit.
+                    # The latest break carries the current nesting context.
                     if item.prefix:
                         # Keep the prefix required by the next line
                         para_break_prefix = item.prefix
@@ -964,16 +1100,11 @@ class HTMLMarkdownConverter(HTMLConverter):
 
         # Preserve literal whitespace inside code blocks
         if ctx["preserve_cr"]:
-            # Buffer raw text instead of writing straight to _result -- the
-            # matching close tag needs the full content up front to size a
-            # delimiter that cannot collide with backticks already present in
-            # the text.
+            # Buffer raw text so the closing delimiter can be sized safely.
             ctx["buffer"].append(data)
             return
 
-        # A &nbsp; (decoded by the parser to U+00A0) on its own, with nothing
-        # but ordinary whitespace around it, is a deliberate space -- unlike
-        # plain whitespace it's kept no matter where it falls.
+        # Preserve deliberate non-breaking spaces even at block boundaries.
         if not data.strip() and "\xa0" in data:
             self._emit("\xa0")
             return
@@ -1007,9 +1138,7 @@ class HTMLMarkdownConverter(HTMLConverter):
             # Prevent plain text from becoming a Markdown block
             content = self._escape_line_start(content)
 
-        # The first real content directly inside an <em>/<i>/<strong>/ <b>
-        # span: relocate any leading whitespace to sit before the opening
-        # delimiter instead of after it.
+        # Keep leading whitespace outside an emphasis delimiter.
         if ctx.get("emphasis_delim") and not ctx["emphasis_started"]:
             # Separate leading whitespace from the emphasized content
             stripped = content.lstrip(self._ASCII_WHITESPACE)
@@ -1024,10 +1153,7 @@ class HTMLMarkdownConverter(HTMLConverter):
 
             # Drop an emphasis span that still has no real content
             if not content:
-                # Nothing real left after trimming -- handle_endtag() (or
-                # close(), for a span left open at end of document) will see
-                # the delimiter is still the last thing written and drop it as
-                # an empty span.
+                # The close handler removes an empty span.
                 return
 
             # Mark the emphasis span as started
@@ -1049,9 +1175,7 @@ class HTMLMarkdownConverter(HTMLConverter):
         # Track list type, depth, and numbering.
 
         if tag in ("ul", "ol"):
-            # Honor a "start" attribute on <ol> -- defaults to 1, same as the
-            # value CommonMark itself assumes when an ordered list's Markdown
-            # source has no leading number override.
+            # CommonMark ordered lists default to one.
             counter = 1
 
             # Read an explicit starting number for ordered lists
@@ -1080,9 +1204,7 @@ class HTMLMarkdownConverter(HTMLConverter):
             if ctx["depth"] == 0:
                 overrides["list_indent_base"] = ctx["list_indent"]
 
-            # A boundary before the list -- strong, unless it's a sublist
-            # directly continuing a <li>'s own content, in which case no
-            # boundary is added here at all.
+            # A direct child list continues its parent item without a break.
             if ctx["do_store"] and ctx["tag"] != "li":
                 self._open_line_boundary(ctx, strong=True)
 
@@ -1093,15 +1215,13 @@ class HTMLMarkdownConverter(HTMLConverter):
         # Emit a list marker and enable item content.
 
         if tag == "li":
-            # A "value" attribute resets the ordered-list counter for this item
-            # (and, since ctx is the live parent ul/ol frame, every sibling
-            # after it too) -- same as it would in an actual rendered <ol>.
+            # An item value resets numbering for it and following siblings.
             if ctx["list_type"] == "ol" and ctx["counter"] is not None:
                 # Read an item-specific number override
                 value_attr = next((v for k, v in attrs if k == "value"), None)
                 if value_attr is not None:
                     with contextlib.suppress(TypeError, ValueError):
-                        # Same clamp as <ol start=> -- see its comment
+                        # Match the non-negative <ol start> constraint.
                         ctx["counter"] = max(0, int(value_attr))
 
             # Indent scales with nesting depth (depth 1 = no indent), capped at
@@ -1122,9 +1242,7 @@ class HTMLMarkdownConverter(HTMLConverter):
             # <head>) is suppressing content
             do_store = ctx["list_do_store"]
 
-            # Snapshot _content_seq so the closing tag can tell in O(1) whether
-            # anything real was written for this item -- see _emit() and
-            # handle_endtag("li").
+            # Snapshot content state for constant-time empty-item detection.
             self._push_frame(
                 self._make_frame(
                     tag,
@@ -1137,10 +1255,7 @@ class HTMLMarkdownConverter(HTMLConverter):
             )
 
             if do_store:
-                # Glue directly onto whatever marker is already pending on this
-                # same line (e.g. an enclosing <blockquote>'s "> ", when this
-                # <li> is its first child) instead of forcing a fresh boundary
-                # that would lose it.
+                # Reuse a pending quote or list marker on this line.
                 if not (
                     self._result and isinstance(self._result[-1], _Marker)
                 ):
@@ -1164,7 +1279,8 @@ class HTMLMarkdownConverter(HTMLConverter):
             depth = min(ctx["quote_depth"] + 1, BLOCKQUOTE_DEPTH_MAX)
 
             # Activate the new quote context
-            self._push_frame(self._make_frame(tag, quote_depth=depth))
+            new_frame = self._make_frame(tag, quote_depth=depth)
+            self._push_frame(new_frame)
 
             # Emit a prefix only when this context stores content
             if ctx["do_store"]:
@@ -1182,14 +1298,16 @@ class HTMLMarkdownConverter(HTMLConverter):
                 elif isinstance(last, _Marker):
                     self._result.append(self._quote_prefix(depth))
 
-                # Start a new quoted line
+                # Separate a quote from preceding text.
+                elif isinstance(last, str):
+                    # Write the boundary using ctx's own (pre-nesting) depth.
+                    self._write_boundary(ctx, strong=True)
+
+                    if depth > ctx["quote_depth"]:
+                        self._result.append(_QuoteMarker("> "))
+
+                # Emit the prefix directly at the start of a context.
                 else:
-                    if isinstance(last, str):
-                        # Real text content (not a marker, not a boundary --
-                        # the elif/if above already ruled those out) is
-                        # directly preceding this blockquote with nothing
-                        # separating them yet.
-                        self._write_boundary(ctx, strong=True)
                     self._result.append(
                         _QuoteMarker(
                             ctx["list_indent"] + self._quote_prefix(depth)
@@ -1197,13 +1315,17 @@ class HTMLMarkdownConverter(HTMLConverter):
                     )
             return
 
-        # Tables: <thead>/<tbody>/<tfoot> are intentionally not handled here at
-        # all -- they push no frame of their own and so are fully transparent
-        # to everything below.
+        # Table section tags are transparent.
 
         if tag == "table":
+            # Markdown cannot represent a table nested inside a cell.
+            nested_in_cell = bool(
+                self._tag_open_counts.get("td")
+                or self._tag_open_counts.get("th")
+            )
+
             # Separate the table from preceding content
-            if ctx["do_store"]:
+            if ctx["do_store"] and not nested_in_cell:
                 self._open_line_boundary(ctx, strong=True)
 
             # Activate a table context and suppress formatting whitespace
@@ -1211,17 +1333,17 @@ class HTMLMarkdownConverter(HTMLConverter):
                 self._make_frame(
                     tag,
                     do_store=False,
-                    # Cells restore the table parent's storage state.
-                    table_do_store=ctx["do_store"],
+                    # Nested table cells remain suppressed.
+                    table_do_store=(
+                        False if nested_in_cell else ctx["do_store"]
+                    ),
                     table_rows=0,
                 )
             )
             return
 
         if tag == "tr":
-            # A previous row (and/or its own last cell) left open with no
-            # closing tag at all is finalized first -- same reasoning as <li>
-            # below, just one level up.
+            # Finalize a malformed, unterminated previous row first.
             self._close_stale_row()
 
             # Inspect the context containing this row
@@ -1236,9 +1358,7 @@ class HTMLMarkdownConverter(HTMLConverter):
                     tag,
                     do_store=False,
                     cells=[],
-                    # None when there's no enclosing <table> (a stray <tr>) --
-                    # _close_row_frame() then treats this row as a one-row
-                    # table of its own.
+                    # A stray row becomes a standalone one-row table.
                     table_frame=(row_ctx if is_table else None),
                     table_do_store=(
                         row_ctx["table_do_store"]
@@ -1250,8 +1370,7 @@ class HTMLMarkdownConverter(HTMLConverter):
             return
 
         if tag in ("td", "th"):
-            # A previous cell in this same row left open with no closing tag at
-            # all is finalized first.
+            # Finalize an unterminated previous cell first.
             self._close_stale_cell()
 
             # Inspect the context containing this cell
@@ -1303,12 +1422,8 @@ class HTMLMarkdownConverter(HTMLConverter):
             self._emit("  \n" + self._continuation_prefix(ctx))
 
         elif tag == "hr":
-            # <hr> is a void element, so unlike other block tags it can't lean
-            # on handle_endtag for its closing boundary -- that may never fire
-            # (a bare "<hr>" has no closing tag for the parser to call it on).
-            #
-            # Keep a blank line before "---" so it cannot become a setext
-            # heading.
+            # A void <hr> supplies its own boundaries; the leading blank line
+            # prevents it from becoming a setext heading.
             self._open_line_boundary(ctx, strong=True)
             self._emit("---")
             self._result.append(self.BLOCK_END)
@@ -1334,10 +1449,7 @@ class HTMLMarkdownConverter(HTMLConverter):
 
         # Open an emphasis frame for bold or italic content
         elif tag in ("strong", "b", "em", "i"):
-            # Pushed as a frame (rather than just emitting the delimiter
-            # outright, as every other inline tag here does) so handle_endtag()
-            # can tell a genuine close from a stray one with no matching open,
-            # and handle_data() can relocate leading whitespace.
+            # A frame validates closing tags and relocates edge whitespace.
             delim = "**" if tag in ("strong", "b") else "*"
 
             # Track the delimiter and output position for this span
@@ -1347,10 +1459,7 @@ class HTMLMarkdownConverter(HTMLConverter):
                     emphasis_delim=delim,
                     emphasis_started=False,
                     content_seq_at_open=self._content_seq,
-                    # Index of the delim about to be appended below -- see
-                    # _close_emphasis_frame()'s "not has_content" case for why
-                    # this needs to be the exact index rather than just
-                    # checking self._result[-1].
+                    # Exact delimiter index used when removing an empty span.
                     emphasis_result_start=len(self._result),
                 )
             )
@@ -1360,9 +1469,7 @@ class HTMLMarkdownConverter(HTMLConverter):
 
         # Open a Markdown link when an href is available
         elif tag == "a":
-            # Push a frame that carries the href so ALL content between <a> and
-            # </a> -- including nested bold/italic -- is wrapped in Markdown
-            # link syntax by handle_endtag("a")
+            # Keep the target on a frame so nested label markup is included.
             href = next(
                 (v for k, v in attrs if k == "href"),
                 None,
@@ -1373,10 +1480,7 @@ class HTMLMarkdownConverter(HTMLConverter):
                 # Remove controls that invalidate angle-bracket destinations
                 href = self._HREF_CONTROL_CHARS.sub("", href)
 
-                # Browsers trim leading/trailing space before parsing a
-                # URL's scheme, so an unstripped href (e.g. "  javascript:
-                # ...") would otherwise slip past the scheme check below
-                # while still executing once rendered.
+                # Match browser URL parsing by trimming ASCII whitespace.
                 href = href.strip(self._ASCII_WHITESPACE)
 
                 # Identify any explicit URI scheme
@@ -1387,16 +1491,11 @@ class HTMLMarkdownConverter(HTMLConverter):
                     scheme
                     and scheme.group(1).lower() in self._UNSAFE_HREF_SCHEMES
                 ):
-                    # Neutralize rather than drop -- this keeps the link link-
-                    # shaped (matching whatever surrounding text described it)
-                    # instead of silently losing the fact that a link was even
-                    # there.
+                    # Preserve link shape while neutralizing unsafe targets.
                     href = "#"
 
             if href is not None:
-                # Always use the angle-bracket destination form so the href
-                # cannot break out of the link early via an unescaped ')';
-                # escape the characters that are meaningful within that form.
+                # Angle destinations safely contain parentheses.
                 safe_href = self.HREF_ESCAPE.sub(r"\\\1", href)
                 target = "<{}>".format(safe_href)
 
@@ -1427,9 +1526,7 @@ class HTMLMarkdownConverter(HTMLConverter):
             # Remove the anchor and any malformed child frames
             self._pop_to(tag)
 
-            # Only emit the closing if there was an href; a bare <a> without
-            # href, or one suppressed entirely by an ignored ancestor, never
-            # pushed a frame -- this is then a no-op
+            # Bare or suppressed anchors do not create link frames.
             if href is not None:
                 # Complete the Markdown link
                 self._emit("](" + href + ")")
@@ -1439,8 +1536,9 @@ class HTMLMarkdownConverter(HTMLConverter):
         # Track list type, depth, and numbering.
 
         if tag in ("ul", "ol"):
-            # Restore the list's parent context
-            self._pop_to(tag)
+            # Restore the list's parent context.
+            if not self._pop_to(tag):
+                return
             parent = self._stack[-1]
 
             # Separate following content when storage is active
@@ -1451,6 +1549,11 @@ class HTMLMarkdownConverter(HTMLConverter):
         # Emit a list marker and enable item content.
 
         if tag == "li":
+            # A stray closing tag with no open <li> anywhere on the stack is
+            # a no-op -- nothing below should run against an unrelated frame.
+            if not self._tag_open_counts.get(tag):
+                return
+
             # Empty items are dropped and do not advance ordered-list
             # numbering.
             has_content = ctx["do_store"] and self._content_seq != ctx.get(
@@ -1476,8 +1579,10 @@ class HTMLMarkdownConverter(HTMLConverter):
 
         # Track blockquote depth and emit its prefix.
         if tag == "blockquote":
-            # Restore the quote's parent context
-            self._pop_to(tag)
+            # Restore the quote's parent context -- a stray closing tag with
+            # no open <blockquote> anywhere on the stack is a no-op.
+            if not self._pop_to(tag):
+                return
             parent = self._stack[-1]
 
             # Separate following content from the completed quote
@@ -1488,12 +1593,11 @@ class HTMLMarkdownConverter(HTMLConverter):
         # Close only matching table frames; ignore stray closing tags.
 
         if tag in ("td", "th"):
-            # Finalize only the matching active cell
+            # Ignore stray cell closers instead of emitting a block boundary.
             if ctx["tag"] == tag:
                 self._pop_to(tag)
                 self._close_cell_frame(ctx)
-                return
-            # else: falls through to BLOCK_TAGS treatment below
+            return
 
         elif tag == "tr":
             # Recover any cell left open by malformed HTML
@@ -1522,68 +1626,7 @@ class HTMLMarkdownConverter(HTMLConverter):
         if tag in ("code", "pre", "samp"):
             # Render only the matching preformatted frame
             if ctx["do_store"] and ctx["tag"] == tag:
-                # Join the buffered literal content
-                content = "".join(ctx.get("buffer", ()))
-
-                # Size the delimiter beyond any embedded backtick run
-                run = self._longest_backtick_run(content)
-
-                if tag == "code":
-                    # Inline code -- pad with a space when the content starts
-                    # or ends with a backtick (CommonMark's code span
-                    # disambiguation rule)
-                    delim = "`" * (run + 1)
-                    pad = (
-                        " "
-                        if not content
-                        or content[0] == "`"
-                        or content[-1] == "`"
-                        else ""
-                    )
-
-                    # Emit the complete inline code span
-                    self._emit(delim + pad + content + pad + delim)
-
-                else:
-                    # Fenced block -- widen the fence past the longest run of
-                    # backticks already present in the content
-                    fence = "`" * max(3, run + 1)
-
-                    # Every line of the block -- both fences and every line of
-                    # the content between them -- needs a list item's
-                    # indentation and/or an enclosing blockquote's "> "
-                    # restated to stay part of it, the same as any other
-                    # continuation line would.
-                    prefix = self._continuation_prefix(ctx)
-
-                    # Prefix every fenced line inside a list or quote
-                    if prefix:
-                        marker = (
-                            _QuoteMarker(prefix)
-                            if ctx["quote_depth"]
-                            else _ListIndent(prefix)
-                        )
-                        content = ("\n" + prefix).join(content.split("\n"))
-
-                    # Emit the opening fence
-                    self._emit(fence)
-                    self._result.append(self.BLOCK_END)
-
-                    # Restate nesting before the code content
-                    if prefix:
-                        self._result.append(marker)
-
-                    # Emit the literal block content
-                    self._emit(content)
-                    self._result.append(self.BLOCK_END)
-
-                    # Restate nesting before the closing fence
-                    if prefix:
-                        self._result.append(marker)
-
-                    # Emit the closing fence and boundary
-                    self._emit(fence)
-                    self._result.append(self.BLOCK_END)
+                self._close_pre_frame(ctx, tag)
 
             # Restore the context surrounding the code block
             self._pop_to(tag)
@@ -1596,9 +1639,7 @@ class HTMLMarkdownConverter(HTMLConverter):
                 self._pop_to(tag)
             return
 
-        # Close block-level content on the correct boundary.
-        #
-        # Paragraph-like tags use strong boundaries for following bare text.
+        # Paragraph-like tags strongly separate following bare text.
         if tag in self.BLOCK_TAGS:
             self._write_boundary(ctx, strong=tag in self._PARA_LIKE_TAGS)
 

--- a/apprise/plugins/base.py
+++ b/apprise/plugins/base.py
@@ -871,12 +871,17 @@ class NotifyBase(URLBase):
 
             elif (
                 self.notify_format == NotifyFormat.MARKDOWN
-                and body_format == NotifyFormat.TEXT
+                and body_format
+                in (
+                    NotifyFormat.TEXT,
+                    NotifyFormat.HTML,
+                )
             ):
-                # Content is appended to body as markdown
+                # Body was plain text or HTML converted to CommonMark;
+                # render the title as a Markdown heading.
                 title = title.lstrip("\r\n \t\v\f#-")
                 if title:
-                    body = f"# {title}\r\n{body}"
+                    body = f"# {title}\n{body}"
 
             else:
                 body = f"{title}\r\n{body}"

--- a/apprise/plugins/evolution.py
+++ b/apprise/plugins/evolution.py
@@ -47,6 +47,7 @@
 # Phone numbers must be in international format without the leading '+',
 # e.g. 5511999999999 for a Brazilian mobile number.
 
+from bisect import bisect_left
 from json import dumps
 
 import requests
@@ -191,8 +192,191 @@ class NotifyEvolution(NotifyBase):
 
         return
 
-    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+    # Adapt HTML-derived CommonMark to WhatsApp formatting.
+    # Direct WhatsApp Markdown is left unchanged.
+    # Syntax: https://faq.whatsapp.com/539178204879377/
+
+    @classmethod
+    def _build_backtick_run_index(cls, text):
+        """Index unescaped backtick runs by width in one pass."""
+
+        index = {}
+        i = 0
+        n = len(text)
+
+        while i < n:
+            ch = text[i]
+
+            if ch == "\\" and i + 1 < n:
+                i += 2
+                continue
+
+            if ch == "`":
+                j = i
+                while j < n and text[j] == "`":
+                    j += 1
+                index.setdefault(j - i, []).append(i)
+                i = j
+                continue
+
+            i += 1
+
+        return index
+
+    @staticmethod
+    def _find_unescaped_run(index, start, run):
+        """Find the next indexed backtick run of the requested width."""
+
+        positions = index.get(run)
+        if not positions:
+            return None
+
+        pos = bisect_left(positions, start)
+        return positions[pos] if pos < len(positions) else None
+
+    @classmethod
+    def _commonmark_to_whatsapp(cls, body):
+        """Adapt html_to_markdown()'s CommonMark output to WhatsApp's own
+        text formatting dialect."""
+
+        out = []
+        # Open emphasis spans as (delimiter, output index), innermost last.
+        stack = []
+        # Index in `out` of each currently-open link's "[", innermost last.
+        link_stack = []
+        i = 0
+        n = len(body)
+        backtick_runs = cls._build_backtick_run_index(body)
+
+        while i < n:
+            ch = body[i]
+
+            # WhatsApp needs the literal character, not CommonMark's escape.
+            if ch == "\\" and i + 1 < n:
+                out.append(body[i + 1])
+                i += 2
+                continue
+
+            # WhatsApp uses triple backticks for all monospace content.
+            if ch == "`":
+                j = i
+                while j < n and body[j] == "`":
+                    j += 1
+                run = j - i
+                close = cls._find_unescaped_run(backtick_runs, j, run)
+
+                if close is not None:
+                    out.append("```" + body[j:close] + "```")
+                    i = close + run
+                    continue
+
+                # No matching close -- not a real code span; just literal
+                # backticks.
+                out.append(body[i:j])
+                i = j
+                continue
+
+            # Track CommonMark labels for conversion to plain labeled URLs.
+            if ch == "[":
+                link_stack.append(len(out))
+                out.append("[")
+                i += 1
+                continue
+
+            if body.startswith("](<", i) and link_stack:
+                # Find the destination's next unescaped closing `>)`.
+                close = None
+                k = i + 3
+                while k < n - 1:
+                    if body[k] == "\\" and k + 1 < n:
+                        k += 2
+                        continue
+                    if body[k] == ">" and body[k + 1] == ")":
+                        close = k
+                        break
+                    k += 1
+
+                if close is not None:
+                    # Preserve the label beside WhatsApp's auto-linked URL.
+                    raw_url = body[i + 3 : close]
+                    url = []
+                    j2 = 0
+                    while j2 < len(raw_url):
+                        c2 = raw_url[j2]
+                        if c2 == "\\" and j2 + 1 < len(raw_url):
+                            url.append(raw_url[j2 + 1])
+                            j2 += 2
+                            continue
+                        url.append(c2)
+                        j2 += 1
+                    url = "".join(url)
+
+                    open_index = link_stack.pop()
+                    text = "".join(out[open_index + 1 :])
+                    del out[open_index:]
+                    out.append(f"{text} ({url})" if text else url)
+                    i = close + 2
+                    continue
+
+            # Convert CommonMark emphasis while preserving LIFO nesting.
+            if ch == "*":
+                j = i
+                while j < n and body[j] == "*":
+                    j += 1
+                run = j - i
+
+                while run > 0:
+                    if stack and (
+                        (stack[-1][0] == "*" and run >= 2)
+                        or (stack[-1][0] == "_" and run >= 1)
+                    ):
+                        delim, open_index = stack.pop()
+                        if open_index == len(out) - 1:
+                            out.pop()
+                        else:
+                            out.append(delim)
+                        run -= 2 if delim == "*" else 1
+                    elif run >= 2:
+                        out.append("*")
+                        stack.append(("*", len(out) - 1))
+                        run -= 2
+                    else:
+                        out.append("_")
+                        stack.append(("_", len(out) - 1))
+                        run -= 1
+
+                i = j
+                continue
+
+            out.append(ch)
+            i += 1
+
+        # Close out anything still open so the result is valid on its own.
+        while stack:
+            delim, open_index = stack.pop()
+            if open_index == len(out) - 1:
+                out.pop()
+            else:
+                out.append(delim)
+
+        return "".join(out)
+
+    def send(
+        self,
+        body,
+        title="",
+        notify_type=NotifyType.INFO,
+        body_format=None,
+        **kwargs,
+    ):
         """Perform Evolution API Notification."""
+
+        if (
+            self.notify_format == NotifyFormat.MARKDOWN
+            and body_format == NotifyFormat.HTML
+        ):
+            # Adapt converted CommonMark; direct WhatsApp input is unchanged.
+            body = self._commonmark_to_whatsapp(body)
 
         # Build the base URL
         schema = "https" if self.secure else "http"

--- a/apprise/plugins/evolution.py
+++ b/apprise/plugins/evolution.py
@@ -203,152 +203,220 @@ class NotifyEvolution(NotifyBase):
     @classmethod
     def _commonmark_to_whatsapp(cls, body):
         """Adapt html_to_markdown()'s CommonMark output to WhatsApp's own
-        text formatting dialect."""
+        text formatting dialect.
+
+        Overview
+        --------
+        html_to_markdown() produces CommonMark.  WhatsApp uses a different
+        dialect with these key differences:
+
+          CommonMark            WhatsApp
+          ----------            --------
+          **bold**              *bold*
+          *italic*              _italic_
+          `code`                ```code```  (always triple backtick)
+          [label](<url>)        label (url)  (no hyperlink syntax; WhatsApp
+                                             auto-links bare URLs)
+          \\*                   *  (backslash escapes dropped; WhatsApp
+                                   does not support them)
+
+        Links are rendered as "label (url)" because WhatsApp has no rich
+        anchor syntax -- it auto-links URLs that appear inline.  When the
+        label and the URL are the same, the label is omitted and only the
+        bare URL is emitted.
+
+        Data structures
+        ---------------
+        out        -- list of str fragments accumulated during the scan;
+                      joined once at the end to form the result string.
+                      Using a list avoids O(n^2) string concatenation.
+        stack      -- list of (delimiter, open_index) pairs, innermost
+                      frame last (LIFO order).  "delimiter" is "*" (bold)
+                      or "_" (italic).  "open_index" is the index in `out`
+                      where the opening delimiter was placed; used to drop
+                      empty spans at the force-close step.
+        link_stack -- list of out-indices for unmatched "[" characters that
+                      may start a CommonMark link label.  When we reach the
+                      matching "](<url>)", we splice in the "label (url)"
+                      form and discard the buffered "[".  Stray "[" chars
+                      that never match stay as plain text.
+        i          -- current position in the input string body[i].
+        n          -- len(body); cached to avoid repeated attribute lookup.
+        backtick_runs -- pre-built index of all unescaped backtick run
+                      positions indexed by run length so code-span matching
+                      is O(log n) instead of O(n^2).
+        """
 
         # Accumulate translated characters one item at a time.
         out = []
-        # Each entry is (delimiter, index-in-out) for an open emphasis span,
-        # innermost last, so we can close spans in LIFO order.
+        # Open emphasis spans in LIFO order.  Each entry is
+        # (delimiter, out_index) where out_index is where the opening
+        # delimiter sits in `out`.
         stack = []
-        # Each entry is the out-index of the opening "[" for a pending link,
-        # innermost last; used to splice the label text out when we find "]".
+        # Stack of out-indices for "[" chars that may open a link label.
+        # Innermost "[" is last so we match "](<url>)" LIFO.
         link_stack = []
         i = 0
         n = len(body)
-        # Pre-scan all unescaped backtick run positions indexed by run length
-        # so code-span open/close matching is O(log n) rather than O(n^2).
+        # Pre-scan all unescaped backtick run positions indexed by run
+        # length so code-span open/close matching is O(log n) not O(n^2).
         backtick_runs = build_backtick_run_index(body)
 
         while i < n:
             ch = body[i]
 
-            # WhatsApp does not use backslash escaping; emit the escaped
-            # character as a plain literal and discard the backslash.
+            # ----------------------------------------------------------------
+            # Backslash escapes
+            # ----------------------------------------------------------------
+            # WhatsApp does not recognise backslash escaping.  We discard
+            # the backslash and emit just the following literal character
+            # so it appears in the output without any escape prefix.
             if ch == "\\" and i + 1 < n:
                 out.append(body[i + 1])
                 i += 2
                 continue
 
-            # WhatsApp normalises all code spans to triple backticks
-            # regardless of how wide the original CommonMark delimiter was.
+            # ----------------------------------------------------------------
+            # Code spans  (` ... ` or ``` ... ```)
+            # ----------------------------------------------------------------
+            # Locate the matching close run of the same backtick width.
+            # WhatsApp only renders triple-backtick code spans, so we
+            # normalise all matched code spans to "```content```" form.
             if ch == "`":
                 j = i
                 # Measure the run length by counting consecutive backticks.
                 while j < n and body[j] == "`":
                     j += 1
                 run = j - i
-                # Search the pre-built index for the next run of the same
-                # length after the opening run ends.
+                # Search the pre-built index for the next matching close run.
                 close = find_unescaped_run(backtick_runs, j, run)
 
                 if close is not None:
-                    # Matched code span: collapse to triple-backtick form.
-                    # WhatsApp does not support single or double backtick code.
+                    # Matched code span: emit as triple backtick regardless
+                    # of the original delimiter width (single, double, etc.).
                     out.append("```" + body[j:close] + "```")
-                    # Advance past the closing run.
+                    # Skip past the closing backtick run.
                     i = close + run
                     continue
 
-                # No matching close -- not a real code span; emit the
-                # backticks as literal text.
+                # No matching close found -- not a real code span.
+                # Emit the raw backticks as literal text.
                 out.append(body[i:j])
                 i = j
                 continue
 
-            # CommonMark inline links look like [label](<url>).
+            # ----------------------------------------------------------------
+            # Link labels  [  (start of [label](<url>) construct)
+            # ----------------------------------------------------------------
             # Push the current out-index so we can retrieve the label text
-            # once we encounter the matching "](<".
+            # once we encounter the matching "](<url>)" further in the body.
+            # If no matching destination follows, the "[" stays as plain text.
             if ch == "[":
                 link_stack.append(len(out))
                 out.append("[")
                 i += 1
                 continue
 
+            # ----------------------------------------------------------------
+            # Link destination  ](<url>)  -->  label (url)
+            # ----------------------------------------------------------------
+            # When we see "](<" and there is an open "[" on link_stack,
+            # we have a complete CommonMark link.  Convert it to WhatsApp's
+            # plain "label (url)" form by scanning for the ">)" terminator,
+            # decoding the URL, and splicing the result back into `out`.
             if body.startswith("](<", i) and link_stack:
-                # We are at the "](<" that closes a pending link label.
-                # Scan forward with escape awareness to find ">)" which marks
-                # the end of the angle-bracketed destination.
+                # Scan forward with escape awareness so a literal ">)" inside
+                # the URL (e.g. a ">" in a query string) does not terminate
+                # the scan prematurely.
                 close = None
                 k = i + 3
                 while k < n - 1:
                     if body[k] == "\\" and k + 1 < n:
-                        # Skip escaped characters inside the destination so a
-                        # literal ">)" in the URL does not falsely terminate.
+                        # Skip escape sequences -- cannot be the terminator.
                         k += 2
                         continue
                     if body[k] == ">" and body[k + 1] == ")":
+                        # Found the closing ">)" of the destination.
                         close = k
                         break
                     k += 1
 
                 if close is not None:
-                    # Preserve the label beside the URL using WhatsApp's plain
-                    # "label (url)" convention -- WhatsApp auto-links the URL.
+                    # Decode CommonMark backslash escapes in the raw URL
+                    # fragment (body[i+3 : close]) to get the actual URL.
                     raw_url = body[i + 3 : close]
-                    # Decode CommonMark backslash escapes in the URL so we
-                    # work with the actual URL characters before re-encoding.
                     url = []
                     j2 = 0
                     while j2 < len(raw_url):
                         c2 = raw_url[j2]
                         if c2 == "\\" and j2 + 1 < len(raw_url):
-                            # Consume the backslash; keep only the next char.
+                            # Discard the backslash; keep only the next char.
                             url.append(raw_url[j2 + 1])
                             j2 += 2
                             continue
+                        # Plain character: pass through unchanged.
                         url.append(c2)
                         j2 += 1
                     url = "".join(url)
 
-                    # Retrieve the label text that was buffered after "[".
+                    # Retrieve the index of the matching "[" in out.
                     open_index = link_stack.pop()
+                    # Collect the label text buffered between "[" and "]".
                     text = "".join(out[open_index + 1 :])
-                    # Splice out everything from "[" onward.
+                    # Remove everything from "[" onward -- we will replace
+                    # it with the WhatsApp-native "label (url)" form.
                     del out[open_index:]
-                    # Percent-encode ")" so WhatsApp's auto-link parser does
-                    # not mistake a closing paren in the URL for the end of
-                    # the surrounding "label (url)" wrapper.
+                    # Percent-encode ")" inside the URL so WhatsApp's
+                    # auto-link parser does not mistake a paren in the URL
+                    # for the end of the "label (url)" wrapper parentheses.
                     safe_url = url.replace(")", "%29")
+                    # Emit "label (url)" when a label exists;
+                    # bare URL when no label text was present.
                     out.append(f"{text} ({safe_url})" if text else safe_url)
-                    # Skip past the closing ">)".
+                    # Skip past the closing ">)" of the destination.
                     i = close + 2
                     continue
 
-            # Emphasis: CommonMark uses * for bold (**) and italic (*).
-            # Convert to WhatsApp's dialect while preserving LIFO nesting.
+            # ----------------------------------------------------------------
+            # Emphasis runs  (* or **)
+            # ----------------------------------------------------------------
+            # CommonMark uses "*" (italic) and "**" (bold).  WhatsApp uses
+            # "_" (italic) and "*" (bold) -- the same mapping as Google Chat
+            # and Telegram.  Process the run one span at a time using the
+            # LIFO stack to always close the most recently opened span first.
             if ch == "*":
                 j = i
-                # Measure how many consecutive "*" characters are here.
+                # Measure the full asterisk run.
                 while j < n and body[j] == "*":
                     j += 1
                 run = j - i
 
-                # Consume the run one span at a time.  "**" maps to WhatsApp
-                # bold (*) and "*" maps to WhatsApp italic (_).  LIFO: close
-                # the most recently opened span if this run can satisfy it.
+                # Consume the run width one span at a time.
+                # Each iteration either closes the top-of-stack span (if the
+                # remaining run width satisfies it) or opens a new span.
                 while run > 0:
                     if stack and (
                         (stack[-1][0] == "*" and run >= 2)
                         or (stack[-1][0] == "_" and run >= 1)
                     ):
-                        # Close the innermost open span.
+                        # The top-of-stack span can be closed.  Pop it and
+                        # emit the close delimiter (or drop it if empty).
                         delim, open_index = stack.pop()
                         if open_index == len(out) - 1:
-                            # The span opened but collected no content --
-                            # drop the empty opening delimiter too.
+                            # Span collected no content -- drop the orphan.
                             out.pop()
                         else:
-                            # Emit the matching close delimiter.
+                            # Emit the close delimiter for this span.
                             out.append(delim)
-                        # Bold consumes 2 asterisks; italic consumes 1.
+                        # Bold ("*") consumes 2 asterisks; italic ("_") 1.
                         run -= 2 if delim == "*" else 1
                     elif run >= 2:
-                        # Open a new bold (*) span.
+                        # No closeable bold on stack; open a new bold span.
                         out.append("*")
                         stack.append(("*", len(out) - 1))
                         run -= 2
                     else:
-                        # Open a new italic (_) span.
+                        # run == 1: open a new italic span.
                         out.append("_")
                         stack.append(("_", len(out) - 1))
                         run -= 1
@@ -357,18 +425,25 @@ class NotifyEvolution(NotifyBase):
                 i = j
                 continue
 
+            # ----------------------------------------------------------------
             # All other characters pass through unchanged.
+            # ----------------------------------------------------------------
             out.append(ch)
             i += 1
 
-        # Force-close any spans still open so each chunk of output is
-        # independently valid WhatsApp markup even if the input was malformed.
+        # --------------------------------------------------------------------
+        # Force-close spans left open by malformed or truncated source.
+        # --------------------------------------------------------------------
+        # Pop innermost-first (LIFO) so the emitted close delimiters are in
+        # the right order.  Empty spans (open_index == last item) are dropped
+        # so the output contains no empty delimiter pairs.
         while stack:
             delim, open_index = stack.pop()
             if open_index == len(out) - 1:
-                # Opened but empty -- drop the dangling delimiter.
+                # Span opened but collected no content -- remove the orphan.
                 out.pop()
             else:
+                # Emit the close delimiter to produce valid WhatsApp markup.
                 out.append(delim)
 
         return "".join(out)

--- a/apprise/plugins/evolution.py
+++ b/apprise/plugins/evolution.py
@@ -47,12 +47,12 @@
 # Phone numbers must be in international format without the leading '+',
 # e.g. 5511999999999 for a Brazilian mobile number.
 
-from bisect import bisect_left
 from json import dumps
 
 import requests
 
 from ..common import NotifyFormat, NotifyType
+from ..conversion import build_backtick_run_index, find_unescaped_run
 from ..locale import gettext_lazy as _
 from ..utils.parse import (
     is_phone_no,
@@ -196,87 +196,68 @@ class NotifyEvolution(NotifyBase):
     # Direct WhatsApp Markdown is left unchanged.
     # Syntax: https://faq.whatsapp.com/539178204879377/
 
-    @classmethod
-    def _build_backtick_run_index(cls, text):
-        """Index unescaped backtick runs by width in one pass."""
-
-        index = {}
-        i = 0
-        n = len(text)
-
-        while i < n:
-            ch = text[i]
-
-            if ch == "\\" and i + 1 < n:
-                i += 2
-                continue
-
-            if ch == "`":
-                j = i
-                while j < n and text[j] == "`":
-                    j += 1
-                index.setdefault(j - i, []).append(i)
-                i = j
-                continue
-
-            i += 1
-
-        return index
-
-    @staticmethod
-    def _find_unescaped_run(index, start, run):
-        """Find the next indexed backtick run of the requested width."""
-
-        positions = index.get(run)
-        if not positions:
-            return None
-
-        pos = bisect_left(positions, start)
-        return positions[pos] if pos < len(positions) else None
+    # Expose shared delimiter helpers for classmethods, tests, and subclasses.
+    build_backtick_run_index = staticmethod(build_backtick_run_index)
+    find_unescaped_run = staticmethod(find_unescaped_run)
 
     @classmethod
     def _commonmark_to_whatsapp(cls, body):
         """Adapt html_to_markdown()'s CommonMark output to WhatsApp's own
         text formatting dialect."""
 
+        # Accumulate translated characters one item at a time.
         out = []
-        # Open emphasis spans as (delimiter, output index), innermost last.
+        # Each entry is (delimiter, index-in-out) for an open emphasis span,
+        # innermost last, so we can close spans in LIFO order.
         stack = []
-        # Index in `out` of each currently-open link's "[", innermost last.
+        # Each entry is the out-index of the opening "[" for a pending link,
+        # innermost last; used to splice the label text out when we find "]".
         link_stack = []
         i = 0
         n = len(body)
-        backtick_runs = cls._build_backtick_run_index(body)
+        # Pre-scan all unescaped backtick run positions indexed by run length
+        # so code-span open/close matching is O(log n) rather than O(n^2).
+        backtick_runs = build_backtick_run_index(body)
 
         while i < n:
             ch = body[i]
 
-            # WhatsApp needs the literal character, not CommonMark's escape.
+            # WhatsApp does not use backslash escaping; emit the escaped
+            # character as a plain literal and discard the backslash.
             if ch == "\\" and i + 1 < n:
                 out.append(body[i + 1])
                 i += 2
                 continue
 
-            # WhatsApp uses triple backticks for all monospace content.
+            # WhatsApp normalises all code spans to triple backticks
+            # regardless of how wide the original CommonMark delimiter was.
             if ch == "`":
                 j = i
+                # Measure the run length by counting consecutive backticks.
                 while j < n and body[j] == "`":
                     j += 1
                 run = j - i
-                close = cls._find_unescaped_run(backtick_runs, j, run)
+                # Search the pre-built index for the next run of the same
+                # length after the opening run ends.
+                close = find_unescaped_run(backtick_runs, j, run)
 
                 if close is not None:
+                    # Matched code span: collapse to triple-backtick form.
+                    # WhatsApp does not support single or double backtick code.
                     out.append("```" + body[j:close] + "```")
+                    # Advance past the closing run.
                     i = close + run
                     continue
 
-                # No matching close -- not a real code span; just literal
-                # backticks.
+                # No matching close -- not a real code span; emit the
+                # backticks as literal text.
                 out.append(body[i:j])
                 i = j
                 continue
 
-            # Track CommonMark labels for conversion to plain labeled URLs.
+            # CommonMark inline links look like [label](<url>).
+            # Push the current out-index so we can retrieve the label text
+            # once we encounter the matching "](<".
             if ch == "[":
                 link_stack.append(len(out))
                 out.append("[")
@@ -284,11 +265,15 @@ class NotifyEvolution(NotifyBase):
                 continue
 
             if body.startswith("](<", i) and link_stack:
-                # Find the destination's next unescaped closing `>)`.
+                # We are at the "](<" that closes a pending link label.
+                # Scan forward with escape awareness to find ">)" which marks
+                # the end of the angle-bracketed destination.
                 close = None
                 k = i + 3
                 while k < n - 1:
                     if body[k] == "\\" and k + 1 < n:
+                        # Skip escaped characters inside the destination so a
+                        # literal ">)" in the URL does not falsely terminate.
                         k += 2
                         continue
                     if body[k] == ">" and body[k + 1] == ")":
@@ -297,13 +282,17 @@ class NotifyEvolution(NotifyBase):
                     k += 1
 
                 if close is not None:
-                    # Preserve the label beside WhatsApp's auto-linked URL.
+                    # Preserve the label beside the URL using WhatsApp's plain
+                    # "label (url)" convention -- WhatsApp auto-links the URL.
                     raw_url = body[i + 3 : close]
+                    # Decode CommonMark backslash escapes in the URL so we
+                    # work with the actual URL characters before re-encoding.
                     url = []
                     j2 = 0
                     while j2 < len(raw_url):
                         c2 = raw_url[j2]
                         if c2 == "\\" and j2 + 1 < len(raw_url):
+                            # Consume the backslash; keep only the next char.
                             url.append(raw_url[j2 + 1])
                             j2 += 2
                             continue
@@ -311,55 +300,121 @@ class NotifyEvolution(NotifyBase):
                         j2 += 1
                     url = "".join(url)
 
+                    # Retrieve the label text that was buffered after "[".
                     open_index = link_stack.pop()
                     text = "".join(out[open_index + 1 :])
+                    # Splice out everything from "[" onward.
                     del out[open_index:]
-                    out.append(f"{text} ({url})" if text else url)
+                    # Percent-encode ")" so WhatsApp's auto-link parser does
+                    # not mistake a closing paren in the URL for the end of
+                    # the surrounding "label (url)" wrapper.
+                    safe_url = url.replace(")", "%29")
+                    out.append(f"{text} ({safe_url})" if text else safe_url)
+                    # Skip past the closing ">)".
                     i = close + 2
                     continue
 
-            # Convert CommonMark emphasis while preserving LIFO nesting.
+            # Emphasis: CommonMark uses * for bold (**) and italic (*).
+            # Convert to WhatsApp's dialect while preserving LIFO nesting.
             if ch == "*":
                 j = i
+                # Measure how many consecutive "*" characters are here.
                 while j < n and body[j] == "*":
                     j += 1
                 run = j - i
 
+                # Consume the run one span at a time.  "**" maps to WhatsApp
+                # bold (*) and "*" maps to WhatsApp italic (_).  LIFO: close
+                # the most recently opened span if this run can satisfy it.
                 while run > 0:
                     if stack and (
                         (stack[-1][0] == "*" and run >= 2)
                         or (stack[-1][0] == "_" and run >= 1)
                     ):
+                        # Close the innermost open span.
                         delim, open_index = stack.pop()
                         if open_index == len(out) - 1:
+                            # The span opened but collected no content --
+                            # drop the empty opening delimiter too.
                             out.pop()
                         else:
+                            # Emit the matching close delimiter.
                             out.append(delim)
+                        # Bold consumes 2 asterisks; italic consumes 1.
                         run -= 2 if delim == "*" else 1
                     elif run >= 2:
+                        # Open a new bold (*) span.
                         out.append("*")
                         stack.append(("*", len(out) - 1))
                         run -= 2
                     else:
+                        # Open a new italic (_) span.
                         out.append("_")
                         stack.append(("_", len(out) - 1))
                         run -= 1
 
+                # Advance past the entire asterisk run.
                 i = j
                 continue
 
+            # All other characters pass through unchanged.
             out.append(ch)
             i += 1
 
-        # Close out anything still open so the result is valid on its own.
+        # Force-close any spans still open so each chunk of output is
+        # independently valid WhatsApp markup even if the input was malformed.
         while stack:
             delim, open_index = stack.pop()
             if open_index == len(out) - 1:
+                # Opened but empty -- drop the dangling delimiter.
                 out.pop()
             else:
                 out.append(delim)
 
         return "".join(out)
+
+    def _build_send_calls(
+        self, body=None, title=None, body_format=None, **kwargs
+    ):
+        """Convert CommonMark to WhatsApp before splitting it into chunks."""
+
+        # Only adapt HTML-derived Markdown; pass other formats through.
+        if not (
+            self.notify_format == NotifyFormat.MARKDOWN
+            and body_format == NotifyFormat.HTML
+        ):
+            yield from super()._build_send_calls(
+                body=body,
+                title=title,
+                body_format=body_format,
+                **kwargs,
+            )
+            return
+
+        # Merge the title before conversion; WhatsApp has no title field.
+        if self.title_maxlen <= 0 and title:
+            # Strip leading whitespace and Markdown heading / list chars that
+            # would otherwise produce a malformed "# # Title" heading.
+            title_text = title.lstrip("\r\n \t\v\f#-")
+            if title_text:
+                # Prepend the title as a level-1 heading above the body.
+                body = f"# {title_text}\n{body}" if body else f"# {title_text}"
+            # Clear the title so the base class does not try to send it
+            # separately as a second field.
+            title = ""
+
+        # Apply the WhatsApp dialect adapter to convert CommonMark constructs
+        # (backslash escapes, links, emphasis, code spans) to WhatsApp syntax.
+        body = self._commonmark_to_whatsapp(body)
+
+        # Tell the base splitter that the body is now WhatsApp Markdown so
+        # that split heuristics protect link and code-span constructs.
+        yield from super()._build_send_calls(
+            body=body,
+            title=title,
+            body_format=NotifyFormat.MARKDOWN,
+            **kwargs,
+        )
 
     def send(
         self,
@@ -370,13 +425,6 @@ class NotifyEvolution(NotifyBase):
         **kwargs,
     ):
         """Perform Evolution API Notification."""
-
-        if (
-            self.notify_format == NotifyFormat.MARKDOWN
-            and body_format == NotifyFormat.HTML
-        ):
-            # Adapt converted CommonMark; direct WhatsApp input is unchanged.
-            body = self._commonmark_to_whatsapp(body)
 
         # Build the base URL
         schema = "https" if self.secure else "http"

--- a/apprise/plugins/evolution.py
+++ b/apprise/plugins/evolution.py
@@ -48,11 +48,18 @@
 # e.g. 5511999999999 for a Brazilian mobile number.
 
 from json import dumps
+import re
 
 import requests
 
 from ..common import NotifyFormat, NotifyType
-from ..conversion import build_backtick_run_index, find_unescaped_run
+from ..conversion import (
+    build_backtick_run_index,
+    commonmark_emphasis_run,
+    commonmark_force_close_spans,
+    commonmark_scan_angle_dest,
+    find_unescaped_run,
+)
 from ..locale import gettext_lazy as _
 from ..utils.parse import (
     is_phone_no,
@@ -196,92 +203,46 @@ class NotifyEvolution(NotifyBase):
     # Direct WhatsApp Markdown is left unchanged.
     # Syntax: https://faq.whatsapp.com/539178204879377/
 
-    # Expose shared delimiter helpers for classmethods, tests, and subclasses.
-    build_backtick_run_index = staticmethod(build_backtick_run_index)
-    find_unescaped_run = staticmethod(find_unescaped_run)
-
     @classmethod
     def _commonmark_to_whatsapp(cls, body):
-        """Adapt html_to_markdown()'s CommonMark output to WhatsApp's own
-        text formatting dialect.
+        """Translate CommonMark to WhatsApp formatting.
 
-        Overview
-        --------
-        html_to_markdown() produces CommonMark.  WhatsApp uses a different
-        dialect with these key differences:
+        CommonMark          WhatsApp
+        ------------------  ---------------------------
+        **bold**            *bold*
+        *italic*            _italic_
+        `code`              ```code``` (triple backticks)
+        [label](<url>)      label (url)
+        \\*                 *
 
-          CommonMark            WhatsApp
-          ----------            --------
-          **bold**              *bold*
-          *italic*              _italic_
-          `code`                ```code```  (always triple backtick)
-          [label](<url>)        label (url)  (no hyperlink syntax; WhatsApp
-                                             auto-links bare URLs)
-          \\*                   *  (backslash escapes dropped; WhatsApp
-                                   does not support them)
-
-        Links are rendered as "label (url)" because WhatsApp has no rich
-        anchor syntax -- it auto-links URLs that appear inline.  When the
-        label and the URL are the same, the label is omitted and only the
-        bare URL is emitted.
-
-        Data structures
-        ---------------
-        out        -- list of str fragments accumulated during the scan;
-                      joined once at the end to form the result string.
-                      Using a list avoids O(n^2) string concatenation.
-        stack      -- list of (delimiter, open_index) pairs, innermost
-                      frame last (LIFO order).  "delimiter" is "*" (bold)
-                      or "_" (italic).  "open_index" is the index in `out`
-                      where the opening delimiter was placed; used to drop
-                      empty spans at the force-close step.
-        link_stack -- list of out-indices for unmatched "[" characters that
-                      may start a CommonMark link label.  When we reach the
-                      matching "](<url>)", we splice in the "label (url)"
-                      form and discard the buffered "[".  Stray "[" chars
-                      that never match stay as plain text.
-        i          -- current position in the input string body[i].
-        n          -- len(body); cached to avoid repeated attribute lookup.
-        backtick_runs -- pre-built index of all unescaped backtick run
-                      positions indexed by run length so code-span matching
-                      is O(log n) instead of O(n^2).
+        WhatsApp auto-links bare URLs but has no custom-label link syntax.
+        Backslash escapes are removed because WhatsApp does not use them.
         """
 
         # Accumulate translated characters one item at a time.
         out = []
-        # Open emphasis spans in LIFO order.  Each entry is
-        # (delimiter, out_index) where out_index is where the opening
-        # delimiter sits in `out`.
+        # Track open emphasis as ``(delimiter, output index)`` pairs.
         stack = []
-        # Stack of out-indices for "[" chars that may open a link label.
-        # Innermost "[" is last so we match "](<url>)" LIFO.
+        # Track possible link-label openings in LIFO order.
         link_stack = []
+
+        # Initialize the single-pass scanner.
         i = 0
         n = len(body)
-        # Pre-scan all unescaped backtick run positions indexed by run
-        # length so code-span open/close matching is O(log n) not O(n^2).
+
+        # Index backtick runs for efficient closing-delimiter lookups.
         backtick_runs = build_backtick_run_index(body)
 
         while i < n:
             ch = body[i]
 
-            # ----------------------------------------------------------------
-            # Backslash escapes
-            # ----------------------------------------------------------------
-            # WhatsApp does not recognise backslash escaping.  We discard
-            # the backslash and emit just the following literal character
-            # so it appears in the output without any escape prefix.
+            # Drop CommonMark escapes because WhatsApp does not use them.
             if ch == "\\" and i + 1 < n:
                 out.append(body[i + 1])
                 i += 2
                 continue
 
-            # ----------------------------------------------------------------
-            # Code spans  (` ... ` or ``` ... ```)
-            # ----------------------------------------------------------------
-            # Locate the matching close run of the same backtick width.
-            # WhatsApp only renders triple-backtick code spans, so we
-            # normalise all matched code spans to "```content```" form.
+            # Normalize matched CommonMark code spans to triple backticks.
             if ch == "`":
                 j = i
                 # Measure the run length by counting consecutive backticks.
@@ -292,58 +253,34 @@ class NotifyEvolution(NotifyBase):
                 close = find_unescaped_run(backtick_runs, j, run)
 
                 if close is not None:
-                    # Matched code span: emit as triple backtick regardless
-                    # of the original delimiter width (single, double, etc.).
-                    out.append("```" + body[j:close] + "```")
+                    # WhatsApp uses triple backticks for monospace text.
+                    # Collapse runs of three or more backticks to two so
+                    # embedded content cannot close the WhatsApp span early.
+                    content = re.sub(r"`{3,}", "``", body[j:close])
+                    out.append("```" + content + "```")
                     # Skip past the closing backtick run.
                     i = close + run
                     continue
 
-                # No matching close found -- not a real code span.
-                # Emit the raw backticks as literal text.
+                # Preserve unmatched backticks as literal text.
                 out.append(body[i:j])
                 i = j
                 continue
 
-            # ----------------------------------------------------------------
-            # Link labels  [  (start of [label](<url>) construct)
-            # ----------------------------------------------------------------
-            # Push the current out-index so we can retrieve the label text
-            # once we encounter the matching "](<url>)" further in the body.
-            # If no matching destination follows, the "[" stays as plain text.
+            # Record a possible CommonMark link-label opening.
             if ch == "[":
                 link_stack.append(len(out))
                 out.append("[")
                 i += 1
                 continue
 
-            # ----------------------------------------------------------------
-            # Link destination  ](<url>)  -->  label (url)
-            # ----------------------------------------------------------------
-            # When we see "](<" and there is an open "[" on link_stack,
-            # we have a complete CommonMark link.  Convert it to WhatsApp's
-            # plain "label (url)" form by scanning for the ">)" terminator,
-            # decoding the URL, and splicing the result back into `out`.
+            # Convert a complete CommonMark link to ``label (url)``.
             if body.startswith("](<", i) and link_stack:
-                # Scan forward with escape awareness so a literal ">)" inside
-                # the URL (e.g. a ">" in a query string) does not terminate
-                # the scan prematurely.
-                close = None
-                k = i + 3
-                while k < n - 1:
-                    if body[k] == "\\" and k + 1 < n:
-                        # Skip escape sequences -- cannot be the terminator.
-                        k += 2
-                        continue
-                    if body[k] == ">" and body[k + 1] == ")":
-                        # Found the closing ">)" of the destination.
-                        close = k
-                        break
-                    k += 1
+                # Scan forward with escape awareness for the ">)" terminator.
+                close = commonmark_scan_angle_dest(body, i, n)
 
                 if close is not None:
-                    # Decode CommonMark backslash escapes in the raw URL
-                    # fragment (body[i+3 : close]) to get the actual URL.
+                    # Decode CommonMark escapes from the raw destination.
                     raw_url = body[i + 3 : close]
                     url = []
                     j2 = 0
@@ -359,99 +296,42 @@ class NotifyEvolution(NotifyBase):
                         j2 += 1
                     url = "".join(url)
 
-                    # Retrieve the index of the matching "[" in out.
+                    # Recover the buffered label and remove its opening ``[``.
                     open_index = link_stack.pop()
-                    # Collect the label text buffered between "[" and "]".
                     text = "".join(out[open_index + 1 :])
-                    # Remove everything from "[" onward -- we will replace
-                    # it with the WhatsApp-native "label (url)" form.
                     del out[open_index:]
-                    # Percent-encode ")" inside the URL so WhatsApp's
-                    # auto-link parser does not mistake a paren in the URL
-                    # for the end of the "label (url)" wrapper parentheses.
+
+                    # Protect wrapper parentheses from URL content.
                     safe_url = url.replace(")", "%29")
-                    # Emit "label (url)" when a label exists;
-                    # bare URL when no label text was present.
+
+                    # Omit the label when only a bare URL is available.
                     out.append(f"{text} ({safe_url})" if text else safe_url)
                     # Skip past the closing ">)" of the destination.
                     i = close + 2
                     continue
 
-            # ----------------------------------------------------------------
-            # Emphasis runs  (* or **)
-            # ----------------------------------------------------------------
-            # CommonMark uses "*" (italic) and "**" (bold).  WhatsApp uses
-            # "_" (italic) and "*" (bold) -- the same mapping as Google Chat
-            # and Telegram.  Process the run one span at a time using the
-            # LIFO stack to always close the most recently opened span first.
+            # Map CommonMark emphasis to WhatsApp's ``*``/``_`` syntax.
             if ch == "*":
-                j = i
-                # Measure the full asterisk run.
-                while j < n and body[j] == "*":
-                    j += 1
-                run = j - i
-
-                # Consume the run width one span at a time.
-                # Each iteration either closes the top-of-stack span (if the
-                # remaining run width satisfies it) or opens a new span.
-                while run > 0:
-                    if stack and (
-                        (stack[-1][0] == "*" and run >= 2)
-                        or (stack[-1][0] == "_" and run >= 1)
-                    ):
-                        # The top-of-stack span can be closed.  Pop it and
-                        # emit the close delimiter (or drop it if empty).
-                        delim, open_index = stack.pop()
-                        if open_index == len(out) - 1:
-                            # Span collected no content -- drop the orphan.
-                            out.pop()
-                        else:
-                            # Emit the close delimiter for this span.
-                            out.append(delim)
-                        # Bold ("*") consumes 2 asterisks; italic ("_") 1.
-                        run -= 2 if delim == "*" else 1
-                    elif run >= 2:
-                        # No closeable bold on stack; open a new bold span.
-                        out.append("*")
-                        stack.append(("*", len(out) - 1))
-                        run -= 2
-                    else:
-                        # run == 1: open a new italic span.
-                        out.append("_")
-                        stack.append(("_", len(out) - 1))
-                        run -= 1
-
-                # Advance past the entire asterisk run.
-                i = j
+                i = commonmark_emphasis_run(body, i, n, stack, out)
                 continue
 
-            # ----------------------------------------------------------------
-            # All other characters pass through unchanged.
-            # ----------------------------------------------------------------
+            # Preserve ordinary characters.
             out.append(ch)
             i += 1
 
-        # --------------------------------------------------------------------
-        # Force-close spans left open by malformed or truncated source.
-        # --------------------------------------------------------------------
-        # Pop innermost-first (LIFO) so the emitted close delimiters are in
-        # the right order.  Empty spans (open_index == last item) are dropped
-        # so the output contains no empty delimiter pairs.
-        while stack:
-            delim, open_index = stack.pop()
-            if open_index == len(out) - 1:
-                # Span opened but collected no content -- remove the orphan.
-                out.pop()
-            else:
-                # Emit the close delimiter to produce valid WhatsApp markup.
-                out.append(delim)
+        # Close spans left open by malformed or truncated input.
+        commonmark_force_close_spans(out, stack)
 
+        # Join the translated fragments once.
         return "".join(out)
 
     def _build_send_calls(
         self, body=None, title=None, body_format=None, **kwargs
     ):
-        """Convert CommonMark to WhatsApp before splitting it into chunks."""
+        """Convert HTML-derived CommonMark before splitting for WhatsApp.
+
+        Direct Markdown and other source formats pass through unchanged.
+        """
 
         # Only adapt HTML-derived Markdown; pass other formats through.
         if not (
@@ -466,16 +346,15 @@ class NotifyEvolution(NotifyBase):
             )
             return
 
-        # Merge the title before conversion; WhatsApp has no title field.
+        # WhatsApp has no title field or heading syntax, so use bold text.
         if self.title_maxlen <= 0 and title:
-            # Strip leading whitespace and Markdown heading / list chars that
-            # would otherwise produce a malformed "# # Title" heading.
+            # Strip leading whitespace and Markdown heading / list chars.
             title_text = title.lstrip("\r\n \t\v\f#-")
             if title_text:
-                # Prepend the title as a level-1 heading above the body.
-                body = f"# {title_text}\n{body}" if body else f"# {title_text}"
-            # Clear the title so the base class does not try to send it
-            # separately as a second field.
+                # Prepend the title as a bold line above the body.
+                heading = f"**{title_text}**"
+                body = f"{heading}\n{body}" if body else heading
+            # Clear the title so the base class does not send it separately.
             title = ""
 
         # Apply the WhatsApp dialect adapter to convert CommonMark constructs

--- a/apprise/plugins/google_chat.py
+++ b/apprise/plugins/google_chat.py
@@ -213,64 +213,114 @@ class NotifyGoogleChat(NotifyBase):
     @classmethod
     def _commonmark_to_google_chat(cls, body):
         """Adapt html_to_markdown()'s CommonMark output to Google Chat's
-        own text formatting dialect."""
+        own text formatting dialect.
+
+        Overview
+        --------
+        html_to_markdown() produces CommonMark.  Google Chat uses a
+        different dialect with these key differences:
+
+          CommonMark            Google Chat
+          ----------            -----------
+          **bold**              *bold*
+          *italic*              _italic_
+          `code`                `code`  (same delimiter, but content must
+                                         be HTML-entity-escaped)
+          [label](<url>)        <url|label>  (Chat anchor syntax)
+          & < > in text         &amp; &lt; &gt;  (Chat renders HTML)
+          \\< or \\>            &lt; / &gt;  (prevent Chat anchor parsing)
+
+        Data structures
+        ---------------
+        out        -- list of str fragments accumulated during the scan;
+                      joined once at the end to form the result string.
+                      Using a list avoids O(n^2) string concatenation.
+        stack      -- list of (delimiter, open_index) pairs, innermost
+                      frame last (LIFO order).  "delimiter" is "*" (bold)
+                      or "_" (italic).  "open_index" is the index in `out`
+                      where the opening delimiter was placed; used to drop
+                      empty spans (open_index == last item) at cleanup.
+        link_stack -- list of out-indices for unmatched "[" characters that
+                      may start a CommonMark link label.  When we reach the
+                      matching "](<url>)", we retrieve the buffered label
+                      text and rewrite the construct as <url|label>.  Stray
+                      "[" characters that never find a destination are kept
+                      as plain text (they were already appended to `out`).
+        i          -- current position in the input string body[i].
+        n          -- len(body); cached to avoid repeated attribute lookup.
+        backtick_runs -- pre-built index of all unescaped backtick run
+                      positions indexed by run length so code-span matching
+                      is O(log n) instead of O(n^2).
+        """
 
         # Accumulate translated characters one item at a time.
         out = []
-        # Each entry is (delimiter, index-in-out) for an open emphasis span,
-        # innermost last, so we can close spans in LIFO order.
+        # Open emphasis spans in LIFO order.  Each entry is
+        # (delimiter, out_index) where out_index is where the opening
+        # delimiter sits in `out`.
         stack = []
-        # Each entry is the out-index of the opening "[" for a pending link,
-        # innermost last; used to splice the label text out when we find "]".
+        # Stack of out-indices for "[" chars that may open a link label.
+        # Innermost "[" is last so we match "](<url>)" LIFO.
         link_stack = []
         i = 0
         n = len(body)
-        # Pre-scan all unescaped backtick run positions indexed by run length
-        # so code-span open/close matching is O(log n) rather than O(n^2).
+        # Pre-scan all unescaped backtick run positions indexed by run
+        # length so code-span open/close matching is O(log n) not O(n^2).
         backtick_runs = build_backtick_run_index(body)
 
         while i < n:
             ch = body[i]
 
-            # CommonMark backslash escapes: translate into Chat-safe forms.
+            # ----------------------------------------------------------------
+            # Backslash escapes
+            # ----------------------------------------------------------------
+            # CommonMark escapes look like "\*" or "\[".  We strip the
+            # backslash and emit just the literal character, but we must
+            # also HTML-entity-escape "<" and ">" because Google Chat's
+            # renderer will otherwise interpret them as anchor delimiters.
             if ch == "\\" and i + 1 < n:
                 nxt = body[i + 1]
                 if nxt == "<":
-                    # "<" must be entity-escaped so Chat does not treat it as
-                    # the start of a <url|label> anchor.
+                    # "<" starts a Chat anchor; escape it to prevent that.
                     out.append("&lt;")
                 elif nxt == ">":
-                    # Symmetric: ">" closes Chat anchors and must be escaped.
+                    # ">" closes a Chat anchor; escape it symmetrically.
                     out.append("&gt;")
                 else:
-                    # All other escapes: emit just the escaped character so
-                    # the backslash is not passed through to the Chat renderer.
+                    # All other escapes: emit just the escaped character.
+                    # The backslash itself is not sent to Chat's renderer.
                     out.append(nxt)
                 i += 2
                 continue
 
-            # Chat requires literal ampersands to be entity-escaped so they
-            # are not confused with HTML entity sequences in the payload.
+            # ----------------------------------------------------------------
+            # Literal ampersands
+            # ----------------------------------------------------------------
+            # Chat's renderer interprets "&" as the start of an HTML entity.
+            # Escape every bare "&" so it renders as a literal ampersand.
             if ch == "&":
                 out.append("&amp;")
                 i += 1
                 continue
 
-            # Code spans: locate the matching closing run of the same length
-            # and entity-escape HTML controls inside the span content.
+            # ----------------------------------------------------------------
+            # Code spans  (` ... ` or ``` ... ```)
+            # ----------------------------------------------------------------
+            # Locate the matching closing run of the same backtick width.
+            # Inside code spans, HTML control characters must be entity-escaped
+            # so Chat does not interpret them as markup.
             if ch == "`":
                 j = i
                 # Measure the run length by counting consecutive backticks.
                 while j < n and body[j] == "`":
                     j += 1
                 run = j - i
-                # Search the pre-built index for the next run of the same
-                # length after the opening run ends.
+                # Search the pre-built index for the matching close run.
                 close = find_unescaped_run(backtick_runs, j, run)
 
                 if close is not None:
-                    # Matched code span: entity-escape its content so Chat
-                    # does not interpret HTML inside monospace runs.
+                    # Matched code span: entity-escape HTML controls inside
+                    # so Chat does not interpret them as markup.
                     content = body[j:close]
                     content = (
                         content.replace("&", "&amp;")
@@ -280,92 +330,111 @@ class NotifyGoogleChat(NotifyBase):
                     # Preserve the original delimiter width (1, 2, or 3+).
                     delim = body[i:j]
                     out.append(delim + content + delim)
-                    # Advance past the closing run.
+                    # Skip past the closing backtick run.
                     i = close + run
                     continue
 
-                # No matching close -- not a real code span; emit the
-                # backticks as literal text.
+                # No matching close found -- not a real code span.
+                # Emit the raw backticks as literal text.
                 out.append(body[i:j])
                 i = j
                 continue
 
-            # CommonMark inline links look like [label](<url>).
+            # ----------------------------------------------------------------
+            # Link labels  [  (start of [label](<url>) construct)
+            # ----------------------------------------------------------------
             # Push the current out-index so we can retrieve the label text
-            # once we encounter the matching "](<".
+            # once we encounter the matching "](<url>)" further in the body.
+            # If no matching destination follows, the "[" stays as plain text.
             if ch == "[":
                 link_stack.append(len(out))
                 out.append("[")
                 i += 1
                 continue
 
+            # ----------------------------------------------------------------
+            # Link destination  ](<url>)  -->  <url|label>
+            # ----------------------------------------------------------------
+            # When we see "](<" and there is an open "[" on link_stack,
+            # we have a complete CommonMark link.  Rewrite it as a Chat
+            # anchor by: scanning forward for ">)" (the destination end),
+            # decoding the URL, and splicing the label+destination back
+            # into `out` as "<url|label>".
             if body.startswith("](<", i) and link_stack:
-                # We are at the "](<" that closes a pending link label.
-                # Scan forward with escape awareness to find ">)" which marks
-                # the end of the angle-bracketed destination.
+                # Scan forward with escape awareness so a literal ">)" inside
+                # the URL does not falsely terminate the destination scan.
                 close = None
                 k = i + 3
                 while k < n - 1:
                     if body[k] == "\\" and k + 1 < n:
-                        # Skip escaped characters inside the destination so a
-                        # literal ">)" in the URL does not falsely terminate.
+                        # Skip escape sequences -- cannot be the terminator.
                         k += 2
                         continue
                     if body[k] == ">" and body[k + 1] == ")":
+                        # Found the closing ">)" of the destination.
                         close = k
                         break
                     k += 1
 
                 if close is not None:
-                    # Decode CommonMark escapes in the URL and re-encode
-                    # characters that would break the <url|label> syntax.
+                    # Decode CommonMark backslash escapes in the URL and
+                    # re-encode characters that would break Chat's anchor
+                    # syntax (e.g. a literal "<", ">", or "|" in the URL).
                     url = commonmark_escape_link_url(body[i + 3 : close])
-                    # Retrieve the label text that was buffered after "[".
+                    # Retrieve the index of the matching "[" in out.
                     open_index = link_stack.pop()
+                    # Collect the label text that was buffered after "[".
                     text = "".join(out[open_index + 1 :])
-                    # Splice out everything from "[" onward and replace with
-                    # the Chat-native anchor format.
+                    # Remove everything from "[" onward from out and replace
+                    # it with the Chat-native anchor in one splice.
                     del out[open_index:]
                     out.append(f"<{url}|{text}>")
-                    # Skip past the closing ">)".
+                    # Skip past the closing ">)" of the destination.
                     i = close + 2
                     continue
 
-            # Emphasis: CommonMark uses * for bold (**) and italic (*).
-            # Convert to Chat Markdown while preserving LIFO nesting order.
+            # ----------------------------------------------------------------
+            # Emphasis runs  (* or **)
+            # ----------------------------------------------------------------
+            # CommonMark uses "*" (italic) and "**" (bold).  Google Chat
+            # uses "_" (italic) and "*" (bold).  We process each asterisk
+            # run one span at a time using the LIFO stack to match the most
+            # recently opened span first, preserving correct nesting order.
             if ch == "*":
                 j = i
-                # Measure how many consecutive "*" characters are here.
+                # Measure the full asterisk run.
                 while j < n and body[j] == "*":
                     j += 1
                 run = j - i
 
-                # Consume the run one span at a time.  "**" maps to Chat bold
-                # (*) and "*" maps to Chat italic (_).  LIFO: close the most
-                # recently opened span if this run width can satisfy it.
+                # Consume the run width one span at a time.
+                # Each iteration either closes the top-of-stack span (if the
+                # remaining run width satisfies it) or opens a new span.
                 while run > 0:
                     if stack and (
                         (stack[-1][0] == "*" and run >= 2)
                         or (stack[-1][0] == "_" and run >= 1)
                     ):
-                        # Close the innermost open span.
+                        # The top-of-stack span can be closed by the
+                        # current run width.  Pop and emit the close
+                        # delimiter (or drop it if the span is empty).
                         delim, open_index = stack.pop()
                         if open_index == len(out) - 1:
                             # The span opened but collected no content --
-                            # drop the empty opening delimiter too.
+                            # remove the orphan opening delimiter entirely.
                             out.pop()
                         else:
-                            # Emit the matching close delimiter.
+                            # Emit the close delimiter for this span.
                             out.append(delim)
-                        # Bold consumes 2 asterisks; italic consumes 1.
+                        # Bold ("*") consumes 2 asterisks; italic ("_") 1 each.
                         run -= 2 if delim == "*" else 1
                     elif run >= 2:
-                        # Open a new bold (*) span.
+                        # No closeable bold on stack; open a new bold span.
                         out.append("*")
                         stack.append(("*", len(out) - 1))
                         run -= 2
                     else:
-                        # Open a new italic (_) span.
+                        # run == 1: open a new italic span.
                         out.append("_")
                         stack.append(("_", len(out) - 1))
                         run -= 1
@@ -374,18 +443,25 @@ class NotifyGoogleChat(NotifyBase):
                 i = j
                 continue
 
+            # ----------------------------------------------------------------
             # All other characters pass through unchanged.
+            # ----------------------------------------------------------------
             out.append(ch)
             i += 1
 
-        # Force-close any spans still open so each chunk of output is
-        # independently valid Chat Markdown even if the input was malformed.
+        # --------------------------------------------------------------------
+        # Force-close spans left open by malformed or truncated source.
+        # --------------------------------------------------------------------
+        # Pop innermost-first (LIFO) so the emitted close delimiters are in
+        # the right order.  Empty spans (open_index == last item) are dropped
+        # so the output contains no empty delimiter pairs.
         while stack:
             delim, open_index = stack.pop()
             if open_index == len(out) - 1:
-                # Opened but empty -- drop the dangling delimiter.
+                # Span opened but collected no content -- remove the orphan.
                 out.pop()
             else:
+                # Emit the close delimiter to produce valid Chat Markdown.
                 out.append(delim)
 
         text = "".join(out)

--- a/apprise/plugins/google_chat.py
+++ b/apprise/plugins/google_chat.py
@@ -53,13 +53,17 @@
 #         incoming-bot-python
 #    - https://developers.google.com/hangouts/chat/reference/rest
 #
-from bisect import bisect_left
 from json import dumps
 import re
 
 import requests
 
 from ..common import NotifyFormat, NotifyType
+from ..conversion import (
+    build_backtick_run_index,
+    commonmark_escape_link_url,
+    find_unescaped_run,
+)
 from ..locale import gettext_lazy as _
 from ..utils.parse import validate_regex
 from .base import NotifyBase
@@ -202,129 +206,93 @@ class NotifyGoogleChat(NotifyBase):
     # Direct Google Chat Markdown is left unchanged.
     # Syntax: https://developers.google.com/workspace/chat/format-messages
 
-    @classmethod
-    def _build_backtick_run_index(cls, text):
-        """Index unescaped backtick runs by width in one pass."""
-
-        index = {}
-        i = 0
-        n = len(text)
-
-        while i < n:
-            ch = text[i]
-
-            if ch == "\\" and i + 1 < n:
-                i += 2
-                continue
-
-            if ch == "`":
-                j = i
-                while j < n and text[j] == "`":
-                    j += 1
-                index.setdefault(j - i, []).append(i)
-                i = j
-                continue
-
-            i += 1
-
-        return index
-
-    @staticmethod
-    def _find_unescaped_run(index, start, run):
-        """Find the next indexed backtick run of the requested width."""
-
-        positions = index.get(run)
-        if not positions:
-            return None
-
-        pos = bisect_left(positions, start)
-        return positions[pos] if pos < len(positions) else None
-
-    @classmethod
-    def _escape_link_url(cls, url):
-        """Adapt a CommonMark destination for Chat's ``<url|text>`` form."""
-
-        # Resolve CommonMark escapes before applying Chat escaping.
-        out = []
-        i = 0
-        n = len(url)
-        while i < n:
-            ch = url[i]
-            if ch == "\\" and i + 1 < n:
-                out.append(url[i + 1])
-                i += 2
-                continue
-            out.append(ch)
-            i += 1
-        url = "".join(out)
-
-        # Entity-escape Chat controls and encode its URL-label separator.
-        url = url.replace("&", "&amp;").replace("<", "&lt;")
-        url = url.replace(">", "&gt;")
-        return url.replace("|", "%7C")
+    # Expose shared delimiter helpers for classmethods, tests, and subclasses.
+    build_backtick_run_index = staticmethod(build_backtick_run_index)
+    find_unescaped_run = staticmethod(find_unescaped_run)
 
     @classmethod
     def _commonmark_to_google_chat(cls, body):
         """Adapt html_to_markdown()'s CommonMark output to Google Chat's
         own text formatting dialect."""
 
+        # Accumulate translated characters one item at a time.
         out = []
-        # Open emphasis spans as (delimiter, output index), innermost last.
+        # Each entry is (delimiter, index-in-out) for an open emphasis span,
+        # innermost last, so we can close spans in LIFO order.
         stack = []
-        # Index in `out` of each currently-open link's "[", innermost last.
+        # Each entry is the out-index of the opening "[" for a pending link,
+        # innermost last; used to splice the label text out when we find "]".
         link_stack = []
         i = 0
         n = len(body)
-        backtick_runs = cls._build_backtick_run_index(body)
+        # Pre-scan all unescaped backtick run positions indexed by run length
+        # so code-span open/close matching is O(log n) rather than O(n^2).
+        backtick_runs = build_backtick_run_index(body)
 
         while i < n:
             ch = body[i]
 
-            # Translate CommonMark escapes into Chat's supported forms.
+            # CommonMark backslash escapes: translate into Chat-safe forms.
             if ch == "\\" and i + 1 < n:
                 nxt = body[i + 1]
                 if nxt == "<":
+                    # "<" must be entity-escaped so Chat does not treat it as
+                    # the start of a <url|label> anchor.
                     out.append("&lt;")
                 elif nxt == ">":
+                    # Symmetric: ">" closes Chat anchors and must be escaped.
                     out.append("&gt;")
                 else:
+                    # All other escapes: emit just the escaped character so
+                    # the backslash is not passed through to the Chat renderer.
                     out.append(nxt)
                 i += 2
                 continue
 
-            # Chat requires literal ampersands to be entity-escaped.
+            # Chat requires literal ampersands to be entity-escaped so they
+            # are not confused with HTML entity sequences in the payload.
             if ch == "&":
                 out.append("&amp;")
                 i += 1
                 continue
 
-            # Chat still requires entity escaping inside code spans.
+            # Code spans: locate the matching closing run of the same length
+            # and entity-escape HTML controls inside the span content.
             if ch == "`":
                 j = i
+                # Measure the run length by counting consecutive backticks.
                 while j < n and body[j] == "`":
                     j += 1
                 run = j - i
-                close = cls._find_unescaped_run(backtick_runs, j, run)
+                # Search the pre-built index for the next run of the same
+                # length after the opening run ends.
+                close = find_unescaped_run(backtick_runs, j, run)
 
                 if close is not None:
+                    # Matched code span: entity-escape its content so Chat
+                    # does not interpret HTML inside monospace runs.
                     content = body[j:close]
                     content = (
                         content.replace("&", "&amp;")
                         .replace("<", "&lt;")
                         .replace(">", "&gt;")
                     )
+                    # Preserve the original delimiter width (1, 2, or 3+).
                     delim = body[i:j]
                     out.append(delim + content + delim)
+                    # Advance past the closing run.
                     i = close + run
                     continue
 
-                # No matching close -- not a real code span; just literal
-                # backticks.
+                # No matching close -- not a real code span; emit the
+                # backticks as literal text.
                 out.append(body[i:j])
                 i = j
                 continue
 
-            # Track CommonMark labels for conversion to <url|text>.
+            # CommonMark inline links look like [label](<url>).
+            # Push the current out-index so we can retrieve the label text
+            # once we encounter the matching "](<".
             if ch == "[":
                 link_stack.append(len(out))
                 out.append("[")
@@ -332,11 +300,15 @@ class NotifyGoogleChat(NotifyBase):
                 continue
 
             if body.startswith("](<", i) and link_stack:
-                # Find the destination's next unescaped closing `>)`.
+                # We are at the "](<" that closes a pending link label.
+                # Scan forward with escape awareness to find ">)" which marks
+                # the end of the angle-bracketed destination.
                 close = None
                 k = i + 3
                 while k < n - 1:
                     if body[k] == "\\" and k + 1 < n:
+                        # Skip escaped characters inside the destination so a
+                        # literal ">)" in the URL does not falsely terminate.
                         k += 2
                         continue
                     if body[k] == ">" and body[k + 1] == ")":
@@ -345,56 +317,133 @@ class NotifyGoogleChat(NotifyBase):
                     k += 1
 
                 if close is not None:
-                    url = cls._escape_link_url(body[i + 3 : close])
+                    # Decode CommonMark escapes in the URL and re-encode
+                    # characters that would break the <url|label> syntax.
+                    url = commonmark_escape_link_url(body[i + 3 : close])
+                    # Retrieve the label text that was buffered after "[".
                     open_index = link_stack.pop()
                     text = "".join(out[open_index + 1 :])
+                    # Splice out everything from "[" onward and replace with
+                    # the Chat-native anchor format.
                     del out[open_index:]
                     out.append(f"<{url}|{text}>")
+                    # Skip past the closing ">)".
                     i = close + 2
                     continue
 
-            # Convert CommonMark emphasis while preserving LIFO nesting.
+            # Emphasis: CommonMark uses * for bold (**) and italic (*).
+            # Convert to Chat Markdown while preserving LIFO nesting order.
             if ch == "*":
                 j = i
+                # Measure how many consecutive "*" characters are here.
                 while j < n and body[j] == "*":
                     j += 1
                 run = j - i
 
+                # Consume the run one span at a time.  "**" maps to Chat bold
+                # (*) and "*" maps to Chat italic (_).  LIFO: close the most
+                # recently opened span if this run width can satisfy it.
                 while run > 0:
                     if stack and (
                         (stack[-1][0] == "*" and run >= 2)
                         or (stack[-1][0] == "_" and run >= 1)
                     ):
+                        # Close the innermost open span.
                         delim, open_index = stack.pop()
                         if open_index == len(out) - 1:
+                            # The span opened but collected no content --
+                            # drop the empty opening delimiter too.
                             out.pop()
                         else:
+                            # Emit the matching close delimiter.
                             out.append(delim)
+                        # Bold consumes 2 asterisks; italic consumes 1.
                         run -= 2 if delim == "*" else 1
                     elif run >= 2:
+                        # Open a new bold (*) span.
                         out.append("*")
                         stack.append(("*", len(out) - 1))
                         run -= 2
                     else:
+                        # Open a new italic (_) span.
                         out.append("_")
                         stack.append(("_", len(out) - 1))
                         run -= 1
 
+                # Advance past the entire asterisk run.
                 i = j
                 continue
 
+            # All other characters pass through unchanged.
             out.append(ch)
             i += 1
 
-        # Close out anything still open so the result is valid on its own.
+        # Force-close any spans still open so each chunk of output is
+        # independently valid Chat Markdown even if the input was malformed.
         while stack:
             delim, open_index = stack.pop()
             if open_index == len(out) - 1:
+                # Opened but empty -- drop the dangling delimiter.
                 out.pop()
             else:
                 out.append(delim)
 
-        return "".join(out)
+        text = "".join(out)
+
+        # Google Chat requires four spaces per nested-list level, versus two
+        # in the generated CommonMark, so double leading indentation.
+        lines = text.split("\n")
+        result = []
+        for line in lines:
+            stripped = line.lstrip(" ")
+            # Count how many leading spaces the CommonMark version had.
+            spaces = len(line) - len(stripped)
+            # Each original space expands to two spaces (1 level -> 4 spaces).
+            result.append("  " * spaces + stripped)
+        return "\n".join(result)
+
+    def _build_send_calls(
+        self, body=None, title=None, body_format=None, **kwargs
+    ):
+        """Convert CommonMark to Chat Markdown before splitting into chunks."""
+
+        # Only adapt HTML-derived Markdown; pass other formats through.
+        if not (
+            self.notify_format == NotifyFormat.MARKDOWN
+            and body_format == NotifyFormat.HTML
+        ):
+            yield from super()._build_send_calls(
+                body=body,
+                title=title,
+                body_format=body_format,
+                **kwargs,
+            )
+            return
+
+        # Merge the title before conversion because Chat has no title field.
+        if self.title_maxlen <= 0 and title:
+            # Strip leading whitespace and Markdown heading / list chars that
+            # would otherwise produce a malformed "# # Title" heading.
+            title_text = title.lstrip("\r\n \t\v\f#-")
+            if title_text:
+                # Prepend the title as a level-1 heading above the body.
+                body = f"# {title_text}\n{body}" if body else f"# {title_text}"
+            # Clear the title so the base class does not try to send it
+            # separately as a second field.
+            title = ""
+
+        # Apply the Chat dialect adapter to convert CommonMark constructs
+        # (backslash escapes, links, emphasis) into Chat-native syntax.
+        body = self._commonmark_to_google_chat(body)
+
+        # Tell the base splitter that the body is now Chat Markdown so that
+        # the split heuristics protect link and code-span constructs.
+        yield from super()._build_send_calls(
+            body=body,
+            title=title,
+            body_format=NotifyFormat.MARKDOWN,
+            **kwargs,
+        )
 
     def send(
         self,
@@ -405,13 +454,6 @@ class NotifyGoogleChat(NotifyBase):
         **kwargs,
     ):
         """Perform Google Chat Notification."""
-
-        if (
-            self.notify_format == NotifyFormat.MARKDOWN
-            and body_format == NotifyFormat.HTML
-        ):
-            # Adapt converted CommonMark; direct Chat Markdown is unchanged.
-            body = self._commonmark_to_google_chat(body)
 
         # Our headers
         headers = {

--- a/apprise/plugins/google_chat.py
+++ b/apprise/plugins/google_chat.py
@@ -61,7 +61,11 @@ import requests
 from ..common import NotifyFormat, NotifyType
 from ..conversion import (
     build_backtick_run_index,
+    commonmark_emphasis_run,
     commonmark_escape_link_url,
+    commonmark_force_close_spans,
+    commonmark_prepend_title,
+    commonmark_scan_angle_dest,
     find_unescaped_run,
 )
 from ..locale import gettext_lazy as _
@@ -206,78 +210,40 @@ class NotifyGoogleChat(NotifyBase):
     # Direct Google Chat Markdown is left unchanged.
     # Syntax: https://developers.google.com/workspace/chat/format-messages
 
-    # Expose shared delimiter helpers for classmethods, tests, and subclasses.
-    build_backtick_run_index = staticmethod(build_backtick_run_index)
-    find_unescaped_run = staticmethod(find_unescaped_run)
-
     @classmethod
     def _commonmark_to_google_chat(cls, body):
-        """Adapt html_to_markdown()'s CommonMark output to Google Chat's
-        own text formatting dialect.
+        """Translate CommonMark to Google Chat formatting.
 
-        Overview
-        --------
-        html_to_markdown() produces CommonMark.  Google Chat uses a
-        different dialect with these key differences:
+        CommonMark          Google Chat
+        ------------------  -----------------
+        **bold**            *bold*
+        *italic*            _italic_
+        `code`              `code`
+        [label](<url>)      <url|label>
+        &, <, >             HTML entities
 
-          CommonMark            Google Chat
-          ----------            -----------
-          **bold**              *bold*
-          *italic*              _italic_
-          `code`                `code`  (same delimiter, but content must
-                                         be HTML-entity-escaped)
-          [label](<url>)        <url|label>  (Chat anchor syntax)
-          & < > in text         &amp; &lt; &gt;  (Chat renders HTML)
-          \\< or \\>            &lt; / &gt;  (prevent Chat anchor parsing)
-
-        Data structures
-        ---------------
-        out        -- list of str fragments accumulated during the scan;
-                      joined once at the end to form the result string.
-                      Using a list avoids O(n^2) string concatenation.
-        stack      -- list of (delimiter, open_index) pairs, innermost
-                      frame last (LIFO order).  "delimiter" is "*" (bold)
-                      or "_" (italic).  "open_index" is the index in `out`
-                      where the opening delimiter was placed; used to drop
-                      empty spans (open_index == last item) at cleanup.
-        link_stack -- list of out-indices for unmatched "[" characters that
-                      may start a CommonMark link label.  When we reach the
-                      matching "](<url>)", we retrieve the buffered label
-                      text and rewrite the construct as <url|label>.  Stray
-                      "[" characters that never find a destination are kept
-                      as plain text (they were already appended to `out`).
-        i          -- current position in the input string body[i].
-        n          -- len(body); cached to avoid repeated attribute lookup.
-        backtick_runs -- pre-built index of all unescaped backtick run
-                      positions indexed by run length so code-span matching
-                      is O(log n) instead of O(n^2).
+        Chat uses HTML-like anchors, so text and code escape ``&``, ``<``,
+        and ``>`` before delivery.
         """
 
         # Accumulate translated characters one item at a time.
         out = []
-        # Open emphasis spans in LIFO order.  Each entry is
-        # (delimiter, out_index) where out_index is where the opening
-        # delimiter sits in `out`.
+        # Track open emphasis as ``(delimiter, output index)`` pairs.
         stack = []
-        # Stack of out-indices for "[" chars that may open a link label.
-        # Innermost "[" is last so we match "](<url>)" LIFO.
+        # Track possible link-label openings in LIFO order.
         link_stack = []
+
+        # Initialize the single-pass scanner.
         i = 0
         n = len(body)
-        # Pre-scan all unescaped backtick run positions indexed by run
-        # length so code-span open/close matching is O(log n) not O(n^2).
+
+        # Index backtick runs for efficient closing-delimiter lookups.
         backtick_runs = build_backtick_run_index(body)
 
         while i < n:
             ch = body[i]
 
-            # ----------------------------------------------------------------
-            # Backslash escapes
-            # ----------------------------------------------------------------
-            # CommonMark escapes look like "\*" or "\[".  We strip the
-            # backslash and emit just the literal character, but we must
-            # also HTML-entity-escape "<" and ">" because Google Chat's
-            # renderer will otherwise interpret them as anchor delimiters.
+            # Decode CommonMark escapes and protect Chat anchor delimiters.
             if ch == "\\" and i + 1 < n:
                 nxt = body[i + 1]
                 if nxt == "<":
@@ -286,29 +252,22 @@ class NotifyGoogleChat(NotifyBase):
                 elif nxt == ">":
                     # ">" closes a Chat anchor; escape it symmetrically.
                     out.append("&gt;")
+                elif nxt in ("*", "_", "~", "`"):
+                    # Preserve escapes for Chat formatting characters.
+                    out.append("\\" + nxt)
                 else:
-                    # All other escapes: emit just the escaped character.
-                    # The backslash itself is not sent to Chat's renderer.
+                    # Other escapes become their literal character.
                     out.append(nxt)
                 i += 2
                 continue
 
-            # ----------------------------------------------------------------
-            # Literal ampersands
-            # ----------------------------------------------------------------
-            # Chat's renderer interprets "&" as the start of an HTML entity.
-            # Escape every bare "&" so it renders as a literal ampersand.
+            # Escape ampersands before Chat interprets them as entities.
             if ch == "&":
                 out.append("&amp;")
                 i += 1
                 continue
 
-            # ----------------------------------------------------------------
-            # Code spans  (` ... ` or ``` ... ```)
-            # ----------------------------------------------------------------
-            # Locate the matching closing run of the same backtick width.
-            # Inside code spans, HTML control characters must be entity-escaped
-            # so Chat does not interpret them as markup.
+            # Preserve code spans while escaping HTML-sensitive content.
             if ch == "`":
                 j = i
                 # Measure the run length by counting consecutive backticks.
@@ -319,8 +278,7 @@ class NotifyGoogleChat(NotifyBase):
                 close = find_unescaped_run(backtick_runs, j, run)
 
                 if close is not None:
-                    # Matched code span: entity-escape HTML controls inside
-                    # so Chat does not interpret them as markup.
+                    # Escape HTML controls inside the matched span.
                     content = body[j:close]
                     content = (
                         content.replace("&", "&amp;")
@@ -334,154 +292,96 @@ class NotifyGoogleChat(NotifyBase):
                     i = close + run
                     continue
 
-                # No matching close found -- not a real code span.
-                # Emit the raw backticks as literal text.
+                # Preserve unmatched backticks as literal text.
                 out.append(body[i:j])
                 i = j
                 continue
 
-            # ----------------------------------------------------------------
-            # Link labels  [  (start of [label](<url>) construct)
-            # ----------------------------------------------------------------
-            # Push the current out-index so we can retrieve the label text
-            # once we encounter the matching "](<url>)" further in the body.
-            # If no matching destination follows, the "[" stays as plain text.
+            # Record a possible CommonMark link-label opening.
             if ch == "[":
                 link_stack.append(len(out))
                 out.append("[")
                 i += 1
                 continue
 
-            # ----------------------------------------------------------------
-            # Link destination  ](<url>)  -->  <url|label>
-            # ----------------------------------------------------------------
-            # When we see "](<" and there is an open "[" on link_stack,
-            # we have a complete CommonMark link.  Rewrite it as a Chat
-            # anchor by: scanning forward for ">)" (the destination end),
-            # decoding the URL, and splicing the label+destination back
-            # into `out` as "<url|label>".
+            # Convert a complete CommonMark link to ``<url|label>``.
             if body.startswith("](<", i) and link_stack:
-                # Scan forward with escape awareness so a literal ">)" inside
-                # the URL does not falsely terminate the destination scan.
-                close = None
-                k = i + 3
-                while k < n - 1:
-                    if body[k] == "\\" and k + 1 < n:
-                        # Skip escape sequences -- cannot be the terminator.
-                        k += 2
-                        continue
-                    if body[k] == ">" and body[k + 1] == ")":
-                        # Found the closing ">)" of the destination.
-                        close = k
-                        break
-                    k += 1
+                # Scan forward with escape awareness for the ">)" terminator.
+                close = commonmark_scan_angle_dest(body, i, n)
 
                 if close is not None:
-                    # Decode CommonMark backslash escapes in the URL and
-                    # re-encode characters that would break Chat's anchor
-                    # syntax (e.g. a literal "<", ">", or "|" in the URL).
+                    # Re-encode characters reserved by Chat anchors.
                     url = commonmark_escape_link_url(body[i + 3 : close])
-                    # Retrieve the index of the matching "[" in out.
+
+                    # Recover the buffered label and replace its opening.
                     open_index = link_stack.pop()
-                    # Collect the label text that was buffered after "[".
                     text = "".join(out[open_index + 1 :])
-                    # Remove everything from "[" onward from out and replace
-                    # it with the Chat-native anchor in one splice.
                     del out[open_index:]
                     out.append(f"<{url}|{text}>")
                     # Skip past the closing ">)" of the destination.
                     i = close + 2
                     continue
 
-            # ----------------------------------------------------------------
-            # Emphasis runs  (* or **)
-            # ----------------------------------------------------------------
-            # CommonMark uses "*" (italic) and "**" (bold).  Google Chat
-            # uses "_" (italic) and "*" (bold).  We process each asterisk
-            # run one span at a time using the LIFO stack to match the most
-            # recently opened span first, preserving correct nesting order.
+            # Map CommonMark emphasis to Chat's ``*``/``_`` syntax.
             if ch == "*":
-                j = i
-                # Measure the full asterisk run.
-                while j < n and body[j] == "*":
-                    j += 1
-                run = j - i
-
-                # Consume the run width one span at a time.
-                # Each iteration either closes the top-of-stack span (if the
-                # remaining run width satisfies it) or opens a new span.
-                while run > 0:
-                    if stack and (
-                        (stack[-1][0] == "*" and run >= 2)
-                        or (stack[-1][0] == "_" and run >= 1)
-                    ):
-                        # The top-of-stack span can be closed by the
-                        # current run width.  Pop and emit the close
-                        # delimiter (or drop it if the span is empty).
-                        delim, open_index = stack.pop()
-                        if open_index == len(out) - 1:
-                            # The span opened but collected no content --
-                            # remove the orphan opening delimiter entirely.
-                            out.pop()
-                        else:
-                            # Emit the close delimiter for this span.
-                            out.append(delim)
-                        # Bold ("*") consumes 2 asterisks; italic ("_") 1 each.
-                        run -= 2 if delim == "*" else 1
-                    elif run >= 2:
-                        # No closeable bold on stack; open a new bold span.
-                        out.append("*")
-                        stack.append(("*", len(out) - 1))
-                        run -= 2
-                    else:
-                        # run == 1: open a new italic span.
-                        out.append("_")
-                        stack.append(("_", len(out) - 1))
-                        run -= 1
-
-                # Advance past the entire asterisk run.
-                i = j
+                i = commonmark_emphasis_run(body, i, n, stack, out)
                 continue
 
-            # ----------------------------------------------------------------
-            # All other characters pass through unchanged.
-            # ----------------------------------------------------------------
+            # Preserve ordinary characters.
             out.append(ch)
             i += 1
 
-        # --------------------------------------------------------------------
-        # Force-close spans left open by malformed or truncated source.
-        # --------------------------------------------------------------------
-        # Pop innermost-first (LIFO) so the emitted close delimiters are in
-        # the right order.  Empty spans (open_index == last item) are dropped
-        # so the output contains no empty delimiter pairs.
-        while stack:
-            delim, open_index = stack.pop()
-            if open_index == len(out) - 1:
-                # Span opened but collected no content -- remove the orphan.
-                out.pop()
-            else:
-                # Emit the close delimiter to produce valid Chat Markdown.
-                out.append(delim)
+        # Close spans left open by malformed or truncated input.
+        commonmark_force_close_spans(out, stack)
 
+        # Join the translated fragments once before adjusting indentation.
         text = "".join(out)
 
         # Google Chat requires four spaces per nested-list level, versus two
         # in the generated CommonMark, so double leading indentation.
+        # Track fence boundaries so code-block indentation remains unchanged.
         lines = text.split("\n")
         result = []
+        # Track the opening fence width; zero means no fence is active.
+        # Shorter backtick runs inside the block remain ordinary content.
+        fence_run = 0
         for line in lines:
-            stripped = line.lstrip(" ")
-            # Count how many leading spaces the CommonMark version had.
-            spaces = len(line) - len(stripped)
-            # Each original space expands to two spaces (1 level -> 4 spaces).
-            result.append("  " * spaces + stripped)
+            # Count leading backticks on the stripped line.
+            stripped_line = line.lstrip(" ")
+            run = len(stripped_line) - len(stripped_line.lstrip("`"))
+
+            # Assume ordinary content until a fence boundary is recognized.
+            is_boundary = False
+            if fence_run == 0:
+                # Outside a fence, three or more backticks open one.
+                if run >= 3:
+                    fence_run = run
+                    is_boundary = True
+            else:
+                # A close needs the opening width or more and no other text.
+                if run >= fence_run and stripped_line[run:].strip() == "":
+                    fence_run = 0
+                    is_boundary = True
+
+            if is_boundary or fence_run != 0:
+                # Fence boundary lines and lines inside a fence are kept as-is.
+                result.append(line)
+            else:
+                # Outside a code block: double leading spaces so CommonMark
+                # 2-space list indentation maps to Chat's 4-space indent.
+                stripped = line.lstrip(" ")
+                spaces = len(line) - len(stripped)
+                result.append("  " * spaces + stripped)
+
         return "\n".join(result)
 
     def _build_send_calls(
         self, body=None, title=None, body_format=None, **kwargs
     ):
-        """Convert CommonMark to Chat Markdown before splitting into chunks."""
+        """Convert HTML-derived CommonMark before splitting for Chat.
+
+        Direct Markdown and other source formats pass through unchanged.
+        """
 
         # Only adapt HTML-derived Markdown; pass other formats through.
         if not (
@@ -498,15 +398,7 @@ class NotifyGoogleChat(NotifyBase):
 
         # Merge the title before conversion because Chat has no title field.
         if self.title_maxlen <= 0 and title:
-            # Strip leading whitespace and Markdown heading / list chars that
-            # would otherwise produce a malformed "# # Title" heading.
-            title_text = title.lstrip("\r\n \t\v\f#-")
-            if title_text:
-                # Prepend the title as a level-1 heading above the body.
-                body = f"# {title_text}\n{body}" if body else f"# {title_text}"
-            # Clear the title so the base class does not try to send it
-            # separately as a second field.
-            title = ""
+            body, title = commonmark_prepend_title(body, title)
 
         # Apply the Chat dialect adapter to convert CommonMark constructs
         # (backslash escapes, links, emphasis) into Chat-native syntax.

--- a/apprise/plugins/google_chat.py
+++ b/apprise/plugins/google_chat.py
@@ -53,6 +53,7 @@
 #         incoming-bot-python
 #    - https://developers.google.com/hangouts/chat/reference/rest
 #
+from bisect import bisect_left
 from json import dumps
 import re
 
@@ -197,8 +198,220 @@ class NotifyGoogleChat(NotifyBase):
 
         return
 
-    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+    # Adapt HTML-derived CommonMark to Google Chat's Markdown subset.
+    # Direct Google Chat Markdown is left unchanged.
+    # Syntax: https://developers.google.com/workspace/chat/format-messages
+
+    @classmethod
+    def _build_backtick_run_index(cls, text):
+        """Index unescaped backtick runs by width in one pass."""
+
+        index = {}
+        i = 0
+        n = len(text)
+
+        while i < n:
+            ch = text[i]
+
+            if ch == "\\" and i + 1 < n:
+                i += 2
+                continue
+
+            if ch == "`":
+                j = i
+                while j < n and text[j] == "`":
+                    j += 1
+                index.setdefault(j - i, []).append(i)
+                i = j
+                continue
+
+            i += 1
+
+        return index
+
+    @staticmethod
+    def _find_unescaped_run(index, start, run):
+        """Find the next indexed backtick run of the requested width."""
+
+        positions = index.get(run)
+        if not positions:
+            return None
+
+        pos = bisect_left(positions, start)
+        return positions[pos] if pos < len(positions) else None
+
+    @classmethod
+    def _escape_link_url(cls, url):
+        """Adapt a CommonMark destination for Chat's ``<url|text>`` form."""
+
+        # Resolve CommonMark escapes before applying Chat escaping.
+        out = []
+        i = 0
+        n = len(url)
+        while i < n:
+            ch = url[i]
+            if ch == "\\" and i + 1 < n:
+                out.append(url[i + 1])
+                i += 2
+                continue
+            out.append(ch)
+            i += 1
+        url = "".join(out)
+
+        # Entity-escape Chat controls and encode its URL-label separator.
+        url = url.replace("&", "&amp;").replace("<", "&lt;")
+        url = url.replace(">", "&gt;")
+        return url.replace("|", "%7C")
+
+    @classmethod
+    def _commonmark_to_google_chat(cls, body):
+        """Adapt html_to_markdown()'s CommonMark output to Google Chat's
+        own text formatting dialect."""
+
+        out = []
+        # Open emphasis spans as (delimiter, output index), innermost last.
+        stack = []
+        # Index in `out` of each currently-open link's "[", innermost last.
+        link_stack = []
+        i = 0
+        n = len(body)
+        backtick_runs = cls._build_backtick_run_index(body)
+
+        while i < n:
+            ch = body[i]
+
+            # Translate CommonMark escapes into Chat's supported forms.
+            if ch == "\\" and i + 1 < n:
+                nxt = body[i + 1]
+                if nxt == "<":
+                    out.append("&lt;")
+                elif nxt == ">":
+                    out.append("&gt;")
+                else:
+                    out.append(nxt)
+                i += 2
+                continue
+
+            # Chat requires literal ampersands to be entity-escaped.
+            if ch == "&":
+                out.append("&amp;")
+                i += 1
+                continue
+
+            # Chat still requires entity escaping inside code spans.
+            if ch == "`":
+                j = i
+                while j < n and body[j] == "`":
+                    j += 1
+                run = j - i
+                close = cls._find_unescaped_run(backtick_runs, j, run)
+
+                if close is not None:
+                    content = body[j:close]
+                    content = (
+                        content.replace("&", "&amp;")
+                        .replace("<", "&lt;")
+                        .replace(">", "&gt;")
+                    )
+                    delim = body[i:j]
+                    out.append(delim + content + delim)
+                    i = close + run
+                    continue
+
+                # No matching close -- not a real code span; just literal
+                # backticks.
+                out.append(body[i:j])
+                i = j
+                continue
+
+            # Track CommonMark labels for conversion to <url|text>.
+            if ch == "[":
+                link_stack.append(len(out))
+                out.append("[")
+                i += 1
+                continue
+
+            if body.startswith("](<", i) and link_stack:
+                # Find the destination's next unescaped closing `>)`.
+                close = None
+                k = i + 3
+                while k < n - 1:
+                    if body[k] == "\\" and k + 1 < n:
+                        k += 2
+                        continue
+                    if body[k] == ">" and body[k + 1] == ")":
+                        close = k
+                        break
+                    k += 1
+
+                if close is not None:
+                    url = cls._escape_link_url(body[i + 3 : close])
+                    open_index = link_stack.pop()
+                    text = "".join(out[open_index + 1 :])
+                    del out[open_index:]
+                    out.append(f"<{url}|{text}>")
+                    i = close + 2
+                    continue
+
+            # Convert CommonMark emphasis while preserving LIFO nesting.
+            if ch == "*":
+                j = i
+                while j < n and body[j] == "*":
+                    j += 1
+                run = j - i
+
+                while run > 0:
+                    if stack and (
+                        (stack[-1][0] == "*" and run >= 2)
+                        or (stack[-1][0] == "_" and run >= 1)
+                    ):
+                        delim, open_index = stack.pop()
+                        if open_index == len(out) - 1:
+                            out.pop()
+                        else:
+                            out.append(delim)
+                        run -= 2 if delim == "*" else 1
+                    elif run >= 2:
+                        out.append("*")
+                        stack.append(("*", len(out) - 1))
+                        run -= 2
+                    else:
+                        out.append("_")
+                        stack.append(("_", len(out) - 1))
+                        run -= 1
+
+                i = j
+                continue
+
+            out.append(ch)
+            i += 1
+
+        # Close out anything still open so the result is valid on its own.
+        while stack:
+            delim, open_index = stack.pop()
+            if open_index == len(out) - 1:
+                out.pop()
+            else:
+                out.append(delim)
+
+        return "".join(out)
+
+    def send(
+        self,
+        body,
+        title="",
+        notify_type=NotifyType.INFO,
+        body_format=None,
+        **kwargs,
+    ):
         """Perform Google Chat Notification."""
+
+        if (
+            self.notify_format == NotifyFormat.MARKDOWN
+            and body_format == NotifyFormat.HTML
+        ):
+            # Adapt converted CommonMark; direct Chat Markdown is unchanged.
+            body = self._commonmark_to_google_chat(body)
 
         # Our headers
         headers = {

--- a/apprise/plugins/slack.py
+++ b/apprise/plugins/slack.py
@@ -83,7 +83,10 @@ from ..apprise_attachment import AppriseAttachment
 from ..common import NotifyFormat, NotifyImageSize, NotifyType
 from ..conversion import (
     build_backtick_run_index,
+    commonmark_emphasis_run,
     commonmark_escape_link_url,
+    commonmark_force_close_spans,
+    commonmark_scan_angle_dest,
     find_unescaped_run,
 )
 from ..locale import gettext_lazy as _
@@ -387,14 +390,21 @@ class NotifySlack(NotifyBase):
         re.IGNORECASE,
     )
 
-    # Expose shared delimiter helpers for classmethods, tests, and subclasses.
-    build_backtick_run_index = staticmethod(build_backtick_run_index)
-    find_unescaped_run = staticmethod(find_unescaped_run)
-
     @classmethod
     def _commonmark_to_slack(cls, body):
-        """Adapt html_to_markdown()'s CommonMark output to Slack's own
-        mrkdwn dialect."""
+        """Translate CommonMark to Slack ``mrkdwn``.
+
+        CommonMark          Slack mrkdwn
+        ------------------  -----------------
+        **bold**            *bold*
+        *italic*            _italic_
+        `code`              `code`
+        [label](<url>)      <url|label>
+        &, <, >             HTML entities
+
+        Slack retains supported backslash escapes and uses its native anchor
+        syntax for labeled links.
+        """
 
         # Accumulate translated characters one item at a time.
         out = []
@@ -487,20 +497,8 @@ class NotifySlack(NotifyBase):
 
             if body.startswith("](<", i) and link_stack:
                 # We are at the "](<" that closes a pending link label.
-                # Scan forward with escape awareness to find ">)" which marks
-                # the end of the angle-bracketed destination.
-                close = None
-                k = i + 3
-                while k < n - 1:
-                    if body[k] == "\\" and k + 1 < n:
-                        # Skip escaped characters inside the destination so a
-                        # literal ">)" in the URL does not falsely terminate.
-                        k += 2
-                        continue
-                    if body[k] == ">" and body[k + 1] == ")":
-                        close = k
-                        break
-                    k += 1
+                # Scan forward with escape awareness for the ">)" terminator.
+                close = commonmark_scan_angle_dest(body, i, n)
 
                 if close is not None:
                     # Decode CommonMark escapes in the URL and re-encode
@@ -518,46 +516,9 @@ class NotifySlack(NotifyBase):
                     continue
 
             # Emphasis: CommonMark uses * for bold (**) and italic (*).
-            # Convert to Slack mrkdwn while preserving LIFO nesting order.
+            # Convert to Slack mrkdwn using the shared LIFO helper.
             if ch == "*":
-                j = i
-                # Measure how many consecutive "*" characters are here.
-                while j < n and body[j] == "*":
-                    j += 1
-                run = j - i
-
-                # Consume the run one span at a time.  "**" maps to Slack bold
-                # (*) and "*" maps to Slack italic (_).  LIFO: close the most
-                # recently opened span if this run width can satisfy it.
-                while run > 0:
-                    if stack and (
-                        (stack[-1][0] == "*" and run >= 2)
-                        or (stack[-1][0] == "_" and run >= 1)
-                    ):
-                        # Close the innermost open span.
-                        delim, open_index = stack.pop()
-                        if open_index == len(out) - 1:
-                            # The span opened but collected no content --
-                            # drop the empty opening delimiter too.
-                            out.pop()
-                        else:
-                            # Emit the matching close delimiter.
-                            out.append(delim)
-                        # Bold consumes 2 asterisks; italic consumes 1.
-                        run -= 2 if delim == "*" else 1
-                    elif run >= 2:
-                        # Open a new bold (*) span.
-                        out.append("*")
-                        stack.append(("*", len(out) - 1))
-                        run -= 2
-                    else:
-                        # Open a new italic (_) span.
-                        out.append("_")
-                        stack.append(("_", len(out) - 1))
-                        run -= 1
-
-                # Advance past the entire asterisk run.
-                i = j
+                i = commonmark_emphasis_run(body, i, n, stack, out)
                 continue
 
             # All other characters pass through unchanged.
@@ -566,13 +527,7 @@ class NotifySlack(NotifyBase):
 
         # Force-close any spans still open so each chunk of output is
         # independently valid Slack mrkdwn even if the input was malformed.
-        while stack:
-            delim, open_index = stack.pop()
-            if open_index == len(out) - 1:
-                # Opened but empty -- drop the dangling delimiter.
-                out.pop()
-            else:
-                out.append(delim)
+        commonmark_force_close_spans(out, stack)
 
         return "".join(out)
 
@@ -596,10 +551,7 @@ class NotifySlack(NotifyBase):
         """Initialize Slack Object."""
         super().__init__(**kwargs)
 
-        # Store our webhook mode
-        # Track whether the caller supplied an explicit mode so we can
-        # decide later whether to validate exact segment count or
-        # auto-detect the workflow sub-mode from segment count.
+        # Track explicit modes; otherwise workflow segments select the mode.
         _mode_explicit = bool(mode and isinstance(mode, str))
         if _mode_explicit:
             self.mode = next(
@@ -636,9 +588,7 @@ class NotifySlack(NotifyBase):
             else:
                 self.workflow_path = []
 
-            # Segment counts are fixed by Slack:
-            #   /workflows/ URLs have exactly 4 segments
-            #   /triggers/  URLs have exactly 3 segments
+            # Slack workflows use four segments and triggers use three.
             seg_count = len(self.workflow_path)
             if _mode_explicit:
                 # Validate exact count for the declared mode
@@ -841,12 +791,7 @@ class NotifySlack(NotifyBase):
         # Templates are always Block Kit JSON; enforce JSON escaping
         tokens["app_mode"] = TemplateType.JSON
 
-        # Coerce all substitution values to str before JSON-escaping.
-        # apply_template's _escape_json() calls json.dumps(v)[1:-1] which
-        # is only correct for strings; None produces "ul" and other non-
-        # string types produce similarly corrupted output.  app_mode is a
-        # TemplateType sentinel passed as a named parameter, not a
-        # substitution value, so it is left as-is.
+        # Stringify substitutions before JSON escaping; preserve app_mode.
         safe_tokens = {
             k: (
                 v
@@ -918,7 +863,11 @@ class NotifySlack(NotifyBase):
     def _build_send_calls(
         self, body=None, title=None, body_format=None, **kwargs
     ):
-        """Convert CommonMark to mrkdwn before splitting into chunks."""
+        """Split HTML-derived CommonMark before Slack conversion.
+
+        Markdown-aware splitting protects links; ``send()`` then converts each
+        chunk to independently valid ``mrkdwn``.
+        """
 
         # Only adapt HTML-derived Markdown; pass other formats through.
         if not (
@@ -933,12 +882,8 @@ class NotifySlack(NotifyBase):
             )
             return
 
-        # Split on the CommonMark body so markdown_adjust can protect
-        # [label](<url>) constructs from being severed across chunk
-        # boundaries (body_format=MARKDOWN activates that path in
-        # smart_split).  Restore body_format=HTML in each yielded chunk
-        # so send() still applies _commonmark_to_slack() and the correct
-        # entity-escape pass on every chunk independently.
+        # Split as Markdown to protect links, then restore HTML provenance.
+        # Each resulting chunk is converted independently by ``send()``.
         for chunk in super()._build_send_calls(
             body=body,
             title=title,

--- a/apprise/plugins/slack.py
+++ b/apprise/plugins/slack.py
@@ -71,6 +71,7 @@
 #        - You will be able to select the Bot App you previously created
 #        - Your bot will join your channel.
 
+from bisect import bisect_left
 import contextlib
 from json import dumps, loads
 from json.decoder import JSONDecodeError
@@ -382,6 +383,206 @@ class NotifySlack(NotifyBase):
         re.IGNORECASE,
     )
 
+    # HTML bodies arrive as CommonMark and require a single-pass conversion
+    # to Slack mrkdwn. Caller-supplied mrkdwn is left unchanged.
+
+    @classmethod
+    def _build_backtick_run_index(cls, text):
+        """Index unescaped backtick runs by width in one pass."""
+
+        index = {}
+        i = 0
+        n = len(text)
+
+        while i < n:
+            ch = text[i]
+
+            if ch == "\\" and i + 1 < n:
+                i += 2
+                continue
+
+            if ch == "`":
+                j = i
+                while j < n and text[j] == "`":
+                    j += 1
+                index.setdefault(j - i, []).append(i)
+                i = j
+                continue
+
+            i += 1
+
+        return index
+
+    @staticmethod
+    def _find_unescaped_run(index, start, run):
+        """Find the next indexed backtick run of the requested width."""
+
+        positions = index.get(run)
+        if not positions:
+            return None
+
+        pos = bisect_left(positions, start)
+        return positions[pos] if pos < len(positions) else None
+
+    @classmethod
+    def _escape_link_url(cls, url):
+        """Adapt a CommonMark destination for Slack's ``<url|text>`` form."""
+
+        # Resolve CommonMark escapes before applying Slack escaping.
+        out = []
+        i = 0
+        n = len(url)
+        while i < n:
+            ch = url[i]
+            if ch == "\\" and i + 1 < n:
+                out.append(url[i + 1])
+                i += 2
+                continue
+            out.append(ch)
+            i += 1
+        url = "".join(out)
+
+        # Entity-escape Slack controls and encode its URL-label separator.
+        url = url.replace("&", "&amp;").replace("<", "&lt;")
+        url = url.replace(">", "&gt;")
+        return url.replace("|", "%7C")
+
+    @classmethod
+    def _commonmark_to_slack(cls, body):
+        """Adapt html_to_markdown()'s CommonMark output to Slack's own
+        mrkdwn dialect."""
+
+        out = []
+        # Open emphasis spans as (delimiter, output index), innermost last.
+        stack = []
+        # Index in `out` of each currently-open link's "[", innermost last.
+        link_stack = []
+        i = 0
+        n = len(body)
+        backtick_runs = cls._build_backtick_run_index(body)
+
+        while i < n:
+            ch = body[i]
+
+            # Translate CommonMark escapes into Slack's supported forms.
+            if ch == "\\" and i + 1 < n:
+                nxt = body[i + 1]
+                if nxt == "<":
+                    out.append("&lt;")
+                elif nxt == ">":
+                    out.append("&gt;")
+                elif nxt in "()[]!#":
+                    out.append(nxt)
+                else:
+                    out.append(body[i : i + 2])
+                i += 2
+                continue
+
+            # Slack requires literal ampersands to be entity-escaped.
+            if ch == "&":
+                out.append("&amp;")
+                i += 1
+                continue
+
+            # Slack still requires entity escaping inside code spans.
+            if ch == "`":
+                j = i
+                while j < n and body[j] == "`":
+                    j += 1
+                run = j - i
+                close = cls._find_unescaped_run(backtick_runs, j, run)
+
+                if close is not None:
+                    content = body[j:close]
+                    content = (
+                        content.replace("&", "&amp;")
+                        .replace("<", "&lt;")
+                        .replace(">", "&gt;")
+                    )
+                    delim = body[i:j]
+                    out.append(delim + content + delim)
+                    i = close + run
+                    continue
+
+                # No matching close -- not a real code span; just literal
+                # backticks (Slack has no escaping mechanism for these).
+                out.append(body[i:j])
+                i = j
+                continue
+
+            # Track CommonMark labels for conversion to <url|text>.
+            if ch == "[":
+                link_stack.append(len(out))
+                out.append("[")
+                i += 1
+                continue
+
+            if body.startswith("](<", i) and link_stack:
+                # Find the destination's next unescaped closing `>)`.
+                close = None
+                k = i + 3
+                while k < n - 1:
+                    if body[k] == "\\" and k + 1 < n:
+                        k += 2
+                        continue
+                    if body[k] == ">" and body[k + 1] == ")":
+                        close = k
+                        break
+                    k += 1
+
+                if close is not None:
+                    url = cls._escape_link_url(body[i + 3 : close])
+                    open_index = link_stack.pop()
+                    text = "".join(out[open_index + 1 :])
+                    del out[open_index:]
+                    out.append(f"<{url}|{text}>")
+                    i = close + 2
+                    continue
+
+            # Convert CommonMark emphasis while preserving LIFO nesting.
+            if ch == "*":
+                j = i
+                while j < n and body[j] == "*":
+                    j += 1
+                run = j - i
+
+                while run > 0:
+                    if stack and (
+                        (stack[-1][0] == "*" and run >= 2)
+                        or (stack[-1][0] == "_" and run >= 1)
+                    ):
+                        delim, open_index = stack.pop()
+                        if open_index == len(out) - 1:
+                            # Drop empty entities.
+                            out.pop()
+                        else:
+                            out.append(delim)
+                        run -= 2 if delim == "*" else 1
+                    elif run >= 2:
+                        out.append("*")
+                        stack.append(("*", len(out) - 1))
+                        run -= 2
+                    else:
+                        out.append("_")
+                        stack.append(("_", len(out) - 1))
+                        run -= 1
+
+                i = j
+                continue
+
+            out.append(ch)
+            i += 1
+
+        # Close dangling spans so the output remains independently valid.
+        while stack:
+            delim, open_index = stack.pop()
+            if open_index == len(out) - 1:
+                out.pop()
+            else:
+                out.append(delim)
+
+        return "".join(out)
+
     def __init__(
         self,
         access_token=None,
@@ -615,12 +816,7 @@ class NotifySlack(NotifyBase):
     def gen_payload(
         self, body, title="", notify_type=NotifyType.INFO, **kwargs
     ):
-        """Generate our payload from an external Block Kit JSON template.
-
-        Returns the validated attachment content dict (which must contain
-        a non-empty 'blocks' list with typed entries) to be placed into
-        the Slack attachments array.  Returns False on any failure.
-        """
+        """Return a validated Block Kit attachment, or ``False``."""
         # Acquire the first template attachment
         template = self.template[0]
         if not template:
@@ -732,12 +928,19 @@ class NotifySlack(NotifyBase):
         title="",
         notify_type=NotifyType.INFO,
         attach=None,
+        body_format=None,
         **kwargs,
     ):
         """Perform Slack Notification."""
 
         # error tracking (used for function return)
         has_error = False
+
+        if self.notify_format == NotifyFormat.MARKDOWN and (
+            body_format == NotifyFormat.HTML
+        ):
+            # Adapt converted CommonMark; direct mrkdwn input is unchanged.
+            body = self._commonmark_to_slack(body)
 
         #
         # Workflow Builder mode: fixed endpoint, no channel iteration
@@ -860,7 +1063,10 @@ class NotifySlack(NotifyBase):
             #
             # Legacy API Formatting
             #
-            if self.notify_format == NotifyFormat.MARKDOWN:
+            # Apply legacy formatting only to direct Slack mrkdwn input.
+            if self.notify_format == NotifyFormat.MARKDOWN and (
+                body_format != NotifyFormat.HTML
+            ):
                 body = self._re_formatting_rules.sub(  # pragma: no branch
                     lambda x: self._re_formatting_map[x.group()],
                     body,
@@ -1575,10 +1781,7 @@ class NotifySlack(NotifyBase):
         # Get unquoted path entries
         entries = NotifySlack.split_path(results["fullpath"])
 
-        # Peek at mode early to guide path parsing.
-        # Resolve via the same prefix-matching used in __init__ so that
-        # abbreviated inputs (e.g. mode=tri or mode=work) are handled
-        # identically in both places.
+        # Resolve abbreviated modes before parsing path segments.
         _mode_raw = results["qsd"].get("mode", "")
         _mode = (
             next(

--- a/apprise/plugins/slack.py
+++ b/apprise/plugins/slack.py
@@ -71,7 +71,6 @@
 #        - You will be able to select the Bot App you previously created
 #        - Your bot will join your channel.
 
-from bisect import bisect_left
 import contextlib
 from json import dumps, loads
 from json.decoder import JSONDecodeError
@@ -82,6 +81,11 @@ import requests
 
 from ..apprise_attachment import AppriseAttachment
 from ..common import NotifyFormat, NotifyImageSize, NotifyType
+from ..conversion import (
+    build_backtick_run_index,
+    commonmark_escape_link_url,
+    find_unescaped_run,
+)
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_email, parse_bool, parse_list, validate_regex
 from ..utils.templates import TemplateType, apply_template
@@ -383,134 +387,98 @@ class NotifySlack(NotifyBase):
         re.IGNORECASE,
     )
 
-    # HTML bodies arrive as CommonMark and require a single-pass conversion
-    # to Slack mrkdwn. Caller-supplied mrkdwn is left unchanged.
-
-    @classmethod
-    def _build_backtick_run_index(cls, text):
-        """Index unescaped backtick runs by width in one pass."""
-
-        index = {}
-        i = 0
-        n = len(text)
-
-        while i < n:
-            ch = text[i]
-
-            if ch == "\\" and i + 1 < n:
-                i += 2
-                continue
-
-            if ch == "`":
-                j = i
-                while j < n and text[j] == "`":
-                    j += 1
-                index.setdefault(j - i, []).append(i)
-                i = j
-                continue
-
-            i += 1
-
-        return index
-
-    @staticmethod
-    def _find_unescaped_run(index, start, run):
-        """Find the next indexed backtick run of the requested width."""
-
-        positions = index.get(run)
-        if not positions:
-            return None
-
-        pos = bisect_left(positions, start)
-        return positions[pos] if pos < len(positions) else None
-
-    @classmethod
-    def _escape_link_url(cls, url):
-        """Adapt a CommonMark destination for Slack's ``<url|text>`` form."""
-
-        # Resolve CommonMark escapes before applying Slack escaping.
-        out = []
-        i = 0
-        n = len(url)
-        while i < n:
-            ch = url[i]
-            if ch == "\\" and i + 1 < n:
-                out.append(url[i + 1])
-                i += 2
-                continue
-            out.append(ch)
-            i += 1
-        url = "".join(out)
-
-        # Entity-escape Slack controls and encode its URL-label separator.
-        url = url.replace("&", "&amp;").replace("<", "&lt;")
-        url = url.replace(">", "&gt;")
-        return url.replace("|", "%7C")
+    # Expose shared delimiter helpers for classmethods, tests, and subclasses.
+    build_backtick_run_index = staticmethod(build_backtick_run_index)
+    find_unescaped_run = staticmethod(find_unescaped_run)
 
     @classmethod
     def _commonmark_to_slack(cls, body):
         """Adapt html_to_markdown()'s CommonMark output to Slack's own
         mrkdwn dialect."""
 
+        # Accumulate translated characters one item at a time.
         out = []
-        # Open emphasis spans as (delimiter, output index), innermost last.
+        # Each entry is (delimiter, index-in-out) for an open emphasis span,
+        # innermost last, so we can close spans in LIFO order.
         stack = []
-        # Index in `out` of each currently-open link's "[", innermost last.
+        # Each entry is the out-index of the opening "[" for a pending link,
+        # innermost last; used to splice the label text out when we find "]".
         link_stack = []
         i = 0
         n = len(body)
-        backtick_runs = cls._build_backtick_run_index(body)
+        # Pre-scan all unescaped backtick run positions indexed by run length
+        # so code-span open/close matching is O(log n) rather than O(n^2).
+        backtick_runs = build_backtick_run_index(body)
 
         while i < n:
             ch = body[i]
 
-            # Translate CommonMark escapes into Slack's supported forms.
+            # CommonMark uses backslash escapes for literal punctuation.
+            # Translate them into the forms Slack's mrkdwn parser expects.
             if ch == "\\" and i + 1 < n:
                 nxt = body[i + 1]
                 if nxt == "<":
+                    # "<" must be entity-escaped so Slack does not treat it as
+                    # the start of a <url|label> anchor.
                     out.append("&lt;")
                 elif nxt == ">":
+                    # Symmetric: ">" closes Slack anchors and must be escaped.
                     out.append("&gt;")
                 elif nxt in "()[]!#":
+                    # CommonMark escapes these for Markdown disambiguation;
+                    # Slack treats them as plain characters -- emit as-is.
                     out.append(nxt)
                 else:
+                    # All other escape pairs are valid Slack mrkdwn escapes
+                    # (e.g. \* or \_), so keep the backslash.
                     out.append(body[i : i + 2])
                 i += 2
                 continue
 
-            # Slack requires literal ampersands to be entity-escaped.
+            # Slack requires literal ampersands to be entity-escaped so they
+            # are not confused with HTML entity sequences in the payload.
             if ch == "&":
                 out.append("&amp;")
                 i += 1
                 continue
 
-            # Slack still requires entity escaping inside code spans.
+            # Code spans: locate the matching closing run of the same length
+            # and entity-escape HTML controls inside the span content.
             if ch == "`":
                 j = i
+                # Measure the run length by counting consecutive backticks.
                 while j < n and body[j] == "`":
                     j += 1
                 run = j - i
-                close = cls._find_unescaped_run(backtick_runs, j, run)
+                # Search the pre-built index for the next run of the same
+                # length after the opening run ends.
+                close = find_unescaped_run(backtick_runs, j, run)
 
                 if close is not None:
+                    # Matched code span: entity-escape its content so Slack
+                    # does not interpret HTML inside monospace runs.
                     content = body[j:close]
                     content = (
                         content.replace("&", "&amp;")
                         .replace("<", "&lt;")
                         .replace(">", "&gt;")
                     )
+                    # Preserve the original delimiter width (1, 2, or 3+).
                     delim = body[i:j]
                     out.append(delim + content + delim)
+                    # Advance past the closing run.
                     i = close + run
                     continue
 
-                # No matching close -- not a real code span; just literal
-                # backticks (Slack has no escaping mechanism for these).
+                # No matching close -- not a real code span; emit the
+                # backticks as literal text (Slack has no escape for them).
                 out.append(body[i:j])
                 i = j
                 continue
 
-            # Track CommonMark labels for conversion to <url|text>.
+            # CommonMark inline links look like [label](<url>).
+            # Push the current out-index so we can retrieve the label text
+            # once we encounter the matching "](<".
             if ch == "[":
                 link_stack.append(len(out))
                 out.append("[")
@@ -518,11 +486,15 @@ class NotifySlack(NotifyBase):
                 continue
 
             if body.startswith("](<", i) and link_stack:
-                # Find the destination's next unescaped closing `>)`.
+                # We are at the "](<" that closes a pending link label.
+                # Scan forward with escape awareness to find ">)" which marks
+                # the end of the angle-bracketed destination.
                 close = None
                 k = i + 3
                 while k < n - 1:
                     if body[k] == "\\" and k + 1 < n:
+                        # Skip escaped characters inside the destination so a
+                        # literal ">)" in the URL does not falsely terminate.
                         k += 2
                         continue
                     if body[k] == ">" and body[k + 1] == ")":
@@ -531,52 +503,73 @@ class NotifySlack(NotifyBase):
                     k += 1
 
                 if close is not None:
-                    url = cls._escape_link_url(body[i + 3 : close])
+                    # Decode CommonMark escapes in the URL and re-encode
+                    # characters that would break the <url|label> syntax.
+                    url = commonmark_escape_link_url(body[i + 3 : close])
+                    # Retrieve the label text that was buffered after "[".
                     open_index = link_stack.pop()
                     text = "".join(out[open_index + 1 :])
+                    # Splice out everything from "[" onward and replace with
+                    # the Slack-native anchor format.
                     del out[open_index:]
                     out.append(f"<{url}|{text}>")
+                    # Skip past the closing ">)".
                     i = close + 2
                     continue
 
-            # Convert CommonMark emphasis while preserving LIFO nesting.
+            # Emphasis: CommonMark uses * for bold (**) and italic (*).
+            # Convert to Slack mrkdwn while preserving LIFO nesting order.
             if ch == "*":
                 j = i
+                # Measure how many consecutive "*" characters are here.
                 while j < n and body[j] == "*":
                     j += 1
                 run = j - i
 
+                # Consume the run one span at a time.  "**" maps to Slack bold
+                # (*) and "*" maps to Slack italic (_).  LIFO: close the most
+                # recently opened span if this run width can satisfy it.
                 while run > 0:
                     if stack and (
                         (stack[-1][0] == "*" and run >= 2)
                         or (stack[-1][0] == "_" and run >= 1)
                     ):
+                        # Close the innermost open span.
                         delim, open_index = stack.pop()
                         if open_index == len(out) - 1:
-                            # Drop empty entities.
+                            # The span opened but collected no content --
+                            # drop the empty opening delimiter too.
                             out.pop()
                         else:
+                            # Emit the matching close delimiter.
                             out.append(delim)
+                        # Bold consumes 2 asterisks; italic consumes 1.
                         run -= 2 if delim == "*" else 1
                     elif run >= 2:
+                        # Open a new bold (*) span.
                         out.append("*")
                         stack.append(("*", len(out) - 1))
                         run -= 2
                     else:
+                        # Open a new italic (_) span.
                         out.append("_")
                         stack.append(("_", len(out) - 1))
                         run -= 1
 
+                # Advance past the entire asterisk run.
                 i = j
                 continue
 
+            # All other characters pass through unchanged.
             out.append(ch)
             i += 1
 
-        # Close dangling spans so the output remains independently valid.
+        # Force-close any spans still open so each chunk of output is
+        # independently valid Slack mrkdwn even if the input was malformed.
         while stack:
             delim, open_index = stack.pop()
             if open_index == len(out) - 1:
+                # Opened but empty -- drop the dangling delimiter.
                 out.pop()
             else:
                 out.append(delim)
@@ -921,6 +914,38 @@ class NotifySlack(NotifyBase):
 
         # Return the validated attachment content dict
         return content
+
+    def _build_send_calls(
+        self, body=None, title=None, body_format=None, **kwargs
+    ):
+        """Convert CommonMark to mrkdwn before splitting into chunks."""
+
+        # Only adapt HTML-derived Markdown; pass other formats through.
+        if not (
+            self.notify_format == NotifyFormat.MARKDOWN
+            and body_format == NotifyFormat.HTML
+        ):
+            yield from super()._build_send_calls(
+                body=body,
+                title=title,
+                body_format=body_format,
+                **kwargs,
+            )
+            return
+
+        # Split on the CommonMark body so markdown_adjust can protect
+        # [label](<url>) constructs from being severed across chunk
+        # boundaries (body_format=MARKDOWN activates that path in
+        # smart_split).  Restore body_format=HTML in each yielded chunk
+        # so send() still applies _commonmark_to_slack() and the correct
+        # entity-escape pass on every chunk independently.
+        for chunk in super()._build_send_calls(
+            body=body,
+            title=title,
+            body_format=NotifyFormat.MARKDOWN,
+            **kwargs,
+        ):
+            yield {**chunk, "body_format": NotifyFormat.HTML}
 
     def send(
         self,
@@ -1781,7 +1806,10 @@ class NotifySlack(NotifyBase):
         # Get unquoted path entries
         entries = NotifySlack.split_path(results["fullpath"])
 
-        # Resolve abbreviated modes before parsing path segments.
+        # Peek at mode early to guide path parsing.
+        # Resolve via the same prefix-matching used in __init__ so that
+        # abbreviated inputs (e.g. mode=tri or mode=work) are handled
+        # identically in both places.
         _mode_raw = results["qsd"].get("mode", "")
         _mode = (
             next(

--- a/apprise/plugins/splunk.py
+++ b/apprise/plugins/splunk.py
@@ -137,7 +137,7 @@ class NotifySplunk(NotifyBase):
         "{schema}://{routing_key}@{apikey}/{entity_id}",
     )
 
-    # The title is not used
+    # Maximum allowable title length
     title_maxlen = 60
 
     # body limit

--- a/apprise/plugins/telegram.py
+++ b/apprise/plugins/telegram.py
@@ -51,7 +51,6 @@
 #
 # Development API Reference::
 #  - https://core.telegram.org/bots/api
-from bisect import bisect_left
 from json import dumps, loads
 import os
 import re
@@ -65,6 +64,7 @@ from ..common import (
     NotifyType,
     PersistentStoreMode,
 )
+from ..conversion import build_backtick_run_index, find_unescaped_run
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_bool, parse_list, validate_regex
 from .base import NotifyBase
@@ -788,43 +788,9 @@ class NotifyTelegram(NotifyBase):
         )
         return 0
 
-    @classmethod
-    def _build_backtick_run_index(cls, text):
-        """Index unescaped backtick runs by width in one pass."""
-
-        index = {}
-        i = 0
-        n = len(text)
-
-        while i < n:
-            ch = text[i]
-
-            if ch == "\\" and i + 1 < n:
-                i += 2
-                continue
-
-            if ch == "`":
-                j = i
-                while j < n and text[j] == "`":
-                    j += 1
-                index.setdefault(j - i, []).append(i)
-                i = j
-                continue
-
-            i += 1
-
-        return index
-
-    @staticmethod
-    def _find_unescaped_run(index, start, run):
-        """Find the next indexed backtick run of the requested width."""
-
-        positions = index.get(run)
-        if not positions:
-            return None
-
-        pos = bisect_left(positions, start)
-        return positions[pos] if pos < len(positions) else None
+    # Expose shared delimiter helpers for classmethods and tests.
+    build_backtick_run_index = staticmethod(build_backtick_run_index)
+    find_unescaped_run = staticmethod(find_unescaped_run)
 
     # Convert HTML-derived CommonMark to Telegram Markdown in one pass while
     # preserving nested entities and independently valid message chunks.
@@ -867,7 +833,7 @@ class NotifyTelegram(NotifyBase):
         stack = []
         i = 0
         n = len(body)
-        backtick_runs = cls._build_backtick_run_index(body)
+        backtick_runs = cls.build_backtick_run_index(body)
 
         while i < n:
             ch = body[i]
@@ -888,7 +854,7 @@ class NotifyTelegram(NotifyBase):
                 while j < n and body[j] == "`":
                     j += 1
                 run = j - i
-                close = cls._find_unescaped_run(backtick_runs, j, run)
+                close = cls.find_unescaped_run(backtick_runs, j, run)
 
                 if close is not None:
                     content = body[j:close]
@@ -905,8 +871,20 @@ class NotifyTelegram(NotifyBase):
 
             # Convert angle-bracket destinations to Telegram's bare form.
             if body.startswith("](<", i):
-                close = body.find(">)", i + 3)
-                if close != -1:
+                # Scan with escape awareness so ">)" inside a URL does not
+                # falsely terminate the destination.
+                close = None
+                k = i + 3
+                while k < n - 1:
+                    if body[k] == "\\" and k + 1 < n:
+                        k += 2
+                        continue
+                    if body[k] == ">" and body[k + 1] == ")":
+                        close = k
+                        break
+                    k += 1
+
+                if close is not None:
                     url = body[i + 3 : close]
                     url = url.replace("\\", "\\\\").replace(")", "\\)")
                     out.append("](" + url + ")")
@@ -938,9 +916,6 @@ class NotifyTelegram(NotifyBase):
                         if open_index is None:
                             # Suppressed legacy nesting emits no close.
                             pass
-                        elif open_index == len(out) - 1:
-                            # Drop empty entities.
-                            out.pop()
                         else:
                             out.append(delim)
                     i = j
@@ -957,15 +932,6 @@ class NotifyTelegram(NotifyBase):
                         else:
                             out.append(delim)
                         run -= 2
-                    elif stack and stack[-1][0] == "_" and run == 1:
-                        delim, open_index = stack.pop()
-                        if open_index is None:
-                            pass
-                        elif open_index == len(out) - 1:
-                            out.pop()
-                        else:
-                            out.append(delim)
-                        run -= 1
                     elif run >= 2:
                         if strict or not stack:
                             out.append("*")
@@ -1019,11 +985,11 @@ class NotifyTelegram(NotifyBase):
         link_stack = []
         i = 0
         n = len(text)
-        backtick_runs = cls._build_backtick_run_index(text)
+        backtick_runs = cls.build_backtick_run_index(text)
 
         in_code_width = pending.pop("in_code", None)
         if in_code_width and strict:
-            close = cls._find_unescaped_run(backtick_runs, 0, in_code_width)
+            close = cls.find_unescaped_run(backtick_runs, 0, in_code_width)
             if close is not None:
                 out.append(cls._strict_escape(text[:close]))
                 i = close + in_code_width
@@ -1068,7 +1034,7 @@ class NotifyTelegram(NotifyBase):
                 while j < n and text[j] == "`":
                     j += 1
                 run = j - i
-                close = cls._find_unescaped_run(backtick_runs, j, run)
+                close = cls.find_unescaped_run(backtick_runs, j, run)
                 if close is not None:
                     out.append(text[i : close + run])
                     i = close + run
@@ -1187,10 +1153,15 @@ class NotifyTelegram(NotifyBase):
 
         strict = self.markdown_ver == TelegramMarkdownVersion.TWO
 
-        if body:
-            body = self._commonmark_to_telegram(body, strict=strict)
-        if title:
-            title = self._commonmark_to_telegram(title, strict=strict)
+        # Merge the title into the CommonMark body before dialect conversion
+        # so the heading syntax is translated to Telegram markup correctly.
+        if self.title_maxlen <= 0 and title:
+            title_text = title.lstrip("\r\n \t\v\f#-")
+            if title_text:
+                body = f"# {title_text}\n{body}" if body else f"# {title_text}"
+            title = ""
+
+        body = self._commonmark_to_telegram(body, strict=strict)
 
         pending = {}
         for kwargs2 in super()._build_send_calls(
@@ -1249,12 +1220,15 @@ class NotifyTelegram(NotifyBase):
                 body_format == NotifyFormat.TEXT
                 and self.markdown_ver == TelegramMarkdownVersion.TWO
             ):
-                # Escape reserved characters in plain MarkdownV2 input.
+                # Escape MarkdownV2-only reserved characters in plain text.
+                # See: https://stackoverflow.com/a/69892704/355584
+                # Also: https://core.telegram.org/bots/api#markdownv2-style
+                # HTML bodies were already escaped during dialect adaptation.
                 body = re.sub(r"(?<!\\)([_*[\]()~`>#+=|{}.!-])", r"\\\1", body)
 
-            # HTML was adapted before splitting; direct Telegram Markdown is
-            # left unchanged.
-
+            # HTML was converted to Telegram Markdown before splitting so no
+            # further transformation is required here; direct Telegram Markdown
+            # input is left unchanged regardless of version.
             payload_["parse_mode"] = self.markdown_ver
             payload_["text"] = body
 

--- a/apprise/plugins/telegram.py
+++ b/apprise/plugins/telegram.py
@@ -832,7 +832,12 @@ class NotifyTelegram(NotifyBase):
         # Prepare Message Body
         if self.notify_format == NotifyFormat.MARKDOWN:
             if (
-                body_format not in (None, NotifyFormat.MARKDOWN)
+                body_format
+                not in (
+                    None,
+                    NotifyFormat.MARKDOWN,
+                    NotifyFormat.HTML,
+                )
                 and self.markdown_ver == TelegramMarkdownVersion.TWO
             ):
                 # Telegram Markdown v2 is not very accomodating to some
@@ -840,6 +845,7 @@ class NotifyTelegram(NotifyBase):
                 # To try and be accomodating we escape them in advance
                 # See: https://stackoverflow.com/a/69892704/355584
                 # Also: https://core.telegram.org/bots/api#markdownv2-style
+                # Note: We only escape characters that are not already escaped.
                 body = re.sub(r"(?<!\\)([_*[\]()~`>#+=|{}.!-])", r"\\\1", body)
 
             payload_["parse_mode"] = self.markdown_ver

--- a/apprise/plugins/telegram.py
+++ b/apprise/plugins/telegram.py
@@ -64,7 +64,12 @@ from ..common import (
     NotifyType,
     PersistentStoreMode,
 )
-from ..conversion import build_backtick_run_index, find_unescaped_run
+from ..conversion import (
+    build_backtick_run_index,
+    commonmark_prepend_title,
+    commonmark_scan_angle_dest,
+    find_unescaped_run,
+)
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_bool, parse_list, validate_regex
 from .base import NotifyBase
@@ -788,16 +793,12 @@ class NotifyTelegram(NotifyBase):
         )
         return 0
 
-    # Expose shared delimiter helpers for classmethods and tests.
-    build_backtick_run_index = staticmethod(build_backtick_run_index)
-    find_unescaped_run = staticmethod(find_unescaped_run)
-
     # Convert HTML-derived CommonMark to Telegram Markdown in one pass while
     # preserving nested entities and independently valid message chunks.
     _TELEGRAM_STRICT_CHARS = "~#+=|{}.!<>-"
 
     # Legacy Markdown recognizes escapes only for these characters.
-    _TELEGRAM_V1_ESCAPABLE = "`*_["
+    _TELEGRAM_V1_ESCAPABLE = "`*_[]"
 
     # Full MarkdownV2 reserved set for previously unescaped fragments.
     _TELEGRAM_RESERVED_FULL = "_*[]()~`>#+=|{}.!<>-"
@@ -824,62 +825,36 @@ class NotifyTelegram(NotifyBase):
 
     @classmethod
     def _commonmark_to_telegram(cls, body, strict=False):
-        """Adapt html_to_markdown()'s CommonMark output to Telegram's own
-        Markdown dialect ("Markdown"/v1, or strictly for "MarkdownV2"/v2).
+        """Translate CommonMark to Telegram Markdown v1 or v2.
 
-        Overview
-        --------
-        html_to_markdown() produces CommonMark: emphasis with * and **,
-        links as [label](<url>), code spans with backticks, and backslash
-        escapes.  Telegram uses a different dialect:
+        CommonMark     Markdown v1     MarkdownV2
+        -------------  --------------  --------------------
+        **bold**       *bold*          *bold*
+        *italic*       _italic_        _italic_
+        `code`         `code`          `code`
+        [l](<u>)       [l](u)          [l](u)
+        \\*            known escapes   all reserved escapes
 
-          CommonMark   V1 ("Markdown")   V2 ("MarkdownV2")
-          ----------   ---------------   -----------------
-          **bold**     *bold*            *bold*
-          *italic*     _italic_          _italic_
-          `code`       `code`            `code`
-          [l](<u>)     [l](u)            [l](u)   -- angle brackets stripped
-          \\*          * (literal)       \\*       -- only some escapes kept
-
-        Both dialects share the same emphasis mapping; strict=True adds
-        per-character escaping of all MarkdownV2 reserved characters.
-
-        Data structures
-        ---------------
-        out   -- list of str fragments; joined at the end to form the result.
-                 Using a list avoids O(n^2) string concatenation.
-        stack -- list of (delimiter, open_index) pairs, innermost frame last
-                 (LIFO order).  "delimiter" is "*" (bold) or "_" (italic).
-                 "open_index" is the index in `out` where the opening
-                 delimiter was placed; None marks a span that was suppressed
-                 (V1 only -- legacy Markdown forbids nesting emphasis).
-        i     -- byte position in the input string body[i].
-        n     -- len(body); cached to avoid repeated calls in the hot loop.
-        backtick_runs -- pre-built index of all unescaped backtick run
-                 positions so code-span matching is O(log n) not O(n^2).
+        Both versions strip angle brackets from link destinations. Strict
+        mode additionally escapes every MarkdownV2-reserved character.
         """
 
         # Accumulate output fragments; joined once at the end.
         out = []
-        # Open emphasis spans tracked in LIFO order.  Each entry is
-        # (delimiter, open_index_in_out) where open_index is None when
-        # V1 nesting suppression is in effect for that span.
+        # Track emphasis spans; ``None`` marks nesting suppressed by v1.
         stack = []
+
+        # Initialize the single-pass scanner.
         i = 0
         n = len(body)
+
         # Pre-compute backtick run positions once; reused for every "`" hit.
-        backtick_runs = cls.build_backtick_run_index(body)
+        backtick_runs = build_backtick_run_index(body)
 
         while i < n:
             ch = body[i]
 
-            # ----------------------------------------------------------------
-            # Backslash escapes
-            # ----------------------------------------------------------------
-            # CommonMark escapes look like "\*" or "\[".  V2 (strict) keeps
-            # ALL of them because MarkdownV2 requires many chars to be escaped.
-            # V1 only keeps the small set of characters that Telegram's legacy
-            # Markdown actually reserves; others are emitted as plain chars.
+            # Preserve escapes required by v2 or recognized by legacy v1.
             if ch == "\\" and i + 1 < n:
                 nxt = body[i + 1]
                 if strict or nxt in cls._TELEGRAM_V1_ESCAPABLE:
@@ -891,13 +866,7 @@ class NotifyTelegram(NotifyBase):
                 i += 2
                 continue
 
-            # ----------------------------------------------------------------
-            # Code spans  (` ... ` or ``` ... ```)
-            # ----------------------------------------------------------------
-            # Measure the backtick run length (1, 2, or 3+) then use the
-            # pre-built index to find the matching closing run at exactly
-            # the same width.  CommonMark allows any run width as long as
-            # the open and close widths match exactly.
+            # Convert matched CommonMark code runs to Telegram delimiters.
             if ch == "`":
                 j = i
                 # Count consecutive backticks to get the run length.
@@ -905,53 +874,29 @@ class NotifyTelegram(NotifyBase):
                     j += 1
                 run = j - i
                 # Find the next unescaped run of the same length.
-                close = cls.find_unescaped_run(backtick_runs, j, run)
+                close = find_unescaped_run(backtick_runs, j, run)
 
                 if close is not None:
                     # Extract the code span content between the delimiters.
                     content = body[j:close]
-                    # Telegram requires literal backslashes and backticks
-                    # inside code spans to be escaped so the renderer does
-                    # not mistake them for control characters.
+                    # Escape Telegram control characters inside code.
                     content = content.replace("\\", "\\\\").replace("`", "\\`")
-                    # Normalise the delimiter: Telegram only recognises single
-                    # or triple backtick code spans, so choose the narrowest
-                    # form that is valid (triple when multiline or 3+ chars).
+
+                    # Use fences for multiline or wide CommonMark spans.
                     delim = "```" if run >= 3 or "\n" in content else "`"
                     out.append(delim + content + delim)
                     # Skip past the closing backtick run.
                     i = close + run
                     continue
 
-                # No matching close found -- not a real code span.
-                # Emit the backticks as literal text (escaped in V2).
+                # Preserve unmatched backticks, escaping them only in v2.
                 out.append(("\\`" if strict else "`") * run)
                 i = j
                 continue
 
-            # ----------------------------------------------------------------
-            # Inline link destination  ](<url>)  -->  ](url)
-            # ----------------------------------------------------------------
-            # html_to_markdown() wraps URLs in angle brackets for safety
-            # (CommonMark angle-bracket destinations allow any URL character).
-            # Telegram's link format does not use angle brackets, so we strip
-            # them and re-escape the URL for Telegram's reserved characters.
+            # Strip CommonMark angle brackets from Telegram link destinations.
             if body.startswith("](<", i):
-                # Scan forward with escape awareness so a literal ">)" inside
-                # the URL (e.g. a query string with ">" encoded as itself)
-                # does not falsely terminate the destination scan.
-                close = None
-                k = i + 3
-                while k < n - 1:
-                    if body[k] == "\\" and k + 1 < n:
-                        # Skip escaped characters; they cannot be terminators.
-                        k += 2
-                        continue
-                    if body[k] == ">" and body[k + 1] == ")":
-                        # Found the closing ">)" -- mark and stop.
-                        close = k
-                        break
-                    k += 1
+                close = commonmark_scan_angle_dest(body, i, n)
 
                 if close is not None:
                     # Extract the URL content between "(" and ">".
@@ -964,27 +909,7 @@ class NotifyTelegram(NotifyBase):
                     i = close + 2
                     continue
 
-            # ----------------------------------------------------------------
-            # Emphasis runs  (* or **)
-            # ----------------------------------------------------------------
-            # CommonMark uses "*" for italic and "**" for bold.  Telegram V1
-            # uses "_" for italic and "*" for bold; V2 uses the same chars but
-            # with strict escaping everywhere else.
-            #
-            # A single "*" run in the input can carry multiple emphasis levels
-            # at once: "***" is bold+italic opened or closed simultaneously.
-            # We handle this with two strategies:
-            #
-            #   CASCADE  -- when the run width matches the exact total width
-            #               of one or more consecutive frames on the stack,
-            #               close all of them in one step.  Example:
-            #               "***text***" opens bold+italic; the closing "***"
-            #               pops both frames and emits both close delimiters.
-            #
-            #   WHILE RUN -- otherwise, consume the run width one span at a
-            #               time, either closing the top-of-stack span if it
-            #               satisfies the remaining width, or opening a new
-            #               span.
+            # Map CommonMark emphasis, including combined ``***`` runs.
             if ch == "*":
                 j = i
                 # Measure the full asterisk run.
@@ -992,12 +917,7 @@ class NotifyTelegram(NotifyBase):
                     j += 1
                 run = j - i
 
-                # ---- Cascade detection ----
-                # Walk the stack from the top (innermost frame) accumulating
-                # the width each frame would need for its close delimiter.
-                # Bold ("*") needs 2 asterisks; italic ("_") needs 1.
-                # Stop as soon as the accumulated width matches the run, or
-                # would exceed it (no exact match is possible past that point).
+                # Detect runs that exactly close multiple nested spans.
                 cascade_levels = 0
                 cascade_width = 0
                 for delim, _ in reversed(stack):
@@ -1028,11 +948,7 @@ class NotifyTelegram(NotifyBase):
                     i = j
                     continue
 
-                # ---- Consume run width one span at a time ----
-                # No exact cascade match; process the run piecemeal.
-                # Each iteration either closes the top-of-stack span (if it
-                # can be satisfied by the remaining run width) or opens a
-                # new span.  Loop until the entire run has been consumed.
+                # Otherwise consume the run one span at a time.
                 while run > 0:
                     if stack and stack[-1][0] == "*" and run >= 2:
                         # Top of stack is a bold span; 2 asterisks close it.
@@ -1050,16 +966,12 @@ class NotifyTelegram(NotifyBase):
                         run -= 2
                     elif run >= 2:
                         # No closeable bold on stack; open a new bold span.
-                        # In strict (V2) mode or when the stack is empty,
-                        # emit the delimiter immediately.  In V1 with an
-                        # existing open span, suppress the nested delimiter
-                        # (V1 Markdown does not support nesting emphasis).
+                        # Legacy v1 suppresses nested emphasis delimiters.
                         if strict or not stack:
                             out.append("*")
                             stack.append(("*", len(out) - 1))
                         else:
-                            # Suppressed: record None so the cascade close
-                            # knows not to emit a closing delimiter either.
+                            # Record suppression for the matching close.
                             stack.append(("*", None))
                         run -= 2
                     else:
@@ -1075,29 +987,17 @@ class NotifyTelegram(NotifyBase):
                 i = j
                 continue
 
-            # ----------------------------------------------------------------
-            # MarkdownV2 reserved characters
-            # ----------------------------------------------------------------
-            # In strict mode every character that MarkdownV2 reserves must be
-            # backslash-escaped so Telegram's parser does not misinterpret it.
+            # Escape remaining MarkdownV2-reserved characters.
             if strict and ch in cls._TELEGRAM_STRICT_CHARS:
                 out.append("\\" + ch)
                 i += 1
                 continue
 
-            # ----------------------------------------------------------------
-            # All other characters pass through unchanged.
-            # ----------------------------------------------------------------
+            # Preserve ordinary characters.
             out.append(ch)
             i += 1
 
-        # --------------------------------------------------------------------
-        # Force-close spans left open by malformed or truncated source.
-        # --------------------------------------------------------------------
-        # Any span still on the stack was not closed by a matching "*" run.
-        # Pop innermost-first (LIFO) so the emitted delimiters are correctly
-        # ordered.  An empty span (open_index == len(out) - 1) is dropped
-        # entirely rather than left as a dangling delimiter in the output.
+        # Close nonempty spans left open by malformed or truncated input.
         while stack:
             delim, open_index = stack.pop()
             if open_index is None:
@@ -1111,99 +1011,59 @@ class NotifyTelegram(NotifyBase):
                 # Emit the close delimiter to produce valid Telegram Markdown.
                 out.append(delim)
 
+        # Join the translated fragments once.
         return "".join(out)
 
     @classmethod
     def _repair_split_chunk(cls, text, strict, pending):
-        """Repair Telegram Markdown entities split across message chunks.
+        """Repair one Telegram Markdown chunk and return its pending state.
 
-        Overview
-        --------
-        The base splitter cuts the body into body_maxlen-sized pieces
-        without awareness of Markdown structure.  A cut can land:
-          - Inside a code span  (` ... ` or ``` ... ```)
-          - Inside a link destination  [label]( ... )
-          - Inside an emphasis span  *word* or _word_
+        Each returned chunk is independently valid. ``pending`` carries only
+        the state needed to interpret delimiters appearing in later chunks:
 
-        This method processes one already-split chunk and:
-          1. Handles any open entity that was carried over from the
-             previous chunk via the `pending` state dict.
-          2. Walks the chunk character by character, tracking emphasis
-             spans that open or close within this chunk.
-          3. Forces every open span closed at the chunk edge (so each
-             message is independently valid Telegram Markdown).
-          4. Returns the repaired text and an updated `pending` dict for
-             the next chunk to consume.
+        Key             Meaning
+        --------------  ----------------------------------------------
+        ``in_code``     Width of a code fence continued from this chunk
+        ``in_link_dest`` Link destination continues into the next chunk
+        ``*`` / ``_``   Emphasis closes to discard in a later chunk
 
-        `pending` keys
-        --------------
-        "in_code" : int   -- The backtick run width of an open code span
-                            that started in the previous chunk.  The chunk
-                            begins inside the code span's content; we scan
-                            for the matching close run and strict-escape
-                            everything up to it.
-        "in_link_dest" : bool -- True when the previous chunk ended inside
-                            a link destination "...](url..." with no closing
-                            ")".  We scan for the unescaped ")" and
-                            strict-escape the URL fragment.
-        "*" / "_" : int  -- Count of emphasis spans opened in a previous
-                            chunk whose CLOSE delimiter will appear in this
-                            or a later chunk.  When we encounter that close
-                            delimiter we discard it (the open was already
-                            dropped) rather than emitting an unmatched close.
-
-        Data structures
-        ---------------
-        out        -- list of str fragments accumulated for this chunk.
-        open_state -- {"*": bool, "_": bool}  True while the delimiter is
-                      open inside this chunk (not carried over).
-        open_pos   -- {"*": int|None, "_": int|None}  Index in `out` where
-                      the opening delimiter was placed; used to drop empty
-                      spans at the chunk edge.
-        link_stack -- list of out-indices for unmatched "[" characters seen
-                      in this chunk; escaped if no matching "](" follows.
+        Returns ``(repaired_text, next_pending)``.
         """
 
         # Output fragment list; joined once at the end.
         out = []
-        # Track which emphasis delimiters are currently open in this chunk.
+        # Track emphasis opened within this chunk.
         open_state = {"*": False, "_": False}
         # Record the out-index of each open delimiter for empty-span cleanup.
         open_pos = {"*": None, "_": None}
         # Work on a mutable copy so we do not mutate the caller's dict.
         pending = dict(pending)
-        # Stack of out-indices for "[" characters that may start a link.
+        # Track possible link-label openings in this chunk.
         link_stack = []
+
+        # Initialize the single-pass scanner.
         i = 0
         n = len(text)
         # Pre-compute backtick run positions once for O(log n) code matching.
-        backtick_runs = cls.build_backtick_run_index(text)
+        backtick_runs = build_backtick_run_index(text)
 
-        # --------------------------------------------------------------------
-        # Resume any entity that was still open at the end of the last chunk.
-        # --------------------------------------------------------------------
-
+        # Resume an entity left open by the previous chunk.
         in_code_width = pending.pop("in_code", None)
         if in_code_width and strict:
-            # The previous chunk ended inside a code span whose opening fence
-            # had `in_code_width` backticks.  Scan from the start of this
-            # chunk for the matching closing fence.
-            close = cls.find_unescaped_run(backtick_runs, 0, in_code_width)
+            # Search this chunk for the carried code span's closing fence.
+            close = find_unescaped_run(backtick_runs, 0, in_code_width)
             if close is not None:
-                # Found the close fence in this chunk: strict-escape the code
-                # content up to the fence, then skip past the fence itself.
+                # Escape carried code content and consume its closing fence.
                 out.append(cls._strict_escape(text[:close]))
                 i = close + in_code_width
             else:
-                # The code span has not closed yet: escape the entire chunk
-                # and carry "in_code" into the next pending state.
+                # Escape this chunk and carry the code state forward.
                 out.append(cls._strict_escape(text))
                 pending["in_code"] = in_code_width
                 i = n
 
         elif pending.pop("in_link_dest", False) and strict:
-            # The previous chunk ended inside a link destination "](url..."
-            # with no closing ")".  Scan from the start for the unescaped ")".
+            # Search for a carried link destination's closing parenthesis.
             close = None
             k = 0
             while k < n:
@@ -1228,26 +1088,17 @@ class NotifyTelegram(NotifyBase):
                 pending["in_link_dest"] = True
                 i = n
 
-        # --------------------------------------------------------------------
-        # Main character loop: scan the remainder of this chunk.
-        # --------------------------------------------------------------------
-
+        # Scan the remainder of this chunk.
         while i < n:
             ch = text[i]
 
-            # Backslash escape: pass through verbatim so we do not disturb
-            # escaping that _commonmark_to_telegram already applied.
+            # Preserve escapes already applied by the dialect adapter.
             if ch == "\\" and i + 1 < n:
                 out.append(text[i : i + 2])
                 i += 2
                 continue
 
-            # ----------------------------------------------------------------
-            # Code spans
-            # ----------------------------------------------------------------
-            # A complete code span passes through unchanged.  If the span is
-            # not closed within this chunk, its content must be strict-escaped
-            # and the open fence width recorded in pending for the next chunk.
+            # Preserve complete code spans or carry split spans forward.
             if ch == "`":
                 j = i
                 # Measure the opening backtick run.
@@ -1255,7 +1106,7 @@ class NotifyTelegram(NotifyBase):
                     j += 1
                 run = j - i
                 # Look for the matching close run in the pre-built index.
-                close = cls.find_unescaped_run(backtick_runs, j, run)
+                close = find_unescaped_run(backtick_runs, j, run)
                 if close is not None:
                     # Complete span in this chunk: copy verbatim.
                     out.append(text[i : close + run])
@@ -1270,28 +1121,16 @@ class NotifyTelegram(NotifyBase):
                     i = n
                     continue
 
-            # ----------------------------------------------------------------
-            # Emphasis delimiters  (* and _)
-            # ----------------------------------------------------------------
-            # Each delimiter is either:
-            #   a) A close for a span opened in a previous chunk (discard it
-            #      because the open was dropped at the prior chunk edge), or
-            #   b) A toggle within this chunk (open if not yet open, else
-            #      close).
+            # Reconcile carried or local emphasis delimiters.
             if ch in "*_":
                 if pending.get(ch, 0) > 0:
-                    # This close matches an open that was dropped when the
-                    # previous chunk ended.  Discard the close and decrement
-                    # the pending count so we stop discarding when balanced.
+                    # Discard the close for an opening dropped previously.
                     pending[ch] -= 1
                     i += 1
                     continue
 
                 if open_state[ch]:
-                    # This delimiter closes a span opened earlier in this
-                    # chunk.  If the span collected no content (open_pos is
-                    # the last item in out), drop the orphan opening delimiter
-                    # rather than emitting an empty span pair.
+                    # Close the local span, dropping an empty opening.
                     if open_pos[ch] == len(out) - 1:
                         out.pop()
                     else:
@@ -1307,9 +1146,7 @@ class NotifyTelegram(NotifyBase):
                 i += 1
                 continue
 
-            # ----------------------------------------------------------------
-            # Link labels  [  and  ](dest)  -- strict (V2) mode only
-            # ----------------------------------------------------------------
+            # Track link labels only in strict MarkdownV2 mode.
             if strict and ch == "[":
                 # Record the position of this "[" in out so we can escape it
                 # later if we never find a matching "](dest)" in this chunk.
@@ -1351,9 +1188,7 @@ class NotifyTelegram(NotifyBase):
                     i = close + 1
                     continue
 
-                # Destination has no closing ")" in this chunk.  Escape the
-                # "](" we have so far, escape the partial URL, and carry the
-                # "in_link_dest" state so the next chunk knows to continue.
+                # Escape the partial destination and carry it forward.
                 out.append("\\]\\(")
                 out.append(cls._strict_escape(text[i + 2 :]))
                 pending["in_link_dest"] = True
@@ -1371,45 +1206,38 @@ class NotifyTelegram(NotifyBase):
             out.append(ch)
             i += 1
 
-        # --------------------------------------------------------------------
-        # Post-loop cleanup: unmatched labels, empty spans, open-span closes
-        # --------------------------------------------------------------------
-
-        # Any "[" that never found its "](" must be escaped in-place before
-        # any deletions happen (deletions shift indexes, so we fix first).
+        # Escape unmatched labels before index-changing cleanup.
         if strict:
             for idx in link_stack:
                 out[idx] = "\\" + out[idx]
 
-        # Classify each delimiter that is still open at the chunk edge:
-        # empty (open_pos is the last item -- span has no content yet) or
-        # nonempty (span has content and must be force-closed).
-        # Classify before deleting because deletions shift recorded indexes.
+        # Classify open spans before deletions shift their indexes.
         empty, nonempty = [], []
         for d in ("*", "_"):
             if not open_state[d]:
                 continue
             (empty if open_pos[d] == len(out) - 1 else nonempty).append(d)
 
-        # Delete empty-span delimiters from highest index to lowest so that
-        # earlier indexes remain valid as we delete.
+        # Delete empty spans from right to left to preserve earlier indexes.
         for d in sorted(empty, key=lambda d: open_pos[d], reverse=True):
             del out[open_pos[d]]
 
-        # Force-close nonempty spans by appending the close delimiter and
-        # recording each one in pending so the next chunk can discard the
-        # matching close when it appears there.
+        # Close nonempty spans and carry their unmatched closes forward.
         new_pending = dict(pending)
         for d in nonempty:
             out.append(d)
             new_pending[d] = new_pending.get(d, 0) + 1
 
+        # Return the repaired chunk and state for its successor.
         return "".join(out), new_pending
 
     def _build_send_calls(
         self, body=None, title=None, body_format=None, **kwargs
     ):
-        """Adapt CommonMark before splitting, then repair split entities."""
+        """Convert HTML-derived CommonMark and repair each split chunk.
+
+        Pending Telegram entity state is carried between generated calls.
+        """
 
         if not (
             self.notify_format == NotifyFormat.MARKDOWN
@@ -1422,13 +1250,9 @@ class NotifyTelegram(NotifyBase):
 
         strict = self.markdown_ver == TelegramMarkdownVersion.TWO
 
-        # Merge the title into the CommonMark body before dialect conversion
-        # so the heading syntax is translated to Telegram markup correctly.
+        # Merge the title before translating its heading syntax.
         if self.title_maxlen <= 0 and title:
-            title_text = title.lstrip("\r\n \t\v\f#-")
-            if title_text:
-                body = f"# {title_text}\n{body}" if body else f"# {title_text}"
-            title = ""
+            body, title = commonmark_prepend_title(body, title)
 
         body = self._commonmark_to_telegram(body, strict=strict)
 
@@ -1436,9 +1260,7 @@ class NotifyTelegram(NotifyBase):
         for kwargs2 in super()._build_send_calls(
             body=body,
             title=title,
-            # The body is now Telegram Markdown, not raw HTML.  Pass
-            # MARKDOWN so smart_split uses markdown_adjust (link-construct
-            # protection) rather than html_adjust (entity-only protection).
+            # Use Markdown-aware splitting on the translated body.
             body_format=NotifyFormat.MARKDOWN,
             **kwargs,
         ):

--- a/apprise/plugins/telegram.py
+++ b/apprise/plugins/telegram.py
@@ -832,20 +832,17 @@ class NotifyTelegram(NotifyBase):
         # Prepare Message Body
         if self.notify_format == NotifyFormat.MARKDOWN:
             if (
-                body_format
-                not in (
-                    None,
-                    NotifyFormat.MARKDOWN,
-                    NotifyFormat.HTML,
-                )
+                body_format not in (None, NotifyFormat.MARKDOWN)
                 and self.markdown_ver == TelegramMarkdownVersion.TWO
             ):
                 # Telegram Markdown v2 is not very accomodating to some
-                # characters such as the hashtag (#) which is fine in v1.
-                # To try and be accomodating we escape them in advance
-                # See: https://stackoverflow.com/a/69892704/355584
-                # Also: https://core.telegram.org/bots/api#markdownv2-style
-                # Note: We only escape characters that are not already escaped.
+                # characters such as the hashtag (#) which is fine in v1. To
+                # try and be accomodating we escape them in advance See:
+                # https://stackoverflow.com/a/69892704/355584 Also:
+                # https://core.telegram.org/bots/api#markdownv2-style Note: We
+                # only escape characters that are not already escaped.
+                #
+                # Telegram v2 needs its own escaping for converted HTML.
                 body = re.sub(r"(?<!\\)([_*[\]()~`>#+=|{}.!-])", r"\\\1", body)
 
             payload_["parse_mode"] = self.markdown_ver
@@ -856,8 +853,8 @@ class NotifyTelegram(NotifyBase):
             payload_["parse_mode"] = "HTML"
             for r, v, m in self.__telegram_escape_html_entries:
                 if "html" in m:
-                    # Handle special cases where we need to alter new lines
-                    # for presentation purposes
+                    # Handle special cases where we need to alter new lines for
+                    # presentation purposes
                     v = v.format(
                         m["html"]
                         if body_format

--- a/apprise/plugins/telegram.py
+++ b/apprise/plugins/telegram.py
@@ -825,121 +825,245 @@ class NotifyTelegram(NotifyBase):
     @classmethod
     def _commonmark_to_telegram(cls, body, strict=False):
         """Adapt html_to_markdown()'s CommonMark output to Telegram's own
-        Markdown dialect ("Markdown"/v1, or strictly for "MarkdownV2"/v2)."""
+        Markdown dialect ("Markdown"/v1, or strictly for "MarkdownV2"/v2).
 
+        Overview
+        --------
+        html_to_markdown() produces CommonMark: emphasis with * and **,
+        links as [label](<url>), code spans with backticks, and backslash
+        escapes.  Telegram uses a different dialect:
+
+          CommonMark   V1 ("Markdown")   V2 ("MarkdownV2")
+          ----------   ---------------   -----------------
+          **bold**     *bold*            *bold*
+          *italic*     _italic_          _italic_
+          `code`       `code`            `code`
+          [l](<u>)     [l](u)            [l](u)   -- angle brackets stripped
+          \\*          * (literal)       \\*       -- only some escapes kept
+
+        Both dialects share the same emphasis mapping; strict=True adds
+        per-character escaping of all MarkdownV2 reserved characters.
+
+        Data structures
+        ---------------
+        out   -- list of str fragments; joined at the end to form the result.
+                 Using a list avoids O(n^2) string concatenation.
+        stack -- list of (delimiter, open_index) pairs, innermost frame last
+                 (LIFO order).  "delimiter" is "*" (bold) or "_" (italic).
+                 "open_index" is the index in `out` where the opening
+                 delimiter was placed; None marks a span that was suppressed
+                 (V1 only -- legacy Markdown forbids nesting emphasis).
+        i     -- byte position in the input string body[i].
+        n     -- len(body); cached to avoid repeated calls in the hot loop.
+        backtick_runs -- pre-built index of all unescaped backtick run
+                 positions so code-span matching is O(log n) not O(n^2).
+        """
+
+        # Accumulate output fragments; joined once at the end.
         out = []
-        # Open spans as (delimiter, output index), innermost last. A None index
-        # marks nesting suppressed for legacy Markdown.
+        # Open emphasis spans tracked in LIFO order.  Each entry is
+        # (delimiter, open_index_in_out) where open_index is None when
+        # V1 nesting suppression is in effect for that span.
         stack = []
         i = 0
         n = len(body)
+        # Pre-compute backtick run positions once; reused for every "`" hit.
         backtick_runs = cls.build_backtick_run_index(body)
 
         while i < n:
             ch = body[i]
 
-            # Keep valid escapes and drop unsupported legacy backslashes.
+            # ----------------------------------------------------------------
+            # Backslash escapes
+            # ----------------------------------------------------------------
+            # CommonMark escapes look like "\*" or "\[".  V2 (strict) keeps
+            # ALL of them because MarkdownV2 requires many chars to be escaped.
+            # V1 only keeps the small set of characters that Telegram's legacy
+            # Markdown actually reserves; others are emitted as plain chars.
             if ch == "\\" and i + 1 < n:
                 nxt = body[i + 1]
                 if strict or nxt in cls._TELEGRAM_V1_ESCAPABLE:
+                    # Preserve the entire two-character escape sequence.
                     out.append(body[i : i + 2])
                 else:
+                    # V1 does not escape this char; emit just the literal.
                     out.append(nxt)
                 i += 2
                 continue
 
-            # Telegram uses fixed code delimiters and escapes their contents.
+            # ----------------------------------------------------------------
+            # Code spans  (` ... ` or ``` ... ```)
+            # ----------------------------------------------------------------
+            # Measure the backtick run length (1, 2, or 3+) then use the
+            # pre-built index to find the matching closing run at exactly
+            # the same width.  CommonMark allows any run width as long as
+            # the open and close widths match exactly.
             if ch == "`":
                 j = i
+                # Count consecutive backticks to get the run length.
                 while j < n and body[j] == "`":
                     j += 1
                 run = j - i
+                # Find the next unescaped run of the same length.
                 close = cls.find_unescaped_run(backtick_runs, j, run)
 
                 if close is not None:
+                    # Extract the code span content between the delimiters.
                     content = body[j:close]
+                    # Telegram requires literal backslashes and backticks
+                    # inside code spans to be escaped so the renderer does
+                    # not mistake them for control characters.
                     content = content.replace("\\", "\\\\").replace("`", "\\`")
+                    # Normalise the delimiter: Telegram only recognises single
+                    # or triple backtick code spans, so choose the narrowest
+                    # form that is valid (triple when multiline or 3+ chars).
                     delim = "```" if run >= 3 or "\n" in content else "`"
                     out.append(delim + content + delim)
+                    # Skip past the closing backtick run.
                     i = close + run
                     continue
 
-                # Treat unmatched backticks as reserved literal text.
+                # No matching close found -- not a real code span.
+                # Emit the backticks as literal text (escaped in V2).
                 out.append(("\\`" if strict else "`") * run)
                 i = j
                 continue
 
-            # Convert angle-bracket destinations to Telegram's bare form.
+            # ----------------------------------------------------------------
+            # Inline link destination  ](<url>)  -->  ](url)
+            # ----------------------------------------------------------------
+            # html_to_markdown() wraps URLs in angle brackets for safety
+            # (CommonMark angle-bracket destinations allow any URL character).
+            # Telegram's link format does not use angle brackets, so we strip
+            # them and re-escape the URL for Telegram's reserved characters.
             if body.startswith("](<", i):
-                # Scan with escape awareness so ">)" inside a URL does not
-                # falsely terminate the destination.
+                # Scan forward with escape awareness so a literal ">)" inside
+                # the URL (e.g. a query string with ">" encoded as itself)
+                # does not falsely terminate the destination scan.
                 close = None
                 k = i + 3
                 while k < n - 1:
                     if body[k] == "\\" and k + 1 < n:
+                        # Skip escaped characters; they cannot be terminators.
                         k += 2
                         continue
                     if body[k] == ">" and body[k + 1] == ")":
+                        # Found the closing ">)" -- mark and stop.
                         close = k
                         break
                     k += 1
 
                 if close is not None:
+                    # Extract the URL content between "(" and ">".
                     url = body[i + 3 : close]
+                    # In Telegram's format, backslashes and closing
+                    # parentheses inside the URL must be escaped.
                     url = url.replace("\\", "\\\\").replace(")", "\\)")
+                    # Emit the Telegram-style destination and skip past ">)".
                     out.append("](" + url + ")")
                     i = close + 2
                     continue
 
-            # Convert emphasis in LIFO order; legacy mode suppresses nesting.
+            # ----------------------------------------------------------------
+            # Emphasis runs  (* or **)
+            # ----------------------------------------------------------------
+            # CommonMark uses "*" for italic and "**" for bold.  Telegram V1
+            # uses "_" for italic and "*" for bold; V2 uses the same chars but
+            # with strict escaping everywhere else.
+            #
+            # A single "*" run in the input can carry multiple emphasis levels
+            # at once: "***" is bold+italic opened or closed simultaneously.
+            # We handle this with two strategies:
+            #
+            #   CASCADE  -- when the run width matches the exact total width
+            #               of one or more consecutive frames on the stack,
+            #               close all of them in one step.  Example:
+            #               "***text***" opens bold+italic; the closing "***"
+            #               pops both frames and emits both close delimiters.
+            #
+            #   WHILE RUN -- otherwise, consume the run width one span at a
+            #               time, either closing the top-of-stack span if it
+            #               satisfies the remaining width, or opening a new
+            #               span.
             if ch == "*":
                 j = i
+                # Measure the full asterisk run.
                 while j < n and body[j] == "*":
                     j += 1
                 run = j - i
 
-                # Wide runs close nested spans only on an exact width match.
+                # ---- Cascade detection ----
+                # Walk the stack from the top (innermost frame) accumulating
+                # the width each frame would need for its close delimiter.
+                # Bold ("*") needs 2 asterisks; italic ("_") needs 1.
+                # Stop as soon as the accumulated width matches the run, or
+                # would exceed it (no exact match is possible past that point).
                 cascade_levels = 0
                 cascade_width = 0
                 for delim, _ in reversed(stack):
+                    # Width contribution of this stack frame's close delimiter.
                     need = 2 if delim == "*" else 1
                     if cascade_width + need > run:
+                        # Adding this frame would overshoot; no cascade match.
                         break
                     cascade_width += need
                     cascade_levels += 1
                     if cascade_width == run:
+                        # Exact match found; cascade will close these frames.
                         break
 
                 if cascade_levels and cascade_width == run:
+                    # The run exactly closes cascade_levels stack frames.
+                    # Pop them innermost-first and emit each close delimiter.
                     for _ in range(cascade_levels):
                         delim, open_index = stack.pop()
                         if open_index is None:
-                            # Suppressed legacy nesting emits no close.
+                            # V1 suppressed span: nesting was not emitted,
+                            # so no close delimiter is needed here either.
                             pass
                         else:
+                            # Emit the closing delimiter for this span.
                             out.append(delim)
+                    # Advance past the entire asterisk run and move on.
                     i = j
                     continue
 
+                # ---- Consume run width one span at a time ----
+                # No exact cascade match; process the run piecemeal.
+                # Each iteration either closes the top-of-stack span (if it
+                # can be satisfied by the remaining run width) or opens a
+                # new span.  Loop until the entire run has been consumed.
                 while run > 0:
-                    # Extra bold pairs may begin the next sibling span.
                     if stack and stack[-1][0] == "*" and run >= 2:
+                        # Top of stack is a bold span; 2 asterisks close it.
                         delim, open_index = stack.pop()
                         if open_index is None:
+                            # V1 suppressed bold: discard silently.
                             pass
                         elif open_index == len(out) - 1:
+                            # Bold was opened but no content followed --
+                            # remove the dangling open delimiter entirely.
                             out.pop()
                         else:
+                            # Emit the bold close delimiter.
                             out.append(delim)
                         run -= 2
                     elif run >= 2:
+                        # No closeable bold on stack; open a new bold span.
+                        # In strict (V2) mode or when the stack is empty,
+                        # emit the delimiter immediately.  In V1 with an
+                        # existing open span, suppress the nested delimiter
+                        # (V1 Markdown does not support nesting emphasis).
                         if strict or not stack:
                             out.append("*")
                             stack.append(("*", len(out) - 1))
                         else:
+                            # Suppressed: record None so the cascade close
+                            # knows not to emit a closing delimiter either.
                             stack.append(("*", None))
                         run -= 2
                     else:
+                        # run == 1: open (or close, via cascade) an italic.
                         if strict or not stack:
                             out.append("_")
                             stack.append(("_", len(out) - 1))
@@ -947,158 +1071,289 @@ class NotifyTelegram(NotifyBase):
                             stack.append(("_", None))
                         run -= 1
 
+                # Advance past the entire asterisk run.
                 i = j
                 continue
 
+            # ----------------------------------------------------------------
+            # MarkdownV2 reserved characters
+            # ----------------------------------------------------------------
+            # In strict mode every character that MarkdownV2 reserves must be
+            # backslash-escaped so Telegram's parser does not misinterpret it.
             if strict and ch in cls._TELEGRAM_STRICT_CHARS:
                 out.append("\\" + ch)
                 i += 1
                 continue
 
+            # ----------------------------------------------------------------
+            # All other characters pass through unchanged.
+            # ----------------------------------------------------------------
             out.append(ch)
             i += 1
 
-        # Close spans left open by malformed source.
+        # --------------------------------------------------------------------
+        # Force-close spans left open by malformed or truncated source.
+        # --------------------------------------------------------------------
+        # Any span still on the stack was not closed by a matching "*" run.
+        # Pop innermost-first (LIFO) so the emitted delimiters are correctly
+        # ordered.  An empty span (open_index == len(out) - 1) is dropped
+        # entirely rather than left as a dangling delimiter in the output.
         while stack:
             delim, open_index = stack.pop()
             if open_index is None:
+                # V1 suppressed span: never emitted an open, nothing to close.
                 pass
             elif open_index == len(out) - 1:
+                # Span opened but collected no content -- remove the orphan
+                # opening delimiter so the output contains no empty spans.
                 out.pop()
             else:
+                # Emit the close delimiter to produce valid Telegram Markdown.
                 out.append(delim)
 
         return "".join(out)
 
     @classmethod
     def _repair_split_chunk(cls, text, strict, pending):
-        """Repair entities split across Telegram messages.
+        """Repair Telegram Markdown entities split across message chunks.
 
-        Pending state identifies closing delimiters or opaque content that
-        continues from the previous chunk. Returns text and updated state.
+        Overview
+        --------
+        The base splitter cuts the body into body_maxlen-sized pieces
+        without awareness of Markdown structure.  A cut can land:
+          - Inside a code span  (` ... ` or ``` ... ```)
+          - Inside a link destination  [label]( ... )
+          - Inside an emphasis span  *word* or _word_
+
+        This method processes one already-split chunk and:
+          1. Handles any open entity that was carried over from the
+             previous chunk via the `pending` state dict.
+          2. Walks the chunk character by character, tracking emphasis
+             spans that open or close within this chunk.
+          3. Forces every open span closed at the chunk edge (so each
+             message is independently valid Telegram Markdown).
+          4. Returns the repaired text and an updated `pending` dict for
+             the next chunk to consume.
+
+        `pending` keys
+        --------------
+        "in_code" : int   -- The backtick run width of an open code span
+                            that started in the previous chunk.  The chunk
+                            begins inside the code span's content; we scan
+                            for the matching close run and strict-escape
+                            everything up to it.
+        "in_link_dest" : bool -- True when the previous chunk ended inside
+                            a link destination "...](url..." with no closing
+                            ")".  We scan for the unescaped ")" and
+                            strict-escape the URL fragment.
+        "*" / "_" : int  -- Count of emphasis spans opened in a previous
+                            chunk whose CLOSE delimiter will appear in this
+                            or a later chunk.  When we encounter that close
+                            delimiter we discard it (the open was already
+                            dropped) rather than emitting an unmatched close.
+
+        Data structures
+        ---------------
+        out        -- list of str fragments accumulated for this chunk.
+        open_state -- {"*": bool, "_": bool}  True while the delimiter is
+                      open inside this chunk (not carried over).
+        open_pos   -- {"*": int|None, "_": int|None}  Index in `out` where
+                      the opening delimiter was placed; used to drop empty
+                      spans at the chunk edge.
+        link_stack -- list of out-indices for unmatched "[" characters seen
+                      in this chunk; escaped if no matching "](" follows.
         """
 
+        # Output fragment list; joined once at the end.
         out = []
+        # Track which emphasis delimiters are currently open in this chunk.
         open_state = {"*": False, "_": False}
+        # Record the out-index of each open delimiter for empty-span cleanup.
         open_pos = {"*": None, "_": None}
+        # Work on a mutable copy so we do not mutate the caller's dict.
         pending = dict(pending)
+        # Stack of out-indices for "[" characters that may start a link.
         link_stack = []
         i = 0
         n = len(text)
+        # Pre-compute backtick run positions once for O(log n) code matching.
         backtick_runs = cls.build_backtick_run_index(text)
+
+        # --------------------------------------------------------------------
+        # Resume any entity that was still open at the end of the last chunk.
+        # --------------------------------------------------------------------
 
         in_code_width = pending.pop("in_code", None)
         if in_code_width and strict:
+            # The previous chunk ended inside a code span whose opening fence
+            # had `in_code_width` backticks.  Scan from the start of this
+            # chunk for the matching closing fence.
             close = cls.find_unescaped_run(backtick_runs, 0, in_code_width)
             if close is not None:
+                # Found the close fence in this chunk: strict-escape the code
+                # content up to the fence, then skip past the fence itself.
                 out.append(cls._strict_escape(text[:close]))
                 i = close + in_code_width
             else:
+                # The code span has not closed yet: escape the entire chunk
+                # and carry "in_code" into the next pending state.
                 out.append(cls._strict_escape(text))
                 pending["in_code"] = in_code_width
                 i = n
 
         elif pending.pop("in_link_dest", False) and strict:
+            # The previous chunk ended inside a link destination "](url..."
+            # with no closing ")".  Scan from the start for the unescaped ")".
             close = None
             k = 0
             while k < n:
                 if text[k] == "\\" and k + 1 < n:
+                    # Skip escape sequences -- they cannot be the terminator.
                     k += 2
                     continue
                 if text[k] == ")":
+                    # Found the unescaped closing parenthesis.
                     close = k
                     break
                 k += 1
 
             if close is not None:
+                # Strict-escape the URL fragment up to ")" then emit "\\)".
                 out.append(cls._strict_escape(text[:close]))
                 out.append("\\)")
                 i = close + 1
             else:
-                # Carry an unterminated destination into the next chunk.
+                # Destination has not closed yet: carry the state forward.
                 out.append(cls._strict_escape(text))
                 pending["in_link_dest"] = True
                 i = n
 
+        # --------------------------------------------------------------------
+        # Main character loop: scan the remainder of this chunk.
+        # --------------------------------------------------------------------
+
         while i < n:
             ch = text[i]
 
+            # Backslash escape: pass through verbatim so we do not disturb
+            # escaping that _commonmark_to_telegram already applied.
             if ch == "\\" and i + 1 < n:
                 out.append(text[i : i + 2])
                 i += 2
                 continue
 
-            # Preserve complete code entities unchanged.
+            # ----------------------------------------------------------------
+            # Code spans
+            # ----------------------------------------------------------------
+            # A complete code span passes through unchanged.  If the span is
+            # not closed within this chunk, its content must be strict-escaped
+            # and the open fence width recorded in pending for the next chunk.
             if ch == "`":
                 j = i
+                # Measure the opening backtick run.
                 while j < n and text[j] == "`":
                     j += 1
                 run = j - i
+                # Look for the matching close run in the pre-built index.
                 close = cls.find_unescaped_run(backtick_runs, j, run)
                 if close is not None:
+                    # Complete span in this chunk: copy verbatim.
                     out.append(text[i : close + run])
                     i = close + run
                     continue
 
                 if strict:
-                    # Drop a split fence and carry its escaped content forward.
+                    # Split code span: escape the partial content and carry
+                    # the fence width so the next chunk knows where to close.
                     pending["in_code"] = run
                     out.append(cls._strict_escape(text[j:]))
                     i = n
                     continue
 
+            # ----------------------------------------------------------------
+            # Emphasis delimiters  (* and _)
+            # ----------------------------------------------------------------
+            # Each delimiter is either:
+            #   a) A close for a span opened in a previous chunk (discard it
+            #      because the open was dropped at the prior chunk edge), or
+            #   b) A toggle within this chunk (open if not yet open, else
+            #      close).
             if ch in "*_":
                 if pending.get(ch, 0) > 0:
-                    # Discard a close whose open was dropped earlier.
+                    # This close matches an open that was dropped when the
+                    # previous chunk ended.  Discard the close and decrement
+                    # the pending count so we stop discarding when balanced.
                     pending[ch] -= 1
                     i += 1
                     continue
 
                 if open_state[ch]:
+                    # This delimiter closes a span opened earlier in this
+                    # chunk.  If the span collected no content (open_pos is
+                    # the last item in out), drop the orphan opening delimiter
+                    # rather than emitting an empty span pair.
                     if open_pos[ch] == len(out) - 1:
                         out.pop()
                     else:
+                        # Emit the close delimiter.
                         out.append(ch)
                     open_state[ch] = False
                     open_pos[ch] = None
                 else:
+                    # This delimiter opens a new span in this chunk.
                     out.append(ch)
                     open_pos[ch] = len(out) - 1
                     open_state[ch] = True
                 i += 1
                 continue
 
+            # ----------------------------------------------------------------
+            # Link labels  [  and  ](dest)  -- strict (V2) mode only
+            # ----------------------------------------------------------------
             if strict and ch == "[":
+                # Record the position of this "[" in out so we can escape it
+                # later if we never find a matching "](dest)" in this chunk.
                 link_stack.append(len(out))
                 out.append(ch)
                 i += 1
                 continue
 
             if strict and text.startswith("](", i):
-                # Find the destination's next unescaped closing parenthesis.
+                # We are at the "](" that closes a pending link label.
+                # Scan forward for the unescaped closing ")" of the URL.
                 close = None
                 k = i + 2
                 while k < n:
                     if text[k] == "\\" and k + 1 < n:
+                        # Skip escaped chars inside the destination.
                         k += 2
                         continue
                     if text[k] == ")":
+                        # Found the closing paren -- mark and stop.
                         close = k
                         break
                     k += 1
 
                 if close is not None:
                     if link_stack:
+                        # Matched a "[" from this chunk: emit the full
+                        # "](...)" substring verbatim.
                         link_stack.pop()
                         out.append(text[i : close + 1])
                     else:
+                        # No matching "[" in this chunk (it was in a previous
+                        # chunk that ended mid-label).  Escape the brackets
+                        # and strict-escape the destination so the output is
+                        # valid MarkdownV2 literal text.
                         out.append("\\]\\(")
                         out.append(cls._strict_escape(text[i + 2 : close]))
                         out.append("\\)")
                     i = close + 1
                     continue
 
-                # Escape and carry an incomplete destination forward.
+                # Destination has no closing ")" in this chunk.  Escape the
+                # "](" we have so far, escape the partial URL, and carry the
+                # "in_link_dest" state so the next chunk knows to continue.
                 out.append("\\]\\(")
                 out.append(cls._strict_escape(text[i + 2 :]))
                 pending["in_link_dest"] = True
@@ -1106,30 +1361,44 @@ class NotifyTelegram(NotifyBase):
                 continue
 
             if strict and ch in "[]()":
-                # Escape link punctuation outside a complete entity.
+                # Stray link punctuation outside a complete construct must be
+                # escaped so MarkdownV2's strict parser does not reject it.
                 out.append("\\" + ch)
                 i += 1
                 continue
 
+            # All other characters pass through unchanged.
             out.append(ch)
             i += 1
 
-        # Escape unmatched labels before later index-changing cleanup.
+        # --------------------------------------------------------------------
+        # Post-loop cleanup: unmatched labels, empty spans, open-span closes
+        # --------------------------------------------------------------------
+
+        # Any "[" that never found its "](" must be escaped in-place before
+        # any deletions happen (deletions shift indexes, so we fix first).
         if strict:
             for idx in link_stack:
                 out[idx] = "\\" + out[idx]
 
-        # Drop empty spans and force-close nonempty spans at the chunk edge.
-        # Classify first because deletions shift recorded output indexes.
+        # Classify each delimiter that is still open at the chunk edge:
+        # empty (open_pos is the last item -- span has no content yet) or
+        # nonempty (span has content and must be force-closed).
+        # Classify before deleting because deletions shift recorded indexes.
         empty, nonempty = [], []
         for d in ("*", "_"):
             if not open_state[d]:
                 continue
             (empty if open_pos[d] == len(out) - 1 else nonempty).append(d)
 
+        # Delete empty-span delimiters from highest index to lowest so that
+        # earlier indexes remain valid as we delete.
         for d in sorted(empty, key=lambda d: open_pos[d], reverse=True):
             del out[open_pos[d]]
 
+        # Force-close nonempty spans by appending the close delimiter and
+        # recording each one in pending so the next chunk can discard the
+        # matching close when it appears there.
         new_pending = dict(pending)
         for d in nonempty:
             out.append(d)
@@ -1165,7 +1434,13 @@ class NotifyTelegram(NotifyBase):
 
         pending = {}
         for kwargs2 in super()._build_send_calls(
-            body=body, title=title, body_format=body_format, **kwargs
+            body=body,
+            title=title,
+            # The body is now Telegram Markdown, not raw HTML.  Pass
+            # MARKDOWN so smart_split uses markdown_adjust (link-construct
+            # protection) rather than html_adjust (entity-only protection).
+            body_format=NotifyFormat.MARKDOWN,
+            **kwargs,
         ):
             kwargs2["body"], pending = self._repair_split_chunk(
                 kwargs2["body"], strict, pending

--- a/apprise/plugins/telegram.py
+++ b/apprise/plugins/telegram.py
@@ -51,6 +51,7 @@
 #
 # Development API Reference::
 #  - https://core.telegram.org/bots/api
+from bisect import bisect_left
 from json import dumps, loads
 import os
 import re
@@ -787,6 +788,419 @@ class NotifyTelegram(NotifyBase):
         )
         return 0
 
+    @classmethod
+    def _build_backtick_run_index(cls, text):
+        """Index unescaped backtick runs by width in one pass."""
+
+        index = {}
+        i = 0
+        n = len(text)
+
+        while i < n:
+            ch = text[i]
+
+            if ch == "\\" and i + 1 < n:
+                i += 2
+                continue
+
+            if ch == "`":
+                j = i
+                while j < n and text[j] == "`":
+                    j += 1
+                index.setdefault(j - i, []).append(i)
+                i = j
+                continue
+
+            i += 1
+
+        return index
+
+    @staticmethod
+    def _find_unescaped_run(index, start, run):
+        """Find the next indexed backtick run of the requested width."""
+
+        positions = index.get(run)
+        if not positions:
+            return None
+
+        pos = bisect_left(positions, start)
+        return positions[pos] if pos < len(positions) else None
+
+    # Convert HTML-derived CommonMark to Telegram Markdown in one pass while
+    # preserving nested entities and independently valid message chunks.
+    _TELEGRAM_STRICT_CHARS = "~#+=|{}.!<>-"
+
+    # Legacy Markdown recognizes escapes only for these characters.
+    _TELEGRAM_V1_ESCAPABLE = "`*_["
+
+    # Full MarkdownV2 reserved set for previously unescaped fragments.
+    _TELEGRAM_RESERVED_FULL = "_*[]()~`>#+=|{}.!<>-"
+
+    @classmethod
+    def _strict_escape(cls, text):
+        """Escape an unescaped MarkdownV2 fragment without double-escaping."""
+
+        out = []
+        i = 0
+        n = len(text)
+        while i < n:
+            ch = text[i]
+            if ch == "\\" and i + 1 < n:
+                out.append(text[i : i + 2])
+                i += 2
+                continue
+            if ch in cls._TELEGRAM_RESERVED_FULL:
+                out.append("\\" + ch)
+            else:
+                out.append(ch)
+            i += 1
+        return "".join(out)
+
+    @classmethod
+    def _commonmark_to_telegram(cls, body, strict=False):
+        """Adapt html_to_markdown()'s CommonMark output to Telegram's own
+        Markdown dialect ("Markdown"/v1, or strictly for "MarkdownV2"/v2)."""
+
+        out = []
+        # Open spans as (delimiter, output index), innermost last. A None index
+        # marks nesting suppressed for legacy Markdown.
+        stack = []
+        i = 0
+        n = len(body)
+        backtick_runs = cls._build_backtick_run_index(body)
+
+        while i < n:
+            ch = body[i]
+
+            # Keep valid escapes and drop unsupported legacy backslashes.
+            if ch == "\\" and i + 1 < n:
+                nxt = body[i + 1]
+                if strict or nxt in cls._TELEGRAM_V1_ESCAPABLE:
+                    out.append(body[i : i + 2])
+                else:
+                    out.append(nxt)
+                i += 2
+                continue
+
+            # Telegram uses fixed code delimiters and escapes their contents.
+            if ch == "`":
+                j = i
+                while j < n and body[j] == "`":
+                    j += 1
+                run = j - i
+                close = cls._find_unescaped_run(backtick_runs, j, run)
+
+                if close is not None:
+                    content = body[j:close]
+                    content = content.replace("\\", "\\\\").replace("`", "\\`")
+                    delim = "```" if run >= 3 or "\n" in content else "`"
+                    out.append(delim + content + delim)
+                    i = close + run
+                    continue
+
+                # Treat unmatched backticks as reserved literal text.
+                out.append(("\\`" if strict else "`") * run)
+                i = j
+                continue
+
+            # Convert angle-bracket destinations to Telegram's bare form.
+            if body.startswith("](<", i):
+                close = body.find(">)", i + 3)
+                if close != -1:
+                    url = body[i + 3 : close]
+                    url = url.replace("\\", "\\\\").replace(")", "\\)")
+                    out.append("](" + url + ")")
+                    i = close + 2
+                    continue
+
+            # Convert emphasis in LIFO order; legacy mode suppresses nesting.
+            if ch == "*":
+                j = i
+                while j < n and body[j] == "*":
+                    j += 1
+                run = j - i
+
+                # Wide runs close nested spans only on an exact width match.
+                cascade_levels = 0
+                cascade_width = 0
+                for delim, _ in reversed(stack):
+                    need = 2 if delim == "*" else 1
+                    if cascade_width + need > run:
+                        break
+                    cascade_width += need
+                    cascade_levels += 1
+                    if cascade_width == run:
+                        break
+
+                if cascade_levels and cascade_width == run:
+                    for _ in range(cascade_levels):
+                        delim, open_index = stack.pop()
+                        if open_index is None:
+                            # Suppressed legacy nesting emits no close.
+                            pass
+                        elif open_index == len(out) - 1:
+                            # Drop empty entities.
+                            out.pop()
+                        else:
+                            out.append(delim)
+                    i = j
+                    continue
+
+                while run > 0:
+                    # Extra bold pairs may begin the next sibling span.
+                    if stack and stack[-1][0] == "*" and run >= 2:
+                        delim, open_index = stack.pop()
+                        if open_index is None:
+                            pass
+                        elif open_index == len(out) - 1:
+                            out.pop()
+                        else:
+                            out.append(delim)
+                        run -= 2
+                    elif stack and stack[-1][0] == "_" and run == 1:
+                        delim, open_index = stack.pop()
+                        if open_index is None:
+                            pass
+                        elif open_index == len(out) - 1:
+                            out.pop()
+                        else:
+                            out.append(delim)
+                        run -= 1
+                    elif run >= 2:
+                        if strict or not stack:
+                            out.append("*")
+                            stack.append(("*", len(out) - 1))
+                        else:
+                            stack.append(("*", None))
+                        run -= 2
+                    else:
+                        if strict or not stack:
+                            out.append("_")
+                            stack.append(("_", len(out) - 1))
+                        else:
+                            stack.append(("_", None))
+                        run -= 1
+
+                i = j
+                continue
+
+            if strict and ch in cls._TELEGRAM_STRICT_CHARS:
+                out.append("\\" + ch)
+                i += 1
+                continue
+
+            out.append(ch)
+            i += 1
+
+        # Close spans left open by malformed source.
+        while stack:
+            delim, open_index = stack.pop()
+            if open_index is None:
+                pass
+            elif open_index == len(out) - 1:
+                out.pop()
+            else:
+                out.append(delim)
+
+        return "".join(out)
+
+    @classmethod
+    def _repair_split_chunk(cls, text, strict, pending):
+        """Repair entities split across Telegram messages.
+
+        Pending state identifies closing delimiters or opaque content that
+        continues from the previous chunk. Returns text and updated state.
+        """
+
+        out = []
+        open_state = {"*": False, "_": False}
+        open_pos = {"*": None, "_": None}
+        pending = dict(pending)
+        link_stack = []
+        i = 0
+        n = len(text)
+        backtick_runs = cls._build_backtick_run_index(text)
+
+        in_code_width = pending.pop("in_code", None)
+        if in_code_width and strict:
+            close = cls._find_unescaped_run(backtick_runs, 0, in_code_width)
+            if close is not None:
+                out.append(cls._strict_escape(text[:close]))
+                i = close + in_code_width
+            else:
+                out.append(cls._strict_escape(text))
+                pending["in_code"] = in_code_width
+                i = n
+
+        elif pending.pop("in_link_dest", False) and strict:
+            close = None
+            k = 0
+            while k < n:
+                if text[k] == "\\" and k + 1 < n:
+                    k += 2
+                    continue
+                if text[k] == ")":
+                    close = k
+                    break
+                k += 1
+
+            if close is not None:
+                out.append(cls._strict_escape(text[:close]))
+                out.append("\\)")
+                i = close + 1
+            else:
+                # Carry an unterminated destination into the next chunk.
+                out.append(cls._strict_escape(text))
+                pending["in_link_dest"] = True
+                i = n
+
+        while i < n:
+            ch = text[i]
+
+            if ch == "\\" and i + 1 < n:
+                out.append(text[i : i + 2])
+                i += 2
+                continue
+
+            # Preserve complete code entities unchanged.
+            if ch == "`":
+                j = i
+                while j < n and text[j] == "`":
+                    j += 1
+                run = j - i
+                close = cls._find_unescaped_run(backtick_runs, j, run)
+                if close is not None:
+                    out.append(text[i : close + run])
+                    i = close + run
+                    continue
+
+                if strict:
+                    # Drop a split fence and carry its escaped content forward.
+                    pending["in_code"] = run
+                    out.append(cls._strict_escape(text[j:]))
+                    i = n
+                    continue
+
+            if ch in "*_":
+                if pending.get(ch, 0) > 0:
+                    # Discard a close whose open was dropped earlier.
+                    pending[ch] -= 1
+                    i += 1
+                    continue
+
+                if open_state[ch]:
+                    if open_pos[ch] == len(out) - 1:
+                        out.pop()
+                    else:
+                        out.append(ch)
+                    open_state[ch] = False
+                    open_pos[ch] = None
+                else:
+                    out.append(ch)
+                    open_pos[ch] = len(out) - 1
+                    open_state[ch] = True
+                i += 1
+                continue
+
+            if strict and ch == "[":
+                link_stack.append(len(out))
+                out.append(ch)
+                i += 1
+                continue
+
+            if strict and text.startswith("](", i):
+                # Find the destination's next unescaped closing parenthesis.
+                close = None
+                k = i + 2
+                while k < n:
+                    if text[k] == "\\" and k + 1 < n:
+                        k += 2
+                        continue
+                    if text[k] == ")":
+                        close = k
+                        break
+                    k += 1
+
+                if close is not None:
+                    if link_stack:
+                        link_stack.pop()
+                        out.append(text[i : close + 1])
+                    else:
+                        out.append("\\]\\(")
+                        out.append(cls._strict_escape(text[i + 2 : close]))
+                        out.append("\\)")
+                    i = close + 1
+                    continue
+
+                # Escape and carry an incomplete destination forward.
+                out.append("\\]\\(")
+                out.append(cls._strict_escape(text[i + 2 :]))
+                pending["in_link_dest"] = True
+                i = n
+                continue
+
+            if strict and ch in "[]()":
+                # Escape link punctuation outside a complete entity.
+                out.append("\\" + ch)
+                i += 1
+                continue
+
+            out.append(ch)
+            i += 1
+
+        # Escape unmatched labels before later index-changing cleanup.
+        if strict:
+            for idx in link_stack:
+                out[idx] = "\\" + out[idx]
+
+        # Drop empty spans and force-close nonempty spans at the chunk edge.
+        # Classify first because deletions shift recorded output indexes.
+        empty, nonempty = [], []
+        for d in ("*", "_"):
+            if not open_state[d]:
+                continue
+            (empty if open_pos[d] == len(out) - 1 else nonempty).append(d)
+
+        for d in sorted(empty, key=lambda d: open_pos[d], reverse=True):
+            del out[open_pos[d]]
+
+        new_pending = dict(pending)
+        for d in nonempty:
+            out.append(d)
+            new_pending[d] = new_pending.get(d, 0) + 1
+
+        return "".join(out), new_pending
+
+    def _build_send_calls(
+        self, body=None, title=None, body_format=None, **kwargs
+    ):
+        """Adapt CommonMark before splitting, then repair split entities."""
+
+        if not (
+            self.notify_format == NotifyFormat.MARKDOWN
+            and body_format == NotifyFormat.HTML
+        ):
+            yield from super()._build_send_calls(
+                body=body, title=title, body_format=body_format, **kwargs
+            )
+            return
+
+        strict = self.markdown_ver == TelegramMarkdownVersion.TWO
+
+        if body:
+            body = self._commonmark_to_telegram(body, strict=strict)
+        if title:
+            title = self._commonmark_to_telegram(title, strict=strict)
+
+        pending = {}
+        for kwargs2 in super()._build_send_calls(
+            body=body, title=title, body_format=body_format, **kwargs
+        ):
+            kwargs2["body"], pending = self._repair_split_chunk(
+                kwargs2["body"], strict, pending
+            )
+            yield kwargs2
+
     def send(
         self,
         body,
@@ -832,18 +1246,14 @@ class NotifyTelegram(NotifyBase):
         # Prepare Message Body
         if self.notify_format == NotifyFormat.MARKDOWN:
             if (
-                body_format not in (None, NotifyFormat.MARKDOWN)
+                body_format == NotifyFormat.TEXT
                 and self.markdown_ver == TelegramMarkdownVersion.TWO
             ):
-                # Telegram Markdown v2 is not very accomodating to some
-                # characters such as the hashtag (#) which is fine in v1. To
-                # try and be accomodating we escape them in advance See:
-                # https://stackoverflow.com/a/69892704/355584 Also:
-                # https://core.telegram.org/bots/api#markdownv2-style Note: We
-                # only escape characters that are not already escaped.
-                #
-                # Telegram v2 needs its own escaping for converted HTML.
+                # Escape reserved characters in plain MarkdownV2 input.
                 body = re.sub(r"(?<!\\)([_*[\]()~`>#+=|{}.!-])", r"\\\1", body)
+
+            # HTML was adapted before splitting; direct Telegram Markdown is
+            # left unchanged.
 
             payload_["parse_mode"] = self.markdown_ver
             payload_["text"] = body

--- a/apprise/utils/format.py
+++ b/apprise/utils/format.py
@@ -89,32 +89,44 @@ def markdown_adjust(
 ) -> int:
     """
     Adjust the split point to avoid splitting inside simple Markdown
-    link / image constructs like [Text](URL) or ![Alt](URL).
+    link / image constructs like [Text](URL) or ![Alt](URL), and also
+    angle-bracket link constructs like <URL|label> used by Slack and
+    Google Chat dialects.
 
     This is a best-effort heuristic and does not attempt full Markdown
-    parsing. If the boundary falls between '['/'!' and the closing ')'
-    of a nearby link/image, move the split back to that start.
+    parsing. If the boundary falls inside a nearby link/image, move the
+    split back to the start of that construct.
     """
     if split_at <= window_start or split_at > len(text):
         return split_at
 
     search_start = max(window_start, split_at - MARKDOWN_CONSTRUCT_LOOKBACK)
+    forward_end = min(len(text), split_at + MARKDOWN_CONSTRUCT_LOOKBACK)
 
-    # Prefer '[' as the starting marker for links/images.
+    # Protect [Text](URL) and ![Alt](URL) CommonMark constructs.
     link_start_idx = text.rfind("[", search_start, split_at)
     if link_start_idx == -1:
         # As a fallback, consider '!' as a possible start, e.g. '![Alt](...)'.
         link_start_idx = text.rfind("!", search_start, split_at)
 
-    if link_start_idx == -1:
-        return split_at
+    if link_start_idx != -1:
+        # Look ahead for a closing ')' to bound the construct.
+        link_end_idx = text.find(")", link_start_idx, forward_end)
+        if link_end_idx != -1 and link_start_idx < split_at < link_end_idx:
+            return link_start_idx
 
-    # Look ahead for a closing ')' to bound the construct.
-    forward_end = min(len(text), split_at + MARKDOWN_CONSTRUCT_LOOKBACK)
-    link_end_idx = text.find(")", link_start_idx, forward_end)
-
-    if link_end_idx != -1 and link_start_idx < split_at < link_end_idx:
-        return link_start_idx
+    # Protect <URL|label> angle-bracket constructs (Slack mrkdwn, Chat).
+    # Require a '|' inside the brackets to avoid matching bare '<...>' tags.
+    angle_start_idx = text.rfind("<", search_start, split_at)
+    if angle_start_idx != -1:
+        pipe_idx = text.find("|", angle_start_idx + 1, split_at)
+        if pipe_idx != -1:
+            angle_end_idx = text.find(">", pipe_idx, forward_end)
+            if (
+                angle_end_idx != -1
+                and angle_start_idx < split_at <= angle_end_idx
+            ):
+                return angle_start_idx
 
     return split_at
 

--- a/apprise/utils/format.py
+++ b/apprise/utils/format.py
@@ -41,10 +41,6 @@ PUNCT_SPLIT_PATTERN = re.compile(
 HTML_ENTITY_LOOKBACK = 16
 HTML_ENTITY_LOOKAHEAD = 16
 
-# Support Markdown constructs (e.g., links, formatting)
-# Longer lookback for links [text](url)
-MARKDOWN_CONSTRUCT_LOOKBACK = 32
-
 
 def html_adjust(
     text: str,
@@ -87,40 +83,73 @@ def markdown_adjust(
     window_start: int,
     split_at: int,
 ) -> int:
-    """
-    Adjust the split point to avoid splitting inside simple Markdown
-    link / image constructs like [Text](URL) or ![Alt](URL), and also
-    angle-bracket link constructs like <URL|label> used by Slack and
-    Google Chat dialects.
+    """Adjust split_at to avoid cutting inside a Markdown link construct.
 
-    This is a best-effort heuristic and does not attempt full Markdown
-    parsing. If the boundary falls inside a nearby link/image, move the
-    split back to the start of that construct.
+    Protects two construct shapes:
+      - CommonMark links/images: [Text](URL) and ![Alt](URL)
+      - Angle-bracket links:     <URL|label>  (Slack mrkdwn, Google Chat)
+
+    Backward scan: from window_start to split_at, so that a long URL
+    whose opening "[" or "<" sits anywhere in the current chunk window
+    is still detected correctly.
+
+    Forward scan: capped at split_at + (split_at - window_start) + 1.
+    The cap is symmetric with the backward scan distance and keeps the
+    total work per call O(window_size) rather than O(body_length).
+    Without the cap, an adversarial body of many unterminated "[" openers
+    would cause O(n^2) work as each split point scans to len(text) finding
+    no ")".  Any construct whose closing delimiter lies beyond the cap is
+    also so long that moving the split back to its opener would land at or
+    before window_start, which smart_split() would reset anyway.
+
+    Returns the (possibly moved-left) split position.
     """
     if split_at <= window_start or split_at > len(text):
         return split_at
 
-    search_start = max(window_start, split_at - MARKDOWN_CONSTRUCT_LOOKBACK)
-    forward_end = min(len(text), split_at + MARKDOWN_CONSTRUCT_LOOKBACK)
+    # Scan backward through the entire current chunk window so that any
+    # construct opener within the window is detected regardless of distance.
+    search_start = window_start
 
-    # Protect [Text](URL) and ![Alt](URL) CommonMark constructs.
+    # Cap the forward scan symmetrically with the backward window size.
+    # This bounds the per-call cost to O(window_size) and still covers
+    # every construct whose closing delimiter fits within one chunk-length
+    # past the split point (the only ones where moving the split is useful).
+    forward_end = min(
+        len(text),
+        split_at + (split_at - window_start) + 1,
+    )
+
+    # Protect [Text](URL) and ![Alt](URL) CommonMark link/image constructs.
+    # rfind searches backward from split_at; if the split falls inside a
+    # link the "[" (or "!" for images) will be found somewhere to the left.
     link_start_idx = text.rfind("[", search_start, split_at)
     if link_start_idx == -1:
-        # As a fallback, consider '!' as a possible start, e.g. '![Alt](...)'.
+        # Fallback: check for an image opener "!" immediately before "[".
         link_start_idx = text.rfind("!", search_start, split_at)
 
     if link_start_idx != -1:
-        # Look ahead for a closing ')' to bound the construct.
+        # The construct is only active when split_at lands inside the
+        # URL / destination parentheses; verify a closing ")" lies ahead.
         link_end_idx = text.find(")", link_start_idx, forward_end)
         if link_end_idx != -1 and link_start_idx < split_at < link_end_idx:
+            # Move the split back to before the opening "[" or "!".
             return link_start_idx
 
     # Protect <URL|label> angle-bracket constructs (Slack mrkdwn, Chat).
-    # Require a '|' inside the brackets to avoid matching bare '<...>' tags.
+    # The "|" requirement distinguishes these from bare HTML tags like <br>.
     angle_start_idx = text.rfind("<", search_start, split_at)
     if angle_start_idx != -1:
-        pipe_idx = text.find("|", angle_start_idx + 1, split_at)
+        # Search for the "|" separator across the full forward scan range,
+        # not just up to split_at.  This is necessary because the split
+        # can land INSIDE the URL portion (between "<" and "|"), in which
+        # case the pipe is ahead of split_at.  Both cases -- split in the
+        # URL part and split in the label part -- reduce to the same check:
+        # angle_start_idx < split_at <= angle_end_idx.
+        pipe_idx = text.find("|", angle_start_idx + 1, forward_end)
         if pipe_idx != -1:
+            # The construct closes at ">" after the pipe; if split_at
+            # lands anywhere inside "<URL|label>" move it to before "<".
             angle_end_idx = text.find(">", pipe_idx, forward_end)
             if (
                 angle_end_idx != -1

--- a/apprise/utils/format.py
+++ b/apprise/utils/format.py
@@ -83,73 +83,48 @@ def markdown_adjust(
     window_start: int,
     split_at: int,
 ) -> int:
-    """Adjust split_at to avoid cutting inside a Markdown link construct.
+    """Move a split left when it cuts a Markdown or Chat link.
 
-    Protects two construct shapes:
-      - CommonMark links/images: [Text](URL) and ![Alt](URL)
-      - Angle-bracket links:     <URL|label>  (Slack mrkdwn, Google Chat)
+    Protected forms are ``[label](url)``, ``![alt](url)``, and
+    ``<url|label>``. The scan looks backward for an opener and at most one
+    window forward for its closer, keeping adjustment work linear.
 
-    Backward scan: from window_start to split_at, so that a long URL
-    whose opening "[" or "<" sits anywhere in the current chunk window
-    is still detected correctly.
-
-    Forward scan: capped at split_at + (split_at - window_start) + 1.
-    The cap is symmetric with the backward scan distance and keeps the
-    total work per call O(window_size) rather than O(body_length).
-    Without the cap, an adversarial body of many unterminated "[" openers
-    would cause O(n^2) work as each split point scans to len(text) finding
-    no ")".  Any construct whose closing delimiter lies beyond the cap is
-    also so long that moving the split back to its opener would land at or
-    before window_start, which smart_split() would reset anyway.
-
-    Returns the (possibly moved-left) split position.
+    Returns the original split or the construct's opening position.
     """
     if split_at <= window_start or split_at > len(text):
         return split_at
 
-    # Scan backward through the entire current chunk window so that any
-    # construct opener within the window is detected regardless of distance.
+    # Search the entire current chunk for a construct opener.
     search_start = window_start
 
-    # Cap the forward scan symmetrically with the backward window size.
-    # This bounds the per-call cost to O(window_size) and still covers
-    # every construct whose closing delimiter fits within one chunk-length
-    # past the split point (the only ones where moving the split is useful).
+    # Cap the forward scan to one window to avoid quadratic work.
     forward_end = min(
         len(text),
         split_at + (split_at - window_start) + 1,
     )
 
-    # Protect [Text](URL) and ![Alt](URL) CommonMark link/image constructs.
-    # rfind searches backward from split_at; if the split falls inside a
-    # link the "[" (or "!" for images) will be found somewhere to the left.
+    # Find a possible CommonMark link or image opener.
     link_start_idx = text.rfind("[", search_start, split_at)
     if link_start_idx == -1:
-        # Fallback: check for an image opener "!" immediately before "[".
-        link_start_idx = text.rfind("!", search_start, split_at)
+        # Accept ``!`` only when it begins an image label.
+        bang = text.rfind("!", search_start, split_at)
+        if bang != -1 and bang + 1 < len(text) and text[bang + 1] == "[":
+            link_start_idx = bang
 
     if link_start_idx != -1:
-        # The construct is only active when split_at lands inside the
-        # URL / destination parentheses; verify a closing ")" lies ahead.
+        # Confirm that the split lands before the closing parenthesis.
         link_end_idx = text.find(")", link_start_idx, forward_end)
         if link_end_idx != -1 and link_start_idx < split_at < link_end_idx:
             # Move the split back to before the opening "[" or "!".
             return link_start_idx
 
-    # Protect <URL|label> angle-bracket constructs (Slack mrkdwn, Chat).
-    # The "|" requirement distinguishes these from bare HTML tags like <br>.
+    # Find a possible Slack or Chat ``<URL|label>`` opener.
     angle_start_idx = text.rfind("<", search_start, split_at)
     if angle_start_idx != -1:
-        # Search for the "|" separator across the full forward scan range,
-        # not just up to split_at.  This is necessary because the split
-        # can land INSIDE the URL portion (between "<" and "|"), in which
-        # case the pipe is ahead of split_at.  Both cases -- split in the
-        # URL part and split in the label part -- reduce to the same check:
-        # angle_start_idx < split_at <= angle_end_idx.
+        # Locate the separator even when the split falls inside the URL.
         pipe_idx = text.find("|", angle_start_idx + 1, forward_end)
         if pipe_idx != -1:
-            # The construct closes at ">" after the pipe; if split_at
-            # lands anywhere inside "<URL|label>" move it to before "<".
+            # Move splits inside the complete construct before ``<``.
             angle_end_idx = text.find(">", pipe_idx, forward_end)
             if (
                 angle_end_idx != -1
@@ -165,20 +140,17 @@ def smart_split(
     limit: int,
     body_format: NotifyFormat,
 ) -> list[str]:
-    """
-    Split `text` into chunks of at most `limit` characters.
+    """Split text within ``limit``, preferring natural boundaries.
 
-    Soft split priority:
-      1. Last newline before `limit` (\\n or \\r)
-      2. Last space or tab before `limit`
-      3. Last punctuation+whitespace (.,!?:; followed by space/tab/newline)
-      4. Hard split at `limit`
+    Priority             Boundary
+    -------------------  ---------------------------------------
+    1                    Newline
+    2                    Space or tab
+    3                    Punctuation followed by whitespace
+    4                    Hard character limit
 
-    `body_format` controls additional safety rules:
-      - NotifyFormat.TEXT: generic splitting only
-      - NotifyFormat.HTML: avoid splitting inside '&...;' entities
-      - NotifyFormat.MARKDOWN: same as HTML, plus a best-effort check to
-        avoid splitting inside [Text](URL) / ![Alt](URL) patterns.
+    HTML avoids splitting entities. Markdown additionally protects common
+    link constructs when they can fit within a chunk.
     """
 
     if not text or limit <= 0:

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -33,7 +33,7 @@ import logging
 import pytest
 
 from apprise import NotifyFormat
-from apprise.conversion import convert_between
+from apprise.conversion import HTMLMarkdownConverter, convert_between
 
 logging.disable(logging.CRITICAL)
 
@@ -256,6 +256,16 @@ def test_conversion_html_to_markdown():
         == "line 1\nline 2\nline 3"
     )
 
+    # HTMLParser lowercases ALL tag names -- inline tags included
+    assert to_md("<B>bold text</B>") == "**bold text**"
+    assert to_md("<I>italic</I>") == "*italic*"
+
+    # Uppercase and mixed-case self-closing <BR/> also produce newlines
+    assert (
+        to_md("line one<BR/>line two<BR />line three")
+        == "line one\nline two\nline three"
+    )
+
     # <br> and self-closing <br/> both emit a literal newline
     assert (
         to_md("some information<br/><br>and more information")
@@ -311,8 +321,42 @@ def test_conversion_html_to_markdown():
         == "test [my link](#)"
     )
 
+    # <a> with nested inline markup -- the href must survive the child tags
+    assert (
+        to_md("<a href='/x'><b>hello</b> world</a>") == "[**hello** world](/x)"
+    )
+    assert (
+        to_md("<a href='/x'><strong>label</strong></a>") == "[**label**](/x)"
+    )
+    assert (
+        to_md("<a href='/x'><em>italic</em> and plain</a>")
+        == "[*italic* and plain](/x)"
+    )
+
+    # Nested <a> -- inner href wins for its own span; outer wraps the rest
+    assert (
+        to_md("<a href='/outer'>text <a href='/inner'>link</a></a>")
+        == "[text [link](/inner)](/outer)"
+    )
+
     # <a> with no href attribute -- content rendered as plain text
     assert to_md("<span>test</span> <a>no link</a>") == "test no link"
+
+    # Bare <a name="..."> anchor (no href) -- text passes through unchanged
+    assert to_md("<a name='top'>jump target</a>") == "jump target"
+
+    # <span> is inline -- it passes text through without a newline;
+    # <div> is block-level and always produces a newline around its content
+    assert to_md("<div>block</div><span>inline</span>") == "block\ninline"
+
+    # HTML comments are stripped entirely; surrounding text is preserved
+    assert to_md("<!-- comment --> text") == "text"
+    assert to_md("a<!-- c1 -->b<!-- c2 -->c") == "abc"
+
+    # <![CDATA[...]]> sections are gracefully ignored (content is dropped,
+    # text outside the CDATA boundary is kept)
+    assert to_md("text<![CDATA[data]]> here") == "text here"
+    assert to_md("<![CDATA[data]]>text") == "text"
 
     # Inline <code> wraps in backticks without a block boundary
     assert to_md("<code>func()</code>") == "`func()`"
@@ -408,6 +452,298 @@ def test_conversion_html_to_markdown():
 
     with pytest.raises(TypeError):
         to_md(object)
+
+
+def test_conversion_html_to_markdown_lists():
+    """conversion: Test HTML list nesting and numbering in Markdown."""
+
+    def to_md(body):
+        """Wrapper to simplify html-to-markdown conversion tests."""
+        return convert_between(NotifyFormat.HTML, NotifyFormat.MARKDOWN, body)
+
+    # Flat unordered list
+
+    assert (
+        to_md("<ul><li>alpha</li><li>beta</li><li>gamma</li></ul>")
+        == "- alpha\n- beta\n- gamma"
+    )
+
+    # Flat ordered list with auto-incrementing counter
+
+    assert (
+        to_md("<ol><li>first</li><li>second</li><li>third</li></ol>")
+        == "1. first\n2. second\n3. third"
+    )
+
+    # Nested unordered lists (2 levels)
+
+    assert (
+        to_md(
+            "<ul><li>top A<ul><li>nested A</li></ul></li><li>top B</li></ul>"
+        )
+        == "- top A\n  - nested A\n- top B"
+    )
+
+    # Nested unordered lists (3 levels)
+
+    assert (
+        to_md("<ul><li>L1<ul><li>L2<ul><li>L3</li></ul></li></ul></li></ul>")
+        == "- L1\n  - L2\n    - L3"
+    )
+
+    # Mixed nesting: ol inside ul
+
+    assert (
+        to_md(
+            "<ul>"
+            "<li>intro<ol>"
+            "<li>step one</li>"
+            "<li>step two</li>"
+            "</ol></li>"
+            "</ul>"
+        )
+        == "- intro\n  1. step one\n  2. step two"
+    )
+
+    # Mixed nesting: ul inside ol
+
+    assert (
+        to_md(
+            "<ol>"
+            "<li>first<ul>"
+            "<li>sub A</li>"
+            "<li>sub B</li>"
+            "</ul></li>"
+            "<li>second</li>"
+            "</ol>"
+        )
+        == "1. first\n  - sub A\n  - sub B\n2. second"
+    )
+
+    # Malformed HTML: missing </li> in a <ul>
+    # HTMLParser does not synthesize implicit close events; each missing
+    # </li> is simply absent, but the next <li> still starts a new item
+    assert (
+        to_md("<ul><li>item A<li>item B<li>item C</ul>")
+        == "- item A\n- item B\n- item C"
+    )
+
+    # Malformed HTML: missing </li> in a <ol>
+    # Without </li> the counter is never incremented, so all items
+    # render as "1." -- this is expected garbage-in/garbage-out behaviour
+    assert (
+        to_md("<ol><li>one<li>two<li>three</ol>") == "1. one\n1. two\n1. three"
+    )
+
+    # Malformed HTML: missing closing </ul>
+
+    assert to_md("<ul><li>item A</li><li>item B</li>") == "- item A\n- item B"
+
+    # Malformed HTML: missing </li> AND missing </ul>
+
+    assert to_md("<ul><li>item A<li>item B") == "- item A\n- item B"
+
+    # Malformed HTML: bare text inside <ul> (no <li> wrapper)
+    # <ul> is in IGNORE_TAGS so unwrapped text is suppressed entirely
+    assert to_md("<ul>bare text</ul>") == ""
+
+    # <code> inside <li>: inline code preserved with backticks
+
+    assert (
+        to_md("<ul><li>run <code>cmd --flag</code> now</li></ul>")
+        == "- run `cmd --flag` now"
+    )
+
+    # Markdown special characters inside <code> are NOT escaped
+    assert (
+        to_md("<ul><li>see <code>x*2 #tag</code></li></ul>")
+        == "- see `x*2 #tag`"
+    )
+
+    # <pre> inside <li>: fenced block with indentation preserved
+
+    assert (
+        to_md("<ul><li>code:<pre>  indented\n  here</pre></li></ul>")
+        == "- code:\n```\n  indented\n  here\n```"
+    )
+
+    # <pre> inside a nested <li>: indentation inside the fence is
+    # preserved regardless of the surrounding list nesting depth
+    assert (
+        to_md(
+            "<ul><li>outer<ul><li>inner:<pre>  x = 1</pre></li></ul></li></ul>"
+        )
+        == "- outer\n  - inner:\n```\n  x = 1\n```"
+    )
+
+    # A block element as the first child of <li> used to emit a spurious
+    # BLOCK_END that orphaned the marker on its own line.  The fix detects
+    # a list marker as _result[-1] and suppresses the redundant BLOCK_END.
+
+    # Single item with a <p> first child
+    assert to_md("<ul><li><p>alpha</p></li></ul>") == "- alpha"
+
+    # Multiple items each with a <p> first child
+    assert (
+        to_md("<ul><li><p>alpha</p></li><li><p>beta</p></li></ul>")
+        == "- alpha\n- beta"
+    )
+
+    # Multiple <p> children inside one <li>: first is joined to marker,
+    # subsequent ones start on new lines
+    assert to_md("<ul><li><p>one</p><p>two</p></li></ul>") == "- one\ntwo"
+
+    # Mixed: direct text for first item, <p> for second
+    assert (
+        to_md("<ul><li>direct</li><li><p>wrapped</p></li></ul>")
+        == "- direct\n- wrapped"
+    )
+
+    # Numbered list with <p> children
+    assert (
+        to_md("<ol><li><p>first</p></li><li><p>second</p></li></ol>")
+        == "1. first\n2. second"
+    )
+
+    # <a> link as first child of <li> -- the marker must share the line
+    assert to_md("<ul><li><a href='/x'>link</a></li></ul>") == "- [link](/x)"
+
+    # <a> with nested markup as first (and only) child of <li>
+    assert (
+        to_md("<ul><li><a href='/x'><b>bold link</b></a></li></ul>")
+        == "- [**bold link**](/x)"
+    )
+
+    # <a> link followed by a <p> sibling inside the same <li>
+    assert (
+        to_md("<ul><li><a href='/x'>link</a><p>more</p></li></ul>")
+        == "- [link](/x)\nmore"
+    )
+
+
+def test_conversion_html_to_markdown_escaping():
+    """conversion: HTMLMarkdownConverter avoids generating broken
+    Markdown when content collides with its own delimiters, or when
+    ignored containers would otherwise leak Markdown syntax."""
+
+    def to_md(body):
+        """Wrapper to simplify html-to-markdown conversion tests."""
+        return convert_between(NotifyFormat.HTML, NotifyFormat.MARKDOWN, body)
+
+    # Code/pre delimiter collision
+    # A backtick inside <code> widens the inline delimiter so it can't
+    # be closed early by a backtick already present in the content
+    assert to_md("<code>a`b</code>") == "``a`b``"
+
+    # Content starting or ending with a backtick gets a padding space,
+    # per CommonMark's code-span disambiguation rule
+    assert to_md("<code>`x</code>") == "`` `x ``"
+    assert to_md("<code>x`</code>") == "`` x` ``"
+
+    # A run of 3 backticks inside <pre> widens the fence past 3
+    assert to_md("<pre>boom```</pre>") == "````\nboom```\n````"
+
+    # Plain content with no backticks still uses the minimal delimiter
+    assert to_md("<pre>x</pre>") == "```\nx\n```"
+
+    # Ignored containers must not leak Markdown markers
+    # Only the suppressed text is dropped in the original report --
+    # here the "**" markers from <b> must not leak either
+    assert (
+        to_md(
+            "<html><head><b>ignore</b></head><body><p>keep</p></body></html>"
+        )
+        == "keep"
+    )
+
+    # A heading marker ("# ") must not leak from a suppressed container
+    assert (
+        to_md("<head><h1>hidden heading</h1></head><body>text</body>")
+        == "text"
+    )
+
+    # A list marker ("- ") must not leak from a <li> nested inside a
+    # suppressed container, even though <li> normally re-enables storage
+    assert (
+        to_md("<head><ul><li>hidden item</li></ul></head><body>text</body>")
+        == "text"
+    )
+
+    # <script> content (already suppressed) must not leak nested markers
+    assert to_md("<script>ignore <b>this</b></script><p>keep</p>") == "keep"
+
+    # A <pre> block fully inside a suppressed container emits nothing,
+    # not even an empty fence
+    assert to_md("<script>ignore<pre>code</pre></script><p>keep</p>") == "keep"
+
+    # --- Link destinations with whitespace ---
+    # A bare Markdown link destination cannot contain a space; wrap it
+    # in angle brackets so the link target isn't silently truncated
+    assert to_md("<a href='/my page'>link</a>") == "[link](</my page>)"
+
+    # --- Nested tags inside code/pre are inert ---
+    # Their own markup carries no meaning, but their literal text still
+    # joins the buffered content (no out-of-order marker leakage)
+    assert (
+        to_md("<pre>before <a href='/x'>link</a> after</pre>")
+        == "```\nbefore link after\n```"
+    )
+    assert (
+        to_md("<code>before <b>bold</b> after</code>") == "`before bold after`"
+    )
+
+    # --- Stray code/pre/samp close tags ---
+    # _pop_to() finds no matching frame; the early-return path in
+    # handle_endtag must not crash or emit a spurious delimiter
+    assert to_md("</code>text") == "text"
+    assert to_md("</pre>text") == "text"
+    assert to_md("</samp>text") == "text"
+
+
+def test_conversion_html_to_markdown_hardening():
+    """conversion: HTMLMarkdownConverter is robust against stack edge cases."""
+
+    def to_md(body):
+        """Wrapper to simplify html-to-markdown conversion tests."""
+        return convert_between(NotifyFormat.HTML, NotifyFormat.MARKDOWN, body)
+
+    # Stray close tags before any matching open tag
+    # _pop_to() must find no matching frame and silently do nothing;
+    # the root sentinel frame must remain untouched throughout.
+
+    # </ul> and </ol> take the early-return path in handle_endtag
+    assert to_md("</ul>text") == "text"
+    assert to_md("</ol>text") == "text"
+
+    # </li> emits a BLOCK_END but _pop_to still finds nothing -- the
+    # text that follows is unindented and stored normally
+    assert to_md("</li>text") == "text"
+
+    # Multiple stray close tags in a row must not crash or corrupt state
+    assert to_md("</ul></ol></li>preamble") == "preamble"
+
+    # A valid list after a stray close must still render correctly
+    assert to_md("</ul><ul><li>A</li><li>B</li></ul>") == "- A\n- B"
+
+    # _make_frame() empty-stack guard
+    # The root sentinel makes this path unreachable through normal
+    # parsing; we force it by clearing _stack directly to verify the
+    # fallback produces safe root-equivalent defaults.
+
+    conv = HTMLMarkdownConverter()
+
+    # Force the stack empty -- this can only happen via direct attribute
+    # manipulation, never through the public parsing API
+    conv._stack = []
+    frame = conv._make_frame("div")
+
+    # The fallback defaults must match the root sentinel values
+    assert frame["tag"] == "div"
+    assert frame["do_store"] is True
+    assert frame["preserve_cr"] is False
+    assert frame["list_type"] is None
+    assert frame["depth"] == 0
+    assert frame["counter"] is None
 
 
 def test_conversion_text_to():

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -39,7 +39,9 @@ from apprise.conversion import (
     LIST_DEPTH_MAX,
     MAX_FRAME_DEPTH,
     HTMLMarkdownConverter,
+    build_backtick_run_index,
     convert_between,
+    find_unescaped_run,
 )
 
 logging.disable(logging.CRITICAL)
@@ -772,6 +774,18 @@ def test_conversion_html_to_markdown_escaping():
         "[click](<#>)"
     )
     assert to_md('<a href="javascript:alert(1)  ">click</a>') == (
+        "[click](<#>)"
+    )
+
+    # BiDi override/embedding characters must not defeat scheme detection.
+    assert to_md('<a href="‮javascript:alert(1)">click</a>') == (
+        "[click](<#>)"
+    )
+    assert to_md('<a href="‪javascript:alert(1)">click</a>') == (
+        "[click](<#>)"
+    )
+    # U+2066 (LEFT-TO-RIGHT ISOLATE) must also be stripped.
+    assert to_md('<a href="⁦javascript:alert(1)">click</a>') == (
         "[click](<#>)"
     )
 
@@ -1674,31 +1688,30 @@ def test_conversion_html_to_markdown_table_code_pipe():
     conv = HTMLMarkdownConverter()
     assert conv._escape_cell_pipes("a`b|c") == "a`b\\|c"
 
-    # build_backtick_run_index() / find_unescaped_run() skip escape pairs
-    # while indexing, and the lookup returns None when no run of the exact.
+    # The shared index skips escape pairs and groups runs by exact width.
+    # A lookup returns None when the requested width does not exist.
+    assert find_unescaped_run(build_backtick_run_index("\\` `"), 0, 1) == 3
     assert (
-        conv.find_unescaped_run(conv.build_backtick_run_index("\\` `"), 0, 1)
-        == 3
-    )
-    assert (
-        conv.find_unescaped_run(
-            conv.build_backtick_run_index("no backticks here"), 0, 1
-        )
+        find_unescaped_run(build_backtick_run_index("no backticks here"), 0, 1)
         is None
     )
     assert (
-        conv.find_unescaped_run(
-            conv.build_backtick_run_index("``too short"), 0, 3
-        )
+        find_unescaped_run(build_backtick_run_index("``too short"), 0, 3)
         is None
     )
 
+    # Runs of different widths are indexed separately.
+    assert find_unescaped_run(build_backtick_run_index("`` `"), 0, 1) == 3
+
+    # Skip an escaped single backtick before matching a width-two run.
+    assert find_unescaped_run(build_backtick_run_index("\\` ``x"), 0, 2) == 3
+
+    # Skip an unescaped run of the wrong width before matching width two.
+    assert find_unescaped_run(build_backtick_run_index("` ``x"), 0, 2) == 2
+
     # A genuine match arbitrarily far from `start` is still found.
     far = "a" * 200_000 + "`"
-    assert (
-        conv.find_unescaped_run(conv.build_backtick_run_index(far), 0, 1)
-        == 200_000
-    )
+    assert find_unescaped_run(build_backtick_run_index(far), 0, 1) == 200_000
 
     # A cell containing many distinct, non-matching backtick-run lengths must
     # still resolve in roughly linear time, not quadratic.
@@ -1718,8 +1731,7 @@ def test_conversion_html_to_markdown_table_code_pipe():
     conv._escape_cell_pipes(large)
     large_time = default_timer() - start
 
-    # Doubling the adversarial width count should roughly double the (tiny)
-    # runtime, not quadruple it.
+    # Double the adversarial width count.
     assert large_time < small_time * 6 + 0.05
 
 

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -1529,6 +1529,15 @@ def test_conversion_html_to_markdown_tables_hardening():
         "| A |\n| --- |\n| B |\n| C |"
     )
 
+    # An unclosed inline element (<em>) inside a <td> is silently discarded
+    # when a sibling <td> opens; the cell's text is still captured.
+    assert (
+        to_md(
+            "<table><tr><td><em>unclosed text<td>second cell</td></tr></table>"
+        )
+        == "| *unclosed text | second cell |\n| --- | --- |"
+    )
+
     # Performance: many rows, each with unclosed <td>/<tr> tags (the legacy-
     # markup shape), large enough to expose quadratic recovery.
     n = 20000
@@ -1628,21 +1637,21 @@ def test_conversion_html_to_markdown_table_code_pipe():
     conv = HTMLMarkdownConverter()
     assert conv._escape_cell_pipes("a`b|c") == "a`b\\|c"
 
-    # _build_backtick_run_index() / _find_unescaped_run() skip escape pairs
+    # build_backtick_run_index() / find_unescaped_run() skip escape pairs
     # while indexing, and the lookup returns None when no run of the exact.
     assert (
-        conv._find_unescaped_run(conv._build_backtick_run_index("\\` `"), 0, 1)
+        conv.find_unescaped_run(conv.build_backtick_run_index("\\` `"), 0, 1)
         == 3
     )
     assert (
-        conv._find_unescaped_run(
-            conv._build_backtick_run_index("no backticks here"), 0, 1
+        conv.find_unescaped_run(
+            conv.build_backtick_run_index("no backticks here"), 0, 1
         )
         is None
     )
     assert (
-        conv._find_unescaped_run(
-            conv._build_backtick_run_index("``too short"), 0, 3
+        conv.find_unescaped_run(
+            conv.build_backtick_run_index("``too short"), 0, 3
         )
         is None
     )
@@ -1650,7 +1659,7 @@ def test_conversion_html_to_markdown_table_code_pipe():
     # A genuine match arbitrarily far from `start` is still found.
     far = "a" * 200_000 + "`"
     assert (
-        conv._find_unescaped_run(conv._build_backtick_run_index(far), 0, 1)
+        conv.find_unescaped_run(conv.build_backtick_run_index(far), 0, 1)
         == 200_000
     )
 

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -231,6 +231,185 @@ def test_conversion_html_to_text():
         assert to_html(object)
 
 
+def test_conversion_html_to_markdown():
+    """conversion: Test HTML to Markdown."""
+
+    def to_md(body):
+        """Wrapper to simplify html-to-markdown conversion tests."""
+        return convert_between(NotifyFormat.HTML, NotifyFormat.MARKDOWN, body)
+
+    # Plain text with no HTML passes through unchanged
+    assert to_md("No HTML code here.") == "No HTML code here."
+
+    # Empty string in, empty string out
+    assert to_md("") == ""
+
+    # Paragraphs collapse to newline-separated text
+    assert (
+        to_md("<p>line 1</p><p>line 2</p><p>line 3</p>")
+        == "line 1\nline 2\nline 3"
+    )
+
+    # Case sensitivity -- tag names are case-insensitive in HTML
+    assert (
+        to_md("<p>line 1</P><P>line 2</P><P>line 3</P>")
+        == "line 1\nline 2\nline 3"
+    )
+
+    # <br> and self-closing <br/> both emit a literal newline
+    assert (
+        to_md("some information<br/><br>and more information")
+        == "some information\n\nand more information"
+    )
+
+    # Each heading level maps to the correct number of # characters
+    assert to_md("<h1>Heading 1</h1>") == "# Heading 1"
+    assert to_md("<h2>Heading 2</h2>") == "## Heading 2"
+    assert to_md("<h3>Heading 3</h3>") == "### Heading 3"
+    assert to_md("<h4>Heading 4</h4>") == "#### Heading 4"
+    assert to_md("<h5>Heading 5</h5>") == "##### Heading 5"
+    assert to_md("<h6>Heading 6</h6>") == "###### Heading 6"
+
+    # Multiple headings and paragraphs together
+    assert to_md(
+        "<h1>Heading 1</h1>"
+        "<h2>Heading 2</h2>"
+        "<h3>Heading 3</h3>"
+        "<h4>Heading 4</h4>"
+        "<h5>Heading 5</h5>"
+        "<h6>Heading 6</h6>"
+        "<p>line 1</>"
+        "<p><em>line 2</em></gar>"
+        "<p>line 3>"
+    ) == (
+        "# Heading 1\n## Heading 2\n### Heading 3\n"
+        "#### Heading 4\n##### Heading 5\n###### Heading 6\n"
+        "line 1\n*line 2*\nline 3>"
+    )
+
+    # <b> and <strong> both produce bold markers
+    assert to_md("<b>bold text</b>") == "**bold text**"
+    assert to_md("<strong>bold text</strong>") == "**bold text**"
+
+    # <i> and <em> both produce italic markers
+    assert to_md("<i>italic</i>") == "*italic*"
+    assert to_md("<em>italic</em>") == "*italic*"
+
+    # Inline bold wrapping a paragraph
+    assert (
+        to_md(
+            "<body><div>line 1 <b>bold</b></div> "
+            " <a href='/link'>my link</a>"
+            "<p>3rd line</body>"
+        )
+        == "line 1 **bold**\n[my link](/link)\n3rd line"
+    )
+
+    # <a href="..."> produces Markdown link syntax
+    assert (
+        to_md("<span></span<<span>test</span> <a href='#'>my link</a>")
+        == "test [my link](#)"
+    )
+
+    # <a> with no href attribute -- content rendered as plain text
+    assert to_md("<span>test</span> <a>no link</a>") == "test no link"
+
+    # Inline <code> wraps in backticks without a block boundary
+    assert to_md("<code>func()</code>") == "`func()`"
+
+    # Markdown special characters inside <code> are NOT escaped --
+    # backtick delimiters already make content literal
+    assert to_md("<code>x*2 and #tag</code>") == "`x*2 and #tag`"
+
+    # <pre> produces a fenced code block
+    assert to_md("<pre>line a\nline b</pre>") == "```\nline a\nline b\n```"
+
+    # <samp> is treated the same as <pre> (fenced block)
+    assert to_md("<samp>output\nhere</samp>") == "```\noutput\nhere\n```"
+
+    # Inline code followed immediately by a pre block
+    assert to_md(
+        "<code>multi-line 1\nmulti-line 2</code>more content"
+        "<pre>multi-line 1\nmulti-line 2</pre>more content"
+    ) == (
+        "`multi-line 1\nmulti-line 2`more content"
+        "\n```\nmulti-line 1\nmulti-line 2\n```\nmore content"
+    )
+
+    # Unordered lists produce "- " prefixed items
+    result = to_md("<ul><li>Lots and lots</li><li>of lists.</li></ul>")
+    assert "- Lots and lots" in result
+    assert "- of lists." in result
+
+    assert (
+        to_md("<blockquote>To be or not to be.</blockquote>")
+        == "> To be or not to be."
+    )
+
+    # Standalone <hr/> produces just "---"
+    assert to_md("<hr/>") == "---"
+    assert to_md("<hr>") == "---"
+
+    # <style> content is suppressed
+    assert (
+        to_md(
+            "<style>body { font: 200%; }</style>"
+            "<p>Some obnoxious text here.</p>"
+        )
+        == "Some obnoxious text here."
+    )
+
+    # <script> content is suppressed
+    assert (
+        to_md(
+            "<script>ignore this</script>"
+            "<p>line 1</p>"
+            "Another line without being enclosed"
+        )
+        == "line 1\nAnother line without being enclosed"
+    )
+
+    # '*' outside code is escaped so it does not trigger emphasis
+    assert to_md("<p>price: 5 * 3</p>") == r"price: 5 \* 3"
+
+    # '#' outside code is escaped so it does not trigger a heading
+    assert to_md("<p>Tag #1</p>") == r"Tag \#1"
+
+    # Backtick outside code is escaped
+    assert to_md("<p>Use `func`</p>") == r"Use \`func\`"
+
+    assert (
+        to_md(
+            """
+        <html>
+            <title>ignore this entry</title>
+        <body>
+          Let&apos;s handle&nbsp;special html encoding
+          <hr/>
+        </body>
+        """
+        )
+        == "Let's handle special html encoding\n---"
+    )
+
+    # Missing </p> is handled gracefully
+    assert (
+        to_md(
+            "<h2>Heading</h2><p>And a paragraph too.<br>Plus line break.</p>"
+        )
+        == "## Heading\nAnd a paragraph too.\nPlus line break."
+    )
+
+    with pytest.raises(TypeError):
+        to_md(None)
+
+    with pytest.raises(TypeError):
+        to_md(42)
+
+    with pytest.raises(TypeError):
+        to_md(object)
+
+
 def test_conversion_text_to():
     """conversion: Test Text to all types"""
 

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -29,11 +29,17 @@ from inspect import cleandoc
 
 # Disable logging for a cleaner testing output
 import logging
+from timeit import default_timer
 
 import pytest
 
 from apprise import NotifyFormat
-from apprise.conversion import HTMLMarkdownConverter, convert_between
+from apprise.conversion import (
+    BLOCKQUOTE_DEPTH_MAX,
+    LIST_DEPTH_MAX,
+    HTMLMarkdownConverter,
+    convert_between,
+)
 
 logging.disable(logging.CRITICAL)
 
@@ -232,7 +238,7 @@ def test_conversion_html_to_text():
 
 
 def test_conversion_html_to_markdown():
-    """conversion: Test HTML to Markdown."""
+    """Test basic HTML-to-Markdown conversion."""
 
     def to_md(body):
         """Wrapper to simplify html-to-markdown conversion tests."""
@@ -244,32 +250,36 @@ def test_conversion_html_to_markdown():
     # Empty string in, empty string out
     assert to_md("") == ""
 
-    # Paragraphs collapse to newline-separated text
+    # Paragraphs need a full blank line between them -- a single newline is
+    # just a soft line break within one paragraph under CommonMark, not a
+    # separate paragraph
     assert (
         to_md("<p>line 1</p><p>line 2</p><p>line 3</p>")
-        == "line 1\nline 2\nline 3"
+        == "line 1\n\nline 2\n\nline 3"
     )
 
     # Case sensitivity -- tag names are case-insensitive in HTML
     assert (
         to_md("<p>line 1</P><P>line 2</P><P>line 3</P>")
-        == "line 1\nline 2\nline 3"
+        == "line 1\n\nline 2\n\nline 3"
     )
 
     # HTMLParser lowercases ALL tag names -- inline tags included
     assert to_md("<B>bold text</B>") == "**bold text**"
     assert to_md("<I>italic</I>") == "*italic*"
 
-    # Uppercase and mixed-case self-closing <BR/> also produce newlines
+    # Uppercase and mixed-case self-closing <BR/> also produce a hard break
+    # (two trailing spaces then a newline -- see handle_starttag("br") for why
+    # a bare "\n" isn't enough)
     assert (
         to_md("line one<BR/>line two<BR />line three")
-        == "line one\nline two\nline three"
+        == "line one  \nline two  \nline three"
     )
 
-    # <br> and self-closing <br/> both emit a literal newline
+    # <br> and self-closing <br/> both emit a hard break
     assert (
         to_md("some information<br/><br>and more information")
-        == "some information\n\nand more information"
+        == "some information  \n  \nand more information"
     )
 
     # Each heading level maps to the correct number of # characters
@@ -293,8 +303,8 @@ def test_conversion_html_to_markdown():
         "<p>line 3>"
     ) == (
         "# Heading 1\n## Heading 2\n### Heading 3\n"
-        "#### Heading 4\n##### Heading 5\n###### Heading 6\n"
-        "line 1\n*line 2*\nline 3>"
+        "#### Heading 4\n##### Heading 5\n###### Heading 6\n\n"
+        "line 1\n\n*line 2*\n\nline 3\\>"
     )
 
     # <b> and <strong> both produce bold markers
@@ -306,37 +316,42 @@ def test_conversion_html_to_markdown():
     assert to_md("<em>italic</em>") == "*italic*"
 
     # Inline bold wrapping a paragraph
+    #
+    # Every href is wrapped in angle brackets ("<...>" rather than a bare
+    # "(...)" destination) -- this is what prevents a crafted href value from
+    # breaking out of the link early via an unescaped ')' and injecting
+    # additional Markdown.
     assert (
         to_md(
             "<body><div>line 1 <b>bold</b></div> "
             " <a href='/link'>my link</a>"
             "<p>3rd line</body>"
         )
-        == "line 1 **bold**\n[my link](/link)\n3rd line"
+        == "line 1 **bold**\n\n[my link](</link>)\n\n3rd line"
     )
 
     # <a href="..."> produces Markdown link syntax
     assert (
         to_md("<span></span<<span>test</span> <a href='#'>my link</a>")
-        == "test [my link](#)"
+        == "test [my link](<#>)"
     )
 
     # <a> with nested inline markup -- the href must survive the child tags
-    assert (
-        to_md("<a href='/x'><b>hello</b> world</a>") == "[**hello** world](/x)"
+    assert to_md("<a href='/x'><b>hello</b> world</a>") == (
+        "[**hello** world](</x>)"
     )
-    assert (
-        to_md("<a href='/x'><strong>label</strong></a>") == "[**label**](/x)"
+    assert to_md("<a href='/x'><strong>label</strong></a>") == (
+        "[**label**](</x>)"
     )
     assert (
         to_md("<a href='/x'><em>italic</em> and plain</a>")
-        == "[*italic* and plain](/x)"
+        == "[*italic* and plain](</x>)"
     )
 
     # Nested <a> -- inner href wins for its own span; outer wraps the rest
     assert (
         to_md("<a href='/outer'>text <a href='/inner'>link</a></a>")
-        == "[text [link](/inner)](/outer)"
+        == "[text [link](</inner>)](</outer>)"
     )
 
     # <a> with no href attribute -- content rendered as plain text
@@ -345,24 +360,25 @@ def test_conversion_html_to_markdown():
     # Bare <a name="..."> anchor (no href) -- text passes through unchanged
     assert to_md("<a name='top'>jump target</a>") == "jump target"
 
-    # <span> is inline -- it passes text through without a newline;
-    # <div> is block-level and always produces a newline around its content
-    assert to_md("<div>block</div><span>inline</span>") == "block\ninline"
+    # <span> is inline -- it passes text through without a newline; <div> is
+    # block-level and paragraph-like, so it's followed by a full blank line the
+    # same way two <p> tags are
+    assert to_md("<div>block</div><span>inline</span>") == "block\n\ninline"
 
     # HTML comments are stripped entirely; surrounding text is preserved
     assert to_md("<!-- comment --> text") == "text"
     assert to_md("a<!-- c1 -->b<!-- c2 -->c") == "abc"
 
-    # <![CDATA[...]]> sections are gracefully ignored (content is dropped,
-    # text outside the CDATA boundary is kept)
+    # <![CDATA[...]]> sections are gracefully ignored (content is dropped, text
+    # outside the CDATA boundary is kept)
     assert to_md("text<![CDATA[data]]> here") == "text here"
     assert to_md("<![CDATA[data]]>text") == "text"
 
     # Inline <code> wraps in backticks without a block boundary
     assert to_md("<code>func()</code>") == "`func()`"
 
-    # Markdown special characters inside <code> are NOT escaped --
-    # backtick delimiters already make content literal
+    # Markdown special characters inside <code> are NOT escaped -- backtick
+    # delimiters already make content literal
     assert to_md("<code>x*2 and #tag</code>") == "`x*2 and #tag`"
 
     # <pre> produces a fenced code block
@@ -410,7 +426,7 @@ def test_conversion_html_to_markdown():
             "<p>line 1</p>"
             "Another line without being enclosed"
         )
-        == "line 1\nAnother line without being enclosed"
+        == "line 1\n\nAnother line without being enclosed"
     )
 
     # '*' outside code is escaped so it does not trigger emphasis
@@ -433,7 +449,7 @@ def test_conversion_html_to_markdown():
         </body>
         """
         )
-        == "Let's handle special html encoding\n---"
+        == "Let's handle special html encoding\n\n---"
     )
 
     # Missing </p> is handled gracefully
@@ -441,7 +457,7 @@ def test_conversion_html_to_markdown():
         to_md(
             "<h2>Heading</h2><p>And a paragraph too.<br>Plus line break.</p>"
         )
-        == "## Heading\nAnd a paragraph too.\nPlus line break."
+        == "## Heading\n\nAnd a paragraph too.  \nPlus line break."
     )
 
     with pytest.raises(TypeError):
@@ -455,7 +471,7 @@ def test_conversion_html_to_markdown():
 
 
 def test_conversion_html_to_markdown_lists():
-    """conversion: Test HTML list nesting and numbering in Markdown."""
+    """Test list nesting and numbering."""
 
     def to_md(body):
         """Wrapper to simplify html-to-markdown conversion tests."""
@@ -474,6 +490,28 @@ def test_conversion_html_to_markdown_lists():
         to_md("<ol><li>first</li><li>second</li><li>third</li></ol>")
         == "1. first\n2. second\n3. third"
     )
+
+    # <ol start=> shifts where the auto-incrementing counter begins
+    assert to_md('<ol start="4"><li>a</li><li>b</li></ol>') == "4. a\n5. b"
+    assert to_md('<ol start="0"><li>a</li></ol>') == "0. a"
+
+    # CommonMark list markers cannot represent negative starting values.
+    assert to_md('<ol start="-3"><li>a</li><li>b</li></ol>') == "0. a\n1. b"
+
+    # A non-numeric start is ignored, same as no attribute at all
+    assert to_md('<ol start="abc"><li>a</li></ol>') == "1. a"
+
+    # <li value=> resets the counter for that item and every sibling after it
+    assert to_md('<ol><li value="5">a</li><li>b</li></ol>') == "5. a\n6. b"
+    assert (
+        to_md('<ol><li>a</li><li value="10">b</li><li>c</li></ol>')
+        == "1. a\n10. b\n11. c"
+    )
+    assert to_md('<ol><li value="-5">a</li><li>b</li></ol>') == "0. a\n1. b"
+
+    # A non-numeric value is ignored too -- the counter just keeps incrementing
+    # normally, same as if the attribute weren't there
+    assert to_md('<ol><li value="abc">a</li><li>b</li></ol>') == "1. a\n2. b"
 
     # Nested unordered lists (2 levels)
 
@@ -520,17 +558,17 @@ def test_conversion_html_to_markdown_lists():
         == "1. first\n  - sub A\n  - sub B\n2. second"
     )
 
-    # Malformed HTML: missing </li> in a <ul>
-    # HTMLParser does not synthesize implicit close events; each missing
-    # </li> is simply absent, but the next <li> still starts a new item
+    # Malformed HTML: missing </li> in a <ul> HTMLParser does not synthesize
+    # implicit close events; each missing </li> is simply absent, but the next
+    # <li> still starts a new item
     assert (
         to_md("<ul><li>item A<li>item B<li>item C</ul>")
         == "- item A\n- item B\n- item C"
     )
 
-    # Malformed HTML: missing </li> in a <ol>
-    # Without </li> the counter is never incremented, so all items
-    # render as "1." -- this is expected garbage-in/garbage-out behaviour
+    # Malformed HTML: missing </li> in a <ol> Without </li> the counter is
+    # never incremented, so all items render as "1." -- this is expected
+    # garbage-in/garbage- out behaviour
     assert (
         to_md("<ol><li>one<li>two<li>three</ol>") == "1. one\n1. two\n1. three"
     )
@@ -543,8 +581,8 @@ def test_conversion_html_to_markdown_lists():
 
     assert to_md("<ul><li>item A<li>item B") == "- item A\n- item B"
 
-    # Malformed HTML: bare text inside <ul> (no <li> wrapper)
-    # <ul> is in IGNORE_TAGS so unwrapped text is suppressed entirely
+    # Malformed HTML: bare text inside <ul> (no <li> wrapper) <ul> is in
+    # IGNORE_TAGS so unwrapped text is suppressed entirely
     assert to_md("<ul>bare text</ul>") == ""
 
     # <code> inside <li>: inline code preserved with backticks
@@ -560,40 +598,46 @@ def test_conversion_html_to_markdown_lists():
         == "- see `x*2 #tag`"
     )
 
-    # <pre> inside <li>: fenced block with indentation preserved
-
+    # <pre> inside <li>: fenced block with indentation preserved, and every
+    # line of the fence (both fences plus the content) gets the list item's own
+    # indentation in front -- without it, the fence wouldn't be recognized as
+    # part of the same list.
     assert (
         to_md("<ul><li>code:<pre>  indented\n  here</pre></li></ul>")
-        == "- code:\n```\n  indented\n  here\n```"
+        == "- code:\n  ```\n    indented\n    here\n  ```"
     )
 
-    # <pre> inside a nested <li>: indentation inside the fence is
-    # preserved regardless of the surrounding list nesting depth
+    # <pre> inside a nested <li>: indentation inside the fence is preserved
+    # regardless of the surrounding list nesting depth, with the list's own
+    # indentation (4 spaces here, matching " - ") added in front of it, not
+    # replacing it
     assert (
         to_md(
             "<ul><li>outer<ul><li>inner:<pre>  x = 1</pre></li></ul></li></ul>"
         )
-        == "- outer\n  - inner:\n```\n  x = 1\n```"
+        == "- outer\n  - inner:\n    ```\n      x = 1\n    ```"
     )
 
     # A block element as the first child of <li> used to emit a spurious
-    # BLOCK_END that orphaned the marker on its own line.  The fix detects
-    # a list marker as _result[-1] and suppresses the redundant BLOCK_END.
+    # BLOCK_END that orphaned the marker on its own line.
 
     # Single item with a <p> first child
     assert to_md("<ul><li><p>alpha</p></li></ul>") == "- alpha"
 
-    # Multiple items each with a <p> first child
+    # Multiple items each with a <p> first child -- each <li>'s own <p> closes
+    # and reopens with a full blank line, the same as any other two paragraph-
+    # like blocks would
     assert (
         to_md("<ul><li><p>alpha</p></li><li><p>beta</p></li></ul>")
-        == "- alpha\n- beta"
+        == "- alpha\n\n- beta"
     )
 
-    # Multiple <p> children inside one <li>: first is joined to marker,
-    # subsequent ones start on new lines
-    assert to_md("<ul><li><p>one</p><p>two</p></li></ul>") == "- one\ntwo"
+    # Multiple <p> children inside one <li>
+    assert to_md("<ul><li><p>one</p><p>two</p></li></ul>") == "- one\n\n  two"
 
-    # Mixed: direct text for first item, <p> for second
+    # Mixed: direct text for first item, <p> for second -- the 2nd <li>'s own
+    # marker glues directly onto its <p> (no preceding paragraph to separate
+    # from within that item), so this one stays single-spaced
     assert (
         to_md("<ul><li>direct</li><li><p>wrapped</p></li></ul>")
         == "- direct\n- wrapped"
@@ -602,41 +646,42 @@ def test_conversion_html_to_markdown_lists():
     # Numbered list with <p> children
     assert (
         to_md("<ol><li><p>first</p></li><li><p>second</p></li></ol>")
-        == "1. first\n2. second"
+        == "1. first\n\n2. second"
     )
 
     # <a> link as first child of <li> -- the marker must share the line
-    assert to_md("<ul><li><a href='/x'>link</a></li></ul>") == "- [link](/x)"
+    assert to_md("<ul><li><a href='/x'>link</a></li></ul>") == "- [link](</x>)"
 
     # <a> with nested markup as first (and only) child of <li>
     assert (
         to_md("<ul><li><a href='/x'><b>bold link</b></a></li></ul>")
-        == "- [**bold link**](/x)"
+        == "- [**bold link**](</x>)"
     )
 
-    # <a> link followed by a <p> sibling inside the same <li>
+    # <a> link followed by a <p> sibling inside the same <li> -- the <p> still
+    # gets a full blank line before it, the same as any paragraph, and (still
+    # being part of the same item) the item's own indentation in front of it
+    # too
     assert (
         to_md("<ul><li><a href='/x'>link</a><p>more</p></li></ul>")
-        == "- [link](/x)\nmore"
+        == "- [link](</x>)\n\n  more"
     )
 
 
 def test_conversion_html_to_markdown_escaping():
-    """conversion: HTMLMarkdownConverter avoids generating broken
-    Markdown when content collides with its own delimiters, or when
-    ignored containers would otherwise leak Markdown syntax."""
+    """Test Markdown escaping."""
 
     def to_md(body):
         """Wrapper to simplify html-to-markdown conversion tests."""
         return convert_between(NotifyFormat.HTML, NotifyFormat.MARKDOWN, body)
 
-    # Code/pre delimiter collision
-    # A backtick inside <code> widens the inline delimiter so it can't
-    # be closed early by a backtick already present in the content
+    # Code/pre delimiter collision A backtick inside <code> widens the inline
+    # delimiter so it can't be closed early by a backtick already present in
+    # the content
     assert to_md("<code>a`b</code>") == "``a`b``"
 
-    # Content starting or ending with a backtick gets a padding space,
-    # per CommonMark's code-span disambiguation rule
+    # Content starting or ending with a backtick gets a padding space, per
+    # CommonMark's code-span disambiguation rule
     assert to_md("<code>`x</code>") == "`` `x ``"
     assert to_md("<code>x`</code>") == "`` x` ``"
 
@@ -646,9 +691,9 @@ def test_conversion_html_to_markdown_escaping():
     # Plain content with no backticks still uses the minimal delimiter
     assert to_md("<pre>x</pre>") == "```\nx\n```"
 
-    # Ignored containers must not leak Markdown markers
-    # Only the suppressed text is dropped in the original report --
-    # here the "**" markers from <b> must not leak either
+    # Ignored containers must not leak Markdown markers Only the suppressed
+    # text is dropped in the original report -- here the "**" markers from <b>
+    # must not leak either
     assert (
         to_md(
             "<html><head><b>ignore</b></head><body><p>keep</p></body></html>"
@@ -662,8 +707,8 @@ def test_conversion_html_to_markdown_escaping():
         == "text"
     )
 
-    # A list marker ("- ") must not leak from a <li> nested inside a
-    # suppressed container, even though <li> normally re-enables storage
+    # A list marker ("- ") must not leak from a <li> nested inside a suppressed
+    # container, even though <li> normally re-enables storage
     assert (
         to_md("<head><ul><li>hidden item</li></ul></head><body>text</body>")
         == "text"
@@ -672,18 +717,18 @@ def test_conversion_html_to_markdown_escaping():
     # <script> content (already suppressed) must not leak nested markers
     assert to_md("<script>ignore <b>this</b></script><p>keep</p>") == "keep"
 
-    # A <pre> block fully inside a suppressed container emits nothing,
-    # not even an empty fence
+    # A <pre> block fully inside a suppressed container emits nothing, not even
+    # an empty fence
     assert to_md("<script>ignore<pre>code</pre></script><p>keep</p>") == "keep"
 
-    # --- Link destinations with whitespace ---
-    # A bare Markdown link destination cannot contain a space; wrap it
-    # in angle brackets so the link target isn't silently truncated
+    # --- Link destinations with whitespace --- A bare Markdown link
+    # destination cannot contain a space; wrap it in angle brackets so the link
+    # target isn't silently truncated
     assert to_md("<a href='/my page'>link</a>") == "[link](</my page>)"
 
-    # --- Nested tags inside code/pre are inert ---
-    # Their own markup carries no meaning, but their literal text still
-    # joins the buffered content (no out-of-order marker leakage)
+    # --- Nested tags inside code/pre are inert --- Their own markup carries no
+    # meaning, but their literal text still joins the buffered content (no out-
+    # of-order marker leakage)
     assert (
         to_md("<pre>before <a href='/x'>link</a> after</pre>")
         == "```\nbefore link after\n```"
@@ -692,31 +737,175 @@ def test_conversion_html_to_markdown_escaping():
         to_md("<code>before <b>bold</b> after</code>") == "`before bold after`"
     )
 
-    # --- Stray code/pre/samp close tags ---
-    # _pop_to() finds no matching frame; the early-return path in
-    # handle_endtag must not crash or emit a spurious delimiter
+    # Stray code/pre/samp close tags
     assert to_md("</code>text") == "text"
     assert to_md("</pre>text") == "text"
     assert to_md("</samp>text") == "text"
 
+    # Markdown/HTML injection via plain text content
+    assert (
+        to_md("<p>Click [here](https://evil.example.com) now</p>")
+        == r"Click \[here\]\(https://evil.example.com\) now"
+    )
+    assert (
+        to_md("<p>An image ![x](https://evil.example.com/x.png) too</p>")
+        == r"An image \!\[x\]\(https://evil.example.com/x.png\) too"
+    )
+
+    # A literal backslash must itself be escaped
+    assert to_md("<p>back\\*slash</p>") == r"back\\\*slash"
+
+    # '_' (CommonMark's other emphasis delimiter) and '~' (GFM/chat- dialect
+    # strikethrough) are escaped unconditionally, the same as '*' -- otherwise
+    # plain text containing them risks being read as emphasis/strikethrough it
+    # was never meant to be
+    assert to_md("<p>_literal_</p>") == r"\_literal\_"
+    assert to_md("<p>my_variable_name</p>") == r"my\_variable\_name"
+    assert to_md("<p>~strikethrough~</p>") == r"\~strikethrough\~"
+
+    # Entity-encoded HTML (decoded to literal "<"/">" text by the parser) must
+    # not survive into the Markdown output unescaped
+    assert (
+        to_md("<p>previously &lt;script&gt;alert(1)&lt;/script&gt;</p>")
+        == r"previously \<script\>alert\(1\)\</script\>"
+    )
+
+    # href cannot break out of the link destination
+    assert to_md(
+        '<a href="https://safe.example.com)[FAKE](https://evil.example.com/p)">'
+        "legit link</a>"
+    ) == (
+        "[legit link]"
+        "(<https://safe.example.com)[FAKE](https://evil.example.com/p)>)"
+    )
+
+    # A '<' or '>' inside the href itself must be escaped, since both are
+    # meaningful within the angle-bracket destination form.
+    assert to_md('<a href="https://x.example.com/<script>">y</a>') == (
+        r"[y](<https://x.example.com/\<script\>>)"
+    )
+
+    # Strip line endings before placing a URL in an angle-bracket destination.
+    assert (
+        to_md('<a href="https://safe/x\n\n# injected">click</a>')
+        == "[click](<https://safe/x# injected>)"
+    )
+
+    # Neutralize schemes that can execute content or expose local files.
+    assert to_md('<a href="javascript:alert(1)">click me</a>') == (
+        "[click me](<#>)"
+    )
+    assert to_md('<a href="data:text/html,x">click</a>') == "[click](<#>)"
+    assert to_md('<a href="vbscript:msgbox(1)">click</a>') == "[click](<#>)"
+    assert to_md('<a href="file:///etc/passwd">click</a>') == "[click](<#>)"
+    assert to_md('<a href="JaVaScRiPt:alert(1)">click</a>') == "[click](<#>)"
+
+    # Leading/trailing whitespace must not defeat scheme detection\
+    assert to_md('<a href="  javascript:alert(1)">click</a>') == (
+        "[click](<#>)"
+    )
+    assert to_md('<a href=" \tjavascript:alert(1)">click</a>') == (
+        "[click](<#>)"
+    )
+    assert to_md('<a href="javascript:alert(1)  ">click</a>') == (
+        "[click](<#>)"
+    )
+
+    # Keep legitimate app-specific schemes that are not explicitly unsafe.
+    assert to_md('<a href="https://example.com">x</a>') == (
+        "[x](<https://example.com>)"
+    )
+    assert to_md('<a href="mailto:test@example.com">x</a>') == (
+        "[x](<mailto:test@example.com>)"
+    )
+    assert to_md('<a href="tel:+15551234567">x</a>') == (
+        "[x](<tel:+15551234567>)"
+    )
+    assert to_md('<a href="sms:+15551234567">x</a>') == (
+        "[x](<sms:+15551234567>)"
+    )
+    assert to_md('<a href="geo:37.7,-122.4">x</a>') == (
+        "[x](<geo:37.7,-122.4>)"
+    )
+    assert to_md('<a href="msteams:meeting?id=123">x</a>') == (
+        "[x](<msteams:meeting?id=123>)"
+    )
+    assert to_md('<a href="sharepoint://site/doc">x</a>') == (
+        "[x](<sharepoint://site/doc>)"
+    )
+    assert to_md('<a href="/relative/path">x</a>') == ("[x](</relative/path>)")
+    assert to_md('<a href="#anchor">x</a>') == "[x](<#anchor>)"
+
+
+def test_conversion_html_to_markdown_line_start_escaping():
+    """Test block syntax escaping."""
+
+    def to_md(body):
+        """Wrapper to simplify html-to-markdown conversion tests."""
+        return convert_between(NotifyFormat.HTML, NotifyFormat.MARKDOWN, body)
+
+    # Escape ordered-list-shaped text only at the start of a line.
+    assert to_md("<p>1. Apples</p><p>2. Oranges</p>") == (
+        "1\\. Apples\n\n2\\. Oranges"
+    )
+    assert to_md("<p>23. done</p>") == "23\\. done"
+
+    # Match bullet markers at the start of a line.
+    assert to_md("<p>- not a bullet, just a dash</p>") == (
+        "\\- not a bullet, just a dash"
+    )
+    assert to_md("<p>+ plus sign list?</p>") == "\\+ plus sign list?"
+
+    # A line that's nothing but repeated "-" is escaped so it can't be read as
+    # a thematic break (<hr>) -- or, repeated "-"/"=" directly under a
+    # preceding line with no blank line between them (joined by <br>), as a
+    # setext heading underline.
+    assert to_md("<p>Some text</p><p>---</p><p>more text</p>") == (
+        "Some text\n\n\\---\n\nmore text"
+    )
+
+    # Escaping the first dash is enough to prevent a thematic break.
+    rendered = convert_between(
+        NotifyFormat.MARKDOWN,
+        NotifyFormat.HTML,
+        to_md("<p>Some text</p><p>---</p><p>more text</p>"),
+    )
+    assert "<hr" not in rendered
+    assert "<h1" not in rendered
+    assert "<h2" not in rendered
+    assert "---" in rendered
+
+    assert to_md("<p>***</p>") == "\\*\\*\\*"
+    assert to_md("<p>___</p>") == "\\_\\_\\_"
+    assert to_md("<p>- - -</p>") == "\\- - -"
+    assert to_md("<p>Hello world<br>===</p>") == "Hello world  \n\\==="
+    assert to_md("<p>Heading<br>---</p>") == "Heading  \n\\---"
+
+    # None of this is ambiguous -- and so isn't escaped -- anywhere other than
+    # a true line start
+    assert to_md("<p>well-known v1.2 it is not - really</p>") == (
+        "well-known v1.2 it is not - really"
+    )
+    assert to_md("<p>price is $5.00</p>") == "price is $5.00"
+    assert to_md("<p>a-b-c</p>") == "a-b-c"
+    assert to_md("<p>5 - 3 = 2</p>") == "5 - 3 = 2"
+
 
 def test_conversion_html_to_markdown_hardening():
-    """conversion: HTMLMarkdownConverter is robust against stack edge cases."""
+    """Test malformed stack input."""
 
     def to_md(body):
         """Wrapper to simplify html-to-markdown conversion tests."""
         return convert_between(NotifyFormat.HTML, NotifyFormat.MARKDOWN, body)
 
     # Stray close tags before any matching open tag
-    # _pop_to() must find no matching frame and silently do nothing;
-    # the root sentinel frame must remain untouched throughout.
 
     # </ul> and </ol> take the early-return path in handle_endtag
     assert to_md("</ul>text") == "text"
     assert to_md("</ol>text") == "text"
 
-    # </li> emits a BLOCK_END but _pop_to still finds nothing -- the
-    # text that follows is unindented and stored normally
+    # </li> emits a BLOCK_END but _pop_to still finds nothing -- the text that
+    # follows is unindented and stored normally
     assert to_md("</li>text") == "text"
 
     # Multiple stray close tags in a row must not crash or corrupt state
@@ -726,10 +915,6 @@ def test_conversion_html_to_markdown_hardening():
     assert to_md("</ul><ul><li>A</li><li>B</li></ul>") == "- A\n- B"
 
     # _make_frame() empty-stack guard
-    # The root sentinel makes this path unreachable through normal
-    # parsing; we force it by clearing _stack directly to verify the
-    # fallback produces safe root-equivalent defaults.
-
     conv = HTMLMarkdownConverter()
 
     # Force the stack empty -- this can only happen via direct attribute
@@ -744,6 +929,665 @@ def test_conversion_html_to_markdown_hardening():
     assert frame["list_type"] is None
     assert frame["depth"] == 0
     assert frame["counter"] is None
+    assert frame["list_do_store"] is True
+
+    # A stale open-tag count must not corrupt the stack.
+    conv = HTMLMarkdownConverter()
+    conv._tag_open_counts["nonexistent"] = 1
+    conv._pop_to("nonexistent")  # must not raise or corrupt state
+    assert len(conv._stack) == 1  # only the root sentinel remains
+
+    # ignore content found in head
+    assert (
+        to_md(
+            "<head>"
+            + "<ul>" * 50
+            + "<li>hidden</li>"
+            + "</ul>" * 50
+            + "</head><body>text</body>"
+        )
+        == "text"
+    )
+
+    # deep <ul> nesting still resolve correctly.
+    assert (
+        to_md("<ul>" * 50 + "<li>visible</li>" + "</ul>" * 50) == "- visible"
+    )
+
+    # List indentation is capped at LIST_DEPTH_MAX ---
+    assert LIST_DEPTH_MAX == 4
+
+    one_per_level = "<ul><li>x" * 10 + "</li></ul>" * 10
+    out = to_md(one_per_level)
+    lines = out.split("\n")
+    assert len(lines) == 10
+    # Indent grows for the first LIST_DEPTH_MAX levels...
+    assert lines[0] == "- x"
+    assert lines[1] == "  - x"
+    assert lines[2] == "    - x"
+    assert lines[3] == "      - x"
+    # ...then holds steady for every level beyond the cap
+    for line in lines[4:]:
+        assert line == "      - x"
+
+    # Performance: same shape, large enough that the old O(N^2)
+    n = 20000
+    deep = "<ul><li>x" * n + "</li></ul>" * n
+    start = default_timer()
+    out = to_md(deep)
+    elapsed = default_timer() - start
+    assert len(out) < 20 * n
+    assert elapsed < 3.0
+
+    # Performance: many UNCLOSED <li> tags nested directly inside one another.
+    n = 20000
+    html = "<li>x" * n
+    start = default_timer()
+    out = to_md(html)
+    elapsed = default_timer() - start
+    assert len(out) < 10 * n  # output itself is linear, not quadratic
+    assert elapsed < 3.0
+
+    # Performance: many open <blockquote> tags followed by many closing tags of
+    # a *different* kind that's never actually open ("</pre>").
+    n = 20000
+    html = "<blockquote>" * n + "</pre>" * n
+    start = default_timer()
+    out = to_md(html)
+    elapsed = default_timer() - start
+    assert len(out) < 20 * n
+    assert elapsed < 3.0
+
+    # Blockquote depth is capped at BLOCKQUOTE_DEPTH_MAX
+    assert BLOCKQUOTE_DEPTH_MAX == 4
+
+    # Each level is its own <p>, so every line of real content is followed by a
+    # blank (but still "> "-prefixed) separator line -- see
+    # test_conversion_html_to_markdown_blockquotes for that part on its own.
+    one_per_level = "<blockquote><p>x</p>" * 10 + "</blockquote>" * 10
+    out = to_md(one_per_level)
+    lines = out.split("\n")
+    assert len(lines) == 19
+    content_lines = lines[0::2]
+    separator_lines = lines[1::2]
+    assert len(content_lines) == 10
+    assert content_lines[0] == "> x"
+    assert content_lines[1] == "> > x"
+    assert content_lines[2] == "> > > x"
+    assert content_lines[3] == "> > > > x"
+    for line in content_lines[4:]:
+        assert line == "> > > > x"
+    # Each separator matches its preceding content line, minus the "x"
+    for content, separator in zip(content_lines, separator_lines):
+        assert separator == content[: -len("x")].rstrip()
+
+    n = 20000
+    deep = "<blockquote><p>x</p>" * n + "</blockquote>" * n
+    start = default_timer()
+    out = to_md(deep)
+    elapsed = default_timer() - start
+    assert len(out) < 20 * n
+    assert elapsed < 3.0
+
+
+def test_conversion_html_to_markdown_blockquotes():
+    """Test blockquote conversion."""
+
+    def to_md(body):
+        """Wrapper to simplify html-to-markdown conversion tests."""
+        return convert_between(NotifyFormat.HTML, NotifyFormat.MARKDOWN, body)
+
+    # Single paragraph -- marker and content share the first line
+    assert to_md("<blockquote><p>line1</p></blockquote>") == "> line1"
+
+    # Multiple paragraphs
+    assert (
+        to_md("<blockquote><p>line1</p><p>line2</p></blockquote>")
+        == "> line1\n>\n> line2"
+    )
+    assert (
+        to_md("<blockquote><p>a</p><p>b</p><p>c</p></blockquote>")
+        == "> a\n>\n> b\n>\n> c"
+    )
+
+    # A heading doesn't need that same blank-line treatment -- ATX headings are
+    # self- delimiting (a single line), so whatever follows already starts its
+    # own block regardless of blank lines
+    assert (
+        to_md("<blockquote><h2>Title</h2><p>body</p></blockquote>")
+        == "> ## Title\n> body"
+    )
+
+    # Inline-only content needs no internal prefixing -- it never hits a
+    # boundary inside the quote in the first place
+    assert (
+        to_md("<blockquote>To be or not to be.</blockquote>")
+        == "> To be or not to be."
+    )
+
+    # Nested blockquotes accumulate one "> " per level, not per ancestor's full
+    # prefix (that would double-count: a naive fix that writes the *cumulative*
+    # prefix on every open, rather than one unit per level, turns two nested
+    # quotes into "> > > ".
+    assert (
+        to_md("<blockquote><blockquote>nested</blockquote></blockquote>")
+        == "> > nested"
+    )
+    assert to_md(
+        "<blockquote><blockquote><p>a</p><p>b</p></blockquote></blockquote>"
+    ) == ("> > a\n> >\n> > b")
+
+    # Content after a blockquote needs a full boundary without the quote
+    # prefix.
+    assert (
+        to_md("<blockquote><p>line1</p></blockquote><p>after</p>")
+        == "> line1\n\nafter"
+    )
+    assert (
+        to_md("<p>before</p><blockquote><p>line1</p></blockquote>")
+        == "before\n\n> line1"
+    )
+
+    # An entirely empty blockquote (no children at all, nested or not) produces
+    # no output -- there's no content to quote, so the marker it would have
+    # written is removed rather than left dangling on its own.
+    assert to_md("<blockquote></blockquote>") == ""
+    assert to_md("<blockquote><blockquote></blockquote></blockquote>") == ""
+
+    # A blockquote entirely inside a suppressed context contributes nothing,
+    # and does not disturb sibling content outside it
+    assert (
+        to_md(
+            "<head><blockquote><p>hidden</p></blockquote></head>"
+            "<body>text</body>"
+        )
+        == "text"
+    )
+
+    # A blockquote following bare text still needs its own boundary.
+    assert to_md("text<blockquote>quoted</blockquote>") == ("text\n\n> quoted")
+    assert to_md("text<blockquote></blockquote>") == "text"
+    assert to_md("<p>text<blockquote></blockquote></p>") == "text"
+
+
+def test_conversion_html_to_markdown_emphasis():
+    """Test emphasis edge cases."""
+
+    def to_md(body):
+        """Wrapper to simplify html-to-markdown conversion tests."""
+        return convert_between(NotifyFormat.HTML, NotifyFormat.MARKDOWN, body)
+
+    # Leading/trailing whitespace inside the tag must end up outside the
+    # delimiters -- a CommonMark delimiter directly touching whitespace can
+    # never open/close emphasis ("* text *" renders as literal asterisks, not
+    # emphasis)
+    assert to_md("<em> text </em>") == "*text*"
+    assert to_md("<strong> bold </strong>") == "**bold**"
+    assert to_md("<em>  multi  space  </em>") == "*multi space*"
+
+    # Leading-only and trailing-only whitespace
+    assert to_md("<em> text</em>") == "*text*"
+    assert to_md("<em>text </em>") == "*text*"
+
+    # Relocating emphasis whitespace must not disturb surrounding text.
+    assert (
+        to_md("<p>Hello <strong> bold </strong> world</p>")
+        == "Hello  **bold**  world"
+    )
+
+    # Relocate trailing whitespace even when empty tags split the text
+    # fragments.
+    assert to_md("<strong>text<span></span> </strong>x") == "**text** x"
+
+    # Fully empty, or whitespace-only, spans contribute nothing at all -- not
+    # even an unpaired delimiter
+    assert to_md("<strong></strong>") == ""
+    assert to_md("<em>   </em>") == ""
+    assert to_md("<strong><em></em></strong>") == ""
+
+    # Adjacent tags, one empty -- the empty one's delimiters must not collide
+    # with the next tag's into an ambiguous run of asterisks
+    assert to_md("<strong></strong><strong>bold</strong>") == "**bold**"
+    assert to_md("<em></em><em>x</em>") == "*x*"
+
+    # A stray close tag with no matching open is a no-op, the same as other
+    # malformed- HTML cases elsewhere in this parser -- it must not emit an
+    # unpaired closing delimiter
+    assert to_md("</b>text") == "text"
+    assert to_md("<p>a</b>b</p>") == "ab"
+
+    # Mismatched open/close tags ("<i>x</b>y") -- the close belongs to neither
+    # this <i> nor anything else, so it's a no-op; <i> stays open and is auto-
+    # closed at end of document (see below) once "y" has joined it
+    assert to_md("<i>x</b>y") == "*xy*"
+
+    # A tag left open with no closing tag at all is auto-closed at end of
+    # document rather than leaving its opening delimiter unpaired
+    assert to_md("<b>text") == "**text**"
+    assert to_md("<p><em>a<strong>b") == "*a**b***"
+
+    # Normal, well-formed cases are unaffected
+    assert to_md("<strong>bold</strong>") == "**bold**"
+    assert to_md("<em>italic</em>") == "*italic*"
+    assert to_md("<strong>A</strong><strong>B</strong>") == "**A****B**"
+
+    # Empty block content inside emphasis must not leave an opening delimiter.
+    assert to_md("<em><ul><li></li></ul></em>x") == "x"
+    assert to_md("a<em><ul><li></li></ul></em>b") == "ab"
+
+    # Empty trailing blocks must not hide whitespace from emphasis cleanup.
+    assert to_md("<em>text<blockquote></blockquote></em>") == ("*text\n\n> *")
+
+
+def test_conversion_html_to_markdown_empty_blocks():
+    """Test empty block handling."""
+
+    def to_md(body):
+        """Wrapper to simplify html-to-markdown conversion tests."""
+        return convert_between(NotifyFormat.HTML, NotifyFormat.MARKDOWN, body)
+
+    # Plain, marker-less block tags with nothing inside them already collapse
+    # to nothing extra -- no separate blank line is added for each one.
+    assert to_md("<div></div><div></div><p>text</p>") == "text"
+    assert to_md("<p>a</p><div></div><p>b</p>") == "a\n\nb"
+    assert (
+        to_md("<p>a</p><div></div><div></div><div></div><p>b</p>") == "a\n\nb"
+    )
+
+    # A marker (list bullet or quote prefix) with only empty block tags after
+    # it still glues onto the first real content that eventually follows,
+    # instead of being stranded on its own line
+    assert (
+        to_md("<ul><li><div></div><div></div><p>text</p></li></ul>")
+        == "- text"
+    )
+    assert to_md("<blockquote><div></div><p>text</p></blockquote>") == "> text"
+
+    # A marker with no real content ever attached to it (not even past an empty
+    # block) is dropped entirely, the same way an empty
+    # <blockquote></blockquote> is
+    assert to_md("<ul><li></li></ul>") == ""
+    assert to_md("<ul><li><div></div></li></ul>") == ""
+
+    # A sibling marker arriving after the first one's empty block tags replaces
+    # it rather than gluing onto it -- "- " followed by another "- " from a
+    # different <li> must not become "- - "
+    assert to_md("<ul><li><div></div></li><li>real</li></ul>") == "- real"
+
+    # Same idea for a blockquote restating its own prefix on a fresh line after
+    # an empty block -- must not double up to "> > ".
+    assert (
+        to_md("<blockquote><p>line1</p><div></div><p>line2</p></blockquote>")
+        == "> line1\n>\n> line2"
+    )
+
+    # Real text between two empty blocks still resets the suppression, so the
+    # block tag right after it starts a new line as normal.
+    assert to_md("<div></div>text<div></div><p>more</p>") == "text\n\nmore"
+
+    # Plain whitespace between tags never counts as content
+    assert to_md("<p>a</p>   <p>b</p>") == "a\n\nb"
+
+    # A standalone &nbsp; is a deliberate space, not incidental formatting
+    # whitespace -- it survives as its own line of content, the same way bare
+    # real text between two blocks would.
+    assert to_md("<p>a</p>&nbsp;<p>b</p>") == "a\n\n\xa0\n\nb"
+
+    # &nbsp; used inline within real text is unaffected, and still collapses to
+    # a regular space like any other inline whitespace
+    assert (
+        to_md("Let's handle&nbsp;special html encoding")
+        == "Let's handle special html encoding"
+    )
+
+    # <hr> is a void element (its closing tag may never fire), but it still
+    # writes real, non-marker content ("---").
+    assert to_md("<hr><hr>") == "---\n\n---"
+    assert to_md("<hr>     <hr>") == "---\n\n---"
+    assert to_md("<hr/><hr/><hr/>") == "---\n\n---\n\n---"
+    assert to_md("<p>a</p><hr><hr><p>b</p>") == "a\n\n---\n\n---\n\nb"
+
+    # <hr> as the first thing in a blockquote/list item glues onto the marker;
+    # inside an open blockquote, its own opening boundary still applies, giving
+    # it a blank "> " line before it the same way a 2nd <p> sibling would get
+    # one
+    assert to_md("<ul><li><hr></li></ul>") == "- ---"
+    assert to_md("<blockquote><p>a</p><hr></blockquote>") == "> a\n>\n> ---"
+
+    # Real page text that happens to *look* like a generated marker (e.g. a
+    # paragraph whose only content is "- ") must never be mistaken for one by
+    # whatever renders the Markdown output -- markers are only ever the ones
+    # this converter writes.
+    assert to_md("<p>- </p><p>real</p>") == "\\-\n\nreal"
+    assert to_md("<p>-  </p>") == "\\-"
+    assert (
+        to_md("<p>- </p><div>real div content</div>")
+        == "\\-\n\nreal div content"
+    )
+    # Real text directly inside a real <li> that itself looks like a marker is
+    # escaped too -- "- -" (genuine marker, then unescaped text starting with
+    # "-") risks being read as a nested sub-list rather than this item's own
+    # text.
+    assert to_md("<ul><li>- </li></ul>") == "- \\-"
+
+
+def test_conversion_html_to_markdown_list_indentation():
+    """Test list continuation indentation."""
+
+    def to_md(body):
+        """Wrapper to simplify html-to-markdown conversion tests."""
+        return convert_between(NotifyFormat.HTML, NotifyFormat.MARKDOWN, body)
+
+    # Baseline: a single <p> as an <li>'s only child still just glues onto the
+    # marker -- no continuation indentation is even needed since there's
+    # nothing beyond the first line
+    assert to_md("<li><p>text</p></li>") == "- text"
+
+    # A 2nd <p> within the same <li> is a continuation line: it needs the
+    # item's own indentation in front (2 spaces, matching "- "), or a
+    # CommonMark-compliant renderer won't recognize it as part of the list item
+    # at all -- it would end the list.
+    assert to_md("<ul><li><p>one</p><p>two</p></li></ul>") == "- one\n\n  two"
+
+    # Ordered lists need the indentation to match their own (wider) marker
+    # width, not the bullet list's fixed 2 spaces
+    assert (
+        to_md("<ol><li><p>one</p><p>two</p></li></ol>") == "1. one\n\n   two"
+    )
+
+    # Sibling <li>s must NOT pick up any indentation from each other -- only a
+    # *continuation within the same item* should ever be indented
+    assert (
+        to_md("<ul><li><p>alpha</p></li><li><p>beta</p></li></ul>")
+        == "- alpha\n\n- beta"
+    )
+    assert (
+        to_md("<ol><li><p>a</p></li><li><p>b</p></li><li><p>c</p></li></ol>")
+        == "1. a\n\n2. b\n\n3. c"
+    )
+
+    # A nested sublist's own marker (computed independently for its own depth)
+    # must not be *additionally* indented on top of that -- that would double-
+    # count the outer level's contribution
+    assert to_md("<ul><li>x<ul><li>x</li></ul></li></ul>") == "- x\n  - x"
+    assert (
+        to_md("<ul><li>L1<ul><li>L2<ul><li>L3</li></ul></li></ul></li></ul>")
+        == "- L1\n  - L2\n    - L3"
+    )
+
+    # A <blockquote> nested inside an <li>, with multiple paragraphs of its
+    # own, needs *both* the list item's indentation and the quote prefix on
+    # every continuation line -- list indentation first, then "> ", matching
+    # how the first line ("- > a").
+    assert to_md(
+        "<ul><li><blockquote><p>a</p><p>b</p></blockquote></li></ul>"
+    ) == ("- > a\n  >\n  > b")
+
+    # The reverse nesting -- an <li> as the first thing inside a <blockquote>
+    # -- must keep the quote prefix; it used to be lost entirely because <li>
+    # always forced a fresh boundary instead of gluing onto a pending marker
+    # the way other block tags.
+    assert to_md("<blockquote><ul><li>text</li></ul></blockquote>") == (
+        "> - text"
+    )
+
+    # Multiple <li>s inside a <blockquote> each need "> " restated
+    assert to_md("<blockquote><ul><li>a</li><li>b</li></ul></blockquote>") == (
+        "> - a\n> - b"
+    )
+
+    # A <blockquote> directly chaining onto another blockquote's restated
+    # prefix (after a paragraph closes) must still build up nesting depth
+    # correctly ("> > ", not just "> ") -- this is the same chaining mechanism
+    # nested.
+    assert to_md(
+        "<blockquote><p>a</p><blockquote>nested</blockquote></blockquote>"
+    ) == ("> a\n>\n> > nested")
+
+    # <pre>/<samp> inside an <li>: every line of the fence -- both fences and
+    # every line of the content between them -- needs the list item's
+    # indentation too, or the fence wouldn't be recognized as staying part of
+    # the same list item.
+    assert to_md("<ul><li>code:<pre>  indented\n  here</pre></li></ul>") == (
+        "- code:\n  ```\n    indented\n    here\n  ```"
+    )
+
+    # Same, but nested one list level deeper (4-space indentation, matching " -
+    # ")
+    assert to_md(
+        "<ul><li>outer<ul><li>inner:<pre>  x = 1</pre></li></ul></li></ul>"
+    ) == ("- outer\n  - inner:\n    ```\n      x = 1\n    ```")
+
+
+def test_conversion_html_to_markdown_br():
+    """Test CommonMark hard breaks."""
+
+    def to_md(body):
+        """Wrapper to simplify html-to-markdown conversion tests."""
+        return convert_between(NotifyFormat.HTML, NotifyFormat.MARKDOWN, body)
+
+    # Two trailing spaces then a newline -- a bare "\n" is only a soft break
+    # under CommonMark (most renderers collapse it to a single space rather
+    # than a visible line break)
+    assert to_md("line1<br>line2") == "line1  \nline2"
+    assert to_md("line1<br/>line2") == "line1  \nline2"
+    assert to_md("line1<br />line2") == "line1  \nline2"
+
+    # Verified against an actual renderer, not just the raw Markdown shape -- a
+    # real <br> must appear, with no leftover stray character from the hard-
+    # break syntax itself
+    rendered = convert_between(
+        NotifyFormat.MARKDOWN, NotifyFormat.HTML, to_md("line1<br>line2")
+    )
+    assert "<br" in rendered
+    assert "\\" not in rendered
+
+    # Consecutive <br> tags each contribute their own hard break
+    assert to_md("a<br><br>b") == "a  \n  \nb"
+
+    # A trailing <br> with nothing after it doesn't leave a dangling hard break
+    # at the very end of the output
+    assert to_md("<p>line1<br></p>") == "line1"
+
+    # A hard break inside a blockquote must restate the "> " prefix on its
+    # continuation line.
+    assert to_md("<blockquote>line1<br>line2</blockquote>") == (
+        "> line1  \n> line2"
+    )
+
+    # Same, but inside a list item -- the continuation line must keep the
+    # marker's indentation so it stays part of the same item.
+    assert to_md("<ul><li>line1<br>line2</li></ul>") == ("- line1  \n  line2")
+
+    # Both nested together -- a blockquote containing a list item.
+    assert to_md(
+        "<blockquote><ul><li>line1<br>line2</li></ul></blockquote>"
+    ) == ("> - line1  \n  > line2")
+
+
+def test_conversion_html_to_markdown_tables():
+    """Test GFM table conversion."""
+
+    def to_md(body):
+        """Wrapper to simplify html-to-markdown conversion tests."""
+        return convert_between(NotifyFormat.HTML, NotifyFormat.MARKDOWN, body)
+
+    # Basic table -- first row becomes the header, a "---" separator row is
+    # inserted right after it
+    assert to_md(
+        "<table><tr><td>A</td><td>B</td></tr>"
+        "<tr><td>1</td><td>2</td></tr></table>"
+    ) == ("| A | B |\n| --- | --- |\n| 1 | 2 |")
+
+    # <thead>/<tbody>/<th> are fully transparent -- header-vs-body is decided
+    # purely by row order, the same as <thead>-less markup
+    assert to_md(
+        "<table><thead><tr><th>Name</th><th>Age</th></tr></thead>"
+        "<tbody><tr><td>Bob</td><td>42</td></tr></tbody></table>"
+    ) == ("| Name | Age |\n| --- | --- |\n| Bob | 42 |")
+
+    # A single-row table still gets its separator row
+    assert to_md("<table><tr><td>only</td></tr></table>") == (
+        "| only |\n| --- |"
+    )
+
+    # Inline formatting inside cells is preserved
+    assert to_md(
+        "<table><tr><td><b>bold</b></td>"
+        '<td><a href="https://x.com">link</a></td></tr></table>'
+    ) == ("| **bold** | [link](<https://x.com>) |\n| --- | --- |")
+
+    # A literal '|' inside a cell is escaped -- it's the cell delimiter itself,
+    # and would otherwise be misread as starting a new column
+    assert to_md("<table><tr><td>a | b</td></tr></table>") == (
+        "| a \\| b |\n| --- |"
+    )
+
+    # A newline a cell's own content produced (here, a <br>) is flattened to a
+    # single space -- a Markdown table row is always exactly one line;
+    # embedding a raw newline would corrupt the row
+    assert to_md("<table><tr><td>a<br>b</td></tr></table>") == (
+        "| a b |\n| --- |"
+    )
+
+    # Surrounding content gets ordinary paragraph separation from the table,
+    # the same as a list or blockquote would
+    assert to_md("<p>before</p><table><tr><td>A</td></tr></table>") == (
+        "before\n\n| A |\n| --- |"
+    )
+    assert to_md("<table><tr><td>A</td></tr></table><p>after</p>") == (
+        "| A |\n| --- |\n\nafter"
+    )
+
+    # An entirely empty table, or a table whose only row has no cells at all,
+    # produces nothing
+    assert to_md("<table></table>") == ""
+    assert to_md("<table><tr></tr></table>") == ""
+
+    # A table fully inside a suppressed container (e.g. <head>) contributes
+    # nothing -- not even an empty "| |" row
+    assert (
+        to_md(
+            "<head><table><tr><td>x</td></tr></table></head><body>text</body>"
+        )
+        == "text"
+    )
+
+    # Stray text directly inside <table>/<tr> but outside any <td>/<th> (almost
+    # always just HTML formatting whitespace in practice) is suppressed, the
+    # same as <ul>/<ol> already suppress stray text outside <li>
+    assert to_md("<table>stray<tr><td>A</td></tr></table>") == (
+        "| A |\n| --- |"
+    )
+    assert to_md("<table><tr>stray<td>A</td></tr></table>") == (
+        "| A |\n| --- |"
+    )
+    assert to_md("<table>\n  <tr>\n    <td>A</td>\n  </tr>\n</table>") == (
+        "| A |\n| --- |"
+    )
+
+    # A stray <td> with no enclosing <tr> at all falls back to ordinary
+    # paragraph-like treatment -- the same as before table support existed
+    assert to_md("<td>standalone</td>") == "standalone"
+
+    # A stray <tr> with no enclosing <table> is treated as a one-row table of
+    # its own
+    assert to_md("<tr><td>a</td><td>b</td></tr>") == (
+        "| a | b |\n| --- | --- |"
+    )
+
+
+def test_conversion_html_to_markdown_tables_indentation():
+    """Test nested table indentation."""
+
+    def to_md(body):
+        """Wrapper to simplify html-to-markdown conversion tests."""
+        return convert_between(NotifyFormat.HTML, NotifyFormat.MARKDOWN, body)
+
+    assert to_md(
+        "<ul><li>before<table><tr><td>A</td></tr></table></li></ul>"
+    ) == ("- before\n\n  | A |\n  | --- |")
+
+    assert to_md(
+        "<ul><li>before<table><tr><td>A</td><td>B</td></tr>"
+        "<tr><td>1</td><td>2</td></tr></table></li></ul>"
+    ) == ("- before\n\n  | A | B |\n  | --- | --- |\n  | 1 | 2 |")
+
+    assert to_md(
+        "<blockquote><table><tr><td>A</td><td>B</td></tr>"
+        "<tr><td>1</td><td>2</td></tr></table></blockquote>"
+    ) == ("> | A | B |\n> | --- | --- |\n> | 1 | 2 |")
+
+
+def test_conversion_html_to_markdown_tables_hardening():
+    """Test malformed table input."""
+
+    def to_md(body):
+        """Wrapper to simplify html-to-markdown conversion tests."""
+        return convert_between(NotifyFormat.HTML, NotifyFormat.MARKDOWN, body)
+
+    # Neither <td> nor <tr> ever closed -- extremely common in real-
+    # world/legacy table markup
+    assert to_md("<table><tr><td>A<td>B<tr><td>1<td>2</table>") == (
+        "| A | B |\n| --- | --- |\n| 1 | 2 |"
+    )
+
+    # Same, but the enclosing </table> is missing too -- the last row and cell
+    # are recovered at end of document
+    assert to_md("<table><tr><td>A<td>B<tr><td>1<td>2") == (
+        "| A | B |\n| --- | --- |\n| 1 | 2 |"
+    )
+
+    # A stray </tr> or </table> with nothing matching open at all (no enclosing
+    # structure whatsoever, not even an open cell) is a no-op -- same as other
+    # malformed-HTML cases elsewhere in this parser, e.g. a stray </ul> or
+    # </li>
+    assert to_md("</tr>text") == "text"
+    assert to_md("</table>text") == "text"
+    assert to_md("<p>a</tr>b</p>") == "ab"
+    assert to_md("<p>a</table>b</p>") == "ab"
+
+    # Only the very first <tr> is ever closed
+    assert to_md("<table><tr><td>A</td></tr><tr><td>B<tr><td>C</table>") == (
+        "| A |\n| --- |\n| B |\n| C |"
+    )
+
+    # Performance: many rows, each with unclosed <td>/<tr> tags (the legacy-
+    # markup shape above), large enough that an O(N^2) recovery path would
+    # dominate.
+    n = 20000
+    html = "<table>" + "<tr><td>a<td>b" * n + "</table>"
+    start = default_timer()
+    out = to_md(html)
+    elapsed = default_timer() - start
+    assert out.count("\n") == n  # one line per row, output stays linear
+    assert elapsed < 5.0
+
+
+def test_conversion_html_to_markdown_pre_code_whitespace():
+    """Test preformatted whitespace."""
+
+    def to_md(body):
+        """Wrapper to simplify html-to-markdown conversion tests."""
+        return convert_between(NotifyFormat.HTML, NotifyFormat.MARKDOWN, body)
+
+    # Internal leading whitespace and blank-looking indentation differences
+    # between lines are preserved exactly
+    assert (
+        to_md("<pre>  leading\n    more leading\nback to zero</pre>")
+        == "```\n  leading\n    more leading\nback to zero\n```"
+    )
+
+    # Leading/trailing spaces inside inline <code> survive too
+    assert to_md("<code>  leading spaces  </code>") == "`  leading spaces  `"
+
+    # Whitespace is preserved the same way even when nested inside a list item
+    # (which now adds its own 2-space indentation in front -- see
+    # test_conversion_html_to_markdown_list_indentation -- without altering
+    # anything the content already had: ".
+    assert to_md("<ul><li><pre>  a\n    b\nc</pre></li></ul>") == (
+        "- ```\n    a\n      b\n  c\n  ```"
+    )
 
 
 def test_conversion_text_to():

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -250,9 +250,7 @@ def test_conversion_html_to_markdown():
     # Empty string in, empty string out
     assert to_md("") == ""
 
-    # Paragraphs need a full blank line between them -- a single newline is
-    # just a soft line break within one paragraph under CommonMark, not a
-    # separate paragraph
+    # Paragraphs need a full blank line between them.
     assert (
         to_md("<p>line 1</p><p>line 2</p><p>line 3</p>")
         == "line 1\n\nline 2\n\nline 3"
@@ -268,9 +266,7 @@ def test_conversion_html_to_markdown():
     assert to_md("<B>bold text</B>") == "**bold text**"
     assert to_md("<I>italic</I>") == "*italic*"
 
-    # Uppercase and mixed-case self-closing <BR/> also produce a hard break
-    # (two trailing spaces then a newline -- see handle_starttag("br") for why
-    # a bare "\n" isn't enough)
+    # Uppercase self-closing <BR/> tags also produce CommonMark hard breaks.
     assert (
         to_md("line one<BR/>line two<BR />line three")
         == "line one  \nline two  \nline three"
@@ -315,12 +311,7 @@ def test_conversion_html_to_markdown():
     assert to_md("<i>italic</i>") == "*italic*"
     assert to_md("<em>italic</em>") == "*italic*"
 
-    # Inline bold wrapping a paragraph
-    #
-    # Every href is wrapped in angle brackets ("<...>" rather than a bare
-    # "(...)" destination) -- this is what prevents a crafted href value from
-    # breaking out of the link early via an unescaped ')' and injecting
-    # additional Markdown.
+    # Angle destinations prevent parentheses in an href from ending links.
     assert (
         to_md(
             "<body><div>line 1 <b>bold</b></div> "
@@ -361,8 +352,7 @@ def test_conversion_html_to_markdown():
     assert to_md("<a name='top'>jump target</a>") == "jump target"
 
     # <span> is inline -- it passes text through without a newline; <div> is
-    # block-level and paragraph-like, so it's followed by a full blank line the
-    # same way two <p> tags are
+    # block-level and paragraph-like, so it adds a blank line.
     assert to_md("<div>block</div><span>inline</span>") == "block\n\ninline"
 
     # HTML comments are stripped entirely; surrounding text is preserved
@@ -559,16 +549,13 @@ def test_conversion_html_to_markdown_lists():
     )
 
     # Malformed HTML: missing </li> in a <ul> HTMLParser does not synthesize
-    # implicit close events; each missing </li> is simply absent, but the next
-    # <li> still starts a new item
+    # implicit close events; each missing </li> is simply absent, but the next.
     assert (
         to_md("<ul><li>item A<li>item B<li>item C</ul>")
         == "- item A\n- item B\n- item C"
     )
 
-    # Malformed HTML: missing </li> in a <ol> Without </li> the counter is
-    # never incremented, so all items render as "1." -- this is expected
-    # garbage-in/garbage- out behaviour
+    # Without </li>, ordered-list counters cannot advance.
     assert (
         to_md("<ol><li>one<li>two<li>three</ol>") == "1. one\n1. two\n1. three"
     )
@@ -598,19 +585,13 @@ def test_conversion_html_to_markdown_lists():
         == "- see `x*2 #tag`"
     )
 
-    # <pre> inside <li>: fenced block with indentation preserved, and every
-    # line of the fence (both fences plus the content) gets the list item's own
-    # indentation in front -- without it, the fence wouldn't be recognized as
-    # part of the same list.
+    # Fenced blocks retain content and list indentation.
     assert (
         to_md("<ul><li>code:<pre>  indented\n  here</pre></li></ul>")
         == "- code:\n  ```\n    indented\n    here\n  ```"
     )
 
-    # <pre> inside a nested <li>: indentation inside the fence is preserved
-    # regardless of the surrounding list nesting depth, with the list's own
-    # indentation (4 spaces here, matching " - ") added in front of it, not
-    # replacing it
+    # Nested fenced blocks combine content indentation with list indentation.
     assert (
         to_md(
             "<ul><li>outer<ul><li>inner:<pre>  x = 1</pre></li></ul></li></ul>"
@@ -618,15 +599,12 @@ def test_conversion_html_to_markdown_lists():
         == "- outer\n  - inner:\n    ```\n      x = 1\n    ```"
     )
 
-    # A block element as the first child of <li> used to emit a spurious
-    # BLOCK_END that orphaned the marker on its own line.
+    # A first-child block shares the list marker's line.
 
     # Single item with a <p> first child
     assert to_md("<ul><li><p>alpha</p></li></ul>") == "- alpha"
 
-    # Multiple items each with a <p> first child -- each <li>'s own <p> closes
-    # and reopens with a full blank line, the same as any other two paragraph-
-    # like blocks would
+    # Multiple items each with a <p> first child.
     assert (
         to_md("<ul><li><p>alpha</p></li><li><p>beta</p></li></ul>")
         == "- alpha\n\n- beta"
@@ -635,9 +613,7 @@ def test_conversion_html_to_markdown_lists():
     # Multiple <p> children inside one <li>
     assert to_md("<ul><li><p>one</p><p>two</p></li></ul>") == "- one\n\n  two"
 
-    # Mixed: direct text for first item, <p> for second -- the 2nd <li>'s own
-    # marker glues directly onto its <p> (no preceding paragraph to separate
-    # from within that item), so this one stays single-spaced
+    # Mixed: direct text for first item, <p> for second.
     assert (
         to_md("<ul><li>direct</li><li><p>wrapped</p></li></ul>")
         == "- direct\n- wrapped"
@@ -658,10 +634,7 @@ def test_conversion_html_to_markdown_lists():
         == "- [**bold link**](</x>)"
     )
 
-    # <a> link followed by a <p> sibling inside the same <li> -- the <p> still
-    # gets a full blank line before it, the same as any paragraph, and (still
-    # being part of the same item) the item's own indentation in front of it
-    # too
+    # <a> link followed by a <p> sibling inside the same <li>.
     assert (
         to_md("<ul><li><a href='/x'>link</a><p>more</p></li></ul>")
         == "- [link](</x>)\n\n  more"
@@ -675,9 +648,7 @@ def test_conversion_html_to_markdown_escaping():
         """Wrapper to simplify html-to-markdown conversion tests."""
         return convert_between(NotifyFormat.HTML, NotifyFormat.MARKDOWN, body)
 
-    # Code/pre delimiter collision A backtick inside <code> widens the inline
-    # delimiter so it can't be closed early by a backtick already present in
-    # the content
+    # Embedded backticks widen code delimiters.
     assert to_md("<code>a`b</code>") == "``a`b``"
 
     # Content starting or ending with a backtick gets a padding space, per
@@ -691,9 +662,7 @@ def test_conversion_html_to_markdown_escaping():
     # Plain content with no backticks still uses the minimal delimiter
     assert to_md("<pre>x</pre>") == "```\nx\n```"
 
-    # Ignored containers must not leak Markdown markers Only the suppressed
-    # text is dropped in the original report -- here the "**" markers from <b>
-    # must not leak either
+    # Ignored containers suppress both text and Markdown markers.
     assert (
         to_md(
             "<html><head><b>ignore</b></head><body><p>keep</p></body></html>"
@@ -721,14 +690,10 @@ def test_conversion_html_to_markdown_escaping():
     # an empty fence
     assert to_md("<script>ignore<pre>code</pre></script><p>keep</p>") == "keep"
 
-    # --- Link destinations with whitespace --- A bare Markdown link
-    # destination cannot contain a space; wrap it in angle brackets so the link
-    # target isn't silently truncated
+    # Angle destinations preserve whitespace in link targets.
     assert to_md("<a href='/my page'>link</a>") == "[link](</my page>)"
 
-    # --- Nested tags inside code/pre are inert --- Their own markup carries no
-    # meaning, but their literal text still joins the buffered content (no out-
-    # of-order marker leakage)
+    # Nested tags are inert inside preformatted content.
     assert (
         to_md("<pre>before <a href='/x'>link</a> after</pre>")
         == "```\nbefore link after\n```"
@@ -756,9 +721,7 @@ def test_conversion_html_to_markdown_escaping():
     assert to_md("<p>back\\*slash</p>") == r"back\\\*slash"
 
     # '_' (CommonMark's other emphasis delimiter) and '~' (GFM/chat- dialect
-    # strikethrough) are escaped unconditionally, the same as '*' -- otherwise
-    # plain text containing them risks being read as emphasis/strikethrough it
-    # was never meant to be
+    # strikethrough) are escaped unconditionally, the same as '*'.
     assert to_md("<p>_literal_</p>") == r"\_literal\_"
     assert to_md("<p>my_variable_name</p>") == r"my\_variable\_name"
     assert to_md("<p>~strikethrough~</p>") == r"\~strikethrough\~"
@@ -856,10 +819,7 @@ def test_conversion_html_to_markdown_line_start_escaping():
     )
     assert to_md("<p>+ plus sign list?</p>") == "\\+ plus sign list?"
 
-    # A line that's nothing but repeated "-" is escaped so it can't be read as
-    # a thematic break (<hr>) -- or, repeated "-"/"=" directly under a
-    # preceding line with no blank line between them (joined by <br>), as a
-    # setext heading underline.
+    # Escape repeated dashes that could become a thematic break.
     assert to_md("<p>Some text</p><p>---</p><p>more text</p>") == (
         "Some text\n\n\\---\n\nmore text"
     )
@@ -904,8 +864,8 @@ def test_conversion_html_to_markdown_hardening():
     assert to_md("</ul>text") == "text"
     assert to_md("</ol>text") == "text"
 
-    # </li> emits a BLOCK_END but _pop_to still finds nothing -- the text that
-    # follows is unindented and stored normally
+    # </li> finds no open <li> anywhere on the stack and is a no-op -- the
+    # text that follows is unindented and stored normally
     assert to_md("</li>text") == "text"
 
     # Multiple stray close tags in a row must not crash or corrupt state
@@ -913,6 +873,18 @@ def test_conversion_html_to_markdown_hardening():
 
     # A valid list after a stray close must still render correctly
     assert to_md("</ul><ul><li>A</li><li>B</li></ul>") == "- A\n- B"
+
+    # A stray close tag with content on BOTH sides must be a complete no-op,
+    # not just absorbed because nothing preceded it.
+    assert to_md("a</ul>b") == "ab"
+    assert to_md("a</ol>b") == "ab"
+    assert to_md("a</li>b") == "ab"
+    assert to_md("a</blockquote>b") == "ab"
+    assert to_md("a</td>b") == "ab"
+    assert to_md("a</th>b") == "ab"
+
+    # A stray <td>/<th> close still falls through cleanly when content follows.
+    assert to_md("<p>a</td>b</p>") == "ab"
 
     # _make_frame() empty-stack guard
     conv = HTMLMarkdownConverter()
@@ -1002,8 +974,7 @@ def test_conversion_html_to_markdown_hardening():
     assert BLOCKQUOTE_DEPTH_MAX == 4
 
     # Each level is its own <p>, so every line of real content is followed by a
-    # blank (but still "> "-prefixed) separator line -- see
-    # test_conversion_html_to_markdown_blockquotes for that part on its own.
+    # blank (but still "> "-prefixed) separator line.
     one_per_level = "<blockquote><p>x</p>" * 10 + "</blockquote>" * 10
     out = to_md(one_per_level)
     lines = out.split("\n")
@@ -1050,9 +1021,7 @@ def test_conversion_html_to_markdown_blockquotes():
         == "> a\n>\n> b\n>\n> c"
     )
 
-    # A heading doesn't need that same blank-line treatment -- ATX headings are
-    # self- delimiting (a single line), so whatever follows already starts its
-    # own block regardless of blank lines
+    # A heading doesn't need that same blank-line treatment.
     assert (
         to_md("<blockquote><h2>Title</h2><p>body</p></blockquote>")
         == "> ## Title\n> body"
@@ -1066,9 +1035,7 @@ def test_conversion_html_to_markdown_blockquotes():
     )
 
     # Nested blockquotes accumulate one "> " per level, not per ancestor's full
-    # prefix (that would double-count: a naive fix that writes the *cumulative*
-    # prefix on every open, rather than one unit per level, turns two nested
-    # quotes into "> > > ".
+    # cumulative prefix, which would double-count outer quote levels.
     assert (
         to_md("<blockquote><blockquote>nested</blockquote></blockquote>")
         == "> > nested"
@@ -1076,6 +1043,29 @@ def test_conversion_html_to_markdown_blockquotes():
     assert to_md(
         "<blockquote><blockquote><p>a</p><p>b</p></blockquote></blockquote>"
     ) == ("> > a\n> >\n> > b")
+
+    # Bare text follows the same one-prefix-per-level rule.
+    assert (
+        to_md("<blockquote>outer<blockquote>inner</blockquote></blockquote>")
+        == "> outer\n>\n> > inner"
+    )
+    assert to_md(
+        "<blockquote>a<blockquote>b<blockquote>c</blockquote>"
+        "</blockquote></blockquote>"
+    ) == ("> a\n>\n> > b\n> >\n> > > c")
+
+    # The same text-then-nested-blockquote transition, once depth is already
+    # clamped at BLOCKQUOTE_DEPTH_MAX, must not add yet another level.
+    assert BLOCKQUOTE_DEPTH_MAX == 4
+    capped = (
+        "<blockquote>" * 4
+        + "x<blockquote>y</blockquote>"
+        + ("</blockquote>" * 4)
+    )
+    out = to_md(capped)
+    assert "> > > > x" in out
+    assert "> > > > > y" not in out
+    assert "> > > > y" in out
 
     # Content after a blockquote needs a full boundary without the quote
     # prefix.
@@ -1089,8 +1079,7 @@ def test_conversion_html_to_markdown_blockquotes():
     )
 
     # An entirely empty blockquote (no children at all, nested or not) produces
-    # no output -- there's no content to quote, so the marker it would have
-    # written is removed rather than left dangling on its own.
+    # no output.
     assert to_md("<blockquote></blockquote>") == ""
     assert to_md("<blockquote><blockquote></blockquote></blockquote>") == ""
 
@@ -1118,9 +1107,7 @@ def test_conversion_html_to_markdown_emphasis():
         return convert_between(NotifyFormat.HTML, NotifyFormat.MARKDOWN, body)
 
     # Leading/trailing whitespace inside the tag must end up outside the
-    # delimiters -- a CommonMark delimiter directly touching whitespace can
-    # never open/close emphasis ("* text *" renders as literal asterisks, not
-    # emphasis)
+    # delimiters.
     assert to_md("<em> text </em>") == "*text*"
     assert to_md("<strong> bold </strong>") == "**bold**"
     assert to_md("<em>  multi  space  </em>") == "*multi space*"
@@ -1151,14 +1138,11 @@ def test_conversion_html_to_markdown_emphasis():
     assert to_md("<em></em><em>x</em>") == "*x*"
 
     # A stray close tag with no matching open is a no-op, the same as other
-    # malformed- HTML cases elsewhere in this parser -- it must not emit an
-    # unpaired closing delimiter
+    # malformed- HTML cases elsewhere in this parser.
     assert to_md("</b>text") == "text"
     assert to_md("<p>a</b>b</p>") == "ab"
 
-    # Mismatched open/close tags ("<i>x</b>y") -- the close belongs to neither
-    # this <i> nor anything else, so it's a no-op; <i> stays open and is auto-
-    # closed at end of document (see below) once "y" has joined it
+    # Mismatched open/close tags ("<i>x</b>y").
     assert to_md("<i>x</b>y") == "*xy*"
 
     # A tag left open with no closing tag at all is auto-closed at end of
@@ -1194,28 +1178,22 @@ def test_conversion_html_to_markdown_empty_blocks():
         to_md("<p>a</p><div></div><div></div><div></div><p>b</p>") == "a\n\nb"
     )
 
-    # A marker (list bullet or quote prefix) with only empty block tags after
-    # it still glues onto the first real content that eventually follows,
-    # instead of being stranded on its own line
+    # Empty blocks do not detach a marker from later content.
     assert (
         to_md("<ul><li><div></div><div></div><p>text</p></li></ul>")
         == "- text"
     )
     assert to_md("<blockquote><div></div><p>text</p></blockquote>") == "> text"
 
-    # A marker with no real content ever attached to it (not even past an empty
-    # block) is dropped entirely, the same way an empty
-    # <blockquote></blockquote> is
+    # Drop markers that never receive content.
     assert to_md("<ul><li></li></ul>") == ""
     assert to_md("<ul><li><div></div></li></ul>") == ""
 
     # A sibling marker arriving after the first one's empty block tags replaces
-    # it rather than gluing onto it -- "- " followed by another "- " from a
-    # different <li> must not become "- - "
+    # it rather than gluing onto it.
     assert to_md("<ul><li><div></div></li><li>real</li></ul>") == "- real"
 
-    # Same idea for a blockquote restating its own prefix on a fresh line after
-    # an empty block -- must not double up to "> > ".
+    # Empty blocks do not duplicate a blockquote prefix.
     assert (
         to_md("<blockquote><p>line1</p><div></div><p>line2</p></blockquote>")
         == "> line1\n>\n> line2"
@@ -1229,8 +1207,7 @@ def test_conversion_html_to_markdown_empty_blocks():
     assert to_md("<p>a</p>   <p>b</p>") == "a\n\nb"
 
     # A standalone &nbsp; is a deliberate space, not incidental formatting
-    # whitespace -- it survives as its own line of content, the same way bare
-    # real text between two blocks would.
+    # whitespace.
     assert to_md("<p>a</p>&nbsp;<p>b</p>") == "a\n\n\xa0\n\nb"
 
     # &nbsp; used inline within real text is unaffected, and still collapses to
@@ -1248,16 +1225,11 @@ def test_conversion_html_to_markdown_empty_blocks():
     assert to_md("<p>a</p><hr><hr><p>b</p>") == "a\n\n---\n\n---\n\nb"
 
     # <hr> as the first thing in a blockquote/list item glues onto the marker;
-    # inside an open blockquote, its own opening boundary still applies, giving
-    # it a blank "> " line before it the same way a 2nd <p> sibling would get
-    # one
+    # inside an open blockquote, its own opening boundary still applies.
     assert to_md("<ul><li><hr></li></ul>") == "- ---"
     assert to_md("<blockquote><p>a</p><hr></blockquote>") == "> a\n>\n> ---"
 
-    # Real page text that happens to *look* like a generated marker (e.g. a
-    # paragraph whose only content is "- ") must never be mistaken for one by
-    # whatever renders the Markdown output -- markers are only ever the ones
-    # this converter writes.
+    # Real page text that happens to *look* like a generated marker (e.g.
     assert to_md("<p>- </p><p>real</p>") == "\\-\n\nreal"
     assert to_md("<p>-  </p>") == "\\-"
     assert (
@@ -1265,9 +1237,7 @@ def test_conversion_html_to_markdown_empty_blocks():
         == "\\-\n\nreal div content"
     )
     # Real text directly inside a real <li> that itself looks like a marker is
-    # escaped too -- "- -" (genuine marker, then unescaped text starting with
-    # "-") risks being read as a nested sub-list rather than this item's own
-    # text.
+    # escaped too.
     assert to_md("<ul><li>- </li></ul>") == "- \\-"
 
 
@@ -1279,14 +1249,10 @@ def test_conversion_html_to_markdown_list_indentation():
         return convert_between(NotifyFormat.HTML, NotifyFormat.MARKDOWN, body)
 
     # Baseline: a single <p> as an <li>'s only child still just glues onto the
-    # marker -- no continuation indentation is even needed since there's
-    # nothing beyond the first line
+    # marker.
     assert to_md("<li><p>text</p></li>") == "- text"
 
-    # A 2nd <p> within the same <li> is a continuation line: it needs the
-    # item's own indentation in front (2 spaces, matching "- "), or a
-    # CommonMark-compliant renderer won't recognize it as part of the list item
-    # at all -- it would end the list.
+    # Later paragraphs use the current item's continuation indentation.
     assert to_md("<ul><li><p>one</p><p>two</p></li></ul>") == "- one\n\n  two"
 
     # Ordered lists need the indentation to match their own (wider) marker
@@ -1307,26 +1273,19 @@ def test_conversion_html_to_markdown_list_indentation():
     )
 
     # A nested sublist's own marker (computed independently for its own depth)
-    # must not be *additionally* indented on top of that -- that would double-
-    # count the outer level's contribution
+    # must not be *additionally* indented on top of that.
     assert to_md("<ul><li>x<ul><li>x</li></ul></li></ul>") == "- x\n  - x"
     assert (
         to_md("<ul><li>L1<ul><li>L2<ul><li>L3</li></ul></li></ul></li></ul>")
         == "- L1\n  - L2\n    - L3"
     )
 
-    # A <blockquote> nested inside an <li>, with multiple paragraphs of its
-    # own, needs *both* the list item's indentation and the quote prefix on
-    # every continuation line -- list indentation first, then "> ", matching
-    # how the first line ("- > a").
+    # Nested quotes combine list indentation with quote prefixes.
     assert to_md(
         "<ul><li><blockquote><p>a</p><p>b</p></blockquote></li></ul>"
     ) == ("- > a\n  >\n  > b")
 
-    # The reverse nesting -- an <li> as the first thing inside a <blockquote>
-    # -- must keep the quote prefix; it used to be lost entirely because <li>
-    # always forced a fresh boundary instead of gluing onto a pending marker
-    # the way other block tags.
+    # A first-child list inside a blockquote retains the quote prefix.
     assert to_md("<blockquote><ul><li>text</li></ul></blockquote>") == (
         "> - text"
     )
@@ -1336,24 +1295,17 @@ def test_conversion_html_to_markdown_list_indentation():
         "> - a\n> - b"
     )
 
-    # A <blockquote> directly chaining onto another blockquote's restated
-    # prefix (after a paragraph closes) must still build up nesting depth
-    # correctly ("> > ", not just "> ") -- this is the same chaining mechanism
-    # nested.
+    # Chained blockquotes retain nesting after a paragraph boundary.
     assert to_md(
         "<blockquote><p>a</p><blockquote>nested</blockquote></blockquote>"
     ) == ("> a\n>\n> > nested")
 
-    # <pre>/<samp> inside an <li>: every line of the fence -- both fences and
-    # every line of the content between them -- needs the list item's
-    # indentation too, or the fence wouldn't be recognized as staying part of
-    # the same list item.
+    # <pre>/<samp> inside an <li>: every line of the fence.
     assert to_md("<ul><li>code:<pre>  indented\n  here</pre></li></ul>") == (
         "- code:\n  ```\n    indented\n    here\n  ```"
     )
 
-    # Same, but nested one list level deeper (4-space indentation, matching " -
-    # ")
+    # A deeper list adds another indentation level to the fence.
     assert to_md(
         "<ul><li>outer<ul><li>inner:<pre>  x = 1</pre></li></ul></li></ul>"
     ) == ("- outer\n  - inner:\n    ```\n      x = 1\n    ```")
@@ -1367,15 +1319,12 @@ def test_conversion_html_to_markdown_br():
         return convert_between(NotifyFormat.HTML, NotifyFormat.MARKDOWN, body)
 
     # Two trailing spaces then a newline -- a bare "\n" is only a soft break
-    # under CommonMark (most renderers collapse it to a single space rather
-    # than a visible line break)
+    # under CommonMark (most renderers collapse it to a single space rather.
     assert to_md("line1<br>line2") == "line1  \nline2"
     assert to_md("line1<br/>line2") == "line1  \nline2"
     assert to_md("line1<br />line2") == "line1  \nline2"
 
-    # Verified against an actual renderer, not just the raw Markdown shape -- a
-    # real <br> must appear, with no leftover stray character from the hard-
-    # break syntax itself
+    # Verified against an actual renderer, not just the raw Markdown shape.
     rendered = convert_between(
         NotifyFormat.MARKDOWN, NotifyFormat.HTML, to_md("line1<br>line2")
     )
@@ -1444,8 +1393,7 @@ def test_conversion_html_to_markdown_tables():
     )
 
     # A newline a cell's own content produced (here, a <br>) is flattened to a
-    # single space -- a Markdown table row is always exactly one line;
-    # embedding a raw newline would corrupt the row
+    # single space.
     assert to_md("<table><tr><td>a<br>b</td></tr></table>") == (
         "| a b |\n| --- |"
     )
@@ -1473,9 +1421,7 @@ def test_conversion_html_to_markdown_tables():
         == "text"
     )
 
-    # Stray text directly inside <table>/<tr> but outside any <td>/<th> (almost
-    # always just HTML formatting whitespace in practice) is suppressed, the
-    # same as <ul>/<ol> already suppress stray text outside <li>
+    # Suppress text outside table cells.
     assert to_md("<table>stray<tr><td>A</td></tr></table>") == (
         "| A |\n| --- |"
     )
@@ -1539,13 +1485,44 @@ def test_conversion_html_to_markdown_tables_hardening():
     )
 
     # A stray </tr> or </table> with nothing matching open at all (no enclosing
-    # structure whatsoever, not even an open cell) is a no-op -- same as other
-    # malformed-HTML cases elsewhere in this parser, e.g. a stray </ul> or
-    # </li>
+    # structure whatsoever, not even an open cell) is a no-op.
     assert to_md("</tr>text") == "text"
     assert to_md("</table>text") == "text"
     assert to_md("<p>a</tr>b</p>") == "ab"
     assert to_md("<p>a</table>b</p>") == "ab"
+
+    # A stray <tr> with no enclosing <table> renders as a one-row table of its
+    # own and remains separated from following content.
+    assert to_md("<tr><td>cell</td></tr>after") == (
+        "| cell |\n| --- |\n\nafter"
+    )
+
+    # A <table> nested inside another table's cell has no Markdown
+    # representation.
+    assert to_md(
+        "<table><tr><td>outer<table><tr><td>inner</td></tr></table>"
+        "</td></tr></table>"
+    ) == ("| outer |\n| --- |")
+
+    # Same, with content both before and after the nested table, and the
+    # nested table itself containing more than one row.
+    assert to_md(
+        "<table><tr><td>a<table><tr><td>b</td></tr><tr><td>c</td></tr>"
+        "</table>d</td></tr></table>"
+    ) == ("| a d |\n| --- |")
+
+    # Three levels deep -- only the outermost table survives.
+    assert to_md(
+        "<table><tr><td>L1<table><tr><td>L2<table><tr><td>L3</td></tr>"
+        "</table></td></tr></table></td></tr></table>"
+    ) == ("| L1 |\n| --- |")
+
+    # A literal '|' alongside a nested table in the same cell -- the '|' is
+    # still escaped normally; the nested table still contributes nothing.
+    assert to_md(
+        "<table><tr><td>a|b<table><tr><td>c</td></tr></table></td></tr>"
+        "</table>"
+    ) == ("| a\\|b |\n| --- |")
 
     # Only the very first <tr> is ever closed
     assert to_md("<table><tr><td>A</td></tr><tr><td>B<tr><td>C</table>") == (
@@ -1553,8 +1530,7 @@ def test_conversion_html_to_markdown_tables_hardening():
     )
 
     # Performance: many rows, each with unclosed <td>/<tr> tags (the legacy-
-    # markup shape above), large enough that an O(N^2) recovery path would
-    # dominate.
+    # markup shape), large enough to expose quadratic recovery.
     n = 20000
     html = "<table>" + "<tr><td>a<td>b" * n + "</table>"
     start = default_timer()
@@ -1582,12 +1558,123 @@ def test_conversion_html_to_markdown_pre_code_whitespace():
     assert to_md("<code>  leading spaces  </code>") == "`  leading spaces  `"
 
     # Whitespace is preserved the same way even when nested inside a list item
-    # (which now adds its own 2-space indentation in front -- see
-    # test_conversion_html_to_markdown_list_indentation -- without altering
-    # anything the content already had: ".
+    # (which now adds its own 2-space indentation in front.
     assert to_md("<ul><li><pre>  a\n    b\nc</pre></li></ul>") == (
         "- ```\n    a\n      b\n  c\n  ```"
     )
+
+
+def test_conversion_html_to_markdown_unterminated_pre_code():
+    """Test <pre>/<code>/<samp> left open at end of document."""
+
+    def to_md(body):
+        """Wrapper to simplify html-to-markdown conversion tests."""
+        return convert_between(NotifyFormat.HTML, NotifyFormat.MARKDOWN, body)
+
+    # A <pre>/<code>/<samp> with no closing tag at all is auto-closed and
+    # rendered at end of document.
+    assert to_md("<pre>unterminated code") == "```\nunterminated code\n```"
+    assert to_md("<code>inline unterminated") == "`inline unterminated`"
+    assert to_md("<samp>unterminated output") == (
+        "```\nunterminated output\n```"
+    )
+
+    # Still works with real content before the unterminated block.
+    assert to_md("text<pre>code") == "text\n```\ncode\n```"
+
+    # A suppressed (non-storing) unterminated frame contributes nothing.
+    assert to_md("<head><pre>hidden") == ""
+
+
+def test_conversion_html_to_markdown_table_code_pipe():
+    """Test '|' inside an inline code span within a table cell."""
+
+    def to_md(body):
+        """Wrapper to simplify html-to-markdown conversion tests."""
+        return convert_between(NotifyFormat.HTML, NotifyFormat.MARKDOWN, body)
+
+    # A '|' inside a code span is already literal there.
+    assert to_md("<table><tr><td><code>a|b</code></td></tr></table>") == (
+        "| `a|b` |\n| --- |"
+    )
+
+    # A '|' outside any code span in the same cell is still escaped.
+    assert to_md("<table><tr><td>x|<code>a|b</code>|y</td></tr></table>") == (
+        "| x\\|`a|b`\\|y |\n| --- |"
+    )
+
+    # Literal backtick CHARACTERS typed as ordinary text (not an actual <code>
+    # element) get backslash-escaped by MARKDOWN_ESCAPE like any other.
+    assert to_md("<table><tr><td>`a|b`</td></tr></table>") == (
+        "| \\`a\\|b\\` |\n| --- |"
+    )
+
+    # A real code span and escaped literal backticks can coexist in the same
+    # cell -- only the real one's '|' stays unescaped.
+    assert to_md(
+        "<table><tr><td><code>x|y</code> and `lit|eral`</td></tr></table>"
+    ) == ("| `x|y` and \\`lit\\|eral\\` |\n| --- |")
+
+    # A real code span immediately preceded by an ESCAPED literal backslash (an
+    # even number of '\' characters, i.e.
+    assert to_md(
+        "<table><tr><td>text\\<code>a|b</code></td></tr></table>"
+    ) == ("| text\\\\`a|b` |\n| --- |")
+    assert to_md(
+        "<table><tr><td>text\\\\<code>a|b</code></td></tr></table>"
+    ) == ("| text\\\\\\\\`a|b` |\n| --- |")
+
+    # An unmatched (unbalanced) bare backtick run inside a cell.
+    conv = HTMLMarkdownConverter()
+    assert conv._escape_cell_pipes("a`b|c") == "a`b\\|c"
+
+    # _build_backtick_run_index() / _find_unescaped_run() skip escape pairs
+    # while indexing, and the lookup returns None when no run of the exact.
+    assert (
+        conv._find_unescaped_run(conv._build_backtick_run_index("\\` `"), 0, 1)
+        == 3
+    )
+    assert (
+        conv._find_unescaped_run(
+            conv._build_backtick_run_index("no backticks here"), 0, 1
+        )
+        is None
+    )
+    assert (
+        conv._find_unescaped_run(
+            conv._build_backtick_run_index("``too short"), 0, 3
+        )
+        is None
+    )
+
+    # A genuine match arbitrarily far from `start` is still found.
+    far = "a" * 200_000 + "`"
+    assert (
+        conv._find_unescaped_run(conv._build_backtick_run_index(far), 0, 1)
+        == 200_000
+    )
+
+    # A cell containing many distinct, non-matching backtick-run lengths must
+    # still resolve in roughly linear time, not quadratic.
+    def adversarial_cell(width_count):
+        body = ["`" * w + "x" for w in range(1, width_count + 1)]
+        body.append("`")
+        return "".join(body)
+
+    small = adversarial_cell(400)
+    large = adversarial_cell(800)
+
+    start = default_timer()
+    conv._escape_cell_pipes(small)
+    small_time = default_timer() - start
+
+    start = default_timer()
+    conv._escape_cell_pipes(large)
+    large_time = default_timer() - start
+
+    # Doubling the adversarial width count should roughly double the (tiny)
+    # runtime, not quadruple it.
+    assert large_time < small_time * 6 + 0.05
 
 
 def test_conversion_text_to():

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -778,16 +778,10 @@ def test_conversion_html_to_markdown_escaping():
     )
 
     # BiDi override/embedding characters must not defeat scheme detection.
-    assert to_md('<a href="‮javascript:alert(1)">click</a>') == (
-        "[click](<#>)"
-    )
-    assert to_md('<a href="‪javascript:alert(1)">click</a>') == (
-        "[click](<#>)"
-    )
+    assert to_md('<a href="‮javascript:alert(1)">click</a>') == ("[click](<#>)")
+    assert to_md('<a href="‪javascript:alert(1)">click</a>') == ("[click](<#>)")
     # U+2066 (LEFT-TO-RIGHT ISOLATE) must also be stripped.
-    assert to_md('<a href="⁦javascript:alert(1)">click</a>') == (
-        "[click](<#>)"
-    )
+    assert to_md('<a href="⁦javascript:alert(1)">click</a>') == ("[click](<#>)")
 
     # Keep legitimate app-specific schemes that are not explicitly unsafe.
     assert to_md('<a href="https://example.com">x</a>') == (

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -37,6 +37,7 @@ from apprise import NotifyFormat
 from apprise.conversion import (
     BLOCKQUOTE_DEPTH_MAX,
     LIST_DEPTH_MAX,
+    MAX_FRAME_DEPTH,
     HTMLMarkdownConverter,
     convert_between,
 )
@@ -999,6 +1000,42 @@ def test_conversion_html_to_markdown_hardening():
     elapsed = default_timer() - start
     assert len(out) < 20 * n
     assert elapsed < 3.0
+
+    # When emphasis or anchor tags are nested past MAX_FRAME_DEPTH, _push_frame
+    # returns False and the opening delimiter must NOT be emitted.
+    depth = MAX_FRAME_DEPTH + 1
+    em_open = "<em>" * depth
+    em_close = "</em>" * depth
+    out_em = to_md(f"{em_open}text{em_close}")
+    # The text must appear; no unmatched bare asterisk may leak through.
+    assert "text" in out_em
+    assert out_em.replace("*", "").strip() == "text"
+
+    # Same guard for <a> -- no unmatched "[" in the output.
+    a_open = '<a href="https://example.com">' * depth
+    a_close = "</a>" * depth
+    out_a = to_md(f"{a_open}text{a_close}")
+    assert "text" in out_a
+    # Count "[" and "](" -- every "[" must have a matching "](".
+    assert out_a.count("[") == out_a.count("](")
+
+    # At MAX_FRAME_DEPTH the <blockquote> frame is discarded and _push_frame
+    # returns False.
+    bq_open = "<blockquote>" * depth
+    bq_close = "</blockquote>" * depth
+    out_bq = to_md(f"{bq_open}text{bq_close}")
+    assert "text" in out_bq
+    # Every ">" line-prefix must correspond to a real nested blockquote level.
+    first_line = out_bq.splitlines()[0] if out_bq else ""
+    gt_count = len(first_line) - len(first_line.lstrip("> "))
+    assert gt_count <= BLOCKQUOTE_DEPTH_MAX * 2  # ">" + " " per level
+
+    # At MAX_FRAME_DEPTH the <li> frame is discarded and _push_frame returns
+    # False.  No _ListMarker must be appended without a backing frame.
+    li_open = "<ul>" + "<li>" * depth
+    li_close = "</li>" * depth + "</ul>"
+    out_li = to_md(f"{li_open}text{li_close}")
+    assert "text" in out_li
 
 
 def test_conversion_html_to_markdown_blockquotes():

--- a/tests/test_plugin_bark.py
+++ b/tests/test_plugin_bark.py
@@ -26,10 +26,14 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 # Disable logging for a cleaner testing output
+import json
 import logging
+from unittest import mock
 
 from helpers import AppriseURLTester
+import requests
 
+from apprise import Apprise, NotifyFormat
 from apprise.plugins.bark import NotifyBark
 
 logging.disable(logging.CRITICAL)
@@ -290,3 +294,31 @@ def test_plugin_bark_urls():
 
     # Run our general tests
     AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+@mock.patch("requests.post")
+def test_plugin_bark_html_to_markdown_format(mock_post):
+    """NotifyBark(): HTML body is converted to Markdown."""
+
+    # Prepare Mock
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    # Load via Apprise URL with markdown format enabled
+    aobj = Apprise()
+    assert aobj.add("bark://192.168.0.6:8081/device_key/?format=markdown")
+
+    # Notify with an HTML body; the framework converts it to Markdown
+    # before dispatching to the Bark plugin
+    assert (
+        aobj.notify(
+            body="<b>hello</b> <i>world</i>",
+            body_format=NotifyFormat.HTML,
+        )
+        is True
+    )
+    assert mock_post.call_count == 1
+
+    # The body must arrive as Markdown, not stripped plain text
+    payload = json.loads(mock_post.call_args_list[0][1]["data"])
+    assert payload["markdown"] == "**hello** *world*"

--- a/tests/test_plugin_chime.py
+++ b/tests/test_plugin_chime.py
@@ -26,6 +26,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 # Disable logging for a cleaner testing output
+from json import loads
 import logging
 from unittest import mock
 
@@ -33,7 +34,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
-from apprise import Apprise
+from apprise import Apprise, NotifyFormat
 from apprise.plugins.chime import NotifyChime
 
 logging.disable(logging.CRITICAL)
@@ -443,3 +444,31 @@ def test_plugin_chime_url_identifier(mock_post):
     assert obj1.url_identifier[0] == NotifyChime.secure_protocol
     assert obj1.url_identifier[1] == TEST_WEBHOOK_ID
     assert obj1.url_identifier[2] == TEST_TOKEN
+
+
+@mock.patch("requests.post")
+def test_plugin_chime_html_to_markdown_format(mock_post):
+    """NotifyChime(): HTML body is converted to Markdown."""
+
+    # Prepare Mock
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    # Chime's notify_format is MARKDOWN by default
+    aobj = Apprise()
+    assert aobj.add("chime://{}/{}".format(TEST_WEBHOOK_ID, TEST_TOKEN))
+
+    # Notify with an HTML body; the framework should convert it
+    # to Markdown before dispatching to Chime
+    assert (
+        aobj.notify(
+            body="<b>hello</b> <i>world</i>",
+            body_format=NotifyFormat.HTML,
+        )
+        is True
+    )
+    assert mock_post.call_count == 1
+
+    # The body must arrive as Markdown, not as stripped plain text
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+    assert payload["Content"] == "**hello** *world*"

--- a/tests/test_plugin_dingtalk.py
+++ b/tests/test_plugin_dingtalk.py
@@ -26,10 +26,14 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 # Disable logging for a cleaner testing output
+from json import loads
 import logging
+from unittest import mock
 
 from helpers import AppriseURLTester
+import requests
 
+from apprise import Apprise, NotifyFormat
 from apprise.plugins.dingtalk import NotifyDingTalk
 
 logging.disable(logging.CRITICAL)
@@ -141,3 +145,31 @@ def test_plugin_dingtalk_urls():
 
     # Run our general tests
     AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+@mock.patch("requests.post")
+def test_plugin_dingtalk_html_to_markdown_format(mock_post):
+    """NotifyDingTalk(): HTML body is converted to Markdown."""
+
+    # Prepare Mock
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    # Load via Apprise URL with markdown format enabled
+    aobj = Apprise()
+    assert aobj.add("dingtalk://{}?format=markdown".format("a" * 8))
+
+    # Notify with an HTML body; the framework converts it to Markdown
+    # before dispatching to the DingTalk plugin
+    assert (
+        aobj.notify(
+            body="<b>hello</b> <i>world</i>",
+            body_format=NotifyFormat.HTML,
+        )
+        is True
+    )
+    assert mock_post.call_count == 1
+
+    # The body must arrive as Markdown, not stripped plain text
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+    assert payload["markdown"]["text"] == "**hello** *world*"

--- a/tests/test_plugin_discord.py
+++ b/tests/test_plugin_discord.py
@@ -1214,3 +1214,41 @@ def test_plugin_discord_attach_memory(mock_post):
 
     assert obj.notify(body="Test", attach=mem) is True
     assert mock_post.call_count >= 1
+
+
+@mock.patch("requests.post")
+def test_plugin_discord_html_to_markdown_format(mock_post):
+    """NotifyDiscord(): HTML body is converted to Markdown."""
+
+    webhook_id = "A" * 24
+    webhook_token = "B" * 64
+
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+    mock_post.return_value.content = ""
+    mock_post.return_value.headers = {}
+
+    # Instantiate a Discord plugin in Markdown mode with fields
+    # disabled so the body lands in embeds[0]["description"] directly
+    obj = Apprise.instantiate(
+        f"discord://{webhook_id}/{webhook_token}/?format=markdown&fields=no"
+    )
+
+    aobj = Apprise()
+    aobj.add(obj)
+
+    # Notify with an HTML body; the framework should convert it
+    # to Markdown before dispatching to Discord
+    assert (
+        aobj.notify(
+            body="<b>hello</b> <i>world</i>",
+            body_format=NotifyFormat.HTML,
+        )
+        is True
+    )
+    assert mock_post.call_count == 1
+
+    # The body must arrive in the embed description as Markdown,
+    # not as stripped plain text
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+    assert payload["embeds"][0]["description"] == "**hello** *world*"

--- a/tests/test_plugin_evolution.py
+++ b/tests/test_plugin_evolution.py
@@ -376,6 +376,12 @@ def test_plugin_evolution_html_to_markdown_hardening(mock_post):
     # Preserve unmatched backticks as literal text.
     assert f("text ``unterminated") == "text ``unterminated"
 
+    # Collapse runs of three or more backticks without dropping spaces.
+    # Three backticks collapse to two.
+    assert f("`` code```here ``") == "``` code``here ```"
+    # Longer backtick runs also collapse to two in one substitution.
+    assert f("````` content```` end `````") == "``` content`` end ```"
+
     # Collapse empty entities without affecting following content.
     assert f("****x") == "x"
 
@@ -395,35 +401,6 @@ def test_plugin_evolution_html_to_markdown_hardening(mock_post):
     # rather than emitting a dangling " (url)".
     assert f("[](<https://example.com/x>)") == "https://example.com/x"
 
-    # Indexed lookup skips escapes and requires an exact run width.
-    assert (
-        NotifyEvolution.find_unescaped_run(
-            NotifyEvolution.build_backtick_run_index("\\` `"), 0, 1
-        )
-        == 3
-    )
-    assert (
-        NotifyEvolution.find_unescaped_run(
-            NotifyEvolution.build_backtick_run_index("no backticks"), 0, 1
-        )
-        is None
-    )
-    assert (
-        NotifyEvolution.find_unescaped_run(
-            NotifyEvolution.build_backtick_run_index("`` `"), 0, 1
-        )
-        == 3
-    )
-
-    # Indexed lookup has no distance cutoff.
-    far = "a" * 200_000 + "`"
-    assert (
-        NotifyEvolution.find_unescaped_run(
-            NotifyEvolution.build_backtick_run_index(far), 0, 1
-        )
-        == 200_000
-    )
-
     # HTML body with a title: title is merged into the body as a heading
     # before the WhatsApp dialect conversion runs (covers _build_send_calls
     # title-merge branch).
@@ -438,7 +415,7 @@ def test_plugin_evolution_html_to_markdown_hardening(mock_post):
         is True
     )
     payload = loads(mock_post.call_args_list[-1][1]["data"])
-    assert payload["text"] == "# My Title\n*hello*"
+    assert payload["text"] == "*My Title*\n*hello*"
     mock_post.reset_mock()
 
     # Title that reduces to an empty string after stripping leading heading

--- a/tests/test_plugin_evolution.py
+++ b/tests/test_plugin_evolution.py
@@ -397,20 +397,20 @@ def test_plugin_evolution_html_to_markdown_hardening(mock_post):
 
     # Indexed lookup skips escapes and requires an exact run width.
     assert (
-        NotifyEvolution._find_unescaped_run(
-            NotifyEvolution._build_backtick_run_index("\\` `"), 0, 1
+        NotifyEvolution.find_unescaped_run(
+            NotifyEvolution.build_backtick_run_index("\\` `"), 0, 1
         )
         == 3
     )
     assert (
-        NotifyEvolution._find_unescaped_run(
-            NotifyEvolution._build_backtick_run_index("no backticks"), 0, 1
+        NotifyEvolution.find_unescaped_run(
+            NotifyEvolution.build_backtick_run_index("no backticks"), 0, 1
         )
         is None
     )
     assert (
-        NotifyEvolution._find_unescaped_run(
-            NotifyEvolution._build_backtick_run_index("`` `"), 0, 1
+        NotifyEvolution.find_unescaped_run(
+            NotifyEvolution.build_backtick_run_index("`` `"), 0, 1
         )
         == 3
     )
@@ -418,8 +418,40 @@ def test_plugin_evolution_html_to_markdown_hardening(mock_post):
     # Indexed lookup has no distance cutoff.
     far = "a" * 200_000 + "`"
     assert (
-        NotifyEvolution._find_unescaped_run(
-            NotifyEvolution._build_backtick_run_index(far), 0, 1
+        NotifyEvolution.find_unescaped_run(
+            NotifyEvolution.build_backtick_run_index(far), 0, 1
         )
         == 200_000
     )
+
+    # HTML body with a title: title is merged into the body as a heading
+    # before the WhatsApp dialect conversion runs (covers _build_send_calls
+    # title-merge branch).
+    aobj = Apprise()
+    assert aobj.add("evolutions://key@host/inst/5511999999999")
+    assert (
+        aobj.notify(
+            body="<b>hello</b>",
+            title="My Title",
+            body_format=NotifyFormat.HTML,
+        )
+        is True
+    )
+    payload = loads(mock_post.call_args_list[-1][1]["data"])
+    assert payload["text"] == "# My Title\n*hello*"
+    mock_post.reset_mock()
+
+    # Title that reduces to an empty string after stripping leading heading
+    # and list characters (html_to_markdown converts "  - " to "-").
+    # The heading is skipped and the title field is cleared regardless.
+    assert (
+        aobj.notify(
+            body="<b>hello</b>",
+            title="  - ",
+            body_format=NotifyFormat.HTML,
+        )
+        is True
+    )
+    payload = loads(mock_post.call_args_list[-1][1]["data"])
+    assert payload["text"] == "*hello*"
+    mock_post.reset_mock()

--- a/tests/test_plugin_evolution.py
+++ b/tests/test_plugin_evolution.py
@@ -33,7 +33,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
-from apprise import Apprise
+from apprise import Apprise, NotifyFormat
 from apprise.plugins.evolution import NotifyEvolution
 
 logging.disable(logging.CRITICAL)
@@ -316,3 +316,110 @@ def test_plugin_evolution_https(mock_post):
     assert obj.notify(body="secure msg") is True
     url = mock_post.call_args[0][0]
     assert url.startswith("https://")
+
+
+@mock.patch("requests.post")
+def test_plugin_evolution_html_to_markdown_hardening(mock_post):
+    """Test edge cases in the CommonMark-to-WhatsApp dialect
+    adaptation."""
+
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+    mock_post.return_value.content = b"{}"
+    mock_post.return_value.text = "{}"
+
+    def notify(body):
+        aobj = Apprise()
+        assert aobj.add("evolutions://key@host/inst/5511999999999")
+        assert aobj.notify(body=body, body_format=NotifyFormat.HTML) is True
+        payload = loads(mock_post.call_args_list[-1][1]["data"])
+        mock_post.reset_mock()
+        return payload["text"]
+
+    # Convert CommonMark emphasis to WhatsApp delimiters.
+    assert notify("<b>hello</b> <i>world</i>") == "*hello* _world_"
+
+    # Preserve adjacent nested emphasis.
+    assert notify("<b><i>x</i></b>") == "*_x_*"
+
+    # Non-adjacent nesting and sibling spans are unaffected.
+    assert notify("<b>bold <i>italic</i> still bold</b>") == (
+        "*bold _italic_ still bold*"
+    )
+    assert notify("<b>A</b><b>B</b>") == "*A**B*"
+
+    # Map inline and fenced code to WhatsApp's monospace syntax.
+    assert notify("<code>inline</code>") == "```inline```"
+    assert notify("<pre><code>block code</code></pre>") == (
+        "```\nblock code\n```"
+    )
+
+    # Preserve link labels beside WhatsApp's auto-linked URL.
+    assert (
+        notify('<a href="https://example.com/x">click here</a>')
+        == "click here (https://example.com/x)"
+    )
+
+    # Direct WhatsApp Markdown remains unchanged.
+    aobj = Apprise()
+    assert aobj.add("evolutions://key@host/inst/5511999999999")
+    assert aobj.notify(body="*already* whatsapp-bound markdown") is True
+    payload = loads(mock_post.call_args_list[-1][1]["data"])
+    assert payload["text"] == "*already* whatsapp-bound markdown"
+    mock_post.reset_mock()
+
+    # Drop CommonMark escapes unsupported by WhatsApp.
+    assert notify("<p>literal * asterisk</p>") == "literal * asterisk"
+
+    f = NotifyEvolution._commonmark_to_whatsapp
+
+    # Preserve unmatched backticks as literal text.
+    assert f("text ``unterminated") == "text ``unterminated"
+
+    # Collapse empty entities without affecting following content.
+    assert f("****x") == "x"
+
+    # Close nonempty unterminated emphasis and drop empty spans.
+    assert f("**unterminated") == "*unterminated*"
+    assert f("**") == ""
+
+    # Preserve an incomplete link as literal text.
+    assert f("[text](<https://example.com/unterminated") == (
+        "[text](<https://example.com/unterminated"
+    )
+
+    # Resolve CommonMark escapes inside WhatsApp link destinations.
+    assert f("[click](<https://e/x\\>y>)") == "click (https://e/x>y)"
+
+    # A link with no text at all -- the bare URL is kept on its own
+    # rather than emitting a dangling " (url)".
+    assert f("[](<https://example.com/x>)") == "https://example.com/x"
+
+    # Indexed lookup skips escapes and requires an exact run width.
+    assert (
+        NotifyEvolution._find_unescaped_run(
+            NotifyEvolution._build_backtick_run_index("\\` `"), 0, 1
+        )
+        == 3
+    )
+    assert (
+        NotifyEvolution._find_unescaped_run(
+            NotifyEvolution._build_backtick_run_index("no backticks"), 0, 1
+        )
+        is None
+    )
+    assert (
+        NotifyEvolution._find_unescaped_run(
+            NotifyEvolution._build_backtick_run_index("`` `"), 0, 1
+        )
+        == 3
+    )
+
+    # Indexed lookup has no distance cutoff.
+    far = "a" * 200_000 + "`"
+    assert (
+        NotifyEvolution._find_unescaped_run(
+            NotifyEvolution._build_backtick_run_index(far), 0, 1
+        )
+        == 200_000
+    )

--- a/tests/test_plugin_fluxer.py
+++ b/tests/test_plugin_fluxer.py
@@ -1369,3 +1369,40 @@ def test_plugin_fluxer_attach_memory(mock_post: mock.MagicMock) -> None:
 
     assert obj.notify(body="Test", attach=mem) is True
     assert mock_post.call_count >= 1
+
+
+@mock.patch("requests.post")
+def test_plugin_fluxer_html_to_markdown_format(mock_post):
+    """NotifyFluxer(): HTML body is converted to Markdown."""
+
+    webhook_id, webhook_token = _tokens()
+
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+    mock_post.return_value.content = ""
+    mock_post.return_value.headers = {}
+
+    # Instantiate a Fluxer plugin in Markdown mode with fields
+    # disabled so the body lands in embeds[0]["description"] directly
+    obj = Apprise.instantiate(
+        f"fluxer://{webhook_id}/{webhook_token}/?format=markdown&fields=no"
+    )
+
+    aobj = Apprise()
+    aobj.add(obj)
+
+    # Notify with an HTML body; the framework should convert it
+    # to Markdown before dispatching to Fluxer
+    assert (
+        aobj.notify(
+            body="<b>hello</b> <i>world</i>",
+            body_format=NotifyFormat.HTML,
+        )
+        is True
+    )
+    assert mock_post.call_count == 1
+
+    # The body must arrive in the embed description as Markdown,
+    # not as stripped plain text
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+    assert payload["embeds"][0]["description"] == "**hello** *world*"

--- a/tests/test_plugin_google_chat.py
+++ b/tests/test_plugin_google_chat.py
@@ -308,14 +308,14 @@ def test_plugin_google_chat_html_to_markdown_hardening(mock_post):
 
     # Indexed lookup skips escapes and requires an exact run width.
     assert (
-        NotifyGoogleChat._find_unescaped_run(
-            NotifyGoogleChat._build_backtick_run_index("\\` `"), 0, 1
+        NotifyGoogleChat.find_unescaped_run(
+            NotifyGoogleChat.build_backtick_run_index("\\` `"), 0, 1
         )
         == 3
     )
     assert (
-        NotifyGoogleChat._find_unescaped_run(
-            NotifyGoogleChat._build_backtick_run_index("no backticks"), 0, 1
+        NotifyGoogleChat.find_unescaped_run(
+            NotifyGoogleChat.build_backtick_run_index("no backticks"), 0, 1
         )
         is None
     )
@@ -323,8 +323,8 @@ def test_plugin_google_chat_html_to_markdown_hardening(mock_post):
     # A run that's longer than requested doesn't match either -- it's
     # indexed under its own (different) length group.
     assert (
-        NotifyGoogleChat._find_unescaped_run(
-            NotifyGoogleChat._build_backtick_run_index("`` `"), 0, 1
+        NotifyGoogleChat.find_unescaped_run(
+            NotifyGoogleChat.build_backtick_run_index("`` `"), 0, 1
         )
         == 3
     )
@@ -332,8 +332,8 @@ def test_plugin_google_chat_html_to_markdown_hardening(mock_post):
     # Indexed lookup has no distance cutoff.
     far = "a" * 200_000 + "`"
     assert (
-        NotifyGoogleChat._find_unescaped_run(
-            NotifyGoogleChat._build_backtick_run_index(far), 0, 1
+        NotifyGoogleChat.find_unescaped_run(
+            NotifyGoogleChat.build_backtick_run_index(far), 0, 1
         )
         == 200_000
     )
@@ -357,3 +357,35 @@ def test_plugin_google_chat_html_to_markdown_hardening(mock_post):
 
     # Collapse an empty, unterminated emphasis span.
     assert f("**") == ""
+
+    # HTML body with a title: title is merged into the body as a heading
+    # before the Chat dialect conversion runs (covers _build_send_calls
+    # title-merge branch).
+    aobj = Apprise()
+    assert aobj.add("gchat://workspace/key/token")
+    assert (
+        aobj.notify(
+            body="<b>hello</b>",
+            title="My Title",
+            body_format=NotifyFormat.HTML,
+        )
+        is True
+    )
+    payload = loads(mock_post.call_args_list[-1][1]["data"])
+    assert payload["text"] == "# My Title\n*hello*"
+    mock_post.reset_mock()
+
+    # Title that reduces to an empty string after stripping leading heading
+    # and list characters (html_to_markdown converts "  - " to "-").
+    # The heading is skipped and the title field is cleared regardless.
+    assert (
+        aobj.notify(
+            body="<b>hello</b>",
+            title="  - ",
+            body_format=NotifyFormat.HTML,
+        )
+        is True
+    )
+    payload = loads(mock_post.call_args_list[-1][1]["data"])
+    assert payload["text"] == "*hello*"
+    mock_post.reset_mock()

--- a/tests/test_plugin_google_chat.py
+++ b/tests/test_plugin_google_chat.py
@@ -35,7 +35,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
-from apprise import Apprise, NotifyType
+from apprise import Apprise, NotifyFormat, NotifyType
 from apprise.plugins.google_chat import NotifyGoogleChat
 
 logging.disable(logging.CRITICAL)
@@ -231,3 +231,129 @@ def test_plugin_google_chat_edge_case():
     """NotifyGoogleChat() Edge Cases."""
     with pytest.raises(TypeError):
         NotifyGoogleChat("workspace", "webhook", "token", thread_key=object())
+
+
+@mock.patch("requests.post")
+def test_plugin_google_chat_html_to_markdown_hardening(mock_post):
+    """Test edge cases in the CommonMark-to-Google-Chat dialect
+    adaptation."""
+
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+    mock_post.return_value.content = b"{}"
+    mock_post.return_value.text = "{}"
+
+    def notify(body):
+        aobj = Apprise()
+        assert aobj.add("gchat://workspace/key/token")
+        assert aobj.notify(body=body, body_format=NotifyFormat.HTML) is True
+        payload = loads(mock_post.call_args_list[-1][1]["data"])
+        mock_post.reset_mock()
+        return payload["text"]
+
+    # Convert CommonMark emphasis to Google Chat delimiters.
+    assert notify("<b>hello</b> <i>world</i>") == "*hello* _world_"
+
+    # A CommonMark link ("[text](<url>)", html_to_markdown's output) must
+    # arrive as Chat's own "<url|text>" syntax.
+    assert (
+        notify('<a href="https://example.com/x">click here</a>')
+        == "<https://example.com/x|click here>"
+    )
+
+    # '&'/'<'/'>' need entity escaping, since Chat's own <...> link/mention
+    # syntax reserves them.
+    assert notify("<p>2 &lt; 3 &amp; 4</p>") == "2 &lt; 3 &amp; 4"
+
+    # Escape Chat control characters in link destinations.
+    assert (
+        notify('<a href="https://e/x>TAIL">click</a>')
+        == "<https://e/x&gt;TAIL|click>"
+    )
+
+    # Percent-encode Chat's URL-label separator inside destinations.
+    assert (
+        notify('<a href="https://e/x|evil">click</a>')
+        == "<https://e/x%7Cevil|click>"
+    )
+
+    # Entity-escape Chat controls inside code spans.
+    assert notify("<code>a &lt; b &amp; c</code>") == "`a &lt; b &amp; c`"
+
+    # Preserve adjacent nested emphasis.
+    assert notify("<b><i>x</i></b>") == "*_x_*"
+
+    # Non-adjacent nesting and sibling spans are unaffected.
+    assert notify("<b>bold <i>italic</i> still bold</b>") == (
+        "*bold _italic_ still bold*"
+    )
+    assert notify("<b>A</b><b>B</b>") == "*A**B*"
+
+    # Direct Google Chat Markdown remains unchanged.
+    aobj = Apprise()
+    assert aobj.add("gchat://workspace/key/token")
+    assert aobj.notify(body="*already* chat-bound markdown") is True
+    payload = loads(mock_post.call_args_list[-1][1]["data"])
+    assert payload["text"] == "*already* chat-bound markdown"
+    mock_post.reset_mock()
+
+    # Preserve unmatched backticks as literal text.
+    assert (
+        NotifyGoogleChat._commonmark_to_google_chat("text ``unterminated")
+        == "text ``unterminated"
+    )
+
+    # Collapse empty entities without affecting following content.
+    assert NotifyGoogleChat._commonmark_to_google_chat("****x") == "x"
+
+    # Indexed lookup skips escapes and requires an exact run width.
+    assert (
+        NotifyGoogleChat._find_unescaped_run(
+            NotifyGoogleChat._build_backtick_run_index("\\` `"), 0, 1
+        )
+        == 3
+    )
+    assert (
+        NotifyGoogleChat._find_unescaped_run(
+            NotifyGoogleChat._build_backtick_run_index("no backticks"), 0, 1
+        )
+        is None
+    )
+
+    # A run that's longer than requested doesn't match either -- it's
+    # indexed under its own (different) length group.
+    assert (
+        NotifyGoogleChat._find_unescaped_run(
+            NotifyGoogleChat._build_backtick_run_index("`` `"), 0, 1
+        )
+        == 3
+    )
+
+    # Indexed lookup has no distance cutoff.
+    far = "a" * 200_000 + "`"
+    assert (
+        NotifyGoogleChat._find_unescaped_run(
+            NotifyGoogleChat._build_backtick_run_index(far), 0, 1
+        )
+        == 200_000
+    )
+
+    # A backslash-escaped '>' outside of link syntax still needs entity
+    # escaping, the same as a bare one.
+    f = NotifyGoogleChat._commonmark_to_google_chat
+    assert f("\\>literal") == "&gt;literal"
+
+    # Drop CommonMark escapes that Google Chat does not use.
+    assert f("\\!text") == "!text"
+
+    # Preserve an incomplete link as literal text.
+    assert f("[text](<https://example.com/unterminated") == (
+        "[text](<https://example.com/unterminated"
+    )
+
+    # An emphasis span still open at the end of the string is force-closed
+    # rather than left dangling, so the result is valid on its own.
+    assert f("**unterminated") == "*unterminated*"
+
+    # Collapse an empty, unterminated emphasis span.
+    assert f("**") == ""

--- a/tests/test_plugin_google_chat.py
+++ b/tests/test_plugin_google_chat.py
@@ -306,38 +306,6 @@ def test_plugin_google_chat_html_to_markdown_hardening(mock_post):
     # Collapse empty entities without affecting following content.
     assert NotifyGoogleChat._commonmark_to_google_chat("****x") == "x"
 
-    # Indexed lookup skips escapes and requires an exact run width.
-    assert (
-        NotifyGoogleChat.find_unescaped_run(
-            NotifyGoogleChat.build_backtick_run_index("\\` `"), 0, 1
-        )
-        == 3
-    )
-    assert (
-        NotifyGoogleChat.find_unescaped_run(
-            NotifyGoogleChat.build_backtick_run_index("no backticks"), 0, 1
-        )
-        is None
-    )
-
-    # A run that's longer than requested doesn't match either -- it's
-    # indexed under its own (different) length group.
-    assert (
-        NotifyGoogleChat.find_unescaped_run(
-            NotifyGoogleChat.build_backtick_run_index("`` `"), 0, 1
-        )
-        == 3
-    )
-
-    # Indexed lookup has no distance cutoff.
-    far = "a" * 200_000 + "`"
-    assert (
-        NotifyGoogleChat.find_unescaped_run(
-            NotifyGoogleChat.build_backtick_run_index(far), 0, 1
-        )
-        == 200_000
-    )
-
     # A backslash-escaped '>' outside of link syntax still needs entity
     # escaping, the same as a bare one.
     f = NotifyGoogleChat._commonmark_to_google_chat
@@ -345,6 +313,18 @@ def test_plugin_google_chat_html_to_markdown_hardening(mock_post):
 
     # Drop CommonMark escapes that Google Chat does not use.
     assert f("\\!text") == "!text"
+
+    # A three-backtick content line cannot close a four-backtick fence.
+    # Preserve indentation until the matching four-backtick closing fence.
+    assert f("````\n``` nested\n  indented\nlast\n````") == (
+        "````\n``` nested\n  indented\nlast\n````"
+    )
+
+    # Preserve escapes so Chat formatting characters remain literal.
+    assert f("\\*text\\*") == "\\*text\\*"
+    assert f("\\_text\\_") == "\\_text\\_"
+    assert f("\\~text\\~") == "\\~text\\~"
+    assert f("\\`text\\`") == "\\`text\\`"
 
     # Preserve an incomplete link as literal text.
     assert f("[text](<https://example.com/unterminated") == (

--- a/tests/test_plugin_gotify.py
+++ b/tests/test_plugin_gotify.py
@@ -26,6 +26,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 # Disable logging for a cleaner testing output
+from json import loads
 import logging
 from unittest import mock
 
@@ -34,6 +35,7 @@ import pytest
 import requests
 
 import apprise
+from apprise import NotifyFormat
 from apprise.plugins.gotify import GotifyPriority, NotifyGotify
 
 logging.disable(logging.CRITICAL)
@@ -221,3 +223,31 @@ def test_plugin_gotify_config_files(mock_post):
     assert (
         next(aobj.find(tag="gotify_invalid")).priority == GotifyPriority.NORMAL
     )
+
+
+@mock.patch("requests.post")
+def test_plugin_gotify_html_to_markdown_format(mock_post):
+    """NotifyGotify(): HTML body is converted to Markdown."""
+
+    # Prepare Mock
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    # Instantiate a Gotify plugin in Markdown mode
+    aobj = apprise.Apprise()
+    assert aobj.add("gotify://hostname/{}?format=markdown".format("t" * 16))
+
+    # Notify with an HTML body; the framework should convert it
+    # to Markdown before dispatching to Gotify
+    assert (
+        aobj.notify(
+            body="<b>hello</b> <i>world</i>",
+            body_format=NotifyFormat.HTML,
+        )
+        is True
+    )
+    assert mock_post.call_count == 1
+
+    # The body must arrive as Markdown, not as stripped plain text
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+    assert payload["message"] == "**hello** *world*"

--- a/tests/test_plugin_ntfy.py
+++ b/tests/test_plugin_ntfy.py
@@ -37,6 +37,7 @@ from helpers import AppriseURLTester
 import requests
 
 import apprise
+from apprise import NotifyFormat
 from apprise.plugins.ntfy import NotifyNtfy, NtfyPriority
 
 logging.disable(logging.CRITICAL)
@@ -852,3 +853,32 @@ def test_plugin_ntfy_xtags_no_apprise_tag_collision():
     assert not s.tags, (
         "tags= in a YAML ntfy URL must not create an Apprise routing tag"
     )
+
+
+@mock.patch("requests.post")
+def test_plugin_ntfy_html_to_markdown_format(mock_post):
+    """NotifyNtfy(): HTML body is converted to Markdown."""
+
+    # Prepare Mock
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+    mock_post.return_value.content = b"{}"
+
+    # Instantiate an ntfy plugin in Markdown mode using a private server
+    aobj = apprise.Apprise()
+    assert aobj.add("ntfy://localhost/topic?format=markdown")
+
+    # Notify with an HTML body; the framework should convert it
+    # to Markdown before dispatching to ntfy
+    assert (
+        aobj.notify(
+            body="<b>hello</b> <i>world</i>",
+            body_format=NotifyFormat.HTML,
+        )
+        is True
+    )
+    assert mock_post.call_count == 1
+
+    # The body must arrive as Markdown, not as stripped plain text
+    payload = json.loads(mock_post.call_args_list[0][1]["data"])
+    assert payload["message"] == "**hello** *world*"

--- a/tests/test_plugin_revolt.py
+++ b/tests/test_plugin_revolt.py
@@ -26,7 +26,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from datetime import datetime, timedelta
-from json import dumps
+from json import dumps, loads
 
 # Disable logging for a cleaner testing output
 import logging
@@ -568,3 +568,35 @@ def test_plugin_revolt_markdown_extra(mock_post):
         a.notify(body="body", title="title", notify_type=NotifyType.INFO)
         is True
     )
+
+
+@mock.patch("requests.post")
+def test_plugin_revolt_html_to_markdown_format(mock_post):
+    """NotifyRevolt(): HTML body is converted to Markdown."""
+
+    # Initialize some generic (but valid) tokens
+    bot_token = "A" * 24
+    channel_id = "B" * 64
+
+    # Prepare Mock
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+    mock_post.return_value.content = REVOLT_GOOD_RESPONSE
+
+    # Instantiate a Revolt plugin in Markdown mode
+    aobj = Apprise()
+    assert aobj.add(f"revolt://{bot_token}/{channel_id}/?format=markdown")
+
+    # Notify with an HTML body; the framework should convert it
+    # to Markdown before dispatching to Revolt
+    result = aobj.notify(
+        body="<b>hello</b> <i>world</i>",
+        body_format=NotifyFormat.HTML,
+    )
+    assert result is True
+    assert mock_post.call_count == 1
+
+    # The body must arrive inside the Markdown embed, not as
+    # stripped plain text in "content"
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+    assert payload["embeds"][0]["description"] == "**hello** *world*"

--- a/tests/test_plugin_rocket_chat.py
+++ b/tests/test_plugin_rocket_chat.py
@@ -26,6 +26,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 # Disable logging for a cleaner testing output
+from json import loads
 import logging
 from unittest import mock
 
@@ -33,7 +34,8 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
-from apprise import NotifyType
+import apprise
+from apprise import NotifyFormat, NotifyType
 from apprise.plugins.rocketchat import NotifyRocketChat
 
 logging.disable(logging.CRITICAL)
@@ -430,3 +432,32 @@ def test_plugin_rocket_chat_edge_cases(mock_post, mock_get):
     # Logout
     #
     assert obj.logout() is False
+
+
+@mock.patch("requests.post")
+def test_plugin_rocket_chat_html_to_markdown_format(mock_post):
+    """NotifyRocketChat(): HTML body is converted to Markdown."""
+
+    # Prepare Mock -- webhook mode needs only one POST, no login
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+    mock_post.return_value.content = ""
+
+    # Use webhook mode to avoid the login/logout GET flow
+    aobj = apprise.Apprise()
+    assert aobj.add("rockets://web/token@localhost/")
+
+    # Notify with an HTML body; the framework should convert it
+    # to Markdown before dispatching to RocketChat
+    assert (
+        aobj.notify(
+            body="<b>hello</b> <i>world</i>",
+            body_format=NotifyFormat.HTML,
+        )
+        is True
+    )
+    assert mock_post.call_count == 1
+
+    # The body must arrive as Markdown, not as stripped plain text
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+    assert payload["text"] == "**hello** *world*"

--- a/tests/test_plugin_slack.py
+++ b/tests/test_plugin_slack.py
@@ -2378,39 +2378,6 @@ def test_plugin_slack_html_to_markdown_hardening(mock_request):
         assert text.count("*") % 2 == 0
         assert text.count("_") % 2 == 0
 
-    # build_backtick_run_index() / find_unescaped_run() -- the lookup
-    # returns None outright when the requested run never appears at all.
-    assert (
-        NotifySlack.find_unescaped_run(
-            NotifySlack.build_backtick_run_index("no match here"), 0, 2
-        )
-        is None
-    )
-
-    # It also skips an escape pair while indexing, and a run of the wrong
-    # length doesn't match the real one's length group.
-    assert (
-        NotifySlack.find_unescaped_run(
-            NotifySlack.build_backtick_run_index("\\` ``x"), 0, 2
-        )
-        == 3
-    )
-    assert (
-        NotifySlack.find_unescaped_run(
-            NotifySlack.build_backtick_run_index("` ``x"), 0, 2
-        )
-        == 2
-    )
-
-    # A genuine match arbitrarily far from `start` is still found.
-    far = "a" * 200_000 + "`"
-    assert (
-        NotifySlack.find_unescaped_run(
-            NotifySlack.build_backtick_run_index(far), 0, 1
-        )
-        == 200_000
-    )
-
     # Every backslash-escape branch of the main scan: '>' becomes an HTML
     # entity, '(', ')', '[', ']', '!', '#' have their backslash dropped (none
     assert (

--- a/tests/test_plugin_slack.py
+++ b/tests/test_plugin_slack.py
@@ -2244,7 +2244,185 @@ def test_plugin_slack_html_to_markdown_format(mock_request):
     )
     assert mock_request.call_count == 1
 
-    # The body must arrive as Markdown in the legacy attachment text,
-    # not as stripped plain text
+    # The body must arrive as Markdown in the legacy attachment text, not as
+    # stripped plain text.
     payload = loads(mock_request.call_args_list[0][1]["data"])
-    assert payload["attachments"][0]["text"] == "**hello** *world*"
+    assert payload["attachments"][0]["text"] == "*hello* _world_"
+
+    mock_request.reset_mock()
+
+    # Convert CommonMark links to Slack's ``<url|text>`` syntax.
+    assert (
+        aobj.notify(
+            body='<a href="https://example.com/x">click here</a>',
+            body_format=NotifyFormat.HTML,
+        )
+        is True
+    )
+    payload = loads(mock_request.call_args_list[0][1]["data"])
+    assert (
+        payload["attachments"][0]["text"]
+        == "<https://example.com/x|click here>"
+    )
+
+    mock_request.reset_mock()
+
+    # '&'/'<'/'>' need Slack's HTML-entity escaping, not CommonMark's backslash
+    # escaping (which Slack doesn't support for these and would otherwise.
+    assert (
+        aobj.notify(
+            body="<p>2 &lt; 3 &amp; 4</p>",
+            body_format=NotifyFormat.HTML,
+        )
+        is True
+    )
+    payload = loads(mock_request.call_args_list[0][1]["data"])
+    assert payload["attachments"][0]["text"] == "2 &lt; 3 &amp; 4"
+
+    mock_request.reset_mock()
+
+    # Direct Slack mrkdwn input remains unchanged.
+    assert aobj.notify(body="**already** slack-bound markdown #tag") is True
+    payload = loads(mock_request.call_args_list[0][1]["data"])
+    assert (
+        payload["attachments"][0]["text"]
+        == "**already** slack-bound markdown #tag"
+    )
+
+
+@mock.patch("requests.request")
+def test_plugin_slack_html_to_markdown_hardening(mock_request):
+    """Test edge cases in the CommonMark-to-Slack dialect adaptation."""
+
+    slack_token = "T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ"
+
+    mock_request.return_value = requests.Request()
+    mock_request.return_value.status_code = requests.codes.ok
+    mock_request.return_value.content = b"ok"
+    mock_request.return_value.text = "ok"
+
+    def notify(body):
+        aobj = Apprise()
+        assert aobj.add("slack://{}/#general".format(slack_token))
+        assert aobj.notify(body=body, body_format=NotifyFormat.HTML) is True
+        payload = loads(mock_request.call_args_list[-1][1]["data"])
+        mock_request.reset_mock()
+        return payload["attachments"][0]["text"]
+
+    # <code>/<pre> content is buffered raw by html_to_markdown.
+    assert notify("<code>a &lt; b &amp; c</code>") == "`a &lt; b &amp; c`"
+
+    # Immediately-adjacent nested emphasis (no text between the outer and inner
+    # tag's open) must stay correctly nested ("*_x_*"), not cross ("*_x*_").
+    assert notify("<b><i>x</i></b>") == "*_x_*"
+
+    # Bold/italic text nested inside a link is preserved in Slack's own
+    # "<url|text>" form.
+    assert (
+        notify('<a href="https://example.com/x"><b>click</b></a>')
+        == "<https://example.com/x|*click*>"
+    )
+
+    # Sibling (non-nested) bold spans stay separate, not merged.
+    assert notify("<b>A</b><b>B</b>") == "*A**B*"
+
+    # Entity-escape Slack control characters in link destinations.
+    assert (
+        notify('<a href="https://e/x>TAIL">click</a>')
+        == "<https://e/x&gt;TAIL|click>"
+    )
+    assert (
+        notify('<a href="https://e/x?a=1&b=2">click</a>')
+        == "<https://e/x?a=1&amp;b=2|click>"
+    )
+
+    # '|' has no entity form and is what separates the URL from its label in
+    # Slack's own syntax.
+    assert (
+        notify('<a href="https://e/x|evil">click</a>')
+        == "<https://e/x%7Cevil|click>"
+    )
+
+    # A literal "\x02<digits>\x02"-shaped sequence in ordinary text must pass
+    # through completely unaltered.
+    assert notify("literal \x020\x02 text, no code or links at all") == (
+        "literal \x020\x02 text, no code or links at all"
+    )
+
+    # An unmatched (unbalanced) bare backtick run.
+    assert NotifySlack._commonmark_to_slack("text ``unterminated") == (
+        "text ``unterminated"
+    )
+
+    # An empty entity collapse mid-string (not just a final one at the end of
+    # the scan).
+    assert NotifySlack._commonmark_to_slack("****x") == "x"
+
+    # overflow=split can hand this method just one chunk of a longer body, with
+    # a span that doesn't open or close until a different chunk entirely.
+    aobj = Apprise()
+    assert aobj.add("slack://{}/#general?overflow=split".format(slack_token))
+    assert (
+        aobj.notify(
+            body="<b>" + ("x" * 39990) + "</b>",
+            body_format=NotifyFormat.HTML,
+        )
+        is True
+    )
+    assert mock_request.call_count == 2
+    texts = [
+        loads(c[1]["data"])["attachments"][0]["text"]
+        for c in mock_request.call_args_list
+    ]
+    for text in texts:
+        assert text.count("*") % 2 == 0
+        assert text.count("_") % 2 == 0
+
+    # _build_backtick_run_index() / _find_unescaped_run() -- the lookup
+    # returns None outright when the requested run never appears at all.
+    assert (
+        NotifySlack._find_unescaped_run(
+            NotifySlack._build_backtick_run_index("no match here"), 0, 2
+        )
+        is None
+    )
+
+    # It also skips an escape pair while indexing, and a run of the wrong
+    # length doesn't match the real one's length group.
+    assert (
+        NotifySlack._find_unescaped_run(
+            NotifySlack._build_backtick_run_index("\\` ``x"), 0, 2
+        )
+        == 3
+    )
+    assert (
+        NotifySlack._find_unescaped_run(
+            NotifySlack._build_backtick_run_index("` ``x"), 0, 2
+        )
+        == 2
+    )
+
+    # A genuine match arbitrarily far from `start` is still found.
+    far = "a" * 200_000 + "`"
+    assert (
+        NotifySlack._find_unescaped_run(
+            NotifySlack._build_backtick_run_index(far), 0, 1
+        )
+        == 200_000
+    )
+
+    # Every backslash-escape branch of the main scan: '>' becomes an HTML
+    # entity, '(', ')', '[', ']', '!', '#' have their backslash dropped (none
+    assert (
+        NotifySlack._commonmark_to_slack(
+            "a\\>b\\(c\\)d\\[e\\]f\\!g\\#h\\*i\\_j\\~k\\\\l"
+        )
+        == "a&gt;b(c)d[e]f!g#h\\*i\\_j\\~k\\\\l"
+    )
+
+    # A '[' with no matching "](<url>)" close at all by the time the scan ends
+    # (e.g.
+    assert (
+        NotifySlack._commonmark_to_slack("[text](<https://incomplete")
+        == "[text](<https://incomplete"
+    )

--- a/tests/test_plugin_slack.py
+++ b/tests/test_plugin_slack.py
@@ -37,7 +37,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
-from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise import Apprise, AppriseAttachment, NotifyFormat, NotifyType
 from apprise.plugins.slack import NotifySlack, SlackMode
 
 logging.disable(logging.CRITICAL)
@@ -2213,3 +2213,38 @@ def test_plugin_slack_workflow_template(mock_request, tmpdir):
         obj2.notify(body="x", title="", notify_type=NotifyType.INFO) is False
     )
     assert mock_request.call_count == 1  # no new request made
+
+
+@mock.patch("requests.request")
+def test_plugin_slack_html_to_markdown_format(mock_request):
+    """NotifySlack(): HTML body is converted to Markdown."""
+
+    # Use the classic incoming webhook token format
+    slack_token = "T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ"
+
+    # Slack's _send() uses requests.request(), not requests.post();
+    # webhook mode confirms success via content == b"ok"
+    mock_request.return_value = requests.Request()
+    mock_request.return_value.status_code = requests.codes.ok
+    mock_request.return_value.content = b"ok"
+    mock_request.return_value.text = "ok"
+
+    # Instantiate a Slack plugin (notify_format is MARKDOWN by default)
+    aobj = Apprise()
+    assert aobj.add("slack://{}/#general".format(slack_token))
+
+    # Notify with an HTML body; the framework should convert it
+    # to Markdown before dispatching to Slack
+    assert (
+        aobj.notify(
+            body="<b>hello</b> <i>world</i>",
+            body_format=NotifyFormat.HTML,
+        )
+        is True
+    )
+    assert mock_request.call_count == 1
+
+    # The body must arrive as Markdown in the legacy attachment text,
+    # not as stripped plain text
+    payload = loads(mock_request.call_args_list[0][1]["data"])
+    assert payload["attachments"][0]["text"] == "**hello** *world*"

--- a/tests/test_plugin_slack.py
+++ b/tests/test_plugin_slack.py
@@ -2378,11 +2378,11 @@ def test_plugin_slack_html_to_markdown_hardening(mock_request):
         assert text.count("*") % 2 == 0
         assert text.count("_") % 2 == 0
 
-    # _build_backtick_run_index() / _find_unescaped_run() -- the lookup
+    # build_backtick_run_index() / find_unescaped_run() -- the lookup
     # returns None outright when the requested run never appears at all.
     assert (
-        NotifySlack._find_unescaped_run(
-            NotifySlack._build_backtick_run_index("no match here"), 0, 2
+        NotifySlack.find_unescaped_run(
+            NotifySlack.build_backtick_run_index("no match here"), 0, 2
         )
         is None
     )
@@ -2390,14 +2390,14 @@ def test_plugin_slack_html_to_markdown_hardening(mock_request):
     # It also skips an escape pair while indexing, and a run of the wrong
     # length doesn't match the real one's length group.
     assert (
-        NotifySlack._find_unescaped_run(
-            NotifySlack._build_backtick_run_index("\\` ``x"), 0, 2
+        NotifySlack.find_unescaped_run(
+            NotifySlack.build_backtick_run_index("\\` ``x"), 0, 2
         )
         == 3
     )
     assert (
-        NotifySlack._find_unescaped_run(
-            NotifySlack._build_backtick_run_index("` ``x"), 0, 2
+        NotifySlack.find_unescaped_run(
+            NotifySlack.build_backtick_run_index("` ``x"), 0, 2
         )
         == 2
     )
@@ -2405,8 +2405,8 @@ def test_plugin_slack_html_to_markdown_hardening(mock_request):
     # A genuine match arbitrarily far from `start` is still found.
     far = "a" * 200_000 + "`"
     assert (
-        NotifySlack._find_unescaped_run(
-            NotifySlack._build_backtick_run_index(far), 0, 1
+        NotifySlack.find_unescaped_run(
+            NotifySlack.build_backtick_run_index(far), 0, 1
         )
         == 200_000
     )
@@ -2425,4 +2425,16 @@ def test_plugin_slack_html_to_markdown_hardening(mock_request):
     assert (
         NotifySlack._commonmark_to_slack("[text](<https://incomplete")
         == "[text](<https://incomplete"
+    )
+
+
+def test_plugin_slack_parse_native_url_fallthrough():
+    """parse_native_url() returns None for unrecognized URLs."""
+
+    # A URL that doesn't match any known Slack pattern should yield None.
+    assert (
+        NotifySlack.parse_native_url(
+            "https://not-slack.com/services/ABC/DEF/GHI"
+        )
+        is None
     )

--- a/tests/test_plugin_telegram.py
+++ b/tests/test_plugin_telegram.py
@@ -1736,9 +1736,8 @@ def test_plugin_telegram_html_to_markdown_hardening(mock_post):
     # in the output buffer (empty entity) -- the delimiter is dropped.
     assert NotifyTelegram._commonmark_to_telegram("******") == ""
 
-    # Unclosed spans at the end of the V1 input are force-closed by the
-    # cleanup loop.  A suppressed nesting (open_index None) is silently
-    # skipped; a real one appends the closing delimiter.
+    # Unclosed spans at the end of the V1 input are force-closed by the cleanup
+    # loop.
     f1 = NotifyTelegram._commonmark_to_telegram
     assert f1("***italic text") == "*italic text*"
     assert f1("**text") == "*text*"
@@ -1765,9 +1764,8 @@ def test_plugin_telegram_html_to_markdown_hardening(mock_post):
     assert payload["text"] == "# My Title\n*hello*"
     mock_post.reset_mock()
 
-    # Title that reduces to an empty string after stripping leading heading
-    # and list characters (html_to_markdown converts "  - " to "-").
-    # The heading is skipped and the title field is cleared regardless.
+    # Title that reduces to an empty string after stripping leading heading and
+    # list characters (html_to_markdown converts " - " to "-").
     assert aobj_v1.notify(
         body="<b>hello</b>", title="  - ", body_format=NotifyFormat.HTML
     )
@@ -1840,6 +1838,7 @@ def test_plugin_telegram_overflow_split_repair(mock_post):
     texts = notify_split(f'<a href="{url}">click here</a>')
     assert len(texts) >= 2
     for text in texts:
+        # Every chunk must be valid MarkdownV2: no unescaped reserved chars.
         assert not re.search(r"(?<!\\)[_*\[\]()~`>#+=|{}.!<-]", text)
 
     # A <pre> block long enough to force a split.
@@ -1872,8 +1871,7 @@ def test_plugin_telegram_overflow_split_repair(mock_post):
     repair = NotifyTelegram._repair_split_chunk
 
     # V1 (non-strict) with an unmatched backtick: the backtick run has no
-    # closing partner, so the `if strict:` branch is NOT taken -- the
-    # backtick passes through as plain text.
+    # closing partner, so the `if strict:` branch is NOT taken.
     assert repair("`code no close", False, {}) == ("`code no close", {})
 
     # A pending close count for '*' in strict mode: the matching close

--- a/tests/test_plugin_telegram.py
+++ b/tests/test_plugin_telegram.py
@@ -1668,7 +1668,7 @@ def test_plugin_telegram_html_to_markdown_hardening(mock_post):
     )
     assert (
         notify("<p>a[b]c *lit* _lit_ `lit`</p>", mdv="1")
-        == "a\\[b]c \\*lit\\* \\_lit\\_ \\`lit\\`"
+        == "a\\[b\\]c \\*lit\\* \\_lit\\_ \\`lit\\`"
     )
 
     # Non-adjacent nesting and sibling spans are unaffected.
@@ -1772,24 +1772,6 @@ def test_plugin_telegram_html_to_markdown_hardening(mock_post):
     payload = loads(mock_post.call_args_list[-1][1]["data"])
     assert payload["text"] == "*hello*"
     mock_post.reset_mock()
-
-    # build_backtick_run_index() / find_unescaped_run() -- the lookup
-    # returns None outright when the requested run never appears at all.
-    assert (
-        NotifyTelegram.find_unescaped_run(
-            NotifyTelegram.build_backtick_run_index("no match here"), 0, 2
-        )
-        is None
-    )
-
-    # A genuine match arbitrarily far from `start` is still found.
-    far = "a" * 200_000 + "`"
-    assert (
-        NotifyTelegram.find_unescaped_run(
-            NotifyTelegram.build_backtick_run_index(far), 0, 1
-        )
-        == 200_000
-    )
 
 
 @mock.patch("requests.post")

--- a/tests/test_plugin_telegram.py
+++ b/tests/test_plugin_telegram.py
@@ -1134,7 +1134,7 @@ def test_plugin_telegram_formatting(mock_post):
 
     # Test that everything is escaped properly in a MARKDOWN mode
     assert (
-        payload["text"] == "# A Great Title\r\n"
+        payload["text"] == "# A Great Title\n"
         "_[Apprise Body Title](http://localhost)_ had "
         "[a change](http://127.0.0.2)"
     )
@@ -1167,7 +1167,7 @@ def test_plugin_telegram_formatting(mock_post):
 
     # Test that everything is escaped properly in a MARKDOWN mode
     assert (
-        payload["text"] == "\\# A Great Title\r\n"
+        payload["text"] == "\\# A Great Title\n"
         "\\_\\[Apprise Body Title\\]\\(http://localhost\\)\\_ had "
         "\\[a change\\]\\(http://127\\.0\\.0\\.2\\)"
     )
@@ -1732,11 +1732,54 @@ def test_plugin_telegram_html_to_markdown_hardening(mock_post):
     # Empty adjacent entities collapse without affecting following text.
     assert NotifyTelegram._commonmark_to_telegram("****x") == "x"
 
-    # _build_backtick_run_index() / _find_unescaped_run() -- the lookup
+    # Cascade close that pops an open span whose delimiter was the LAST item
+    # in the output buffer (empty entity) -- the delimiter is dropped.
+    assert NotifyTelegram._commonmark_to_telegram("******") == ""
+
+    # Unclosed spans at the end of the V1 input are force-closed by the
+    # cleanup loop.  A suppressed nesting (open_index None) is silently
+    # skipped; a real one appends the closing delimiter.
+    f1 = NotifyTelegram._commonmark_to_telegram
+    assert f1("***italic text") == "*italic text*"
+    assert f1("**text") == "*text*"
+    # An unterminated open with no content at all collapses to nothing.
+    assert f1("**") == ""
+
+    # A link destination containing a backslash-escaped '>' in V1 mode:
+    # the scan skips escaped characters and still finds the '>)' terminator.
+    assert (
+        notify('<a href="https://example.com/x>y">click</a>', mdv="1")
+        == r"[click](https://example.com/x\\>y)"
+    )
+
+    # HTML body with a title in V1 mode: _build_send_calls merges the title
+    # as a heading before dialect conversion (covers the title-merge branch).
+    aobj_v1 = Apprise()
+    aobj_v1.add(
+        "tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=1"
+    )
+    assert aobj_v1.notify(
+        body="<b>hello</b>", title="My Title", body_format=NotifyFormat.HTML
+    )
+    payload = loads(mock_post.call_args_list[-1][1]["data"])
+    assert payload["text"] == "# My Title\n*hello*"
+    mock_post.reset_mock()
+
+    # Title that reduces to an empty string after stripping leading heading
+    # and list characters (html_to_markdown converts "  - " to "-").
+    # The heading is skipped and the title field is cleared regardless.
+    assert aobj_v1.notify(
+        body="<b>hello</b>", title="  - ", body_format=NotifyFormat.HTML
+    )
+    payload = loads(mock_post.call_args_list[-1][1]["data"])
+    assert payload["text"] == "*hello*"
+    mock_post.reset_mock()
+
+    # build_backtick_run_index() / find_unescaped_run() -- the lookup
     # returns None outright when the requested run never appears at all.
     assert (
-        NotifyTelegram._find_unescaped_run(
-            NotifyTelegram._build_backtick_run_index("no match here"), 0, 2
+        NotifyTelegram.find_unescaped_run(
+            NotifyTelegram.build_backtick_run_index("no match here"), 0, 2
         )
         is None
     )
@@ -1744,8 +1787,8 @@ def test_plugin_telegram_html_to_markdown_hardening(mock_post):
     # A genuine match arbitrarily far from `start` is still found.
     far = "a" * 200_000 + "`"
     assert (
-        NotifyTelegram._find_unescaped_run(
-            NotifyTelegram._build_backtick_run_index(far), 0, 1
+        NotifyTelegram.find_unescaped_run(
+            NotifyTelegram.build_backtick_run_index(far), 0, 1
         )
         == 200_000
     )
@@ -1825,6 +1868,46 @@ def test_plugin_telegram_overflow_split_repair(mock_post):
     assert NotifyTelegram._repair_split_chunk(
         "still no close here", True, {"in_link_dest": True}
     ) == ("still no close here", {"in_link_dest": True})
+
+    repair = NotifyTelegram._repair_split_chunk
+
+    # V1 (non-strict) with an unmatched backtick: the backtick run has no
+    # closing partner, so the `if strict:` branch is NOT taken -- the
+    # backtick passes through as plain text.
+    assert repair("`code no close", False, {}) == ("`code no close", {})
+
+    # A pending close count for '*' in strict mode: the matching close
+    # delimiter in this chunk is discarded (the open was already dropped).
+    assert repair("*text", True, {"*": 1}) == ("text", {"*": 0})
+
+    # Same for '_'.
+    assert repair("_text", True, {"_": 1}) == ("text", {"_": 0})
+
+    # Strict mode: '](url)' with NO matching '[' on the link stack escapes
+    # the construct rather than emitting it verbatim.
+    assert repair("](https://e.com)", True, {}) == (
+        "\\]\\(https://e\\.com\\)",
+        {},
+    )
+
+    # Strict mode: '](url' with no closing ')' sets in_link_dest pending.
+    assert repair("](https://e.com no-close", True, {}) == (
+        "\\]\\(https://e\\.com no\\-close",
+        {"in_link_dest": True},
+    )
+
+    # Strict mode: opening and immediately closing the same delimiter with no
+    # content in between -- the empty span is dropped from the output.
+    assert repair("**", True, {}) == ("", {})
+
+    # Strict mode: a stray ']', '(', or ')' outside any complete link entity
+    # is backslash-escaped rather than passed through verbatim.
+    assert repair("]text", True, {}) == ("\\]text", {})
+    assert repair("(text)", True, {}) == ("\\(text\\)", {})
+
+    # Strict mode: a dangling open at the end of the chunk with no content
+    # after it is removed as an empty span (not propagated as pending).
+    assert repair("text*", True, {}) == ("text", {})
 
 
 @mock.patch("requests.post")

--- a/tests/test_plugin_telegram.py
+++ b/tests/test_plugin_telegram.py
@@ -1430,7 +1430,7 @@ def test_plugin_telegram_html_formatting(mock_post):
 
 @mock.patch("requests.post")
 def test_plugin_telegram_html_to_markdown_format(mock_post):
-    """NotifyTelegram() HTML body delivered to a Markdown-mode target."""
+    """Test HTML delivery to Telegram Markdown targets."""
 
     # Prepare Mock
     mock_post.return_value = requests.Request()
@@ -1440,10 +1440,7 @@ def test_plugin_telegram_html_to_markdown_format(mock_post):
     # Simple HTML that our html_to_markdown converter handles
     body = "<b>hello</b> <i>world</i>"
 
-    # --- Markdown v1 target ---
-    # convert_between(HTML, MARKDOWN) now produces generic Markdown via
-    # html_to_markdown().  For v1, the blunt re.sub escaping is gated on
-    # markdown_ver == TWO, so the converted body passes through unchanged.
+    # Markdown v1 keeps the converted generic Markdown unchanged.
     aobj = Apprise()
     aobj.add("tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=1")
     assert len(aobj) == 1
@@ -1453,14 +1450,13 @@ def test_plugin_telegram_html_to_markdown_format(mock_post):
     assert mock_post.call_count == 1
     payload = loads(mock_post.call_args_list[0][1]["data"])
 
-    # html_to_markdown produced "**hello** *world*"; v1 has no further
-    # escaping for non-Markdown input, so it arrives in the payload intact
+    # The converted formatting reaches the v1 payload intact.
     assert payload["parse_mode"] == "MARKDOWN"
     assert payload["text"] == "**hello** *world*"
 
     mock_post.reset_mock()
 
-    # Markdown v2 target
+    # Markdown v2 applies its own escaping to converted HTML.
     aobj = Apprise()
     aobj.add("tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=2")
     assert len(aobj) == 1
@@ -1471,7 +1467,27 @@ def test_plugin_telegram_html_to_markdown_format(mock_post):
     payload = loads(mock_post.call_args_list[0][1]["data"])
 
     assert payload["parse_mode"] == "MarkdownV2"
-    assert payload["text"] == "**hello** *world*"
+    assert payload["text"] == r"\*\*hello\*\* \*world\*"
+
+    mock_post.reset_mock()
+
+    # Telegram escapes v2-only punctuation not covered by generic Markdown.
+    aobj = Apprise()
+    aobj.add("tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=2")
+    assert len(aobj) == 1
+
+    assert aobj.notify(
+        body="<p>3:00 p.m. (sharp)! Don't be late - see you there.</p>",
+        body_format=NotifyFormat.HTML,
+    )
+
+    assert mock_post.call_count == 1
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+
+    assert payload["parse_mode"] == "MarkdownV2"
+    assert payload["text"] == (
+        r"3:00 p\.m\. \(sharp\)\! Don't be late \- see you there\."
+    )
 
     mock_post.reset_mock()
 

--- a/tests/test_plugin_telegram.py
+++ b/tests/test_plugin_telegram.py
@@ -1460,14 +1460,7 @@ def test_plugin_telegram_html_to_markdown_format(mock_post):
 
     mock_post.reset_mock()
 
-    # --- Markdown v2 target ---
-    # For v2, Telegram's existing blunt re.sub fires on the already-converted
-    # Markdown body (body_format=HTML triggers the condition).  The result is
-    # double-escaped: each '*' becomes '\*', making formatting markers
-    # visible as literal text.  This is a known limitation of the current
-    # Telegram plugin when receiving HTML for a Markdown-mode target; it is
-    # documented here so that any future fix must consciously update this
-    # assertion rather than changing the behaviour silently.
+    # Markdown v2 target
     aobj = Apprise()
     aobj.add("tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=2")
     assert len(aobj) == 1
@@ -1478,8 +1471,39 @@ def test_plugin_telegram_html_to_markdown_format(mock_post):
     payload = loads(mock_post.call_args_list[0][1]["data"])
 
     assert payload["parse_mode"] == "MarkdownV2"
-    # "**hello** *world*" after v2 re.sub escaping
-    assert payload["text"] == r"\*\*hello\*\* \*world\*"
+    assert payload["text"] == "**hello** *world*"
+
+    mock_post.reset_mock()
+
+    # Markdown v2 target, plain TEXT body
+    aobj = Apprise()
+    aobj.add("tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=2")
+    assert len(aobj) == 1
+
+    assert aobj.notify(
+        body="Tag #1 and *not* bold", body_format=NotifyFormat.TEXT
+    )
+
+    assert mock_post.call_count == 1
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+
+    assert payload["parse_mode"] == "MarkdownV2"
+    assert payload["text"] == r"Tag \#1 and \*not\* bold"
+
+    mock_post.reset_mock()
+
+    # Markdown v2 target, no body_format specified
+    aobj = Apprise()
+    aobj.add("tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=2")
+    assert len(aobj) == 1
+
+    assert aobj.notify(body="**already** markdown #tag")
+
+    assert mock_post.call_count == 1
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+
+    assert payload["parse_mode"] == "MarkdownV2"
+    assert payload["text"] == "**already** markdown #tag"
 
 
 @mock.patch("requests.post")

--- a/tests/test_plugin_telegram.py
+++ b/tests/test_plugin_telegram.py
@@ -30,6 +30,7 @@ from json import dumps, loads
 # Disable logging for a cleaner testing output
 import logging
 import os
+import re
 from unittest import mock
 
 from helpers import AppriseURLTester
@@ -1440,7 +1441,8 @@ def test_plugin_telegram_html_to_markdown_format(mock_post):
     # Simple HTML that our html_to_markdown converter handles
     body = "<b>hello</b> <i>world</i>"
 
-    # Markdown v1 keeps the converted generic Markdown unchanged.
+    # Markdown v1 gets the converted body in Telegram's own Markdown dialect
+    # (single-asterisk bold, single-underscore italic).
     aobj = Apprise()
     aobj.add("tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=1")
     assert len(aobj) == 1
@@ -1450,13 +1452,13 @@ def test_plugin_telegram_html_to_markdown_format(mock_post):
     assert mock_post.call_count == 1
     payload = loads(mock_post.call_args_list[0][1]["data"])
 
-    # The converted formatting reaches the v1 payload intact.
     assert payload["parse_mode"] == "MARKDOWN"
-    assert payload["text"] == "**hello** *world*"
+    assert payload["text"] == "*hello* _world_"
 
     mock_post.reset_mock()
 
-    # Markdown v2 applies its own escaping to converted HTML.
+    # Markdown v2 gets the same dialect-correct delimiters, left unescaped so
+    # Telegram still parses them as real formatting.
     aobj = Apprise()
     aobj.add("tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=2")
     assert len(aobj) == 1
@@ -1467,7 +1469,7 @@ def test_plugin_telegram_html_to_markdown_format(mock_post):
     payload = loads(mock_post.call_args_list[0][1]["data"])
 
     assert payload["parse_mode"] == "MarkdownV2"
-    assert payload["text"] == r"\*\*hello\*\* \*world\*"
+    assert payload["text"] == "*hello* _world_"
 
     mock_post.reset_mock()
 
@@ -1520,6 +1522,309 @@ def test_plugin_telegram_html_to_markdown_format(mock_post):
 
     assert payload["parse_mode"] == "MarkdownV2"
     assert payload["text"] == "**already** markdown #tag"
+
+    mock_post.reset_mock()
+
+    # A heading has no MarkdownV2 entity -- its '#' must be escaped (not left
+    # bare), or Telegram rejects the entire message outright rather than just.
+    aobj = Apprise()
+    aobj.add("tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=2")
+    assert len(aobj) == 1
+
+    assert aobj.notify(
+        body="<h1>Title</h1><p>body text</p>", body_format=NotifyFormat.HTML
+    )
+
+    assert mock_post.call_count == 1
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+
+    assert payload["parse_mode"] == "MarkdownV2"
+    assert payload["text"] == "\\# Title\n\nbody text"
+
+    mock_post.reset_mock()
+
+    # Convert CommonMark links to Telegram's bare-destination syntax.
+    aobj = Apprise()
+    aobj.add("tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=2")
+    assert len(aobj) == 1
+
+    assert aobj.notify(
+        body='<a href="https://example.com/x">click</a>',
+        body_format=NotifyFormat.HTML,
+    )
+
+    assert mock_post.call_count == 1
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+
+    assert payload["parse_mode"] == "MarkdownV2"
+    assert payload["text"] == "[click](https://example.com/x)"
+
+    mock_post.reset_mock()
+
+    # Lists and tables have no MarkdownV2 entity either -- their markers
+    # need the same escaping as a heading's, for the same reason.
+    aobj = Apprise()
+    aobj.add("tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=2")
+    assert len(aobj) == 1
+
+    assert aobj.notify(
+        body="<ul><li>one</li><li>two</li></ul>",
+        body_format=NotifyFormat.HTML,
+    )
+
+    assert mock_post.call_count == 1
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+
+    assert payload["parse_mode"] == "MarkdownV2"
+    assert payload["text"] == "\\- one\n\\- two"
+
+    mock_post.reset_mock()
+
+    aobj = Apprise()
+    aobj.add("tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=2")
+    assert len(aobj) == 1
+
+    assert aobj.notify(
+        body="<table><tr><td>A</td><td>B</td></tr></table>",
+        body_format=NotifyFormat.HTML,
+    )
+
+    assert mock_post.call_count == 1
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+
+    assert payload["parse_mode"] == "MarkdownV2"
+    assert payload["text"] == (
+        "\\| A \\| B \\|\n\\| \\-\\-\\- \\| \\-\\-\\- \\|"
+    )
+
+    mock_post.reset_mock()
+
+    # A code span's content is just as literal to Telegram as it is to
+    # CommonMark -- the strict escape pass must not touch it.
+    aobj = Apprise()
+    aobj.add("tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=2")
+    assert len(aobj) == 1
+
+    assert aobj.notify(
+        body="<code>a.b-c|d</code>", body_format=NotifyFormat.HTML
+    )
+
+    assert mock_post.call_count == 1
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+
+    assert payload["parse_mode"] == "MarkdownV2"
+    assert payload["text"] == "`a.b-c|d`"
+
+
+@mock.patch("requests.post")
+def test_plugin_telegram_html_to_markdown_hardening(mock_post):
+    """Test edge cases in the CommonMark-to-Telegram dialect adaptation."""
+
+    # Prepare Mock
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+    mock_post.return_value.content = dumps({"ok": True, "result": True})
+
+    def notify(body, mdv="2"):
+        aobj = Apprise()
+        aobj.add(
+            "tgram://123456789:abcdefg_hijklmnop/12345"
+            f"?format=markdown&mdv={mdv}"
+        )
+        assert len(aobj) == 1
+        assert aobj.notify(body=body, body_format=NotifyFormat.HTML)
+        payload = loads(mock_post.call_args_list[-1][1]["data"])
+        mock_post.reset_mock()
+        return payload["text"]
+
+    # A link destination containing a literal ')' or '\' must have those
+    # escaped.
+    assert notify('<a href="https://example.com/a(b)c">x</a>') == (
+        "[x](https://example.com/a(b\\)c)"
+    )
+
+    # A code span's content needs every '`'/'\' inside it escaped.
+    assert notify("<code>a\\b</code>") == "`a\\\\b`"
+    assert notify("<code>a`b</code>") == "`a\\`b`"
+
+    # Immediately-adjacent nested emphasis (no text between the outer and inner
+    # tag's open) must stay correctly nested ("*_x_*"), not cross ("*_x*_").
+    assert notify("<b><i>x</i></b>") == "*_x_*"
+    assert notify("<i><b>x</b></i>") == "*_x_*"
+
+    # Legacy Markdown (v1) doesn't support nested entities at all.
+    assert notify("<b>a <i>b</i> c</b>", mdv="1") == "*a b c*"
+    assert notify("<b><i>x</i></b>", mdv="1") == "*x*"
+
+    # <i><b>x</b></i> and <b><i>x</i></b> both flatten to the identical
+    # CommonMark "***x***" (html_to_markdown has no separating text to anchor
+    assert notify("<i><b>x</b></i>", mdv="1") == "*x*"
+
+    # Legacy Markdown only recognizes a backslash escape in front of
+    # '`'/'*'/'_'/'['.
+    assert (
+        notify("<p>#tag (test)! &lt;x&gt; ~wave~</p>", mdv="1")
+        == "#tag (test)! <x> ~wave~"
+    )
+    assert (
+        notify("<p>a[b]c *lit* _lit_ `lit`</p>", mdv="1")
+        == "a\\[b]c \\*lit\\* \\_lit\\_ \\`lit\\`"
+    )
+
+    # Non-adjacent nesting and sibling spans are unaffected.
+    assert notify("<b>bold <i>italic</i> still bold</b>") == (
+        "*bold _italic_ still bold*"
+    )
+    assert notify("<b>A</b><b>B</b>") == "*A**B*"
+
+    # A nested bold opening *while italic is already open, with real text in
+    # between* (so the two opening delimiters aren't touching) is a completely.
+    assert notify("<i>a <b>b</b> c</i>") == "_a *b* c_"
+    assert notify("<i>a <b>b</b> c</i>", mdv="1") == "_a b c_"
+
+    # The reverse nesting (bold containing italic, separated by text) was
+    # already correct, and must stay that way.
+    assert notify("<b>a <i>b</i> c</b>") == "*a _b_ c*"
+
+    # A literal "\x01<digits>\x01"-shaped sequence in ordinary text must pass
+    # through completely unaltered.
+    assert notify("literal \x010\x01 text, no code or links at all") == (
+        "literal \x010\x01 text, no code or links at all"
+    )
+
+    # overflow=split can hand this method just one chunk of a longer body, with
+    # a span that doesn't open or close until a different chunk entirely.
+    aobj = Apprise()
+    aobj.add(
+        "tgram://123456789:abcdefg_hijklmnop/12345"
+        "?format=markdown&mdv=2&overflow=split"
+    )
+    assert len(aobj) == 1
+    assert aobj.notify(
+        body="<b>" + ("x" * 4990) + "</b>", body_format=NotifyFormat.HTML
+    )
+    assert mock_post.call_count == 2
+    texts = [loads(c[1]["data"])["text"] for c in mock_post.call_args_list]
+
+    # Each half is independently balanced -- an odd number of un-escaped
+    # '*'/'_' in either one would mean Telegram still rejects it.
+    for text in texts:
+        assert text.count("*") % 2 == 0
+        assert text.count("_") % 2 == 0
+
+    # A split at a bold close must not leave an empty entity.
+    assert texts[1] == "x" * (len(texts[1]))
+
+    # The same overflow split can also land mid-code-span or mid-link.
+    assert (
+        NotifyTelegram._commonmark_to_telegram(
+            "text ``unterminated", strict=True
+        )
+        == "text \\`\\`unterminated"
+    )
+    assert (
+        NotifyTelegram._commonmark_to_telegram(
+            "a](<https://incomplete no close", strict=True
+        )
+        == "a](\\<https://incomplete no close"
+    )
+
+    # Empty adjacent entities collapse without affecting following text.
+    assert NotifyTelegram._commonmark_to_telegram("****x") == "x"
+
+    # _build_backtick_run_index() / _find_unescaped_run() -- the lookup
+    # returns None outright when the requested run never appears at all.
+    assert (
+        NotifyTelegram._find_unescaped_run(
+            NotifyTelegram._build_backtick_run_index("no match here"), 0, 2
+        )
+        is None
+    )
+
+    # A genuine match arbitrarily far from `start` is still found.
+    far = "a" * 200_000 + "`"
+    assert (
+        NotifyTelegram._find_unescaped_run(
+            NotifyTelegram._build_backtick_run_index(far), 0, 1
+        )
+        == 200_000
+    )
+
+
+@mock.patch("requests.post")
+def test_plugin_telegram_overflow_split_repair(mock_post):
+    """Test that overflow=split can't break entity boundaries across
+    messages: _build_send_calls() adapts the whole body to Telegram's
+    dialect before splitting (not per-chunk after), and
+    _repair_split_chunk() patches up whatever the split itself still cuts
+    in half across two messages."""
+
+    # Prepare Mock
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+    mock_post.return_value.content = dumps({"ok": True, "result": True})
+
+    def notify_split(body):
+        aobj = Apprise()
+        aobj.add(
+            "tgram://123456789:abcdefg_hijklmnop/12345"
+            "?format=markdown&mdv=2&overflow=split"
+        )
+        assert len(aobj) == 1
+        assert aobj.notify(body=body, body_format=NotifyFormat.HTML)
+        texts = [loads(c[1]["data"])["text"] for c in mock_post.call_args_list]
+        mock_post.reset_mock()
+        return texts
+
+    # A bold span long enough to force a split, immediately followed by plain
+    # text that was never part of it.
+    texts = notify_split(
+        "<b>" + ("x" * 4990) + "</b>" + "TAIL_SHOULD_NOT_BE_BOLD"
+    )
+    assert len(texts) == 2
+    # The part that fit keeps its formatting...
+    assert texts[0].startswith("*x")
+    assert texts[0].endswith("x*")
+    # ...but the unrelated trailing text does not become bold.
+    assert "TAIL" in texts[1]
+    assert not texts[1].startswith("*")
+    for text in texts:
+        assert text.count("*") % 2 == 0
+        assert text.count("_") % 2 == 0
+
+    # A link long enough that its URL alone forces a split.
+    url = "https://example.com/" + ("a" * 4990)
+    texts = notify_split(f'<a href="{url}">click here</a>')
+    assert len(texts) >= 2
+    for text in texts:
+        assert not re.search(r"(?<!\\)[_*\[\]()~`>#+=|{}.!<-]", text)
+
+    # A <pre> block long enough to force a split.
+    content = "line.with.dots-and-dashes_under " * 200
+    texts = notify_split(f"<pre>{content}</pre>")
+    assert len(texts) >= 2
+    for text in texts:
+        assert not re.search(r"(?<!\\)[_*\[\]()~`>#+=|{}.!<-]", text)
+
+    # A short message that never triggers a split at all is unaffected.
+    texts = notify_split("<b>short</b> <i>text</i>")
+    assert texts == ["*short* _text_"]
+
+    # A continuation chunk where the carried-over destination *does* close
+    # within this same chunk (not needing yet another one), even with an.
+    assert NotifyTelegram._repair_split_chunk(
+        "a\\)b)more text\\.", True, {"in_link_dest": True}
+    ) == ("a\\)b\\)more text\\.", {})
+
+    # A carried-over code span closing within this chunk, same idea.
+    assert NotifyTelegram._repair_split_chunk(
+        "code```more text\\.", True, {"in_code": 3}
+    ) == ("codemore text\\.", {})
+
+    # A carried-over destination that doesn't end in *this* chunk either.
+    assert NotifyTelegram._repair_split_chunk(
+        "still no close here", True, {"in_link_dest": True}
+    ) == ("still no close here", {"in_link_dest": True})
 
 
 @mock.patch("requests.post")

--- a/tests/test_plugin_telegram.py
+++ b/tests/test_plugin_telegram.py
@@ -1429,6 +1429,60 @@ def test_plugin_telegram_html_formatting(mock_post):
 
 
 @mock.patch("requests.post")
+def test_plugin_telegram_html_to_markdown_format(mock_post):
+    """NotifyTelegram() HTML body delivered to a Markdown-mode target."""
+
+    # Prepare Mock
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+    mock_post.return_value.content = dumps({"ok": True, "result": True})
+
+    # Simple HTML that our html_to_markdown converter handles
+    body = "<b>hello</b> <i>world</i>"
+
+    # --- Markdown v1 target ---
+    # convert_between(HTML, MARKDOWN) now produces generic Markdown via
+    # html_to_markdown().  For v1, the blunt re.sub escaping is gated on
+    # markdown_ver == TWO, so the converted body passes through unchanged.
+    aobj = Apprise()
+    aobj.add("tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=1")
+    assert len(aobj) == 1
+
+    assert aobj.notify(body=body, body_format=NotifyFormat.HTML)
+
+    assert mock_post.call_count == 1
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+
+    # html_to_markdown produced "**hello** *world*"; v1 has no further
+    # escaping for non-Markdown input, so it arrives in the payload intact
+    assert payload["parse_mode"] == "MARKDOWN"
+    assert payload["text"] == "**hello** *world*"
+
+    mock_post.reset_mock()
+
+    # --- Markdown v2 target ---
+    # For v2, Telegram's existing blunt re.sub fires on the already-converted
+    # Markdown body (body_format=HTML triggers the condition).  The result is
+    # double-escaped: each '*' becomes '\*', making formatting markers
+    # visible as literal text.  This is a known limitation of the current
+    # Telegram plugin when receiving HTML for a Markdown-mode target; it is
+    # documented here so that any future fix must consciously update this
+    # assertion rather than changing the behaviour silently.
+    aobj = Apprise()
+    aobj.add("tgram://123456789:abcdefg_hijklmnop/12345?format=markdown&mdv=2")
+    assert len(aobj) == 1
+
+    assert aobj.notify(body=body, body_format=NotifyFormat.HTML)
+
+    assert mock_post.call_count == 1
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+
+    assert payload["parse_mode"] == "MarkdownV2"
+    # "**hello** *world*" after v2 re.sub escaping
+    assert payload["text"] == r"\*\*hello\*\* \*world\*"
+
+
+@mock.patch("requests.post")
 def test_plugin_telegram_threads(mock_post):
     """NotifyTelegram() Threads/Topics."""
     # Prepare Mock

--- a/tests/test_plugin_twist.py
+++ b/tests/test_plugin_twist.py
@@ -35,7 +35,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
-from apprise import Apprise
+from apprise import Apprise, NotifyFormat
 from apprise.plugins.twist import NotifyTwist
 
 logging.disable(logging.CRITICAL)
@@ -558,3 +558,54 @@ def test_plugin_twist_fetch(mock_post, mock_get):
     # When we can't parse the content, we still default to an empty
     # dictionary
     assert response == {}
+
+
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_twist_html_to_markdown_format(mock_post, mock_get):
+    """NotifyTwist(): HTML body is converted to Markdown."""
+
+    def _response(url, *args, **kwargs):
+        # Default configuration
+        request = mock.Mock()
+        request.status_code = requests.codes.ok
+
+        if url.endswith("/login"):
+            # Simulate a successful login
+            request.content = dumps(
+                {
+                    "token": "2e82c1e4e8b0091fdaa34ff3972351821406f796",
+                    "default_workspace": 1,
+                }
+            )
+
+        else:
+            # All other endpoints return an empty JSON object
+            request.content = "{}"
+
+        return request
+
+    mock_get.side_effect = _response
+    mock_post.side_effect = _response
+
+    # Twist has class-level notify_format = MARKDOWN, so no ?format=
+    # is needed; incoming HTML bodies are converted before dispatch
+    aobj = Apprise()
+    assert aobj.add("twist://password:user@example.com/1:1")
+
+    # Notify with an HTML body; the framework converts it to Markdown
+    # before dispatching to the Twist plugin
+    assert (
+        aobj.notify(
+            body="<b>hello</b> <i>world</i>",
+            body_format=NotifyFormat.HTML,
+        )
+        is True
+    )
+
+    # Two POST calls are expected: login then threads/add
+    assert mock_post.call_count == 2
+
+    # The body must arrive as Markdown in the threads/add payload
+    data = mock_post.call_args_list[1][1]["data"]
+    assert data["content"] == "**hello** *world*"

--- a/tests/test_plugin_webex_teams.py
+++ b/tests/test_plugin_webex_teams.py
@@ -26,6 +26,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 # Disable logging for a cleaner testing output
+from json import loads
 import logging
 import os
 from unittest import mock
@@ -34,7 +35,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
-from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise import Apprise, AppriseAttachment, NotifyFormat, NotifyType
 from apprise.plugins.webexteams import (
     NotifyWebexTeams,
     WebexTeamsMode,
@@ -703,3 +704,32 @@ def test_plugin_webex_teams_apprise_integration(mock_post):
     app2 = Apprise()
     assert app2.add("wxteams://{}/{}".format(BOT_TOKEN, ROOM_ID))
     assert app2.notify(body="bot test") is True
+
+
+@mock.patch("requests.post")
+def test_plugin_webex_teams_html_to_markdown_format(mock_post):
+    """NotifyWebexTeams(): HTML body is converted to Markdown."""
+
+    # Prepare Mock
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    # Use a webhook URL (80-char token, webhook mode)
+    aobj = Apprise()
+    assert aobj.add("wxteams://{}".format("a" * 80))
+
+    # Notify with an HTML body; the framework should convert it
+    # to Markdown before dispatching to Webex Teams
+    assert (
+        aobj.notify(
+            body="<b>hello</b> <i>world</i>",
+            body_format=NotifyFormat.HTML,
+        )
+        is True
+    )
+    assert mock_post.call_count == 1
+
+    # The body must arrive as Markdown (not plain text) in the
+    # "markdown" key, since notify_format is MARKDOWN by default
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+    assert payload["markdown"] == "**hello** *world*"

--- a/tests/test_plugin_workflows.py
+++ b/tests/test_plugin_workflows.py
@@ -37,7 +37,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
-from apprise import Apprise, AppriseConfig, NotifyType
+from apprise import Apprise, AppriseConfig, NotifyFormat, NotifyType
 from apprise.plugins.workflows import NotifyWorkflows
 
 logging.disable(logging.CRITICAL)
@@ -873,3 +873,34 @@ def test_plugin_workflows_azure_webhooks(request_mock):
     assert obj.workflow == "3XXX5"
     assert obj.signature == "iXXXU"
     assert obj.api_version == "2016-06-01"
+
+
+@mock.patch("requests.post")
+def test_plugin_workflows_html_to_markdown_format(mock_post):
+    """NotifyWorkflows(): HTML body is converted to Markdown."""
+
+    # Prepare Mock
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    # Workflows' notify_format is MARKDOWN by default
+    aobj = Apprise()
+    assert aobj.add("workflow://hostname/workflow1/signature1/?image=no")
+
+    # Notify with an HTML body; the framework should convert it
+    # to Markdown before dispatching to Workflows
+    assert (
+        aobj.notify(
+            body="<b>hello</b> <i>world</i>",
+            body_format=NotifyFormat.HTML,
+        )
+        is True
+    )
+    assert mock_post.call_count == 1
+
+    # The body must arrive as Markdown inside the adaptive card body block,
+    # not as stripped plain text
+    payload = json.loads(mock_post.call_args_list[0][1]["data"])
+    body_blocks = payload["attachments"][0]["content"]["body"]
+    body_text = next(b["text"] for b in body_blocks if b.get("id") == "body")
+    assert body_text == "**hello** *world*"

--- a/tests/test_utils_format.py
+++ b/tests/test_utils_format.py
@@ -326,34 +326,138 @@ def test_markdown_adjust_inside_construct_moves_to_start() -> None:
     Exercise the positive path in markdown_adjust where the split lands
     inside a [text](url) construct and the function moves the split
     back to the start of the construct.
+
+    The forward scan is capped at split_at + (split_at - window_start) + 1
+    to prevent O(n^2) work on adversarial input (see
+    test_markdown_adjust_dos_cap). This means split_at must be at least half
+    the link length so the cap reaches the closing ')'.  Realistic splits from
+    smart_split() always satisfy this because the following applies for any
+    link that fits in a single chunk:
+        split_at - window_start >= limit >= link_length // 2
     """
     link = "[link](https://example.com)"
-    # Choose a split point inside the URL
-    split_at = link.index("(") + 3  # somewhere inside "(https..."
+    # Choose a split point in the latter half of the link so the symmetric
+    # forward-scan cap (split_at + window_size) reaches the closing ')'.
+    split_at = len(link) // 2  # index 13, inside "ps://example.com"
     adjusted = markdown_adjust(link, window_start=0, split_at=split_at)
 
     # Should move back to the '[' at index 0
     assert adjusted == 0
 
 
-def test_smart_split_markdown_guard_split_at_start_is_reset() -> None:
-    """
-    Cover the smart_split guard 'if split_at <= start: split_at = orig_split'.
+def test_markdown_adjust_inside_angle_bracket_construct() -> None:
+    """Exercise the <URL|label> angle-bracket path in markdown_adjust.
 
-    We force markdown_adjust to move the split back to the window start,
-    then verify smart_split resets to the original split so progress is
-    still made and chunks join back to the original text.
+    When a split point lands ANYWHERE inside a '<url|label>' construct (as
+    used by Slack mrkdwn and Google Chat), the function must move it back to
+    the opening '<'.  This covers three sub-cases:
+
+      (a) Split in the label portion (after the pipe).
+      (b) Split exactly on the pipe character.
+      (c) Split in the URL portion (before the pipe) -- previously the pipe
+          search stopped at split_at so no pipe was found; the fix extends
+          the search to forward_end so this case is now also protected.
     """
-    text = "[link](https://example.com)"
-    limit = 5  # will cause the first soft split to land inside the link
+    # A Slack/Google Chat anchor -- '<' at 0, '|' at 21, '>' at 31.
+    text = "<https://example.com|click here>"
+    pipe_pos = text.index("|")  # == 20
+
+    # (a) Split a few characters after the pipe, inside the label portion.
+    split_at = pipe_pos + 3
+    adjusted = markdown_adjust(text, window_start=0, split_at=split_at)
+    # Should move back to the '<' at index 0.
+    assert adjusted == 0
+
+    # Split right at the closing '>' -- still inside the construct.
+    split_at2 = text.index(">")
+    adjusted2 = markdown_adjust(text, window_start=0, split_at=split_at2)
+    # Also moves back to '<'.
+    assert adjusted2 == 0
+
+    # (b) Split exactly ON the '|' separator.
+    split_on_pipe = pipe_pos
+    assert markdown_adjust(text, 0, split_on_pipe) == 0
+
+    # (c) Split inside the URL portion (before '|').
+    # The pipe search now extends to forward_end, not just to split_at.
+    # forward_end = min(32, 17 + 17 + 1) = 32, which covers '>' at 31.
+    # Both pipe (20) and '>' (31) are within range; the construct is detected
+    # and the split moves to '<' at 0.
+    split_in_url = pipe_pos - 3  # index 17, inside "example.com"
+    assert markdown_adjust(text, 0, split_in_url) == 0
+
+    # Same scenario with a preamble before '<' so the move is actually
+    # useful -- '<' is no longer at window_start so smart_split would
+    # keep the adjusted position (not reset it).
+    # "<" at 4, "|" at 24, ">" at 35 in the prefixed string.
+    prefixed = "pre " + text
+    split_in_url2 = 20  # index 20, inside "example.com", before '|' at 24
+    # forward_end = min(36, 20+20+1) = 36 > 35 ('>').
+    assert markdown_adjust(prefixed, 0, split_in_url2) == 4  # '<' position
+
+    # When split_at is so small that forward_end doesn't reach the pipe,
+    # the construct is undetectable and the split falls through unchanged.
+    # forward_end = min(32, 5 + 5 + 1) = 11 < pipe_pos(20), so no pipe found.
+    # Even if we detected the '<' at 0, moving the split there would equal
+    # window_start so smart_split() would reset it anyway -- no net change.
+    split_too_small = 5
+    assert markdown_adjust(text, 0, split_too_small) == split_too_small
+
+    # '<' and '|' are both found, but split_at is past the closing '>'
+    # so the condition angle_start_idx < split_at <= angle_end_idx is
+    # False -- the function returns the split point unchanged.
+    split_past_end = len(text)
+    assert markdown_adjust(text, 0, split_past_end) == split_past_end
+
+
+def test_markdown_adjust_dos_cap() -> None:
+    """markdown_adjust forward scan is capped to O(window_size).
+
+    An adversarial body of repeated unterminated '[' openers must not
+    cause O(n^2) work.  We verify the cap by checking that a large body
+    produces the same split position as a small one (the cap does not
+    change the output for well-formed constructs within the window).
+    """
+    from timeit import default_timer
+
+    # 1 MB of repeated '[broken ' with no closing ')'.
+    body = "[broken " * 128_000
+    limit = 80
+    start = default_timer()
+    chunks = smart_split(body, limit, body_format=NotifyFormat.MARKDOWN)
+    elapsed = default_timer() - start
+
+    # Must complete well under 1 second (the DoS took ~14 s before the cap).
+    assert elapsed < 1.0
+    # All chunks must be non-empty and re-join to the original.
+    assert all(chunks)
+    assert "".join(chunks) == body
+
+
+def test_smart_split_markdown_guard_split_at_start_is_reset() -> None:
+    """Cover smart_split guard 'if split_at <= start: split_at = orig_split'.
+
+    We force markdown_adjust to move the split back to the window start
+    (link_start_idx == start == 0), then verify smart_split resets to the
+    original split so progress is still made and chunks join back to the
+    original text.
+
+    The link "[link](url)" is 11 chars.  With limit=7 the first hard split
+    lands at index 7 (inside the URL).  The forward-scan cap is
+    7 + (7 - 0) + 1 = 15, which is > 10 (position of ")"), so markdown_adjust
+    finds the closer and moves split to link_start_idx=0.  Since 0 == start,
+    smart_split resets to orig_split=7 and emits the next chunk from there.
+    """
+    text = "[link](url)"  # 12 chars; ")" at index 11
+    limit = 7  # hard split at 7 (inside url); cap = 15 > 11 so ")" is found
 
     chunks = smart_split(text, limit, body_format=NotifyFormat.MARKDOWN)
 
-    # We should never get stuck; all chunks must be non-empty
+    # We should never get stuck; all chunks must be non-empty.
     assert len(chunks) >= 2
     assert all(chunks)
 
-    # Re-joining all chunks must restore the original text
+    # Re-joining all chunks must restore the original text.
     assert "".join(chunks) == text
 
 

--- a/tests/test_utils_format.py
+++ b/tests/test_utils_format.py
@@ -461,6 +461,18 @@ def test_smart_split_markdown_guard_split_at_start_is_reset() -> None:
     assert "".join(chunks) == text
 
 
+def test_markdown_adjust_image_bang_opener_path() -> None:
+    """Cover the '!' opener path in markdown_adjust."""
+    # Bang found, but no '[' after it, so the fallback path is taken.
+    text = "AAAAAA![b](c)"
+    assert markdown_adjust(text, window_start=0, split_at=7) == 6
+
+    # Stray '!' not followed by '[' -- bang found but condition is False;
+    # no link construct detected, split point returned unchanged.
+    text2 = "hello!world"
+    assert markdown_adjust(text2, window_start=0, split_at=6) == 6
+
+
 def test_smart_split_uses_punctuation_branch_on_rare_whitespace() -> None:
     """
     When punctuation is followed by rare whitespace (vertical tab / form feed)


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1600

This implements a proper HTML-to-Markdown converter for Apprise, completing the work started in PR #932.

The converter now emits structured Markdown instead of falling back to plain-text extraction when a Markdown-capable notification service receives HTML input. This is also a starting marker for the broader #1600 effort, which extends beyond this PR.

| Element | Output |
|---------|--------|
| `<h1>` … `<h6>` | `#` … `######` prefixed line |
| `<b>`, `<strong>` | `**text**` |
| `<em>`, `<i>` | `*text*` |
| `<code>` | `` `text` `` inline code |
| `<pre>`, `<samp>` | fenced code block |
| `<a href="…">` | `[text](<url>)` |
| `<a>` without `href` | plain text |
| `<blockquote>` | `> text` |
| `<ul>`, `<ol>`, `<li>` | Markdown lists |
| `<hr>` | `---` |
| `<br>` | Markdown hard line break |
| `<table>`, `<thead>`, `<tbody>`, `<tr>`, `<th>`, `<td>` | Markdown table |
| Markdown-sensitive text characters | escaped where needed |
| `<script>`, `<style>`, `<head>`, etc. | suppressed |

Docs: https://github.com/caronc/apprise-docs/pull/89

## Checklist
* [ ] Documentation ticket created (if applicable): n/a
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:

```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1600-html-to-markdown

# Send HTML to a Markdown-capable service
apprise -t "Test Title" \
  -b '<h1>Hello</h1><p>This is <b>bold</b>, <i>italic</i>, and <a href="https://github.com/caronc/apprise">linked</a>.</p>' \
  --format html \
  '<apprise url that supports markdown, e.g. gotify://...>'
```

If you have cloned the branch and have tox available:

```bash
tox -e lint
tox -e qa

tox -e apprise -- -t "Test Title" \
  -b '<p>This is <b>HTML</b> converted to Markdown.</p>' \
  --format html \
  '<apprise url that supports markdown, e.g. gotify://...>'
```