### PR TITLE
Discord templating support added

### DIFF
--- a/apprise/plugins/discord.py
+++ b/apprise/plugins/discord.py
@@ -46,16 +46,19 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from itertools import chain
-from json import dumps
+from json import dumps, loads
+from json.decoder import JSONDecodeError
 import re
 from typing import Any
 
 import requests
 
+from ..apprise_attachment import AppriseAttachment
 from ..attachment.base import AttachBase
 from ..common import NotifyFormat, NotifyImageSize, NotifyType
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_bool, parse_list, validate_regex
+from ..utils.templates import TemplateType, apply_template
 from .base import NotifyBase
 
 # Used to detect user/role IDs and @here/@everyone tokens.
@@ -110,6 +113,10 @@ class NotifyDiscord(NotifyBase):
     # embeds message. This value allows the discord message to safely
     # break into multiple messages to handle these cases.
     discord_max_fields = 10
+
+    # There is no reason we should exceed 35KB when reading in a JSON
+    # file. If it is more than this, then it is not accepted
+    max_discord_template_size = 35000
 
     # Define object templates
     templates = (
@@ -205,8 +212,21 @@ class NotifyDiscord(NotifyBase):
                 "name": _("Ping Users/Roles"),
                 "type": "list:string",
             },
+            "template": {
+                "name": _("Template Path"),
+                "type": "string",
+                "private": True,
+            },
         },
     )
+
+    # Define our token control
+    template_kwargs = {
+        "tokens": {
+            "name": _("Template Tokens"),
+            "prefix": ":",
+        },
+    }
 
     def __init__(
         self,
@@ -223,6 +243,8 @@ class NotifyDiscord(NotifyBase):
         thread: str | None = None,
         flags: int | None = None,
         ping: list[str] | None = None,
+        template: str | None = None,
+        tokens: dict | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize Discord Object."""
@@ -301,7 +323,144 @@ class NotifyDiscord(NotifyBase):
         # Default to 1.0
         self.ratelimit_remaining = 1.0
 
+        # Our template object is just an AppriseAttachment object
+        self.template = AppriseAttachment(asset=self.asset)
+        if template:
+            # Add our definition to our template
+            self.template.add(template)
+            if not len(self.template):
+                # add() failed (unsupported schema, unparseable URL, etc.)
+                msg = "The Discord template specified could not be loaded."
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
+            # Enforce maximum file size
+            self.template[0].max_file_size = self.max_discord_template_size
+
+        # Template functionality
+        self.tokens: dict = {}
+        if isinstance(tokens, dict):
+            self.tokens.update(tokens)
+
+        elif tokens:
+            msg = (
+                "The specified Discord Template Tokens "
+                f"({tokens}) are not identified as a dictionary."
+            )
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # else: NoneType - this is okay
+
         return
+
+    def gen_payload(
+        self, body, title="", notify_type=NotifyType.INFO, **kwargs
+    ):
+        """Return a validated Discord webhook payload from template,
+        or False on failure."""
+
+        # Acquire the first template attachment
+        template = self.template[0]
+        if not template:
+            # We could not access the attachment
+            self.logger.error(
+                "Could not access Discord template"
+                f" {template.url(privacy=True)}."
+            )
+            return False
+
+        # Acquire our image URL for potential token substitution
+        image_url = self.image_url(notify_type)
+
+        # Take a copy of our token dictionary
+        tokens = self.tokens.copy()
+
+        # Apply our standard template variable defaults
+        tokens["app_body"] = body
+        tokens["app_title"] = title
+        tokens["app_type"] = notify_type.value
+        tokens["app_id"] = self.app_id
+        tokens["app_desc"] = self.app_desc
+        tokens["app_color"] = self.color(notify_type)
+        tokens["app_image_url"] = image_url
+        tokens["app_url"] = self.app_url
+
+        # Templates are always JSON; enforce JSON escaping
+        tokens["app_mode"] = TemplateType.JSON
+
+        # Stringify substitutions before JSON escaping; preserve app_mode
+        safe_tokens = {
+            k: (
+                v
+                if k == "app_mode" or isinstance(v, str)
+                else ("" if v is None else str(v))
+            )
+            for k, v in tokens.items()
+        }
+
+        try:
+            with open(template.path) as fp:
+                content = apply_template(fp.read(), **safe_tokens)
+
+        except OSError:
+            self.logger.error(
+                "Discord template"
+                f" {template.url(privacy=True)} could not be read."
+            )
+            return False
+
+        # Parse and validate as JSON
+        try:
+            content = loads(content)
+
+        except (JSONDecodeError, ValueError) as e:
+            self.logger.error(
+                "Discord template"
+                f" {template.url(privacy=True)} contains invalid JSON."
+            )
+            self.logger.debug(f"JSONDecodeError: {e}")
+            return False
+
+        # Template must parse to a JSON object, not an array or scalar
+        if not isinstance(content, dict):
+            self.logger.error(
+                "Discord template"
+                f" {template.url(privacy=True)} must be a JSON object"
+                " (got {}).".format(type(content).__name__)
+            )
+            return False
+
+        # A Discord webhook payload must have a non-empty 'content' string
+        # or a non-empty 'embeds' list containing embed dicts
+        has_content = (
+            isinstance(content.get("content"), str) and content["content"]
+        )
+        has_embeds = (
+            isinstance(content.get("embeds"), list) and content["embeds"]
+        )
+        if not (has_content or has_embeds):
+            self.logger.error(
+                "Discord template"
+                f" {template.url(privacy=True)} must contain"
+                " a non-empty 'content' string or a non-empty 'embeds'"
+                " list."
+            )
+            return False
+
+        # If embeds is present, each entry must be a JSON object (dict)
+        if has_embeds and not all(
+            isinstance(e, dict) for e in content["embeds"]
+        ):
+            self.logger.error(
+                "Discord template"
+                f" {template.url(privacy=True)} contains"
+                " an embed entry that is not a JSON object."
+            )
+            return False
+
+        # Return the validated payload content dict
+        return content
 
     def send(
         self,
@@ -339,21 +498,45 @@ class NotifyDiscord(NotifyBase):
         # Associate our thread_id with our message
         params = {"thread_id": self.thread_id} if self.thread_id else None
 
-        # Ping handling rules:
-        # - If ping= is set, it is an additive if in MARKDOWN mode otherwise
-        #   it is explicit for TEXT/HTML formats.
-        # - Otherwise, ping detection only happens in MARKDOWN mode
-        if self.notify_format == NotifyFormat.MARKDOWN:
-            if self.ping:
-                payload.update(self.ping_payload(body, " ".join(self.ping)))
-            else:
-                payload.update(self.ping_payload(body))
+        # Template mode bypasses ping detection and embed construction;
+        # the template defines the complete payload content.
+        if not self.template:
+            # Ping handling rules:
+            # - If ping= is set, it is an additive if in MARKDOWN mode
+            #   otherwise it is explicit for TEXT/HTML formats.
+            # - Otherwise, ping detection only happens in MARKDOWN mode
+            if self.notify_format == NotifyFormat.MARKDOWN:
+                if self.ping:
+                    payload.update(
+                        self.ping_payload(body, " ".join(self.ping))
+                    )
+                else:
+                    payload.update(self.ping_payload(body))
 
-        # TEXT/HTML: no body parsing, ping= is exclusive
-        elif self.ping:
-            payload.update(self.ping_payload(" ".join(self.ping)))
+            # TEXT/HTML: no body parsing, ping= is exclusive
+            elif self.ping:
+                payload.update(self.ping_payload(" ".join(self.ping)))
 
-        if body:
+        if self.template:
+            # Generate our payload from the user-supplied template file
+            template_payload = self.gen_payload(
+                body=body,
+                title=title,
+                notify_type=notify_type,
+                **kwargs,
+            )
+            if template_payload is False:
+                # gen_payload() already logged the error; bail early
+                return False
+
+            # Merge template content over our base payload
+            payload.update(template_payload)
+
+            if not self._send(payload, params=params):
+                # We failed to post our message
+                return False
+
+        elif body:
             # Track extra embed fields (if used)
             fields: list[dict[str, str]] = []
 
@@ -407,12 +590,13 @@ class NotifyDiscord(NotifyBase):
                             : self.discord_max_fields
                         ]
                         fields = fields[self.discord_max_fields :]
+
             else:
                 # TEXT or HTML:
                 # - No ping detection unless ping= was provided.
                 # - If ping= was provided, ping_payload() already generated
-                #   payload["content"] starting with "👉 ...", and we append
-                #   it.
+                #   payload["content"] starting with "👉 ...", and we
+                #   append it.
                 payload["content"] = (
                     body if not title else f"{title}\r\n{body}"
                 ) + payload.get("content", "")
@@ -675,6 +859,15 @@ class NotifyDiscord(NotifyBase):
             # Let Apprise urlencode handle list formatting
             params["ping"] = ",".join(self.ping)
 
+        if self.template:
+            # Include our template reference
+            params["template"] = NotifyDiscord.quote(
+                self.template[0].url(), safe=""
+            )
+
+        # Store any template token entries if specified
+        params.update({f":{k}": v for k, v in self.tokens.items()})
+
         # Ensure our botname is set
         botname = f"{self.user}@" if self.user else ""
 
@@ -783,6 +976,15 @@ class NotifyDiscord(NotifyBase):
         # Extract ping targets, comma/space separated
         if "ping" in results["qsd"]:
             results["ping"] = NotifyDiscord.unquote(results["qsd"]["ping"])
+
+        # Template Handling
+        if "template" in results["qsd"] and results["qsd"]["template"]:
+            results["template"] = NotifyDiscord.unquote(
+                results["qsd"]["template"]
+            )
+
+        # Store our template tokens
+        results["tokens"] = results["qsd:"]
 
         return results
 

--- a/apprise/plugins/discord.py
+++ b/apprise/plugins/discord.py
@@ -383,6 +383,14 @@ class NotifyDiscord(NotifyBase):
         tokens["app_id"] = self.app_id
         tokens["app_desc"] = self.app_desc
         tokens["app_color"] = self.color(notify_type)
+        # app_color_hex is an explicit alias for app_color, provided so
+        # templates can name the hex variant unambiguously alongside
+        # app_color_int
+        tokens["app_color_hex"] = self.color(notify_type)
+        # Discord embed payloads require color as a decimal integer;
+        # app_color_int provides that while app_color stays hex for
+        # consistency with all other template-capable plugins
+        tokens["app_color_int"] = self.color(notify_type, int)
         tokens["app_image_url"] = image_url
         tokens["app_url"] = self.app_url
 

--- a/apprise/plugins/slack.py
+++ b/apprise/plugins/slack.py
@@ -785,6 +785,9 @@ class NotifySlack(NotifyBase):
         tokens["app_id"] = self.app_id
         tokens["app_desc"] = self.app_desc
         tokens["app_color"] = self.color(notify_type)
+        # app_color_hex is an explicit alias for app_color so templates
+        # can reference the hex variant by a self-documenting name
+        tokens["app_color_hex"] = self.color(notify_type)
         tokens["app_image_url"] = image_url
         tokens["app_url"] = self.app_url
 

--- a/apprise/plugins/sparkpost.py
+++ b/apprise/plugins/sparkpost.py
@@ -605,6 +605,9 @@ class NotifySparkPost(NotifyBase):
         tokens["app_id"] = self.app_id
         tokens["app_desc"] = self.app_desc
         tokens["app_color"] = self.color(notify_type)
+        # app_color_hex is an explicit alias for app_color so templates
+        # can reference the hex variant by a self-documenting name
+        tokens["app_color_hex"] = self.color(notify_type)
         tokens["app_url"] = self.app_url
 
         # Store our tokens if they're identified

--- a/apprise/plugins/workflows.py
+++ b/apprise/plugins/workflows.py
@@ -387,6 +387,9 @@ class NotifyWorkflows(NotifyBase):
         tokens["app_id"] = self.app_id
         tokens["app_desc"] = self.app_desc
         tokens["app_color"] = self.color(notify_type)
+        # app_color_hex is an explicit alias for app_color so templates
+        # can reference the hex variant by a self-documenting name
+        tokens["app_color_hex"] = self.color(notify_type)
         tokens["app_image_url"] = image_url
         tokens["app_url"] = self.app_url
 

--- a/tests/test_plugin_discord.py
+++ b/tests/test_plugin_discord.py
@@ -1252,3 +1252,446 @@ def test_plugin_discord_html_to_markdown_format(mock_post):
     # not as stripped plain text
     payload = loads(mock_post.call_args_list[0][1]["data"])
     assert payload["embeds"][0]["description"] == "**hello** *world*"
+
+
+@mock.patch("requests.post")
+def test_plugin_discord_template_content(mock_post, tmpdir):
+    """NotifyDiscord() template with 'content' field."""
+
+    webhook_id = "A" * 24
+    webhook_token = "B" * 64
+
+    # Prepare a good mock response
+    mock_post.return_value = mock.Mock(
+        status_code=requests.codes.ok,
+        content=b"",
+        headers={},
+    )
+
+    # Write a minimal Discord webhook template to disk
+    template = tmpdir.join("discord.json")
+    template.write('{"content": "{{app_body}}"}')
+
+    # Instantiate via URL with template path
+    obj = Apprise.instantiate(
+        "discord://{}/{}/".format(webhook_id, webhook_token)
+        + "?template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifyDiscord)
+
+    # Verify the template was loaded
+    assert obj.template
+
+    # Notification must succeed
+    assert (
+        obj.notify(body="hello", title="world", notify_type=NotifyType.INFO)
+        is True
+    )
+    assert mock_post.called is True
+
+    # Verify the payload sent - content field contains the body
+    posted = loads(mock_post.call_args_list[0][1]["data"])
+    assert posted["content"] == "hello"
+
+
+@mock.patch("requests.post")
+def test_plugin_discord_template_embeds(mock_post, tmpdir):
+    """NotifyDiscord() template with 'embeds' field."""
+
+    webhook_id = "A" * 24
+    webhook_token = "B" * 64
+
+    # Prepare a good mock response
+    mock_post.return_value = mock.Mock(
+        status_code=requests.codes.ok,
+        content=b"",
+        headers={},
+    )
+
+    # Write a template that uses the embeds structure
+    template = tmpdir.join("embeds.json")
+    template.write(
+        '{"embeds": [{"title": "{{app_title}}", '
+        '"description": "{{app_body}}"}]}'
+    )
+
+    # Instantiate via URL with template path
+    obj = Apprise.instantiate(
+        "discord://{}/{}/".format(webhook_id, webhook_token)
+        + "?template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifyDiscord)
+    assert obj.template
+
+    # Notification must succeed
+    assert (
+        obj.notify(
+            body="my body", title="my title", notify_type=NotifyType.INFO
+        )
+        is True
+    )
+    assert mock_post.called is True
+
+    # Verify the embed payload
+    posted = loads(mock_post.call_args_list[0][1]["data"])
+    assert "embeds" in posted
+    assert posted["embeds"][0]["title"] == "my title"
+    assert posted["embeds"][0]["description"] == "my body"
+
+
+def test_plugin_discord_template_tokens(tmpdir):
+    """NotifyDiscord() template tokens and URL round-trip."""
+
+    webhook_id = "A" * 24
+    webhook_token = "B" * 64
+
+    # Write a minimal content template to disk
+    template = tmpdir.join("discord.json")
+    template.write('{"content": "{{app_body}}"}')
+
+    # Instantiate with explicit tokens dict
+    obj = NotifyDiscord(
+        webhook_id=webhook_id,
+        webhook_token=webhook_token,
+        template=str(template),
+        tokens={"mykey": "myval", "count": "42"},
+    )
+    assert obj.template
+    assert obj.tokens["mykey"] == "myval"
+    assert obj.tokens["count"] == "42"
+
+    # Round-trip through url() and parse_url()
+    url = obj.url()
+    result = NotifyDiscord.parse_url(url)
+    assert result is not None
+    assert "mykey" in result["tokens"]
+    assert result["tokens"]["mykey"] == "myval"
+
+    obj2 = NotifyDiscord(**result)
+    assert obj2.template
+    assert obj2.tokens.get("mykey") == "myval"
+    assert obj2.url_identifier == obj.url_identifier
+
+
+def test_plugin_discord_template_token_invalid():
+    """NotifyDiscord() non-dict tokens raises TypeError."""
+
+    webhook_id = "A" * 24
+    webhook_token = "B" * 64
+
+    with pytest.raises(TypeError):
+        NotifyDiscord(
+            webhook_id=webhook_id,
+            webhook_token=webhook_token,
+            tokens="not-a-dict",
+        )
+
+
+def test_plugin_discord_template_add_failure():
+    """NotifyDiscord() template add() failure raises TypeError."""
+
+    webhook_id = "A" * 24
+    webhook_token = "B" * 64
+
+    # Force add() to report failure so len(self.template) == 0
+    with (
+        mock.patch(
+            "apprise.plugins.discord.AppriseAttachment.add",
+            return_value=False,
+        ),
+        pytest.raises(TypeError),
+    ):
+        NotifyDiscord(
+            webhook_id=webhook_id,
+            webhook_token=webhook_token,
+            template="file:///some/template.json",
+        )
+
+
+@mock.patch("requests.post")
+def test_plugin_discord_template_inaccessible(mock_post, tmpdir):
+    """NotifyDiscord() inaccessible template fails gracefully."""
+
+    webhook_id = "A" * 24
+    webhook_token = "B" * 64
+
+    # Prepare a mock response (should never be called)
+    mock_post.return_value = mock.Mock(
+        status_code=requests.codes.ok,
+        content=b"",
+        headers={},
+    )
+
+    # Create the template so that add() succeeds during init
+    template = tmpdir.join("discord.json")
+    template.write('{"content": "{{app_body}}"}')
+
+    obj = Apprise.instantiate(
+        "discord://{}/{}/".format(webhook_id, webhook_token)
+        + "?template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifyDiscord)
+
+    # Remove the file so the template becomes inaccessible
+    os.remove(str(template))
+
+    # Notification must fail; no HTTP call should be made
+    assert (
+        obj.notify(body="test", title="t", notify_type=NotifyType.INFO)
+        is False
+    )
+    assert mock_post.called is False
+
+
+@mock.patch("requests.post")
+def test_plugin_discord_template_oserror(mock_post, tmpdir):
+    """NotifyDiscord() OSError during template read fails gracefully."""
+
+    webhook_id = "A" * 24
+    webhook_token = "B" * 64
+
+    # Prepare a mock response (should never be called)
+    mock_post.return_value = mock.Mock(
+        status_code=requests.codes.ok,
+        content=b"",
+        headers={},
+    )
+
+    # Write a file so the attachment resolves but open() will be mocked
+    template = tmpdir.join("discord.json")
+    template.write('{"content": "hello"}')
+
+    obj = Apprise.instantiate(
+        "discord://{}/{}/".format(webhook_id, webhook_token)
+        + "?template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifyDiscord)
+
+    # Patch open() to raise OSError when the template is read
+    with mock.patch("builtins.open", side_effect=OSError):
+        assert (
+            obj.notify(body="test", title="t", notify_type=NotifyType.INFO)
+            is False
+        )
+    assert mock_post.called is False
+
+
+@mock.patch("requests.post")
+def test_plugin_discord_template_invalid_json(mock_post, tmpdir):
+    """NotifyDiscord() invalid JSON template fails gracefully."""
+
+    webhook_id = "A" * 24
+    webhook_token = "B" * 64
+
+    # Prepare a mock response (should never be called)
+    mock_post.return_value = mock.Mock(
+        status_code=requests.codes.ok,
+        content=b"",
+        headers={},
+    )
+
+    # Write a syntactically invalid JSON file
+    template = tmpdir.join("bad.json")
+    template.write("{ not valid json }")
+
+    obj = Apprise.instantiate(
+        "discord://{}/{}/".format(webhook_id, webhook_token)
+        + "?template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifyDiscord)
+
+    # Notification must fail due to parse error
+    assert (
+        obj.notify(body="test", title="t", notify_type=NotifyType.INFO)
+        is False
+    )
+    assert mock_post.called is False
+
+
+@mock.patch("requests.post")
+def test_plugin_discord_template_not_dict(mock_post, tmpdir):
+    """NotifyDiscord() template root must be a JSON object, not array."""
+
+    webhook_id = "A" * 24
+    webhook_token = "B" * 64
+
+    # Prepare a mock response (should never be called)
+    mock_post.return_value = mock.Mock(
+        status_code=requests.codes.ok,
+        content=b"",
+        headers={},
+    )
+
+    # Write a JSON array instead of an object
+    template = tmpdir.join("array.json")
+    template.write('[{"content": "hello"}]')
+
+    obj = Apprise.instantiate(
+        "discord://{}/{}/".format(webhook_id, webhook_token)
+        + "?template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifyDiscord)
+
+    # Notification must fail because the root is not a dict
+    assert (
+        obj.notify(body="test", title="t", notify_type=NotifyType.INFO)
+        is False
+    )
+    assert mock_post.called is False
+
+
+@mock.patch("requests.post")
+def test_plugin_discord_template_payload_validation(mock_post, tmpdir):
+    """NotifyDiscord() template payload field validation cases."""
+
+    webhook_id = "A" * 24
+    webhook_token = "B" * 64
+
+    # Prepare a mock response (should never be called during failures)
+    mock_post.return_value = mock.Mock(
+        status_code=requests.codes.ok,
+        content=b"",
+        headers={},
+    )
+
+    template = tmpdir.join("t.json")
+
+    # Case 1: no content and no embeds
+    template.write('{"username": "bot"}')
+    obj = Apprise.instantiate(
+        "discord://{}/{}/".format(webhook_id, webhook_token)
+        + "?template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifyDiscord)
+    assert (
+        obj.notify(body="test", title="t", notify_type=NotifyType.INFO)
+        is False
+    )
+    assert mock_post.called is False
+
+    # Case 2: content is an empty string
+    template.write('{"content": ""}')
+    obj = Apprise.instantiate(
+        "discord://{}/{}/".format(webhook_id, webhook_token)
+        + "?template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifyDiscord)
+    assert (
+        obj.notify(body="test", title="t", notify_type=NotifyType.INFO)
+        is False
+    )
+
+    # Case 3: embeds is an empty list
+    template.write('{"embeds": []}')
+    obj = Apprise.instantiate(
+        "discord://{}/{}/".format(webhook_id, webhook_token)
+        + "?template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifyDiscord)
+    assert (
+        obj.notify(body="test", title="t", notify_type=NotifyType.INFO)
+        is False
+    )
+    assert mock_post.called is False
+
+
+@mock.patch("requests.post")
+def test_plugin_discord_template_bad_embeds(mock_post, tmpdir):
+    """NotifyDiscord() template embeds containing non-dict entries fails."""
+
+    webhook_id = "A" * 24
+    webhook_token = "B" * 64
+
+    # Prepare a mock response (should never be called)
+    mock_post.return_value = mock.Mock(
+        status_code=requests.codes.ok,
+        content=b"",
+        headers={},
+    )
+
+    # Write a template where embeds contains a non-dict entry
+    template = tmpdir.join("bad_embeds.json")
+    template.write('{"embeds": ["not-a-dict"]}')
+
+    obj = Apprise.instantiate(
+        "discord://{}/{}/".format(webhook_id, webhook_token)
+        + "?template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifyDiscord)
+
+    # Notification must fail because the embed entry is not a dict
+    assert (
+        obj.notify(body="test", title="t", notify_type=NotifyType.INFO)
+        is False
+    )
+    assert mock_post.called is False
+
+
+@mock.patch("requests.post")
+def test_plugin_discord_template_send_failure(mock_post, tmpdir):
+    """NotifyDiscord() HTTP failure in template mode."""
+
+    webhook_id = "A" * 24
+    webhook_token = "B" * 64
+
+    # Write a valid template
+    template = tmpdir.join("discord.json")
+    template.write('{"content": "hello"}')
+
+    obj = Apprise.instantiate(
+        "discord://{}/{}/".format(webhook_id, webhook_token)
+        + "?template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifyDiscord)
+
+    # Simulate an HTTP error response
+    mock_post.return_value = mock.Mock(
+        status_code=requests.codes.internal_server_error,
+        content=b"",
+        headers={},
+    )
+    assert (
+        obj.notify(body="test", title="t", notify_type=NotifyType.INFO)
+        is False
+    )
+    assert mock_post.called is True
+
+
+@mock.patch("requests.post")
+def test_plugin_discord_template_with_attachments(mock_post, tmpdir):
+    """NotifyDiscord() template mode still sends attachments."""
+
+    webhook_id = "C" * 24
+    webhook_token = "D" * 64
+
+    # Write a valid template
+    template = tmpdir.join("discord.json")
+    template.write('{"content": "{{app_body}}"}')
+
+    obj = Apprise.instantiate(
+        "discord://{}/{}/".format(webhook_id, webhook_token)
+        + "?template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifyDiscord)
+
+    # Prepare a good mock response for both the template call and attachment
+    mock_post.return_value = mock.Mock(
+        status_code=requests.codes.ok,
+        content=b"",
+        headers={},
+    )
+
+    # Attach a test file
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
+    assert (
+        obj.notify(
+            body="test",
+            title="t",
+            notify_type=NotifyType.INFO,
+            attach=attach,
+        )
+        is True
+    )
+
+    # Both the template message and the attachment should have been posted
+    assert mock_post.call_count == 2


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1289

Adds `?template=` support to the Discord plugin, consistent with how the same feature works in `slack.py` and `workflows.py` (the MS Teams / Power Automate plugin).

When `?template=` is set, Apprise loads the pointed-to JSON file, substitutes any `{{token}}` placeholders with built-in Apprise tokens (title, body, colour, type, image URL, etc.) plus any user-supplied `:key=value` tokens from the URL, then validates and posts the result instead of the default Discord embed payload.

**Built-in tokens available in every template:**

| Token | Description |
|---|---|
| `{{app_body}}` | Notification body (`-b`) |
| `{{app_title}}` | Notification title (`-t`) |
| `{{app_type}}` | Message type (`info`, `warning`, `success`, `failure`) |
| `{{app_color}}` | Decimal colour integer matching the message type |
| `{{app_image_url}}` | Status image URL for the message type |
| `{{app_id}}` | Application identifier (default: `Apprise`) |
| `{{app_desc}}` | Application description (default: `Apprise Notification`) |
| `{{app_url}}` | Apprise instance URL |

Custom tokens are injected via the `:key=value` URL prefix:
```
discord://{WebhookID}/{WebhookToken}/?template=/etc/apprise/deploy.json&:env=prod&:version=v2.3.1
```
Inside the template these appear as `{{env}}` and `{{version}}`.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/94](https://github.com/caronc/apprise-docs/pull/94)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:

```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1289-discord-templating

# Create a minimal template (plain text content field)
cat > /tmp/discord-plain.json << 'EOF'
{
  "content": "{{app_title}}: {{app_body}}"
}
EOF

# Test the plain-text template
apprise -vv -t "Deploy complete" -b "v2.3.1 is live." \
    "discord://{WebhookID}/{WebhookToken}/?template=/tmp/discord-plain.json"

# Create a richer embed template with custom tokens
cat > /tmp/discord-embed.json << 'EOF'
{
  "embeds": [
    {
      "title": "{{app_title}}",
      "description": "{{app_body}}",
      "color": {{app_color}},
      "fields": [
        { "name": "Environment", "value": "{{env}}", "inline": true },
        { "name": "Version",     "value": "{{ver}}", "inline": true }
      ],
      "footer": { "text": "{{app_type}} | {{app_id}}" }
    }
  ]
}
EOF

# Test the embed template with custom tokens
apprise -vv -t "Deploy complete" -b "All checks passed." \
    "discord://{WebhookID}/{WebhookToken}/?template=/tmp/discord-embed.json&:env=production&:ver=v2.3.1"

# Verify that an invalid file is safely rejected
apprise -vv -t "Test" -b "Test" \
    "discord://{WebhookID}/{WebhookToken}/?template=/etc/passwd"
# Expected: notification fails with an error log entry; no content is sent

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Deploy complete" -b "All checks passed." \
    "discord://{WebhookID}/{WebhookToken}/?template=/tmp/discord-embed.json&:env=production&:ver=v2.3.1"
```
