### PR TITLE
name= support fixed on http:// attachments

### DIFF
--- a/apprise/attachment/base.py
+++ b/apprise/attachment/base.py
@@ -433,10 +433,9 @@ class AttachBase(URLBase):
             # (e.g. ?name=/etc/passwd yields "passwd").  If the result is
             # empty after stripping, treat it as though ?name= was not
             # specified so the caller falls through to the next name source.
-            _raw = results["qsd"].get("name", "").strip()
-            _fname = os.path.basename(_raw).strip()
+            _fname = os.path.basename(results["qsd"].get("name", "")).strip()
             if _fname:
-                results["name"] = _fname.lower()
+                results["name"] = _fname
 
         # Our cache value
         if "cache" in results["qsd"]:

--- a/apprise/attachment/base.py
+++ b/apprise/attachment/base.py
@@ -429,7 +429,14 @@ class AttachBase(URLBase):
 
         # Allow overriding the default file name
         if "name" in results["qsd"]:
-            results["name"] = results["qsd"].get("name", "").strip().lower()
+            # Strip any directory components to prevent path traversal
+            # (e.g. ?name=/etc/passwd yields "passwd").  If the result is
+            # empty after stripping, treat it as though ?name= was not
+            # specified so the caller falls through to the next name source.
+            _raw = results["qsd"].get("name", "").strip()
+            _fname = os.path.basename(_raw).strip()
+            if _fname:
+                results["name"] = _fname.lower()
 
         # Our cache value
         if "cache" in results["qsd"]:

--- a/tests/test_attach_base.py
+++ b/tests/test_attach_base.py
@@ -94,3 +94,43 @@ def test_attach_base():
     assert results.get("mimetype") == "image/jpeg"
     # We can retrieve our url
     assert str(results)
+
+
+def test_attach_base_parse_url_name_sanitization():
+    """
+    API: AttachBase.parse_url() ?name= sanitization
+
+    """
+    # Normal name -- returned as-is (lowercased)
+    results = AttachBase.parse_url(
+        url="file://path/to/file?name=thumbnail.jpg"
+    )
+    assert isinstance(results, dict)
+    assert results.get("name") == "thumbnail.jpg"
+
+    # Path traversal stripped; only the basename is kept
+    results = AttachBase.parse_url(url="file://path/to/file?name=/etc/passwd")
+    assert isinstance(results, dict)
+    assert results.get("name") == "passwd"
+
+    # Deep traversal -- same rule applies
+    results = AttachBase.parse_url(
+        url="file://path/to/file?name=../../secret.jpg"
+    )
+    assert isinstance(results, dict)
+    assert results.get("name") == "secret.jpg"
+
+    # Empty ?name= -- treated as not specified; key must be absent
+    results = AttachBase.parse_url(url="file://path/to/file?name=")
+    assert isinstance(results, dict)
+    assert "name" not in results
+
+    # Whitespace-only ?name= (URL-encoded spaces) -- treated as not specified
+    results = AttachBase.parse_url(url="file://path/to/file?name=%20%20%20")
+    assert isinstance(results, dict)
+    assert "name" not in results
+
+    # Directory-only path (no filename component) -- treated as not specified
+    results = AttachBase.parse_url(url="file://path/to/file?name=/")
+    assert isinstance(results, dict)
+    assert "name" not in results


### PR DESCRIPTION
## Description
**Related issue (if applicable):** n/a

Handle issue where`?name=` query parameter not used when provided and `attachment.001` (backup naming) used instead.

## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/84](https://github.com/caronc/apprise-docs/pull/84)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise-api.git@attachment-handling-fix

# Test Bug #1 (TypeError with ?name= in URL): name= trumps naming convention)
curl -X POST http://localhost:8000/notify/ \
  -H "Content-Type: application/json" \
  -d '{"urls":"discord://...", "attach":["https://joiner.live/thumbnails/1/6dba96988a83163dcffe0d75e4a28bc5.jpg?name=thumbnail.jpg"]}'

# Test Bug #2 (attachment name from URL path): utilize the name found in URL if no name= provided
# The attachment should arrive named "6dba96988a83163dcffe0d75e4a28bc5.jpg", not "attachment.001"
curl -X POST http://localhost:8000/notify/ \
  -H "Content-Type: application/json" \
  -d '{"urls":"discord://...", "attach":["https://joiner.live/thumbnails/1/6dba96988a83163dcffe0d75e4a28bc5.jpg"]}'
```
