### PR TITLE
Added Stackfield support

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ The table below identifies the services this tool supports and some example serv
 | [Spike.sh](https://appriseit.com/services/spike/) | spike://  | (TCP) 443   | spike://Token
 | [Splunk](https://appriseit.com/services/splunk/) | splunk:// or victorops:/ | (TCP) 443 | splunk://route_key@apikey<br />splunk://route_key@apikey/entity_id
 | [Spug Push](https://appriseit.com/services/spugpush/) | spugpush://  | (TCP) 443   | spugpush://Token
+| [Stackfield](https://appriseit.com/services/stackfield/) | stackfield://  | (TCP) 443   | stackfield://WebhookToken
 | [Streamlabs](https://appriseit.com/services/streamlabs/) | strmlabs:// | (TCP) 443 | strmlabs://AccessToken/<br/>strmlabs://AccessToken/?name=name&identifier=identifier&amount=0&currency=USD
 | [Synology Chat](https://appriseit.com/services/synology_chat/) | synology:// or synologys:// |  (TCP) 80 or 443 | synology://hostname/token<br />synology://hostname:port/token
 | [Syslog](https://appriseit.com/services/syslog/) | syslog://  | n/a | syslog://<br />syslog://Facility

--- a/apprise/plugins/stackfield.py
+++ b/apprise/plugins/stackfield.py
@@ -1,0 +1,268 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Setting up a Stackfield incoming webhook:
+#  1. Log into Stackfield at https://www.stackfield.com
+#  2. Open the Room you want to receive notifications in
+#  3. Go to Room Settings > Integrations > Add a new WebHook
+#  4. Select "Chat Message" and click "Create Webhook"
+#  5. Name the webhook (e.g. "Apprise") and click "Save and Generate URL"
+#  6. Copy the webhook URL -- it will look like:
+#       https://www.stackfield.com/apiwh/
+#           e5a1cfbd-970e-45a1-b81c-3e004f9bdab5
+#                   |-- webhook token (UUID) --|
+#
+#  Your Apprise URL for this plugin:
+#     stackfield://e5a1cfbd-970e-45a1-b81c-3e004f9bdab5
+#
+# API Reference:
+#   - https://www.stackfield.com/developer-api
+
+from json import dumps
+import re
+
+import requests
+
+from ..common import NotifyType
+from ..locale import gettext_lazy as _
+from ..url import PrivacyMode
+from ..utils.parse import validate_regex
+from .base import NotifyBase
+
+
+class NotifyStackfield(NotifyBase):
+    """A wrapper for Stackfield Notifications."""
+
+    # The default descriptive name associated with the Notification
+    service_name = "Stackfield"
+
+    # The services URL
+    service_url = "https://www.stackfield.com/"
+
+    # The default secure protocol
+    secure_protocol = "stackfield"
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = "https://appriseit.com/services/stackfield/"
+
+    # Stackfield incoming webhook base URL
+    notify_url = "https://www.stackfield.com/apiwh/{token}"
+
+    # Stackfield allows at most one request per second
+    request_rate_per_sec = 1
+
+    # No native title field; framework merges title into body
+    title_maxlen = 0
+
+    # Maximum message length for a Stackfield chat message
+    body_maxlen = 4000
+
+    # Define object URL templates
+    templates = ("{schema}://{token}",)
+
+    # Define our template tokens
+    template_tokens = dict(
+        NotifyBase.template_tokens,
+        **{
+            "token": {
+                "name": _("Webhook Token"),
+                "type": "string",
+                "private": True,
+                "required": True,
+                # Stackfield webhook tokens are standard UUIDs
+                "regex": (
+                    r"^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}"
+                    r"-[a-f0-9]{4}-[a-f0-9]{12}$",
+                    "i",
+                ),
+            },
+        },
+    )
+
+    # Define our template arguments
+    template_args = dict(
+        NotifyBase.template_args,
+        **{
+            # token= allows the webhook UUID to be supplied as a
+            # query-string argument in config files
+            "token": {
+                "alias_of": "token",
+            },
+        },
+    )
+
+    def __init__(self, token, **kwargs):
+        """Initialize Stackfield Object."""
+        super().__init__(**kwargs)
+
+        # Validate our webhook token (UUID format)
+        self.token = validate_regex(
+            token, *self.template_tokens["token"]["regex"]
+        )
+        if not self.token:
+            msg = (
+                f"An invalid Stackfield webhook token ({token}) was specified."
+            )
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+        """Perform Stackfield Notification."""
+
+        # Prepare our headers
+        headers = {
+            "User-Agent": self.app_id,
+            "Content-Type": "application/json",
+        }
+
+        # Prepare our payload; "Title" is the chat message content
+        payload = {
+            "Title": body,
+        }
+
+        # Prepare our URL
+        url = self.notify_url.format(token=self.token)
+
+        self.logger.debug(
+            "Stackfield POST URL: %s (cert_verify=%s)",
+            url,
+            self.verify_certificate,
+        )
+        self.logger.debug("Stackfield Payload: %r", payload)
+
+        # Always call throttle before any remote server i/o is made
+        self.throttle()
+
+        try:
+            r = requests.post(
+                url,
+                data=dumps(payload),
+                headers=headers,
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+                allow_redirects=self.redirects,
+            )
+            if r.status_code != requests.codes.ok:
+                # We had a failure
+                status_str = NotifyStackfield.http_response_code_lookup(
+                    r.status_code
+                )
+                self.logger.warning(
+                    "Failed to send Stackfield notification:"
+                    " {}{}error={}.".format(
+                        status_str,
+                        ", " if status_str else "",
+                        r.status_code,
+                    )
+                )
+                self.logger.debug(
+                    "Response Details:\r\n%r", (r.content or b"")[:2000]
+                )
+
+                # Return; we're done
+                return False
+
+            self.logger.info("Sent Stackfield notification.")
+
+        except requests.RequestException as e:
+            self.logger.warning(
+                "A Connection error occurred sending Stackfield notification."
+            )
+            self.logger.debug("Socket Exception: %s", e)
+
+            # Return; we're done
+            return False
+
+        return True
+
+    @property
+    def url_identifier(self):
+        """Returns all of the identifiers that make this URL unique from
+        another simliar one.
+
+        Targets or end points should never be identified here.
+        """
+        return (self.secure_protocol, self.token)
+
+    def url(self, privacy=False, *args, **kwargs):
+        """Returns the URL built dynamically based on specified arguments."""
+
+        # Define any URL parameters
+        params = self.url_parameters(privacy=privacy, *args, **kwargs)
+
+        return "{schema}://{token}/?{params}".format(
+            schema=self.secure_protocol,
+            token=self.pprint(
+                self.token, privacy, mode=PrivacyMode.Secret, safe=""
+            ),
+            params=NotifyStackfield.urlencode(params),
+        )
+
+    @staticmethod
+    def parse_url(url):
+        """Parses the URL and returns enough arguments that can allow us to
+        re-instantiate this object."""
+
+        results = NotifyBase.parse_url(url, verify_host=False)
+        if not results:
+            # We're done early as we couldn't load the results
+            return results
+
+        # Allow the token to be supplied as a query-string argument too,
+        # which is convenient when using YAML configuration files
+        if "token" in results["qsd"] and results["qsd"]["token"]:
+            results["token"] = NotifyStackfield.unquote(
+                results["qsd"]["token"]
+            )
+
+        else:
+            results["token"] = NotifyStackfield.unquote(results["host"])
+
+        return results
+
+    @staticmethod
+    def parse_native_url(url):
+        """Support https://www.stackfield.com/apiwh/TOKEN"""
+
+        result = re.match(
+            r"^https?://(?:www\.)?stackfield\.com/apiwh/"
+            r"(?P<token>[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}"
+            r"-[a-f0-9]{4}-[a-f0-9]{12})/?"
+            r"(?P<params>\?.+)?$",
+            url,
+            re.I,
+        )
+        if result:
+            return NotifyStackfield.parse_url(
+                "{schema}://{token}/{params}".format(
+                    schema=NotifyStackfield.secure_protocol,
+                    token=result.group("token"),
+                    params=result.group("params") or "",
+                )
+            )
+
+        return None

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -85,7 +85,8 @@ notification services. It supports sending alerts to platforms such as: \
 `SendPulse`, `ServerChan`, `Session Open Group Server`, `Seven`, `SFR`, \
 `Signal`, `SIGNL4`, `SimplePush`, \
 `Sinch`, `Slack`, `SMPP`, `SMSEagle`, `SMS Manager`, `SMTP2Go`, `SparkPost`, \
-`Splunk`, `Spike`, `Spug Push`, `Super Toasty`, `Streamlabs`, `Stride`, \
+`Splunk`, `Spike`, `Spug Push`, `Stackfield`, `Super Toasty`, \
+`Streamlabs`, `Stride`, \
 `Synology Chat`, `Syslog`, `Techulus Push`, `Telegram`, `Threema Gateway`, \
 `Twilio`, `Twitter`, `Twist`, `Vapid`, `Viber`, `VictorOps`, `Voipms`, \
 `Vonage`, `WebPush`, `WeChat (WeCom)`, `WeCom Bot`, `WhatsApp`, \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,7 @@ keywords = [
     "Spike",
     "Splunk",
     "SpugPush",
+    "Stackfield",
     "Streamlabs",
     "Stride",
     "Synology Chat",

--- a/tests/test_plugin_stackfield.py
+++ b/tests/test_plugin_stackfield.py
@@ -1,0 +1,281 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Disable logging for a cleaner testing output
+import logging
+from unittest import mock
+from urllib.parse import urlparse
+
+from helpers import AppriseURLTester
+import pytest
+import requests
+
+from apprise import Apprise
+from apprise.plugins.stackfield import NotifyStackfield
+
+logging.disable(logging.CRITICAL)
+
+# A valid Stackfield webhook token (UUID format)
+TEST_TOKEN = "11111111-2222-3333-4444-555555555555"
+
+apprise_url_tests = (
+    # Missing token
+    (
+        "stackfield://",
+        {
+            "instance": TypeError,
+        },
+    ),
+    # Invalid token -- not a UUID
+    (
+        "stackfield://not-a-valid-uuid",
+        {
+            "instance": TypeError,
+        },
+    ),
+    # Invalid token -- wrong UUID length
+    (
+        "stackfield://11111111-2222-3333-4444-55555555555",
+        {
+            "instance": TypeError,
+        },
+    ),
+    # Valid token in URL path
+    (
+        f"stackfield://{TEST_TOKEN}",
+        {
+            "instance": NotifyStackfield,
+            "privacy_url": "stackfield://****/",
+        },
+    ),
+    # Valid token via ?token= query parameter
+    (
+        f"stackfield://?token={TEST_TOKEN}",
+        {
+            "instance": NotifyStackfield,
+            "privacy_url": "stackfield://****/",
+        },
+    ),
+    # Native Stackfield webhook URL
+    (
+        f"https://www.stackfield.com/apiwh/{TEST_TOKEN}",
+        {
+            "instance": NotifyStackfield,
+        },
+    ),
+    # Native URL without www prefix
+    (
+        f"https://stackfield.com/apiwh/{TEST_TOKEN}",
+        {
+            "instance": NotifyStackfield,
+        },
+    ),
+    # HTTP 500 response
+    (
+        f"stackfield://{TEST_TOKEN}",
+        {
+            "instance": NotifyStackfield,
+            "response": False,
+            "requests_response_code": requests.codes.internal_server_error,
+        },
+    ),
+    # Unknown HTTP error code
+    (
+        f"stackfield://{TEST_TOKEN}",
+        {
+            "instance": NotifyStackfield,
+            "response": False,
+            "requests_response_code": 999,
+        },
+    ),
+    # RequestException
+    (
+        "stackfield://abcdef01-2345-6789-abcd-ef0123456789",
+        {
+            "instance": NotifyStackfield,
+            "test_requests_exceptions": True,
+        },
+    ),
+)
+
+
+def test_plugin_stackfield_urls():
+    """Run the standard AppriseURLTester against all URL test cases."""
+    AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+def test_plugin_stackfield_init():
+    """Test NotifyStackfield init, url(), and url_identifier."""
+
+    # Valid instantiation
+    obj = NotifyStackfield(token=TEST_TOKEN)
+    assert isinstance(obj, NotifyStackfield)
+
+    # url_identifier returns (schema, token)
+    assert obj.url_identifier == ("stackfield", TEST_TOKEN)
+
+    # url() round-trips correctly
+    url = obj.url()
+    assert url.startswith("stackfield://")
+    assert TEST_TOKEN in url
+
+    # privacy URL masks the token
+    privacy = obj.url(privacy=True)
+    assert TEST_TOKEN not in privacy
+    assert "stackfield://" in privacy
+
+    # Round-trip: parse_url(url()) re-creates the same object
+    result = NotifyStackfield.parse_url(obj.url())
+    assert result is not None
+    obj2 = NotifyStackfield(**result)
+    assert obj2.url_identifier == obj.url_identifier
+
+    # Missing token
+    with pytest.raises(TypeError):
+        NotifyStackfield(token=None)
+
+    # Empty token
+    with pytest.raises(TypeError):
+        NotifyStackfield(token="")
+
+    # Invalid token format (not a UUID)
+    with pytest.raises(TypeError):
+        NotifyStackfield(token="not-a-valid-uuid-at-all")
+
+    # Wrong UUID length (too short)
+    with pytest.raises(TypeError):
+        NotifyStackfield(token="11111111-2222-3333-4444-55555555555")
+
+
+@mock.patch("requests.post")
+def test_plugin_stackfield_send(mock_post):
+    """Test send() HTTP success, HTTP error, and RequestException paths."""
+
+    def _mk_resp(code=requests.codes.ok):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = b""
+        return r
+
+    obj = NotifyStackfield(token=TEST_TOKEN)
+
+    # Successful notification
+    mock_post.return_value = _mk_resp(requests.codes.ok)
+    assert obj.send(body="Hello, Stackfield!") is True
+    assert mock_post.call_count == 1
+
+    # Verify POST target hostname
+    call_url = mock_post.call_args[0][0]
+    assert urlparse(call_url).hostname == "www.stackfield.com"
+
+    mock_post.reset_mock()
+
+    # HTTP 500 -> send() returns False
+    mock_post.return_value = _mk_resp(requests.codes.internal_server_error)
+    assert obj.send(body="test") is False
+
+    mock_post.reset_mock()
+
+    # Unknown HTTP code 999 -> send() returns False
+    mock_post.return_value = _mk_resp(999)
+    assert obj.send(body="test") is False
+
+    mock_post.reset_mock()
+
+    # RequestException -> send() returns False
+    mock_post.side_effect = requests.RequestException("connection error")
+    assert obj.send(body="test") is False
+
+
+def test_plugin_stackfield_url_parsing():
+    """Test parse_url() and parse_native_url() edge cases."""
+
+    # Token from URL path (host position)
+    result = NotifyStackfield.parse_url(f"stackfield://{TEST_TOKEN}")
+    assert result is not None
+    assert result["token"] == TEST_TOKEN
+
+    # Token from ?token= query string
+    result = NotifyStackfield.parse_url(f"stackfield://?token={TEST_TOKEN}")
+    assert result is not None
+    assert result["token"] == TEST_TOKEN
+
+    # ?token= wins over host position when both are present
+    other = "abcdef01-2345-6789-abcd-ef0123456789"
+    result = NotifyStackfield.parse_url(
+        f"stackfield://{TEST_TOKEN}?token={other}"
+    )
+    assert result is not None
+    assert result["token"] == other
+
+    # parse_native_url: full https://www.stackfield.com/apiwh/TOKEN
+    result = NotifyStackfield.parse_native_url(
+        f"https://www.stackfield.com/apiwh/{TEST_TOKEN}"
+    )
+    assert result is not None
+    assert result["token"] == TEST_TOKEN
+
+    # parse_native_url: without www
+    result = NotifyStackfield.parse_native_url(
+        f"https://stackfield.com/apiwh/{TEST_TOKEN}"
+    )
+    assert result is not None
+    assert result["token"] == TEST_TOKEN
+
+    # parse_native_url: http variant
+    result = NotifyStackfield.parse_native_url(
+        f"http://www.stackfield.com/apiwh/{TEST_TOKEN}"
+    )
+    assert result is not None
+    assert result["token"] == TEST_TOKEN
+
+    # parse_native_url: invalid token format -> returns None
+    result = NotifyStackfield.parse_native_url(
+        "https://www.stackfield.com/apiwh/not-a-valid-uuid"
+    )
+    assert result is None
+
+    # parse_native_url: unrelated URL -> returns None
+    result = NotifyStackfield.parse_native_url(
+        "https://example.com/webhook/12345"
+    )
+    assert result is None
+
+
+@mock.patch("requests.post")
+def test_plugin_stackfield_apprise_integration(mock_post):
+    """Test that Apprise correctly loads and fires a Stackfield URL."""
+
+    r = mock.Mock()
+    r.status_code = requests.codes.ok
+    r.content = b""
+    mock_post.return_value = r
+
+    a = Apprise()
+    assert a.add(f"stackfield://{TEST_TOKEN}") is True
+    assert a.notify(title="Test", body="Integration test") is True
+    assert mock_post.call_count == 1


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #<!-- issue number if known -->

## *Stackfield* Notifications
* **Source**: https://www.stackfield.com
* **Image Support**: No
* **Message Format**: Plain Text
* **Message Limit**: 4000 characters per message

Stackfield is a project-management and team-collaboration platform. This plugin delivers chat messages to a Stackfield room via an incoming webhook. The webhook URL is self-authenticating (the UUID token encodes the destination room); no additional credentials are needed.

## Account Setup
1. Log into Stackfield and open the Room that should receive notifications.
2. Open Room Settings > Integrations > Add a new WebHook.
3. Choose "Chat Message", name the webhook (e.g. "Apprise"), then click "Save and Generate URL".
4. Copy the generated URL -- the UUID at the end is the webhook token.

## Syntax

Valid syntax is as follows:
- `stackfield://{token}`
- `https://www.stackfield.com/apiwh/{token}` (native URL, accepted directly)

## Parameter Breakdown

| Variable | Required | Description |
| -------- | -------- | ----------- |
| token    | Yes      | UUID webhook token from the Stackfield room integration URL. |

## Examples

```bash
# Send a notification to a Stackfield room
apprise -vv -t "Alert" -b "Server restarted." \
    stackfield://e5a1cfbd-970e-45a1-b81c-3e004f9bdab5

# Native webhook URL also works directly
apprise -vv -t "Alert" -b "Server restarted." \
    "https://www.stackfield.com/apiwh/e5a1cfbd-970e-45a1-b81c-3e004f9bdab5"
```

## New Service Completion Status
* [x] apprise/plugins/stackfield.py
* [x] pyproject.toml
* [x] README.md
* [x] packaging/redhat/python-apprise.spec

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/93](https://github.com/caronc/apprise-docs/pull/93)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@stackfield-support

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    stackfield://your-webhook-uuid-here
```
