### PR TITLE
Fix OneSignal url() doubling @/# target prefixes on reload

### DIFF
--- a/apprise/plugins/one_signal.py
+++ b/apprise/plugins/one_signal.py
@@ -583,28 +583,16 @@ class NotifyOneSignal(NotifyBase):
                         NotifyOneSignal.quote(x)
                         for x in self.targets[OneSignalCategory.EMAIL]
                     ],
+                    # User and segment entries already retain their leading
+                    # @ / # prefix from when they were parsed, so emit them
+                    # as-is; re-adding the prefix here would compound it on
+                    # every url() reload (e.g. @user -> @@user -> @@@user).
                     [
-                        NotifyOneSignal.quote(
-                            "{}{}".format(
-                                NotifyOneSignal.template_tokens["target_user"][
-                                    "prefix"
-                                ],
-                                x,
-                            ),
-                            safe="",
-                        )
+                        NotifyOneSignal.quote(x, safe="")
                         for x in self.targets[OneSignalCategory.USER]
                     ],
                     [
-                        NotifyOneSignal.quote(
-                            "{}{}".format(
-                                NotifyOneSignal.template_tokens[
-                                    "target_segment"
-                                ]["prefix"],
-                                x,
-                            ),
-                            safe="",
-                        )
+                        NotifyOneSignal.quote(x, safe="")
                         for x in self.targets[OneSignalCategory.SEGMENT]
                     ],
                 )

--- a/tests/test_plugin_onesignal.py
+++ b/tests/test_plugin_onesignal.py
@@ -346,6 +346,28 @@ def test_plugin_onesignal_edge_cases():
         )
 
 
+def test_plugin_onesignal_url_round_trip():
+    """NotifyOneSignal() url() is reloadable without mutating targets."""
+    obj = Apprise.instantiate(
+        "onesignal://appid@apikey/@user/#segment/player/user@email.com"
+    )
+    assert isinstance(obj, NotifyOneSignal)
+
+    # The user and segment prefixes are stored as part of the target
+    assert obj.targets["include_external_user_ids"] == ["@user"]
+    assert obj.targets["included_segments"] == ["#segment"]
+
+    # Reloading the url() must not double the @ / # prefixes, and the
+    # generated url() must be stable (idempotent) across reloads.
+    url = obj.url()
+    reloaded = Apprise.instantiate(url)
+    assert isinstance(reloaded, NotifyOneSignal)
+
+    assert reloaded.targets["include_external_user_ids"] == ["@user"]
+    assert reloaded.targets["included_segments"] == ["#segment"]
+    assert reloaded.url() == url
+
+
 @mock.patch("requests.post")
 def test_plugin_onesignal_notifications(mock_post):
     """OneSignal() Notifications Support."""


### PR DESCRIPTION
I noticed a OneSignal URL with `@user` or `#segment` targets doesn't survive a round trip. User and segment targets are stored with their leading `@`/`#` prefix, but `url()` prepends the prefix again when rebuilding the URL, so it grows on every reload:

```
@user    -> @@user    -> @@@user
#segment -> ##segment -> ###segment
```

Reloading a generated URL therefore also corrupts the `include_external_user_ids` / `included_segments` values that get sent. I changed `url()` to emit the stored targets as-is, since they already carry their prefix, so the URL is now stable across reloads.

Added a round-trip test for the user/segment case. `tox -e qa` and `tox -e lint` both pass locally.