### PR TITLE
Add Flowtriq notification service for DDoS alerting

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The table below identifies the services this tool supports and some example serv
 | [FCM](https://appriseit.com/services/fcm/) | fcm://    | (TCP) 443    | fcm://project@apikey/DEVICE_ID<br />fcm://project@apikey/#TOPIC<br/>fcm://project@apikey/DEVICE_ID1/#topic1/#topic2/DEVICE_ID2/
 | [Feishu](https://appriseit.com/services/feishu/) | feishu://    | (TCP) 443    | feishu://token
 | [Flock](https://appriseit.com/services/flock/) | flock://    | (TCP) 443    | flock://token<br/>flock://botname@token<br/>flock://app_token/u:userid<br/>flock://app_token/g:channel_id<br/>flock://app_token/u:userid/g:channel_id
+| [Flowtriq](https://appriseit.com/services/flowtriq/) | flowtriq:// or flowtriqs://    | (TCP) 80 or 443    | flowtriq://apikey@hostname/webhook/path<br />flowtriqs://apikey@hostname/webhook/path
 | [Google Chat](https://appriseit.com/services/googlechat/) | gchat://    | (TCP) 443    | gchat://workspace/key/token
 | [Gotify](https://appriseit.com/services/gotify/) | gotify:// or gotifys://   | (TCP) 80 or 443    | gotify://hostname/token<br />gotifys://hostname/token?priority=high
 | [GroupMe](https://appriseit.com/services/groupme/) | groupme://   | (TCP) 443   | groupme://bot_id<br />groupme://bot_id/access_token

--- a/apprise/plugins/flowtriq.py
+++ b/apprise/plugins/flowtriq.py
@@ -1,0 +1,306 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Flowtriq is a DDoS detection and mitigation platform.
+# This plugin enables any Apprise-connected tool to forward alerts
+# to Flowtriq for network security correlation.
+#
+# URL format:
+#   flowtriq://apikey@hostname/workspace_id/
+#   flowtriq://apikey@hostname:port/workspace_id/
+#
+# The webhook endpoint is:
+#   https://hostname/api/v1/workspaces/{workspace_id}/webhooks/apprise
+#
+# The API key is passed via the X-API-Key header.
+
+from json import dumps
+
+import requests
+
+from ..common import NotifyType
+from ..locale import gettext_lazy as _
+from ..utils.parse import validate_regex
+from .base import NotifyBase
+
+# Map Apprise notification types to Flowtriq severity levels
+FLOWTRIQ_SEVERITY_MAP = {
+    NotifyType.INFO: "info",
+    NotifyType.SUCCESS: "success",
+    NotifyType.WARNING: "warning",
+    NotifyType.FAILURE: "critical",
+}
+
+
+class NotifyFlowtriq(NotifyBase):
+    """A wrapper for Flowtriq Notifications."""
+
+    # The default descriptive name associated with the Notification
+    service_name = "Flowtriq"
+
+    # The services URL
+    service_url = "https://flowtriq.com"
+
+    # The default secure protocol
+    secure_protocol = "flowtriq"
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = "https://github.com/caronc/apprise/wiki/Notify_flowtriq"
+
+    # Disable throttle rate
+    request_rate_per_sec = 0
+
+    # The default hostname to use if none is specified
+    default_host = "app.flowtriq.com"
+
+    # Title is not used for Flowtriq
+    title_maxlen = 250
+
+    # Define object templates
+    templates = (
+        "{schema}://{apikey}@{host}/{workspace_id}/",
+        "{schema}://{apikey}@{host}:{port}/{workspace_id}/",
+    )
+
+    # Define our template tokens
+    template_tokens = dict(
+        NotifyBase.template_tokens,
+        **{
+            "apikey": {
+                "name": _("API Key"),
+                "type": "string",
+                "private": True,
+                "required": True,
+            },
+            "host": {
+                "name": _("Hostname"),
+                "type": "string",
+                "required": True,
+            },
+            "port": {
+                "name": _("Port"),
+                "type": "int",
+                "min": 1,
+                "max": 65535,
+            },
+            "workspace_id": {
+                "name": _("Workspace ID"),
+                "type": "string",
+                "required": True,
+                "regex": (r"^[A-Za-z0-9_-]+$", "i"),
+            },
+        },
+    )
+
+    # Define our template arguments
+    template_args = dict(
+        NotifyBase.template_args,
+        **{},
+    )
+
+    def __init__(self, apikey, workspace_id, **kwargs):
+        """Initialize Flowtriq Object."""
+        super().__init__(**kwargs)
+
+        # API Key
+        self.apikey = validate_regex(apikey)
+        if not self.apikey:
+            msg = f"An invalid Flowtriq API Key ({apikey}) was specified."
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # Workspace ID
+        self.workspace_id = validate_regex(
+            workspace_id,
+            *self.template_tokens["workspace_id"]["regex"],
+        )
+        if not self.workspace_id:
+            msg = (
+                "An invalid Flowtriq Workspace ID "
+                f"({workspace_id}) was specified."
+            )
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        if not self.host:
+            self.host = self.default_host
+
+        return
+
+    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+        """Perform Flowtriq Notification."""
+
+        # Build our URL
+        schema = "https" if self.secure else "http"
+        url = f"{schema}://{self.host}"
+        if self.port:
+            url += f":{self.port}"
+        url += f"/api/v1/workspaces/{self.workspace_id}/webhooks/apprise"
+
+        # Prepare our payload
+        payload = {
+            "title": title,
+            "body": body,
+            "severity": FLOWTRIQ_SEVERITY_MAP.get(notify_type, "info"),
+            "type": notify_type,
+            "source": "apprise",
+        }
+
+        # Prepare our headers
+        headers = {
+            "User-Agent": self.app_id,
+            "Content-Type": "application/json",
+            "X-API-Key": self.apikey,
+        }
+
+        self.logger.debug(
+            "Flowtriq POST URL: "
+            f"{url} (cert_verify={self.verify_certificate!r})"
+        )
+        self.logger.debug(f"Flowtriq Payload: {payload!s}")
+
+        # Always call throttle before any remote server i/o is made
+        self.throttle()
+
+        try:
+            r = requests.post(
+                url,
+                data=dumps(payload),
+                headers=headers,
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+                allow_redirects=self.redirects,
+            )
+            if r.status_code not in (
+                requests.codes.ok,
+                requests.codes.created,
+                requests.codes.accepted,
+                requests.codes.no_content,
+            ):
+                # We had a problem
+                status_str = NotifyFlowtriq.http_response_code_lookup(
+                    r.status_code
+                )
+
+                self.logger.warning(
+                    "Failed to send Flowtriq notification: "
+                    "{}{}error={}.".format(
+                        status_str,
+                        ", " if status_str else "",
+                        r.status_code,
+                    )
+                )
+
+                self.logger.debug(
+                    "Response Details:\r\n%r", (r.content or b"")[:2000]
+                )
+
+                # Mark our failure
+                return False
+
+            else:
+                self.logger.info("Sent Flowtriq notification.")
+
+        except requests.RequestException as e:
+            self.logger.warning(
+                "A Connection error occurred sending Flowtriq "
+                f"notification to {self.host}."
+            )
+            self.logger.debug(f"Socket Exception: {e!s}")
+
+            # Mark our failure
+            return False
+
+        return True
+
+    @property
+    def url_identifier(self):
+        """Returns all of the identifiers that make this URL unique from
+        another simliar one.
+
+        Targets or end points should never be identified here.
+        """
+        return (
+            self.secure_protocol,
+            self.host,
+            self.port if self.port else (443 if self.secure else 80),
+            self.workspace_id,
+        )
+
+    def url(self, privacy=False, *args, **kwargs):
+        """Returns the URL built dynamically based on specified arguments."""
+
+        # Define any URL parameters
+        params = {}
+
+        # Extend our parameters
+        params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
+
+        # Our default port
+        default_port = 443 if self.secure else 80
+        return (
+            "{schema}://{apikey}@{hostname}{port}/"
+            "{workspace_id}/?{params}".format(
+                schema=self.secure_protocol,
+                apikey=self.pprint(self.apikey, privacy, safe=""),
+                hostname=self.host,
+                port=(
+                    ""
+                    if self.port is None or self.port == default_port
+                    else f":{self.port}"
+                ),
+                workspace_id=NotifyFlowtriq.quote(self.workspace_id, safe=""),
+                params=NotifyFlowtriq.urlencode(params),
+            )
+        )
+
+    @staticmethod
+    def parse_url(url):
+        """Parses the URL and returns enough arguments that can allow us to
+        re-instantiate this object."""
+        results = NotifyBase.parse_url(url)
+        if not results:
+            # We're done early as we couldn't load the results
+            return results
+
+        # The API key is stored in the user field
+        results["apikey"] = (
+            NotifyFlowtriq.unquote(results["user"])
+            if results.get("user")
+            else None
+        )
+
+        # Retrieve our escaped entries found on the fullpath
+        entries = NotifyFlowtriq.split_path(results["fullpath"])
+
+        # The first path entry is our workspace ID
+        try:
+            results["workspace_id"] = entries.pop(0)
+        except IndexError:
+            results["workspace_id"] = None
+
+        return results

--- a/apprise/plugins/flowtriq.py
+++ b/apprise/plugins/flowtriq.py
@@ -27,14 +27,21 @@
 
 # Flowtriq is a DDoS detection and mitigation platform.
 # This plugin enables any Apprise-connected tool to forward alerts
-# to Flowtriq for network security correlation.
+# to a Flowtriq webhook channel.
+#
+# Users create a webhook channel in the Flowtriq dashboard, which provides
+# a webhook URL and API key. The webhook URL path is used directly.
 #
 # URL format:
-#   flowtriq://apikey@hostname/workspace_id/
-#   flowtriq://apikey@hostname:port/workspace_id/
+#   flowtriq://apikey@hostname/webhook/path/
+#   flowtriq://apikey@hostname:port/webhook/path/
 #
-# The webhook endpoint is:
-#   https://hostname/api/v1/workspaces/{workspace_id}/webhooks/apprise
+# For example, if the dashboard gives you:
+#   URL:  https://flowtriq.com/hooks/abc123
+#   Key:  ft_key_xxxx
+#
+# Then the Apprise URL is:
+#   flowtriq://ft_key_xxxx@flowtriq.com/hooks/abc123/
 #
 # The API key is passed via the X-API-Key header.
 
@@ -74,16 +81,13 @@ class NotifyFlowtriq(NotifyBase):
     # Disable throttle rate
     request_rate_per_sec = 0
 
-    # The default hostname to use if none is specified
-    default_host = "app.flowtriq.com"
-
     # Title is not used for Flowtriq
     title_maxlen = 250
 
     # Define object templates
     templates = (
-        "{schema}://{apikey}@{host}/{workspace_id}/",
-        "{schema}://{apikey}@{host}:{port}/{workspace_id}/",
+        "{schema}://{apikey}@{host}/{webhook_path}/",
+        "{schema}://{apikey}@{host}:{port}/{webhook_path}/",
     )
 
     # Define our template tokens
@@ -107,11 +111,10 @@ class NotifyFlowtriq(NotifyBase):
                 "min": 1,
                 "max": 65535,
             },
-            "workspace_id": {
-                "name": _("Workspace ID"),
+            "webhook_path": {
+                "name": _("Webhook Path"),
                 "type": "string",
                 "required": True,
-                "regex": (r"^[A-Za-z0-9_-]+$", "i"),
             },
         },
     )
@@ -122,7 +125,7 @@ class NotifyFlowtriq(NotifyBase):
         **{},
     )
 
-    def __init__(self, apikey, workspace_id, **kwargs):
+    def __init__(self, apikey, webhook_path, **kwargs):
         """Initialize Flowtriq Object."""
         super().__init__(**kwargs)
 
@@ -133,21 +136,23 @@ class NotifyFlowtriq(NotifyBase):
             self.logger.warning(msg)
             raise TypeError(msg)
 
-        # Workspace ID
-        self.workspace_id = validate_regex(
-            workspace_id,
-            *self.template_tokens["workspace_id"]["regex"],
-        )
-        if not self.workspace_id:
-            msg = (
-                "An invalid Flowtriq Workspace ID "
-                f"({workspace_id}) was specified."
-            )
+        # Webhook Path (the full path portion of the webhook URL provided
+        # by the Flowtriq dashboard)
+        if not webhook_path:
+            msg = "A Flowtriq Webhook Path must be specified."
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        self.webhook_path = webhook_path.strip("/")
+        if not self.webhook_path:
+            msg = "A Flowtriq Webhook Path must be specified."
             self.logger.warning(msg)
             raise TypeError(msg)
 
         if not self.host:
-            self.host = self.default_host
+            msg = "A Flowtriq hostname must be specified."
+            self.logger.warning(msg)
+            raise TypeError(msg)
 
         return
 
@@ -159,7 +164,7 @@ class NotifyFlowtriq(NotifyBase):
         url = f"{schema}://{self.host}"
         if self.port:
             url += f":{self.port}"
-        url += f"/api/v1/workspaces/{self.workspace_id}/webhooks/apprise"
+        url += f"/{self.webhook_path}"
 
         # Prepare our payload
         payload = {
@@ -248,7 +253,7 @@ class NotifyFlowtriq(NotifyBase):
             self.secure_protocol,
             self.host,
             self.port if self.port else (443 if self.secure else 80),
-            self.workspace_id,
+            self.webhook_path,
         )
 
     def url(self, privacy=False, *args, **kwargs):
@@ -264,7 +269,7 @@ class NotifyFlowtriq(NotifyBase):
         default_port = 443 if self.secure else 80
         return (
             "{schema}://{apikey}@{hostname}{port}/"
-            "{workspace_id}/?{params}".format(
+            "{webhook_path}/?{params}".format(
                 schema=self.secure_protocol,
                 apikey=self.pprint(self.apikey, privacy, safe=""),
                 hostname=self.host,
@@ -273,7 +278,8 @@ class NotifyFlowtriq(NotifyBase):
                     if self.port is None or self.port == default_port
                     else f":{self.port}"
                 ),
-                workspace_id=NotifyFlowtriq.quote(self.workspace_id, safe=""),
+                webhook_path=NotifyFlowtriq.quote(
+                    self.webhook_path, safe="/"),
                 params=NotifyFlowtriq.urlencode(params),
             )
         )
@@ -294,13 +300,11 @@ class NotifyFlowtriq(NotifyBase):
             else None
         )
 
-        # Retrieve our escaped entries found on the fullpath
-        entries = NotifyFlowtriq.split_path(results["fullpath"])
-
-        # The first path entry is our workspace ID
-        try:
-            results["workspace_id"] = entries.pop(0)
-        except IndexError:
-            results["workspace_id"] = None
+        # The full path (minus leading/trailing slashes) is the webhook path
+        fullpath = results.get("fullpath", "")
+        if fullpath:
+            results["webhook_path"] = fullpath.strip("/")
+        else:
+            results["webhook_path"] = None
 
         return results

--- a/apprise/plugins/flowtriq.py
+++ b/apprise/plugins/flowtriq.py
@@ -57,11 +57,10 @@
 # The API key is passed via the X-API-Key header.
 
 from json import dumps
-import re
 
 import requests
 
-from ..common import NotifyFormat, NotifyType
+from ..common import NotifyType
 from ..locale import gettext_lazy as _
 from ..utils.parse import validate_regex
 from .base import NotifyBase
@@ -93,17 +92,11 @@ class NotifyFlowtriq(NotifyBase):
     # A URL that takes you to the setup/help of the specific protocol
     setup_url = "https://appriseit.com/services/flowtriq/"
 
-    # The plugin can connect to a self-hosted Flowtriq instance
-    has_selfhosted = True
-
     # Disable throttle rate
     request_rate_per_sec = 0
 
     # Title is not used for Flowtriq
     title_maxlen = 250
-
-    # Default to plain text since the payload body is plain text
-    notify_format = NotifyFormat.TEXT
 
     # Define object templates
     templates = (
@@ -319,44 +312,3 @@ class NotifyFlowtriq(NotifyBase):
             results["webhook_path"] = None
 
         return results
-
-    @staticmethod
-    def parse_native_url(url):
-        """Support http(s)://apikey@hostname/webhook/path"""
-        result = re.match(
-            r"^http(?P<secure>s?)://(?:(?P<apikey>[^@\s]+)@)?"
-            r"(?P<hostname>[A-Z0-9._-]+)"
-            r"(?::(?P<port>[0-9]+))?"
-            r"(?P<path>/[^?]*)?"
-            r"(?P<params>\?.+)?$",
-            url,
-            re.I,
-        )
-        if result:
-            return NotifyFlowtriq.parse_url(
-                "{schema}://{apikey}{hostname}{port}{path}{params}".format(
-                    schema=(
-                        NotifyFlowtriq.secure_protocol
-                        if result.group("secure")
-                        else NotifyFlowtriq.protocol
-                    ),
-                    apikey=(
-                        "{}@".format(
-                            NotifyFlowtriq.quote(
-                                result.group("apikey"), safe=""
-                            )
-                        )
-                        if result.group("apikey")
-                        else ""
-                    ),
-                    hostname=result.group("hostname"),
-                    port=(
-                        ""
-                        if not result.group("port")
-                        else ":{}".format(result.group("port"))
-                    ),
-                    path=result.group("path") or "",
-                    params=result.group("params") or "",
-                )
-            )
-        return None

--- a/apprise/plugins/flowtriq.py
+++ b/apprise/plugins/flowtriq.py
@@ -32,24 +32,36 @@
 # Users create a webhook channel in the Flowtriq dashboard, which provides
 # a webhook URL and API key. The webhook URL path is used directly.
 #
-# URL format:
+# URL format (HTTP):
 #   flowtriq://apikey@hostname/webhook/path/
 #   flowtriq://apikey@hostname:port/webhook/path/
+#
+# URL format (HTTPS):
+#   flowtriqs://apikey@hostname/webhook/path/
+#   flowtriqs://apikey@hostname:port/webhook/path/
 #
 # For example, if the dashboard gives you:
 #   URL:  https://flowtriq.com/hooks/abc123
 #   Key:  ft_key_xxxx
 #
-# Then the Apprise URL is:
-#   flowtriq://ft_key_xxxx@flowtriq.com/hooks/abc123/
+# Then the Apprise URL is (secure):
+#   flowtriqs://ft_key_xxxx@flowtriq.com/hooks/abc123/
+#
+# Or for a self-hosted instance over plain HTTP:
+#   flowtriq://ft_key_xxxx@myhost/hooks/abc123/
+#
+# Alternatively, the native HTTP/HTTPS URL with the API key in the user
+# field is also accepted by parse_native_url():
+#   https://ft_key_xxxx@flowtriq.com/hooks/abc123
 #
 # The API key is passed via the X-API-Key header.
 
 from json import dumps
+import re
 
 import requests
 
-from ..common import NotifyType
+from ..common import NotifyFormat, NotifyType
 from ..locale import gettext_lazy as _
 from ..utils.parse import validate_regex
 from .base import NotifyBase
@@ -72,11 +84,17 @@ class NotifyFlowtriq(NotifyBase):
     # The services URL
     service_url = "https://flowtriq.com"
 
-    # The default secure protocol
-    secure_protocol = "flowtriq"
+    # The default protocol (plain HTTP for self-hosted instances)
+    protocol = "flowtriq"
+
+    # The default secure protocol (HTTPS)
+    secure_protocol = "flowtriqs"
 
     # A URL that takes you to the setup/help of the specific protocol
-    setup_url = "https://github.com/caronc/apprise/wiki/Notify_flowtriq"
+    setup_url = "https://appriseit.com/services/flowtriq/"
+
+    # The plugin can connect to a self-hosted Flowtriq instance
+    has_selfhosted = True
 
     # Disable throttle rate
     request_rate_per_sec = 0
@@ -84,10 +102,13 @@ class NotifyFlowtriq(NotifyBase):
     # Title is not used for Flowtriq
     title_maxlen = 250
 
+    # Default to plain text since the payload body is plain text
+    notify_format = NotifyFormat.TEXT
+
     # Define object templates
     templates = (
-        "{schema}://{apikey}@{host}/{webhook_path}/",
-        "{schema}://{apikey}@{host}:{port}/{webhook_path}/",
+        "{schema}://{apikey}@{host}/{path}/",
+        "{schema}://{apikey}@{host}:{port}/{path}/",
     )
 
     # Define our template tokens
@@ -111,18 +132,13 @@ class NotifyFlowtriq(NotifyBase):
                 "min": 1,
                 "max": 65535,
             },
-            "webhook_path": {
+            "path": {
                 "name": _("Webhook Path"),
                 "type": "string",
                 "required": True,
+                "map_to": "webhook_path",
             },
         },
-    )
-
-    # Define our template arguments
-    template_args = dict(
-        NotifyBase.template_args,
-        **{},
     )
 
     def __init__(self, apikey, webhook_path, **kwargs):
@@ -132,7 +148,9 @@ class NotifyFlowtriq(NotifyBase):
         # API Key
         self.apikey = validate_regex(apikey)
         if not self.apikey:
-            msg = f"An invalid Flowtriq API Key ({apikey}) was specified."
+            msg = "An invalid Flowtriq API Key ({}) was specified.".format(
+                apikey
+            )
             self.logger.warning(msg)
             raise TypeError(msg)
 
@@ -154,17 +172,15 @@ class NotifyFlowtriq(NotifyBase):
             self.logger.warning(msg)
             raise TypeError(msg)
 
-        return
-
     def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
         """Perform Flowtriq Notification."""
 
         # Build our URL
         schema = "https" if self.secure else "http"
-        url = f"{schema}://{self.host}"
-        if self.port:
-            url += f":{self.port}"
-        url += f"/{self.webhook_path}"
+        url = "{}://{}".format(schema, self.host)
+        if self.port is not None:
+            url += ":{}".format(self.port)
+        url += "/{}".format(self.webhook_path)
 
         # Prepare our payload
         payload = {
@@ -183,10 +199,11 @@ class NotifyFlowtriq(NotifyBase):
         }
 
         self.logger.debug(
-            "Flowtriq POST URL: "
-            f"{url} (cert_verify={self.verify_certificate!r})"
+            "Flowtriq POST URL: %s (cert_verify=%s)",
+            url,
+            self.verify_certificate,
         )
-        self.logger.debug(f"Flowtriq Payload: {payload!s}")
+        self.logger.debug("Flowtriq Payload: %s", str(payload))
 
         # Always call throttle before any remote server i/o is made
         self.throttle()
@@ -220,22 +237,20 @@ class NotifyFlowtriq(NotifyBase):
                     )
                 )
 
-                self.logger.debug(
-                    "Response Details:\r\n%r", (r.content or b"")[:2000]
-                )
+                self.logger.debug("Response Details:\r\n%s", r.content)
 
                 # Mark our failure
                 return False
 
-            else:
-                self.logger.info("Sent Flowtriq notification.")
+            self.logger.info("Sent Flowtriq notification.")
 
         except requests.RequestException as e:
             self.logger.warning(
                 "A Connection error occurred sending Flowtriq "
-                f"notification to {self.host}."
+                "notification to %s.",
+                self.host,
             )
-            self.logger.debug(f"Socket Exception: {e!s}")
+            self.logger.debug("Socket Exception: %s", str(e))
 
             # Mark our failure
             return False
@@ -250,7 +265,7 @@ class NotifyFlowtriq(NotifyBase):
         Targets or end points should never be identified here.
         """
         return (
-            self.secure_protocol,
+            self.secure_protocol if self.secure else self.protocol,
             self.host,
             self.port if self.port else (443 if self.secure else 80),
             self.webhook_path,
@@ -267,21 +282,17 @@ class NotifyFlowtriq(NotifyBase):
 
         # Our default port
         default_port = 443 if self.secure else 80
-        return (
-            "{schema}://{apikey}@{hostname}{port}/"
-            "{webhook_path}/?{params}".format(
-                schema=self.secure_protocol,
-                apikey=self.pprint(self.apikey, privacy, safe=""),
-                hostname=self.host,
-                port=(
-                    ""
-                    if self.port is None or self.port == default_port
-                    else f":{self.port}"
-                ),
-                webhook_path=NotifyFlowtriq.quote(
-                    self.webhook_path, safe="/"),
-                params=NotifyFlowtriq.urlencode(params),
-            )
+        return "{schema}://{apikey}@{hostname}{port}/{path}/?{params}".format(
+            schema=(self.secure_protocol if self.secure else self.protocol),
+            apikey=self.pprint(self.apikey, privacy, safe=""),
+            hostname=self.host,
+            port=(
+                ""
+                if self.port is None or self.port == default_port
+                else ":{}".format(self.port)
+            ),
+            path=NotifyFlowtriq.quote(self.webhook_path, safe="/"),
+            params=NotifyFlowtriq.urlencode(params),
         )
 
     @staticmethod
@@ -308,3 +319,44 @@ class NotifyFlowtriq(NotifyBase):
             results["webhook_path"] = None
 
         return results
+
+    @staticmethod
+    def parse_native_url(url):
+        """Support http(s)://apikey@hostname/webhook/path"""
+        result = re.match(
+            r"^http(?P<secure>s?)://(?:(?P<apikey>[^@\s]+)@)?"
+            r"(?P<hostname>[A-Z0-9._-]+)"
+            r"(?::(?P<port>[0-9]+))?"
+            r"(?P<path>/[^?]*)?"
+            r"(?P<params>\?.+)?$",
+            url,
+            re.I,
+        )
+        if result:
+            return NotifyFlowtriq.parse_url(
+                "{schema}://{apikey}{hostname}{port}{path}{params}".format(
+                    schema=(
+                        NotifyFlowtriq.secure_protocol
+                        if result.group("secure")
+                        else NotifyFlowtriq.protocol
+                    ),
+                    apikey=(
+                        "{}@".format(
+                            NotifyFlowtriq.quote(
+                                result.group("apikey"), safe=""
+                            )
+                        )
+                        if result.group("apikey")
+                        else ""
+                    ),
+                    hostname=result.group("hostname"),
+                    port=(
+                        ""
+                        if not result.group("port")
+                        else ":{}".format(result.group("port"))
+                    ),
+                    path=result.group("path") or "",
+                    params=result.group("params") or "",
+                )
+            )
+        return None

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -63,7 +63,7 @@ notification services. It supports sending alerts to platforms such as: \
 `Burst SMS`, `BulkSMS`, `BulkVS`, \
 `Chanify`, `Clickatell`, `ClickSend`, `DAPNET`, `DingTalk`, `Discord`, \
 `Dot. (Quote/0)`, `E-Mail`, `Emby`, `Evolution API`, `Exotel`, \
-`FCM`, `Feishu`, `Flock`, `Fluxer`, `Free Mobile`, `Google Chat`, \
+`FCM`, `Feishu`, `Flock`, `Flowtriq`, `Fluxer`, `Free Mobile`, `Google Chat`, \
 `Gotify`, `GroupMe`, `Growl`, `Guilded`, `Home Assistant`, `httpSMS`, \
 `HumHub`, \
 `IFTTT`, `IRC`, `Jellyfin`, `Jira`, `Join`, `Kavenegar`, `KODI`, \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ keywords = [
     "FCM",
     "Feishu",
     "Flock",
+    "Flowtriq",
     "Fluxer",
     "Form",
     "Free Mobile",

--- a/tests/test_plugin_flowtriq.py
+++ b/tests/test_plugin_flowtriq.py
@@ -1,0 +1,135 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Disable logging for a cleaner testing output
+import logging
+
+from helpers import AppriseURLTester
+import pytest
+import requests
+
+from apprise.plugins.flowtriq import NotifyFlowtriq
+
+logging.disable(logging.CRITICAL)
+
+# Our Testing URLs
+apprise_url_tests = (
+    (
+        "flowtriq://",
+        {
+            "instance": None,
+        },
+    ),
+    # No workspace ID specified
+    (
+        "flowtriq://apikey@hostname",
+        {
+            "instance": TypeError,
+        },
+    ),
+    # No API key specified
+    (
+        "flowtriq://hostname/workspace123",
+        {
+            "instance": TypeError,
+        },
+    ),
+    # Provide a hostname, apikey, and workspace_id
+    (
+        "flowtriq://myapikey@hostname/workspace123/",
+        {
+            "instance": NotifyFlowtriq,
+            # Our expected url(privacy=True) startswith() response:
+            "privacy_url": "flowtriq://m...y@hostname/workspace123/",
+        },
+    ),
+    # Provide a hostname with port
+    (
+        "flowtriq://myapikey@hostname:8443/workspace123/",
+        {
+            "instance": NotifyFlowtriq,
+        },
+    ),
+    # An invalid url
+    (
+        "flowtriq://:@/",
+        {
+            "instance": None,
+        },
+    ),
+    # Test failure cases
+    (
+        "flowtriq://myapikey@hostname/workspace123/",
+        {
+            "instance": NotifyFlowtriq,
+            # force a failure
+            "response": False,
+            "requests_response_code": requests.codes.internal_server_error,
+        },
+    ),
+    (
+        "flowtriq://myapikey@hostname/workspace123/",
+        {
+            "instance": NotifyFlowtriq,
+            # throw a bizarre code forcing us to fail to look it up
+            "response": False,
+            "requests_response_code": 999,
+        },
+    ),
+    (
+        "flowtriq://myapikey@hostname/workspace123/",
+        {
+            "instance": NotifyFlowtriq,
+            # Throws a series of i/o exceptions with this flag
+            # is set and tests that we gracefully handle them
+            "test_requests_exceptions": True,
+        },
+    ),
+)
+
+
+def test_plugin_flowtriq_urls():
+    """NotifyFlowtriq() Apprise URLs."""
+
+    # Run our general tests
+    AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+def test_plugin_flowtriq_edge_cases():
+    """NotifyFlowtriq() Edge Cases."""
+    # Initializes the plugin with an invalid API key
+    with pytest.raises(TypeError):
+        NotifyFlowtriq(apikey=None, workspace_id="ws123")
+    # Whitespace also acts as an invalid API key
+    with pytest.raises(TypeError):
+        NotifyFlowtriq(apikey="   ", workspace_id="ws123")
+
+    # Invalid workspace ID
+    with pytest.raises(TypeError):
+        NotifyFlowtriq(apikey="validkey", workspace_id=None)
+    with pytest.raises(TypeError):
+        NotifyFlowtriq(apikey="validkey", workspace_id="   ")

--- a/tests/test_plugin_flowtriq.py
+++ b/tests/test_plugin_flowtriq.py
@@ -352,52 +352,6 @@ def test_plugin_flowtriq_url_parsing(mock_post):
     assert "m...y" in priv
 
 
-def test_plugin_flowtriq_native_url():
-    """NotifyFlowtriq() parse_native_url."""
-
-    # https:// maps to flowtriqs:// (secure)
-    result = NotifyFlowtriq.parse_native_url(
-        "https://ft_key_xxxx@flowtriq.com/hooks/abc123"
-    )
-    assert result is not None
-    assert result["apikey"] == "ft_key_xxxx"
-    assert result["webhook_path"] == "hooks/abc123"
-    # round-trips to the secure schema
-    obj = NotifyFlowtriq(**result)
-    assert obj.secure is True
-    assert obj.url_identifier[0] == "flowtriqs"
-
-    # http:// maps to flowtriq:// (insecure)
-    result = NotifyFlowtriq.parse_native_url(
-        "http://mykey@myhost.example.com/hooks/abc123"
-    )
-    assert result is not None
-    assert result["apikey"] == "mykey"
-    obj_ins = NotifyFlowtriq(**result)
-    assert obj_ins.secure is False
-    assert obj_ins.url_identifier[0] == "flowtriq"
-
-    # Native URL with port
-    result = NotifyFlowtriq.parse_native_url(
-        "https://mykey@myhost.example.com:8443/api/v1/wh"
-    )
-    assert result is not None
-    assert result["apikey"] == "mykey"
-    assert result["port"] == 8443
-    assert result["webhook_path"] == "api/v1/wh"
-
-    # Native URL without API key → apikey is None (will TypeError on init)
-    result = NotifyFlowtriq.parse_native_url(
-        "https://flowtriq.com/hooks/abc123"
-    )
-    assert result is not None
-    assert result.get("apikey") is None
-
-    # Non-matching URL returns None
-    result = NotifyFlowtriq.parse_native_url("not-a-url")
-    assert result is None
-
-
 @mock.patch("requests.post")
 def test_plugin_flowtriq_apprise_integration(mock_post):
     """NotifyFlowtriq() Apprise integration."""

--- a/tests/test_plugin_flowtriq.py
+++ b/tests/test_plugin_flowtriq.py
@@ -44,7 +44,7 @@ apprise_url_tests = (
             "instance": None,
         },
     ),
-    # No workspace ID specified
+    # No webhook path specified
     (
         "flowtriq://apikey@hostname",
         {
@@ -53,23 +53,30 @@ apprise_url_tests = (
     ),
     # No API key specified
     (
-        "flowtriq://hostname/workspace123",
+        "flowtriq://hostname/hooks/abc123",
         {
             "instance": TypeError,
         },
     ),
-    # Provide a hostname, apikey, and workspace_id
+    # Provide a hostname, apikey, and webhook path
     (
-        "flowtriq://myapikey@hostname/workspace123/",
+        "flowtriq://myapikey@hostname/hooks/abc123/",
         {
             "instance": NotifyFlowtriq,
             # Our expected url(privacy=True) startswith() response:
-            "privacy_url": "flowtriq://m...y@hostname/workspace123/",
+            "privacy_url": "flowtriq://m...y@hostname/hooks/abc123/",
         },
     ),
     # Provide a hostname with port
     (
-        "flowtriq://myapikey@hostname:8443/workspace123/",
+        "flowtriq://myapikey@hostname:8443/hooks/abc123/",
+        {
+            "instance": NotifyFlowtriq,
+        },
+    ),
+    # Multi-segment webhook path
+    (
+        "flowtriq://myapikey@flowtriq.com/api/v1/webhook/xyz/",
         {
             "instance": NotifyFlowtriq,
         },
@@ -83,7 +90,7 @@ apprise_url_tests = (
     ),
     # Test failure cases
     (
-        "flowtriq://myapikey@hostname/workspace123/",
+        "flowtriq://myapikey@hostname/hooks/abc123/",
         {
             "instance": NotifyFlowtriq,
             # force a failure
@@ -92,7 +99,7 @@ apprise_url_tests = (
         },
     ),
     (
-        "flowtriq://myapikey@hostname/workspace123/",
+        "flowtriq://myapikey@hostname/hooks/abc123/",
         {
             "instance": NotifyFlowtriq,
             # throw a bizarre code forcing us to fail to look it up
@@ -101,7 +108,7 @@ apprise_url_tests = (
         },
     ),
     (
-        "flowtriq://myapikey@hostname/workspace123/",
+        "flowtriq://myapikey@hostname/hooks/abc123/",
         {
             "instance": NotifyFlowtriq,
             # Throws a series of i/o exceptions with this flag
@@ -123,13 +130,13 @@ def test_plugin_flowtriq_edge_cases():
     """NotifyFlowtriq() Edge Cases."""
     # Initializes the plugin with an invalid API key
     with pytest.raises(TypeError):
-        NotifyFlowtriq(apikey=None, workspace_id="ws123")
+        NotifyFlowtriq(apikey=None, webhook_path="hooks/abc123")
     # Whitespace also acts as an invalid API key
     with pytest.raises(TypeError):
-        NotifyFlowtriq(apikey="   ", workspace_id="ws123")
+        NotifyFlowtriq(apikey="   ", webhook_path="hooks/abc123")
 
-    # Invalid workspace ID
+    # Missing webhook path
     with pytest.raises(TypeError):
-        NotifyFlowtriq(apikey="validkey", workspace_id=None)
+        NotifyFlowtriq(apikey="validkey", webhook_path=None)
     with pytest.raises(TypeError):
-        NotifyFlowtriq(apikey="validkey", workspace_id="   ")
+        NotifyFlowtriq(apikey="validkey", webhook_path="   ")

--- a/tests/test_plugin_flowtriq.py
+++ b/tests/test_plugin_flowtriq.py
@@ -26,12 +26,16 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 # Disable logging for a cleaner testing output
+import json
 import logging
+from unittest import mock
+from urllib.parse import urlparse
 
 from helpers import AppriseURLTester
 import pytest
 import requests
 
+from apprise import Apprise, NotifyType
 from apprise.plugins.flowtriq import NotifyFlowtriq
 
 logging.disable(logging.CRITICAL)
@@ -58,7 +62,7 @@ apprise_url_tests = (
             "instance": TypeError,
         },
     ),
-    # Provide a hostname, apikey, and webhook path
+    # Provide a hostname, apikey, and webhook path (insecure)
     (
         "flowtriq://myapikey@hostname/hooks/abc123/",
         {
@@ -67,16 +71,33 @@ apprise_url_tests = (
             "privacy_url": "flowtriq://m...y@hostname/hooks/abc123/",
         },
     ),
-    # Provide a hostname with port
+    # Secure variant (flowtriqs://)
     (
-        "flowtriq://myapikey@hostname:8443/hooks/abc123/",
+        "flowtriqs://myapikey@hostname/hooks/abc123/",
         {
             "instance": NotifyFlowtriq,
+            "privacy_url": "flowtriqs://m...y@hostname/hooks/abc123/",
+        },
+    ),
+    # Provide a hostname with port (insecure)
+    (
+        "flowtriq://myapikey@hostname:8080/hooks/abc123/",
+        {
+            "instance": NotifyFlowtriq,
+            "privacy_url": "flowtriq://m...y@hostname:8080/hooks/abc123/",
+        },
+    ),
+    # Secure with non-default port
+    (
+        "flowtriqs://myapikey@hostname:8443/hooks/abc123/",
+        {
+            "instance": NotifyFlowtriq,
+            "privacy_url": "flowtriqs://m...y@hostname:8443/hooks/abc123/",
         },
     ),
     # Multi-segment webhook path
     (
-        "flowtriq://myapikey@flowtriq.com/api/v1/webhook/xyz/",
+        "flowtriqs://myapikey@flowtriq.com/api/v1/webhook/xyz/",
         {
             "instance": NotifyFlowtriq,
         },
@@ -140,3 +161,252 @@ def test_plugin_flowtriq_edge_cases():
         NotifyFlowtriq(apikey="validkey", webhook_path=None)
     with pytest.raises(TypeError):
         NotifyFlowtriq(apikey="validkey", webhook_path="   ")
+
+    # A webhook path consisting only of slashes strips to empty
+    with pytest.raises(TypeError):
+        NotifyFlowtriq(apikey="validkey", webhook_path="///")
+
+    # Missing host is caught after super().__init__()
+    with pytest.raises(TypeError):
+        NotifyFlowtriq(
+            apikey="validkey", webhook_path="hooks/abc123", host=None
+        )
+
+
+@mock.patch("requests.post")
+def test_plugin_flowtriq_send(mock_post):
+    """NotifyFlowtriq() send path coverage."""
+
+    def _mk_resp(code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = b"{}"
+        return r
+
+    # ------------------------------------------------------------------
+    # Successful send — 200
+    # ------------------------------------------------------------------
+    mock_post.return_value = _mk_resp(requests.codes.ok)
+    obj = NotifyFlowtriq(
+        apikey="ft_key_xxxx",
+        webhook_path="hooks/abc123",
+        host="flowtriq.com",
+    )
+    assert obj.send(body="Test body", title="Test title") is True
+    assert mock_post.call_count == 1
+
+    # Verify the POST landed at the right hostname
+    call_url = mock_post.call_args[0][0]
+    assert urlparse(call_url).hostname == "flowtriq.com"
+
+    # Verify payload structure and severity mapping for INFO
+    payload = json.loads(mock_post.call_args[1]["data"])
+    assert payload["body"] == "Test body"
+    assert payload["title"] == "Test title"
+    assert payload["severity"] == "info"
+    assert payload["source"] == "apprise"
+
+    # Verify the API key header
+    headers = mock_post.call_args[1]["headers"]
+    assert headers["X-API-Key"] == "ft_key_xxxx"
+    assert headers["Content-Type"] == "application/json"
+
+    mock_post.reset_mock()
+
+    # ------------------------------------------------------------------
+    # 201, 202, 204 are also accepted
+    # ------------------------------------------------------------------
+    for code in (
+        requests.codes.created,
+        requests.codes.accepted,
+        requests.codes.no_content,
+    ):
+        mock_post.return_value = _mk_resp(code)
+        assert obj.send(body="body") is True
+
+    mock_post.reset_mock()
+
+    # ------------------------------------------------------------------
+    # Severity mapping for all notify types
+    # ------------------------------------------------------------------
+    severity_cases = [
+        (NotifyType.INFO, "info"),
+        (NotifyType.SUCCESS, "success"),
+        (NotifyType.WARNING, "warning"),
+        (NotifyType.FAILURE, "critical"),
+    ]
+    mock_post.return_value = _mk_resp()
+    for notify_type, expected_severity in severity_cases:
+        obj.send(body="body", notify_type=notify_type)
+        payload = json.loads(mock_post.call_args[1]["data"])
+        assert payload["severity"] == expected_severity
+
+    mock_post.reset_mock()
+
+    # ------------------------------------------------------------------
+    # Port is included in the request URL when set
+    # ------------------------------------------------------------------
+    obj_port = NotifyFlowtriq(
+        apikey="key",
+        webhook_path="hooks/test",
+        host="myhost.example.com",
+        port=8443,
+    )
+    mock_post.return_value = _mk_resp()
+    assert obj_port.send(body="body") is True
+    call_url = mock_post.call_args[0][0]
+    parsed = urlparse(call_url)
+    assert parsed.hostname == "myhost.example.com"
+    assert parsed.port == 8443
+
+    mock_post.reset_mock()
+
+    # ------------------------------------------------------------------
+    # HTTP error response returns False
+    # ------------------------------------------------------------------
+    mock_post.return_value = _mk_resp(requests.codes.internal_server_error)
+    assert obj.send(body="body") is False
+
+    mock_post.reset_mock()
+
+    # ------------------------------------------------------------------
+    # Unknown HTTP error code (no entry in lookup table) returns False
+    # ------------------------------------------------------------------
+    mock_post.return_value = _mk_resp(999)
+    assert obj.send(body="body") is False
+
+    mock_post.reset_mock()
+
+    # ------------------------------------------------------------------
+    # requests.RequestException returns False
+    # ------------------------------------------------------------------
+    mock_post.side_effect = requests.RequestException("boom")
+    assert obj.send(body="body") is False
+
+
+@mock.patch("requests.post")
+def test_plugin_flowtriq_url_parsing(mock_post):
+    """NotifyFlowtriq() URL round-trip and parse_url edge cases."""
+
+    # Round-trip: parse_url(url()) must recover the same object
+    obj = NotifyFlowtriq(
+        apikey="mykey",
+        webhook_path="hooks/abc123",
+        host="flowtriq.com",
+    )
+    result = NotifyFlowtriq.parse_url(obj.url())
+    assert result is not None
+    obj2 = NotifyFlowtriq(**result)
+    assert obj.url_identifier == obj2.url_identifier
+
+    # Round-trip with non-default port
+    obj_port = NotifyFlowtriq(
+        apikey="mykey",
+        webhook_path="api/v1/wh",
+        host="myhost",
+        port=9000,
+    )
+    result = NotifyFlowtriq.parse_url(obj_port.url())
+    assert result is not None
+    obj_port2 = NotifyFlowtriq(**result)
+    assert obj_port.url_identifier == obj_port2.url_identifier
+
+    # url_identifier via URL parse: flowtriq:// is insecure → port fallback 80
+    obj_insecure = NotifyFlowtriq.parse_url("flowtriq://key@h/hooks/x")
+    assert obj_insecure is not None
+    uid_ins = NotifyFlowtriq(**obj_insecure).url_identifier
+    assert uid_ins[0] == "flowtriq"
+    assert uid_ins[1] == "h"
+    assert uid_ins[2] == 80
+
+    # flowtriqs:// is secure → port fallback 443
+    obj_secure = NotifyFlowtriq.parse_url("flowtriqs://key@h/hooks/x")
+    assert obj_secure is not None
+    uid_sec = NotifyFlowtriq(**obj_secure).url_identifier
+    assert uid_sec[0] == "flowtriqs"
+    assert uid_sec[1] == "h"
+    assert uid_sec[2] == 443
+
+    # parse_url with no user field → apikey is None
+    result = NotifyFlowtriq.parse_url("flowtriq://hostname/hooks/abc123")
+    assert result is not None
+    assert result["apikey"] is None
+
+    # parse_url with empty path → webhook_path is None
+    result = NotifyFlowtriq.parse_url("flowtriq://key@hostname")
+    assert result is not None
+    assert not result.get("webhook_path")
+
+    # parse_url returns None for an unparseable URL
+    result = NotifyFlowtriq.parse_url("flowtriq://:@/")
+    assert result is None
+
+    # privacy_url hides the API key
+    obj = NotifyFlowtriq(
+        apikey="myapikey",
+        webhook_path="hooks/abc123",
+        host="hostname",
+    )
+    priv = obj.url(privacy=True)
+    assert "myapikey" not in priv
+    assert "m...y" in priv
+
+
+def test_plugin_flowtriq_native_url():
+    """NotifyFlowtriq() parse_native_url."""
+
+    # https:// maps to flowtriqs:// (secure)
+    result = NotifyFlowtriq.parse_native_url(
+        "https://ft_key_xxxx@flowtriq.com/hooks/abc123"
+    )
+    assert result is not None
+    assert result["apikey"] == "ft_key_xxxx"
+    assert result["webhook_path"] == "hooks/abc123"
+    # round-trips to the secure schema
+    obj = NotifyFlowtriq(**result)
+    assert obj.secure is True
+    assert obj.url_identifier[0] == "flowtriqs"
+
+    # http:// maps to flowtriq:// (insecure)
+    result = NotifyFlowtriq.parse_native_url(
+        "http://mykey@myhost.example.com/hooks/abc123"
+    )
+    assert result is not None
+    assert result["apikey"] == "mykey"
+    obj_ins = NotifyFlowtriq(**result)
+    assert obj_ins.secure is False
+    assert obj_ins.url_identifier[0] == "flowtriq"
+
+    # Native URL with port
+    result = NotifyFlowtriq.parse_native_url(
+        "https://mykey@myhost.example.com:8443/api/v1/wh"
+    )
+    assert result is not None
+    assert result["apikey"] == "mykey"
+    assert result["port"] == 8443
+    assert result["webhook_path"] == "api/v1/wh"
+
+    # Native URL without API key → apikey is None (will TypeError on init)
+    result = NotifyFlowtriq.parse_native_url(
+        "https://flowtriq.com/hooks/abc123"
+    )
+    assert result is not None
+    assert result.get("apikey") is None
+
+    # Non-matching URL returns None
+    result = NotifyFlowtriq.parse_native_url("not-a-url")
+    assert result is None
+
+
+@mock.patch("requests.post")
+def test_plugin_flowtriq_apprise_integration(mock_post):
+    """NotifyFlowtriq() Apprise integration."""
+
+    mock_post.return_value = mock.Mock()
+    mock_post.return_value.status_code = requests.codes.ok
+    mock_post.return_value.content = b"{}"
+
+    app = Apprise()
+    assert app.add("flowtriq://mykey@flowtriq.com/hooks/abc123") is True
+    assert app.notify(title="Title", body="Body") is True
+    assert mock_post.call_count == 1


### PR DESCRIPTION
## Summary

Adds Flowtriq as a notification target. Flowtriq is a DDoS detection platform -- this plugin enables any Apprise-connected tool to forward alerts for network security correlation.

**URL format:** `flowtriq://apikey@hostname/workspace_id/`

- New plugin: `apprise/plugins/flowtriq.py` following the existing plugin pattern (inherits `NotifyBase`, implements `send()`, `url()`, `parse_url()`, `url_identifier`)
- Maps Apprise notification types (info, success, warning, failure) to Flowtriq severity levels
- POSTs JSON payloads to the Flowtriq webhook API with API key authentication via `X-API-Key` header
- Full test suite: `tests/test_plugin_flowtriq.py` with URL parsing tests, edge cases, failure/exception handling

## Test plan

- [x] `pytest tests/test_plugin_flowtriq.py` passes (2 tests, all passing)
- [x] `ruff check` passes with no lint errors
- [x] `ruff format --check` passes with no formatting issues
- [ ] CI should confirm all existing tests remain unaffected