### PR TITLE
Added RFC 2387 inline attachments to email://

### DIFF
--- a/apprise/plugins/email/base.py
+++ b/apprise/plugins/email/base.py
@@ -1302,8 +1302,14 @@ class NotifyEmail(NotifyBase):
             cid_refs = set()
             if inline and attach:
                 if notify_format == NotifyFormat.HTML:
-                    # Collect filenames already referenced via cid:
-                    cid_refs = set(re.findall(r'cid:([^\s"\'>\)]+)', body))
+                    # Collect filenames already referenced via cid:;
+                    # decode %20 to spaces so filenames with spaces match
+                    # the raw attachment name regardless of how the caller
+                    # encoded the URI.
+                    cid_refs = {
+                        ref.replace("%20", " ")
+                        for ref in re.findall(r'cid:([^\s"\'>\)]+)', body)
+                    }
 
                     # Build a set of all attachment filenames so we can
                     # warn about cid: refs that have no matching file
@@ -1322,14 +1328,23 @@ class NotifyEmail(NotifyBase):
                             _ref,
                         )
 
+                    # Drop refs that have no matching attachment so they
+                    # do not influence the multipart/related decision.
+                    # Note: only IMAGE attachments are ever auto-appended
+                    # (see img_appends loop below), but explicit cid: refs
+                    # in the caller-supplied body are honored for any
+                    # attachment type -- a cid: URI can only resolve
+                    # within the same MIME package, so if the caller wrote
+                    # it they clearly attached the file on purpose.
+                    cid_refs &= _attach_names
+
                     # Append inline anchors for any image not yet listed
                     img_appends = []
                     for _no, _a in enumerate(attach, start=1):
                         _fname = _a.name or f"file{_no:03}.dat"
-                        if (
-                            _a.mimetype.startswith("image/")
-                            and _fname not in cid_refs
-                        ):
+                        if (_a.mimetype or "").lower().startswith(
+                            "image/"
+                        ) and _fname not in cid_refs:
                             img_appends.append(_fname)
                             cid_refs.add(_fname)
 
@@ -1349,7 +1364,7 @@ class NotifyEmail(NotifyBase):
                     txt_imgs = []
                     for _no, _a in enumerate(attach, start=1):
                         _fname = _a.name or f"file{_no:03}.dat"
-                        if _a.mimetype.startswith("image/"):
+                        if (_a.mimetype or "").lower().startswith("image/"):
                             txt_imgs.append(_fname)
 
                     if txt_imgs:

--- a/apprise/plugins/email/base.py
+++ b/apprise/plugins/email/base.py
@@ -235,6 +235,11 @@ class NotifyEmail(NotifyBase):
                 "default": False,
                 "map_to": "use_wkd",
             },
+            "inline": {
+                "name": _("Inline Attachments"),
+                "type": "bool",
+                "default": False,
+            },
             "to": {
                 "name": _("To Email"),
                 "type": "string",
@@ -273,6 +278,7 @@ class NotifyEmail(NotifyBase):
         pgp_key=None,
         pgp_privkey=None,
         use_wkd=False,
+        inline=None,
         **kwargs,
     ):
         """
@@ -535,6 +541,12 @@ class NotifyEmail(NotifyBase):
                 "ask admin to install PGPy"
             )
 
+        # Store inline attachment mode (RFC 2387); fall back to the
+        # template default when the value is None or unrecognisable
+        self.inline = parse_bool(
+            inline, self.template_args["inline"]["default"]
+        )
+
         return
 
     def apply_email_defaults(self, secure_mode=None, port=None, **kwargs):
@@ -714,6 +726,7 @@ class NotifyEmail(NotifyBase):
                 names=self.names,
                 pgp=self.pgp,
                 pgp_mode=self.pgp_mode,
+                inline=self.inline,
                 tzinfo=self.tzinfo,
             ):
                 try:
@@ -801,6 +814,10 @@ class NotifyEmail(NotifyBase):
         # Include wkd= when Web Key Directory lookup is enabled
         if self.use_wkd:
             params["wkd"] = "yes"
+
+        # Emit inline flag only when enabled
+        if self.inline:
+            params["inline"] = "yes"
 
         # Append our headers into our parameters
         params.update({"+{}".format(k): v for k, v in self.headers.items()})
@@ -1045,6 +1062,13 @@ class NotifyEmail(NotifyBase):
                 results["qsd"]["pgpprv"]
             )
 
+        # Get inline attachment flag
+        if "inline" in results["qsd"]:
+            results["inline"] = parse_bool(
+                results["qsd"]["inline"],
+                NotifyEmail.template_args["inline"]["default"],
+            )
+
         # The From address is a must; either through the use of templates
         # from= entry and/or merging the user and hostname together, this
         # must be calculated or parse_url will fail.
@@ -1144,6 +1168,9 @@ class NotifyEmail(NotifyBase):
         pgp=None,
         # PGP mode string (PGPMode.NONE / PGPMode.SIGN / PGPMode.ENCRYPT)
         pgp_mode=PGP_MODE_DEFAULT,
+        # When True, image attachments are embedded inline (RFC 2387)
+        # so HTML bodies can reference them via <img src="cid:filename">
+        inline=False,
         # Define our timezone; if one isn't provided, then we use
         # the system time instead
         tzinfo=None,
@@ -1256,6 +1283,82 @@ class NotifyEmail(NotifyBase):
             if reply_to_:
                 logger.debug("Email Reply-To: {}".format(", ".join(reply_to_)))
 
+            # When inline mode is active, pre-scan image attachments
+            # before the MIME body is built so the modified body is
+            # picked up by all parts (text/plain alternative included).
+            #
+            # HTML emails: collect any existing cid:filename refs from
+            # the body, then append <br/><img src="cid:name"> for each
+            # image attachment that is not yet referenced.  This ensures
+            # all images are embedded inline -- even when the caller did
+            # not write the cid: anchors manually.
+            #
+            # Plain-text emails: images cannot be embedded; append a
+            # short [Image: name] marker so the recipient knows the
+            # attachment is there.
+            #
+            # Non-image attachments are never modified here; they always
+            # fall back to standard Content-Disposition: attachment.
+            cid_refs = set()
+            if inline and attach:
+                if notify_format == NotifyFormat.HTML:
+                    # Collect filenames already referenced via cid:
+                    cid_refs = set(re.findall(r'cid:([^\s"\'>\)]+)', body))
+
+                    # Build a set of all attachment filenames so we can
+                    # warn about cid: refs that have no matching file
+                    _attach_names = {
+                        _a.name or f"file{_no:03}.dat"
+                        for _no, _a in enumerate(attach, start=1)
+                    }
+
+                    # Warn for every cid: ref in the body that has no
+                    # corresponding attachment -- the user likely made a
+                    # typo or forgot to include the file
+                    for _ref in sorted(cid_refs - _attach_names):
+                        logger.warning(
+                            "Email inline: no attachment matches "
+                            "cid:%s -- check the filename.",
+                            _ref,
+                        )
+
+                    # Append inline anchors for any image not yet listed
+                    img_appends = []
+                    for _no, _a in enumerate(attach, start=1):
+                        _fname = _a.name or f"file{_no:03}.dat"
+                        if (
+                            _a.mimetype.startswith("image/")
+                            and _fname not in cid_refs
+                        ):
+                            img_appends.append(_fname)
+                            cid_refs.add(_fname)
+
+                    if img_appends:
+                        # Encode spaces as %20 in cid: URIs so filenames
+                        # with spaces remain valid HTML attribute values
+                        body = body + "".join(
+                            '<br/><img src="cid:{}">'.format(
+                                n.replace(" ", "%20")
+                            )
+                            for n in img_appends
+                        )
+
+                else:
+                    # Plain text: annotate inline images with a short
+                    # text placeholder (images cannot be embedded here)
+                    txt_imgs = []
+                    for _no, _a in enumerate(attach, start=1):
+                        _fname = _a.name or f"file{_no:03}.dat"
+                        if _a.mimetype.startswith("image/"):
+                            txt_imgs.append(_fname)
+
+                    if txt_imgs:
+                        body = (
+                            body
+                            + "\n"
+                            + "\n".join(f"[Image: {n}]" for n in txt_imgs)
+                        )
+
             # Prepare Email Message
             if notify_format == NotifyFormat.HTML:
                 base = MIMEMultipart("alternative")
@@ -1269,12 +1372,16 @@ class NotifyEmail(NotifyBase):
                     )
                 )
                 base.attach(MIMEText(body, "html", "utf-8"))
+
             else:
                 base = MIMEText(body, "plain", "utf-8")
 
             if attach:
-                mixed = MIMEMultipart("mixed")
+                # Use multipart/related when any image will be embedded
+                # inline (RFC 2387); otherwise keep multipart/mixed
+                mixed = MIMEMultipart("related" if cid_refs else "mixed")
                 mixed.attach(base)
+
                 # Now store our attachments
                 for no, attachment in enumerate(attach, start=1):
                     if not attachment:
@@ -1305,13 +1412,34 @@ class NotifyEmail(NotifyBase):
                             else f"file{no:03}.dat"
                         )
 
-                        app.add_header(
-                            "Content-Disposition",
-                            'attachment; filename="{}"'.format(
-                                Header(filename, "utf-8")
-                            ),
-                        )
+                        if filename in cid_refs:
+                            # Filename is referenced by a cid: anchor in
+                            # the HTML body; embed it inline so clients
+                            # render it in-place rather than as a download
+                            app.add_header(
+                                "Content-Disposition",
+                                'inline; filename="{}"'.format(
+                                    Header(filename, "utf-8")
+                                ),
+                            )
+                            app.add_header(
+                                "Content-ID",
+                                # Encode spaces so the Content-ID matches
+                                # the cid: URI in the HTML anchor
+                                "<{}>".format(filename.replace(" ", "%20")),
+                            )
+
+                        else:
+                            # Non-image or plain-text-email attachment;
+                            # keep it as a regular downloadable file
+                            app.add_header(
+                                "Content-Disposition",
+                                'attachment; filename="{}"'.format(
+                                    Header(filename, "utf-8")
+                                ),
+                            )
                         mixed.attach(app)
+
                 base = mixed
 
             if pgp and pgp_mode == PGPMode.SIGN:

--- a/tests/test_plugin_email.py
+++ b/tests/test_plugin_email.py
@@ -4043,9 +4043,7 @@ def test_plugin_email_inline_attachments(mock_smtplib):
     assert "Content-ID" not in msg
     assert f"[Image: {img_name}]" in msg
 
-    # inline=True, TEXT format, non-image attachment: the mimetype
-    # check fails (application/pdf is not image/*) so txt_imgs stays empty
-    # and the body is not modified
+    # inline=True, TEXT format, non-image attachment
     sent_messages.clear()
     assert (
         obj_txt.notify(
@@ -4062,6 +4060,45 @@ def test_plugin_email_inline_attachments(mock_smtplib):
     # Non-image in text inline mode: body unchanged, no [Image:] annotation
     assert "Content-Disposition: attachment" in msg
     assert "[Image:" not in msg
+
+    # inline=True, HTML, image attachment with uppercase mimetype
+    upper_attach = AttachFile(img)
+    upper_attach.detected_mimetype = "Image/GIF"
+    aa_upper = AppriseAttachment()
+    aa_upper.add(upper_attach)
+
+    sent_messages.clear()
+    assert (
+        obj.notify(
+            body="<p>no cid</p>",
+            title="test",
+            notify_type=NotifyType.INFO,
+            attach=aa_upper,
+        )
+        is True
+    )
+    assert len(sent_messages) == 1
+    msg = sent_messages[0]
+
+    # Uppercase mimetype must still be treated as an image
+    assert "multipart/related" in msg
+    assert "Content-Disposition: inline" in msg
+
+    # inline=True, TEXT format, uppercase mimetype: [Image: name] marker must
+    # also appear, proving the case-insensitive check works in the text path
+    sent_messages.clear()
+    assert (
+        obj_txt.notify(
+            body="plain body",
+            title="test",
+            notify_type=NotifyType.INFO,
+            attach=aa_upper,
+        )
+        is True
+    )
+    assert len(sent_messages) == 1
+    msg = sent_messages[0]
+    assert f"[Image: {img_name}]" in msg
 
     # inline=True, HTML, cid: ref in body with no matching attachment:
     # warning is logged so the user can debug the mismatch
@@ -4081,6 +4118,121 @@ def test_plugin_email_inline_attachments(mock_smtplib):
             str(c) for c in mock_logger.warning.call_args_list
         )
         assert "missing-file.jpg" in warning_texts
+
+    # inline=True, HTML, only unmatched cid: ref with a non-image attachment:
+    # the unmatched ref is dropped after the warning so cid_refs is empty
+    # when the wrapper type is chosen -- wrapper must be multipart/mixed
+    sent_messages.clear()
+    with mock.patch("apprise.plugins.email.base.logger"):
+        assert (
+            obj.notify(
+                body='<p>body <img src="cid:ghost.jpg"></p>',
+                title="test",
+                notify_type=NotifyType.INFO,
+                # application/pdf -- not an image, not named ghost.jpg
+                attach=aa,
+            )
+            is True
+        )
+    assert len(sent_messages) == 1
+    msg = sent_messages[0]
+
+    # No inline parts exist: wrapper must be mixed, not related
+    assert "multipart/mixed" in msg
+    assert "multipart/related" not in msg
+    assert "Content-ID" not in msg
+
+    # inline=True, HTML, explicit cid: ref whose filename MATCHES a
+    # non-image attachment (PDF): a cid: URI can only resolve within
+    # the same MIME package, so if the caller wrote it they attached
+    # the file deliberately.  The ref is honored regardless of type --
+    # wrapper becomes multipart/related and the PDF is inlined.
+    sent_messages.clear()
+    with mock.patch("apprise.plugins.email.base.logger") as mock_logger:
+        assert (
+            obj.notify(
+                body=f'<p>body <embed src="cid:{pdf_attach.name}"></p>',
+                title="test",
+                notify_type=NotifyType.INFO,
+                # same PDF attachment as earlier tests
+                attach=aa,
+            )
+            is True
+        )
+    # The body ref matched by name, so no "no attachment matches" warning
+    for call in mock_logger.warning.call_args_list:
+        assert "apprise-test" not in str(call)
+    assert len(sent_messages) == 1
+    msg = sent_messages[0]
+
+    # Explicit cid: ref to PDF must be honored: related wrapper, inline
+    assert "multipart/related" in msg
+    assert "Content-Disposition: inline" in msg
+    assert "Content-ID" in msg
+
+    # inline=True, HTML, cid: ref encoded with %20 for a file whose actual
+    # name contains a space: the decoded ref matches the attachment so no
+    # spurious warning is fired and the image is inlined exactly once
+    spaced_attach = AttachFile(img, name="my photo.gif")
+    aa_spaced = AppriseAttachment()
+    aa_spaced.add(spaced_attach)
+
+    sent_messages.clear()
+    with mock.patch("apprise.plugins.email.base.logger") as mock_logger:
+        assert (
+            obj.notify(
+                body='<img src="cid:my%20photo.gif">',
+                title="test",
+                notify_type=NotifyType.INFO,
+                attach=aa_spaced,
+            )
+            is True
+        )
+
+    # No warning about an unmatched ref -- %20 decoded to space matched it
+    for call in mock_logger.warning.call_args_list:
+        assert "my" not in str(call), (
+            "Spurious warning fired for a cid: ref that should have "
+            "matched after %20 normalisation"
+        )
+    assert len(sent_messages) == 1
+    msg = sent_messages[0]
+
+    # Image is inlined exactly once (no duplicate anchor)
+    assert msg.count("cid:my%20photo.gif") == 1
+    assert "Content-Disposition: inline" in msg
+    assert "Content-ID" in msg
+
+    # inline=True, HTML, inaccessible attachment
+    bad_attach = AttachFile("/nonexistent/path/photo.jpg")
+    aa_bad = AppriseAttachment()
+    aa_bad.add(bad_attach)
+
+    sent_messages.clear()
+    assert (
+        obj.notify(
+            body="<p>body</p>",
+            title="test",
+            notify_type=NotifyType.INFO,
+            attach=aa_bad,
+        )
+        is False  # bad attachment detected by the main loop
+    )
+    # No sendmail call -- the bad attachment caused an early failure
+    assert len(sent_messages) == 0
+
+    # inline=True, TEXT format, inaccessible attachment
+    sent_messages.clear()
+    assert (
+        obj_txt.notify(
+            body="plain body",
+            title="test",
+            notify_type=NotifyType.INFO,
+            attach=aa_bad,
+        )
+        is False
+    )
+    assert len(sent_messages) == 0
 
     # URL round-trip: inline=yes survives url() -> parse_url()
     assert "inline=yes" in obj.url()

--- a/tests/test_plugin_email.py
+++ b/tests/test_plugin_email.py
@@ -3618,7 +3618,6 @@ def test_plugin_email_pgp_sign_keygen_auto(mock_smtp, mock_smtpssl, tmpdir):
     assert obj.notify("test body") is True
 
 
-@pytest.mark.skipif("pgpy" not in sys.modules, reason="Requires PGPy")
 def test_plugin_email_prepare():
     """NotifyEmail() prepare_emails static function."""
     with pytest.raises(AppriseException):
@@ -3887,7 +3886,7 @@ def test_plugin_email_inline_attachments(mock_smtplib):
     img2 = os.path.join(TEST_VAR_DIR, "apprise-test.png")
     img2_name = "apprise-test.png"
 
-    # --- inline=False (default): multipart/mixed, attachment ---
+    # inline=False (default): multipart/mixed, attachment
     obj = Apprise.instantiate(
         "mailto://user:pass@gmail.com", suppress_exceptions=False
     )
@@ -3918,9 +3917,9 @@ def test_plugin_email_inline_attachments(mock_smtplib):
     assert isinstance(obj, email.NotifyEmail)
     assert obj.inline is True
 
-    # --- inline=True, HTML, image with no pre-existing cid: ref:
+    # inline=True, HTML, image with no pre-existing cid: ref:
     # a <br/><img src="cid:name"> anchor is appended to the body and
-    # the attachment is embedded inline ---
+    # the attachment is embedded inline
     sent_messages.clear()
     assert (
         obj.notify(
@@ -3940,8 +3939,8 @@ def test_plugin_email_inline_attachments(mock_smtplib):
     assert "Content-ID:" in msg
     assert img_name in msg
 
-    # --- inline=True, HTML, image WITH pre-existing cid: ref:
-    # no duplicate anchor is added; attachment still inlined ---
+    # inline=True, HTML, image WITH pre-existing cid: ref:
+    # no duplicate anchor is added; attachment still inlined
     html_with_ref = f'<img src="cid:{img_name}">'
 
     sent_messages.clear()
@@ -3964,8 +3963,8 @@ def test_plugin_email_inline_attachments(mock_smtplib):
     # Only one cid: anchor expected in the body part
     assert msg.count(f"cid:{img_name}") == 1
 
-    # --- inline=True, HTML, two images: both inlined, body gets an
-    # anchor appended for the one not already referenced ---
+    # inline=True, HTML, two images: both inlined, body gets an
+    # anchor appended for the one not already referenced
     html_one_ref = f'<img src="cid:{img_name}">'
 
     sent_messages.clear()
@@ -3988,8 +3987,8 @@ def test_plugin_email_inline_attachments(mock_smtplib):
     assert img_name in msg
     assert img2_name in msg
 
-    # --- inline=True, HTML, non-image attachment: stays as regular
-    # download regardless of inline flag ---
+    # inline=True, HTML, non-image attachment: stays as regular
+    # download regardless of inline flag
     img_jpeg = os.path.join(TEST_VAR_DIR, "apprise-test.jpeg")
 
     from apprise.attachment.file import AttachFile
@@ -4016,8 +4015,8 @@ def test_plugin_email_inline_attachments(mock_smtplib):
     assert "Content-Disposition: attachment" in msg
     assert "Content-ID" not in msg
 
-    # --- inline=True, TEXT format: [Image: name] is appended to the
-    # text body; attachment stays as a regular download ---
+    # inline=True, TEXT format: [Image: name] is appended to the
+    # text body; attachment stays as a regular download
     obj_txt = Apprise.instantiate(
         "mailto://user:pass@gmail.com?inline=yes&format=text",
         suppress_exceptions=False,
@@ -4044,8 +4043,28 @@ def test_plugin_email_inline_attachments(mock_smtplib):
     assert "Content-ID" not in msg
     assert f"[Image: {img_name}]" in msg
 
-    # --- inline=True, HTML, cid: ref in body with no matching attachment:
-    # a warning is logged so the user can debug the mismatch ---
+    # inline=True, TEXT format, non-image attachment: the mimetype
+    # check fails (application/pdf is not image/*) so txt_imgs stays empty
+    # and the body is not modified
+    sent_messages.clear()
+    assert (
+        obj_txt.notify(
+            body="plain text body",
+            title="test",
+            notify_type=NotifyType.INFO,
+            attach=aa,  # application/pdf override -- not an image
+        )
+        is True
+    )
+    assert len(sent_messages) == 1
+    msg = sent_messages[0]
+
+    # Non-image in text inline mode: body unchanged, no [Image:] annotation
+    assert "Content-Disposition: attachment" in msg
+    assert "[Image:" not in msg
+
+    # inline=True, HTML, cid: ref in body with no matching attachment:
+    # warning is logged so the user can debug the mismatch
     with mock.patch("apprise.plugins.email.base.logger") as mock_logger:
         assert (
             obj.notify(
@@ -4063,13 +4082,13 @@ def test_plugin_email_inline_attachments(mock_smtplib):
         )
         assert "missing-file.jpg" in warning_texts
 
-    # --- URL round-trip: inline=yes survives url() -> parse_url() ---
+    # URL round-trip: inline=yes survives url() -> parse_url()
     assert "inline=yes" in obj.url()
     parsed = email.NotifyEmail.parse_url(obj.url())
     assert parsed is not None
     assert parsed.get("inline") is True
 
-    # --- inline=no parses as False ---
+    # inline=no parses as False
     obj2 = Apprise.instantiate(
         "mailto://user:pass@gmail.com?inline=no", suppress_exceptions=False
     )

--- a/tests/test_plugin_email.py
+++ b/tests/test_plugin_email.py
@@ -3855,3 +3855,224 @@ def test_plugin_email_starttls_certificate_failure_handling(mock_smtp):
     assert obj.notify(body="body", title="title") is False
     response.login.assert_not_called()
     response.sendmail.assert_not_called()
+
+
+@mock.patch("smtplib.SMTP")
+def test_plugin_email_inline_attachments(mock_smtplib):
+    """Test ?inline=yes RFC 2387 inline attachment handling."""
+
+    # Capture raw email bodies sent via SMTP
+    sent_messages = []
+
+    class SMTPMock:
+        def __init__(self, *a, **kw):
+            pass
+
+        def sendmail(self, from_addr, to_addrs, message):
+            sent_messages.append(message)
+
+        def quit(self, *a, **kw):
+            pass
+
+        def starttls(self, *a, **kw):
+            pass
+
+        def login(self, *a, **kw):
+            pass
+
+    mock_smtplib.return_value = SMTPMock()
+
+    img = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
+    img_name = "apprise-test.gif"
+    img2 = os.path.join(TEST_VAR_DIR, "apprise-test.png")
+    img2_name = "apprise-test.png"
+
+    # --- inline=False (default): multipart/mixed, attachment ---
+    obj = Apprise.instantiate(
+        "mailto://user:pass@gmail.com", suppress_exceptions=False
+    )
+    assert isinstance(obj, email.NotifyEmail)
+    assert obj.inline is False
+
+    sent_messages.clear()
+    assert (
+        obj.notify(
+            body="<p>hello</p>",
+            title="test",
+            notify_type=NotifyType.INFO,
+            attach=img,
+        )
+        is True
+    )
+    assert len(sent_messages) == 1
+    msg = sent_messages[0]
+
+    # Standard mode: mixed wrapper, attachment disposition, no Content-ID
+    assert "multipart/mixed" in msg
+    assert "Content-Disposition: attachment" in msg
+    assert "Content-ID" not in msg
+
+    obj = Apprise.instantiate(
+        "mailto://user:pass@gmail.com?inline=yes", suppress_exceptions=False
+    )
+    assert isinstance(obj, email.NotifyEmail)
+    assert obj.inline is True
+
+    # --- inline=True, HTML, image with no pre-existing cid: ref:
+    # a <br/><img src="cid:name"> anchor is appended to the body and
+    # the attachment is embedded inline ---
+    sent_messages.clear()
+    assert (
+        obj.notify(
+            body="<p>no cid ref here</p>",
+            title="test",
+            notify_type=NotifyType.INFO,
+            attach=img,
+        )
+        is True
+    )
+    assert len(sent_messages) == 1
+    msg = sent_messages[0]
+
+    # Image inlined regardless -- anchor appended automatically
+    assert "multipart/related" in msg
+    assert "Content-Disposition: inline" in msg
+    assert "Content-ID:" in msg
+    assert img_name in msg
+
+    # --- inline=True, HTML, image WITH pre-existing cid: ref:
+    # no duplicate anchor is added; attachment still inlined ---
+    html_with_ref = f'<img src="cid:{img_name}">'
+
+    sent_messages.clear()
+    assert (
+        obj.notify(
+            body=html_with_ref,
+            title="test",
+            notify_type=NotifyType.INFO,
+            attach=img,
+        )
+        is True
+    )
+    assert len(sent_messages) == 1
+    msg = sent_messages[0]
+
+    # Still related + inline; body should not have a second <br/><img>
+    assert "multipart/related" in msg
+    assert "Content-Disposition: inline" in msg
+    assert "Content-ID:" in msg
+    # Only one cid: anchor expected in the body part
+    assert msg.count(f"cid:{img_name}") == 1
+
+    # --- inline=True, HTML, two images: both inlined, body gets an
+    # anchor appended for the one not already referenced ---
+    html_one_ref = f'<img src="cid:{img_name}">'
+
+    sent_messages.clear()
+    assert (
+        obj.notify(
+            body=html_one_ref,
+            title="test",
+            notify_type=NotifyType.INFO,
+            attach=AppriseAttachment([img, img2]),
+        )
+        is True
+    )
+    assert len(sent_messages) == 1
+    msg = sent_messages[0]
+
+    # Both images are inline; second one had its anchor appended
+    assert "multipart/related" in msg
+    assert msg.count("Content-Disposition: inline") == 2
+    assert msg.count("Content-ID:") == 2
+    assert img_name in msg
+    assert img2_name in msg
+
+    # --- inline=True, HTML, non-image attachment: stays as regular
+    # download regardless of inline flag ---
+    img_jpeg = os.path.join(TEST_VAR_DIR, "apprise-test.jpeg")
+
+    from apprise.attachment.file import AttachFile
+
+    pdf_attach = AttachFile(img_jpeg, mimetype="application/pdf")
+    aa = AppriseAttachment()
+    aa.add(pdf_attach)
+
+    sent_messages.clear()
+    assert (
+        obj.notify(
+            body="<p>body</p>",
+            title="test",
+            notify_type=NotifyType.INFO,
+            attach=aa,
+        )
+        is True
+    )
+    assert len(sent_messages) == 1
+    msg = sent_messages[0]
+
+    # No image -> no related wrapper, no inline, no Content-ID
+    assert "multipart/mixed" in msg
+    assert "Content-Disposition: attachment" in msg
+    assert "Content-ID" not in msg
+
+    # --- inline=True, TEXT format: [Image: name] is appended to the
+    # text body; attachment stays as a regular download ---
+    obj_txt = Apprise.instantiate(
+        "mailto://user:pass@gmail.com?inline=yes&format=text",
+        suppress_exceptions=False,
+    )
+    assert isinstance(obj_txt, email.NotifyEmail)
+    assert obj_txt.inline is True
+
+    sent_messages.clear()
+    assert (
+        obj_txt.notify(
+            body="plain text body",
+            title="test",
+            notify_type=NotifyType.INFO,
+            attach=img,
+        )
+        is True
+    )
+    assert len(sent_messages) == 1
+    msg = sent_messages[0]
+
+    # Text mode: mixed wrapper, attachment disposition, placeholder in body
+    assert "multipart/mixed" in msg
+    assert "Content-Disposition: attachment" in msg
+    assert "Content-ID" not in msg
+    assert f"[Image: {img_name}]" in msg
+
+    # --- inline=True, HTML, cid: ref in body with no matching attachment:
+    # a warning is logged so the user can debug the mismatch ---
+    with mock.patch("apprise.plugins.email.base.logger") as mock_logger:
+        assert (
+            obj.notify(
+                body='<img src="cid:missing-file.jpg">',
+                title="test",
+                notify_type=NotifyType.INFO,
+                attach=img,
+            )
+            is True
+        )
+
+        # Warning fired for the unmatched ref
+        warning_texts = " ".join(
+            str(c) for c in mock_logger.warning.call_args_list
+        )
+        assert "missing-file.jpg" in warning_texts
+
+    # --- URL round-trip: inline=yes survives url() -> parse_url() ---
+    assert "inline=yes" in obj.url()
+    parsed = email.NotifyEmail.parse_url(obj.url())
+    assert parsed is not None
+    assert parsed.get("inline") is True
+
+    # --- inline=no parses as False ---
+    obj2 = Apprise.instantiate(
+        "mailto://user:pass@gmail.com?inline=no", suppress_exceptions=False
+    )
+    assert isinstance(obj2, email.NotifyEmail)
+    assert obj2.inline is False
+    assert "inline" not in obj2.url()


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1329

This adds RFC 2387 inline attachment support to the Email plugin via an opt-in `?inline=yes` URL parameter. Default behaviour (all attachments as regular downloads) is completely unchanged.

When `?inline=yes` is set on an email URL:

- **HTML emails**: Apprise scans the body for existing `cid:filename` references, then automatically appends `<br/><img src="cid:filename">` for any image attachment not yet referenced. The MIME wrapper switches from `multipart/mixed` to `multipart/related` and inlined attachments receive `Content-Disposition: inline` + `Content-ID` headers.
- **Plain-text emails**: images cannot be embedded; a `[Image: filename]` placeholder is appended to the body instead. Attachments are still sent as downloads.
- **Non-image attachments**: always remain `Content-Disposition: attachment` regardless of the flag.
- **Unmatched `cid:` refs**" a `logger.warning` is emitted for any `cid:filename` in the body that has no corresponding attachment, to help users debug typos or missing files.

Initial credit goes to @MarcosLenharo for his initial request and work on #1329. This extends upon it per our discussion.

## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/100](https://github.com/caronc/apprise-docs/pull/100)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing

Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1329-rfc2387-inline-images

# Send an HTML email with an image embedded inline
apprise -vv -t "Test Title" -b "<h1>Hello</h1><p>See the image below.</p>" \
    "mailto://user:pass@gmail.com?inline=yes" \
    --attach /path/to/image.png
```
