### PR TITLE
Support MS Teams user mentions

### DIFF
--- a/apprise/plugins/workflows.py
+++ b/apprise/plugins/workflows.py
@@ -79,6 +79,18 @@ class APIVersion:
     POWER_AUTOMATE = "2022-03-01-preview"
 
 
+# Match Teams ``<at>...</at>`` mentions in the message body.
+# Adaptive Cards require a matching entity for each resolved mention.
+#
+# ``[^<]+`` keeps matching linear and stops before a nested opening tag.
+# This allows a valid inner mention to survive a malformed outer wrapper,
+# such as ``<at><at>user</at>`` or ``<at>text<at>user</at>``.
+#
+# Detection runs only for generated Teams Adaptive Cards. Template-based
+# Power Automate flows bypass this payload path.
+WORKFLOWS_MENTION_RE = re.compile(r"<at>([^<]+)</at>", re.I)
+
+
 class NotifyWorkflows(NotifyBase):
     """A wrapper for Microsoft Workflows (MS Teams) Notifications."""
 
@@ -345,6 +357,30 @@ class NotifyWorkflows(NotifyBase):
             # By default we use a generic working payload if there was
             # no template specified
             schema = "http://adaptivecards.io/schemas/adaptive-card.json"
+
+            # Collect the explicit entities required to resolve Teams mentions.
+            # Dict insertion order preserves the first occurrence of each ID.
+            seen = {}
+            for m in WORKFLOWS_MENTION_RE.finditer(body):
+                # Normalize the ID and skip empty or duplicate mentions.
+                key = m.group(1).strip()
+                if not key or key in seen:
+                    continue
+
+                seen[key] = {
+                    "type": "mention",
+                    "text": f"<at>{key}</at>",
+                    "mentioned": {
+                        "id": key,
+                        "name": key,
+                    },
+                }
+
+            # Build the Teams metadata and include entities only when present.
+            msteams = {"width": "full"}
+            if seen:
+                msteams["entities"] = list(seen.values())
+
             payload = {
                 "type": "message",
                 "attachments": [
@@ -359,7 +395,7 @@ class NotifyWorkflows(NotifyBase):
                             "version": self.adaptive_card_version,
                             "body": body_content,
                             # Additionally
-                            "msteams": {"width": "full"},
+                            "msteams": msteams,
                         },
                     }
                 ],

--- a/apprise/plugins/workflows.py
+++ b/apprise/plugins/workflows.py
@@ -369,7 +369,9 @@ class NotifyWorkflows(NotifyBase):
 
                 seen[key] = {
                     "type": "mention",
-                    "text": f"<at>{key}</at>",
+                    # Preserve the original tag because Teams matches mention
+                    # text verbatim, including its casing and whitespace.
+                    "text": m.group(0),
                     "mentioned": {
                         "id": key,
                         "name": key,
@@ -377,9 +379,14 @@ class NotifyWorkflows(NotifyBase):
                 }
 
             # Build the Teams metadata and include entities only when present.
-            msteams = {"width": "full"}
-            if seen:
-                msteams["entities"] = list(seen.values())
+            msteams = (
+                {
+                    "width": "full",
+                    "entities": list(seen.values()),
+                }
+                if seen
+                else {"width": "full"}
+            )
 
             payload = {
                 "type": "message",
@@ -432,12 +439,8 @@ class NotifyWorkflows(NotifyBase):
         # Enforce Application mode
         tokens["app_mode"] = TemplateType.JSON
 
-        # Coerce all substitution values to str before JSON-escaping.
-        # apply_template's _escape_json() calls json.dumps(v)[1:-1] which
-        # is only correct for strings; None produces "ul" and other non-
-        # string types produce similarly corrupted output.  app_mode is a
-        # TemplateType sentinel passed as a named parameter, not a
-        # substitution value, so it is left as-is.
+        # JSON escaping expects string substitutions; map None to empty text.
+        # Preserve app_mode because it controls the template escaping mode.
         safe_tokens = {
             k: (
                 v

--- a/tests/test_plugin_workflows.py
+++ b/tests/test_plugin_workflows.py
@@ -904,3 +904,117 @@ def test_plugin_workflows_html_to_markdown_format(mock_post):
     body_blocks = payload["attachments"][0]["content"]["body"]
     body_text = next(b["text"] for b in body_blocks if b.get("id") == "body")
     assert body_text == "**hello** *world*"
+
+
+@mock.patch("requests.post")
+def test_plugin_workflows_mention_entities(mock_post):
+    """Teams mention tags populate unique ``msteams.entities`` entries."""
+
+    # Prepare a successful mocked HTTP response.
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    aobj = Apprise()
+    assert aobj.add("workflow://hostname/workflow1/signature1/?image=no")
+
+    # Keep Teams metadata minimal when the body contains no mentions.
+    assert aobj.notify(body="Hello world", title="T") is True
+    payload = json.loads(mock_post.call_args_list[0][1]["data"])
+    msteams = payload["attachments"][0]["content"]["msteams"]
+    assert msteams == {"width": "full"}
+    mock_post.reset_mock()
+
+    # Add one entity for a single mention.
+    assert (
+        aobj.notify(
+            body="Hello <at>foo@example.com</at>!",
+            title="T",
+        )
+        is True
+    )
+    payload = json.loads(mock_post.call_args_list[0][1]["data"])
+    msteams = payload["attachments"][0]["content"]["msteams"]
+    assert msteams == {
+        "width": "full",
+        "entities": [
+            {
+                "type": "mention",
+                "text": "<at>foo@example.com</at>",
+                "mentioned": {
+                    "id": "foo@example.com",
+                    "name": "foo@example.com",
+                },
+            }
+        ],
+    }
+    mock_post.reset_mock()
+
+    # Preserve source order for distinct mentions.
+    assert (
+        aobj.notify(
+            body=(
+                "Hi <at>alice@example.com</at> and <at>bob@example.com</at>!"
+            ),
+            title="T",
+        )
+        is True
+    )
+    payload = json.loads(mock_post.call_args_list[0][1]["data"])
+    entities = payload["attachments"][0]["content"]["msteams"]["entities"]
+    assert len(entities) == 2
+    assert entities[0]["mentioned"]["id"] == "alice@example.com"
+    assert entities[1]["mentioned"]["id"] == "bob@example.com"
+    mock_post.reset_mock()
+
+    # Deduplicate repeated mention IDs.
+    assert (
+        aobj.notify(
+            body=(
+                "<at>dup@example.com</at> and <at>dup@example.com</at> again"
+            ),
+            title="T",
+        )
+        is True
+    )
+    payload = json.loads(mock_post.call_args_list[0][1]["data"])
+    entities = payload["attachments"][0]["content"]["msteams"]["entities"]
+    assert len(entities) == 1
+    assert entities[0]["mentioned"]["id"] == "dup@example.com"
+    mock_post.reset_mock()
+
+    # Recover the valid inner tag from a nested opening sequence.
+    assert (
+        aobj.notify(
+            body="Hi <at><at>user@example.com</at>!",
+            title="T",
+        )
+        is True
+    )
+    payload = json.loads(mock_post.call_args_list[0][1]["data"])
+    entities = payload["attachments"][0]["content"]["msteams"]["entities"]
+    assert len(entities) == 1
+    assert entities[0]["mentioned"]["id"] == "user@example.com"
+    mock_post.reset_mock()
+
+    # Recover an inner mention when text invalidates the outer tag.
+    assert (
+        aobj.notify(
+            body="<at>garbage<at>inner@example.com</at>",
+            title="T",
+        )
+        is True
+    )
+    payload = json.loads(mock_post.call_args_list[0][1]["data"])
+    entities = payload["attachments"][0]["content"]["msteams"]["entities"]
+    assert len(entities) == 1
+    assert entities[0]["mentioned"]["id"] == "inner@example.com"
+    mock_post.reset_mock()
+
+    # Ignore empty, whitespace-only, and unclosed mention tags.
+    for bad_body in ("<at></at>", "<at>   </at>", "<at>unclosed"):
+        assert aobj.notify(body=bad_body, title="T") is True
+        payload = json.loads(mock_post.call_args_list[-1][1]["data"])
+        msteams = payload["attachments"][0]["content"]["msteams"]
+        assert msteams == {"width": "full"}, (
+            f"expected no entities for {bad_body!r}"
+        )

--- a/tests/test_plugin_workflows.py
+++ b/tests/test_plugin_workflows.py
@@ -1018,3 +1018,32 @@ def test_plugin_workflows_mention_entities(mock_post):
         assert msteams == {"width": "full"}, (
             f"expected no entities for {bad_body!r}"
         )
+
+    mock_post.reset_mock()
+
+    # Preserve mixed-case entity text for Teams' verbatim body match.
+    assert (
+        aobj.notify(
+            body="Hi <AT>user@example.com</AT>!",
+            title="T",
+        )
+        is True
+    )
+    payload = json.loads(mock_post.call_args_list[0][1]["data"])
+    entity = payload["attachments"][0]["content"]["msteams"]["entities"][0]
+    assert entity["text"] == "<AT>user@example.com</AT>"
+    assert entity["mentioned"]["id"] == "user@example.com"
+    mock_post.reset_mock()
+
+    # Preserve tag padding while trimming the ID used for user resolution.
+    assert (
+        aobj.notify(
+            body="Hi <at>  padded@example.com  </at>!",
+            title="T",
+        )
+        is True
+    )
+    payload = json.loads(mock_post.call_args_list[0][1]["data"])
+    entity = payload["attachments"][0]["content"]["msteams"]["entities"][0]
+    assert entity["text"] == "<at>  padded@example.com  </at>"
+    assert entity["mentioned"]["id"] == "padded@example.com"


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1326


Auto-detects `<at>...</at>` tags in the message body and ensures the user identified there is mentioned.

An example would be: `<at>foo@example.com</at>`

## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/101](https://github.com/caronc/apprise-docs/pull/101)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1326-msteams-workflow-mentions

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Mention Test" \
    -b "Hello <at>someone@example.com</at>!" \
    "workflow://credentials"
```
