### PR TITLE
Added Kook Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ The table below identifies the services this tool supports and some example serv
 | [Jira](https://appriseit.com/services/jira/) | jira:// | (TCP) 443 | jira://APIKey<br/>jira://APIKey/@UserID<br/>jira://APIKey/#Team<br/>jira://APIKey/\*Schedule<br/>jira://APIKey/^Escalation
 | [Join](https://appriseit.com/services/join/) | join://   | (TCP) 443    | join://apikey/device<br />join://apikey/device1/device2/deviceN/<br />join://apikey/group<br />join://apikey/groupA/groupB/groupN<br />join://apikey/DeviceA/groupA/groupN/DeviceN/
 | [KODI](https://appriseit.com/services/kodi/) | kodi:// or kodis://    | (TCP) 8080 or 443   | kodi://hostname<br />kodi://user@hostname<br />kodi://user:password@hostname:port
+| [Kook](https://appriseit.com/services/kook/) | kook:// | (TCP) 443 | kook://token/channel_id<br/>kook://token/channel1/channel2<br/>kook://token/@user_id<br/>kook://webhook_key?mode=webhook
 | [Kumulos](https://appriseit.com/services/kumulos/) | kumulos:// | (TCP) 443 | kumulos://apikey/serverkey
 | [LaMetric Time](https://appriseit.com/services/lametric/) | lametric:// | (TCP) 443 | lametric://apikey@device_ipaddr<br/>lametric://apikey@hostname:port<br/>lametric://client_id@client_secret
 | [Lark](https://appriseit.com/services/lark/) | lark://  | (TCP) 443   | lark://BotToken

--- a/apprise/plugins/kook.py
+++ b/apprise/plugins/kook.py
@@ -1,0 +1,797 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Kook (formerly Kaihei / KOOK / 开黑啦) is a Chinese gaming-focused
+# communication platform similar to Discord. It supports text channels,
+# voice channels, and direct messaging.
+#
+# === Bot Mode (Recommended) ===
+# 1. Visit https://developer.kookapp.cn and sign in.
+# 2. Click "Create Application" and give it a name like "Apprise".
+# 3. Under your application, go to "Bot" in the left sidebar.
+# 4. Copy the bot token shown on the Bot page.
+# 5. Add the bot to your server (OAuth2 Invite page).
+# 6. Enable Developer Mode in Kook:
+#      Settings -> Others -> Developer Mode
+# 7. Right-click a channel and select "Copy ID" to obtain the channel ID.
+# 8. Assemble your Apprise URL:
+#       kook://{bot_token}/{channel_id}
+#       kook://{bot_token}/{channel1}/{channel2}
+#
+# For direct messages, prefix the user ID with @:
+#       kook://{bot_token}/@{user_id}
+#
+# === Webhook Mode ===
+# 1. In Kook, go to Server Settings -> Integrations -> Webhooks.
+# 2. Create a new webhook for the desired channel.
+# 3. Copy the webhook key from the generated webhook URL or the key field.
+# 4. Assemble your Apprise URL:
+#       kook://{webhook_key}?mode=webhook
+#
+# Native Kook incoming webhook URLs are also accepted directly:
+#   https://www.kookapp.cn/api/v3/incoming/{webhook_key}
+#
+# API Documentation:
+#   https://developer.kookapp.cn/doc/
+#   https://developer.kookapp.cn/doc/http/channel-message
+#   https://developer.kookapp.cn/doc/http/direct-message
+#   https://developer.kookapp.cn/doc/http/asset
+
+from json import dumps, loads
+import re
+
+import requests
+
+from ..common import NotifyFormat, NotifyType
+from ..locale import gettext_lazy as _
+from ..utils.parse import parse_list
+from .base import NotifyBase
+
+# Extended HTTP error messages for Kook API responses
+KOOK_HTTP_ERROR_MAP = {
+    400: "Bad Request - Malformed or missing parameters.",
+    401: "Unauthorized - Invalid token.",
+    403: "Forbidden - Insufficient permissions.",
+    404: "Not Found - Invalid channel or endpoint.",
+    429: "Too many consecutive requests were made.",
+    500: "Internal Server Error.",
+}
+
+# Kook API base URL
+KOOK_API_URL = "https://www.kookapp.cn/api/v3"
+
+
+class KookMsgType:
+    """Tracks the Kook message-body format sent to the API."""
+
+    # KMarkdown rich text (type=9); best for markdown-formatted content
+    KMARKDOWN = "kmarkdown"
+
+    # Plain text (type=1); no formatting applied by Kook
+    TEXT = "text"
+
+
+# Valid msg_type values for template_args
+KOOK_MSG_TYPES = (
+    KookMsgType.KMARKDOWN,
+    KookMsgType.TEXT,
+)
+
+# Maps our friendly msg_type strings to Kook API integer type values
+KOOK_MSGTYPE_TO_INT = {
+    KookMsgType.TEXT: 1,
+    KookMsgType.KMARKDOWN: 9,
+}
+
+# Kook API image and file type integers used when posting attachments
+KOOK_API_TYPE_IMAGE = 2
+KOOK_API_TYPE_FILE = 4
+
+
+class KookMode:
+    """Tracks the mode of operation for the Kook plugin."""
+
+    # Incoming webhook - simple, no attachment support
+    WEBHOOK = "webhook"
+
+    # Bot API - full API access with attachment support
+    BOT = "bot"
+
+
+# Valid mode values
+KOOK_MODES = (
+    KookMode.BOT,
+    KookMode.WEBHOOK,
+)
+
+# Validates a Kook channel or user ID (numeric snowflake-style)
+IS_TARGET_ID = re.compile(r"^\d{1,20}$")
+
+# Prefix used in Apprise URLs to denote a DM target rather than a channel
+KOOK_DM_PREFIX = "@"
+
+
+class NotifyKook(NotifyBase):
+    """A wrapper for Kook Notifications."""
+
+    # The default descriptive name associated with the Notification
+    service_name = "Kook"
+
+    # The services URL
+    service_url = "https://www.kookapp.cn/"
+
+    # The default secure protocol
+    secure_protocol = "kook"
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = "https://appriseit.com/services/kook/"
+
+    # Kook Bot API - post a channel message
+    notify_url = KOOK_API_URL + "/message/create"
+
+    # Kook Bot API - post a direct message
+    dm_url = KOOK_API_URL + "/direct-message/create"
+
+    # Kook CDN upload endpoint for file attachments
+    asset_url = KOOK_API_URL + "/asset/create"
+
+    # Kook incoming webhook URL template (webhook mode)
+    webhook_notify_url = KOOK_API_URL + "/incoming/{key}"
+
+    # Bot mode supports file attachments via the CDN upload path
+    attachment_support = True
+
+    # Kook supports up to 5000 characters per message
+    body_maxlen = 5000
+
+    # No native title field; the framework prepends title to body
+    title_maxlen = 0
+
+    # Default to markdown since Kook supports KMarkdown natively
+    notify_format = NotifyFormat.MARKDOWN
+
+    # Define object URL templates
+    templates = (
+        # Webhook mode (single key, ?mode=webhook)
+        "{schema}://{token}",
+        # Bot mode with one or more channel/DM targets in the path
+        "{schema}://{token}/{targets}",
+    )
+
+    # Define our template tokens
+    template_tokens = dict(
+        NotifyBase.template_tokens,
+        **{
+            "token": {
+                "name": _("Token"),
+                "type": "string",
+                "private": True,
+                "required": True,
+            },
+            "targets": {
+                "name": _("Targets"),
+                "type": "list:string",
+            },
+        },
+    )
+
+    # Define our template arguments
+    template_args = dict(
+        NotifyBase.template_args,
+        **{
+            # Allow the token to also be supplied as a query param
+            "token": {
+                "alias_of": "token",
+            },
+            # Comma-separated alias for targets
+            "to": {
+                "alias_of": "targets",
+            },
+            # Operating mode: bot (default) or webhook
+            "mode": {
+                "name": _("Mode"),
+                "type": "choice:string",
+                "values": KOOK_MODES,
+                "default": KookMode.BOT,
+            },
+            # Message body type: kmarkdown (default) or text
+            "msg_type": {
+                "name": _("Message Type"),
+                "type": "choice:string",
+                "values": KOOK_MSG_TYPES,
+                "default": KookMsgType.KMARKDOWN,
+            },
+        },
+    )
+
+    def __init__(
+        self,
+        token,
+        targets=None,
+        mode=None,
+        msg_type=None,
+        **kwargs,
+    ):
+        """Initialize Kook Object."""
+        super().__init__(**kwargs)
+
+        # Validate and store the bot token / webhook key
+        self.token = token
+        if not self.token:
+            msg = "A Kook token must be specified."
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # Resolve operating mode
+        if mode and isinstance(mode, str):
+            # Accept a partial prefix match (e.g. "web" -> "webhook")
+            self.mode = next(
+                (m for m in KOOK_MODES if m.startswith(mode.lower())),
+                None,
+            )
+            if self.mode not in KOOK_MODES:
+                msg = f"The Kook mode specified ({mode}) is not valid."
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
+        else:
+            # Default to bot mode
+            self.mode = KookMode.BOT
+
+        # Disable attachment support in webhook mode (CDN upload requires auth)
+        if self.mode == KookMode.WEBHOOK:
+            self.attachment_support = False
+
+        # Resolve message type
+        if msg_type and isinstance(msg_type, str):
+            self.msg_type = next(
+                (t for t in KOOK_MSG_TYPES if t.startswith(msg_type.lower())),
+                None,
+            )
+            if self.msg_type not in KOOK_MSG_TYPES:
+                msg = f"The Kook msg_type specified ({msg_type}) is not valid."
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
+        else:
+            # Default: KMarkdown for maximum formatting support
+            self.msg_type = KookMsgType.KMARKDOWN
+
+        # Process targets: channel IDs (bare) and DM users (@user_id)
+        self.channels = []
+        self.dm_users = []
+
+        # Track invalid targets so they survive a URL round-trip
+        self._invalid_targets = []
+
+        for target in parse_list(targets):
+            # Detect DM prefix
+            if target.startswith(KOOK_DM_PREFIX):
+                user_id = target[len(KOOK_DM_PREFIX) :]
+                if IS_TARGET_ID.match(user_id):
+                    # Valid DM user ID
+                    self.dm_users.append(user_id)
+
+                else:
+                    self.logger.warning(
+                        "Dropping invalid Kook DM user ID: %s",
+                        target,
+                    )
+                    self._invalid_targets.append(target)
+
+            else:
+                # Strip optional # channel prefix for convenience
+                channel_id = target[1:] if target.startswith("#") else target
+                if IS_TARGET_ID.match(channel_id):
+                    # Valid channel ID
+                    self.channels.append(channel_id)
+
+                else:
+                    self.logger.warning(
+                        "Dropping invalid Kook channel ID: %s",
+                        target,
+                    )
+                    self._invalid_targets.append(target)
+
+        return
+
+    def send(
+        self,
+        body,
+        title="",
+        notify_type=NotifyType.INFO,
+        attach=None,
+        **kwargs,
+    ):
+        """Perform Kook Notification."""
+
+        # Dispatch to the appropriate sending method based on mode
+        if self.mode == KookMode.WEBHOOK:
+            return self._send_webhook(body)
+
+        return self._send_bot(body, attach=attach)
+
+    def _send_webhook(self, body):
+        """Post a notification via Kook incoming webhook."""
+
+        # Prepare the API endpoint
+        url = self.webhook_notify_url.format(key=self.token)
+
+        # Determine the Kook API type integer for the message
+        kook_type = KOOK_MSGTYPE_TO_INT[self.msg_type]
+
+        # Prepare the payload
+        payload = {
+            "type": kook_type,
+            "content": body,
+        }
+
+        self.logger.debug(
+            "Kook Webhook POST URL: %s (cert_verify=%s)",
+            url,
+            self.verify_certificate,
+        )
+        self.logger.debug("Kook Webhook Payload: %s", str(payload))
+
+        # Throttle before the network request
+        self.throttle()
+
+        try:
+            r = requests.post(
+                url,
+                data=dumps(payload),
+                headers={
+                    "User-Agent": self.app_id,
+                    "Content-Type": "application/json",
+                },
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+                allow_redirects=self.redirects,
+            )
+
+            if r.status_code != requests.codes.ok:
+                # Failed
+                status_str = NotifyKook.http_response_code_lookup(
+                    r.status_code, KOOK_HTTP_ERROR_MAP
+                )
+                self.logger.warning(
+                    "Failed to send Kook webhook notification: %s%serror=%s.",
+                    status_str,
+                    ", " if status_str else "",
+                    r.status_code,
+                )
+                self.logger.debug("Response Details:\r\n%s", r.content)
+                return False
+
+            # Check for API-level error in the JSON response
+            try:
+                content = loads(r.content) or {}
+
+            except (AttributeError, TypeError, ValueError):
+                content = {}
+
+            if content.get("code", 0) != 0:
+                self.logger.warning(
+                    "Failed to send Kook webhook notification:"
+                    " code=%s, message=%s.",
+                    content.get("code"),
+                    content.get("message", "Unknown"),
+                )
+                return False
+
+        except requests.RequestException as e:
+            self.logger.warning(
+                "A Connection error occurred sending"
+                " Kook webhook notification."
+            )
+            self.logger.debug("Socket Exception: %s", str(e))
+            return False
+
+        self.logger.info("Sent Kook webhook notification.")
+        return True
+
+    def _send_bot(self, body, attach=None):
+        """Post a notification via Kook Bot API to channels and DM users."""
+
+        # No targets means nothing to send
+        if not self.channels and not self.dm_users:
+            self.logger.warning(
+                "Kook: no targets specified; nothing to notify."
+            )
+            return False
+
+        # Determine the Kook API type integer for the message
+        kook_type = KOOK_MSGTYPE_TO_INT[self.msg_type]
+
+        # Prepare the authorization header
+        headers = {
+            "User-Agent": self.app_id,
+            "Authorization": f"Bot {self.token}",
+            "Content-Type": "application/json",
+        }
+
+        # Track overall success
+        has_error = False
+
+        # Build the combined target list: (url, target_id) pairs
+        targets = [(self.notify_url, ch) for ch in self.channels] + [
+            (self.dm_url, uid) for uid in self.dm_users
+        ]
+
+        for endpoint, target_id in targets:
+            # Prepare the message payload for this target
+            payload = {
+                "type": kook_type,
+                "target_id": target_id,
+                "content": body,
+            }
+
+            self.logger.debug(
+                "Kook Bot POST URL: %s (cert_verify=%s)",
+                endpoint,
+                self.verify_certificate,
+            )
+            self.logger.debug("Kook Bot Payload: %s", str(payload))
+
+            # Throttle before each network request
+            self.throttle()
+
+            try:
+                r = requests.post(
+                    endpoint,
+                    data=dumps(payload),
+                    headers=headers,
+                    verify=self.verify_certificate,
+                    timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
+                )
+
+                if r.status_code != requests.codes.ok:
+                    status_str = NotifyKook.http_response_code_lookup(
+                        r.status_code, KOOK_HTTP_ERROR_MAP
+                    )
+                    self.logger.warning(
+                        "Failed to send Kook Bot notification to"
+                        " %s: %s%serror=%s.",
+                        target_id,
+                        status_str,
+                        ", " if status_str else "",
+                        r.status_code,
+                    )
+                    self.logger.debug("Response Details:\r\n%s", r.content)
+                    has_error = True
+                    continue
+
+                # Check API-level error code
+                try:
+                    content = loads(r.content) or {}
+
+                except (AttributeError, TypeError, ValueError):
+                    content = {}
+
+                if content.get("code", 0) != 0:
+                    self.logger.warning(
+                        "Failed to send Kook Bot notification to"
+                        " %s: code=%s, message=%s.",
+                        target_id,
+                        content.get("code"),
+                        content.get("message", "Unknown"),
+                    )
+                    has_error = True
+                    continue
+
+                self.logger.info(
+                    "Sent Kook Bot notification to %s.", target_id
+                )
+
+            except requests.RequestException as e:
+                self.logger.warning(
+                    "A Connection error occurred sending Kook Bot"
+                    " notification to %s.",
+                    target_id,
+                )
+                self.logger.debug("Socket Exception: %s", str(e))
+                has_error = True
+                continue
+
+        # Handle file attachments after the text message is sent
+        if attach and self.attachment_support and not has_error:
+            for attachment in attach:
+                # Upload each attachment to the Kook CDN and post a
+                # follow-up message per target referencing the returned URL
+                cdn_url = self._upload(attachment)
+                if cdn_url is None:
+                    # Upload failed; abort attachments for this send
+                    return False
+
+                # Determine the Kook type for the attachment message
+                attach_type = (
+                    KOOK_API_TYPE_IMAGE
+                    if attachment.mimetype.startswith("image/")
+                    else KOOK_API_TYPE_FILE
+                )
+
+                for endpoint, target_id in targets:
+                    # Prepare the attachment message payload
+                    payload = {
+                        "type": attach_type,
+                        "target_id": target_id,
+                        "content": cdn_url,
+                    }
+
+                    self.logger.debug(
+                        "Kook Bot Attachment POST URL: %s (cert_verify=%s)",
+                        endpoint,
+                        self.verify_certificate,
+                    )
+                    self.logger.debug(
+                        "Kook Bot Attachment Payload: %s", str(payload)
+                    )
+
+                    # Throttle before each attachment post
+                    self.throttle()
+
+                    try:
+                        r = requests.post(
+                            endpoint,
+                            data=dumps(payload),
+                            headers=headers,
+                            verify=self.verify_certificate,
+                            timeout=self.request_timeout,
+                            allow_redirects=self.redirects,
+                        )
+
+                        if r.status_code != requests.codes.ok:
+                            status_str = NotifyKook.http_response_code_lookup(
+                                r.status_code, KOOK_HTTP_ERROR_MAP
+                            )
+                            self.logger.warning(
+                                "Failed to post Kook attachment to"
+                                " %s: %s%serror=%s.",
+                                target_id,
+                                status_str,
+                                ", " if status_str else "",
+                                r.status_code,
+                            )
+                            self.logger.debug(
+                                "Response Details:\r\n%s", r.content
+                            )
+                            has_error = True
+
+                    except requests.RequestException as e:
+                        self.logger.warning(
+                            "A Connection error occurred posting"
+                            " Kook attachment to %s.",
+                            target_id,
+                        )
+                        self.logger.debug("Socket Exception: %s", str(e))
+                        has_error = True
+
+        return not has_error
+
+    def _upload(self, attachment):
+        """Upload a file to the Kook CDN and return the CDN URL.
+
+        Returns None on any failure.
+        """
+
+        # Guard 1: verify the attachment is accessible before opening it
+        if not attachment:
+            self.logger.warning(
+                "Could not access Kook attachment %s.",
+                attachment.url(privacy=True),
+            )
+            return None
+
+        # Prepare the file tuple; handle open errors explicitly
+        files = None
+        try:
+            # Guard 2: OSError is caught in the except below
+            files = {
+                "file": (
+                    attachment.name or "attachment.dat",
+                    attachment.open(),
+                    attachment.mimetype,
+                ),
+            }
+
+            self.logger.debug(
+                "Kook CDN Upload URL: %s (cert_verify=%s)",
+                self.asset_url,
+                self.verify_certificate,
+            )
+
+            # Throttle before the network request
+            self.throttle()
+
+            r = requests.post(
+                self.asset_url,
+                headers={
+                    "User-Agent": self.app_id,
+                    "Authorization": f"Bot {self.token}",
+                },
+                files=files,
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+                allow_redirects=self.redirects,
+            )
+
+            if r.status_code != requests.codes.ok:
+                status_str = NotifyKook.http_response_code_lookup(
+                    r.status_code, KOOK_HTTP_ERROR_MAP
+                )
+                self.logger.warning(
+                    "Failed to upload Kook attachment: %s%serror=%s.",
+                    status_str,
+                    ", " if status_str else "",
+                    r.status_code,
+                )
+                self.logger.debug("Response Details:\r\n%s", r.content)
+                return None
+
+            # Parse the CDN URL from the response body
+            try:
+                content = loads(r.content) or {}
+
+            except (AttributeError, TypeError, ValueError):
+                content = {}
+
+            cdn_url = content.get("data", {}).get("url")
+            if not cdn_url:
+                self.logger.warning("Kook CDN upload returned no URL.")
+                return None
+
+            self.logger.debug("Kook CDN upload succeeded: %s", cdn_url)
+            return cdn_url
+
+        except requests.RequestException as e:
+            self.logger.warning(
+                "A Connection error occurred uploading Kook attachment."
+            )
+            self.logger.debug("Socket Exception: %s", str(e))
+            return None
+
+        except OSError as e:
+            self.logger.warning(
+                "An I/O error occurred while reading Kook attachment %s.",
+                attachment.name or "attachment",
+            )
+            self.logger.debug("I/O Exception: %s", str(e))
+            return None
+
+        finally:
+            # Guard 3: always close the file handle
+            if files:
+                files["file"][1].close()
+
+    @property
+    def url_identifier(self):
+        """Returns all of the identifiers that make this URL unique."""
+        return (self.secure_protocol, self.mode, self.token)
+
+    def url(self, privacy=False, *args, **kwargs):
+        """Returns the URL built dynamically based on specified arguments."""
+
+        # Collect optional query parameters
+        params = {}
+
+        # Include mode only when non-default (webhook)
+        if self.mode != KookMode.BOT:
+            params["mode"] = self.mode
+
+        # Include msg_type only when non-default (text)
+        if self.msg_type != KookMsgType.KMARKDOWN:
+            params["msg_type"] = self.msg_type
+
+        # Append standard Apprise URL parameters
+        params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
+
+        # Reconstruct the targets list from channels and DM users
+        all_targets = list(self.channels) + [
+            f"{KOOK_DM_PREFIX}{uid}" for uid in self.dm_users
+        ]
+        # Preserve invalid targets so they survive a round-trip
+        all_targets += self._invalid_targets
+
+        if all_targets:
+            return "{schema}://{token}/{targets}/?{params}".format(
+                schema=self.secure_protocol,
+                token=self.pprint(self.token, privacy, safe=""),
+                targets="/".join(
+                    NotifyKook.quote(t, safe="@") for t in all_targets
+                ),
+                params=NotifyKook.urlencode(params),
+            )
+
+        return "{schema}://{token}/?{params}".format(
+            schema=self.secure_protocol,
+            token=self.pprint(self.token, privacy, safe=""),
+            params=NotifyKook.urlencode(params),
+        )
+
+    @staticmethod
+    def parse_url(url):
+        """Parses the URL and returns enough arguments that can allow
+        us to re-instantiate this object."""
+        results = NotifyBase.parse_url(url, verify_host=False)
+        if not results:
+            # We're done early as we couldn't load the results
+            return results
+
+        # The host field holds the bot token / webhook key
+        results["token"] = NotifyKook.unquote(results["host"])
+
+        # Allow ?token= to override the host-supplied token
+        if "token" in results["qsd"] and results["qsd"]["token"]:
+            results["token"] = NotifyKook.unquote(results["qsd"]["token"])
+
+        # Collect path entries as targets
+        results["targets"] = NotifyKook.split_path(results["fullpath"])
+
+        # Allow ?to= as a comma-separated alias for targets
+        if "to" in results["qsd"] and results["qsd"]["to"]:
+            results["targets"] += NotifyKook.parse_list(results["qsd"]["to"])
+
+        # Extract operating mode
+        if "mode" in results["qsd"] and results["qsd"]["mode"]:
+            results["mode"] = NotifyKook.unquote(results["qsd"]["mode"])
+
+        # Extract message type override
+        if "msg_type" in results["qsd"] and results["qsd"]["msg_type"]:
+            results["msg_type"] = NotifyKook.unquote(
+                results["qsd"]["msg_type"]
+            )
+
+        return results
+
+    @staticmethod
+    def parse_native_url(url):
+        """Support pasting full Kook incoming webhook URLs directly.
+
+        Supports: https://www.kookapp.cn/api/v3/incoming/{key}
+        """
+        result = re.match(
+            r"^https?://www\.kookapp\.cn/api/v3/incoming/"
+            r"(?P<key>[A-Za-z0-9_=+/-]+)/?"
+            r"(?P<params>\?.+)?$",
+            url,
+            re.I,
+        )
+        if result:
+            return NotifyKook.parse_url(
+                "{schema}://{key}/?mode=webhook{extra}".format(
+                    schema=NotifyKook.secure_protocol,
+                    key=result.group("key"),
+                    extra=(
+                        "&" + result.group("params").lstrip("?")
+                        if result.group("params")
+                        else ""
+                    ),
+                )
+            )
+
+        return None

--- a/apprise/plugins/kook.py
+++ b/apprise/plugins/kook.py
@@ -546,6 +546,24 @@ class NotifyKook(NotifyBase):
                                 "Response Details:\r\n%s", r.content
                             )
                             has_error = True
+                            continue
+
+                        # Check API-level error code in the attachment response
+                        try:
+                            content = loads(r.content) or {}
+
+                        except (AttributeError, TypeError, ValueError):
+                            content = {}
+
+                        if content.get("code", 0) != 0:
+                            self.logger.warning(
+                                "Failed to post Kook attachment to"
+                                " %s: code=%s, message=%s.",
+                                target_id,
+                                content.get("code"),
+                                content.get("message", "Unknown"),
+                            )
+                            has_error = True
 
                     except requests.RequestException as e:
                         self.logger.warning(

--- a/apprise/plugins/kook.py
+++ b/apprise/plugins/kook.py
@@ -85,31 +85,11 @@ KOOK_HTTP_ERROR_MAP = {
 KOOK_API_URL = "https://www.kookapp.cn/api/v3"
 
 
-class KookMsgType:
-    """Tracks the Kook message-body format sent to the API."""
-
-    # KMarkdown rich text (type=9); best for markdown-formatted content
-    KMARKDOWN = "kmarkdown"
-
-    # Plain text (type=1); no formatting applied by Kook
-    TEXT = "text"
-
-
-# Valid msg_type values for template_args
-KOOK_MSG_TYPES = (
-    KookMsgType.KMARKDOWN,
-    KookMsgType.TEXT,
-)
-
-# Maps our friendly msg_type strings to Kook API integer type values
-KOOK_MSGTYPE_TO_INT = {
-    KookMsgType.TEXT: 1,
-    KookMsgType.KMARKDOWN: 9,
-}
-
-# Kook API image and file type integers used when posting attachments
+# Kook API message and asset type integers
+KOOK_API_TYPE_TEXT = 1
 KOOK_API_TYPE_IMAGE = 2
 KOOK_API_TYPE_FILE = 4
+KOOK_API_TYPE_KMARKDOWN = 9
 
 
 class KookMode:
@@ -218,13 +198,6 @@ class NotifyKook(NotifyBase):
                 "values": KOOK_MODES,
                 "default": KookMode.BOT,
             },
-            # Message body type: kmarkdown (default) or text
-            "msg_type": {
-                "name": _("Message Type"),
-                "type": "choice:string",
-                "values": KOOK_MSG_TYPES,
-                "default": KookMsgType.KMARKDOWN,
-            },
         },
     )
 
@@ -233,7 +206,6 @@ class NotifyKook(NotifyBase):
         token,
         targets=None,
         mode=None,
-        msg_type=None,
         **kwargs,
     ):
         """Initialize Kook Object."""
@@ -265,21 +237,6 @@ class NotifyKook(NotifyBase):
         # Disable attachment support in webhook mode (CDN upload requires auth)
         if self.mode == KookMode.WEBHOOK:
             self.attachment_support = False
-
-        # Resolve message type
-        if msg_type and isinstance(msg_type, str):
-            self.msg_type = next(
-                (t for t in KOOK_MSG_TYPES if t.startswith(msg_type.lower())),
-                None,
-            )
-            if self.msg_type not in KOOK_MSG_TYPES:
-                msg = f"The Kook msg_type specified ({msg_type}) is not valid."
-                self.logger.warning(msg)
-                raise TypeError(msg)
-
-        else:
-            # Default: KMarkdown for maximum formatting support
-            self.msg_type = KookMsgType.KMARKDOWN
 
         # Process targets: channel IDs (bare) and DM users (@user_id)
         self.channels = []
@@ -341,8 +298,12 @@ class NotifyKook(NotifyBase):
         # Prepare the API endpoint
         url = self.webhook_notify_url.format(key=self.token)
 
-        # Determine the Kook API type integer for the message
-        kook_type = KOOK_MSGTYPE_TO_INT[self.msg_type]
+        # Use KMarkdown when the body is markdown; plain text otherwise
+        kook_type = (
+            KOOK_API_TYPE_KMARKDOWN
+            if self.notify_format == NotifyFormat.MARKDOWN
+            else KOOK_API_TYPE_TEXT
+        )
 
         # Prepare the payload
         payload = {
@@ -424,8 +385,12 @@ class NotifyKook(NotifyBase):
             )
             return False
 
-        # Determine the Kook API type integer for the message
-        kook_type = KOOK_MSGTYPE_TO_INT[self.msg_type]
+        # Use KMarkdown when the body is markdown; plain text otherwise
+        kook_type = (
+            KOOK_API_TYPE_KMARKDOWN
+            if self.notify_format == NotifyFormat.MARKDOWN
+            else KOOK_API_TYPE_TEXT
+        )
 
         # Prepare the authorization header
         headers = {
@@ -703,10 +668,6 @@ class NotifyKook(NotifyBase):
         if self.mode != KookMode.BOT:
             params["mode"] = self.mode
 
-        # Include msg_type only when non-default (text)
-        if self.msg_type != KookMsgType.KMARKDOWN:
-            params["msg_type"] = self.msg_type
-
         # Append standard Apprise URL parameters
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
 
@@ -760,12 +721,6 @@ class NotifyKook(NotifyBase):
         if "mode" in results["qsd"] and results["qsd"]["mode"]:
             results["mode"] = NotifyKook.unquote(results["qsd"]["mode"])
 
-        # Extract message type override
-        if "msg_type" in results["qsd"] and results["qsd"]["msg_type"]:
-            results["msg_type"] = NotifyKook.unquote(
-                results["qsd"]["msg_type"]
-            )
-
         return results
 
     @staticmethod
@@ -776,7 +731,7 @@ class NotifyKook(NotifyBase):
         """
         result = re.match(
             r"^https?://www\.kookapp\.cn/api/v3/incoming/"
-            r"(?P<key>[A-Za-z0-9_=+/-]+)/?"
+            r"(?P<key>[A-Za-z0-9_=+-]+)/?"
             r"(?P<params>\?.+)?$",
             url,
             re.I,

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -67,7 +67,7 @@ notification services. It supports sending alerts to platforms such as: \
 `FCM`, `Feishu`, `Flock`, `Flowtriq`, `Fluxer`, `Free Mobile`, `Google Chat`, \
 `Gotify`, `GroupMe`, `Growl`, `Guilded`, `Home Assistant`, `httpSMS`, \
 `HumHub`, \
-`IFTTT`, `IRC`, `Jellyfin`, `Jira`, `Join`, `Kavenegar`, `KODI`, \
+`IFTTT`, `IRC`, `Jellyfin`, `Jira`, `Join`, `Kavenegar`, `KODI`, `Kook`, \
 `Kumulos`, `LaMetric`, `Lark`, `Line`, `MacOSX`, `Mailgun`, `MailerSend`, \
 `Mastodon`, \
 `Mattermost`, `Matrix`, `MessageBird`, `Microsoft Windows`, \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ keywords = [
     "JSON",
     "Kavenegar",
     "KODI",
+    "Kook",
     "Kumulos",
     "LaMetric",
     "Lark",

--- a/tests/test_plugin_kook.py
+++ b/tests/test_plugin_kook.py
@@ -1,0 +1,890 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Disable logging for a cleaner testing output
+import logging
+import os
+from json import dumps
+from unittest import mock
+from urllib.parse import urlparse
+
+from helpers import AppriseURLTester
+import pytest
+import requests
+
+from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise.plugins.kook import (
+    KOOK_MODES,
+    KOOK_MSG_TYPES,
+    KookMode,
+    KookMsgType,
+    NotifyKook,
+)
+
+logging.disable(logging.CRITICAL)
+
+# Attachment directory
+TEST_VAR_DIR = os.path.join(os.path.dirname(__file__), "var")
+
+# A realistic-looking fake bot token
+BOT_TOKEN = "1/MTQ3OTE5MTA3MzQ1ODE4OTQ0/YJVvSXB0IK+ABC123XYZ"
+
+# Fake channel / user IDs (numeric snowflakes)
+CHANNEL_ID = "1234567890"
+CHANNEL_ID2 = "9876543210"
+USER_ID = "5555555555"
+
+# Fake webhook key
+WEBHOOK_KEY = "abc123webhookkey"
+
+
+# -----------------------------------------------------------------------
+# URL tester table
+# -----------------------------------------------------------------------
+TEST_URLS = (
+    ##
+    # Invalid cases
+    ##
+    # Missing token
+    (
+        "kook://",
+        {
+            "instance": TypeError,
+        },
+    ),
+    # Invalid mode
+    (
+        f"kook://{BOT_TOKEN}/?mode=invalid",
+        {
+            "instance": TypeError,
+        },
+    ),
+    # Invalid msg_type
+    (
+        f"kook://{BOT_TOKEN}/{CHANNEL_ID}/?msg_type=invalid",
+        {
+            "instance": TypeError,
+        },
+    ),
+    ##
+    # Webhook mode
+    ##
+    # Basic webhook
+    (
+        f"kook://{WEBHOOK_KEY}/?mode=webhook",
+        {
+            "instance": NotifyKook,
+            "privacy_url": "kook://a...y/?mode=webhook",
+        },
+    ),
+    # Webhook via ?token= override
+    (
+        f"kook://ignored/?token={WEBHOOK_KEY}&mode=webhook",
+        {
+            "instance": NotifyKook,
+        },
+    ),
+    # Webhook HTTP 500
+    (
+        f"kook://{WEBHOOK_KEY}/?mode=webhook",
+        {
+            "instance": NotifyKook,
+            "response": False,
+            "requests_response_code": requests.codes.internal_server_error,
+        },
+    ),
+    # Webhook unknown response code
+    (
+        f"kook://{WEBHOOK_KEY}/?mode=webhook",
+        {
+            "instance": NotifyKook,
+            "response": False,
+            "requests_response_code": 999,
+        },
+    ),
+    # Webhook RequestException
+    (
+        f"kook://{WEBHOOK_KEY}/?mode=webhook",
+        {
+            "instance": NotifyKook,
+            "test_requests_exceptions": True,
+        },
+    ),
+    ##
+    # Bot mode - single channel
+    # attach_response=False because _upload() needs a CDN URL in the
+    # response body; the default mock returns empty content so the CDN
+    # upload step returns None and the send returns False.
+    ##
+    (
+        f"kook://{BOT_TOKEN}/{CHANNEL_ID}",
+        {
+            "instance": NotifyKook,
+            "attach_response": False,
+        },
+    ),
+    # Bot mode - multiple channels
+    (
+        f"kook://{BOT_TOKEN}/{CHANNEL_ID}/{CHANNEL_ID2}",
+        {
+            "instance": NotifyKook,
+            "attach_response": False,
+        },
+    ),
+    # Bot mode - DM target
+    (
+        f"kook://{BOT_TOKEN}/@{USER_ID}",
+        {
+            "instance": NotifyKook,
+            "attach_response": False,
+        },
+    ),
+    # Bot mode - channel + DM mixed
+    (
+        f"kook://{BOT_TOKEN}/{CHANNEL_ID}/@{USER_ID}",
+        {
+            "instance": NotifyKook,
+            "attach_response": False,
+        },
+    ),
+    # Bot mode - no targets (loads but notify() returns False)
+    (
+        f"kook://{BOT_TOKEN}",
+        {
+            "instance": NotifyKook,
+            "notify_response": False,
+        },
+    ),
+    # Bot mode via ?to=
+    (
+        f"kook://{BOT_TOKEN}/?to={CHANNEL_ID}",
+        {
+            "instance": NotifyKook,
+            "attach_response": False,
+        },
+    ),
+    # Bot mode with msg_type=text
+    (
+        f"kook://{BOT_TOKEN}/{CHANNEL_ID}/?msg_type=text",
+        {
+            "instance": NotifyKook,
+            "attach_response": False,
+        },
+    ),
+    # Bot mode HTTP 500
+    (
+        f"kook://{BOT_TOKEN}/{CHANNEL_ID}",
+        {
+            "instance": NotifyKook,
+            "response": False,
+            "requests_response_code": requests.codes.internal_server_error,
+        },
+    ),
+    # Bot mode unknown response code
+    (
+        f"kook://{BOT_TOKEN}/{CHANNEL_ID}",
+        {
+            "instance": NotifyKook,
+            "response": False,
+            "requests_response_code": 999,
+        },
+    ),
+    # Bot mode RequestException
+    (
+        f"kook://{BOT_TOKEN}/{CHANNEL_ID}",
+        {
+            "instance": NotifyKook,
+            "test_requests_exceptions": True,
+        },
+    ),
+    # Native webhook URL
+    (
+        "https://www.kookapp.cn/api/v3/incoming/nativekey123",
+        {
+            "instance": NotifyKook,
+            "privacy_url": "kook://n...3/?mode=webhook",
+        },
+    ),
+)
+
+
+@pytest.fixture
+def apprise_url_tester():
+    return AppriseURLTester(tests=TEST_URLS)
+
+
+def test_plugin_kook_urls(apprise_url_tester):
+    """Run all URL test table entries through AppriseURLTester."""
+    apprise_url_tester.run_all()
+
+
+# -----------------------------------------------------------------------
+# __init__ and url() round-trip tests
+# -----------------------------------------------------------------------
+
+
+def test_plugin_kook_bot_mode():
+    """Verify bot-mode init, url(), url_identifier, and round-trip."""
+
+    # Single channel
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
+    assert obj.mode == KookMode.BOT
+    assert obj.msg_type == KookMsgType.KMARKDOWN
+    assert obj.channels == [CHANNEL_ID]
+    assert obj.dm_users == []
+    assert obj.attachment_support is True
+
+    # url_identifier must only reference connection identity, not targets
+    ident = obj.url_identifier
+    assert ident == ("kook", KookMode.BOT, BOT_TOKEN)
+
+    # Round-trip
+    url = obj.url()
+    parsed = NotifyKook.parse_url(url)
+    assert parsed is not None
+    obj2 = NotifyKook(**parsed)
+    assert obj2.url_identifier == obj.url_identifier
+    assert len(obj2.channels) == len(obj.channels)
+
+    # privacy_url should mask the token
+    purl = obj.url(privacy=True)
+    assert BOT_TOKEN not in purl
+
+    # Multiple channels
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID, CHANNEL_ID2])
+    assert len(obj.channels) == 2
+    url = obj.url()
+    parsed = NotifyKook.parse_url(url)
+    obj2 = NotifyKook(**parsed)
+    assert len(obj2.channels) == 2
+
+    # DM target
+    obj = NotifyKook(token=BOT_TOKEN, targets=[f"@{USER_ID}"])
+    assert obj.dm_users == [USER_ID]
+    assert obj.channels == []
+    url = obj.url()
+    parsed = NotifyKook.parse_url(url)
+    obj2 = NotifyKook(**parsed)
+    assert obj2.dm_users == [USER_ID]
+
+    # Mixed channel + DM
+    obj = NotifyKook(
+        token=BOT_TOKEN,
+        targets=[CHANNEL_ID, f"@{USER_ID}"],
+    )
+    assert len(obj.channels) == 1
+    assert len(obj.dm_users) == 1
+    url = obj.url()
+    parsed = NotifyKook.parse_url(url)
+    obj2 = NotifyKook(**parsed)
+    assert len(obj2.channels) == 1
+    assert len(obj2.dm_users) == 1
+
+    # # prefix stripped from channel
+    obj = NotifyKook(token=BOT_TOKEN, targets=[f"#{CHANNEL_ID}"])
+    assert obj.channels == [CHANNEL_ID]
+
+    # Invalid channel and DM IDs are stored in _invalid_targets and
+    # survive the round-trip
+    obj = NotifyKook(
+        token=BOT_TOKEN,
+        targets=["notanumber", "@notanumber"],
+    )
+    assert obj.channels == []
+    assert obj.dm_users == []
+    assert len(obj._invalid_targets) == 2
+    url = obj.url()
+    parsed = NotifyKook.parse_url(url)
+    obj2 = NotifyKook(**parsed)
+    assert len(obj2._invalid_targets) == 2
+
+    # No targets
+    obj = NotifyKook(token=BOT_TOKEN)
+    assert obj.channels == []
+    assert obj.dm_users == []
+
+    # msg_type = text
+    obj = NotifyKook(
+        token=BOT_TOKEN, targets=[CHANNEL_ID], msg_type="text"
+    )
+    assert obj.msg_type == KookMsgType.TEXT
+    url = obj.url()
+    assert "msg_type=text" in url
+    parsed = NotifyKook.parse_url(url)
+    obj2 = NotifyKook(**parsed)
+    assert obj2.msg_type == KookMsgType.TEXT
+
+    # Default msg_type not emitted in URL
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
+    url = obj.url()
+    assert "msg_type" not in url
+
+    # Default mode not emitted in URL
+    assert "mode" not in url
+
+
+def test_plugin_kook_webhook_mode():
+    """Verify webhook-mode init, url(), and url_identifier."""
+
+    obj = NotifyKook(token=WEBHOOK_KEY, mode="webhook")
+    assert obj.mode == KookMode.WEBHOOK
+    assert obj.attachment_support is False
+    assert obj.channels == []
+    assert obj.dm_users == []
+
+    # url_identifier includes mode
+    assert obj.url_identifier == ("kook", KookMode.WEBHOOK, WEBHOOK_KEY)
+
+    # url() emits mode=webhook
+    url = obj.url()
+    assert "mode=webhook" in url
+
+    # Round-trip
+    parsed = NotifyKook.parse_url(url)
+    obj2 = NotifyKook(**parsed)
+    assert obj2.url_identifier == obj.url_identifier
+    assert obj2.mode == KookMode.WEBHOOK
+
+    # Missing token
+    with pytest.raises(TypeError):
+        NotifyKook(token=None)
+
+    with pytest.raises(TypeError):
+        NotifyKook(token="")
+
+
+def test_plugin_kook_mode_invalid():
+    """Invalid mode raises TypeError."""
+    with pytest.raises(TypeError):
+        NotifyKook(token=BOT_TOKEN, mode="invalid_mode")
+
+
+def test_plugin_kook_msg_type_invalid():
+    """Invalid msg_type raises TypeError."""
+    with pytest.raises(TypeError):
+        NotifyKook(
+            token=BOT_TOKEN, targets=[CHANNEL_ID], msg_type="card"
+        )
+
+
+def test_plugin_kook_url_parsing():
+    """Exercise parse_url edge cases."""
+
+    # ?token= query param overrides the host
+    url = f"kook://ignored/?token={BOT_TOKEN}&to={CHANNEL_ID}"
+    parsed = NotifyKook.parse_url(url)
+    assert parsed is not None
+    assert parsed["token"] == BOT_TOKEN
+    assert CHANNEL_ID in parsed["targets"]
+
+    # split_path collects multiple targets
+    url = f"kook://{BOT_TOKEN}/{CHANNEL_ID}/{CHANNEL_ID2}"
+    parsed = NotifyKook.parse_url(url)
+    assert CHANNEL_ID in parsed["targets"]
+    assert CHANNEL_ID2 in parsed["targets"]
+
+    # None input returns None
+    assert NotifyKook.parse_url(None) is None
+
+
+def test_plugin_kook_native_url():
+    """parse_native_url accepts a full Kook webhook URL."""
+    url = "https://www.kookapp.cn/api/v3/incoming/mywebhookkey"
+    parsed = NotifyKook.parse_native_url(url)
+    assert parsed is not None
+    assert parsed["token"] == "mywebhookkey"
+    assert parsed["mode"] == KookMode.WEBHOOK
+
+    # Native URL with trailing slash
+    url = "https://www.kookapp.cn/api/v3/incoming/mywebhookkey/"
+    parsed = NotifyKook.parse_native_url(url)
+    assert parsed is not None
+    assert parsed["token"] == "mywebhookkey"
+
+    # Non-matching URL returns None
+    assert NotifyKook.parse_native_url("https://example.com/") is None
+
+
+# -----------------------------------------------------------------------
+# send() tests - webhook mode
+# -----------------------------------------------------------------------
+
+
+@mock.patch("requests.post")
+def test_plugin_kook_webhook_send(mock_post):
+    """Webhook mode send: success, HTTP error, API error, RequestException."""
+
+    def _mk_resp(code=requests.codes.ok, api_code=0):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = dumps({"code": api_code, "message": "ok"}).encode()
+        return r
+
+    # Success
+    mock_post.return_value = _mk_resp()
+    obj = NotifyKook(token=WEBHOOK_KEY, mode="webhook")
+    assert obj.notify(body="hello") is True
+    assert mock_post.call_count == 1
+
+    # Verify the endpoint URL
+    call_url = mock_post.call_args[0][0]
+    assert urlparse(call_url).hostname == "www.kookapp.cn"
+    assert "/incoming/" in call_url
+
+    # HTTP 500 -> False
+    mock_post.return_value = _mk_resp(
+        code=requests.codes.internal_server_error
+    )
+    assert obj.notify(body="hello") is False
+
+    # Unknown HTTP code -> False
+    mock_post.return_value = _mk_resp(code=999)
+    assert obj.notify(body="hello") is False
+
+    # API-level error (code != 0) -> False
+    mock_post.return_value = _mk_resp(api_code=40001)
+    assert obj.notify(body="hello") is False
+
+    # Unparseable JSON body is handled gracefully
+    r = mock.Mock()
+    r.status_code = requests.codes.ok
+    r.content = b"not-json"
+    mock_post.return_value = r
+    # code defaults to 0 -> success (unparseable treated as ok)
+    assert obj.notify(body="hello") is True
+
+    # RequestException -> False
+    mock_post.side_effect = requests.RequestException("conn error")
+    assert obj.notify(body="hello") is False
+    mock_post.side_effect = None
+
+
+# -----------------------------------------------------------------------
+# send() tests - bot mode
+# -----------------------------------------------------------------------
+
+
+@mock.patch("requests.post")
+def test_plugin_kook_bot_send(mock_post):
+    """Bot mode send: no targets, single channel, multiple, DM, error."""
+
+    def _ok():
+        r = mock.Mock()
+        r.status_code = requests.codes.ok
+        r.content = dumps({"code": 0}).encode()
+        return r
+
+    def _err(code=requests.codes.internal_server_error):
+        r = mock.Mock()
+        r.status_code = code
+        r.content = b""
+        return r
+
+    # No targets -> False without making a network call
+    obj = NotifyKook(token=BOT_TOKEN)
+    mock_post.reset_mock()
+    assert obj.notify(body="hello") is False
+    assert mock_post.call_count == 0
+
+    # Single channel success
+    mock_post.return_value = _ok()
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
+    assert obj.notify(body="hello") is True
+    assert mock_post.call_count == 1
+
+    # Verify Authorization header
+    call_kwargs = mock_post.call_args[1]
+    assert f"Bot {BOT_TOKEN}" in call_kwargs["headers"]["Authorization"]
+
+    # Multiple channels
+    mock_post.return_value = _ok()
+    obj = NotifyKook(
+        token=BOT_TOKEN, targets=[CHANNEL_ID, CHANNEL_ID2]
+    )
+    mock_post.reset_mock()
+    assert obj.notify(body="hello") is True
+    assert mock_post.call_count == 2
+
+    # DM target (uses dm_url endpoint)
+    mock_post.return_value = _ok()
+    obj = NotifyKook(token=BOT_TOKEN, targets=[f"@{USER_ID}"])
+    mock_post.reset_mock()
+    assert obj.notify(body="hello") is True
+    assert mock_post.call_count == 1
+    call_url = mock_post.call_args[0][0]
+    assert "direct-message" in call_url
+
+    # Mixed channel + DM
+    mock_post.return_value = _ok()
+    obj = NotifyKook(
+        token=BOT_TOKEN, targets=[CHANNEL_ID, f"@{USER_ID}"]
+    )
+    mock_post.reset_mock()
+    assert obj.notify(body="hello") is True
+    assert mock_post.call_count == 2
+
+    # HTTP 500 on one target -> has_error=True -> False
+    mock_post.return_value = _err()
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
+    assert obj.notify(body="hello") is False
+
+    # Unknown HTTP code
+    mock_post.return_value = _err(code=999)
+    assert obj.notify(body="hello") is False
+
+    # API-level error code
+    r = mock.Mock()
+    r.status_code = requests.codes.ok
+    r.content = dumps({"code": 40001, "message": "error"}).encode()
+    mock_post.return_value = r
+    assert obj.notify(body="hello") is False
+
+    # RequestException
+    mock_post.side_effect = requests.RequestException("boom")
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
+    assert obj.notify(body="hello") is False
+    mock_post.side_effect = None
+
+    # Partial failure: first channel fails, second would succeed,
+    # but has_error is still True so overall False
+    obj = NotifyKook(
+        token=BOT_TOKEN, targets=[CHANNEL_ID, CHANNEL_ID2]
+    )
+    mock_post.side_effect = [_err(), _ok()]
+    assert obj.notify(body="hello") is False
+    mock_post.side_effect = None
+
+    # msg_type=text uses Kook type integer 1 in the payload
+    mock_post.return_value = _ok()
+    obj = NotifyKook(
+        token=BOT_TOKEN, targets=[CHANNEL_ID], msg_type="text"
+    )
+    mock_post.reset_mock()
+    assert obj.notify(body="hello") is True
+    import json
+    payload = json.loads(mock_post.call_args[1]["data"])
+    assert payload["type"] == 1
+
+    # Default (kmarkdown) uses Kook type integer 9
+    mock_post.return_value = _ok()
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
+    mock_post.reset_mock()
+    assert obj.notify(body="hello") is True
+    payload = json.loads(mock_post.call_args[1]["data"])
+    assert payload["type"] == 9
+
+
+# -----------------------------------------------------------------------
+# Attachment tests
+# -----------------------------------------------------------------------
+
+
+@mock.patch("requests.post")
+def test_plugin_kook_attachments_success(mock_post):
+    """Attachment upload succeeds and a follow-up message is posted."""
+
+    def _ok(cdn_url="https://img.kookapp.cn/assets/test.png"):
+        r = mock.Mock()
+        r.status_code = requests.codes.ok
+        r.content = dumps({
+            "code": 0, "data": {"url": cdn_url},
+        }).encode()
+        return r
+
+    # call order: (1) text message, (2) CDN upload, (3) attach-msg POST
+    mock_post.side_effect = [_ok(), _ok(), _ok()]
+
+    attach = AppriseAttachment(
+        os.path.join(TEST_VAR_DIR, "apprise-test.png")
+    )
+
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
+    assert obj.notify(body="hello", attach=attach) is True
+    assert mock_post.call_count == 3
+
+
+@mock.patch("requests.post")
+def test_plugin_kook_attachments_inaccessible(mock_post):
+    """Attachment that cannot be accessed returns False without HTTP call."""
+    mock_post.return_value = mock.Mock(
+        status_code=requests.codes.ok,
+        content=dumps({"code": 0}).encode(),
+    )
+
+    attach = AppriseAttachment(
+        os.path.join(TEST_VAR_DIR, "apprise-test.png")
+    )
+
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
+
+    with mock.patch("os.path.isfile", return_value=False):
+        # Text message succeeds; attachment upload returns None -> False
+        assert obj.notify(body="hello", attach=attach) is False
+
+
+@mock.patch("requests.post")
+def test_plugin_kook_attachments_oserror(mock_post):
+    """OSError on attachment open is handled gracefully."""
+    # Text message POST returns ok
+    mock_post.return_value = mock.Mock(
+        status_code=requests.codes.ok,
+        content=dumps({"code": 0}).encode(),
+    )
+
+    attach = AppriseAttachment(
+        os.path.join(TEST_VAR_DIR, "apprise-test.png")
+    )
+
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
+
+    with mock.patch("builtins.open", side_effect=OSError("read error")):
+        assert obj.notify(body="hello", attach=attach) is False
+
+
+@mock.patch("requests.post")
+def test_plugin_kook_attachments_upload_http_error(mock_post):
+    """HTTP error during CDN upload returns False."""
+    ok_resp = mock.Mock()
+    ok_resp.status_code = requests.codes.ok
+    ok_resp.content = dumps({"code": 0}).encode()
+
+    upload_err = mock.Mock()
+    upload_err.status_code = requests.codes.internal_server_error
+    upload_err.content = b""
+
+    # Text message OK, then upload fails
+    mock_post.side_effect = [ok_resp, upload_err]
+
+    attach = AppriseAttachment(
+        os.path.join(TEST_VAR_DIR, "apprise-test.png")
+    )
+
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
+    assert obj.notify(body="hello", attach=attach) is False
+
+
+@mock.patch("requests.post")
+def test_plugin_kook_attachments_upload_no_url(mock_post):
+    """CDN upload returns HTTP 200 but no URL in response body -> False."""
+    ok_resp = mock.Mock()
+    ok_resp.status_code = requests.codes.ok
+    ok_resp.content = dumps({"code": 0}).encode()
+
+    no_url_resp = mock.Mock()
+    no_url_resp.status_code = requests.codes.ok
+    no_url_resp.content = dumps({"code": 0, "data": {}}).encode()
+
+    mock_post.side_effect = [ok_resp, no_url_resp]
+
+    attach = AppriseAttachment(
+        os.path.join(TEST_VAR_DIR, "apprise-test.png")
+    )
+
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
+    assert obj.notify(body="hello", attach=attach) is False
+
+
+@mock.patch("requests.post")
+def test_plugin_kook_attachments_upload_request_exception(mock_post):
+    """RequestException during CDN upload returns False."""
+    ok_resp = mock.Mock()
+    ok_resp.status_code = requests.codes.ok
+    ok_resp.content = dumps({"code": 0}).encode()
+
+    mock_post.side_effect = [
+        ok_resp,
+        requests.RequestException("upload error"),
+    ]
+
+    attach = AppriseAttachment(
+        os.path.join(TEST_VAR_DIR, "apprise-test.png")
+    )
+
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
+    assert obj.notify(body="hello", attach=attach) is False
+
+
+@mock.patch("requests.post")
+def test_plugin_kook_attachments_post_http_error(mock_post):
+    """HTTP error when posting attachment message returns False."""
+
+    def _ok(cdn_url="https://img.kookapp.cn/assets/test.png"):
+        r = mock.Mock()
+        r.status_code = requests.codes.ok
+        r.content = dumps({
+            "code": 0, "data": {"url": cdn_url},
+        }).encode()
+        return r
+
+    err_resp = mock.Mock()
+    err_resp.status_code = requests.codes.internal_server_error
+    err_resp.content = b""
+
+    # Text message OK, CDN upload OK, attachment-message POST fails
+    mock_post.side_effect = [_ok(), _ok(), err_resp]
+
+    attach = AppriseAttachment(
+        os.path.join(TEST_VAR_DIR, "apprise-test.png")
+    )
+
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
+    assert obj.notify(body="hello", attach=attach) is False
+
+
+@mock.patch("requests.post")
+def test_plugin_kook_attachments_post_request_exception(mock_post):
+    """RequestException when posting attachment message returns False."""
+
+    def _ok(cdn_url="https://img.kookapp.cn/assets/test.png"):
+        r = mock.Mock()
+        r.status_code = requests.codes.ok
+        r.content = dumps({
+            "code": 0, "data": {"url": cdn_url},
+        }).encode()
+        return r
+
+    # Text message OK, CDN upload OK, attachment-message POST raises
+    mock_post.side_effect = [
+        _ok(),
+        _ok(),
+        requests.RequestException("post error"),
+    ]
+
+    attach = AppriseAttachment(
+        os.path.join(TEST_VAR_DIR, "apprise-test.png")
+    )
+
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
+    assert obj.notify(body="hello", attach=attach) is False
+
+
+@mock.patch("requests.post")
+def test_plugin_kook_attachments_image_and_file(mock_post):
+    """Image attachment uses type=2; non-image uses type=4."""
+    import json as _json
+
+    def _ok(cdn_url="https://img.kookapp.cn/assets/f"):
+        r = mock.Mock()
+        r.status_code = requests.codes.ok
+        r.content = dumps({
+            "code": 0, "data": {"url": cdn_url},
+        }).encode()
+        return r
+
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
+
+    # --- Image attachment (PNG) ---
+    # call order: text-msg, upload, attach-msg
+    mock_post.side_effect = [_ok(), _ok(), _ok()]
+    attach_img = AppriseAttachment(
+        os.path.join(TEST_VAR_DIR, "apprise-test.png")
+    )
+    assert obj.notify(body="hello", attach=attach_img) is True
+    attach_msg_payload = _json.loads(mock_post.call_args_list[2][1]["data"])
+    assert attach_msg_payload["type"] == 2
+
+    # --- Non-image attachment (mp4 file) ---
+    mock_post.side_effect = [_ok(), _ok(), _ok()]
+    attach_file = AppriseAttachment(
+        os.path.join(TEST_VAR_DIR, "apprise-test.mp4")
+    )
+    mock_post.reset_mock()
+    mock_post.side_effect = [_ok(), _ok(), _ok()]
+    assert obj.notify(body="hello", attach=attach_file) is True
+    attach_msg_payload = _json.loads(mock_post.call_args_list[2][1]["data"])
+    assert attach_msg_payload["type"] == 4
+
+
+@mock.patch("requests.post")
+def test_plugin_kook_webhook_no_attachment_support(mock_post):
+    """Webhook mode ignores attachments since attachment_support=False."""
+    r = mock.Mock()
+    r.status_code = requests.codes.ok
+    r.content = dumps({"code": 0}).encode()
+    mock_post.return_value = r
+
+    attach = AppriseAttachment(
+        os.path.join(TEST_VAR_DIR, "apprise-test.png")
+    )
+
+    obj = NotifyKook(token=WEBHOOK_KEY, mode="webhook")
+    assert obj.attachment_support is False
+    # Apprise framework skips attach when attachment_support=False
+    assert obj.notify(body="hello", attach=attach) is True
+    # Only one POST (the webhook message itself)
+    assert mock_post.call_count == 1
+
+
+# -----------------------------------------------------------------------
+# Apprise integration test
+# -----------------------------------------------------------------------
+
+
+@mock.patch("requests.post")
+def test_plugin_kook_invalid_json_responses(mock_post):
+    """Verify invalid JSON in API responses is handled gracefully."""
+
+    # --- _send_bot: API response with unparseable JSON (lines 493-494) ---
+    # The message POST returns 200 but with invalid JSON body; the except
+    # clause must handle it and fall back to code=0 (success).
+    r = mock.Mock()
+    r.status_code = requests.codes.ok
+    r.content = b"not-json"
+    mock_post.return_value = r
+
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
+    assert obj.notify(body="hello") is True
+
+    # --- _upload: CDN upload response with unparseable JSON (lines 660-661)
+    # Text message POST returns ok with bad JSON; CDN upload also returns ok
+    # with bad JSON. The except fires, cdn_url is None, send returns False.
+    mock_post.return_value = r  # same bad JSON response for all calls
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
+    attach = AppriseAttachment(
+        os.path.join(TEST_VAR_DIR, "apprise-test.png")
+    )
+    # Text succeeds (code defaults to 0); CDN upload has no URL -> False
+    assert obj.notify(body="hello", attach=attach) is False
+
+
+@mock.patch("requests.post")
+def test_plugin_kook_apprise_integration(mock_post):
+    """Apprise().add() and notify() work for both modes."""
+    r = mock.Mock()
+    r.status_code = requests.codes.ok
+    r.content = dumps({"code": 0}).encode()
+    mock_post.return_value = r
+
+    # Bot mode
+    a = Apprise()
+    assert a.add(f"kook://{BOT_TOKEN}/{CHANNEL_ID}") is True
+    assert a.notify(title="Test", body="Message") is True
+
+    # Webhook mode
+    a = Apprise()
+    assert a.add(f"kook://{WEBHOOK_KEY}/?mode=webhook") is True
+    assert a.notify(body="webhook message") is True

--- a/tests/test_plugin_kook.py
+++ b/tests/test_plugin_kook.py
@@ -59,9 +59,6 @@ USER_ID = "5555555555"
 WEBHOOK_KEY = "abc123webhookkey"
 
 
-# -----------------------------------------------------------------------
-# URL tester table
-# -----------------------------------------------------------------------
 TEST_URLS = (
     ##
     # Invalid cases
@@ -230,11 +227,6 @@ def apprise_url_tester():
 def test_plugin_kook_urls(apprise_url_tester):
     """Run all URL test table entries through AppriseURLTester."""
     apprise_url_tester.run_all()
-
-
-# -----------------------------------------------------------------------
-# __init__ and url() round-trip tests
-# -----------------------------------------------------------------------
 
 
 def test_plugin_kook_bot_mode():
@@ -411,11 +403,6 @@ def test_plugin_kook_native_url():
     assert NotifyKook.parse_native_url("https://example.com/") is None
 
 
-# -----------------------------------------------------------------------
-# send() tests - webhook mode
-# -----------------------------------------------------------------------
-
-
 @mock.patch("requests.post")
 def test_plugin_kook_webhook_send(mock_post):
     """Webhook mode send: success, HTTP error, API error, RequestException."""
@@ -463,11 +450,6 @@ def test_plugin_kook_webhook_send(mock_post):
     mock_post.side_effect = requests.RequestException("conn error")
     assert obj.notify(body="hello") is False
     mock_post.side_effect = None
-
-
-# -----------------------------------------------------------------------
-# send() tests - bot mode
-# -----------------------------------------------------------------------
 
 
 @mock.patch("requests.post")
@@ -574,11 +556,6 @@ def test_plugin_kook_bot_send(mock_post):
     assert obj.notify(body="hello") is True
     payload = json.loads(mock_post.call_args[1]["data"])
     assert payload["type"] == 9
-
-
-# -----------------------------------------------------------------------
-# Attachment tests
-# -----------------------------------------------------------------------
 
 
 @mock.patch("requests.post")
@@ -754,6 +731,36 @@ def test_plugin_kook_attachments_post_request_exception(mock_post):
 
 
 @mock.patch("requests.post")
+def test_plugin_kook_attachments_post_api_error(mock_post):
+    """API error in attach-message response sets has_error -> False."""
+
+    def _ok(cdn_url="https://img.kookapp.cn/assets/test.png"):
+        r = mock.Mock()
+        r.status_code = requests.codes.ok
+        r.content = dumps(
+            {
+                "code": 0,
+                "data": {"url": cdn_url},
+            }
+        ).encode()
+        return r
+
+    def _api_err():
+        r = mock.Mock()
+        r.status_code = requests.codes.ok
+        r.content = dumps({"code": 40001, "message": "forbidden"}).encode()
+        return r
+
+    # Text message OK, CDN upload OK, attach-msg POST returns API error
+    mock_post.side_effect = [_ok(), _ok(), _api_err()]
+
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
+
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
+    assert obj.notify(body="hello", attach=attach) is False
+
+
+@mock.patch("requests.post")
 def test_plugin_kook_attachments_image_and_file(mock_post):
     """Image attachment uses type=2; non-image uses type=4."""
     import json as _json
@@ -771,7 +778,7 @@ def test_plugin_kook_attachments_image_and_file(mock_post):
 
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
 
-    # --- Image attachment (PNG) ---
+    # Image attachment (PNG)
     # call order: text-msg, upload, attach-msg
     mock_post.side_effect = [_ok(), _ok(), _ok()]
     attach_img = AppriseAttachment(
@@ -781,7 +788,7 @@ def test_plugin_kook_attachments_image_and_file(mock_post):
     attach_msg_payload = _json.loads(mock_post.call_args_list[2][1]["data"])
     assert attach_msg_payload["type"] == 2
 
-    # --- Non-image attachment (mp4 file) ---
+    # Non-image attachment (mp4 file)
     mock_post.side_effect = [_ok(), _ok(), _ok()]
     attach_file = AppriseAttachment(
         os.path.join(TEST_VAR_DIR, "apprise-test.mp4")
@@ -811,16 +818,11 @@ def test_plugin_kook_webhook_no_attachment_support(mock_post):
     assert mock_post.call_count == 1
 
 
-# -----------------------------------------------------------------------
-# Apprise integration test
-# -----------------------------------------------------------------------
-
-
 @mock.patch("requests.post")
 def test_plugin_kook_invalid_json_responses(mock_post):
     """Verify invalid JSON in API responses is handled gracefully."""
 
-    # --- _send_bot: API response with unparseable JSON (lines 493-494) ---
+    # _send_bot: API response with unparseable JSON
     # The message POST returns 200 but with invalid JSON body; the except
     # clause must handle it and fall back to code=0 (success).
     r = mock.Mock()
@@ -831,7 +833,7 @@ def test_plugin_kook_invalid_json_responses(mock_post):
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
     assert obj.notify(body="hello") is True
 
-    # --- _upload: CDN upload response with unparseable JSON (lines 660-661)
+    # _upload: CDN upload response with unparseable JSON
     # Text message POST returns ok with bad JSON; CDN upload also returns ok
     # with bad JSON. The except fires, cdn_url is None, send returns False.
     mock_post.return_value = r  # same bad JSON response for all calls
@@ -839,6 +841,28 @@ def test_plugin_kook_invalid_json_responses(mock_post):
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
     # Text succeeds (code defaults to 0); CDN upload has no URL -> False
     assert obj.notify(body="hello", attach=attach) is False
+
+    # _send_bot: attach-message POST response with unparseable JSON
+    # text OK, CDN upload OK (valid cdn_url), attach-msg POST returns bad JSON;
+    # the except fires, content defaults to {}, code=0 -> treated as success.
+    def _ok_cdn():
+        resp = mock.Mock()
+        resp.status_code = requests.codes.ok
+        resp.content = dumps(
+            {"code": 0, "data": {"url": "https://cdn/f"}}
+        ).encode()
+        return resp
+
+    bad_json_resp = mock.Mock()
+    bad_json_resp.status_code = requests.codes.ok
+    bad_json_resp.content = b"not-json"
+
+    mock_post.side_effect = [_ok_cdn(), _ok_cdn(), bad_json_resp]
+    mock_post.return_value = None
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
+    assert obj.notify(body="hello", attach=attach) is True
+    mock_post.side_effect = None
 
 
 @mock.patch("requests.post")

--- a/tests/test_plugin_kook.py
+++ b/tests/test_plugin_kook.py
@@ -36,10 +36,9 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
-from apprise import Apprise, AppriseAttachment
+from apprise import Apprise, AppriseAttachment, NotifyFormat
 from apprise.plugins.kook import (
     KookMode,
-    KookMsgType,
     NotifyKook,
 )
 
@@ -48,8 +47,8 @@ logging.disable(logging.CRITICAL)
 # Attachment directory
 TEST_VAR_DIR = os.path.join(os.path.dirname(__file__), "var")
 
-# A realistic-looking fake bot token
-BOT_TOKEN = "1/MTQ3OTE5MTA3MzQ1ODE4OTQ0/YJVvSXB0IK+ABC123XYZ"
+# A realistic-looking fake bot token (no slashes so URL interpolation works)
+BOT_TOKEN = "MTQ3OTE5MTA3MzQ1ODE4OTQ0ABC123XYZ"
 
 # Fake channel / user IDs (numeric snowflakes)
 CHANNEL_ID = "1234567890"
@@ -77,13 +76,6 @@ TEST_URLS = (
     # Invalid mode
     (
         f"kook://{BOT_TOKEN}/?mode=invalid",
-        {
-            "instance": TypeError,
-        },
-    ),
-    # Invalid msg_type
-    (
-        f"kook://{BOT_TOKEN}/{CHANNEL_ID}/?msg_type=invalid",
         {
             "instance": TypeError,
         },
@@ -185,9 +177,9 @@ TEST_URLS = (
             "attach_response": False,
         },
     ),
-    # Bot mode with msg_type=text
+    # Bot mode with ?format=text (plain text delivery)
     (
-        f"kook://{BOT_TOKEN}/{CHANNEL_ID}/?msg_type=text",
+        f"kook://{BOT_TOKEN}/{CHANNEL_ID}/?format=text",
         {
             "instance": NotifyKook,
             "attach_response": False,
@@ -251,7 +243,7 @@ def test_plugin_kook_bot_mode():
     # Single channel
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
     assert obj.mode == KookMode.BOT
-    assert obj.msg_type == KookMsgType.KMARKDOWN
+    assert obj.notify_format == NotifyFormat.MARKDOWN
     assert obj.channels == [CHANNEL_ID]
     assert obj.dm_users == []
     assert obj.attachment_support is True
@@ -325,17 +317,19 @@ def test_plugin_kook_bot_mode():
     assert obj.channels == []
     assert obj.dm_users == []
 
-    # msg_type = text
-    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID], msg_type="text")
-    assert obj.msg_type == KookMsgType.TEXT
-    url = obj.url()
-    assert "msg_type=text" in url
+    # ?format=text sets notify_format to TEXT; url() round-trips it
+    url = f"kook://{BOT_TOKEN}/{CHANNEL_ID}/?format=text"
     parsed = NotifyKook.parse_url(url)
-    obj2 = NotifyKook(**parsed)
-    assert obj2.msg_type == KookMsgType.TEXT
+    obj = NotifyKook(**parsed)
+    assert obj.notify_format == NotifyFormat.TEXT
+    url2 = obj.url()
+    parsed2 = NotifyKook.parse_url(url2)
+    obj2 = NotifyKook(**parsed2)
+    assert obj2.notify_format == NotifyFormat.TEXT
 
-    # Default msg_type not emitted in URL
+    # Default notify_format stays MARKDOWN (kmarkdown mode)
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
+    assert obj.notify_format == NotifyFormat.MARKDOWN
     url = obj.url()
     assert "msg_type" not in url
 
@@ -377,12 +371,6 @@ def test_plugin_kook_mode_invalid():
     """Invalid mode raises TypeError."""
     with pytest.raises(TypeError):
         NotifyKook(token=BOT_TOKEN, mode="invalid_mode")
-
-
-def test_plugin_kook_msg_type_invalid():
-    """Invalid msg_type raises TypeError."""
-    with pytest.raises(TypeError):
-        NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID], msg_type="card")
 
 
 def test_plugin_kook_url_parsing():
@@ -566,17 +554,20 @@ def test_plugin_kook_bot_send(mock_post):
     assert obj.notify(body="hello") is False
     mock_post.side_effect = None
 
-    # msg_type=text uses Kook type integer 1 in the payload
-    mock_post.return_value = _ok()
-    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID], msg_type="text")
-    mock_post.reset_mock()
-    assert obj.notify(body="hello") is True
+    # ?format=text -> notify_format=TEXT -> Kook API type 1 in the payload
     import json
 
+    mock_post.return_value = _ok()
+    parsed = NotifyKook.parse_url(
+        f"kook://{BOT_TOKEN}/{CHANNEL_ID}/?format=text"
+    )
+    obj = NotifyKook(**parsed)
+    mock_post.reset_mock()
+    assert obj.notify(body="hello") is True
     payload = json.loads(mock_post.call_args[1]["data"])
     assert payload["type"] == 1
 
-    # Default (kmarkdown) uses Kook type integer 9
+    # Default (markdown) -> notify_format=MARKDOWN -> Kook API type 9
     mock_post.return_value = _ok()
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
     mock_post.reset_mock()

--- a/tests/test_plugin_kook.py
+++ b/tests/test_plugin_kook.py
@@ -26,9 +26,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 # Disable logging for a cleaner testing output
+from json import dumps
 import logging
 import os
-from json import dumps
 from unittest import mock
 from urllib.parse import urlparse
 
@@ -36,10 +36,8 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
-from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise import Apprise, AppriseAttachment
 from apprise.plugins.kook import (
-    KOOK_MODES,
-    KOOK_MSG_TYPES,
     KookMode,
     KookMsgType,
     NotifyKook,
@@ -328,9 +326,7 @@ def test_plugin_kook_bot_mode():
     assert obj.dm_users == []
 
     # msg_type = text
-    obj = NotifyKook(
-        token=BOT_TOKEN, targets=[CHANNEL_ID], msg_type="text"
-    )
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID], msg_type="text")
     assert obj.msg_type == KookMsgType.TEXT
     url = obj.url()
     assert "msg_type=text" in url
@@ -386,9 +382,7 @@ def test_plugin_kook_mode_invalid():
 def test_plugin_kook_msg_type_invalid():
     """Invalid msg_type raises TypeError."""
     with pytest.raises(TypeError):
-        NotifyKook(
-            token=BOT_TOKEN, targets=[CHANNEL_ID], msg_type="card"
-        )
+        NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID], msg_type="card")
 
 
 def test_plugin_kook_url_parsing():
@@ -522,9 +516,7 @@ def test_plugin_kook_bot_send(mock_post):
 
     # Multiple channels
     mock_post.return_value = _ok()
-    obj = NotifyKook(
-        token=BOT_TOKEN, targets=[CHANNEL_ID, CHANNEL_ID2]
-    )
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID, CHANNEL_ID2])
     mock_post.reset_mock()
     assert obj.notify(body="hello") is True
     assert mock_post.call_count == 2
@@ -540,9 +532,7 @@ def test_plugin_kook_bot_send(mock_post):
 
     # Mixed channel + DM
     mock_post.return_value = _ok()
-    obj = NotifyKook(
-        token=BOT_TOKEN, targets=[CHANNEL_ID, f"@{USER_ID}"]
-    )
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID, f"@{USER_ID}"])
     mock_post.reset_mock()
     assert obj.notify(body="hello") is True
     assert mock_post.call_count == 2
@@ -571,21 +561,18 @@ def test_plugin_kook_bot_send(mock_post):
 
     # Partial failure: first channel fails, second would succeed,
     # but has_error is still True so overall False
-    obj = NotifyKook(
-        token=BOT_TOKEN, targets=[CHANNEL_ID, CHANNEL_ID2]
-    )
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID, CHANNEL_ID2])
     mock_post.side_effect = [_err(), _ok()]
     assert obj.notify(body="hello") is False
     mock_post.side_effect = None
 
     # msg_type=text uses Kook type integer 1 in the payload
     mock_post.return_value = _ok()
-    obj = NotifyKook(
-        token=BOT_TOKEN, targets=[CHANNEL_ID], msg_type="text"
-    )
+    obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID], msg_type="text")
     mock_post.reset_mock()
     assert obj.notify(body="hello") is True
     import json
+
     payload = json.loads(mock_post.call_args[1]["data"])
     assert payload["type"] == 1
 
@@ -610,17 +597,18 @@ def test_plugin_kook_attachments_success(mock_post):
     def _ok(cdn_url="https://img.kookapp.cn/assets/test.png"):
         r = mock.Mock()
         r.status_code = requests.codes.ok
-        r.content = dumps({
-            "code": 0, "data": {"url": cdn_url},
-        }).encode()
+        r.content = dumps(
+            {
+                "code": 0,
+                "data": {"url": cdn_url},
+            }
+        ).encode()
         return r
 
     # call order: (1) text message, (2) CDN upload, (3) attach-msg POST
     mock_post.side_effect = [_ok(), _ok(), _ok()]
 
-    attach = AppriseAttachment(
-        os.path.join(TEST_VAR_DIR, "apprise-test.png")
-    )
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
 
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
     assert obj.notify(body="hello", attach=attach) is True
@@ -635,9 +623,7 @@ def test_plugin_kook_attachments_inaccessible(mock_post):
         content=dumps({"code": 0}).encode(),
     )
 
-    attach = AppriseAttachment(
-        os.path.join(TEST_VAR_DIR, "apprise-test.png")
-    )
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
 
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
 
@@ -655,9 +641,7 @@ def test_plugin_kook_attachments_oserror(mock_post):
         content=dumps({"code": 0}).encode(),
     )
 
-    attach = AppriseAttachment(
-        os.path.join(TEST_VAR_DIR, "apprise-test.png")
-    )
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
 
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
 
@@ -679,9 +663,7 @@ def test_plugin_kook_attachments_upload_http_error(mock_post):
     # Text message OK, then upload fails
     mock_post.side_effect = [ok_resp, upload_err]
 
-    attach = AppriseAttachment(
-        os.path.join(TEST_VAR_DIR, "apprise-test.png")
-    )
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
 
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
     assert obj.notify(body="hello", attach=attach) is False
@@ -700,9 +682,7 @@ def test_plugin_kook_attachments_upload_no_url(mock_post):
 
     mock_post.side_effect = [ok_resp, no_url_resp]
 
-    attach = AppriseAttachment(
-        os.path.join(TEST_VAR_DIR, "apprise-test.png")
-    )
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
 
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
     assert obj.notify(body="hello", attach=attach) is False
@@ -720,9 +700,7 @@ def test_plugin_kook_attachments_upload_request_exception(mock_post):
         requests.RequestException("upload error"),
     ]
 
-    attach = AppriseAttachment(
-        os.path.join(TEST_VAR_DIR, "apprise-test.png")
-    )
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
 
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
     assert obj.notify(body="hello", attach=attach) is False
@@ -735,9 +713,12 @@ def test_plugin_kook_attachments_post_http_error(mock_post):
     def _ok(cdn_url="https://img.kookapp.cn/assets/test.png"):
         r = mock.Mock()
         r.status_code = requests.codes.ok
-        r.content = dumps({
-            "code": 0, "data": {"url": cdn_url},
-        }).encode()
+        r.content = dumps(
+            {
+                "code": 0,
+                "data": {"url": cdn_url},
+            }
+        ).encode()
         return r
 
     err_resp = mock.Mock()
@@ -747,9 +728,7 @@ def test_plugin_kook_attachments_post_http_error(mock_post):
     # Text message OK, CDN upload OK, attachment-message POST fails
     mock_post.side_effect = [_ok(), _ok(), err_resp]
 
-    attach = AppriseAttachment(
-        os.path.join(TEST_VAR_DIR, "apprise-test.png")
-    )
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
 
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
     assert obj.notify(body="hello", attach=attach) is False
@@ -762,9 +741,12 @@ def test_plugin_kook_attachments_post_request_exception(mock_post):
     def _ok(cdn_url="https://img.kookapp.cn/assets/test.png"):
         r = mock.Mock()
         r.status_code = requests.codes.ok
-        r.content = dumps({
-            "code": 0, "data": {"url": cdn_url},
-        }).encode()
+        r.content = dumps(
+            {
+                "code": 0,
+                "data": {"url": cdn_url},
+            }
+        ).encode()
         return r
 
     # Text message OK, CDN upload OK, attachment-message POST raises
@@ -774,9 +756,7 @@ def test_plugin_kook_attachments_post_request_exception(mock_post):
         requests.RequestException("post error"),
     ]
 
-    attach = AppriseAttachment(
-        os.path.join(TEST_VAR_DIR, "apprise-test.png")
-    )
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
 
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
     assert obj.notify(body="hello", attach=attach) is False
@@ -790,9 +770,12 @@ def test_plugin_kook_attachments_image_and_file(mock_post):
     def _ok(cdn_url="https://img.kookapp.cn/assets/f"):
         r = mock.Mock()
         r.status_code = requests.codes.ok
-        r.content = dumps({
-            "code": 0, "data": {"url": cdn_url},
-        }).encode()
+        r.content = dumps(
+            {
+                "code": 0,
+                "data": {"url": cdn_url},
+            }
+        ).encode()
         return r
 
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
@@ -827,9 +810,7 @@ def test_plugin_kook_webhook_no_attachment_support(mock_post):
     r.content = dumps({"code": 0}).encode()
     mock_post.return_value = r
 
-    attach = AppriseAttachment(
-        os.path.join(TEST_VAR_DIR, "apprise-test.png")
-    )
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
 
     obj = NotifyKook(token=WEBHOOK_KEY, mode="webhook")
     assert obj.attachment_support is False
@@ -864,9 +845,7 @@ def test_plugin_kook_invalid_json_responses(mock_post):
     # with bad JSON. The except fires, cdn_url is None, send returns False.
     mock_post.return_value = r  # same bad JSON response for all calls
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
-    attach = AppriseAttachment(
-        os.path.join(TEST_VAR_DIR, "apprise-test.png")
-    )
+    attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
     # Text succeeds (code defaults to 0); CDN upload has no URL -> False
     assert obj.notify(body="hello", attach=attach) is False
 


### PR DESCRIPTION
## Description
**Related issue (if applicable):** n/a

## *Kook* Notifications
* **Source**: https://www.kookapp.cn
* **Image Support**: No
* **Message Format**: KMarkdown / Plain Text
* **Message Limit**: 5000 characters

Kook (formerly Kaihei / 开黑啦) is a Chinese gaming-focused communication platform similar to Discord, offering text channels, voice channels, and direct messaging.

## Account Setup

### Bot Mode (Recommended)
1. Visit https://developer.kookapp.cn and sign in.
2. Click "Create Application" and give it a name like "Apprise".
3. Under your application, go to "Bot" in the left sidebar and copy the **Token**.
4. Invite the bot to your server via the OAuth2 page.
5. Enable Developer Mode in Kook (Settings → Others → Developer Mode).
6. Right-click any channel and select "Copy ID" to get its numeric ID.

### Webhook Mode
1. In Kook, go to Server Settings → Integrations → Webhooks.
2. Create a webhook for the desired channel and copy the webhook key.

## Syntax

Valid syntax is as follows:
- `kook://{bot_token}/{channel_id}`
- `kook://{bot_token}/{channel1}/{channel2}`
- `kook://{bot_token}/@{user_id}`
- `kook://{webhook_key}?mode=webhook`

Native webhook URLs (`https://www.kookapp.cn/api/v3/incoming/{key}`) are also accepted via `parse_native_url`.

## Parameter Breakdown

| Variable | Required | Description |
| -------- | -------- | ----------- |
| `token` | Yes | Bot token (bot mode) or webhook key (webhook mode) |
| `channel_id` | No | Numeric channel ID. Repeat for multiple channels |
| `user_id` | No | Numeric user ID for a direct message; prefix with `@` |
| `mode` | No | `bot` (default) or `webhook` |
| `msg_type` | No | `kmarkdown` (default) or `text` |

## Examples

```bash
# Bot mode - single channel
apprise -vv -t "Title" -b "**Hello** from Apprise" kook://TOKEN/CHANNEL_ID

# Bot mode - multiple channels
apprise -vv -b "Alert!" kook://TOKEN/CHANNEL1/CHANNEL2

# Bot mode - direct message
apprise -vv -b "DM" kook://TOKEN/@USER_ID

# Webhook mode
apprise -vv -b "Webhook msg" "kook://WEBHOOK_KEY?mode=webhook"

# Force plain text
apprise -vv -b "Plain" "kook://TOKEN/CHANNEL_ID?msg_type=text"
```

## New Service Completion Status
* [x] apprise/plugins/kook.py
* [x] tests/test_plugin_kook.py
* [x] pyproject.toml
* [x] README.md
* [x] packaging/redhat/python-apprise.spec

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/95](https://github.com/caronc/apprise-docs/pull/95)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`). 100% coverage on `apprise/plugins/kook.py`.

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@kook-support

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    kook://BOT_TOKEN/CHANNEL_ID
```
