### PR TITLE
regex improvements to token parsing

### DIFF
--- a/apprise/utils/parse.py
+++ b/apprise/utils/parse.py
@@ -97,7 +97,7 @@ IS_PHONE_NO = re.compile(r"^\+?(?P<phone>[0-9\s)(+-]+)\s*$")
 
 # Regular expression used to destinguish between multiple phone numbers
 PHONE_NO_DETECTION_RE = re.compile(
-    r"\s*([+(\s]*[0-9][0-9()\s-]+[0-9])(?=$|[\s,+(]+[0-9])", re.I
+    r"((?:[+(][+(\s]*)?[0-9][0-9()\s-]+[0-9])(?=$|[\s,+(]+[0-9])", re.I
 )
 
 IS_DOMAIN_SERVICE_TARGET = re.compile(
@@ -109,13 +109,13 @@ IS_DOMAIN_SERVICE_TARGET = re.compile(
 DOMAIN_SERVICE_TARGET_DETECTION_RE = re.compile(
     r"\s*((?:[a-z0-9_-]+\.)?[a-z0-9_-]+"
     r"(?::(?:[a-z0-9_-]+(?:,+[a-z0-9_-]+)+?))?)"
-    r"(?=$|(?:\s|,+\s|\s,+)+(?:[a-z0-9_-]+\.)?[a-z0-9_-]+)",
+    r"(?=$|[\s,]+(?:[a-z0-9_-]+\.)?[a-z0-9_-]+)",
     re.I,
 )
 
 # Support for prefix: (string followed by colon) infront of phone no
 PHONE_NO_WPREFIX_DETECTION_RE = re.compile(
-    r"\s*((?:[a-z]+:)?[+(\s]*[0-9][0-9()\s-]+[0-9])"
+    r"((?:[a-z]+:)?(?:[+(][+(\s]*)?[0-9][0-9()\s-]+[0-9])"
     r"(?=$|(?:[a-z]+:)?[\s,+(]+[0-9])",
     re.I,
 )
@@ -140,10 +140,20 @@ URL_DETECTION_RE = re.compile(
     r"([a-z0-9]+?:\/\/.*?)(?=$|[\s,]+[a-z0-9]{1,32}?:\/\/)", re.I
 )
 
+# No leading separator; first-char anchors make separator positions O(1)-fail
+# so findall skips them without any backtracking blowup.
 EMAIL_DETECTION_RE = re.compile(
-    r"[\s,]*([^@]+@.*?)(?=$|[\s,]+"
-    r"(?:[^:<]+?[:<\s]+?)?"
-    r"[^@\s,]+@[^\s,]+)",
+    r"("
+    # Angle-bracketed: bounded display name then <local@domain>
+    r"(?=[^\s,;])"
+    r'(?:"(?:[^"\\]|\\.){0,256}"|[^<>"@,;\r\n]){0,256}?'
+    r"<[^@>\r\n]{1,64}@"
+    r"(?:[a-z0-9][a-z0-9_-]{0,62}\.){1,10}[a-z]{2,63}>"
+    r"|"
+    # Bare email: non-space/non-separator first char, then local@domain
+    r"[^\s@,;\r\n][^@,;\r\n]{0,255}"
+    r"@(?:[a-z0-9][a-z0-9_-]{0,62}\.){1,10}[a-z]{2,63}"
+    r")",
     re.IGNORECASE,
 )
 
@@ -1012,7 +1022,7 @@ def parse_emails(*args, store_unparseable=True, **kwargs):
     result = []
     for arg in args:
         if isinstance(arg, str) and arg:
-            result_ = EMAIL_DETECTION_RE.findall(arg)
+            result_ = EMAIL_DETECTION_RE.findall(arg) if "@" in arg else []
             if result_:
                 result += result_
 
@@ -1128,7 +1138,9 @@ def parse_urls(*args, store_unparseable=True, **kwargs):
     result = []
     for arg in args:
         if isinstance(arg, str) and arg:
-            result_ = URL_DETECTION_RE.findall(arg)
+            result_ = (
+                URL_DETECTION_RE.findall(arg.rstrip()) if "://" in arg else []
+            )
             if result_:
                 result += result_
 

--- a/tests/test_apprise_utils.py
+++ b/tests/test_apprise_utils.py
@@ -33,6 +33,7 @@ import logging
 import os
 import re
 import sys
+import time
 from unittest import mock
 from urllib.parse import unquote
 
@@ -2010,6 +2011,11 @@ def test_parse_domain_service_targets():
     assert isinstance(results, list)
     assert len(results) == 0
 
+    # Verify many separators complete in reasonable time.
+    t0 = time.monotonic()
+    utils.parse.parse_domain_service_targets("ha.smtp" + " , " * 30)
+    assert time.monotonic() - t0 < 5.0
+
 
 def test_parse_phone_no():
     """utils: parse_phone_no() testing"""
@@ -2095,6 +2101,12 @@ def test_parse_phone_no():
     assert len(results) == 2
     assert "911" in results
     assert "+ 1 ( 123 ) 123-1234" in results
+
+    # Verify trailing-whitespace runs complete in reasonable time.
+    t0 = time.monotonic()
+    results = utils.parse.parse_phone_no("+12345678901" + " " * 1000)
+    assert time.monotonic() - t0 < 5.0
+    assert results == ["+12345678901"]
 
 
 def test_parse_emails():
@@ -2213,6 +2225,25 @@ def test_parse_emails():
     results = utils.parse.parse_emails([None, object, 42])
     assert isinstance(results, list)
     assert len(results) == 0
+
+    # Verify trailing-whitespace runs complete in reasonable time.
+    t0 = time.monotonic()
+    results = utils.parse.parse_emails("victim@example.com" + " " * 400)
+    assert time.monotonic() - t0 < 5.0
+    assert results == ["victim@example.com"]
+
+    # Quoted display names containing commas are kept as a single token.
+    results = utils.parse.parse_emails(
+        '"John, Jason & Mike" <team@example.com>'
+    )
+    assert results == ['"John, Jason & Mike" <team@example.com>']
+
+    results = utils.parse.parse_emails(
+        '"Smith, Jane" <jane@example.com>, Bob Jones <bob@example.com>'
+    )
+    assert len(results) == 2
+    assert '"Smith, Jane" <jane@example.com>' in results
+    assert "Bob Jones <bob@example.com>" in results
 
 
 def test_parse_urls():
@@ -2345,6 +2376,12 @@ def test_parse_urls():
     results = utils.parse.parse_urls([None, object, 42])
     assert isinstance(results, list)
     assert len(results) == 0
+
+    # Verify trailing-whitespace runs complete in reasonable time.
+    t0 = time.monotonic()
+    results = utils.parse.parse_urls("https://example.com" + " " * 50000)
+    assert time.monotonic() - t0 < 5.0
+    assert results == ["https://example.com"]
 
 
 def test_dict_full_update():


### PR DESCRIPTION
## Description
**Related issue (if applicable):** n/a

Improvements to parsers surrounding emails and phone numbers that could potentially introduce ReDoS scenarios.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [ ] Documentation ticket created (if applicable): n/a
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@regex-parse-improvements

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    <apprise url related to this change>
```
