### PR TITLE
Verify SMTP TLS certificates for SMTPS and STARTTLS connections

### DIFF
--- a/apprise/plugins/email/base.py
+++ b/apprise/plugins/email/base.py
@@ -34,6 +34,7 @@ from email.mime.text import MIMEText
 from email.utils import format_datetime, formataddr, make_msgid
 import re
 import smtplib
+import ssl
 from typing import Optional
 
 from ...common import NotifyFormat, NotifyType, PersistentStoreMode
@@ -650,24 +651,36 @@ class NotifyEmail(NotifyBase):
         # Always call throttle before any remote server i/o is made
         self.throttle()
 
+        # Build an SSL context that honours our verify_certificate setting so
+        # that SMTPS/STARTTLS connections actually validate the remote server's
+        # certificate (and hostname) instead of silently accepting any
+        # certificate presented to us.
+        context = ssl.create_default_context()
+        if not self.verify_certificate:
+            context.check_hostname = False
+            context.verify_mode = ssl.CERT_NONE
+
         try:
             self.logger.debug("Connecting to remote SMTP server...")
             socket_func = smtplib.SMTP
+            socket_args = {}
             if self.secure_mode == SecureMailMode.SSL:
                 self.logger.debug("Securing connection with SSL...")
                 socket_func = smtplib.SMTP_SSL
+                socket_args["context"] = context
 
             socket = socket_func(
                 self.smtp_host,
                 self.port,
                 None,
                 timeout=self.socket_connect_timeout,
+                **socket_args,
             )
 
             if self.secure_mode == SecureMailMode.STARTTLS:
                 # Handle Secure Connections
                 self.logger.debug("Securing connection with STARTTLS...")
-                socket.starttls()
+                socket.starttls(context=context)
 
             self.logger.trace("Login ID: {}".format(self.user))
             if self.user and self.password:

--- a/apprise/plugins/email/base.py
+++ b/apprise/plugins/email/base.py
@@ -25,6 +25,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import contextlib
 from datetime import datetime
 from email.header import Header
 from email.mime.application import MIMEApplication
@@ -748,7 +749,13 @@ class NotifyEmail(NotifyBase):
         finally:
             # Gracefully terminate the connection with the server
             if socket is not None:
-                socket.quit()
+                with contextlib.suppress(
+                    OSError, smtplib.SMTPException, RuntimeError
+                ):
+                    # Handles a failed TLS handshake that may have already
+                    # invalidated the socket.
+                    socket.quit()
+                    pass
 
         # Reduce our dictionary (eliminate expired keys if any)
         self.pgp.prune()

--- a/tests/test_plugin_email.py
+++ b/tests/test_plugin_email.py
@@ -33,6 +33,7 @@ import os
 import re
 import shutil
 import smtplib
+import ssl
 import sys
 from unittest import mock
 
@@ -3747,3 +3748,86 @@ def test_plugin_email_gmx_template_lookup(mock_smtp):
 
         # GMX should authenticate with full email, not just the local part
         assert login_user == f"user@{domain}"
+
+
+@mock.patch("smtplib.SMTP")
+@mock.patch("smtplib.SMTP_SSL")
+def test_plugin_email_tls_certificate_verification(mock_smtpssl, mock_smtp):
+    """Verify that SMTPS and STARTTLS honour the verify_certificate setting by
+    passing a validating SSL context to smtplib."""
+
+    response = mock.Mock()
+    response.starttls.return_value = True
+    response.login.return_value = True
+    response.sendmail.return_value = True
+    response.quit.return_value = True
+    mock_smtp.return_value = response
+    mock_smtpssl.return_value = response
+
+    # 1. SMTPS (mode=ssl) with the default verify_certificate=True should
+    #    pass a context that validates the certificate and hostname.
+    obj = Apprise.instantiate(
+        "mailtos://user:pass@example.com?mode=ssl",
+        suppress_exceptions=False,
+    )
+    assert isinstance(obj, email.NotifyEmail)
+    assert obj.verify_certificate is True
+    assert obj.notify(body="body", title="title") is True
+
+    assert mock_smtpssl.call_count == 1
+    context = mock_smtpssl.call_args.kwargs.get("context")
+    assert isinstance(context, ssl.SSLContext)
+    assert context.verify_mode == ssl.CERT_REQUIRED
+    assert context.check_hostname is True
+
+    mock_smtp.reset_mock()
+    mock_smtpssl.reset_mock()
+
+    # 2. SMTPS (mode=ssl) with verify=no should pass a context that does not
+    #    validate the certificate.
+    obj = Apprise.instantiate(
+        "mailtos://user:pass@example.com?mode=ssl&verify=no",
+        suppress_exceptions=False,
+    )
+    assert obj.verify_certificate is False
+    assert obj.notify(body="body", title="title") is True
+
+    assert mock_smtpssl.call_count == 1
+    context = mock_smtpssl.call_args.kwargs.get("context")
+    assert isinstance(context, ssl.SSLContext)
+    assert context.verify_mode == ssl.CERT_NONE
+    assert context.check_hostname is False
+
+    mock_smtp.reset_mock()
+    mock_smtpssl.reset_mock()
+
+    # 3. STARTTLS with the default verify_certificate=True should pass a
+    #    validating context to starttls().
+    obj = Apprise.instantiate(
+        "mailtos://user:pass@example.com?mode=starttls",
+        suppress_exceptions=False,
+    )
+    assert obj.verify_certificate is True
+    assert obj.notify(body="body", title="title") is True
+
+    assert response.starttls.call_count == 1
+    context = response.starttls.call_args.kwargs.get("context")
+    assert isinstance(context, ssl.SSLContext)
+    assert context.verify_mode == ssl.CERT_REQUIRED
+    assert context.check_hostname is True
+
+    response.starttls.reset_mock()
+
+    # 4. STARTTLS with verify=no should pass a non-validating context.
+    obj = Apprise.instantiate(
+        "mailtos://user:pass@example.com?mode=starttls&verify=no",
+        suppress_exceptions=False,
+    )
+    assert obj.verify_certificate is False
+    assert obj.notify(body="body", title="title") is True
+
+    assert response.starttls.call_count == 1
+    context = response.starttls.call_args.kwargs.get("context")
+    assert isinstance(context, ssl.SSLContext)
+    assert context.verify_mode == ssl.CERT_NONE
+    assert context.check_hostname is False

--- a/tests/test_plugin_email.py
+++ b/tests/test_plugin_email.py
@@ -3831,3 +3831,27 @@ def test_plugin_email_tls_certificate_verification(mock_smtpssl, mock_smtp):
     assert isinstance(context, ssl.SSLContext)
     assert context.verify_mode == ssl.CERT_NONE
     assert context.check_hostname is False
+
+
+@mock.patch("smtplib.SMTP")
+def test_plugin_email_starttls_certificate_failure_handling(mock_smtp):
+    """A rejected STARTTLS certificate must be a normal send failure."""
+    response = mock.Mock()
+    response.starttls.side_effect = ssl.SSLCertVerificationError(
+        "certificate verify failed"
+    )
+    # A real socket is no longer connected after the failed TLS handshake.
+    response.quit.side_effect = smtplib.SMTPServerDisconnected(
+        "Server not connected"
+    )
+    mock_smtp.return_value = response
+
+    obj = Apprise.instantiate(
+        "mailtos://user:pass@example.com?mode=starttls",
+        suppress_exceptions=False,
+    )
+    assert isinstance(obj, email.NotifyEmail)
+
+    assert obj.notify(body="body", title="title") is False
+    response.login.assert_not_called()
+    response.sendmail.assert_not_called()


### PR DESCRIPTION
## Description

The email plugin opens SMTPS / STARTTLS connections without ever passing an
SSL context, so `smtplib` falls back to `ssl._create_stdlib_context()` — which
does **not** validate the certificate chain or hostname. Because of that, the
URL-level `verify_certificate` setting (which defaults to `True`) was silently
ignored for the SMTP path, and a self-signed or hostname-mismatched server
certificate is accepted before any credentials or message data are sent.

This means an attacker who can intercept or redirect SMTP traffic can present
an untrusted certificate, complete the TLS handshake, and capture SMTP
credentials / notification contents.

## Cause

In `NotifyEmail.send()`:

- `smtplib.SMTP_SSL(...)` is called with no `context=` argument.
- `socket.starttls()` is called with no `context=` argument.

`self.verify_certificate` is exposed on the URL (and already used for the WKD
HTTP lookup) but was never wired into the SMTP TLS handshake.

## Fix

Build an SSL context from `verify_certificate` and pass it to both
`SMTP_SSL(context=...)` and `starttls(context=...)`:

- By default (`verify_certificate=True`) the context validates the CA chain and
  hostname (`ssl.create_default_context()`).
- `verify=no` still produces an unverified context (`CERT_NONE`,
  `check_hostname=False`), preserving the existing opt-out.

Plain (non-TLS) SMTP is unaffected.

## Testing

Added `test_plugin_email_tls_certificate_verification` covering SMTPS and
STARTTLS with `verify_certificate` both on and off, asserting the context
passed to `smtplib` has the expected `verify_mode` / `check_hostname`. The test
fails on `master` (no context is passed) and passes with this change. The full
email test file plus the api/cli suites pass, and `ruff check` / `ruff format
--check` are clean.

Fixes #1639
