### PR TITLE
Preserve x/y coordinate of 0 in dbus/glib url() (round-trip crash on x=0)

### DIFF
--- a/apprise/plugins/dbus.py
+++ b/apprise/plugins/dbus.py
@@ -407,11 +407,14 @@ class NotifyDBus(NotifyBase):
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
 
         # x in (x,y) screen coordinates
-        if self.x_axis:
+        # Use an explicit None check so a valid coordinate of 0 (a screen
+        # edge) is preserved; this mirrors the send() payload which guards
+        # on `is None` rather than truthiness.
+        if self.x_axis is not None:
             params["x"] = str(self.x_axis)
 
         # y in (x,y) screen coordinates
-        if self.y_axis:
+        if self.y_axis is not None:
             params["y"] = str(self.y_axis)
 
         return f"{self.schema}://_/?{NotifyDBus.urlencode(params)}"

--- a/apprise/plugins/glib.py
+++ b/apprise/plugins/glib.py
@@ -365,11 +365,14 @@ class NotifyGLib(NotifyBase):
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
 
         # x in (x,y) screen coordinates
-        if self.x_axis:
+        # Use an explicit None check so a valid coordinate of 0 (a screen
+        # edge) is preserved; this mirrors the send() payload which guards
+        # on `is None` rather than truthiness.
+        if self.x_axis is not None:
             params["x"] = str(self.x_axis)
 
         # y in (x,y) screen coordinates
-        if self.y_axis:
+        if self.y_axis is not None:
             params["y"] = str(self.y_axis)
 
         schema = self.protocol[0]

--- a/tests/test_plugin_dbus.py
+++ b/tests/test_plugin_dbus.py
@@ -313,6 +313,45 @@ def test_plugin_dbus_url_parsing(mock_dbus_module):
         NotifyDBus(x_axis="invalid")
 
 
+def test_plugin_dbus_zero_coordinate_round_trip(mock_dbus_module):
+    """
+    Coordinate 0 is a valid screen edge (send() emits it via an `is None`
+    guard); url() must preserve it so the configuration survives a
+    save/reload cycle instead of being silently dropped.
+    """
+    reload_plugin("dbus")
+    from apprise.plugins.dbus import NotifyDBus
+
+    obj = apprise.Apprise.instantiate(
+        "dbus://_/?x=0&y=0", suppress_exceptions=False
+    )
+    assert isinstance(obj, NotifyDBus)
+    assert obj.x_axis == 0
+    assert obj.y_axis == 0
+
+    url = obj.url()
+    assert "x=0" in url
+    assert "y=0" in url
+
+    # The rendered URL must round-trip back to an identical object rather
+    # than dropping x=0 (which previously also raised a TypeError on reload
+    # whenever the surviving axis kept the guard truthy).
+    reloaded = apprise.Apprise.instantiate(url, suppress_exceptions=False)
+    assert isinstance(reloaded, NotifyDBus)
+    assert reloaded.x_axis == 0
+    assert reloaded.y_axis == 0
+
+    # A single zero axis must also survive without dropping the other value.
+    obj = apprise.Apprise.instantiate(
+        "dbus://_/?x=0&y=5", suppress_exceptions=False
+    )
+    reloaded = apprise.Apprise.instantiate(
+        obj.url(), suppress_exceptions=False
+    )
+    assert reloaded.x_axis == 0
+    assert reloaded.y_axis == 5
+
+
 def test_plugin_dbus_schema_not_supported(mock_dbus_module, mocker):
     """
     Dbus test for unsupported schema warning

--- a/tests/test_plugin_glib.py
+++ b/tests/test_plugin_glib.py
@@ -130,6 +130,42 @@ def test_plugin_glib_url_includes_coordinates(enabled_glib_environment):
     assert "y=9" in url
 
 
+def test_plugin_glib_zero_coordinate_round_trip(enabled_glib_environment):
+    """
+    Coordinate 0 is a valid screen edge (send() emits it via an `is None`
+    guard); url() must preserve it so the configuration survives a
+    save/reload cycle instead of being silently dropped.
+    """
+    obj = apprise.Apprise.instantiate(
+        "glib://_/?x=0&y=0", suppress_exceptions=False
+    )
+    assert isinstance(obj, NotifyGLib)
+    assert obj.x_axis == 0
+    assert obj.y_axis == 0
+
+    url = obj.url()
+    assert "x=0" in url
+    assert "y=0" in url
+
+    # The rendered URL must round-trip back to an identical object rather
+    # than dropping x=0 (which previously also raised a TypeError on reload
+    # whenever the surviving axis kept the guard truthy).
+    reloaded = apprise.Apprise.instantiate(url, suppress_exceptions=False)
+    assert isinstance(reloaded, NotifyGLib)
+    assert reloaded.x_axis == 0
+    assert reloaded.y_axis == 0
+
+    # A single zero axis must also survive without dropping the other value.
+    obj = apprise.Apprise.instantiate(
+        "glib://_/?x=0&y=5", suppress_exceptions=False
+    )
+    reloaded = apprise.Apprise.instantiate(
+        obj.url(), suppress_exceptions=False
+    )
+    assert reloaded.x_axis == 0
+    assert reloaded.y_axis == 5
+
+
 def test_plugin_glib_icon_fails_gracefully(mocker, enabled_glib_environment):
     """Simulate image load failure"""
     import gi


### PR DESCRIPTION
The DBus and GLib plugins drop a valid screen coordinate of `0` when serializing back to a URL, which breaks the `url()` → parse round-trip — and for a partial-zero coordinate it crashes on reload.

```python
from apprise import Apprise
a = Apprise()
a.add("dbus://_/?x=0&y=5")
url = a[0].url()          # -> "dbus://_/?...&y=5"   (x=0 dropped)
Apprise().add(url)        # TypeError: The x,y coordinates specified (None, 5) are invalid.
```

`x=0&y=0` is instead silently lost (re-parses to `(None, None)`).

**Cause.** `NotifyDBus.url()` / `NotifyGLib.url()` guard the coordinates with truthiness:

```python
if self.x_axis:
    params["x"] = str(self.x_axis)
```

But `0` is an explicitly valid coordinate — the template declares `"x": {"type": "int", "min": 0}`, `__init__` accepts and stores it, and the `send()` payload guards the very same attributes with `is None` (not truthiness), emitting `x=0` correctly. Only `url()` disagreed, so a screen-edge coordinate cannot survive a save/reload.

**Fix.** Guard with `is not None` in both plugins, matching `send()`. `x`/`y` of `0` now round-trip.

**Tests.** `test_plugin_dbus_zero_coordinate_round_trip` and the GLib equivalent instantiate `x=0&y=0` and `x=0&y=5`, assert `url()` contains `x=0`/`y=0`, and assert a full re-instantiation preserves both axes without raising. `test_plugin_dbus.py` + `test_plugin_glib.py`: 29 passed, 1 skipped.