### PR TITLE
Added support for 800.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ SMS Notifications for the most part do not have a both a `title` and `body`.  Th
 | Notification Service | Service ID | Default Port | Example Syntax |
 | -------------------- | ---------- | ------------ | -------------- |
 | [46elks](https://appriseit.com/services/46elks/) | 46elks://  | (TCP) 443   | 46elks://user:password@FromPhoneNo<br/>46elks://user:password@FromPhoneNo/ToPhoneNo<br/>46elks://user:password@FromPhoneNo/ToPhoneNo1/ToPhoneNo2/ToPhoneNoN/
+| [800.com](https://appriseit.com/services/eight00com/) | eight00com://  | (TCP) 443   | eight00com://Token@FromPhoneNo<br/>eight00com://Token@FromPhoneNo/ToPhoneNo<br/>eight00com://Token@FromPhoneNo/ToPhoneNo1/ToPhoneNo2/ToPhoneNoN/
 | [Africas Talking](https://appriseit.com/services/africas_talking/) | atalk://  | (TCP) 443   | atalk://AppUser@ApiKey/ToPhoneNo<br/>atalk://AppUser@ApiKey/ToPhoneNo1/ToPhoneNo2/ToPhoneNoN/
 | [Automated Packet Reporting System (ARPS)](https://appriseit.com/services/aprs/)  | aprs:// | (TCP) 10152 | aprs://user:pass@callsign<br/>aprs://user:pass@callsign1/callsign2/callsignN
 | [AWS SNS](https://appriseit.com/services/sns/)  | sns://   | (TCP) 443   | sns://AccessKeyID/AccessSecretKey/RegionName/+PhoneNo<br/>sns://AccessKeyID/AccessSecretKey/RegionName/+PhoneNo1/+PhoneNo2/+PhoneNoN<br/>sns://AccessKeyID/AccessSecretKey/RegionName/Topic<br/>sns://AccessKeyID/AccessSecretKey/RegionName/Topic1/Topic2/TopicN

--- a/apprise/plugins/eight00com.py
+++ b/apprise/plugins/eight00com.py
@@ -1,0 +1,504 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# To use this service you will need an 800.com account
+#
+#  1. Visit https://www.800.com and sign in or create an account.
+#  2. Go to User Settings (top-right avatar -> Settings).
+#  3. In the API section, click "Generate Token".
+#  4. Copy the token immediately -- it is only displayed once.
+#
+#  Your Apprise URL should be assembled as:
+#    eight00com://TOKEN@FromPhoneNo
+#    eight00com://TOKEN@FromPhoneNo/ToPhoneNo
+#    eight00com://TOKEN@FromPhoneNo/ToPhoneNo1/ToPhoneNo2
+#
+#  Where:
+#    TOKEN       : Your 800.com Personal Access Token
+#    FromPhoneNo : Your text-enabled 800.com number (e.g. 8005551234)
+#    ToPhoneNo   : Recipient phone number(s)
+#
+# The API also supports MMS (picture messaging).  Apprise will
+# automatically send any provided attachments as MMS when possible.
+#
+# API Reference:
+#   https://api.800.com/docs
+
+from json import dumps
+
+import requests
+
+from ..common import NotifyType
+from ..locale import gettext_lazy as _
+from ..utils.parse import is_phone_no, parse_phone_no, validate_regex
+from .base import NotifyBase
+
+# Extend HTTP Error Messages
+EIGHT00COM_HTTP_ERROR_MAP = {
+    401: "Unauthorized - Invalid or missing Bearer Token.",
+    422: "Validation Error - Check sender/recipient number format.",
+    429: "Too many requests - Rate limit exceeded.",
+}
+
+
+class NotifyEight00com(NotifyBase):
+    """A wrapper for 800.com SMS/MMS Notifications."""
+
+    # The default descriptive name associated with the Notification
+    service_name = "800.com"
+
+    # The services URL
+    service_url = "https://www.800.com"
+
+    # All notification requests are sent over HTTPS
+    secure_protocol = "eight00com"
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = "https://appriseit.com/services/eight00com/"
+
+    # 800.com REST API endpoint for outbound messages
+    notify_url = "https://api.800.com/message"
+
+    # The maximum SMS body length (800.com supports long-form texts
+    # up to 600 characters)
+    body_maxlen = 600
+
+    # A title cannot be used for SMS messages; setting this to zero
+    # causes any title to be prepended to the body automatically.
+    title_maxlen = 0
+
+    # 800.com supports MMS (picture messaging / attachments)
+    attachment_support = True
+
+    # Define object URL templates
+    templates = (
+        "{schema}://{token}@{from_phone}",
+        "{schema}://{token}@{from_phone}/{targets}",
+    )
+
+    # Define our template tokens
+    template_tokens = dict(
+        NotifyBase.template_tokens,
+        **{
+            "token": {
+                "name": _("API Token"),
+                "type": "string",
+                "private": True,
+                "required": True,
+            },
+            "from_phone": {
+                "name": _("From Phone No"),
+                "type": "string",
+                "regex": (r"^\+?[0-9\s)(+-]+$", "i"),
+                "map_to": "source",
+                "required": True,
+            },
+            "target_phone": {
+                "name": _("Target Phone No"),
+                "type": "string",
+                "prefix": "+",
+                "regex": (r"^[0-9\s)(+-]+$", "i"),
+                "map_to": "targets",
+            },
+            "targets": {
+                "name": _("Targets"),
+                "type": "list:string",
+            },
+        },
+    )
+
+    # Define our template arguments
+    template_args = dict(
+        NotifyBase.template_args,
+        **{
+            "token": {
+                "alias_of": "token",
+            },
+            "from": {
+                "name": _("From Phone No"),
+                "type": "string",
+                "map_to": "source",
+            },
+            "to": {
+                "alias_of": "targets",
+            },
+        },
+    )
+
+    def __init__(self, token=None, source=None, targets=None, **kwargs):
+        """Initialize 800.com Object."""
+        super().__init__(**kwargs)
+
+        # Validate our Personal Access Token
+        self.token = validate_regex(token)
+        if not self.token:
+            msg = "An 800.com Personal Access Token must be specified."
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # Validate the from (source) phone number
+        result = is_phone_no(source)
+        if not result:
+            msg = "The 800.com from phone # ({}) is invalid.".format(source)
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # Store our source number as digits only
+        self.source = result["full"]
+
+        # Parse our targets list
+        self.targets = []
+
+        # Track if we encountered any error parsing targets
+        has_error = False
+        for target in parse_phone_no(targets):
+            # Validate each target phone number
+            result = is_phone_no(target)
+            if result:
+                self.targets.append(result["full"])
+                continue
+
+            has_error = True
+            self.logger.warning(
+                "Dropped invalid 800.com phone # (%s).",
+                target,
+            )
+
+        if not targets and not has_error:
+            # Default: send to ourselves when no target is provided
+            self.targets.append(self.source)
+
+        return
+
+    def send(
+        self,
+        body,
+        title="",
+        notify_type=NotifyType.INFO,
+        attach=None,
+        **kwargs,
+    ):
+        """Perform 800.com SMS/MMS Notification."""
+
+        # Ensure we have at least one target
+        if not self.targets:
+            self.logger.warning("No 800.com targets to notify.")
+            return False
+
+        # Prepare our authorization header (shared by SMS and MMS)
+        headers = {
+            "User-Agent": self.app_id,
+            "Authorization": "Bearer {}".format(self.token),
+        }
+
+        # Error tracking variable
+        has_error = False
+
+        # Work through a copy so the original list is preserved
+        targets = list(self.targets)
+        while targets:
+            # Pop the next recipient
+            target = targets.pop(0)
+
+            # Build the E.164-style sender and recipient strings
+            sender = "+{}".format(self.source)
+            recipient = "+{}".format(target)
+
+            self.logger.debug(
+                "800.com POST URL: %s (cert_verify=%s)",
+                self.notify_url,
+                self.verify_certificate,
+            )
+
+            if attach and self.attachment_support:
+                # Send as MMS with attachment(s)
+                if not self._send_mms(
+                    sender, recipient, body, attach, headers
+                ):
+                    has_error = True
+
+            else:
+                # Send as a plain SMS
+                if not self._send_sms(sender, recipient, body, headers):
+                    has_error = True
+
+        return not has_error
+
+    def _send_sms(self, sender, recipient, body, headers):
+        """Send a plain text SMS via the 800.com REST API."""
+
+        # Prepare our JSON payload
+        payload = {
+            "sender": sender,
+            "recipient": recipient,
+            "message": body,
+        }
+
+        # Copy headers and add JSON content type
+        sms_headers = dict(headers)
+        sms_headers["Content-Type"] = "application/json"
+
+        self.logger.debug("800.com SMS Payload: %s", payload)
+
+        # Always call throttle before any remote server i/o is made
+        self.throttle()
+
+        try:
+            r = requests.post(
+                self.notify_url,
+                data=dumps(payload),
+                headers=sms_headers,
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+                allow_redirects=self.redirects,
+            )
+
+            if r.status_code != requests.codes.ok:
+                # We had a problem
+                status_str = NotifyEight00com.http_response_code_lookup(
+                    r.status_code, EIGHT00COM_HTTP_ERROR_MAP
+                )
+                self.logger.warning(
+                    "Failed to send 800.com SMS to %s: %s%serror=%s.",
+                    recipient,
+                    status_str,
+                    ", " if status_str else "",
+                    r.status_code,
+                )
+                self.logger.debug(
+                    "Response Details:\r\n%r",
+                    (r.content or b"")[:2000],
+                )
+                return False
+
+            else:
+                self.logger.info("Sent 800.com SMS to %s.", recipient)
+
+        except requests.RequestException as e:
+            self.logger.warning(
+                "A Connection error occurred sending 800.com SMS to %s.",
+                recipient,
+            )
+            self.logger.debug("Socket Exception: %s", str(e))
+            return False
+
+        return True
+
+    def _send_mms(self, sender, recipient, body, attach, headers):
+        """Send an MMS with one or more attachments via the 800.com API.
+
+        Uses Pattern B (multi-file multipart/form-data).
+        """
+
+        # Accumulate open file handles for cleanup in the finally block
+        handles = []
+        files = []
+        attach_ok = True
+
+        try:
+            for attachment in attach:
+                # Guard 1: verify the attachment is accessible
+                if not attachment:
+                    self.logger.warning(
+                        "Could not access 800.com attachment %s.",
+                        attachment.url(privacy=True),
+                    )
+                    attach_ok = False
+                    break
+
+                # Guard 2: catch I/O errors when opening the file
+                try:
+                    handle = attachment.open()
+                except OSError as exc:
+                    self.logger.warning(
+                        "An I/O error occurred reading 800.com attachment %s.",
+                        attachment.name,
+                    )
+                    self.logger.debug("I/O Exception: %s", str(exc))
+                    attach_ok = False
+                    break
+
+                # Register handle immediately so finally closes it
+                handles.append(handle)
+                files.append(
+                    (
+                        "media[]",
+                        (
+                            attachment.name,
+                            handle,
+                            attachment.mimetype,
+                        ),
+                    )
+                )
+
+            if not attach_ok:
+                # Bail early; finally block will close any open handles
+                return False
+
+            # Prepare the multipart form fields.
+            # Do NOT set Content-Type -- requests sets the multipart
+            # boundary header automatically when files is not None.
+            data = {
+                "sender": sender,
+                "recipient": recipient,
+                "message": body,
+            }
+
+            self.logger.debug("800.com MMS data: %s", data)
+
+            # Always call throttle before any remote server i/o is made
+            self.throttle()
+
+            r = requests.post(
+                self.notify_url,
+                data=data,
+                headers=headers,
+                files=files,
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+                allow_redirects=self.redirects,
+            )
+
+            if r.status_code != requests.codes.ok:
+                # We had a problem
+                status_str = NotifyEight00com.http_response_code_lookup(
+                    r.status_code, EIGHT00COM_HTTP_ERROR_MAP
+                )
+                self.logger.warning(
+                    "Failed to send 800.com MMS to %s: %s%serror=%s.",
+                    recipient,
+                    status_str,
+                    ", " if status_str else "",
+                    r.status_code,
+                )
+                self.logger.debug(
+                    "Response Details:\r\n%r",
+                    (r.content or b"")[:2000],
+                )
+                return False
+
+            else:
+                self.logger.info("Sent 800.com MMS to %s.", recipient)
+
+        except requests.RequestException as e:
+            self.logger.warning(
+                "A Connection error occurred sending 800.com MMS to %s.",
+                recipient,
+            )
+            self.logger.debug("Socket Exception: %s", str(e))
+            return False
+
+        finally:
+            # Guard 3: close every file handle regardless of outcome
+            for handle in handles:
+                handle.close()
+
+        return True
+
+    @property
+    def url_identifier(self):
+        """Returns all of the identifiers that make this URL unique from
+        another simliar one.
+
+        Targets or end points should never be identified here.
+        """
+        return (self.secure_protocol, self.source, self.token)
+
+    def url(self, privacy=False, *args, **kwargs):
+        """Returns the URL built dynamically based on specified
+        arguments."""
+
+        # Prepare our standard parameters
+        params = self.url_parameters(privacy=privacy, *args, **kwargs)
+
+        # Omit the target list when the only target is ourselves
+        targets = (
+            []
+            if len(self.targets) == 1 and self.targets[0] == self.source
+            else self.targets
+        )
+
+        return "{schema}://{token}@{source}/{targets}?{params}".format(
+            schema=self.secure_protocol,
+            token=self.pprint(self.token, privacy, safe=""),
+            source=self.source,
+            targets="/".join(
+                NotifyEight00com.quote(x, safe="+") for x in targets
+            ),
+            params=NotifyEight00com.urlencode(params),
+        )
+
+    def __len__(self):
+        """Returns the number of targets associated with this
+        notification."""
+        return len(self.targets) if self.targets else 1
+
+    @staticmethod
+    def parse_url(url):
+        """Parses the URL and returns enough arguments that can allow
+        us to re-instantiate this object."""
+
+        results = NotifyBase.parse_url(url, verify_host=False)
+        if not results:
+            return results
+
+        # Support ?from= to specify the source number separately,
+        # in which case the hostname becomes an additional target.
+        if "from" in results["qsd"] and len(results["qsd"]["from"]):
+            results["source"] = NotifyEight00com.unquote(
+                results["qsd"]["from"]
+            )
+            results["targets"] = [
+                *NotifyEight00com.parse_phone_no(results["host"]),
+                *NotifyEight00com.split_path(results["fullpath"]),
+            ]
+
+        else:
+            # Hostname is the source (from) phone number
+            results["source"] = NotifyEight00com.unquote(results["host"])
+            # Path entries are target phone numbers
+            results["targets"] = NotifyEight00com.split_path(
+                results["fullpath"]
+            )
+
+        # Support ?to= as an alias for targets
+        if "to" in results["qsd"] and len(results["qsd"]["to"]):
+            results["targets"] += NotifyEight00com.parse_phone_no(
+                results["qsd"]["to"]
+            )
+
+        # Support ?token= to override the token in the URL user field
+        if "token" in results["qsd"] and len(results["qsd"]["token"]):
+            results["token"] = NotifyEight00com.unquote(
+                results["qsd"]["token"]
+            )
+
+        else:
+            # Token lives in the user position of the URL
+            results["token"] = NotifyEight00com.unquote(results["user"] or "")
+
+        return results

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -58,7 +58,8 @@
 Apprise is a Python package that simplifies access to many popular \
 notification services. It supports sending alerts to platforms such as: \
 \
-`46elks`, `AfricasTalking`, `Amazon Chime`, `Apprise API`, `APRS`, \
+`46elks`, `800.com`, `AfricasTalking`, `Amazon Chime`, `Apprise API`, \
+`APRS`, \
 `AWS SES`, `AWS SNS`, `Bark`, `Blink(1)`, `BlueSky`, `Brevo`, \
 `Burst SMS`, `BulkSMS`, `BulkVS`, \
 `Chanify`, `Clickatell`, `ClickSend`, `DAPNET`, `DingTalk`, `Discord`, \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
 # Identifies all of the supported plugins
 keywords = [
     "46elks",
+    "800.com",
     "Africas Talking",
     "Alerts",
     "Apprise API",

--- a/tests/test_plugin_eight00com.py
+++ b/tests/test_plugin_eight00com.py
@@ -1,0 +1,583 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Disable logging for a cleaner testing output
+from json import loads
+import logging
+import os
+from unittest import mock
+from urllib.parse import urlparse
+
+from helpers import AppriseURLTester
+import pytest
+import requests
+
+from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise.plugins.eight00com import NotifyEight00com
+
+logging.disable(logging.CRITICAL)
+
+# Attachment Directory
+TEST_VAR_DIR = os.path.join(os.path.dirname(__file__), "var")
+
+# Our Testing URLs
+apprise_url_tests = (
+    (
+        "eight00com://",
+        {
+            # No token -> TypeError
+            "instance": TypeError,
+        },
+    ),
+    (
+        "eight00com://:@/",
+        {
+            # Empty token -> TypeError
+            "instance": TypeError,
+        },
+    ),
+    (
+        "eight00com://GOODTOKEN@badphone",
+        {
+            # Non-numeric from-phone -> TypeError
+            "instance": TypeError,
+        },
+    ),
+    (
+        "eight00com://GOODTOKEN@9876543210/12",
+        {
+            # Target too short to be a valid phone number; it is
+            # dropped, leaving no targets -> notify_response False
+            "instance": NotifyEight00com,
+            "notify_response": False,
+        },
+    ),
+    (
+        "eight00com://{}@{}".format("t" * 10, "8" * 10),
+        {
+            # Valid token + source only; defaults to texting ourselves
+            "instance": NotifyEight00com,
+        },
+    ),
+    (
+        "eight00com://{}@{}/{}".format("t" * 10, "8" * 10, "5" * 11),
+        {
+            # Valid token, source, and one target
+            "instance": NotifyEight00com,
+            "privacy_url": (
+                "eight00com://t...t@{}/{}".format("8" * 10, "5" * 11)
+            ),
+        },
+    ),
+    (
+        "eight00com://{}@{}/{}/{}".format(
+            "t" * 10, "8" * 10, "5" * 11, "6" * 11
+        ),
+        {
+            # Multiple targets
+            "instance": NotifyEight00com,
+        },
+    ),
+    (
+        "eight00com://?token={}&from={}".format("t" * 10, "8" * 10),
+        {
+            # Token and source via query params
+            "instance": NotifyEight00com,
+        },
+    ),
+    (
+        "eight00com://?token={}&from={}&to={}".format(
+            "t" * 10, "8" * 10, "5" * 11
+        ),
+        {
+            # Token, source, and target all via query params
+            "instance": NotifyEight00com,
+        },
+    ),
+    (
+        "eight00com://{}@{}".format("t" * 10, "8" * 10),
+        {
+            "instance": NotifyEight00com,
+            # HTTP 500 -> failure
+            "response": False,
+            "requests_response_code": requests.codes.internal_server_error,
+        },
+    ),
+    (
+        "eight00com://{}@{}".format("t" * 10, "8" * 10),
+        {
+            "instance": NotifyEight00com,
+            # Unknown HTTP code -> failure
+            "response": False,
+            "requests_response_code": 999,
+        },
+    ),
+    (
+        "eight00com://{}@{}".format("t" * 10, "8" * 10),
+        {
+            "instance": NotifyEight00com,
+            # Simulate network I/O exceptions
+            "test_requests_exceptions": True,
+        },
+    ),
+)
+
+
+def test_plugin_eight00com_urls():
+    """NotifyEight00com() Apprise URLs."""
+    AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+@mock.patch("requests.post")
+def test_plugin_eight00com_init(mock_post):
+    """NotifyEight00com() initialization and edge cases."""
+
+    # Prepare a generic success response
+    response = requests.Request()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    # Missing token -> TypeError
+    with pytest.raises(TypeError):
+        NotifyEight00com(token=None, source="8005551234")
+
+    # Empty token -> TypeError
+    with pytest.raises(TypeError):
+        NotifyEight00com(token="", source="8005551234")
+
+    # Invalid source phone -> TypeError
+    with pytest.raises(TypeError):
+        NotifyEight00com(token="mytoken", source="notaphone")
+
+    # Valid with source only: defaults to texting ourselves
+    obj = NotifyEight00com(token="mytoken", source="8005551234")
+    assert obj.targets == ["8005551234"]
+    assert len(obj) == 1
+
+    # Invalid target is dropped with a warning logged
+    obj = NotifyEight00com(
+        token="mytoken",
+        source="8005551234",
+        targets=["12"],
+    )
+    assert obj.targets == []
+    # __len__ returns 1 minimum (consistent with httpsms pattern)
+    assert len(obj) == 1
+
+    # Multiple valid targets
+    obj = NotifyEight00com(
+        token="mytoken",
+        source="8005551234",
+        targets=["5551234567", "6661234567"],
+    )
+    assert len(obj.targets) == 2
+    assert len(obj) == 2
+
+
+@mock.patch("requests.post")
+def test_plugin_eight00com_sms(mock_post):
+    """NotifyEight00com() SMS send path."""
+
+    response = requests.Request()
+    response.status_code = requests.codes.ok
+    response.content = b"{}"
+    mock_post.return_value = response
+
+    # Single target
+    obj = NotifyEight00com(
+        token="mytoken",
+        source="8005551234",
+        targets=["5559876543"],
+    )
+    assert obj.notify(body="Test", title="Title") is True
+    assert mock_post.call_count == 1
+
+    # Verify payload
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["sender"] == "+8005551234"
+    assert payload["recipient"] == "+5559876543"
+    assert payload["message"] == "Title\r\nTest"
+
+    # Verify Authorization header
+    headers = mock_post.call_args[1]["headers"]
+    assert headers["Authorization"] == "Bearer mytoken"
+
+    mock_post.reset_mock()
+
+    # Two targets -> two POST calls
+    obj = NotifyEight00com(
+        token="mytoken",
+        source="8005551234",
+        targets=["5559876543", "4445551234"],
+    )
+    assert obj.notify(body="Hello") is True
+    assert mock_post.call_count == 2
+
+    mock_post.reset_mock()
+
+    # HTTP 500 -> failure
+    response.status_code = requests.codes.internal_server_error
+    obj = NotifyEight00com(
+        token="mytoken",
+        source="8005551234",
+        targets=["5559876543"],
+    )
+    assert obj.notify(body="Test") is False
+
+    mock_post.reset_mock()
+
+    # Unknown status code -> failure
+    response.status_code = 999
+    assert obj.notify(body="Test") is False
+
+    mock_post.reset_mock()
+
+    # RequestException -> failure
+    mock_post.side_effect = requests.RequestException("Connection error")
+    response.status_code = requests.codes.ok
+    assert obj.notify(body="Test") is False
+
+    mock_post.side_effect = None
+
+    # No targets after bad-number drops -> failure without HTTP call
+    obj = NotifyEight00com(
+        token="mytoken",
+        source="8005551234",
+        targets=["12"],
+    )
+    mock_post.reset_mock()
+    assert obj.notify(body="Test") is False
+    assert mock_post.call_count == 0
+
+
+@mock.patch("requests.post")
+def test_plugin_eight00com_url_round_trip(mock_post):
+    """NotifyEight00com() URL round-trip and privacy_url."""
+
+    response = requests.Request()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    # Round-trip with one target
+    obj1 = NotifyEight00com(
+        token="secrettoken",
+        source="8005551234",
+        targets=["5559876543"],
+    )
+    result = NotifyEight00com.parse_url(obj1.url())
+    obj2 = NotifyEight00com(**result)
+    assert obj1.url_identifier == obj2.url_identifier
+    assert len(obj1.targets) == len(obj2.targets)
+
+    # Privacy URL masks the token
+    privacy = obj1.url(privacy=True)
+    assert "secrettoken" not in privacy
+    assert "s...n" in privacy
+
+    # Round-trip with no explicit target (self-send omits path)
+    obj3 = NotifyEight00com(token="mytoken", source="8005551234")
+    result = NotifyEight00com.parse_url(obj3.url())
+    obj4 = NotifyEight00com(**result)
+    assert obj3.url_identifier == obj4.url_identifier
+    # Self-send: targets are preserved
+    assert obj3.targets == obj4.targets
+
+    # url_identifier is schema / source / token -- not targets
+    assert obj1.url_identifier == (
+        "eight00com",
+        "8005551234",
+        "secrettoken",
+    )
+
+
+@mock.patch("requests.post")
+def test_plugin_eight00com_parse_url(mock_post):
+    """NotifyEight00com() parse_url edge cases."""
+
+    response = requests.Request()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    # Standard form: token@source/target
+    result = NotifyEight00com.parse_url(
+        "eight00com://mytoken@8005551234/5559876543"
+    )
+    assert result["token"] == "mytoken"
+    assert result["source"] == "8005551234"
+    assert "5559876543" in result["targets"]
+
+    # ?token= override
+    result = NotifyEight00com.parse_url(
+        "eight00com://8005551234?token=newtoken&from=8009876543&to=5551234567"
+    )
+    assert result["token"] == "newtoken"
+    assert result["source"] == "8009876543"
+
+    # ?from= causes host to become a target instead of source
+    result = NotifyEight00com.parse_url(
+        "eight00com://mytoken@9998887776?from=8005551234"
+    )
+    assert result["token"] == "mytoken"
+    assert result["source"] == "8005551234"
+    # The host (9998887776) becomes a target
+    assert "9998887776" in " ".join(result["targets"])
+
+    # ?to= adds targets
+    result = NotifyEight00com.parse_url(
+        "eight00com://mytoken@8005551234?to=5559876543"
+    )
+    assert "5559876543" in " ".join(result["targets"])
+
+    # Unparseable URL -> None
+    assert NotifyEight00com.parse_url(None) is None
+
+
+@mock.patch("requests.post")
+def test_plugin_eight00com_attach_success(mock_post):
+    """NotifyEight00com() attachment send -- success path."""
+
+    response = requests.Request()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    obj = NotifyEight00com(
+        token="mytoken",
+        source="8005551234",
+        targets=["5559876543"],
+    )
+
+    attach = AppriseAttachment.instantiate(
+        os.path.join(TEST_VAR_DIR, "apprise-test.gif")
+    )
+    assert (
+        obj.notify(
+            body="Test MMS",
+            title="",
+            notify_type=NotifyType.INFO,
+            attach=attach,
+        )
+        is True
+    )
+
+    # Exactly one POST for one target
+    assert mock_post.call_count == 1
+
+    # Confirm the MMS fields were sent as multipart (files kwarg set)
+    call_kwargs = mock_post.call_args[1]
+    assert call_kwargs["files"] is not None
+    assert call_kwargs["data"]["sender"] == "+8005551234"
+    assert call_kwargs["data"]["recipient"] == "+5559876543"
+    assert call_kwargs["data"]["message"] == "Test MMS"
+
+    # Confirm authorization header is present
+    assert call_kwargs["headers"]["Authorization"] == "Bearer mytoken"
+
+    # Verify the URL host is correct
+    call_url = mock_post.call_args[0][0]
+    assert urlparse(call_url).hostname == "api.800.com"
+
+
+@mock.patch("requests.post")
+def test_plugin_eight00com_attach_multi(mock_post):
+    """NotifyEight00com() MMS with multiple attachments."""
+
+    response = requests.Request()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    obj = NotifyEight00com(
+        token="mytoken",
+        source="8005551234",
+        targets=["5559876543"],
+    )
+
+    attach = AppriseAttachment()
+    attach.add(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
+    attach.add(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
+
+    assert (
+        obj.notify(
+            body="Multi-attachment MMS",
+            attach=attach,
+        )
+        is True
+    )
+    assert mock_post.call_count == 1
+
+    # Two media[] tuples in the files list
+    files = mock_post.call_args[1]["files"]
+    assert len(files) == 2
+    assert all(f[0] == "media[]" for f in files)
+
+
+@mock.patch("requests.post")
+def test_plugin_eight00com_attach_inaccessible(mock_post):
+    """NotifyEight00com() attachment -- inaccessible file guard."""
+
+    response = requests.Request()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    obj = NotifyEight00com(
+        token="mytoken",
+        source="8005551234",
+        targets=["5559876543"],
+    )
+
+    attach = AppriseAttachment.instantiate(
+        os.path.join(TEST_VAR_DIR, "apprise-test.gif")
+    )
+
+    # Simulate the file being inaccessible (os.path.isfile -> False)
+    with mock.patch("os.path.isfile", return_value=False):
+        assert obj.notify(body="Test", attach=attach) is False
+
+    # No HTTP call should have been made
+    assert mock_post.call_count == 0
+
+
+@mock.patch("requests.post")
+def test_plugin_eight00com_attach_oserror(mock_post):
+    """NotifyEight00com() attachment -- OSError on open guard."""
+
+    response = requests.Request()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    obj = NotifyEight00com(
+        token="mytoken",
+        source="8005551234",
+        targets=["5559876543"],
+    )
+
+    attach = AppriseAttachment.instantiate(
+        os.path.join(TEST_VAR_DIR, "apprise-test.gif")
+    )
+
+    with mock.patch("builtins.open", side_effect=OSError("IO fail")):
+        assert obj.notify(body="Test", attach=attach) is False
+
+    # No HTTP call should have been made
+    assert mock_post.call_count == 0
+
+
+@mock.patch("requests.post")
+def test_plugin_eight00com_attach_http_error(mock_post):
+    """NotifyEight00com() attachment -- server HTTP error response."""
+
+    response = requests.Request()
+    response.status_code = requests.codes.internal_server_error
+    response.content = b"{}"
+    mock_post.return_value = response
+
+    obj = NotifyEight00com(
+        token="mytoken",
+        source="8005551234",
+        targets=["5559876543"],
+    )
+
+    attach = AppriseAttachment.instantiate(
+        os.path.join(TEST_VAR_DIR, "apprise-test.gif")
+    )
+    assert obj.notify(body="Test", attach=attach) is False
+    assert mock_post.call_count == 1
+
+
+@mock.patch("requests.post")
+def test_plugin_eight00com_attach_request_exception(mock_post):
+    """NotifyEight00com() attachment -- RequestException guard."""
+
+    mock_post.side_effect = requests.RequestException("Connection error")
+
+    obj = NotifyEight00com(
+        token="mytoken",
+        source="8005551234",
+        targets=["5559876543"],
+    )
+
+    attach = AppriseAttachment.instantiate(
+        os.path.join(TEST_VAR_DIR, "apprise-test.gif")
+    )
+    assert obj.notify(body="Test", attach=attach) is False
+
+
+@mock.patch("requests.post")
+def test_plugin_eight00com_attach_partial_failure(mock_post):
+    """NotifyEight00com() MMS partial target failure."""
+
+    def _side_effect(*args, **kwargs):
+        # First call succeeds, second fails
+        if mock_post.call_count == 1:
+            resp = requests.Request()
+            resp.status_code = requests.codes.ok
+            return resp
+
+        resp = requests.Request()
+        resp.status_code = requests.codes.internal_server_error
+        resp.content = b"{}"
+        return resp
+
+    mock_post.side_effect = _side_effect
+
+    obj = NotifyEight00com(
+        token="mytoken",
+        source="8005551234",
+        targets=["5559876543", "4441234567"],
+    )
+
+    attach = AppriseAttachment.instantiate(
+        os.path.join(TEST_VAR_DIR, "apprise-test.gif")
+    )
+    # One success and one failure -> overall False
+    assert obj.notify(body="Test", attach=attach) is False
+    assert mock_post.call_count == 2
+
+
+@mock.patch("requests.post")
+def test_plugin_eight00com_apprise_integration(mock_post):
+    """NotifyEight00com() integration with Apprise."""
+
+    response = requests.Request()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    # Load via URL
+    a = Apprise()
+    assert a.add("eight00com://mytoken@8005551234/5559876543") is True
+    assert a.notify(body="Integration test") is True
+    assert mock_post.call_count == 1
+
+    mock_post.reset_mock()
+
+    # Load via URL with ?to= and ?from=
+    a2 = Apprise()
+    assert (
+        a2.add("eight00com://?token=mytoken&from=8005551234&to=5559876543")
+        is True
+    )
+    assert a2.notify(body="Integration test 2") is True
+    assert mock_post.call_count == 1


### PR DESCRIPTION
## Description
**Related issue (if applicable):** n/a

## *800.com* Notifications
* **Source**: https://www.800.com
* **Image Support**: No
* **Message Format**: Plain Text
* **Message Limit**: 600 characters

800.com is a business communications platform offering toll-free, vanity, and local phone numbers with two-way SMS/MMS messaging capabilities. This plugin enables sending SMS and MMS notifications through any text-enabled 800.com number using their REST API and Bearer token authentication.

## Account Setup
1. Sign in to your 800.com account (or create one at https://www.800.com).
2. Click your avatar (top-right) and choose **Settings**.
3. Scroll to the **API** section and click **Generate Token**.
4. Copy the token immediately -- it is only displayed once.

## Syntax

Valid syntax is as follows:
- `eight00com://{token}@{fromPhoneNo}`
- `eight00com://{token}@{fromPhoneNo}/{toPhoneNo}`
- `eight00com://{token}@{fromPhoneNo}/{toPhoneNo1}/{toPhoneNo2}`

## Parameter Breakdown

| Variable    | Required | Description                                           |
|-------------|----------|-------------------------------------------------------|
| token       | Yes      | Your 800.com Personal Access Token                    |
| fromPhoneNo | Yes      | Your text-enabled 800.com phone number                |
| toPhoneNo   | No       | Recipient phone number(s); defaults to fromPhoneNo    |
| to          | No       | Alias for toPhoneNo (comma-separated list)            |
| from        | No       | Alternative way to supply the sender number as a query parameter |

## Examples

Send an SMS:
```bash
apprise -vv -t "Test Title" -b "Test Message Body" \
    eight00com://mytoken@8005551234/5559876543
```

Send an MMS with an image attachment:
```bash
apprise -vv -t "Test Title" -b "Test Message Body" \
    --attach /path/to/image.jpg \
    eight00com://mytoken@8005551234/5559876543
```

## New Service Completion Status
* [x] apprise/plugins/eight00com.py
* [x] pyproject.toml
    - Added `800.com` to the `keywords` list
* [x] README.md
    - Added entry for 800.com to the SMS notifications table
* [x] packaging/redhat/python-apprise.spec
    - Added `800.com` to the `%global common_description`

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/91](https://github.com/caronc/apprise-docs/pull/91)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@800-dot-com-support

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message Body" \
    eight00com://your-token@your-800-number/recipient-number
```
