### PR TITLE
support multi-attachments in single in discord message

### DIFF
--- a/apprise/plugins/discord.py
+++ b/apprise/plugins/discord.py
@@ -687,9 +687,7 @@ class NotifyDiscord(NotifyBase):
                 # Size is only needed for byte-limit batching; skip the
                 # stat()/download() it triggers when batching is off
                 size = (
-                    (len(attachment) if attachment else 0)
-                    if self.batch
-                    else 0
+                    (len(attachment) if attachment else 0) if self.batch else 0
                 )
 
                 if current and (

--- a/apprise/plugins/discord.py
+++ b/apprise/plugins/discord.py
@@ -118,6 +118,13 @@ class NotifyDiscord(NotifyBase):
     # file. If it is more than this, then it is not accepted
     max_discord_template_size = 35000
 
+    # Maximum number of attachments Discord accepts in a single message
+    discord_max_attachments = 10
+
+    # Maximum total attachment bytes per message.
+    # Discord's documented default is 25 MiB for most users.
+    discord_max_attach_bytes = 25 * 1024 * 1024
+
     # Define object templates
     templates = (
         "{schema}://{webhook_id}/{webhook_token}",
@@ -217,6 +224,14 @@ class NotifyDiscord(NotifyBase):
                 "type": "string",
                 "private": True,
             },
+            # When True (default) multiple attachments are grouped into
+            # batches and sent in a single message where possible.
+            # Set to no/false to revert to one attachment per message.
+            "batch": {
+                "name": _("Batch Attachments"),
+                "type": "bool",
+                "default": True,
+            },
         },
     )
 
@@ -245,6 +260,7 @@ class NotifyDiscord(NotifyBase):
         ping: list[str] | None = None,
         template: str | None = None,
         tokens: dict | None = None,
+        batch: bool | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize Discord Object."""
@@ -317,6 +333,18 @@ class NotifyDiscord(NotifyBase):
 
         # Ping targets (tokens from URL, already split by parse_list)
         self.ping: list[str] = parse_list(ping)
+
+        # When True, group multiple attachments into a single message
+        # where count and size limits allow; False reverts to one per
+        # message (old behaviour)
+        self.batch = (
+            self.template_args["batch"]["default"]
+            if batch is None
+            else parse_bool(
+                batch,
+                default=self.template_args["batch"]["default"],
+            )
+        )
 
         self.ratelimit_reset = datetime.now(timezone.utc).replace(tzinfo=None)
 
@@ -644,14 +672,50 @@ class NotifyDiscord(NotifyBase):
             payload.pop("allow_mentions", None)
 
             #
-            # Send our attachments
+            # Build attachment batches in strict serial order.
+            # Each batch respects the per-message attachment count and
+            # total byte limits.  When batch=False every attachment is
+            # its own message (legacy one-per-message behaviour).
             #
+            max_per = self.discord_max_attachments if self.batch else 1
+
+            batches: list[list[AttachBase]] = []
+            current: list[AttachBase] = []
+            current_size = 0
+
             for attachment in attach:
-                self.logger.info(
-                    f"Posting Discord Attachment {attachment.name}"
+                # Size is only needed for byte-limit batching; skip the
+                # stat()/download() it triggers when batching is off
+                size = (
+                    (len(attachment) if attachment else 0)
+                    if self.batch
+                    else 0
                 )
-                if not self._send(payload, params=params, attach=attachment):
-                    # We failed to post our message
+
+                if current and (
+                    len(current) >= max_per
+                    or (
+                        self.batch
+                        and current_size + size > self.discord_max_attach_bytes
+                    )
+                ):
+                    # Current batch is full; flush and start a new one
+                    batches.append(current)
+                    current = []
+                    current_size = 0
+
+                current.append(attachment)
+                current_size += size
+
+            # current always holds at least the last attachment here
+            batches.append(current)
+
+            #
+            # Send each attachment batch
+            #
+            for batch in batches:
+                if not self._send(payload, params=params, attach=batch):
+                    # We failed to post our attachment batch
                     return False
 
         # Otherwise return
@@ -660,7 +724,7 @@ class NotifyDiscord(NotifyBase):
     def _send(
         self,
         payload: dict[str, Any],
-        attach: AttachBase | None = None,
+        attach: list[AttachBase] | None = None,
         params: dict[str, str] | None = None,
         rate_limit: int = 1,
         **kwargs: Any,
@@ -704,40 +768,70 @@ class NotifyDiscord(NotifyBase):
         # Always call throttle before any remote server i/o is made;
         self.throttle(wait=wait)
 
-        # Perform some simple error checking
-        if isinstance(attach, AttachBase):
-            if not attach:
-                # We could not access the attachment
-                self.logger.error(
-                    f"Could not access attachment {attach.url(privacy=True)}."
-                )
-                return False
+        # File handles opened for this call; all closed in `finally`
+        handles: list[Any] = []
+        # Multipart file list built from the attach batch
+        files: list[Any] | None = None
+        attach_ok = True
 
-            self.logger.debug(
-                f"Posting Discord attachment {attach.url(privacy=True)}"
-            )
-
-        # Our attachment path (if specified)
-        files = None
         try:
-            # Open our attachment path if required:
+            # Open our attachment path(s) if required:
             if attach:
-                files = {
-                    "file": (
-                        attach.name,
-                        # file handle is safely closed in `finally`; inline
-                        # open is intentional; attach.open() dispatches to
-                        # BytesIO for memory attachments
-                        attach.open(),
+                files = []
+                for idx, attachment in enumerate(attach):
+                    # Verify accessibility before opening
+                    if not attachment:
+                        self.logger.warning(
+                            "Could not access Discord attachment %s.",
+                            attachment.url(privacy=True),
+                        )
+                        attach_ok = False
+                        break
+
+                    self.logger.debug(
+                        "Posting Discord attachment %s",
+                        attachment.url(privacy=True),
                     )
-                }
+
+                    # Catch OSError per attachment open
+                    try:
+                        handle = attachment.open()
+                    except OSError as e:
+                        self.logger.warning(
+                            "An I/O error occurred while reading %s.",
+                            attachment.name or "attachment",
+                        )
+                        self.logger.debug("I/O Exception: %s", str(e))
+                        attach_ok = False
+                        break
+
+                    # Register handle before appending to files
+                    handles.append(handle)
+                    files.append(
+                        (
+                            f"files[{idx}]",
+                            (
+                                attachment.name,
+                                handle,
+                                attachment.mimetype,
+                            ),
+                        )
+                    )
+
+                if not attach_ok:
+                    return False
+
             else:
                 headers["Content-Type"] = "application/json; charset=utf-8"
 
             r = requests.post(
                 notify_url,
                 params=params,
-                data=payload if files else dumps(payload),
+                data=(
+                    {"payload_json": dumps(payload)}
+                    if files
+                    else dumps(payload)
+                ),
                 headers=headers,
                 files=files,
                 verify=self.verify_certificate,
@@ -790,13 +884,15 @@ class NotifyDiscord(NotifyBase):
                     )
 
                 self.logger.warning(
-                    "Failed to send {}to Discord notification: "
-                    "{}{}error={}.".format(
-                        attach.name if attach else "",
-                        status_str,
-                        ", " if status_str else "",
-                        r.status_code,
-                    )
+                    "Failed to send Discord %s: %s%serror=%s.",
+                    (
+                        "{} attachment(s)".format(len(attach))
+                        if attach
+                        else "notification"
+                    ),
+                    status_str,
+                    ", " if status_str else "",
+                    r.status_code,
                 )
 
                 self.logger.debug(
@@ -807,35 +903,31 @@ class NotifyDiscord(NotifyBase):
                 return False
 
             else:
-                self.logger.info(
-                    "Sent Discord {}.".format(
-                        "attachment" if attach else "notification"
+                if attach:
+                    self.logger.info(
+                        "Sent Discord %d attachment(s).", len(attach)
                     )
-                )
+                else:
+                    self.logger.info("Sent Discord notification.")
 
         except requests.RequestException as e:
             self.logger.warning(
-                "A Connection error occurred posting {}to Discord.".format(
-                    attach.name if attach else ""
-                )
+                "A Connection error occurred posting to Discord."
             )
             self.logger.debug(f"Socket Exception: {e!s}")
             return False
 
         except OSError as e:
-            self.logger.warning(
-                "An I/O error occurred while reading {}.".format(
-                    attach.name if attach else "attachment"
-                )
-            )
+            # Catches I/O errors from requests.post() and any unexpected
+            # file-system errors not caught by the per-attachment check above
+            self.logger.warning("An I/O error occurred posting to Discord.")
             self.logger.debug(f"I/O Exception: {e!s}")
             return False
 
         finally:
-            # Close our file (if it's open) stored in the second element
-            # of our files tuple (index 1)
-            if files:
-                files["file"][1].close()
+            # Close all handles regardless of success or failure
+            for handle in handles:
+                handle.close()
 
         return True
 
@@ -849,6 +941,7 @@ class NotifyDiscord(NotifyBase):
             "footer_logo": "yes" if self.footer_logo else "no",
             "image": "yes" if self.include_image else "no",
             "fields": "yes" if self.fields else "no",
+            "batch": "yes" if self.batch else "no",
         }
 
         if self.avatar_url:
@@ -993,6 +1086,14 @@ class NotifyDiscord(NotifyBase):
 
         # Store our template tokens
         results["tokens"] = results["qsd:"]
+
+        # Batch attachments flag
+        results["batch"] = parse_bool(
+            results["qsd"].get(
+                "batch",
+                NotifyDiscord.template_args["batch"]["default"],
+            )
+        )
 
         return results
 

--- a/tests/test_plugin_discord.py
+++ b/tests/test_plugin_discord.py
@@ -252,6 +252,22 @@ apprise_url_tests = (
             "include_image": False,
         },
     ),
+    # Test batch attachment mode enabled (default)
+    (
+        "discord://{}/{}?batch=yes".format("i" * 24, "t" * 64),
+        {
+            "instance": NotifyDiscord,
+            "requests_response_code": requests.codes.no_content,
+        },
+    ),
+    # Test batch attachment mode disabled (legacy one-per-message)
+    (
+        "discord://{}/{}?batch=no".format("i" * 24, "t" * 64),
+        {
+            "instance": NotifyDiscord,
+            "requests_response_code": requests.codes.no_content,
+        },
+    ),
     (
         "discord://{}/{}/".format("a" * 24, "b" * 64),
         {
@@ -1695,3 +1711,117 @@ def test_plugin_discord_template_with_attachments(mock_post, tmpdir):
 
     # Both the template message and the attachment should have been posted
     assert mock_post.call_count == 2
+
+
+@mock.patch("requests.post")
+def test_plugin_discord_attach_multi_batch(mock_post):
+    """NotifyDiscord() multi-attachment batching."""
+
+    webhook_id = "C" * 24
+    webhook_token = "D" * 64
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = b""
+    response.headers = {}
+    mock_post.return_value = response
+
+    obj = Apprise.instantiate(
+        f"discord://{webhook_id}/{webhook_token}/?format=markdown"
+    )
+    assert isinstance(obj, NotifyDiscord)
+    assert obj.batch is True
+
+    # Three test attachments
+    gif = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
+    png = os.path.join(TEST_VAR_DIR, "apprise-test.png")
+    jpg = os.path.join(TEST_VAR_DIR, "apprise-test.jpeg")
+    attach = AppriseAttachment([gif, png, jpg])
+
+    # Default batch mode: all 3 files go in one POST (plus 1 for the message)
+    assert obj.send(body="test", attach=attach) is True
+    assert mock_post.call_count == 2
+    mock_post.reset_mock()
+
+    # Reduce max per batch to 1: each file gets its own POST (4 calls total)
+    obj.discord_max_attachments = 1
+    assert obj.send(body="test", attach=attach) is True
+    assert mock_post.call_count == 4
+    mock_post.reset_mock()
+    obj.discord_max_attachments = 10
+
+    # Size-based split: force a tiny per-batch byte budget
+    obj.discord_max_attach_bytes = 1
+    assert obj.send(body="test", attach=attach) is True
+    assert mock_post.call_count == 4
+    mock_post.reset_mock()
+    obj.discord_max_attach_bytes = 25 * 1024 * 1024
+
+    # batch=False: reverts to legacy one-per-message regardless of max
+    obj_no_batch = Apprise.instantiate(
+        f"discord://{webhook_id}/{webhook_token}/?batch=no"
+    )
+    assert isinstance(obj_no_batch, NotifyDiscord)
+    assert obj_no_batch.batch is False
+    assert obj_no_batch.send(body="test", attach=attach) is True
+    assert mock_post.call_count == 4
+    mock_post.reset_mock()
+
+    # URL round-trip preserves batch flag
+    url_on = NotifyDiscord(
+        webhook_id=webhook_id,
+        webhook_token=webhook_token,
+        batch=True,
+    ).url()
+    assert "batch=yes" in url_on
+    url_off = NotifyDiscord(
+        webhook_id=webhook_id,
+        webhook_token=webhook_token,
+        batch=False,
+    ).url()
+    assert "batch=no" in url_off
+    parsed = NotifyDiscord.parse_url(url_off)
+    assert parsed["batch"] is False
+
+    # Guard 1: inaccessible file causes failure; body POST still goes out
+    with mock.patch("os.path.isfile", return_value=False):
+        assert obj.send(body="test", attach=attach) is False
+    assert mock_post.call_count == 1
+    mock_post.reset_mock()
+
+    # Guard 2: OSError on open causes failure; body POST still goes out
+    with mock.patch("builtins.open", side_effect=OSError()):
+        assert obj.send(body="test", attach=attach) is False
+    assert mock_post.call_count == 1
+    mock_post.reset_mock()
+
+    # HTTP error on the attachment batch POST; body POST succeeds
+    bad_response = mock.Mock()
+    bad_response.status_code = requests.codes.internal_server_error
+    bad_response.content = b""
+    bad_response.headers = {}
+    mock_post.side_effect = [response, bad_response]
+    assert obj.send(body="test", attach=attach) is False
+    mock_post.side_effect = None
+    mock_post.reset_mock()
+
+    # RequestException on the attachment batch POST
+    mock_post.side_effect = [response, requests.RequestException()]
+    assert obj.send(body="test", attach=attach) is False
+    mock_post.side_effect = None
+    mock_post.reset_mock()
+
+    # OSError raised by requests.post() during attachment send
+    mock_post.side_effect = [response, OSError()]
+    assert obj.send(body="test", attach=attach) is False
+    mock_post.side_effect = None
+    mock_post.reset_mock()
+
+    # Partial batch failure: first batch (files 0+1) succeeds, second fails.
+    # Set max=2 so 3 files split into [gif, png] and [jpg].
+    obj.discord_max_attachments = 2
+    mock_post.side_effect = [response, response, bad_response]
+    assert obj.send(body="test", attach=attach) is False
+    assert mock_post.call_count == 3
+    mock_post.side_effect = None
+    obj.discord_max_attachments = 10


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1606

**New `?batch=` parameter (default `yes`)**

When `batch=yes` (the default), attachments are grouped into batches and sent together.

There are however a few restrictions (Apprise looks after handling batches if these values are exeeded):
* **Count**: `discord_max_attachments = 10` files per message (Discord's documented limit)
* **Size**: `discord_max_attach_bytes = 25 MiB` total per batch (Discord's documented default)

Serial order is strictly preserved. Attachments are never reordered or skipped to fill a batch -- if adding the next file would exceed a limit, the current batch is flushed and a new one starts.

When `batch=no`, the plugin reverts to the legacy one-attachment-per-message behaviour.

**Example URLs**

```text
discord://WEBHOOK_ID/WEBHOOK_TOKEN               (batch=yes, default)
discord://WEBHOOK_ID/WEBHOOK_TOKEN?batch=no      (one per message, legacy)
```

## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/96](https://github.com/caronc/apprise-docs/pull/96)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing

Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1606-discord-multiple-attachments

# Send 3 images in a single Discord message (batched)
apprise -vv -t "Test Title" -b "Test Message" \
    --attach /path/to/file1.png \
    --attach /path/to/file2.png \
    --attach /path/to/file3.png \
    "discord://WEBHOOK_ID/WEBHOOK_TOKEN"

# Send using legacy one-per-message mode
apprise -vv -t "Test Title" -b "Test Message" \
    --attach /path/to/file1.png \
    --attach /path/to/file2.png \
    "discord://WEBHOOK_ID/WEBHOOK_TOKEN?batch=no"
```
