### PR TITLE
Added PushWard Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The table below identifies the services this tool supports and some example serv
 | [Pushover](https://appriseit.com/services/pushover/)  | pover://   | (TCP) 443   | pover://user@token<br />pover://user@token/DEVICE<br />pover://user@token/DEVICE1/DEVICE2/DEVICEN<br />**Note**: you must specify both your user_id and token
 | [Pushplus](https://appriseit.com/services/pushplus/) | pushplus://  | (TCP) 443   | pushplus://Token
 | [PushSafer](https://appriseit.com/services/pushsafer/)  | psafer:// or psafers://  | (TCP) 80 or 443  | psafer://privatekey<br />psafers://privatekey/DEVICE<br />psafer://privatekey/DEVICE1/DEVICE2/DEVICEN
+| [PushWard](https://appriseit.com/services/pushward/)  | pushward://  | (TCP) 443  | pushward://hlk_apikey<br />pushward://hlk_apikey?level=critical&volume=0.8
 | [Pushy](https://appriseit.com/services/pushy/)  | pushy://  | (TCP) 443  | pushy://apikey/DEVICE<br />pushy://apikey/DEVICE1/DEVICE2/DEVICEN<br />pushy://apikey/TOPIC<br />pushy://apikey/TOPIC1/TOPIC2/TOPICN
 | [PushDeer](https://appriseit.com/services/pushdeer/) | pushdeer:// or pushdeers:// | (TCP) 80 or 443 | pushdeer://pushKey<br />pushdeer://hostname/pushKey<br />pushdeer://hostname:port/pushKey
 | [QQ Push](https://appriseit.com/services/qq/) | qq://  | (TCP) 443   | qq://Token

--- a/apprise/plugins/pushward.py
+++ b/apprise/plugins/pushward.py
@@ -1,0 +1,361 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# PushWard (https://pushward.app) is a hosted push notification service.
+#
+# To use this plugin you need an integration key from the PushWard app. The
+# key always begins with the prefix "hlk_".
+#
+# Your Apprise URL would be assembled as:
+#   pushward://{integration_key}
+#
+# For example:
+#   pushward://hlk_xxxxxxxxxxxx
+#
+# The level may be set explicitly, otherwise it is derived from the Apprise
+# notification type:
+#   pushward://hlk_xxxxxxxxxxxx?level=critical&volume=0.8
+#
+# References:
+# - https://pushward.app/docs/api
+
+from json import dumps
+
+import requests
+
+from ..common import NotifyFormat, NotifyImageSize, NotifyType
+from ..locale import gettext_lazy as _
+from ..utils.parse import validate_regex
+from .base import NotifyBase
+
+# Extend HTTP Error Messages
+PUSHWARD_HTTP_ERROR_MAP = {
+    401: "Unauthorized - Invalid Integration Key.",
+    403: "Forbidden - The Integration Key lacks permission.",
+    422: "Unprocessable - The notification payload was rejected.",
+    429: "Too many requests; rate-limit exceeded.",
+}
+
+# The PushWard notification levels (interruption levels)
+PUSHWARD_LEVELS = (
+    "passive",
+    "active",
+    "time-sensitive",
+    "critical",
+)
+
+# Maps an Apprise notification type to a default PushWard level. Only used when
+# the URL does not specify an explicit level=; "critical" is never selected
+# automatically as it must be requested on purpose.
+PUSHWARD_LEVEL_MAP = {
+    NotifyType.INFO: "active",
+    NotifyType.SUCCESS: "active",
+    NotifyType.WARNING: "time-sensitive",
+    NotifyType.FAILURE: "time-sensitive",
+}
+
+
+class NotifyPushWard(NotifyBase):
+    """A wrapper for PushWard Notifications."""
+
+    # The default descriptive name associated with the Notification
+    service_name = "PushWard"
+
+    # The services URL
+    service_url = "https://pushward.app/"
+
+    # The default secure protocol
+    secure_protocol = "pushward"
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = "https://appriseit.com/services/pushward/"
+
+    # PushWard notification endpoint (used in send())
+    notify_url = "https://api.pushward.app/notifications"
+
+    # PushWard delivers the body as plain text
+    notify_format = NotifyFormat.TEXT
+
+    # Allow an image to be referenced as the notification icon
+    image_size = NotifyImageSize.XY_128
+
+    # The API accepts a title up to 256 characters and a body up to 4096.  A
+    # notification is delivered as a single APNs alert though, which Apple caps
+    # at a 4KB total payload shared by the title, body, and icon, so the body
+    # is capped lower to keep real pushes within budget (otherwise the API
+    # accepts the request but the oversized push is silently dropped).
+    title_maxlen = 256
+    body_maxlen = 3000
+
+    # PushWard supports media attachments by URL only (not file uploads), so
+    # Apprise file attachments are not wired in at this time
+    attachment_support = False
+
+    # Define object URL templates
+    templates = ("{schema}://{apikey}",)
+
+    # Define our template tokens
+    template_tokens = dict(
+        NotifyBase.template_tokens,
+        **{
+            "apikey": {
+                "name": _("Integration Key"),
+                "type": "string",
+                "private": True,
+                "required": True,
+                "regex": (r"^hlk_[A-Za-z0-9]+$", "i"),
+            },
+        },
+    )
+
+    # Define our template arguments
+    template_args = dict(
+        NotifyBase.template_args,
+        **{
+            "apikey": {
+                "alias_of": "apikey",
+            },
+            "level": {
+                "name": _("Level"),
+                "type": "choice:string",
+                "values": PUSHWARD_LEVELS,
+            },
+            "volume": {
+                "name": _("Volume"),
+                "type": "float",
+                "min": 0.0,
+                "max": 1.0,
+            },
+        },
+    )
+
+    def __init__(self, apikey, level=None, volume=None, **kwargs):
+        """Initialize PushWard Object."""
+        super().__init__(**kwargs)
+
+        # Validate the Integration Key (begins with the hlk_ prefix)
+        self.apikey = validate_regex(
+            apikey, *self.template_tokens["apikey"]["regex"]
+        )
+        if not self.apikey:
+            msg = (
+                "An invalid PushWard Integration Key "
+                f"({apikey}) was specified."
+            )
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # Acquire our level (if one was explicitly provided)
+        if level:
+            self.level = level.strip().lower()
+            if self.level not in PUSHWARD_LEVELS:
+                msg = f"An invalid PushWard level ({level}) was specified."
+                self.logger.warning(msg)
+                raise TypeError(msg)
+        else:
+            self.level = None
+
+        # Acquire our volume (only applied to critical notifications)
+        if volume is not None:
+            try:
+                self.volume = float(volume)
+
+            except (ValueError, TypeError):
+                msg = f"An invalid PushWard volume ({volume}) was specified."
+                self.logger.warning(msg)
+                raise TypeError(msg) from None
+
+            if self.volume < 0.0 or self.volume > 1.0:
+                msg = f"An invalid PushWard volume ({volume}) was specified."
+                self.logger.warning(msg)
+                raise TypeError(msg)
+        else:
+            self.volume = None
+
+        return
+
+    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+        """Perform PushWard Notification."""
+
+        # Prepare our headers
+        headers = {
+            "User-Agent": self.app_id,
+            "Content-Type": "application/json; charset=utf-8",
+            "Authorization": f"Bearer {self.apikey}",
+        }
+
+        # Resolve the level: an explicit override, otherwise derived
+        level = (
+            self.level
+            if self.level
+            else PUSHWARD_LEVEL_MAP.get(notify_type, "active")
+        )
+
+        # PushWard requires a non-empty title; the body is guaranteed by the
+        # framework, but the title can be empty so we fall back to our
+        # application descriptor
+        title = title if title else self.app_desc
+        if not title:
+            title = self.app_id
+
+        # Prepare our payload
+        payload = {
+            "title": title,
+            "body": body,
+            "level": level,
+        }
+
+        # Reference an icon if one is available
+        image_url = self.image_url(notify_type)
+        if image_url:
+            payload["icon_url"] = image_url
+
+        # Volume is only applied to critical notifications
+        if level == "critical" and self.volume is not None:
+            payload["volume"] = self.volume
+
+        self.logger.debug(
+            "PushWard POST URL: %s (cert_verify=%s)",
+            self.notify_url,
+            self.verify_certificate,
+        )
+        self.logger.debug("PushWard Payload: %s", str(payload))
+
+        # Always call throttle before any remote server i/o is made
+        self.throttle()
+
+        try:
+            r = requests.post(
+                self.notify_url,
+                data=dumps(payload),
+                headers=headers,
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+                allow_redirects=self.redirects,
+            )
+
+            if r.status_code not in (
+                requests.codes.ok,
+                requests.codes.created,
+            ):
+                # We had a problem
+                status_str = NotifyPushWard.http_response_code_lookup(
+                    r.status_code, PUSHWARD_HTTP_ERROR_MAP
+                )
+
+                self.logger.warning(
+                    "Failed to send PushWard notification: "
+                    "{}{}error={}.".format(
+                        status_str,
+                        ", " if status_str else "",
+                        r.status_code,
+                    )
+                )
+
+                self.logger.debug(
+                    "Response Details:\r\n%r", (r.content or b"")[:2000]
+                )
+
+                # Return; we're done
+                return False
+
+            else:
+                self.logger.info("Sent PushWard notification.")
+
+        except requests.RequestException as e:
+            self.logger.warning(
+                "A Connection error occurred posting to PushWard."
+            )
+            self.logger.debug("Socket Exception: %s", str(e))
+            return False
+
+        return True
+
+    @property
+    def url_identifier(self):
+        """Returns all of the identifiers that make this URL unique from
+        another simliar one.
+
+        Targets or end points should never be identified here.
+        """
+        return (
+            self.secure_protocol,
+            self.apikey,
+            self.level,
+            self.volume,
+        )
+
+    def url(self, privacy=False, *args, **kwargs):
+        """Returns the URL built dynamically based on specified arguments."""
+
+        # Define any URL parameters
+        params = {}
+        if self.level:
+            params["level"] = self.level
+
+        if self.volume is not None:
+            params["volume"] = str(self.volume)
+
+        # Extend our parameters
+        params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
+
+        return "{schema}://{apikey}/?{params}".format(
+            schema=self.secure_protocol,
+            apikey=self.pprint(self.apikey, privacy, safe=""),
+            params=NotifyPushWard.urlencode(params),
+        )
+
+    @staticmethod
+    def parse_url(url):
+        """Parses the URL and returns enough arguments that can allow us to re-
+        instantiate this object."""
+        results = NotifyBase.parse_url(url, verify_host=False)
+        if not results:
+            # We're done early as we couldn't load the results
+            return results
+
+        # The Integration Key is in the host position (case is preserved
+        # because verify_host=False skips hostname normalization)
+        results["apikey"] = NotifyPushWard.unquote(results["host"])
+
+        # Allow ?apikey= to override the host-supplied key
+        if "apikey" in results["qsd"] and results["qsd"]["apikey"]:
+            results["apikey"] = NotifyPushWard.unquote(
+                results["qsd"]["apikey"]
+            )
+
+        # Allow the level to be set
+        if "level" in results["qsd"] and results["qsd"]["level"]:
+            results["level"] = NotifyPushWard.unquote(results["qsd"]["level"])
+
+        # Allow the volume to be set
+        if "volume" in results["qsd"] and results["qsd"]["volume"]:
+            results["volume"] = NotifyPushWard.unquote(
+                results["qsd"]["volume"]
+            )
+
+        return results

--- a/apprise/plugins/pushward.py
+++ b/apprise/plugins/pushward.py
@@ -47,7 +47,7 @@ from json import dumps
 
 import requests
 
-from ..common import NotifyFormat, NotifyImageSize, NotifyType
+from ..common import NotifyImageSize, NotifyType
 from ..locale import gettext_lazy as _
 from ..utils.parse import validate_regex
 from .base import NotifyBase
@@ -110,18 +110,13 @@ class NotifyPushWard(NotifyBase):
     # PushWard notification endpoint (used in send())
     notify_url = "https://api.pushward.app/notifications"
 
-    # PushWard delivers the body as plain text
-    notify_format = NotifyFormat.TEXT
-
     # Allow an image to be referenced as the notification icon
     image_size = NotifyImageSize.XY_128
 
-    # The API accepts a title up to 256 characters and a body up to 4096.  A
-    # notification is delivered as a single APNs alert though, which Apple caps
-    # at a 4KB total payload shared by the title, body, and icon, so the body
-    # is capped lower to keep real pushes within budget (otherwise the API
-    # accepts the request but the oversized push is silently dropped).
+    # Defines the maximum allowable characters in the title
     title_maxlen = 256
+
+    # Body limit
     body_maxlen = 3000
 
     # PushWard supports media attachments by URL only (not file uploads), so

--- a/apprise/plugins/pushward.py
+++ b/apprise/plugins/pushward.py
@@ -68,15 +68,28 @@ PUSHWARD_LEVELS = (
     "critical",
 )
 
-# Maps an Apprise notification type to a default PushWard level. Only used when
-# the URL does not specify an explicit level=; "critical" is never selected
-# automatically as it must be requested on purpose.
-PUSHWARD_LEVEL_MAP = {
+# The default PushWard level mapped to each Apprise notification type. Each is
+# overridable from the URL (e.g. ?info=passive&failure=critical) so the mapping
+# can match a user's own PushWard setup. "critical" is never a default; it must
+# be opted into as it bypasses the device's silent mode / Focus.
+PUSHWARD_DEFAULT_LEVELS = {
     NotifyType.INFO: "active",
     NotifyType.SUCCESS: "active",
     NotifyType.WARNING: "time-sensitive",
     NotifyType.FAILURE: "time-sensitive",
 }
+
+
+def pushward_level(value):
+    """Resolve a full or short-form level (e.g. 'crit', 'c') to a canonical
+    PushWard level, or None if it does not match one."""
+    value = str(value).strip().lower()
+    if not value:
+        return None
+    return next(
+        (level for level in PUSHWARD_LEVELS if level.startswith(value)),
+        None,
+    )
 
 
 class NotifyPushWard(NotifyBase):
@@ -139,10 +152,36 @@ class NotifyPushWard(NotifyBase):
             "apikey": {
                 "alias_of": "apikey",
             },
+            # Force the level for every notification regardless of its type
             "level": {
                 "name": _("Level"),
                 "type": "choice:string",
                 "values": PUSHWARD_LEVELS,
+            },
+            # Per-type level overrides; default to PUSHWARD_DEFAULT_LEVELS
+            "info": {
+                "name": _("Info Level"),
+                "type": "choice:string",
+                "values": PUSHWARD_LEVELS,
+                "default": PUSHWARD_DEFAULT_LEVELS[NotifyType.INFO],
+            },
+            "success": {
+                "name": _("Success Level"),
+                "type": "choice:string",
+                "values": PUSHWARD_LEVELS,
+                "default": PUSHWARD_DEFAULT_LEVELS[NotifyType.SUCCESS],
+            },
+            "warning": {
+                "name": _("Warning Level"),
+                "type": "choice:string",
+                "values": PUSHWARD_LEVELS,
+                "default": PUSHWARD_DEFAULT_LEVELS[NotifyType.WARNING],
+            },
+            "failure": {
+                "name": _("Failure Level"),
+                "type": "choice:string",
+                "values": PUSHWARD_LEVELS,
+                "default": PUSHWARD_DEFAULT_LEVELS[NotifyType.FAILURE],
             },
             "volume": {
                 "name": _("Volume"),
@@ -153,7 +192,17 @@ class NotifyPushWard(NotifyBase):
         },
     )
 
-    def __init__(self, apikey, level=None, volume=None, **kwargs):
+    def __init__(
+        self,
+        apikey,
+        level=None,
+        info=None,
+        success=None,
+        warning=None,
+        failure=None,
+        volume=None,
+        **kwargs,
+    ):
         """Initialize PushWard Object."""
         super().__init__(**kwargs)
 
@@ -169,15 +218,34 @@ class NotifyPushWard(NotifyBase):
             self.logger.warning(msg)
             raise TypeError(msg)
 
-        # Acquire our level (if one was explicitly provided)
+        # An explicit level forces every notification to that level
+        self.level = None
         if level:
-            self.level = level.strip().lower()
-            if self.level not in PUSHWARD_LEVELS:
+            self.level = pushward_level(level)
+            if self.level is None:
                 msg = f"An invalid PushWard level ({level}) was specified."
                 self.logger.warning(msg)
                 raise TypeError(msg)
-        else:
-            self.level = None
+
+        # Per-notification-type level mapping; each type may be overridden from
+        # the URL, otherwise it falls back to the default
+        self.level_map = {}
+        for ntype, value in (
+            (NotifyType.INFO, info),
+            (NotifyType.SUCCESS, success),
+            (NotifyType.WARNING, warning),
+            (NotifyType.FAILURE, failure),
+        ):
+            if not value:
+                self.level_map[ntype] = PUSHWARD_DEFAULT_LEVELS[ntype]
+                continue
+
+            resolved = pushward_level(value)
+            if resolved is None:
+                msg = f"An invalid PushWard level ({value}) was specified."
+                self.logger.warning(msg)
+                raise TypeError(msg)
+            self.level_map[ntype] = resolved
 
         # Acquire our volume (only applied to critical notifications)
         if volume is not None:
@@ -208,12 +276,9 @@ class NotifyPushWard(NotifyBase):
             "Authorization": f"Bearer {self.apikey}",
         }
 
-        # Resolve the level: an explicit override, otherwise derived
-        level = (
-            self.level
-            if self.level
-            else PUSHWARD_LEVEL_MAP.get(notify_type, "active")
-        )
+        # Resolve the level: an explicit override wins, otherwise the
+        # per-notification-type mapping applies
+        level = self.level if self.level else self.level_map[notify_type]
 
         # PushWard requires a non-empty title; the body is guaranteed by the
         # framework, but the title can be empty so we fall back to our
@@ -305,8 +370,6 @@ class NotifyPushWard(NotifyBase):
         return (
             self.secure_protocol,
             self.apikey,
-            self.level,
-            self.volume,
         )
 
     def url(self, privacy=False, *args, **kwargs):
@@ -316,6 +379,16 @@ class NotifyPushWard(NotifyBase):
         params = {}
         if self.level:
             params["level"] = self.level
+
+        # Include any per-type level that differs from the default
+        for ntype, key in (
+            (NotifyType.INFO, "info"),
+            (NotifyType.SUCCESS, "success"),
+            (NotifyType.WARNING, "warning"),
+            (NotifyType.FAILURE, "failure"),
+        ):
+            if self.level_map[ntype] != PUSHWARD_DEFAULT_LEVELS[ntype]:
+                params[key] = self.level_map[ntype]
 
         if self.volume is not None:
             params["volume"] = str(self.volume)
@@ -348,9 +421,14 @@ class NotifyPushWard(NotifyBase):
                 results["qsd"]["apikey"]
             )
 
-        # Allow the level to be set
+        # Allow the level to be set (forces every notification type)
         if "level" in results["qsd"] and results["qsd"]["level"]:
             results["level"] = NotifyPushWard.unquote(results["qsd"]["level"])
+
+        # Allow per-notification-type level overrides
+        for key in ("info", "success", "warning", "failure"):
+            if key in results["qsd"] and results["qsd"][key]:
+                results[key] = NotifyPushWard.unquote(results["qsd"][key])
 
         # Allow the volume to be set
         if "volume" in results["qsd"] and results["qsd"]["volume"]:

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -74,7 +74,7 @@ notification services. It supports sending alerts to platforms such as: \
 `NextcloudTalk`, `Notica`, `NotificationAPI`, `Notifiarr`, `Notifico`, \
 `ntfy`, `Octopush`, `Office365`, `OneSignal`, `Opsgenie`, `PagerDuty`, \
 `PagerTree`, `ParsePlatform`, `Plivo`, `PopcornNotify`, `Prowl`, \
-`Postmark`, `Pushalot`, `PushBullet`, \
+`Postmark`, `Pushalot`, `PushBullet`, `PushWard`, \
 `Pushjet`, `PushMe`, `Pushover`, `Pushplus`, `PushSafer`, `Pushy`, `PushDeer`, \
 `QQ Push`, `Revolt`, `Reddit`, `Resend`, `RingCentral`, `Rocket.Chat`, \
 `RSyslog`, `SendGrid`, \

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -74,8 +74,9 @@ notification services. It supports sending alerts to platforms such as: \
 `NextcloudTalk`, `Notica`, `NotificationAPI`, `Notifiarr`, `Notifico`, \
 `ntfy`, `Octopush`, `Office365`, `OneSignal`, `Opsgenie`, `PagerDuty`, \
 `PagerTree`, `ParsePlatform`, `Plivo`, `PopcornNotify`, `Prowl`, \
-`Postmark`, `Pushalot`, `PushBullet`, `PushWard`, \
-`Pushjet`, `PushMe`, `Pushover`, `Pushplus`, `PushSafer`, `Pushy`, `PushDeer`, \
+`Postmark`, `Pushalot`, `PushBullet`, \
+`Pushjet`, `PushMe`, `Pushover`, `Pushplus`, `PushSafer`, `PushWard`, \
+`Pushy`, `PushDeer`, \
 `QQ Push`, `Revolt`, `Reddit`, `Resend`, `RingCentral`, `Rocket.Chat`, \
 `RSyslog`, `SendGrid`, \
 `SendPulse`, `ServerChan`, `Session Open Group Server`, `Seven`, `SFR`, \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ keywords = [
     "Pushover",
     "Pushplus",
     "PushSafer",
+    "PushWard",
     "Pushy",
     "QQ Push",
     "Quote/0",

--- a/tests/test_plugin_pushward.py
+++ b/tests/test_plugin_pushward.py
@@ -36,7 +36,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAsset, NotifyType
-from apprise.plugins.pushward import NotifyPushWard
+from apprise.plugins.pushward import NotifyPushWard, pushward_level
 
 logging.disable(logging.CRITICAL)
 
@@ -79,6 +79,21 @@ apprise_url_tests = (
             # critical level with a volume
             "instance": NotifyPushWard,
             "privacy_url": "pushward://h...3/",
+        },
+    ),
+    (
+        "pushward://hlk_abc123?info=passive&failure=critical",
+        {
+            # per-notification-type level overrides
+            "instance": NotifyPushWard,
+            "privacy_url": "pushward://h...3/",
+        },
+    ),
+    (
+        "pushward://hlk_abc123?info=bogus",
+        {
+            # An invalid per-type level
+            "instance": TypeError,
         },
     ),
     (
@@ -372,3 +387,54 @@ def test_plugin_pushward_parse_url():
     # Case is preserved on the key (hlk_ keys are case-sensitive)
     results = NotifyPushWard.parse_url("pushward://hlk_AbC123")
     assert results["apikey"] == "hlk_AbC123"
+
+
+def test_plugin_pushward_level_resolution():
+    """NotifyPushWard() level short-form resolution."""
+
+    # Full names, short-forms, and unique single-letter prefixes
+    assert pushward_level("passive") == "passive"
+    assert pushward_level("crit") == "critical"
+    assert pushward_level("c") == "critical"
+    assert pushward_level("t") == "time-sensitive"
+    assert pushward_level("ACTIVE") == "active"
+
+    # Empty or non-matching input resolves to None
+    assert pushward_level("") is None
+    assert pushward_level("   ") is None
+    assert pushward_level("bogus") is None
+
+
+@mock.patch("requests.post")
+def test_plugin_pushward_per_type_levels(mock_post):
+    """NotifyPushWard() per-notification-type level overrides."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = b""
+    mock_post.return_value = response
+
+    obj = Apprise.instantiate(
+        "pushward://hlk_abc123?info=passive&failure=crit"
+    )
+    assert isinstance(obj, NotifyPushWard)
+    assert obj.level_map[NotifyType.INFO] == "passive"
+    # Short-form resolves to the canonical level
+    assert obj.level_map[NotifyType.FAILURE] == "critical"
+    # Untouched types keep their defaults
+    assert obj.level_map[NotifyType.WARNING] == "time-sensitive"
+
+    assert obj.notify(title="t", body="b", notify_type=NotifyType.INFO) is True
+    assert loads(mock_post.call_args[1]["data"])["level"] == "passive"
+
+    assert (
+        obj.notify(title="t", body="b", notify_type=NotifyType.FAILURE) is True
+    )
+    assert loads(mock_post.call_args[1]["data"])["level"] == "critical"
+
+    # A global ?level= still forces every type
+    obj = Apprise.instantiate(
+        "pushward://hlk_abc123?level=passive&info=critical"
+    )
+    assert obj.notify(title="t", body="b", notify_type=NotifyType.INFO) is True
+    assert loads(mock_post.call_args[1]["data"])["level"] == "passive"

--- a/tests/test_plugin_pushward.py
+++ b/tests/test_plugin_pushward.py
@@ -1,0 +1,374 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from json import loads
+
+# Disable logging for a cleaner testing output
+import logging
+from unittest import mock
+
+from helpers import AppriseURLTester
+import pytest
+import requests
+
+from apprise import Apprise, AppriseAsset, NotifyType
+from apprise.plugins.pushward import NotifyPushWard
+
+logging.disable(logging.CRITICAL)
+
+# Our Testing URLs
+apprise_url_tests = (
+    (
+        "pushward://",
+        {
+            # No API Key specified
+            "instance": TypeError,
+        },
+    ),
+    (
+        "pushward://invalid",
+        {
+            # API Key does not match the hlk_ pattern
+            "instance": TypeError,
+        },
+    ),
+    (
+        "pushward://hlk_abc123",
+        {
+            # A valid API Key
+            "instance": NotifyPushWard,
+            # Our expected url(privacy=True) startswith() response:
+            "privacy_url": "pushward://h...3/",
+        },
+    ),
+    (
+        "pushward://?apikey=hlk_abc123",
+        {
+            # API Key provided as a query argument
+            "instance": NotifyPushWard,
+            "privacy_url": "pushward://h...3/",
+        },
+    ),
+    (
+        "pushward://hlk_abc123?level=critical&volume=0.8",
+        {
+            # critical level with a volume
+            "instance": NotifyPushWard,
+            "privacy_url": "pushward://h...3/",
+        },
+    ),
+    (
+        "pushward://hlk_abc123?level=invalid",
+        {
+            # Invalid level provided
+            "instance": TypeError,
+        },
+    ),
+    (
+        "pushward://hlk_abc123?volume=2.0",
+        {
+            # Volume out of range
+            "instance": TypeError,
+        },
+    ),
+    (
+        "pushward://hlk_abc123?volume=invalid",
+        {
+            # Volume that cannot be parsed as a float
+            "instance": TypeError,
+        },
+    ),
+    (
+        "pushward://hlk_abc123",
+        {
+            "instance": NotifyPushWard,
+            # Force a failure with a known response code
+            "response": False,
+            "requests_response_code": requests.codes.internal_server_error,
+        },
+    ),
+    (
+        "pushward://hlk_abc123",
+        {
+            "instance": NotifyPushWard,
+            # Throw a bizarre code forcing us to fail to look it up
+            "response": False,
+            "requests_response_code": 999,
+        },
+    ),
+    (
+        "pushward://hlk_abc123",
+        {
+            "instance": NotifyPushWard,
+            # Drive it through a series of socket exceptions
+            "test_requests_exceptions": True,
+        },
+    ),
+)
+
+
+def test_plugin_pushward_urls():
+    """NotifyPushWard() Apprise URLs."""
+
+    # Run our general tests
+    AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+def test_plugin_pushward_edge_cases():
+    """NotifyPushWard() Edge Cases."""
+
+    # No API Key
+    with pytest.raises(TypeError):
+        NotifyPushWard(apikey=None)
+
+    # Whitespace only API Key
+    with pytest.raises(TypeError):
+        NotifyPushWard(apikey="  ")
+
+    # API Key that does not match the hlk_ pattern
+    with pytest.raises(TypeError):
+        NotifyPushWard(apikey="invalid")
+
+    # Invalid level
+    with pytest.raises(TypeError):
+        NotifyPushWard(apikey="hlk_abc123", level="invalid")
+
+    # Volume above the allowable range
+    with pytest.raises(TypeError):
+        NotifyPushWard(apikey="hlk_abc123", volume=2.0)
+
+    # Volume below the allowable range
+    with pytest.raises(TypeError):
+        NotifyPushWard(apikey="hlk_abc123", volume=-0.5)
+
+    # Volume that cannot be coerced to a float
+    with pytest.raises(TypeError):
+        NotifyPushWard(apikey="hlk_abc123", volume="invalid")
+
+
+@mock.patch("requests.post")
+def test_plugin_pushward_send(mock_post):
+    """NotifyPushWard() a successful (200) send."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = b""
+    mock_post.return_value = response
+
+    obj = Apprise.instantiate("pushward://hlk_abc123")
+    assert isinstance(obj, NotifyPushWard)
+    assert obj.notify(title="title", body="body") is True
+
+    assert mock_post.call_count == 1
+    details = mock_post.call_args
+    assert details[0][0] == "https://api.pushward.app/notifications"
+
+    headers = details[1]["headers"]
+    assert headers["Authorization"] == "Bearer hlk_abc123"
+    assert headers["User-Agent"] == obj.app_id
+
+    payload = loads(details[1]["data"])
+    assert payload["title"] == "title"
+    assert payload["body"] == "body"
+    # NotifyType.INFO maps to the "active" level
+    assert payload["level"] == "active"
+    # An icon is attached (the default asset provides an image mask)
+    assert "icon_url" in payload
+    # No volume is sent for a non-critical notification
+    assert "volume" not in payload
+
+
+@mock.patch("requests.post")
+def test_plugin_pushward_created(mock_post):
+    """NotifyPushWard() treats a 201 Created response as success."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.created
+    response.content = b""
+    mock_post.return_value = response
+
+    obj = Apprise.instantiate("pushward://hlk_abc123")
+    assert obj.notify(title="title", body="body") is True
+
+
+@mock.patch("requests.post")
+def test_plugin_pushward_level_override(mock_post):
+    """NotifyPushWard() honors an explicit ?level= override."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = b""
+    mock_post.return_value = response
+
+    obj = Apprise.instantiate("pushward://hlk_abc123?level=passive")
+    assert isinstance(obj, NotifyPushWard)
+    assert obj.level == "passive"
+    assert obj.notify(title="t", body="b") is True
+
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["level"] == "passive"
+
+
+@mock.patch("requests.post")
+def test_plugin_pushward_notify_type_mapping(mock_post):
+    """NotifyPushWard() derives the level from notify_type when unset."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = b""
+    mock_post.return_value = response
+
+    obj = Apprise.instantiate("pushward://hlk_abc123")
+    assert (
+        obj.notify(title="t", body="b", notify_type=NotifyType.WARNING) is True
+    )
+
+    payload = loads(mock_post.call_args[1]["data"])
+    # WARNING maps to the "time-sensitive" level
+    assert payload["level"] == "time-sensitive"
+
+
+@mock.patch("requests.post")
+def test_plugin_pushward_critical_volume(mock_post):
+    """NotifyPushWard() sends a volume only for critical notifications."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = b""
+    mock_post.return_value = response
+
+    obj = Apprise.instantiate(
+        "pushward://hlk_abc123?level=critical&volume=0.8"
+    )
+    assert isinstance(obj, NotifyPushWard)
+    assert obj.level == "critical"
+    assert obj.volume == 0.8
+    assert obj.notify(title="t", body="b") is True
+
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["level"] == "critical"
+    assert payload["volume"] == 0.8
+
+    # The volume is dropped when the level is not critical
+    obj = Apprise.instantiate("pushward://hlk_abc123?level=active&volume=0.5")
+    assert obj.notify(title="t", body="b") is True
+    payload = loads(mock_post.call_args[1]["data"])
+    assert "volume" not in payload
+
+
+@mock.patch("requests.post")
+def test_plugin_pushward_no_image(mock_post):
+    """NotifyPushWard() omits icon_url when no image is available."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = b""
+    mock_post.return_value = response
+
+    asset = AppriseAsset(image_url_mask=None)
+    obj = Apprise.instantiate("pushward://hlk_abc123", asset=asset)
+    assert obj.notify(title="t", body="b") is True
+
+    payload = loads(mock_post.call_args[1]["data"])
+    assert "icon_url" not in payload
+
+
+@mock.patch("requests.post")
+def test_plugin_pushward_empty_title(mock_post):
+    """NotifyPushWard() falls back to a default when the title is empty."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = b""
+    mock_post.return_value = response
+
+    # No title provided; falls back to the asset descriptor
+    obj = Apprise.instantiate("pushward://hlk_abc123")
+    assert obj.notify(body="body only") is True
+
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["title"]
+    assert payload["title"] == obj.app_desc
+    assert payload["body"] == "body only"
+
+    # When the descriptor is also empty, fall back to the application id
+    asset = AppriseAsset(app_desc="")
+    obj = Apprise.instantiate("pushward://hlk_abc123", asset=asset)
+    assert obj.notify(body="body only") is True
+
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["title"] == obj.app_id
+
+
+@mock.patch("requests.post")
+def test_plugin_pushward_url_roundtrip(mock_post):
+    """NotifyPushWard() url() round-trips losslessly."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = b""
+    mock_post.return_value = response
+
+    obj = Apprise.instantiate(
+        "pushward://hlk_abc123?level=critical&volume=0.8"
+    )
+    assert isinstance(obj, NotifyPushWard)
+
+    # Regenerate the URL and re-instantiate
+    obj2 = Apprise.instantiate(obj.url())
+    assert isinstance(obj2, NotifyPushWard)
+    assert obj.url_identifier == obj2.url_identifier
+    assert obj2.apikey == "hlk_abc123"
+    assert obj2.level == "critical"
+    assert obj2.volume == 0.8
+
+
+def test_plugin_pushward_parse_url():
+    """NotifyPushWard() parse_url() behavior."""
+
+    # An unparseable (non-string) URL returns None
+    assert NotifyPushWard.parse_url(None) is None
+
+    # API Key carried in the host
+    results = NotifyPushWard.parse_url("pushward://hlk_abc123")
+    assert results["apikey"] == "hlk_abc123"
+
+    # API Key carried in a query argument (overrides the host)
+    results = NotifyPushWard.parse_url("pushward://?apikey=hlk_xyz")
+    assert results["apikey"] == "hlk_xyz"
+
+    # level + volume carried in the query
+    results = NotifyPushWard.parse_url(
+        "pushward://hlk_abc123?level=critical&volume=0.5"
+    )
+    assert results["apikey"] == "hlk_abc123"
+    assert results["level"] == "critical"
+    assert results["volume"] == "0.5"
+
+    # Case is preserved on the key (hlk_ keys are case-sensitive)
+    results = NotifyPushWard.parse_url("pushward://hlk_AbC123")
+    assert results["apikey"] == "hlk_AbC123"


### PR DESCRIPTION
## Description
**Related issue (if applicable):** n/a

## *PushWard* Notifications
* **Source**: https://pushward.app
* **Image Support**: Yes
* **Message Format**: Plain Text
* **Message Limit**: 3000 characters (body), 256 (title); a notification is one APNs alert, so the title and body share Apple's 4 KB push payload

PushWard (https://pushward.app) is a hosted push notification service for iOS.
This adds a `pushward://` plugin that delivers notifications by POSTing JSON to
`https://api.pushward.app/notifications`, authenticating with the user's
integration key as an `Authorization: Bearer hlk_...` header. The Apprise
notification type is mapped to a PushWard notification level (`passive`,
`active`, `time-sensitive`, `critical`); critical notifications may optionally
carry a volume.

PushWard supports media attachments by URL only (not file uploads), so Apprise
file attachments are not wired in at this time.

## Account Setup
1. Sign in to the PushWard app.
2. Copy your integration key (it begins with `hlk_`). That single key is all
   Apprise needs.

## Syntax

Valid syntax is as follows:
- `pushward://{apikey}`
- `pushward://{apikey}?level=critical&volume=0.8`

## Parameter Breakdown

| Variable | Required | Description |
|----------|----------|-------------|
| apikey   | Yes      | Your PushWard integration key (begins `hlk_`). May also be supplied as `?apikey=`. |
| level    | No       | `passive`, `active`, `time-sensitive`, or `critical`. Derived from the notification type when omitted. |
| volume   | No       | Alert volume `0.0`–`1.0`; only applied when `level=critical`. |

## Examples

```bash
apprise -vv -t "Alert" -b "Something happened." \
    "pushward://hlk_xxxxxxxxxxxx"

apprise -vv -t "Server Down" -b "Production is unreachable." \
    "pushward://hlk_xxxxxxxxxxxx?level=critical&volume=0.8"
```

## New Service Completion Status
* [x] apprise/plugins/pushward.py
* [x] pyproject.toml
* [x] README.md
* [x] packaging/redhat/python-apprise.spec

## Checklist
* [x] Documentation ticket created (if applicable): caronc/apprise-docs#83
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
