### PR TITLE
v2 - breaking change: complete refactoring of notify() to return NotifyResult()

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,13 @@
 name: Run Tests
 
 on:
-  # Run tests on push to main, master, or any release/ branch
+  # master             - v1.x branch
+  # apprise-v2-release - v2.x branch
   push:
-    branches: [main, master, 'release/**']
-  # Always test on pull requests targeting main/master
+    # Always test on pull requests targeting main/master
+    branches: [main, master, 'release/**', apprise-v2-release]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, apprise-v2-release]
   # Allow manual triggering via GitHub UI
   workflow_dispatch:
 

--- a/apprise/__init__.py
+++ b/apprise/__init__.py
@@ -65,12 +65,18 @@ from .config.base import ConfigBase
 from .locale import AppriseLocale
 
 # Inherit our logging with our additional entries added to it
-from .logger import LOGGER_NAME, LogCapture, logger, logging
+from .logger import LOGGER_NAME, LogCapture, NotifyLogEntry, logger, logging
 from .manager_attachment import AttachmentManager
 from .manager_config import ConfigurationManager
 from .manager_plugins import NotificationManager
 from .persistent_store import PersistentStore
 from .plugins.base import NotifyBase
+from .result import (
+    AppriseResult,
+    AppriseResultStatus,
+    NotifyAttempt,
+    NotifyResult,
+)
 from .tag import AppriseTag
 from .url import PrivacyMode, URLBase
 
@@ -94,6 +100,8 @@ __all__ = [
     "AppriseAttachment",
     "AppriseConfig",
     "AppriseLocale",
+    "AppriseResult",
+    "AppriseResultStatus",
     "AppriseTag",
     "AttachBase",
     "AttachmentManager",
@@ -105,9 +113,12 @@ __all__ = [
     "LogCapture",
     # Managers
     "NotificationManager",
+    "NotifyAttempt",
     "NotifyBase",
     "NotifyFormat",
     "NotifyImageSize",
+    "NotifyLogEntry",
+    "NotifyResult",
     # Reference
     "NotifyType",
     "OverflowMode",

--- a/apprise/apprise.py
+++ b/apprise/apprise.py
@@ -32,22 +32,30 @@ from collections.abc import Iterator
 import concurrent.futures as cf
 from itertools import chain
 import json
+import math
 import os
+import threading
 import time
-from typing import Any, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 from . import __version__, common, plugins
 from .apprise_attachment import AppriseAttachment
 from .apprise_config import AppriseConfig
 from .asset import AppriseAsset
-from .common import ContentLocation
+from .common import JSON_COMPACT_SEPARATORS, ContentLocation
 from .config.base import ConfigBase
 from .conversion import convert_between
 from .emojis import apply_emojis
 from .locale import AppriseLocale
-from .logger import logger
+from .logger import NotifyLogEntry, _ServiceLogCapture, logger
 from .manager_plugins import NotificationManager
 from .plugins.base import NotifyBase
+from .result import (
+    AppriseResult,
+    AppriseResultStatus,
+    NotifyAttempt,
+    NotifyResult,
+)
 from .tag import AppriseTag
 from .utils.cwe312 import cwe312_url
 from .utils.json import AppriseJSONEncoder
@@ -56,6 +64,235 @@ from .utils.parse import parse_list, parse_urls
 
 # Grant access to our Notification Manager Singleton
 N_MGR = NotificationManager()
+
+# One (server, notify()-kwargs) pair as produced by _create_notify_gen()
+# and threaded through every dispatch primitive below.
+ServerCall = tuple[NotifyBase, dict[str, Any]]
+
+# Extra seconds of patience for notify() calls.
+_ABANDON_GRACE_SECONDS = 0.1
+
+# Shared thread pool for _notify_parallel_threadpool(). One pool for the
+# whole process -- a fresh one per call would leak a thread every time a
+# service hangs.
+_shared_executor: Optional[cf.ThreadPoolExecutor] = None
+_shared_executor_lock = threading.Lock()
+
+
+def _get_shared_executor() -> cf.ThreadPoolExecutor:
+    """Return the shared thread pool, creating it on first use."""
+    global _shared_executor
+    if _shared_executor is None:
+        with _shared_executor_lock:
+            if _shared_executor is None:
+                _shared_executor = cf.ThreadPoolExecutor()
+    return _shared_executor
+
+
+# Services abandoned on timeout that are still genuinely running. Lets
+# cli.py poll instead of just sleeping out its whole grace window.
+_abandoned_futures: list[tuple[cf.Future, str, str]] = []
+_abandoned_futures_lock = threading.Lock()
+
+
+def _track_abandoned_future(future: cf.Future, name: str, url: str) -> None:
+    """Record one abandoned-but-still-running service call."""
+    with _abandoned_futures_lock:
+        _abandoned_futures[:] = [
+            entry for entry in _abandoned_futures if not entry[0].done()
+        ]
+        _abandoned_futures.append((future, name, url))
+
+
+def _any_abandoned_calls_still_running() -> bool:
+    """True if any abandoned service call is still actually running."""
+    with _abandoned_futures_lock:
+        _abandoned_futures[:] = [
+            entry for entry in _abandoned_futures if not entry[0].done()
+        ]
+        return bool(_abandoned_futures)
+
+
+def _abandoned_call_descriptions() -> list[str]:
+    """Return "name (url)" for each still-running abandoned call."""
+    with _abandoned_futures_lock:
+        _abandoned_futures[:] = [
+            entry for entry in _abandoned_futures if not entry[0].done()
+        ]
+        return [f"{name} ({url})" for _, name, url in _abandoned_futures]
+
+
+def _service_metadata(
+    server: NotifyBase,
+) -> tuple[str, str, Optional[str], tuple[str, ...], int]:
+    """Safely gather one service's identifying metadata.
+
+    Plugin metadata helpers can raise. This helper keeps result-building
+    defensive and returns (name, url, url_id, tag, weight).
+    """
+    name = getattr(server, "service_name", "Unknown")
+
+    try:
+        url = server.url(privacy=True)
+
+    except Exception:
+        url = "unknown://"
+
+    try:
+        url_id = server.url_id()
+
+    except Exception:
+        url_id = None
+
+    try:
+        weight = len(server)
+
+    except Exception:
+        weight = 1
+
+    # tags is a set -- sort so output order is stable.
+    tag = tuple(sorted(str(t) for t in getattr(server, "tags", ())))
+
+    return name, url, url_id, tag, weight
+
+
+def _safe_error_result(server: NotifyBase) -> NotifyResult:
+    """Build a best-effort result when a plugin fails outside dispatch."""
+    name, url, url_id, tag, weight = _service_metadata(server)
+
+    return NotifyResult(
+        name=name,
+        url=url,
+        url_id=url_id,
+        tag=tag,
+        optional=getattr(server, "optional", False),
+        weight=weight,
+        max_attempts=1,
+        # No real attempt data exists here, so keep one synthetic failure.
+        # NotifyResult still applies the service's optional flag.
+        attempts=[NotifyAttempt(status=AppriseResultStatus.FAILURE)],
+    )
+
+
+def _compute_deadline(
+    server: NotifyBase, call_deadline: Optional[float]
+) -> Optional[float]:
+    """Return the monotonic deadline for one service dispatch.
+
+    The earlier of these independent limits wins:
+
+      - The service's own AppriseAsset._service_timeout (default 60s,
+        where 0 disables the limit).
+      - *call_deadline*, the shared notify(timeout=...) ceiling for the
+        entire call.
+
+    The service budget begins when dispatch starts, so time spent waiting
+    for a worker does not consume it. ``None`` means the service is unbounded.
+    """
+    service_timeout = getattr(
+        server.asset,
+        "_service_timeout",
+        AppriseAsset._service_timeout,
+    )
+    deadline = time.monotonic() + service_timeout if service_timeout else None
+    if call_deadline is not None:
+        deadline = (
+            call_deadline if deadline is None else min(deadline, call_deadline)
+        )
+
+    # TRACE keeps large batches from spamming normal DEBUG output.
+    logger.trace(
+        "Deadline for '%s': %s",
+        getattr(server, "service_name", "Unknown"),
+        "none"
+        if deadline is None
+        else "{:.3f}s from now".format(deadline - time.monotonic()),
+    )
+    return deadline
+
+
+def _timeout_result(server: NotifyBase, elapsed: float) -> NotifyResult:
+    """Build the result for a service that exceeded the outer wait.
+
+    The worker may still be running. Record only what Apprise knows here:
+    it stopped waiting, and optional handling still belongs to NotifyResult.
+    """
+    name, url, url_id, tag, weight = _service_metadata(server)
+
+    return NotifyResult(
+        name=name,
+        url=url,
+        url_id=url_id,
+        tag=tag,
+        optional=getattr(server, "optional", False),
+        weight=weight,
+        max_attempts=1,
+        attempts=[
+            NotifyAttempt(
+                status=AppriseResultStatus.TIMEOUT,
+                elapsed=elapsed,
+                logs=[_timeout_log_entry(name, elapsed)],
+            )
+        ],
+    )
+
+
+def _timeout_log_entry(name: str, elapsed: float) -> NotifyLogEntry:
+    """Log and return the error entry describing a service timeout.
+
+    All timeout paths use this helper so every TIMEOUT attempt carries the
+    same useful diagnostic instead of only a status value.
+    """
+    message = f"Service '{name}' did not finish within {elapsed:.3f}s."
+    logger.error(message)
+    return NotifyLogEntry(level="ERROR", message=message)
+
+
+def _validate_timeout(value: Union[int, float]) -> float:
+    """Validate a timeout value shared by notify()/async_notify()."""
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise TypeError("timeout must be an int or float.")
+
+    # inf/nan rejected: use 0 to mean "unbounded" instead.
+    if not math.isfinite(value) or value < 0:
+        raise ValueError("timeout must be >= 0 and finite.")
+
+    return float(value)
+
+
+def _aggregate_status(
+    ok: bool, results: list[NotifyResult]
+) -> AppriseResultStatus:
+    """Roll a batch's per-service results up into one overall status.
+
+    All succeeded -> SUCCESS. Some genuinely delivered, some didn't ->
+    PARTIAL. Nothing delivered -> FAILURE beats TIMEOUT.
+    """
+    if ok:
+        return AppriseResultStatus.SUCCESS
+
+    # Real success only -- ignores optional=yes services being forgiven.
+    if any(
+        attempt.status == AppriseResultStatus.SUCCESS
+        for result in results
+        for attempt in result.attempts
+    ):
+        return AppriseResultStatus.PARTIAL
+
+    if any(r.status == AppriseResultStatus.FAILURE for r in results):
+        return AppriseResultStatus.FAILURE
+
+    if any(r.status == AppriseResultStatus.TIMEOUT for r in results):
+        return AppriseResultStatus.TIMEOUT
+
+    return AppriseResultStatus.FAILURE
+
+
+def _attempt_status(success: bool) -> AppriseResultStatus:
+    """Map one attempt's plain success/failure into the shared enum."""
+    return (
+        AppriseResultStatus.SUCCESS if success else AppriseResultStatus.FAILURE
+    )
 
 
 class Apprise:
@@ -76,6 +313,9 @@ class Apprise:
         asset: Optional[AppriseAsset] = None,
         location: Optional[ContentLocation] = None,
         debug: bool = False,
+        log_callback: Optional[
+            Callable[[NotifyLogEntry, NotifyBase], Any]
+        ] = None,
     ) -> None:
         """Loads a set of server urls while applying the Asset() module to each
         if specified.
@@ -84,6 +324,9 @@ class Apprise:
 
         Optionally specify a global ContentLocation for a more strict means of
         handling Attachments.
+
+        log_callback, when given, fires on every warning/error a service
+        logs. Applies to every notify() call unless overridden per-call.
         """
 
         # Initialize a server list of URLs
@@ -111,6 +354,10 @@ class Apprise:
         # of Attachments.  Setting this to None removes any attachment
         # restrictions.
         self.location = location
+
+        # Default log_callback for every notify()/async_notify() call made
+        # with this instance, unless overridden per-call.
+        self._log_callback = log_callback
 
     @staticmethod
     def instantiate(
@@ -411,6 +658,7 @@ class Apprise:
                     ft = AppriseTag.parse(tok)
                     if ft.retry is not None:
                         return ft.retry
+
             else:
                 ft = AppriseTag.parse(str(entry))
                 if ft.retry is not None:
@@ -429,6 +677,7 @@ class Apprise:
         """
         if tag is None or tag == common.MATCH_ALL_TAG:
             return False
+
         for entry in (
             [tag] if isinstance(tag, (str, AppriseTag)) else list(tag)
         ):
@@ -477,14 +726,17 @@ class Apprise:
                 if isinstance(entry, (list, tuple, set))
                 else parse_list(str(entry))
             )
+
             for tok in tokens:
                 ft = AppriseTag.parse(tok)
                 if ft.retry is None:
                     continue
+
                 tag_name = str(ft)
                 if not ft.has_priority:
                     if tag_name in server.tags:
                         return ft.retry
+
                 else:
                     for stag in server.tags:
                         if isinstance(stag, AppriseTag):
@@ -515,6 +767,17 @@ class Apprise:
                 kwargs = dict(kwargs, _retry_override=retry)
             result.append((server, kwargs))
         return result
+
+    @staticmethod
+    def _inject_log_callback(all_calls, log_callback):
+        """Inject _log_callback into every call's kwargs. No-op if
+        log_callback is None."""
+        if log_callback is None:
+            return all_calls
+        return [
+            (service, dict(kwargs, _log_callback=log_callback))
+            for service, kwargs in all_calls
+        ]
 
     @staticmethod
     def _build_tag_chains(all_calls, tag):
@@ -556,8 +819,10 @@ class Apprise:
                 if len(flat) == 1:
                     # single OR token wrapped in a list (CLI convention)
                     or_tag_names.append(str(AppriseTag.parse(flat[0])))
+
                 else:
                     or_tag_names.append("")  # AND group placeholder
+
             else:
                 for tok in parse_list(str(entry)):
                     or_tag_names.append(str(AppriseTag.parse(tok)))
@@ -613,6 +878,87 @@ class Apprise:
         ]
         return min(priorities) if priorities else 0
 
+    @staticmethod
+    def _split_and_dispatch(
+        batch: list[ServerCall], call_deadline: Optional[float] = None
+    ) -> tuple[bool, list[NotifyResult]]:
+        """Dispatch sequential and parallel subsets of ``batch``.
+
+        Results keep the caller's original order. ``call_deadline`` is passed
+        through to the dispatch helpers.
+        """
+        # Tag each entry with its position in *batch* before splitting so
+        # the two dispatched subsets can be recombined in original order.
+        indexed = list(enumerate(batch))
+        sequential = [
+            (i, s, k) for i, (s, k) in indexed if not s.asset.async_mode
+        ]
+        parallel = [(i, s, k) for i, (s, k) in indexed if s.asset.async_mode]
+
+        seq_ok, seq_results = (
+            Apprise._notify_sequential(
+                *[(s, k) for _, s, k in sequential],
+                call_deadline=call_deadline,
+            )
+            if sequential
+            else (True, [])
+        )
+        par_ok, par_results = (
+            Apprise._notify_parallel_threadpool(
+                *[(s, k) for _, s, k in parallel], call_deadline=call_deadline
+            )
+            if parallel
+            else (True, [])
+        )
+
+        # Recombine by original index so the returned list matches the
+        # order entries appeared in *batch*, regardless of which subset
+        # (sequential/parallel) each one was dispatched through.
+        indexed_results = list(zip((i for i, _, _ in sequential), seq_results))
+        indexed_results += list(zip((i for i, _, _ in parallel), par_results))
+        indexed_results.sort(key=lambda entry: entry[0])
+
+        return seq_ok and par_ok, [r for _, r in indexed_results]
+
+    @staticmethod
+    async def _split_and_dispatch_async(
+        batch: list[ServerCall], call_deadline: Optional[float] = None
+    ) -> tuple[bool, list[NotifyResult]]:
+        """Dispatch sequential and asynchronous subsets of ``batch``.
+
+        Blocking entries still use _notify_sequential(); async entries use
+        _notify_parallel_asyncio(). Results keep the original order.
+        """
+        # Preserve each entry's original position before dividing the work.
+        indexed = list(enumerate(batch))
+        sequential = [
+            (i, s, k) for i, (s, k) in indexed if not s.asset.async_mode
+        ]
+        parallel = [(i, s, k) for i, (s, k) in indexed if s.asset.async_mode]
+
+        seq_ok, seq_results = (
+            Apprise._notify_sequential(
+                *[(s, k) for _, s, k in sequential],
+                call_deadline=call_deadline,
+            )
+            if sequential
+            else (True, [])
+        )
+        par_ok, par_results = (
+            await Apprise._notify_parallel_asyncio(
+                *[(s, k) for _, s, k in parallel], call_deadline=call_deadline
+            )
+            if parallel
+            else (True, [])
+        )
+
+        # Merge both result streams back into the caller's batch order.
+        indexed_results = list(zip((i for i, _, _ in sequential), seq_results))
+        indexed_results += list(zip((i for i, _, _ in parallel), par_results))
+        indexed_results.sort(key=lambda entry: entry[0])
+
+        return seq_ok and par_ok, [r for _, r in indexed_results]
+
     def notify(
         self,
         body: Union[str, bytes],
@@ -623,7 +969,11 @@ class Apprise:
         match_always: bool = True,
         attach: Any = None,
         interpret_escapes: Optional[bool] = None,
-    ) -> Optional[bool]:
+        timeout: Union[int, float] = 0,
+        log_callback: Optional[
+            Callable[[NotifyLogEntry, NotifyBase], Any]
+        ] = None,
+    ) -> AppriseResult:
         """Send a notification to all the plugins previously loaded.
 
         If the body_format specified is NotifyFormat.MARKDOWN, it will be
@@ -634,10 +984,15 @@ class Apprise:
         are notified.  By default, all added services are notified
         (tag=MATCH_ALL_TAG)
 
-        This function returns True if all notifications were successfully sent,
-        False if even just one of them fails, and None if no notifications were
-        sent at all as a result of tag filtering and/or simply having empty
-        configuration files that were read.
+        This function always returns an AppriseResult. bool(result) preserves
+        the previous True/False behavior. result.status distinguishes success,
+        failure (including invalid arguments), no match, and timeout (see
+        timeout= below). Iterate the result to inspect each service actually
+        dispatched:
+
+            result = apobj.notify(body="hello")
+            for service_result in result:
+                print(service_result.name, bool(service_result))
 
         A filter tag may carry an optional priority prefix and/or retry suffix:
 
@@ -649,7 +1004,7 @@ class Apprise:
         When no priority prefix is given, matched services are grouped by
         their configured tag priority and dispatched in ascending order
         (lowest number = highest urgency).  If every service in the lowest
-        priority group succeeds, Apprise returns True immediately without
+        priority group succeeds, Apprise returns success immediately without
         running higher-numbered priority groups (escalation chain).
 
         When an explicit priority prefix IS given (e.g. "3:endpoint"), only
@@ -662,7 +1017,38 @@ class Apprise:
 
         Set interpret_escapes to True if you want to pre-escape a string such
         as turning a \n into an actual new line, etc.
+
+        timeout, when given (as a non-zero int or float), is a ceiling in
+        seconds on how long this entire notify() call is allowed to run.
+        Any service not finished by then is reported with
+        AppriseResultStatus.TIMEOUT instead of being waited on further.
+        Each service is independently also bounded by its own
+        AppriseAsset._service_timeout (default 60s, set via
+        AppriseAsset(service_timeout=...); 0 disables it) -- whichever of
+        the two limits is sooner applies to a given service.  timeout
+        defaults to 0 (no call-level override at all), deliberately
+        leaving AppriseAsset._service_timeout as the only thing that
+        controls the default behaviour; negative values raise ValueError,
+        non-numeric values raise TypeError, exactly like
+        AppriseAsset(service_timeout=...) itself.
+
+        log_callback overrides the instance default for this call only.
         """
+        timeout = _validate_timeout(timeout)
+        effective_log_callback = (
+            log_callback if log_callback is not None else self._log_callback
+        )
+
+        # Wall-clock start for AppriseResult.elapsed -- covers the entire
+        # call, including argument validation, not just service dispatch.
+        start = time.monotonic()
+
+        # An absolute time.monotonic() ceiling for the whole call, or None
+        # when no override was given (each service still has its own
+        # AppriseAsset._service_timeout budget -- see _compute_deadline()).
+        call_deadline: Optional[float] = (
+            time.monotonic() + timeout if timeout else None
+        )
 
         try:
             all_calls = list(
@@ -679,34 +1065,42 @@ class Apprise:
             )
 
         except TypeError:
-            return False
+            # Invalid notify() arguments -- no service was ever attempted.
+            return AppriseResult(
+                status=AppriseResultStatus.FAILURE,
+                results=[],
+                elapsed=time.monotonic() - start,
+            )
 
         if not all_calls:
-            return None
+            # Tag filter matched nothing, or no servers are loaded at all.
+            return AppriseResult(
+                status=AppriseResultStatus.NOMATCH,
+                results=[],
+                elapsed=time.monotonic() - start,
+            )
 
         # Inject the per-service call-time retry override.  Each matched
         # service gets the retry from the first filter token that both matches
         # it and carries a retry suffix (e.g. "devops:3" applies retry=3 only
         # to devops-tagged services, not to management-tagged services).
         all_calls = Apprise._inject_per_service_retries(all_calls, tag)
+        all_calls = Apprise._inject_log_callback(
+            all_calls, effective_log_callback
+        )
 
         if Apprise._filter_has_explicit_priority(tag):
             # Tag filter carries an explicit priority prefix (e.g. "2:alerts").
             # Skip the escalation chain: dispatch all matched services as a
             # single flat batch regardless of their individual tag priorities.
-            sequential = [
-                (s, k) for s, k in all_calls if not s.asset.async_mode
-            ]
-            parallel = [(s, k) for s, k in all_calls if s.asset.async_mode]
-            seq_ok = (
-                Apprise._notify_sequential(*sequential) if sequential else True
+            ok, results = Apprise._split_and_dispatch(
+                all_calls, call_deadline=call_deadline
             )
-            par_ok = (
-                Apprise._notify_parallel_threadpool(*parallel)
-                if parallel
-                else True
+            return AppriseResult(
+                status=_aggregate_status(ok, results),
+                results=results,
+                elapsed=time.monotonic() - start,
             )
-            return seq_ok and par_ok
 
         # No explicit priority in the filter -- use per-tag escalation chains.
         #
@@ -714,21 +1108,13 @@ class Apprise:
         # services are grouped by their configured tag priority.  The lowest-
         # numbered group (highest urgency) runs first.  If every service in
         # that group succeeds the chain is done; any failure escalates to the
-        # next priority group.  notify() returns True only when every chain
-        # finds a fully-successful group.
+        # next priority group.  notify() only reports overall success when
+        # every chain finds a fully-successful group.
         #
         # When multiple chains are active in the same round their current
         # priority-group batches run concurrently via a thread pool so that
         # one chain's services cannot delay another chain.
         chains = Apprise._build_tag_chains(all_calls, tag)
-
-        def _run_batch(batch):
-            """Dispatch one priority-group batch; True = all services ok."""
-            seq = [(s, k) for s, k in batch if not s.asset.async_mode]
-            par = [(s, k) for s, k in batch if s.asset.async_mode]
-            seq_ok = Apprise._notify_sequential(*seq) if seq else True
-            par_ok = Apprise._notify_parallel_threadpool(*par) if par else True
-            return seq_ok and par_ok
 
         # Per-chain state: priorities (sorted), groups dict, current index,
         # and a flag marking whether a successful group has been found.
@@ -742,6 +1128,10 @@ class Apprise:
             for key, groups in chains.items()
         }
 
+        # Every NotifyResult actually dispatched across every chain and
+        # every priority-group attempt, in the order each batch was run.
+        all_results = []
+
         while True:
             # When abort_on_chain_failure is enabled, stop as soon as any
             # chain has exhausted all its priority groups without success.
@@ -751,7 +1141,11 @@ class Apprise:
                 not st["succeeded"] and st["idx"] >= len(st["priorities"])
                 for st in chain_states.values()
             ):
-                return False
+                return AppriseResult(
+                    status=_aggregate_status(False, all_results),
+                    results=all_results,
+                    elapsed=time.monotonic() - start,
+                )
 
             # Collect chains that still need to try their next priority group.
             active = [
@@ -764,74 +1158,143 @@ class Apprise:
 
             if len(active) == 1:
                 # Single active chain: dispatch directly, no thread overhead.
-                _, st = active[0]
-                batch = st["groups"][st["priorities"][st["idx"]]]
-                if _run_batch(batch):
+                key, st = active[0]
+                priority = st["priorities"][st["idx"]]
+                batch = st["groups"][priority]
+                ok, batch_results = Apprise._split_and_dispatch(
+                    batch, call_deadline=call_deadline
+                )
+                all_results.extend(batch_results)
+                if ok:
+                    logger.trace(
+                        "Chain '%s' priority group %s succeeded.",
+                        key,
+                        priority,
+                    )
                     st["succeeded"] = True
                 else:
+                    logger.trace(
+                        "Chain '%s' priority group %s failed; escalating.",
+                        key,
+                        priority,
+                    )
                     st["idx"] += 1  # escalate to next priority
             else:
                 # Multiple active chains: run their current-priority batches
                 # concurrently so independent chains don't block each other.
+                # Per-service deadlines are enforced inside
+                # _split_and_dispatch.
                 with cf.ThreadPoolExecutor() as executor:
                     future_map = {
                         executor.submit(
-                            _run_batch,
+                            Apprise._split_and_dispatch,
                             st["groups"][st["priorities"][st["idx"]]],
+                            call_deadline,
                         ): (key, st)
                         for key, st in active
                     }
-                    for future in cf.as_completed(future_map):
-                        _, st = future_map[future]
+                    # Collect in submission order so results are stable even
+                    # when chains finish in a different order.
+                    for future, (key, st) in future_map.items():
                         try:
-                            ok = future.result()
-                        except Exception:
-                            logger.exception(
-                                "Unhandled Notification Exception"
+                            ok, batch_results = future.result()
+                        except Exception as e:
+                            logger.warning(
+                                "Notification chain '%s' priority group %s "
+                                "raised an exception.",
+                                key,
+                                st["priorities"][st["idx"]],
                             )
-                            ok = False
+                            logger.debug("Notification Exception: %s", str(e))
+                            ok, batch_results = False, []
+                        all_results.extend(batch_results)
                         if ok:
+                            logger.trace(
+                                "Chain '%s' priority group %s succeeded.",
+                                key,
+                                st["priorities"][st["idx"]],
+                            )
                             st["succeeded"] = True
                         else:
+                            logger.trace(
+                                "Chain '%s' priority group %s failed; "
+                                "escalating.",
+                                key,
+                                st["priorities"][st["idx"]],
+                            )
                             st["idx"] += 1  # escalate to next priority
 
-        return all(st["succeeded"] for st in chain_states.values())
+        success = all(st["succeeded"] for st in chain_states.values())
+        return AppriseResult(
+            status=_aggregate_status(success, all_results),
+            results=all_results,
+            elapsed=time.monotonic() - start,
+        )
 
-    async def async_notify(self, *args: Any, **kwargs: Any) -> Optional[bool]:
+    async def async_notify(self, *args: Any, **kwargs: Any) -> AppriseResult:
         """Send a notification to all the plugins previously loaded, for
         asynchronous callers.
 
-        The arguments are identical to those of Apprise.notify().
+        The arguments and return value are identical to those of
+        Apprise.notify() -- see its docstring for the full AppriseResult
+        contract, including the timeout= and log_callback= parameters.
         """
         tag = kwargs.get("tag", common.MATCH_ALL_TAG)
+
+        # Pop both -- neither is a _create_notify_gen() parameter.
+        timeout: Union[int, float] = _validate_timeout(
+            kwargs.pop("timeout", 0)
+        )
+        log_callback: Optional[Callable[[NotifyLogEntry, NotifyBase], Any]] = (
+            kwargs.pop("log_callback", None)
+        )
+        effective_log_callback = (
+            log_callback if log_callback is not None else self._log_callback
+        )
+
+        # Wall-clock start for AppriseResult.elapsed -- see notify().
+        start = time.monotonic()
+
+        # See notify() for what this is.
+        call_deadline: Optional[float] = (
+            time.monotonic() + timeout if timeout else None
+        )
 
         try:
             all_calls = list(self._create_notify_gen(*args, **kwargs))
 
         except TypeError:
-            return False
+            # Invalid notify() arguments -- no service was ever attempted.
+            return AppriseResult(
+                status=AppriseResultStatus.FAILURE,
+                results=[],
+                elapsed=time.monotonic() - start,
+            )
 
         if not all_calls:
-            return None
+            # Tag filter matched nothing, or no servers are loaded at all.
+            return AppriseResult(
+                status=AppriseResultStatus.NOMATCH,
+                results=[],
+                elapsed=time.monotonic() - start,
+            )
 
         # Inject per-service call-time retry overrides (same logic as notify).
         all_calls = Apprise._inject_per_service_retries(all_calls, tag)
+        all_calls = Apprise._inject_log_callback(
+            all_calls, effective_log_callback
+        )
 
         if Apprise._filter_has_explicit_priority(tag):
             # Explicit priority prefix: flat dispatch, no escalation.
-            sequential = [
-                (s, k) for s, k in all_calls if not s.asset.async_mode
-            ]
-            parallel = [(s, k) for s, k in all_calls if s.asset.async_mode]
-            seq_ok = (
-                Apprise._notify_sequential(*sequential) if sequential else True
+            ok, results = await Apprise._split_and_dispatch_async(
+                all_calls, call_deadline=call_deadline
             )
-            par_ok = (
-                await Apprise._notify_parallel_asyncio(*parallel)
-                if parallel
-                else True
+            return AppriseResult(
+                status=_aggregate_status(ok, results),
+                results=results,
+                elapsed=time.monotonic() - start,
             )
-            return seq_ok and par_ok
 
         # Per-tag independent escalation chains -- same semantics as notify().
         #
@@ -841,18 +1304,6 @@ class Apprise:
         # simultaneously.  Only chains whose current batch failed advance to
         # the next priority group (escalation).
         chains = Apprise._build_tag_chains(all_calls, tag)
-
-        async def _run_batch_async(batch):
-            """Dispatch one priority-group batch; True = all services ok."""
-            seq = [(s, k) for s, k in batch if not s.asset.async_mode]
-            par = [(s, k) for s, k in batch if s.asset.async_mode]
-            # Sequential items (async_mode=False) run blocking in the caller;
-            # async items are gathered concurrently.
-            seq_ok = Apprise._notify_sequential(*seq) if seq else True
-            par_ok = (
-                await Apprise._notify_parallel_asyncio(*par) if par else True
-            )
-            return seq_ok and par_ok
 
         chain_states = {
             key: {
@@ -864,13 +1315,21 @@ class Apprise:
             for key, groups in chains.items()
         }
 
+        # Every NotifyResult actually dispatched across every chain and
+        # every priority-group attempt, in the order each batch was run.
+        all_results = []
+
         while True:
             # Same abort_on_chain_failure guard as notify().
             if self.asset.abort_on_chain_failure and any(
                 not st["succeeded"] and st["idx"] >= len(st["priorities"])
                 for st in chain_states.values()
             ):
-                return False
+                return AppriseResult(
+                    status=_aggregate_status(False, all_results),
+                    results=all_results,
+                    elapsed=time.monotonic() - start,
+                )
 
             active = [
                 (key, st)
@@ -885,25 +1344,52 @@ class Apprise:
             # different chains can pipeline their I/O simultaneously.
             # return_exceptions=True prevents one failing batch from cancelling
             # the others; exceptions are treated as delivery failures below.
-            results = await asyncio.gather(
+            gathered = await asyncio.gather(
                 *(
-                    _run_batch_async(st["groups"][st["priorities"][st["idx"]]])
+                    Apprise._split_and_dispatch_async(
+                        st["groups"][st["priorities"][st["idx"]]],
+                        call_deadline=call_deadline,
+                    )
                     for _, st in active
                 ),
                 return_exceptions=True,
             )
 
-            for (_, st), ok in zip(active, results):
-                if isinstance(ok, Exception):
+            for (key, st), item in zip(active, gathered):
+                if isinstance(item, Exception):
                     # Escaped exception -- safety net; treat as failure.
-                    logger.exception("Unhandled Notification Exception")
+                    logger.warning(
+                        "Notification chain '%s' priority group %s raised "
+                        "an exception.",
+                        key,
+                        st["priorities"][st["idx"]],
+                    )
+                    logger.debug("Notification Exception: %s", str(item))
                     st["idx"] += 1
-                elif ok:
-                    st["succeeded"] = True
                 else:
-                    st["idx"] += 1  # escalate to next priority group
+                    ok, batch_results = item
+                    all_results.extend(batch_results)
+                    if ok:
+                        logger.trace(
+                            "Chain '%s' priority group %s succeeded.",
+                            key,
+                            st["priorities"][st["idx"]],
+                        )
+                        st["succeeded"] = True
+                    else:
+                        logger.trace(
+                            "Chain '%s' priority group %s failed; escalating.",
+                            key,
+                            st["priorities"][st["idx"]],
+                        )
+                        st["idx"] += 1  # escalate to next priority group
 
-        return all(st["succeeded"] for st in chain_states.values())
+        success = all(st["succeeded"] for st in chain_states.values())
+        return AppriseResult(
+            status=_aggregate_status(success, all_results),
+            results=all_results,
+            elapsed=time.monotonic() - start,
+        )
 
     def _create_notify_calls(self, *args, **kwargs):
         """Creates notifications for all the plugins loaded.
@@ -939,10 +1425,10 @@ class Apprise:
         """Internal generator function for _create_notify_calls()."""
 
         if len(self) == 0:
-            # Nothing to notify
-            msg = "There are no service(s) to notify"
-            logger.error(msg)
-            raise TypeError(msg)
+            # Nothing loaded -- same as an empty tag match: NOMATCH, not
+            # FAILURE.
+            logger.warning("There are no service(s) to notify")
+            return
 
         if not (title or body or attach):
             msg = "No message content specified to deliver"
@@ -1085,321 +1571,667 @@ class Apprise:
             yield (server, kwargs)
 
     @staticmethod
-    def _notify_sequential(*servers_kwargs):
+    def _notify_sequential(
+        *services_kwargs: ServerCall, call_deadline: Optional[float] = None
+    ) -> tuple[bool, list[NotifyResult]]:
         """Process a list of notify() calls sequentially and synchronously.
 
-        Each server is attempted once and then retried up to server.retry
-        additional times on failure before moving on.  When server.wait is
-        greater than zero, the process sleeps that many seconds between
-        each retry attempt.
-
-        A per-call retry override may be injected into kwargs under the key
-        ``_retry_override``; when present it takes precedence over the
-        server's own retry attribute for this invocation only.
-
-        Exceptions raised by a plugin's notify() -- including those from
-        third-party @notify-decorated functions that are outside our control
-        -- are caught here and treated as a delivery failure.  The retry
-        logic still applies, so a plugin that raises on the first attempt
-        will be retried the configured number of times before giving up.
+        Retries, wait times, per-call retry overrides, and deadlines are all
+        handled here. A blocking in-flight call cannot be preempted.
         """
 
         success = True
+        results: list[NotifyResult] = []
 
-        for server, kwargs in servers_kwargs:
-            # Pop the per-call override before forwarding kwargs to the
-            # plugin so it never sees the internal _retry_override key.
-            retry = kwargs.pop("_retry_override", getattr(server, "retry", 0))
-            wait = getattr(server, "wait", 0.0)
+        for service, kwargs in services_kwargs:
+            # Pop the per-call overrides before forwarding kwargs to the
+            # plugin so it never sees these internal keys.
+            retry = kwargs.pop("_retry_override", getattr(service, "retry", 0))
+            wait = getattr(service, "wait", 0.0)
+            log_callback = kwargs.pop("_log_callback", None)
 
-            result = False
+            # The deadline is computed fresh right as this service's own
+            # dispatch begins, per-service, not from when notify() was
+            # first called.
+            deadline = _compute_deadline(service, call_deadline)
+            attempts: list[NotifyAttempt] = []
             for attempt in range(retry + 1):
-                # Attempt delivery.  TypeError comes from Apprise's own
-                # validation; bare Exception guards against buggy or
-                # third-party plugins (including @notify decorators) that
-                # may raise unexpectedly.  Both are treated as failure so
-                # the retry loop can continue.
-                try:
-                    result = server.notify(**kwargs)
-                except TypeError:
-                    result = False
-                except Exception:
-                    logger.exception("Unhandled Notification Exception")
-                    result = False
+                if deadline is not None and time.monotonic() >= deadline:
+                    # Out of time -- do not start another attempt.  Record
+                    # a zero-elapsed TIMEOUT attempt marking the decision
+                    # to stop, with its own diagnostic log entry, rather
+                    # than silently dropping it.
+                    logger.trace(
+                        "Deadline already passed for '%s'; skipping "
+                        "attempt %d/%d.",
+                        service.service_name,
+                        attempt + 1,
+                        retry + 1,
+                    )
+                    attempts.append(
+                        NotifyAttempt(
+                            status=AppriseResultStatus.TIMEOUT,
+                            logs=[
+                                _timeout_log_entry(service.service_name, 0.0)
+                            ],
+                        )
+                    )
+                    break
+
+                # monotonic() avoids wall-clock jumps while timing an attempt.
+                attempt_start = time.monotonic()
+                logger.trace(
+                    "Starting attempt %d/%d for '%s'.",
+                    attempt + 1,
+                    retry + 1,
+                    service.service_name,
+                )
+                # Isolate this attempt's log output so it can be
+                # attributed to exactly this call in the NotifyAttempt
+                # built below (see _ServiceLogCapture).
+                with _ServiceLogCapture(
+                    service, log_callback=log_callback
+                ) as capture:
+                    # Treat validation and plugin exceptions as failed
+                    # attempts.
+                    try:
+                        result = service.notify(**kwargs)
+                    except TypeError:
+                        result = False
+                    except Exception as e:
+                        logger.warning(
+                            "Notification service '%s' raised an exception.",
+                            service.service_name,
+                        )
+                        logger.debug("Notification Exception: %s", str(e))
+                        result = False
+
+                attempt_elapsed = time.monotonic() - attempt_start
+                logger.trace(
+                    "Attempt %d/%d for '%s' finished in %.3fs: %s.",
+                    attempt + 1,
+                    retry + 1,
+                    service.service_name,
+                    attempt_elapsed,
+                    "success" if result else "failure",
+                )
+                attempts.append(
+                    NotifyAttempt(
+                        status=_attempt_status(result),
+                        elapsed=attempt_elapsed,
+                        logs=capture.entries,
+                    )
+                )
 
                 if result:
-                    # Delivered successfully; no need to retry this server.
+                    # Delivered successfully; no need to retry this service.
                     break
 
                 if attempt < retry:
                     # Delivery failed and retries remain.  Log the attempt
                     # number and pause before the next try.
                     logger.warning(
-                        "Retry %d/%d for %s",
+                        "Attempt %d/%d for '%s' failed; trying again.",
                         attempt + 1,
                         retry,
-                        server.service_name,
+                        service.service_name,
                     )
                     if wait > 0:
-                        time.sleep(wait)
+                        # Never sleep past the deadline -- the top-of-loop
+                        # check above will report the timeout on the next
+                        # iteration once we wake up.
+                        sleep_for = wait
+                        if deadline is not None:
+                            sleep_for = min(
+                                wait, max(0.0, deadline - time.monotonic())
+                            )
+                        if sleep_for > 0:
+                            time.sleep(sleep_for)
 
-            # Optional-service check.
+            # Optional-service check after all retries have completed.
+            # NotifyResult reflects optional failures/timeouts as SUCCESS;
+            # this log only records that the underlying delivery failed.
             #
-            # At this point all retry attempts for 'server' have been
-            # exhausted (the for-loop above has finished).  If the final
-            # result is still False *and* the service is marked optional,
-            # we overwrite result to True before folding it into the
-            # running 'success' accumulator.  This silently absorbs the
-            # failure: the caller will not see it as a delivery error.
-            #
-            # Interaction with retries:
-            #   The retry loop above has already run.  optional= does not
-            #   short-circuit or bypass retries -- it only changes the
-            #   interpretation of the *final* result once all attempts
-            #   are done.  A service with retry=3 and optional=True will
-            #   still be attempted four times before the failure is
-            #   absorbed here.
-            if not result and getattr(server, "optional", False):
+            # Optional services still use every retry; only the final status
+            # is interpreted differently.
+            optional = getattr(service, "optional", False)
+            succeeded = any(
+                a.status == AppriseResultStatus.SUCCESS for a in attempts
+            )
+            if not succeeded and optional:
                 logger.info(
-                    "Optional service '%s' failed; ignoring failure.",
-                    server.service_name,
+                    "Optional service '%s' did not send successfully; "
+                    "continuing.",
+                    service.service_name,
                 )
-                result = True
 
-            # Fold this service's result into the running batch outcome.
-            # Boolean AND is used so that a single False from any required
-            # (non-optional) service permanently taints 'success' for the
-            # whole batch -- even if later services succeed.  Optional
-            # failures are already re-mapped to True above, so they never
-            # contribute a False here.
-            success = success and result
+            # Gathered defensively -- see _service_metadata() -- so a
+            # plugin whose url()/url_id()/__len__ raises can never crash
+            # this call or discard a delivery that already succeeded.
+            name, url, url_id, tag, weight = _service_metadata(service)
+            notify_result = NotifyResult(
+                name=name,
+                url=url,
+                url_id=url_id,
+                tag=tag,
+                optional=optional,
+                weight=weight,
+                max_attempts=retry + 1,
+                attempts=attempts,
+            )
+            results.append(notify_result)
 
-        return success
+            # One required failure means the whole batch cannot succeed.
+            # Optional failures already count as SUCCESS in NotifyResult.
+            success = success and bool(notify_result)
+
+        return success, results
 
     @staticmethod
-    def _notify_parallel_threadpool(*servers_kwargs):
+    def _notify_parallel_threadpool(
+        *services_kwargs: ServerCall, call_deadline: Optional[float] = None
+    ) -> tuple[bool, list[NotifyResult]]:
         """Process a list of notify() calls in parallel via a thread pool.
 
-        Each server runs in its own thread.  Within each thread, the server
-        is retried up to server.retry additional times on failure with an
-        optional server.wait second sleep between each attempt.
-
-        Falls back to _notify_sequential() when only a single server is
-        given to avoid the overhead of spawning a thread pool for one call.
-
-        Exceptions from a plugin's notify() -- including those from
-        third-party @notify-decorated functions -- are caught inside each
-        thread and treated as delivery failures so the retry logic can
-        still run.
+        Each worker handles retries and deadlines for one service. Timed-out
+        workers may keep running, but Apprise stops waiting.
         """
 
-        n_calls = len(servers_kwargs)
+        n_calls = len(services_kwargs)
 
         if n_calls == 0:
-            return True
+            return True, []
 
-        # Avoid thread-pool overhead for a single notification.
         if n_calls == 1:
-            return Apprise._notify_sequential(servers_kwargs[0])
+            service, _ = services_kwargs[0]
+            # Only take the no-thread-pool shortcut when this service has
+            # no deadline whatsoever -- there is nothing to abandon, so a
+            # plain blocking call is strictly cheaper and behaves
+            # identically. Otherwise fall through to the thread-pool path
+            # below so the deadline can actually be enforced.
+            if _compute_deadline(service, call_deadline) is None:
+                return Apprise._notify_sequential(
+                    services_kwargs[0], call_deadline=call_deadline
+                )
 
         logger.info(
-            "Notifying %d service(s) with threads.", len(servers_kwargs)
+            "Notifying %d service(s) with threads.", len(services_kwargs)
         )
 
-        def _call_with_retry(server, kwargs):
-            """Execute one server's notify() with retry/wait logic.
+        def _call_with_retry(
+            service: NotifyBase, kwargs: dict[str, Any]
+        ) -> tuple[bool, NotifyResult]:
+            """Execute one service's notify() with retry/wait logic.
 
             Runs inside a worker thread.  Pops ``_retry_override`` from
             kwargs so it is never forwarded to the plugin's notify() call.
             Exceptions are caught and treated as failures so the retry
             loop continues even when a plugin raises unexpectedly.
-            """
-            # Pop the per-call override so it stays internal.
-            retry = kwargs.pop("_retry_override", getattr(server, "retry", 0))
-            wait = getattr(server, "wait", 0.0)
 
-            result = False
+            Returns (bool, NotifyResult) -- the bool is this service's
+            contribution to the batch's aggregate success value (mirrors
+            the NotifyResult's own reflective status, already adjusted
+            for optional=); the NotifyResult also carries every raw,
+            unadjusted NotifyAttempt for the caller's AppriseResult.
+            """
+            # Pop the per-call overrides so they stay internal.
+            retry = kwargs.pop("_retry_override", getattr(service, "retry", 0))
+            wait = getattr(service, "wait", 0.0)
+            log_callback = kwargs.pop("_log_callback", None)
+
+            # The deadline is computed here, right as this worker actually
+            # begins running -- not at submission time -- so time spent
+            # queued behind other work in the pool never counts against
+            # this service's own budget.
+            deadline = _compute_deadline(service, call_deadline)
+            attempts: list[NotifyAttempt] = []
             for attempt in range(retry + 1):
+                if deadline is not None and time.monotonic() >= deadline:
+                    # Out of time -- record a zero-elapsed TIMEOUT attempt
+                    # marking the decision to stop, and do not start
+                    # another one.
+                    logger.trace(
+                        "Deadline already passed for '%s'; skipping "
+                        "attempt %d/%d.",
+                        service.service_name,
+                        attempt + 1,
+                        retry + 1,
+                    )
+                    attempts.append(
+                        NotifyAttempt(
+                            status=AppriseResultStatus.TIMEOUT,
+                            logs=[
+                                _timeout_log_entry(service.service_name, 0.0)
+                            ],
+                        )
+                    )
+                    break
+
+                attempt_start = time.monotonic()
+                logger.trace(
+                    "Starting attempt %d/%d for '%s'.",
+                    attempt + 1,
+                    retry + 1,
+                    service.service_name,
+                )
                 # Same exception handling as _notify_sequential: TypeError
                 # from Apprise validation and bare Exception for buggy or
                 # third-party plugins both map to a retriable failure.
-                try:
-                    result = server.notify(**kwargs)
-                except TypeError:
-                    result = False
-                except Exception:
-                    logger.exception("Unhandled Notification Exception")
-                    result = False
+                with _ServiceLogCapture(
+                    service, log_callback=log_callback
+                ) as capture:
+                    try:
+                        result = service.notify(**kwargs)
+                    except TypeError:
+                        result = False
+                    except Exception as e:
+                        logger.warning(
+                            "Notification service '%s' raised an exception.",
+                            service.service_name,
+                        )
+                        logger.debug("Notification Exception: %s", str(e))
+                        result = False
+
+                attempt_elapsed = time.monotonic() - attempt_start
+                logger.trace(
+                    "Attempt %d/%d for '%s' finished in %.3fs: %s.",
+                    attempt + 1,
+                    retry + 1,
+                    service.service_name,
+                    attempt_elapsed,
+                    "success" if result else "failure",
+                )
+                attempts.append(
+                    NotifyAttempt(
+                        status=_attempt_status(result),
+                        elapsed=attempt_elapsed,
+                        logs=capture.entries,
+                    )
+                )
 
                 if result:
-                    return True
+                    break
 
                 if attempt < retry:
                     logger.warning(
-                        "Retry %d/%d for %s",
+                        "Attempt %d/%d for '%s' failed; trying again.",
                         attempt + 1,
                         retry,
-                        server.service_name,
+                        service.service_name,
                     )
                     if wait > 0:
-                        time.sleep(wait)
+                        sleep_for = wait
+                        if deadline is not None:
+                            sleep_for = min(
+                                wait, max(0.0, deadline - time.monotonic())
+                            )
+                        if sleep_for > 0:
+                            time.sleep(sleep_for)
 
-            # Optional-service check (thread-pool path).
-            #
-            # All retry attempts for this server have been exhausted by the
-            # loop above.  If the final result is still False and the service
-            # is tagged as optional, return True from this worker function
-            # instead of False.  The caller (_notify_parallel_threadpool)
-            # collects each worker's return value via future.result() and
-            # ANDs them together; returning True here prevents this worker's
-            # failure from tainting the aggregate result.
-            #
-            # This is the thread-pool equivalent of the same check in
-            # _notify_sequential.  See the comment there for a full
-            # explanation of the getattr() guard and the retry interaction.
-            if not result and getattr(server, "optional", False):
+            # Optional services can fail quietly, but keep a log breadcrumb.
+            optional = getattr(service, "optional", False)
+            succeeded = any(
+                a.status == AppriseResultStatus.SUCCESS for a in attempts
+            )
+            if not succeeded and optional:
                 logger.info(
-                    "Optional service '%s' failed; ignoring failure.",
-                    server.service_name,
+                    "Optional service '%s' did not send successfully; "
+                    "continuing.",
+                    service.service_name,
                 )
-                # Return True so future.result() in the caller reports
-                # success for this optional worker thread.
-                return True
 
-            # Every attempt for this service failed and it is not optional;
-            # propagate the failure to the caller.
-            return result
+            # Build result metadata defensively; plugin helpers may raise.
+            name, url, url_id, tag, weight = _service_metadata(service)
+            notify_result = NotifyResult(
+                name=name,
+                url=url,
+                url_id=url_id,
+                tag=tag,
+                optional=optional,
+                weight=weight,
+                max_attempts=retry + 1,
+                attempts=attempts,
+            )
 
-        # Submit all server calls to the thread pool and collect results.
-        with cf.ThreadPoolExecutor() as executor:
-            success = True
-            futures = [
-                executor.submit(_call_with_retry, server, kwargs)
-                for (server, kwargs) in servers_kwargs
-            ]
+            return bool(notify_result), notify_result
 
-            for future in cf.as_completed(futures):
+        # Keep output ordered by input, though threads finish out of order.
+        # This is the shared, process-wide pool (see _get_shared_executor()),
+        # not a fresh one per call -- never shut down here, it persists for
+        # the life of the process so a chronically hanging endpoint cannot
+        # leak one more permanently-running thread with every call.
+        executor = _get_shared_executor()
+        success = True
+        results: list[Optional[NotifyResult]] = [None] * n_calls
+
+        # Snapshot every service's deadline once, right at submission
+        # time (they all start at essentially the same instant here).
+        deadlines: list[Optional[float]] = [
+            _compute_deadline(service, call_deadline)
+            for service, kwargs in services_kwargs
+        ]
+        future_to_idx: dict[cf.Future, int] = {
+            executor.submit(_call_with_retry, service, kwargs): i
+            for i, (service, kwargs) in enumerate(services_kwargs)
+        }
+
+        for future, idx in future_to_idx.items():
+            service = services_kwargs[idx][0]
+            # Give each expired service one grace window, not one per loop.
+            abandon_at = (
+                deadlines[idx] + _ABANDON_GRACE_SECONDS
+                if deadlines[idx] is not None
+                else None
+            )
+            wait_start = time.monotonic()
+            wait_for = (
+                max(0.0, abandon_at - wait_start)
+                if abandon_at is not None
+                else None
+            )
+            logger.trace(
+                "Waiting up to %s for '%s'.",
+                "no limit" if wait_for is None else f"{wait_for:.3f}s",
+                service.service_name,
+            )
+            try:
                 # future.result() re-raises any exception that escaped
                 # _call_with_retry (should not happen given the inner
                 # try/except, but guard here as a safety net).
-                try:
-                    success = success and future.result()
-                except Exception:
-                    logger.exception("Unhandled Notification Exception")
-                    success = False
+                ok, notify_result = future.result(timeout=wait_for)
+                logger.trace(
+                    "'%s' finished after %.3fs: %s.",
+                    service.service_name,
+                    time.monotonic() - wait_start,
+                    "success" if ok else "failure",
+                )
 
-            return success
+            except cf.TimeoutError:
+                # Stop waiting once this service's grace window is spent.
+                # NotifyResult keeps optional services successful.
+                wait_elapsed = time.monotonic() - wait_start
+
+                # Still queued -> cancel() succeeds, nothing to track.
+                # Already running -> cancel() fails, so track it instead.
+                cancelled = future.cancel()
+                if not cancelled:
+                    name, url, _, _, _ = _service_metadata(service)
+                    _track_abandoned_future(future, name, url)
+                logger.trace(
+                    "Stopped waiting for '%s' after %.3fs (%s).",
+                    service.service_name,
+                    wait_elapsed,
+                    "it was still queued and has been cancelled"
+                    if cancelled
+                    else "its worker thread may still be running in the "
+                    "background",
+                )
+                notify_result = _timeout_result(service, wait_elapsed)
+                ok = bool(notify_result)
+
+            except Exception as e:
+                logger.warning(
+                    "Notification service '%s' raised an exception.",
+                    service.service_name,
+                )
+                logger.debug("Notification Exception: %s", str(e))
+                notify_result = _safe_error_result(service)
+                ok = bool(notify_result)
+
+            success = success and ok
+            results[idx] = notify_result
+
+        return success, results
 
     @staticmethod
-    async def _notify_parallel_asyncio(*servers_kwargs):
+    async def _notify_parallel_asyncio(
+        *services_kwargs: ServerCall, call_deadline: Optional[float] = None
+    ) -> tuple[bool, list[NotifyResult]]:
         """Process a list of async_notify() calls concurrently via asyncio.
 
-        All coroutines are gathered with asyncio.gather().  Each server is
-        retried up to server.retry additional times on failure with an
-        optional asyncio.sleep(server.wait) between attempts.
+        Each coroutine handles one service, including retry and wait logic.
+        The outer wait_for() keeps one stuck service from blocking its peers.
 
-        Unlike the thread-pool path, there is no single-server optimisation
-        here because asyncio can pipeline work across coroutines while one
-        is awaiting I/O.
-
-        Exceptions from a plugin's async_notify() -- including those from
-        third-party @notify-decorated coroutines -- are caught inside each
-        coroutine and treated as delivery failures so the retry loop can
-        still run for that service.
+        A timeout means Apprise stops waiting and reports TIMEOUT. If the
+        plugin is running sync work in a worker thread, that work may still
+        finish later.
         """
 
-        n_calls = len(servers_kwargs)
+        n_calls = len(services_kwargs)
 
         if n_calls == 0:
-            return True
+            return True, []
 
         logger.info(
-            "Notifying %d service(s) asynchronously.", len(servers_kwargs)
+            "Notifying %d service(s) asynchronously.", len(services_kwargs)
         )
 
-        async def do_call(server, kwargs):
-            """Coroutine driving one server's async_notify() with retry/wait.
+        async def do_call(
+            service: NotifyBase, kwargs: dict[str, Any]
+        ) -> tuple[bool, NotifyResult]:
+            """Coroutine driving one service's async_notify() with retry/wait.
 
             Pops ``_retry_override`` from kwargs so it is never forwarded
             to the plugin.  Exceptions are caught and treated as failures
             so the retry loop continues even when a plugin raises
             unexpectedly (e.g. a third-party @notify-decorated coroutine).
-            """
-            # Pop the per-call override so it stays internal.
-            retry = kwargs.pop("_retry_override", getattr(server, "retry", 0))
-            wait = getattr(server, "wait", 0.0)
 
-            result = False
+            Returns (bool, NotifyResult) -- see _call_with_retry in
+            _notify_parallel_threadpool for the equivalent contract.
+            """
+            # Pop the per-call overrides so they stay internal.
+            retry = kwargs.pop("_retry_override", getattr(service, "retry", 0))
+            wait = getattr(service, "wait", 0.0)
+            log_callback = kwargs.pop("_log_callback", None)
+
+            # Computed fresh as this coroutine actually starts running,
+            # same rationale as _notify_parallel_threadpool's worker.
+            deadline = _compute_deadline(service, call_deadline)
+            attempts: list[NotifyAttempt] = []
             for attempt in range(retry + 1):
+                if deadline is not None and time.monotonic() >= deadline:
+                    # Out of time -- record a zero-elapsed TIMEOUT attempt
+                    # marking the decision to stop, and do not start
+                    # another one.
+                    logger.trace(
+                        "Deadline already passed for '%s'; skipping "
+                        "attempt %d/%d.",
+                        service.service_name,
+                        attempt + 1,
+                        retry + 1,
+                    )
+                    attempts.append(
+                        NotifyAttempt(
+                            status=AppriseResultStatus.TIMEOUT,
+                            logs=[
+                                _timeout_log_entry(service.service_name, 0.0)
+                            ],
+                        )
+                    )
+                    break
+
+                attempt_start = time.monotonic()
+                logger.trace(
+                    "Starting attempt %d/%d for '%s'.",
+                    attempt + 1,
+                    retry + 1,
+                    service.service_name,
+                )
                 # Mirror the exception handling from the synchronous paths:
-                # TypeError from Apprise's own validation layer and bare
-                # Exception for any plugin that raises unexpectedly are both
-                # treated as retriable failures rather than hard crashes.
-                try:
-                    result = await server.async_notify(**kwargs)
-                except TypeError:
-                    result = False
-                except Exception:
-                    logger.exception("Unhandled Notification Exception")
-                    result = False
+                # Treat validation and plugin exceptions as failed attempts.
+                # The retry loop can still continue for this service.
+                with _ServiceLogCapture(
+                    service, log_callback=log_callback
+                ) as capture:
+                    try:
+                        result = await service.async_notify(**kwargs)
+
+                    except TypeError:
+                        result = False
+
+                    except Exception as e:
+                        logger.warning(
+                            "Notification service '%s' raised an exception.",
+                            service.service_name,
+                        )
+                        logger.debug("Notification Exception: %s", str(e))
+                        result = False
+
+                attempt_elapsed = time.monotonic() - attempt_start
+                logger.trace(
+                    "Attempt %d/%d for '%s' finished in %.3fs: %s.",
+                    attempt + 1,
+                    retry + 1,
+                    service.service_name,
+                    attempt_elapsed,
+                    "success" if result else "failure",
+                )
+                attempts.append(
+                    NotifyAttempt(
+                        status=_attempt_status(result),
+                        elapsed=attempt_elapsed,
+                        logs=capture.entries,
+                    )
+                )
 
                 if result:
-                    return True
+                    break
 
                 if attempt < retry:
                     logger.warning(
-                        "Retry %d/%d for %s",
+                        "Attempt %d/%d for '%s' failed; trying again.",
                         attempt + 1,
                         retry,
-                        server.service_name,
+                        service.service_name,
                     )
                     if wait > 0:
-                        await asyncio.sleep(wait)
+                        sleep_for = wait
+                        if deadline is not None:
+                            sleep_for = min(
+                                wait, max(0.0, deadline - time.monotonic())
+                            )
+                        if sleep_for > 0:
+                            await asyncio.sleep(sleep_for)
 
-            # Optional-service check (asyncio coroutine path).
-            #
-            # All retry attempts have been exhausted by the async loop
-            # above.  If the final result is still False and the service
-            # is tagged optional, return True from this coroutine so that
-            # asyncio.gather() receives a truthy value for this task.
-            # The caller inspects all gathered results with all(); a True
-            # here ensures this coroutine does not lower the aggregate
-            # result for the batch.
-            #
-            # This is the asyncio equivalent of the same check in
-            # _notify_sequential and _call_with_retry.  See the comment
-            # in _notify_sequential for a full explanation of the getattr()
-            # guard and the interaction with the retry count.
-            if not result and getattr(server, "optional", False):
+            # Optional services can fail quietly, but keep a log breadcrumb.
+            optional = getattr(service, "optional", False)
+            succeeded = any(
+                a.status == AppriseResultStatus.SUCCESS for a in attempts
+            )
+            if not succeeded and optional:
                 logger.info(
-                    "Optional service '%s' failed; ignoring failure.",
-                    server.service_name,
+                    "Optional service '%s' did not send successfully; "
+                    "continuing.",
+                    service.service_name,
                 )
-                # Return True so asyncio.gather() sees a success value
-                # for this optional coroutine.
-                return True
 
-            # Every attempt for this service failed and it is not optional;
-            # propagate the failure to the caller.
-            return result
+            # Build result metadata defensively; plugin helpers may raise.
+            name, url, url_id, tag, weight = _service_metadata(service)
+            notify_result = NotifyResult(
+                name=name,
+                url=url,
+                url_id=url_id,
+                tag=tag,
+                optional=optional,
+                weight=weight,
+                max_attempts=retry + 1,
+                attempts=attempts,
+            )
+
+            return bool(notify_result), notify_result
+
+        async def do_call_bounded(
+            service: NotifyBase,
+            kwargs: dict[str, Any],
+            deadline: Optional[float],
+        ) -> tuple[bool, NotifyResult]:
+            """Apply an outer asyncio timeout to one service call.
+
+            The service still owns its normal retry deadline inside do_call().
+            This wrapper limits how long this batch waits for the result.
+            """
+            remaining = (
+                max(0.0, deadline - time.monotonic())
+                if deadline is not None
+                else None
+            )
+            # Add one small grace window so a nearly-finished service can
+            # settle before it is reported as abandoned.
+            wait_for = (
+                remaining + _ABANDON_GRACE_SECONDS
+                if remaining is not None
+                else None
+            )
+            logger.trace(
+                "Waiting up to %s for '%s'.",
+                "no limit" if wait_for is None else f"{wait_for:.3f}s",
+                service.service_name,
+            )
+            wait_start = time.monotonic()
+            try:
+                # timeout=None makes wait_for() behave like a plain await.
+                # This keeps the bounded and unbounded paths together.
+                ok, notify_result = await asyncio.wait_for(
+                    do_call(service, kwargs), timeout=wait_for
+                )
+                logger.trace(
+                    "'%s' finished after %.3fs: %s.",
+                    service.service_name,
+                    time.monotonic() - wait_start,
+                    "success" if ok else "failure",
+                )
+                return ok, notify_result
+
+            except asyncio.TimeoutError:
+                # Derive the outcome from NotifyResult so an optional timeout
+                # remains successful.
+                # Apprise stops waiting here; it does not promise delivery
+                # work has stopped underneath.
+                logger.trace(
+                    "Stopped waiting for '%s' after %.3fs; it may still "
+                    "be finishing in the background.",
+                    service.service_name,
+                    time.monotonic() - wait_start,
+                )
+                notify_result = _timeout_result(service, remaining or 0.0)
+                return bool(notify_result), notify_result
+
+        # Snapshot outer wait deadlines before launching the async workers.
+        # do_call() still computes its own deadline once it starts running.
+        deadlines: list[Optional[float]] = [
+            _compute_deadline(service, call_deadline)
+            for service, kwargs in services_kwargs
+        ]
 
         # Run all coroutines concurrently.  return_exceptions=True ensures
-        # that one coroutine raising does not cancel the others; any escaped
-        # exception (beyond what do_call already handles) is caught below.
-        cors = (do_call(server, kwargs) for (server, kwargs) in servers_kwargs)
-        results = await asyncio.gather(*cors, return_exceptions=True)
+        # one escaped exception is reported without cancelling other services.
+        cors = (
+            do_call_bounded(service, kwargs, deadlines[i])
+            for i, (service, kwargs) in enumerate(services_kwargs)
+        )
+        gathered = await asyncio.gather(*cors, return_exceptions=True)
 
-        if any(isinstance(status, Exception) for status in results):
-            # Safety net: an exception escaped do_call's own try/except.
-            # Log each one and treat the whole batch as failed.
-            for status in results:
-                if isinstance(status, Exception):
-                    logger.error(
-                        "Unhandled Notification Exception: %s", status
-                    )
-            return False
+        success = True
+        results: list[NotifyResult] = []
+        for idx, item in enumerate(gathered):
+            service = services_kwargs[idx][0]
+            if isinstance(item, Exception):
+                # Safety net: an exception escaped do_call's own try/except.
+                logger.warning(
+                    "Notification service '%s' raised an exception.",
+                    service.service_name,
+                )
+                logger.debug("Notification Exception: %s", str(item))
+                notify_result = _safe_error_result(service)
+                success = success and bool(notify_result)
+                results.append(notify_result)
 
-        return all(results)
+            else:
+                ok, notify_result = item
+                success = success and ok
+                results.append(notify_result)
+
+        return success, results
 
     def json(
         self,
@@ -1419,7 +2251,7 @@ class Apprise:
         if not path:
             return json.dumps(
                 details,
-                separators=(",", ":"),
+                separators=JSON_COMPACT_SEPARATORS,
                 indent=indent,
                 cls=AppriseJSONEncoder,
             )
@@ -1429,7 +2261,7 @@ class Apprise:
                 json.dump(
                     details,
                     fp,
-                    separators=(",", ":"),
+                    separators=JSON_COMPACT_SEPARATORS,
                     indent=indent,
                     cls=AppriseJSONEncoder,
                     ensure_ascii=False,

--- a/apprise/asset.py
+++ b/apprise/asset.py
@@ -26,6 +26,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from datetime import datetime, tzinfo
+import math
 from os.path import abspath, dirname, isfile, join
 import re
 from typing import Any, Optional, Union
@@ -239,6 +240,10 @@ class AppriseAsset:
     # is uzed
     _tzinfo = None
 
+    # Default budget for one service, including retries and waits. Apprise
+    # reports TIMEOUT after this many seconds; 0 disables the service limit.
+    _service_timeout = 60.0
+
     def __init__(
         self,
         plugin_paths: Optional[list[str]] = None,
@@ -247,9 +252,15 @@ class AppriseAsset:
         storage_salt: Optional[Union[str, bytes]] = None,
         storage_idlen: Optional[int] = None,
         timezone: Optional[Union[str, tzinfo]] = None,
+        service_timeout: Optional[Union[int, float]] = None,
         **kwargs: Any,
     ) -> None:
-        """Asset Initialization."""
+        """Initialize shared Apprise settings and service limits.
+
+        ``service_timeout`` limits the total seconds one service may spend on
+        delivery, retries, and retry waits. ``None`` keeps the class default,
+        while ``0`` disables the per-service limit.
+        """
         # Assign default arguments if specified
         for key, value in kwargs.items():
             if not hasattr(AppriseAsset, key):
@@ -308,6 +319,29 @@ class AppriseAsset:
         else:
             # Default our timezone to what is detected on the system
             self._tzinfo = datetime.now().astimezone().tzinfo
+
+        if service_timeout is not None:
+            # Normalize numeric values to float so deadline calculations use
+            # one consistent representation. bool is rejected explicitly
+            # because it is an int subclass but not a meaningful duration.
+            if not isinstance(service_timeout, (int, float)) or isinstance(
+                service_timeout, bool
+            ):
+                raise TypeError(
+                    "AppriseAsset service_timeout must be an int or float."
+                )
+
+            if not math.isfinite(service_timeout) or service_timeout < 0:
+                # inf might look like a second way to spell "unbounded",
+                # but concurrent.futures.Future.result(timeout=float(
+                # "inf")) raises OverflowError on some platforms -- 0 is
+                # the only supported way to disable the limit.
+                raise ValueError(
+                    "AppriseAsset service_timeout must be >= 0 and "
+                    "finite (0 disables the timeout entirely)."
+                )
+
+            self._service_timeout = float(service_timeout)
 
         if storage_salt is not None:
             # Define the number of characters utilized from our namespace lengh

--- a/apprise/cli.py
+++ b/apprise/cli.py
@@ -25,6 +25,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import contextlib
 import logging
 import os
 from os.path import exists, isfile
@@ -33,6 +34,7 @@ import re
 import shutil
 import sys
 import textwrap
+import time
 
 import click
 
@@ -40,12 +42,17 @@ from . import (
     Apprise,
     AppriseAsset,
     AppriseConfig,
+    AppriseResultStatus,
     NotificationManager,
     PersistentStore,
     __copyright__,
     __license__,
     __title__,
     __version__,
+)
+from .apprise import (
+    _abandoned_call_descriptions,
+    _any_abandoned_calls_still_running,
 )
 from .common import (
     NOTIFY_FORMATS,
@@ -89,6 +96,13 @@ DEFAULT_ENV_APPRISE_PLUGIN_PATH = "APPRISE_PLUGIN_PATH"
 
 # Defines the override path for the persistent storage
 DEFAULT_ENV_APPRISE_STORAGE_PATH = "APPRISE_STORAGE_PATH"
+
+# Grace period for abandoned service calls to finish before forced exit.
+# Normal interpreter shutdown would otherwise wait on those threads.
+CLI_TIMEOUT_EXIT_GRACE_SECONDS = 5.0
+
+# Poll interval while waiting for abandoned service calls to finish.
+CLI_TIMEOUT_EXIT_POLL_INTERVAL = 0.25
 
 # Defines our click context settings adding -h to the additional options that
 # can be specified to get the help menu to come up
@@ -474,6 +488,85 @@ class CustomHelpCommand(click.Command):
         self.format_epilog(ctx, formatter)
 
 
+def _wait_for_abandoned_calls(timeout: float) -> bool:
+    """Poll up to ``timeout`` seconds for any abandoned service call
+    (see _any_abandoned_calls_still_running()) to finish naturally.
+
+    Returns True once nothing is left running.
+    """
+    # Logged once, at DEBUG only: _abandoned_call_descriptions()
+    # includes each service's url(privacy=True), so this stays out of
+    # the default log level even though the privacy mask is applied.
+    # This only reflects what Apprise itself dispatched and is still
+    # waiting on -- a plugin whose underlying library manages its own
+    # separate background resources (e.g. a persistent connection kept
+    # alive independently) is invisible here regardless of whether
+    # it's also still running.
+    descriptions = _abandoned_call_descriptions()
+    logger.debug(
+        "One or more services timed out. Waiting up to %.1fs more for "
+        "these services to finish: %s",
+        timeout,
+        ", ".join(descriptions)
+        if descriptions
+        else "(no services are still running)",
+    )
+    elapsed = 0.0
+    while elapsed < timeout:
+        if not _any_abandoned_calls_still_running():
+            logger.debug(
+                "Timed-out service calls finished after %.2fs.",
+                elapsed,
+            )
+            return True
+        sleep_for = min(CLI_TIMEOUT_EXIT_POLL_INTERVAL, timeout - elapsed)
+        time.sleep(sleep_for)
+        elapsed += sleep_for
+
+    still_running = _any_abandoned_calls_still_running()
+    if still_running:
+        logger.debug(
+            "%.1fs elapsed and some timed-out services are still running; "
+            "exiting now.",
+            timeout,
+        )
+    return not still_running
+
+
+def _force_exit(apobj: Apprise, status: AppriseResultStatus) -> None:
+    """Unconditionally end the process, skipping Python's normal
+    shutdown sequence entirely.
+    """
+    # os._exit() skips normal object cleanup, so flush every store first.
+    # A failed flush must not stop the remaining services from trying.
+    for service in apobj:
+        try:
+            logger.trace(
+                "Flushing persistent store for service: %s",
+                service.url(privacy=True),
+            )
+            service.flush_store()
+
+        except Exception as e:
+            logger.warning(
+                "Could not save one service's persistent data before "
+                "exiting; continuing with the remaining services."
+            )
+            logger.debug("Persistent store save error: %s", e)
+
+    # os._exit() skips atexit hooks, so flush logging and stdio manually.
+    # Each flush is independent; one failure should not block the others.
+    with contextlib.suppress(Exception):
+        logging.shutdown()
+    with contextlib.suppress(Exception):
+        sys.stdout.flush()
+    with contextlib.suppress(Exception):
+        sys.stderr.flush()
+
+    # Hard-exit last so abandoned worker threads cannot keep the CLI alive.
+    os._exit(status)
+
+
 @click.command(context_settings=CONTEXT_SETTINGS, cls=CustomHelpCommand)
 @click.option(
     "--body",
@@ -615,6 +708,32 @@ class CustomHelpCommand(click.Command):
     ),
 )
 @click.option(
+    "--limit",
+    "-L",
+    default=0,
+    type=float,
+    metavar="SECONDS",
+    help=(
+        "Give up on the whole run if it's taking too long, in seconds "
+        "(whole number or decimal, e.g. 2.5). By default (0) there is "
+        "no limit -- see --service-limit to cap each service on its own "
+        "instead."
+    ),
+)
+@click.option(
+    "--service-limit",
+    "-SL",
+    default=None,
+    type=float,
+    metavar="SECONDS",
+    help=(
+        "Give up on any single service if it's taking too long, in "
+        "seconds (whole number or decimal, e.g. 2.5), or 0 to turn this "
+        "off entirely. Leave unset to use Apprise's own default of "
+        f"{AppriseAsset._service_timeout:g} seconds."
+    ),
+)
+@click.option(
     "--disable-async",
     "-Da",
     is_flag=True,
@@ -693,6 +812,8 @@ def main(
     tag,
     input_format,
     dry_run,
+    limit,
+    service_limit,
     recursion_depth,
     verbose,
     disable_async,
@@ -886,6 +1007,8 @@ def main(
         storage_idlen=storage_uid_length,
         # Define if we flush to disk as soon as possible or not when required
         storage_mode=storage_mode,
+        # Apply the optional per-service delivery budget to every plugin.
+        service_timeout=service_limit,
     )
 
     # Create our Apprise object
@@ -1252,7 +1375,7 @@ def main(
                         click.echo(
                             "{:>10}: {}".format(
                                 "tags",
-                                ", ".join(str(t) for t in entry.tags),
+                                ", ".join(sorted(str(t) for t in entry.tags)),
                             )
                         )
 
@@ -1301,14 +1424,32 @@ def main(
             # if no body was specified, then read from STDIN
             body = click.get_text_stream("stdin").read()
 
-        # now print it out
+        # Send the notification. AppriseResult.status maps directly to the
+        # process exit values handled after the dry-run branch.
+        notify_start = time.monotonic()
         result = a.notify(
             body=body,
             title=title,
             notify_type=notification_type,
             tag=tags,
             attach=attach,
+            timeout=limit,
         )
+
+        status = result.status
+
+        # Status report
+        logger.debug(
+            "Finished in %.2fs. %d service(s) tried (%s): %d sent / "
+            "%d failed / %d timed out.",
+            time.monotonic() - notify_start,
+            len(result),
+            status.name,
+            result.success_count,
+            result.failed_count,
+            result.timeout_count,
+        )
+
     else:
         # Number of columns to assume in the terminal.  In future, maybe this
         # can be detected and made dynamic. The actual column count is 80, but
@@ -1345,26 +1486,22 @@ def main(
                 click.echo(
                     "{:>10}: {}".format(
                         "tags",
-                        ", ".join(str(t) for t in server.tags),
+                        ", ".join(sorted(str(t) for t in server.tags)),
                     )
                 )
 
-        # Initialize a default response of nothing matched, otherwise
-        # if we matched at least one entry, we can return True
-        result = None if url is None else True
+        # Dry-run has no AppriseResult, so map its outcome to the same enum.
+        status = (
+            AppriseResultStatus.NOMATCH
+            if url is None
+            else AppriseResultStatus.SUCCESS
+        )
 
-    if result is None:
-        # There were no notifications set.  This is a result of just having
-        # empty configuration files and/or being to restrictive when filtering
-        # by specific tag(s)
+    if status == AppriseResultStatus.TIMEOUT and not _wait_for_abandoned_calls(
+        CLI_TIMEOUT_EXIT_GRACE_SECONDS
+    ):
+        _force_exit(a, status)
 
-        # Exit code 3 is used since Click uses exit code 2 if there is an
-        # error with the parameters specified
-        ctx.exit(3)
-
-    elif result is False:
-        # At least 1 notification service failed to send
-        ctx.exit(1)
-
-    # else:  We're good!
-    ctx.exit(0)
+    # AppriseResultStatus values map directly to CLI exit codes.
+    # Exit code 2 is left to Click for bad command-line parameters.
+    ctx.exit(status)

--- a/apprise/common.py
+++ b/apprise/common.py
@@ -31,6 +31,9 @@ from enum import Enum
 AWARE_DATE_ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.%f%z"
 NAIVE_DATE_ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
 
+# Compact separators (no space after "," or ":").
+JSON_COMPACT_SEPARATORS = (",", ":")
+
 
 class NotifyType(str, Enum):
     """A simple mapping of notification types most commonly used with all types

--- a/apprise/logger.py
+++ b/apprise/logger.py
@@ -25,13 +25,39 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures as cf
 import contextlib
+import contextvars
+from datetime import datetime, timezone
 from io import StringIO
+import json
 import logging
 import os
+from typing import TYPE_CHECKING, Any, Callable, Optional
+
+from .common import AWARE_DATE_ISO_FORMAT, JSON_COMPACT_SEPARATORS
+
+if TYPE_CHECKING:
+    # Import NotifyBase only for static analysis. Importing it at runtime
+    # would create a cycle through apprise.url and this logger module.
+    from .plugins.base import NotifyBase
 
 # The root identifier needed to monitor 'apprise' logging
 LOGGER_NAME = "apprise"
+
+# Upper bound on WARNING+ entries captured for one attempt.
+# This caps memory use if a plugin logs repeatedly in a large batch.
+_MAX_CAPTURED_LOG_ENTRIES = 5000
+
+# Tracks which capture owns logs from the current execution context.
+# ContextVar also survives async-to-thread handoffs when copied explicitly.
+_active_capture: contextvars.ContextVar[Optional[_ServiceLogCapture]] = (
+    contextvars.ContextVar("apprise_active_log_capture", default=None)
+)
+
 
 # Define a verbosity level that is a noisier then debug mode
 logging.TRACE = logging.DEBUG - 1
@@ -65,6 +91,255 @@ logging.Logger.deprecate = deprecate
 
 # Create ourselve a generic (singleton) logging reference
 logger = logging.getLogger(LOGGER_NAME)
+
+
+class NotifyLogEntry:
+    """A single log line captured while one service was being notified."""
+
+    def __init__(
+        self, level: str, message: str, time: Optional[datetime] = None
+    ) -> None:
+        """Initialize a captured message and its UTC timestamp."""
+
+        # The already-formatted log message
+        self.message = message
+
+        # The log level name (e.g. "WARNING", "ERROR")
+        self.level = level
+
+        # The log time
+        self.time = time if time is not None else datetime.now(timezone.utc)
+
+    def __eq__(self, other: object) -> bool:
+        """Check equality of two entries by their (time, level, message)."""
+        if not isinstance(other, NotifyLogEntry):
+            return NotImplemented
+        return (self.time, self.level, self.message) == (
+            other.time,
+            other.level,
+            other.message,
+        )
+
+    def __hash__(self) -> int:
+        """Hash on the same (time, level, message) for __eq__ uses."""
+        return hash((self.time, self.level, self.message))
+
+    def __lt__(self, other: NotifyLogEntry) -> bool:
+        """Order by time alone, for chronological playback"""
+        if not isinstance(other, NotifyLogEntry):
+            return NotImplemented
+        return self.time < other.time
+
+    def __le__(self, other: NotifyLogEntry) -> bool:
+        """Order by time alone, for chronological playback"""
+        if not isinstance(other, NotifyLogEntry):
+            return NotImplemented
+        return self.time <= other.time
+
+    def __gt__(self, other: NotifyLogEntry) -> bool:
+        """See __lt__."""
+        if not isinstance(other, NotifyLogEntry):
+            return NotImplemented
+        return self.time > other.time
+
+    def __ge__(self, other: NotifyLogEntry) -> bool:
+        """See __lt__."""
+        if not isinstance(other, NotifyLogEntry):
+            return NotImplemented
+        return self.time >= other.time
+
+    def asdict(self) -> dict[str, Any]:
+        """Return this entry as a plain, JSON-serializable dict."""
+        return {
+            "level": self.level,
+            "message": self.message,
+            "time": self.time.strftime(AWARE_DATE_ISO_FORMAT),
+        }
+
+    def json(self) -> str:
+        """Return this entry as a JSON string."""
+        return json.dumps(self.asdict(), separators=JSON_COMPACT_SEPARATORS)
+
+    def __str__(self) -> str:
+        """Format the entry like a conventional Python log line."""
+        # Match Python logging's familiar default-style output.
+        asctime = "{},{:03d}".format(
+            self.time.strftime("%Y-%m-%d %H:%M:%S"),
+            self.time.microsecond // 1000,
+        )
+        return "{} - {} - {}".format(asctime, self.level, self.message)
+
+    def __repr__(self) -> str:
+        """Return an unambiguous representation of this entry."""
+        return "<NotifyLogEntry level={!r} message={!r} time={!r}>".format(
+            self.level, self.message, self.time
+        )
+
+
+class _ServiceLogCapture(logging.Handler):
+    """Capture one service's warning and error messages in isolation.
+
+    It attaches one extra handler for a single attempt. ``log_callback``,
+    when provided, receives each captured (entry, service) live.
+    """
+
+    def __init__(
+        self,
+        service: NotifyBase,
+        log_callback: Optional[
+            Callable[[NotifyLogEntry, NotifyBase], Any]
+        ] = None,
+    ) -> None:
+        """Prepare an isolated WARNING-level handler for ``service``."""
+        # Only capture WARNING and above -- this mirrors the level at
+        # which plugins themselves report delivery failures (HTTP errors,
+        # rate limits, etc.); INFO/DEBUG chatter is not useful here.
+        super().__init__(level=logging.WARNING)
+        self._entries: list[NotifyLogEntry] = []
+
+        # Reuse the service's logger; this capture is just another listener.
+        self._logger = getattr(service, "logger", logger)
+
+        # Kept only so log_callback can identify the service.
+        self._service = service
+        self._log_callback = log_callback
+
+        # support for async log_callback.
+        try:
+            self._loop: Optional[asyncio.AbstractEventLoop] = (
+                asyncio.get_running_loop()
+            )
+        except RuntimeError:
+            self._loop = None
+
+        # Set on __enter__, used to restore _active_capture on __exit__.
+        self._token: Optional[contextvars.Token] = None
+
+        # prevent reoccurrance of emit() calls from the same thread.
+        self._in_emit = False
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Wrap and store one captured logging.LogRecord.
+
+        Ignores any record produced on behalf of another service
+        dispatched concurrently -- see _active_capture's own docstring.
+        """
+        if self._in_emit:
+            return
+        self._in_emit = True
+        try:
+            self._emit(record)
+        finally:
+            self._in_emit = False
+
+    def _emit(self, record: logging.LogRecord) -> None:
+        """The actual body of emit(), guarded against re-entrancy by the
+        wrapper above."""
+        try:
+            if _active_capture.get() is not self:
+                return
+
+            if len(self._entries) >= _MAX_CAPTURED_LOG_ENTRIES:
+                # A plugin can log once per item while processing a large
+                # or malformed batch (bulk recipients, malformed config
+                # entries, etc.) -- cap growth instead of buffering an
+                # unbounded number of entries for the lifetime of the
+                # result.
+                return
+
+            entry = NotifyLogEntry(
+                level=record.levelname,
+                # record.getMessage() re-applies %-style formatting
+                # (msg % args) every time it's called, so a plugin's
+                # own malformed logging call (e.g. too few args for
+                # its format string) raises here, exactly as it would
+                # for any other handler -- self.handleError() is the
+                # standard library's own convention for this (see
+                # logging.StreamHandler.emit()), so the caller's
+                # original self.logger.warning(...) call still
+                # returns normally instead of raising through it.
+                message=record.getMessage(),
+                # record.created is a Unix timestamp (seconds since
+                # the epoch); logging itself is timezone-agnostic,
+                # but every other timestamp Apprise reports is an
+                # aware UTC datetime, so this is converted to match.
+                time=datetime.fromtimestamp(record.created, tz=timezone.utc),
+            )
+            self._entries.append(entry)
+
+            callback = self._log_callback
+            if callback is not None:
+                self._invoke_log_callback(entry, callback)
+
+        except Exception:
+            self.handleError(record)
+
+    def _invoke_log_callback(
+        self,
+        entry: NotifyLogEntry,
+        callback: Callable[[NotifyLogEntry, NotifyBase], Any],
+    ) -> None:
+        """Call log_callback(entry, service) for one captured entry.
+
+        The returned value tells us whether it was plain sync work or an
+        async coroutine that still needs scheduling.
+        """
+        try:
+            result = callback(entry, self._service)
+
+        except Exception as e:
+            logger.warning("The log_callback function raised an exception.")
+            logger.debug("log_callback Exception: %s", str(e))
+            return
+
+        if not asyncio.iscoroutine(result):
+            return
+
+        if self._loop is None:
+            # No loop is available; close the coroutine to avoid a warning.
+            result.close()
+            logger.warning(
+                "The log_callback returned async work, but no asyncio event "
+                "loop is running; this live log update was skipped: %s",
+                entry,
+            )
+            return
+
+        # This is safe from worker threads and the loop's own thread.
+        future = asyncio.run_coroutine_threadsafe(result, self._loop)
+        future.add_done_callback(self._log_callback_done)
+
+    @staticmethod
+    def _log_callback_done(future: cf.Future[Any]) -> None:
+        """Surface any exception from a scheduled async log_callback."""
+        if future.cancelled():
+            logger.warning(
+                "A log_callback update was cancelled before it completed. "
+                "The log entry was still saved normally."
+            )
+            return
+
+        exc = future.exception()
+        if exc is not None:
+            logger.warning("The log_callback function raised an exception.")
+            logger.debug("log_callback Exception: %s", str(exc))
+
+    @property
+    def entries(self) -> list[NotifyLogEntry]:
+        """Return every WARNING+ entry captured during this attempt."""
+        return self._entries
+
+    def __enter__(self) -> _ServiceLogCapture:
+        """Attach as an extra handler without disturbing existing ones."""
+        self._logger.addHandler(self)
+        self._token = _active_capture.set(self)
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        """Detach the handler."""
+        self._logger.removeHandler(self)
+        if self._token is not None:
+            _active_capture.reset(self._token)
 
 
 class LogCapture:

--- a/apprise/persistent_store.py
+++ b/apprise/persistent_store.py
@@ -45,6 +45,7 @@ import zlib
 from . import exception
 from .common import (
     AWARE_DATE_ISO_FORMAT,
+    JSON_COMPACT_SEPARATORS,
     NAIVE_DATE_ISO_FORMAT,
     PersistentStoreMode,
 )
@@ -1226,7 +1227,7 @@ class PersistentStore:
                             for k, v in self._cache.items()
                             if v and v.persistent
                         },
-                        separators=(",", ":"),
+                        separators=JSON_COMPACT_SEPARATORS,
                         cls=CacheJSONEncoder,
                     ).encode(self.encoding)
                 )

--- a/apprise/plugins/base.py
+++ b/apprise/plugins/base.py
@@ -27,10 +27,12 @@
 
 import asyncio
 from collections.abc import Generator
+import contextvars
 from datetime import tzinfo
 from functools import partial
 import math
 import re
+import time
 from typing import Any, ClassVar, Optional, TypedDict, Union
 from zoneinfo import ZoneInfo
 
@@ -697,6 +699,21 @@ class NotifyBase(URLBase):
             notify_type=notify_type,
         )
 
+    def _timed_send(self, **kwargs2: Any) -> bool:
+        """Call send() once, logging how long it took at DEBUG.
+
+        Shared by notify() and async_notify() so every attempt is timed
+        the same way.
+        """
+        send_start = time.monotonic()
+        result = self.send(**kwargs2)
+        self.logger.debug(
+            "%s send() completed in %.2fs.",
+            self.service_name,
+            time.monotonic() - send_start,
+        )
+        return result
+
     def notify(self, *args: Any, **kwargs: Any) -> bool:
         """Performs notification."""
         try:
@@ -710,7 +727,7 @@ class NotifyBase(URLBase):
         else:
             # Loop through each call, one at a time. (Use a list rather than a
             # generator to call all the partials, even in case of a failure.)
-            the_calls = [self.send(**kwargs2) for kwargs2 in send_calls]
+            the_calls = [self._timed_send(**kwargs2) for kwargs2 in send_calls]
             return all(the_calls)
 
     async def async_notify(self, *args: Any, **kwargs: Any) -> bool:
@@ -726,12 +743,22 @@ class NotifyBase(URLBase):
         else:
             loop = asyncio.get_event_loop()
 
-            # Wrap each call in a coroutine that uses the default executor.
-            # TODO: In the future, allow plugins to supply a native
-            # async_send() method.
+            # Deferred import to dodge a circular import (apprise.apprise
+            # loads this module first). Fine by call time.
+            from ..apprise import _get_shared_executor
+
+            # Use Apprise's own shared pool, not the loop's default one --
+            # keeps a stuck send() from starving unrelated executor work.
+            # TODO: let plugins supply a native async_send() instead.
+            executor = _get_shared_executor()
+
             async def do_send(**kwargs2):
-                send = partial(self.send, **kwargs2)
-                result = await loop.run_in_executor(None, send)
+                """Run one prepared send() call in the executor."""
+                send = partial(self._timed_send, **kwargs2)
+                # Carries our log-capture ContextVar into the worker
+                # thread -- run_in_executor() doesn't do this on its own.
+                ctx = contextvars.copy_context()
+                result = await loop.run_in_executor(executor, ctx.run, send)
                 return result
 
             # gather() all calls in parallel.
@@ -1314,6 +1341,22 @@ class NotifyBase(URLBase):
             )
 
         return self.__store
+
+    def flush_store(self) -> None:
+        """Write this service's persistent store to disk if it was used.
+
+        A no-op if self.store was never accessed this run. In
+        PersistentStoreMode.AUTO (the default), writes made via
+        self.store.set()/clear() are only kept in memory until flushed;
+        normally that happens naturally when this object is garbage
+        collected (PersistentStore.__del__ calls flush()). A caller
+        that is about to end the process by some means other than
+        normal interpreter shutdown -- which runs pending finalizers,
+        including that one -- needs to call this explicitly first, or
+        those in-memory changes are simply never written.
+        """
+        if self.__store is not None:
+            self.__store.flush()
 
     @property
     def tzinfo(self) -> tzinfo:

--- a/apprise/plugins/base.py
+++ b/apprise/plugins/base.py
@@ -741,7 +741,7 @@ class NotifyBase(URLBase):
             return False
 
         else:
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
 
             # Deferred import to dodge a circular import (apprise.apprise
             # loads this module first). Fine by call time.

--- a/apprise/plugins/macosx.py
+++ b/apprise/plugins/macosx.py
@@ -200,7 +200,10 @@ class NotifyMacOSX(NotifyBase):
 
         if output.returncode:
             self.logger.warning("Failed to send MacOSX notification.")
-            self.logger.exception("MacOSX Exception")
+            self.logger.debug(
+                "MacOSX notification command exited with code %s.",
+                output.returncode,
+            )
             return False
 
         self.logger.info("Sent MacOSX notification.")

--- a/apprise/plugins/matrix/e2ee.py
+++ b/apprise/plugins/matrix/e2ee.py
@@ -82,6 +82,7 @@ except ImportError:
     # E2EE support unavailable; `pip install cryptography` to enable
     MATRIX_E2EE_SUPPORT = False
 
+from ...common import JSON_COMPACT_SEPARATORS
 
 # Rotate the MegOLM session after this many messages
 MEGOLM_ROTATION_MSGS = 100
@@ -177,7 +178,7 @@ def _canonical_json(obj):
         obj,
         sort_keys=True,
         ensure_ascii=False,
-        separators=(",", ":"),
+        separators=JSON_COMPACT_SEPARATORS,
     ).encode("utf-8")
 
 

--- a/apprise/plugins/vapid/__init__.py
+++ b/apprise/plugins/vapid/__init__.py
@@ -33,7 +33,12 @@ import time
 
 import requests
 
-from ...common import NotifyImageSize, NotifyType, PersistentStoreMode
+from ...common import (
+    JSON_COMPACT_SEPARATORS,
+    NotifyImageSize,
+    NotifyType,
+    PersistentStoreMode,
+)
 from ...locale import gettext_lazy as _
 from ...utils import pem as _pem
 from ...utils.base64 import base64_urlencode
@@ -600,10 +605,10 @@ class NotifyVapid(NotifyBase):
 
         # Base64 URL encode header and payload
         header_b64 = base64_urlencode(
-            dumps(header, separators=(",", ":")).encode("utf-8")
+            dumps(header, separators=JSON_COMPACT_SEPARATORS).encode("utf-8")
         )
         payload_b64 = base64_urlencode(
-            dumps(payload, separators=(",", ":")).encode("utf-8")
+            dumps(payload, separators=JSON_COMPACT_SEPARATORS).encode("utf-8")
         )
         signing_input = f"{header_b64}.{payload_b64}".encode()
         signature_b64 = base64_urlencode(self.pem.sign(signing_input))

--- a/apprise/result.py
+++ b/apprise/result.py
@@ -1,0 +1,380 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+#
+#  - AppriseResultStatus -- the outcome of one notify() call,
+#                           as an IntEnum so it can double as a process
+#                           exit code (see apprise/cli.py).
+#  - NotifyAttempt       -- the raw outcome of exactly one call to a
+#                           service's notify()/async_notify() -- one
+#                           retry, or one escalation-chain re-dispatch.
+#  - NotifyResult        -- the outcome of one service actually being
+#                           notified this call (name, url, reflective
+#                           status), wrapping an ordered collection of
+#                           NotifyAttempt entries.
+#  - AppriseResult       -- the overall outcome of one notify() call,
+#                           wrapping an ordered collection of
+#                           NotifyResult entries plus the status above.
+"""Structured outcomes for notification calls, services, and attempts."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+from enum import IntEnum
+import json
+from typing import Any, Optional
+
+from .common import AWARE_DATE_ISO_FORMAT, JSON_COMPACT_SEPARATORS
+from .logger import NotifyLogEntry
+
+
+class AppriseResultStatus(IntEnum):
+    """The overall outcome of a single notify() / async_notify() call.
+
+    Values line up with CLI exit codes, so they can be passed to exit().
+    """
+
+    # Every matched/escalated service accepted the notification.
+    SUCCESS = 0
+
+    # A required service failed, or notify() received invalid arguments.
+    FAILURE = 1
+
+    # NOTE: 2 is intentionally unused because Click reserves it for invalid
+    # command-line arguments.
+
+    # No service was attempted: no loaded servers or no tag match.
+    # Only AppriseResult.status uses NOMATCH.
+    NOMATCH = 3
+
+    # Mixed overall result: at least one real success and one non-delivery.
+    # Only AppriseResult.status uses PARTIAL.
+    PARTIAL = 4
+
+    # The service did not finish before its service or call deadline.
+    TIMEOUT = 5
+
+
+class NotifyAttempt:
+    """The raw outcome of exactly one call to a service's notify()/
+    async_notify() -- one retry within a dispatch, or one escalation-chain
+    re-dispatch of the same service in a later priority tier.
+
+    Optional-service forgiveness happens later at NotifyResult. TIMEOUT means
+    Apprise stopped waiting, or skipped the next attempt after a deadline.
+    """
+
+    def __init__(
+        self,
+        status: AppriseResultStatus,
+        elapsed: float = 0.0,
+        logs: Optional[list[NotifyLogEntry]] = None,
+    ) -> None:
+        """Initialize the outcome, duration, and logs for one attempt."""
+        # The raw outcome of this one call: SUCCESS, FAILURE, or TIMEOUT.
+        # Never NOMATCH -- see the class docstring.
+        self.status = status
+
+        # Wall-clock seconds this one call took.  0.0 for a TIMEOUT entry
+        # that represents a decision not to start a new call at all (as
+        # opposed to one that was abandoned mid-flight).
+        self.elapsed = elapsed
+
+        # Derive start_time from end_time and elapsed so they always agree.
+        self.end_time = datetime.now(timezone.utc)
+        self.start_time = self.end_time - timedelta(seconds=self.elapsed)
+
+        # Every WARNING+ message the plugin logged during this one call.
+        self.logs = list(logs) if logs else []
+
+    def asdict(self) -> dict[str, Any]:
+        """Return this attempt as a plain, JSON-serializable dict."""
+        return {
+            "status": self.status.name,
+            "elapsed": self.elapsed,
+            "start_time": self.start_time.strftime(AWARE_DATE_ISO_FORMAT),
+            "end_time": self.end_time.strftime(AWARE_DATE_ISO_FORMAT),
+            "logs": [entry.asdict() for entry in self.logs],
+        }
+
+    def json(self) -> str:
+        """Return this attempt as a JSON string."""
+        return json.dumps(self.asdict(), separators=JSON_COMPACT_SEPARATORS)
+
+    def __bool__(self) -> bool:
+        """Return ``True`` only when this attempt succeeded."""
+        return self.status == AppriseResultStatus.SUCCESS
+
+    def __iter__(self) -> Iterator[NotifyLogEntry]:
+        """Iterate over log entries captured during this attempt."""
+        # Lets callers do `for line in attempt:` to walk this one call's
+        # captured log entries directly.
+        return iter(self.logs)
+
+    def __repr__(self) -> str:
+        """Return a concise representation of the attempt outcome."""
+        return "<NotifyAttempt status={!r} elapsed={!r}>".format(
+            self.status.name, self.elapsed
+        )
+
+
+class NotifyResult:
+    """The outcome of one service actually being notified this call.
+
+    Contains every NotifyAttempt made for that service in dispatch order.
+    Services skipped by priority escalation do not get a result.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        url: str,
+        url_id: Optional[str] = None,
+        tag: tuple[str, ...] = (),
+        optional: bool = False,
+        weight: int = 1,
+        max_attempts: int = 1,
+        attempts: Optional[list[NotifyAttempt]] = None,
+    ) -> None:
+        """Initialize one service result from its ordered attempts."""
+        # Human readable service name, e.g. "Slack", "Discord".
+        self.name = name
+
+        # The privacy-obfuscated URL that identifies which endpoint was
+        # notified (service.url(privacy=True)); safe to log/print/store.
+        self.url = url
+
+        # Stable URL identifier, when the plugin provides one.
+        self.url_id = url_id
+
+        # The tag(s) (as plain strings) this service was matched under.
+        self.tag = tuple(tag)
+
+        # Whether this service tolerates a non-SUCCESS outcome.
+        self.optional = bool(optional)
+
+        # Number of weighted delivery targets represented by this service.
+        self.weight = weight
+
+        # Maximum attempts allowed for this service.
+        self.max_attempts = max_attempts
+
+        # Every call actually made for this service, in order.  See
+        # NotifyAttempt's docstring for what a TIMEOUT entry here means.
+        self._attempts = list(attempts) if attempts else []
+
+        # SUCCESS and TIMEOUT are terminal, so the last attempt decides first.
+        last_status = (
+            self._attempts[-1].status
+            if self._attempts
+            else AppriseResultStatus.FAILURE
+        )
+
+        if last_status == AppriseResultStatus.SUCCESS or self.optional:
+            self.status = AppriseResultStatus.SUCCESS
+
+        elif last_status == AppriseResultStatus.TIMEOUT and not any(
+            a.status == AppriseResultStatus.FAILURE for a in self._attempts
+        ):
+            # No confirmed failure happened before Apprise ran out of time.
+            self.status = AppriseResultStatus.TIMEOUT
+
+        else:
+            # A confirmed failure is more useful than a later timeout.
+            self.status = AppriseResultStatus.FAILURE
+
+        #  - start_time = the first attempt's own
+        #  - end_time   = the last attempt's own
+        #  - elapsed    = end_time - start_time
+        if self._attempts:
+            self.start_time = self._attempts[0].start_time
+            self.end_time = self._attempts[-1].end_time
+
+        else:
+            # Fall back to 'now'
+            self.end_time = datetime.now(timezone.utc)
+            self.start_time = self.end_time
+
+        self.elapsed = (self.end_time - self.start_time).total_seconds()
+
+    @property
+    def attempts(self) -> tuple[NotifyAttempt, ...]:
+        """Read-only view of every NotifyAttempt made for this service,
+        in the order they were made."""
+        return tuple(self._attempts)
+
+    def logs(self) -> Iterator[NotifyLogEntry]:
+        """Yield every log entry captured across every attempt made for
+        this service, sequentially, in the order the calls were made."""
+        for attempt in self._attempts:
+            yield from attempt.logs
+
+    def asdict(self) -> dict[str, Any]:
+        """Return this result as a plain, JSON-serializable dict."""
+        return {
+            "name": self.name,
+            "url": self.url,
+            "url_id": self.url_id,
+            "tag": list(self.tag),
+            "status": self.status.name,
+            "optional": self.optional,
+            "weight": self.weight,
+            "max_attempts": self.max_attempts,
+            "elapsed": self.elapsed,
+            "start_time": self.start_time.strftime(AWARE_DATE_ISO_FORMAT),
+            "end_time": self.end_time.strftime(AWARE_DATE_ISO_FORMAT),
+            "attempts": [a.asdict() for a in self._attempts],
+        }
+
+    def json(self) -> str:
+        """Return this result as a JSON string."""
+        return json.dumps(self.asdict(), separators=JSON_COMPACT_SEPARATORS)
+
+    def __bool__(self) -> bool:
+        """Return ``True`` when this service result is successful."""
+        return self.status == AppriseResultStatus.SUCCESS
+
+    def __len__(self) -> int:
+        """Return the number of attempts made for this service."""
+        return len(self._attempts)
+
+    def __iter__(self) -> Iterator[NotifyAttempt]:
+        """Iterate over this service's attempts in dispatch order."""
+        # Lets callers do `for attempt in service_result:` to walk every
+        # call made for this service.
+        return iter(self._attempts)
+
+    def __repr__(self) -> str:
+        """Return a concise representation of the service outcome."""
+        return "<NotifyResult name={!r} url={!r} status={!r}>".format(
+            self.name, self.url, self.status.name
+        )
+
+
+class AppriseResult:
+    """The overall outcome of one Apprise.notify() / async_notify() call.
+
+    Wraps an ordered collection of NotifyResult entries (one per service
+    actually dispatched) along with the overall AppriseResultStatus.
+    """
+
+    def __init__(
+        self,
+        status: AppriseResultStatus = AppriseResultStatus.NOMATCH,
+        results: Optional[list[NotifyResult]] = None,
+        elapsed: float = 0.0,
+    ) -> None:
+        """Initialize the overall status and ordered service results."""
+        # Dispatch computes this because priority escalation affects outcome.
+        self.status = status
+
+        # Ordered list of every service actually dispatched, in the order
+        # Apprise attempted them.
+        self._results = list(results) if results else []
+
+        # Wall-clock seconds across the complete call, including every
+        # priority group, escalation round, and chain.
+        self.elapsed = elapsed
+
+        # Derive start_time from end_time and elapsed so they always agree.
+        self.end_time = datetime.now(timezone.utc)
+        self.start_time = self.end_time - timedelta(seconds=self.elapsed)
+
+    @property
+    def results(self) -> tuple[NotifyResult, ...]:
+        """Read-only view of every NotifyResult collected this call."""
+        return tuple(self._results)
+
+    @property
+    def success_count(self) -> int:
+        """Number of dispatched services whose (reflective) status is
+        SUCCESS."""
+        return sum(
+            1 for r in self._results if r.status == AppriseResultStatus.SUCCESS
+        )
+
+    @property
+    def failed_count(self) -> int:
+        """Number of dispatched services whose (reflective) status is not
+        SUCCESS."""
+        return sum(
+            1 for r in self._results if r.status != AppriseResultStatus.SUCCESS
+        )
+
+    @property
+    def timeout_count(self) -> int:
+        """Number of dispatched services whose status is TIMEOUT."""
+        return sum(
+            1 for r in self._results if r.status == AppriseResultStatus.TIMEOUT
+        )
+
+    def logs(self) -> Iterator[NotifyLogEntry]:
+        """Yield every log entry captured across every service and every
+        attempt made this call, in chronological order.
+
+        Concurrent service logs are sorted back into one timeline.
+        """
+        all_entries = (
+            entry for result in self._results for entry in result.logs()
+        )
+        yield from sorted(all_entries)
+
+    def asdict(self) -> dict[str, Any]:
+        """Return this result as a plain, JSON-serializable dict."""
+        return {
+            "status": self.status.name,
+            "success_count": self.success_count,
+            "failed_count": self.failed_count,
+            "elapsed": self.elapsed,
+            "start_time": self.start_time.strftime(AWARE_DATE_ISO_FORMAT),
+            "end_time": self.end_time.strftime(AWARE_DATE_ISO_FORMAT),
+            "results": [r.asdict() for r in self._results],
+        }
+
+    def json(self) -> str:
+        """Return this result as a JSON string."""
+        return json.dumps(self.asdict(), separators=JSON_COMPACT_SEPARATORS)
+
+    def __bool__(self) -> bool:
+        """Return ``True`` only when the overall notification succeeded."""
+        # Preserve the old boolean contract: only SUCCESS is truthy.
+        return self.status == AppriseResultStatus.SUCCESS
+
+    def __len__(self) -> int:
+        """Return the number of services that were dispatched."""
+        return len(self._results)
+
+    def __iter__(self) -> Iterator[NotifyResult]:
+        """Iterate over service results in dispatch order."""
+        return iter(self._results)
+
+    def __repr__(self) -> str:
+        """Return a concise representation of the overall outcome."""
+        return "<AppriseResult status={!r} count={}>".format(
+            self.status.name, len(self._results)
+        )

--- a/packaging/man/apprise.1
+++ b/packaging/man/apprise.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "APPRISE" "1" "May 2026" "Chris Caron <lead2gold@gmail.com>"
+.TH "APPRISE" "1" "July 2026" "Chris Caron <lead2gold@gmail.com>"
 .SH "NAME"
 \fBapprise\fR \- Push Notifications that work with just about every platform!
 .SH "SYNOPSIS"
@@ -64,6 +64,10 @@ Tag values may include an optional priority prefix and/or retry suffix:
 .P
 \fB\-Da\fR, \fB\-\-disable\-async\fR: Send notifications synchronously (one after the other) instead of all at once\.
 .P
+\fB\-L\fR, \fB\-\-limit=\fR\fISECONDS\fR: Give up on the whole run if it's taking too long, e\.g\. \fB\-L 10\fR or \fB\-L 2\.5\fR\. By default (\fB0\fR) there's no limit; see \fB\-\-service\-limit\fR below to cap each service on its own instead\. If a service is truly stuck, Apprise gives it a few extra seconds to wrap up, then exits anyway with status \fB5\fR\.
+.P
+\fB\-SL\fR, \fB\-\-service\-limit=\fR\fISECONDS\fR: Give up on any single service if it's taking too long, e\.g\. \fB\-SL 10\fR or \fB\-SL 2\.5\fR, or \fB0\fR to turn this off entirely\. Leave it unset to use Apprise's own default of 60 seconds\.
+.P
 \fB\-R\fR, \fB\-\-recursion\-depth\fR\fIINTEGER\fR: The number of recursive import entries that can be loaded from within Apprise configuration\. By default this is set to 1\. If this is set to zero, then import statements found in any configuration is ignored\.
 .P
 \fB\-e\fR, \fB\-\-interpret\-escapes\fR Enable interpretation of backslash escapes\. For example, this would convert sequences such as \en and \er to their respected ascii new\-line and carriage return characters prior to the delivery of the notification\.
@@ -116,11 +120,15 @@ The \fBstorage\fR action has the following sub actions:
 .IP "\(bu" 4
 \fB0\fR if all of the notifications were sent successfully\.
 .IP "\(bu" 4
-\fB1\fR if one or more notifications could not be sent\.
+\fB1\fR if every notification failed, or the notification could not start\.
 .IP "\(bu" 4
-\fB2\fR if there was an error specified on the command line such as not providing an valid argument\.
+\fB2\fR if there was an error specified on the command line such as not providing a valid argument\.
 .IP "\(bu" 4
-\fB3\fR if there was one or more Apprise Service URLs successfully loaded but none could be notified due to user filtering (via tags)\.
+\fB3\fR if one or more Apprise Service URLs were successfully loaded but none could be notified due to user filtering (via tags)\.
+.IP "\(bu" 4
+\fB4\fR if at least one notification was sent successfully and at least one other was not (whether it failed outright or ran out of time)\.
+.IP "\(bu" 4
+\fB5\fR if no notification was sent, and the only problem was that one or more services ran out of time\.
 .IP "" 0
 .SH "SERVICE URLS"
 There are too many service URL and combinations to list here\. It's best to visit the Apprise GitHub page \fIhttps://appriseit\.com/services/\fR and see what's available\. Also try out the Apprise URL Builder \fIhttps://appriseit\.com/tools/url\-builder/\fR to easily construct the URLS this tool supports and works with\.

--- a/packaging/man/apprise.1.html
+++ b/packaging/man/apprise.1.html
@@ -166,6 +166,18 @@ accept them).</li>
   Send notifications synchronously (one after the other) instead of
   all at once.</p>
 
+<p><code>-L</code>, <code>--limit=</code><var>SECONDS</var>:
+  Give up on the whole run if it's taking too long, e.g. <code>-L 10</code> or
+  <code>-L 2.5</code>. By default (<code>0</code>) there's no limit; see <code>--service-limit</code>
+  below to cap each service on its own instead. If a service is truly
+  stuck, Apprise gives it a few extra seconds to wrap up, then exits
+  anyway with status <strong>5</strong>.</p>
+
+<p><code>-SL</code>, <code>--service-limit=</code><var>SECONDS</var>:
+  Give up on any single service if it's taking too long, e.g. <code>-SL 10</code>
+  or <code>-SL 2.5</code>, or <code>0</code> to turn this off entirely. Leave it unset to use
+  Apprise's own default of 60 seconds.</p>
+
 <p><code>-R</code>, <code>--recursion-depth</code><var>INTEGER</var>:
   The number of recursive import entries that can be loaded from within
   Apprise configuration. By default this is set to 1. If this is set to
@@ -256,13 +268,19 @@ specify the keyword <strong>storage</strong></p>
   <li>
 <strong>0</strong> if all of the notifications were sent successfully.</li>
   <li>
-<strong>1</strong> if one or more notifications could not be sent.</li>
+<strong>1</strong> if every notification failed, or the notification could not start.</li>
   <li>
 <strong>2</strong> if there was an error specified on the command line such as not
-providing an valid argument.</li>
+providing a valid argument.</li>
   <li>
-<strong>3</strong> if there was one or more Apprise Service URLs successfully
-loaded but none could be notified due to user filtering (via tags).</li>
+<strong>3</strong> if one or more Apprise Service URLs were successfully loaded but
+none could be notified due to user filtering (via tags).</li>
+  <li>
+<strong>4</strong> if at least one notification was sent successfully and at least
+one other was not (whether it failed outright or ran out of time).</li>
+  <li>
+<strong>5</strong> if no notification was sent, and the only problem was that one or
+more services ran out of time.</li>
 </ul>
 
 <h2 id="SERVICE-URLS">SERVICE URLS</h2>
@@ -481,7 +499,7 @@ configuration that you want and only specifically notify a subset of them:</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>Chris Caron &lt;lead2gold@gmail.com&gt;</li>
-    <li class='tc'>May 2026</li>
+    <li class='tc'>July 2026</li>
     <li class='tr'>apprise(1)</li>
   </ol>
 

--- a/packaging/man/apprise.md
+++ b/packaging/man/apprise.md
@@ -73,6 +73,18 @@ The Apprise options are as follows:
   Send notifications synchronously (one after the other) instead of
   all at once.
 
+  `-L`, `--limit=`<SECONDS>:
+  Give up on the whole run if it's taking too long, e.g. `-L 10` or
+  `-L 2.5`. By default (`0`) there's no limit; see `--service-limit`
+  below to cap each service on its own instead. If a service is truly
+  stuck, Apprise gives it a few extra seconds to wrap up, then exits
+  anyway with status **5**.
+
+  `-SL`, `--service-limit=`<SECONDS>:
+  Give up on any single service if it's taking too long, e.g. `-SL 10`
+  or `-SL 2.5`, or `0` to turn this off entirely. Leave it unset to use
+  Apprise's own default of 60 seconds.
+
   `-R`, `--recursion-depth`<INTEGER>:
   The number of recursive import entries that can be loaded from within
   Apprise configuration. By default this is set to 1. If this is set to
@@ -158,11 +170,15 @@ The **storage** action has the following sub actions:
 **apprise** exits with a status of:
 
 * **0** if all of the notifications were sent successfully.
-* **1** if one or more notifications could not be sent.
+* **1** if every notification failed, or the notification could not start.
 * **2** if there was an error specified on the command line such as not
-  providing an valid argument.
-* **3** if there was one or more Apprise Service URLs successfully
-  loaded but none could be notified due to user filtering (via tags).
+  providing a valid argument.
+* **3** if one or more Apprise Service URLs were successfully loaded but
+  none could be notified due to user filtering (via tags).
+* **4** if at least one notification was sent successfully and at least
+  one other was not (whether it failed outright or ran out of time).
+* **5** if no notification was sent, and the only problem was that one or
+  more services ran out of time.
 
 ## SERVICE URLS
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import gc
+import logging
 import mimetypes
 import os
 import sys
@@ -37,6 +38,7 @@ from apprise import (
     ConfigurationManager,
     NotificationManager,
 )
+from apprise.logger import logger as apprise_logger
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))
 
@@ -69,6 +71,30 @@ def no_throttling_everywhere(session_mocker):
 
     for plugin in N_MGR.plugins():
         session_mocker.patch.object(plugin, "request_rate_per_sec", 0)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def _reset_apprise_logger_state():
+    """Force the shared 'apprise' logger back to a known-good baseline
+    before every test, then restore whatever was there beforehand.
+
+    apprise/cli.py's main() sets this same shared logger's level from
+    -v/-q verbosity (and appends a StreamHandler) on every invocation
+    and never undoes it -- harmless for a real one-shot CLI process,
+    but toxic for an in-process test suite: any test that runs main()
+    via CliRunner (e.g. tests/test_apprise_cli.py) with default
+    verbosity leaves the logger at ERROR, silently swallowing any
+    .warning()/.info() calls that later, unrelated tests rely on
+    capturing. Reset to NOTSET (deferring to the root logger's default
+    WARNING) before each test so no test's ambient logger state
+    depends on what a previous test/file happened to leave behind.
+    """
+    original_level = apprise_logger.level
+    original_handlers = list(apprise_logger.handlers)
+    apprise_logger.setLevel(logging.NOTSET)
+    yield
+    apprise_logger.setLevel(original_level)
+    apprise_logger.handlers[:] = original_handlers
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -46,6 +46,7 @@ from apprise import (
     Apprise,
     AppriseAsset,
     AppriseAttachment,
+    AppriseResultStatus,
     NotificationManager,
     NotifyBase,
     NotifyFormat,
@@ -96,6 +97,7 @@ def test_apprise_async():
 
 
 def apprise_test(do_notify):
+    """Exercise the core Apprise container and notification behavior."""
     a = Apprise()
 
     # no items
@@ -191,7 +193,7 @@ def apprise_test(do_notify):
     assert len(a) == 0
 
     # No servers to notify
-    assert do_notify(a, title="my title", body="my body") is False
+    assert bool(do_notify(a, title="my title", body="my body")) is False
 
     # More Variations of Multiple Adding of URLs
     a = Apprise()
@@ -278,7 +280,7 @@ def apprise_test(do_notify):
     assert len(a) == 0
 
     # We'll fail because we've got nothing to notify
-    assert do_notify(a, title="my title", body="my body") is False
+    assert bool(do_notify(a, title="my title", body="my body")) is False
 
     # Clear our server listings again
     a.clear()
@@ -288,87 +290,110 @@ def apprise_test(do_notify):
 
     # Bad Notification Types are not accepted
     assert (
-        do_notify(a, title="my title", body="my body", notify_type="bad")
+        bool(do_notify(a, title="my title", body="my body", notify_type="bad"))
         is False
     )
 
     # Notifications of string type are accepted
     assert (
-        do_notify(a, title="my title", body="my body", notify_type="warning")
+        bool(
+            do_notify(
+                a, title="my title", body="my body", notify_type="warning"
+            )
+        )
         is True
     )
 
     # Notifications of string type are accepted
     assert (
-        do_notify(a, title="my title", body="my body", notify_type="warning")
+        bool(
+            do_notify(
+                a, title="my title", body="my body", notify_type="warning"
+            )
+        )
         is True
     )
 
     # Notifications of string type are accepted
     assert (
-        do_notify(a, title="my title", body="my body", notify_type="warning")
+        bool(
+            do_notify(
+                a, title="my title", body="my body", notify_type="warning"
+            )
+        )
         is True
     )
 
     # Notifications where notify_type is of the NotifyType object is the
     # preferred choice
     assert (
-        do_notify(
-            a, title="my title", body="my body", notify_type=NotifyType.WARNING
+        bool(
+            do_notify(
+                a,
+                title="my title",
+                body="my body",
+                notify_type=NotifyType.WARNING,
+            )
         )
         is True
     )
 
     # No Title/Body combo's
-    assert do_notify(a, title=None, body=None) is False
-    assert do_notify(a, title="", body=None) is False
-    assert do_notify(a, title=None, body="") is False
+    assert bool(do_notify(a, title=None, body=None)) is False
+    assert bool(do_notify(a, title="", body=None)) is False
+    assert bool(do_notify(a, title=None, body="")) is False
 
-    assert do_notify(a, title=5, body=b"bytes") is False
-    assert do_notify(a, title=b"bytes", body=10) is False
-    assert do_notify(a, title=object(), body=b"bytes") is False
-    assert do_notify(a, title=b"bytes", body=object()) is False
+    assert bool(do_notify(a, title=5, body=b"bytes")) is False
+    assert bool(do_notify(a, title=b"bytes", body=10)) is False
+    assert bool(do_notify(a, title=object(), body=b"bytes")) is False
+    assert bool(do_notify(a, title=b"bytes", body=object())) is False
 
     # A Body must be present
-    assert do_notify(a, title="present", body=None) is False
+    assert bool(do_notify(a, title="present", body=None)) is False
 
     # Other combinations work fine
-    assert do_notify(a, title=None, body="present") is True
-    assert do_notify(a, title="present", body="present") is True
+    assert bool(do_notify(a, title=None, body="present")) is True
+    assert bool(do_notify(a, title="present", body="present")) is True
 
     # Send Attachment with success
     attach = join(TEST_VAR_DIR, "apprise-test.gif")
     assert (
-        do_notify(
-            a,
-            body="body",
-            title="test",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            do_notify(
+                a,
+                body="body",
+                title="test",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
 
     # Send the attachment as an AppriseAttachment object
     assert (
-        do_notify(
-            a,
-            body="body",
-            title="test",
-            notify_type=NotifyType.INFO,
-            attach=AppriseAttachment(attach),
+        bool(
+            do_notify(
+                a,
+                body="body",
+                title="test",
+                notify_type=NotifyType.INFO,
+                attach=AppriseAttachment(attach),
+            )
         )
         is True
     )
 
     # test a invalid attachment
     assert (
-        do_notify(
-            a,
-            body="body",
-            title="test",
-            notify_type=NotifyType.INFO,
-            attach="invalid://",
+        bool(
+            do_notify(
+                a,
+                body="body",
+                title="test",
+                notify_type=NotifyType.INFO,
+                attach="invalid://",
+            )
         )
         is False
     )
@@ -377,36 +402,42 @@ def apprise_test(do_notify):
     # however do it by directly accessing the object; this grants the similar
     # results:
     assert (
-        do_notify(
-            a[0],
-            body="body",
-            title="test",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            do_notify(
+                a[0],
+                body="body",
+                title="test",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
 
     # Send the attachment as an AppriseAttachment object
     assert (
-        do_notify(
-            a[0],
-            body="body",
-            title="test",
-            notify_type=NotifyType.INFO,
-            attach=AppriseAttachment(attach),
+        bool(
+            do_notify(
+                a[0],
+                body="body",
+                title="test",
+                notify_type=NotifyType.INFO,
+                attach=AppriseAttachment(attach),
+            )
         )
         is True
     )
 
     # test a invalid attachment
     assert (
-        do_notify(
-            a[0],
-            body="body",
-            title="test",
-            notify_type=NotifyType.INFO,
-            attach="invalid://",
+        bool(
+            do_notify(
+                a[0],
+                body="body",
+                title="test",
+                notify_type=NotifyType.INFO,
+                attach="invalid://",
+            )
         )
         is False
     )
@@ -461,7 +492,7 @@ def apprise_test(do_notify):
 
         # Test when our notify both throws an exception and or just
         # simply returns False
-        assert do_notify(a, title="present", body="present") is False
+        assert bool(do_notify(a, title="present", body="present")) is False
 
     # Create a Notification that throws an unexected exception
     class ThrowInstantiateNotification(NotifyBase):
@@ -692,6 +723,7 @@ def test_apprise_tagging_async(mock_request):
 
 
 def apprise_tagging_test(mock_request, do_notify):
+    """Exercise tag filtering and grouped notification behavior."""
     # A request
     robj = mock.Mock()
     robj.raw = mock.Mock()
@@ -733,23 +765,27 @@ def apprise_tagging_test(mock_request, do_notify):
     # notify the awesome tag; this would notify both services behind the
     # scenes
     assert (
-        do_notify(a, title="my title", body="my body", tag="awesome") is True
+        bool(do_notify(a, title="my title", body="my body", tag="awesome"))
+        is True
     )
 
     # notify all of the tags
     assert (
-        do_notify(
-            a, title="my title", body="my body", tag=["awesome", "mmost"]
+        bool(
+            do_notify(
+                a, title="my title", body="my body", tag=["awesome", "mmost"]
+            )
         )
         is True
     )
 
     # When we query against our loaded notifications for a tag that simply
-    # isn't assigned to anything, we return None.  None (different then False)
-    # tells us that we litterally had nothing to query.  We didn't fail...
-    # but we also didn't do anything...
+    # isn't assigned to anything, we return NOMATCH.  NOMATCH (different
+    # then FAILURE) tells us that we litterally had nothing to query.  We
+    # didn't fail... but we also didn't do anything...
     assert (
-        do_notify(a, title="my title", body="my body", tag="missing") is None
+        do_notify(a, title="my title", body="my body", tag="missing").status
+        == AppriseResultStatus.NOMATCH
     )
 
     # Now to test the ability to and and/or notifications
@@ -777,25 +813,37 @@ def apprise_tagging_test(mock_request, do_notify):
     #   - json://localhost/tagCD/
     #   - json://localhost/tagCDE/
     assert (
-        do_notify(a, title="my title", body="my body", tag=[("TagC", "TagD")])
+        bool(
+            do_notify(
+                a,
+                title="my title",
+                body="my body",
+                tag=[("TagC", "TagD")],
+            )
+        )
         is True
     )
 
     # Expression: (TagY and TagZ) or TagX
-    # Matches nothing, None is returned in this case
+    # Matches nothing, NOMATCH is returned in this case
     assert (
         do_notify(
             a, title="my title", body="my body", tag=[("TagY", "TagZ"), "TagX"]
-        )
-        is None
+        ).status
+        == AppriseResultStatus.NOMATCH
     )
 
     # Expression: (TagY and TagZ) or TagA
     # Matches the following only:
     #   - json://localhost/tagAB/
     assert (
-        do_notify(
-            a, title="my title", body="my body", tag=[("TagY", "TagZ"), "TagA"]
+        bool(
+            do_notify(
+                a,
+                title="my title",
+                body="my body",
+                tag=[("TagY", "TagZ"), "TagA"],
+            )
         )
         is True
     )
@@ -806,8 +854,13 @@ def apprise_tagging_test(mock_request, do_notify):
     #   - json://localhost/tagAB/
     #   - json://localhost/tagB/
     assert (
-        do_notify(
-            a, title="my title", body="my body", tag=[("TagE", "TagD"), "TagB"]
+        bool(
+            do_notify(
+                a,
+                title="my title",
+                body="my body",
+                tag=[("TagE", "TagD"), "TagB"],
+            )
         )
         is True
     )
@@ -815,7 +868,7 @@ def apprise_tagging_test(mock_request, do_notify):
     # Garbage Entries in tag field just get stripped out. the below
     # is the same as notifying no tags at all. Since we have not added
     # any entries that do not have tags (that we can match against)
-    # we fail.  None is returned as a way of letting us know that we
+    # we fail.  NOMATCH is returned as a way of letting us know that we
     # had Notifications to notify, but since none of them matched our tag
     # none were notified.
     assert (
@@ -826,8 +879,8 @@ def apprise_tagging_test(mock_request, do_notify):
             tag=[
                 (object,),
             ],
-        )
-        is None
+        ).status
+        == AppriseResultStatus.NOMATCH
     )
 
 
@@ -1253,24 +1306,32 @@ def test_apprise_notify_formats():
     assert len(a) == 9
 
     assert (
-        a.notify(
-            title="markdown",
-            body="## Testing Markdown",
-            body_format=NotifyFormat.MARKDOWN,
+        bool(
+            a.notify(
+                title="markdown",
+                body="## Testing Markdown",
+                body_format=NotifyFormat.MARKDOWN,
+            )
         )
         is True
     )
 
     assert (
-        a.notify(
-            title="text", body="Testing Text", body_format=NotifyFormat.TEXT
+        bool(
+            a.notify(
+                title="text",
+                body="Testing Text",
+                body_format=NotifyFormat.TEXT,
+            )
         )
         is True
     )
 
     assert (
-        a.notify(
-            title="html", body="<b>HTML</b>", body_format=NotifyFormat.HTML
+        bool(
+            a.notify(
+                title="html", body="<b>HTML</b>", body_format=NotifyFormat.HTML
+            )
         )
         is True
     )
@@ -1554,13 +1615,13 @@ def test_apprise_disabled_plugins():
     plugin.enabled = False
 
     # As a result, we can now no longer send a notification:
-    assert plugin.notify("My Message") is False
+    assert bool(plugin.notify("My Message")) is False
 
     # As just a proof of how you can toggle the state back:
     plugin.enabled = True
 
     # our notifications will go okay now
-    assert plugin.notify("My Message") is True
+    assert bool(plugin.notify("My Message")) is True
 
     # Restore our modules
     N_MGR.unload_modules()
@@ -2298,8 +2359,8 @@ def test_apprise_async_mode(mock_threadpool, mock_gather, mock_request):
     """
     mock_request.return_value.status_code = requests.codes.ok
 
-    # Define some servers
-    servers = [
+    # Define some services
+    services = [
         "xml://localhost",
         "json://localhost",
     ]
@@ -2311,71 +2372,102 @@ def test_apprise_async_mode(mock_threadpool, mock_gather, mock_request):
     # Load our asset
     a = Apprise(asset=asset)
 
-    # add our servers
-    a.add(servers=servers)
+    # add our services
+    a.add(servers=services)
 
-    # 2 servers loaded
+    # 2 services loaded
     assert len(a) == 2
 
-    # Our servers should carry this flag
-    for server in a:
-        assert server.asset.async_mode is True
+    # Our services should carry this flag
+    for service in a:
+        assert service.asset.async_mode is True
 
-    # Send Notifications Asyncronously
-    assert a.notify("async") is True
+    # _notify_parallel_threadpool() shares one ThreadPoolExecutor across
+    # every call for the life of the process (apprise.py's
+    # _get_shared_executor()) rather than creating a new one each time,
+    # so it can only ever be *constructed* once here regardless of how
+    # many dispatches follow. Reset to None so this test observes that
+    # first construction deterministically rather than possibly reusing
+    # one an earlier test already created; mock.patch restores whatever
+    # was actually there once this block exits.
+    with mock.patch("apprise.apprise._shared_executor", None):
+        # Send Notifications Asyncronously
+        assert bool(a.notify("async")) is True
 
-    # Verify our thread pool was created
-    assert mock_threadpool.call_count == 1
-    mock_threadpool.reset_mock()
+        # Verify our thread pool was created
+        assert mock_threadpool.call_count == 1
+        mock_threadpool.reset_mock()
 
-    # Provide an over-ride now
-    asset = AppriseAsset(async_mode=False)
-    assert asset.async_mode is False
+        # Provide an over-ride now
+        asset = AppriseAsset(async_mode=False)
+        assert asset.async_mode is False
 
-    # Load our asset
-    a = Apprise(asset=asset)
+        # Load our asset
+        a = Apprise(asset=asset)
 
-    # Verify our configuration kept
-    assert a.asset.async_mode is False
+        # Verify our configuration kept
+        assert a.asset.async_mode is False
 
-    # add our servers
-    a.add(servers=servers)
+        # add our services
+        a.add(servers=services)
 
-    # 2 servers loaded
-    assert len(a) == 2
+        # 2 services loaded
+        assert len(a) == 2
 
-    # Our servers should carry this flag
-    for server in a:
-        assert server.asset.async_mode is False
+        # Our services should carry this flag
+        for service in a:
+            assert service.asset.async_mode is False
 
-    # Send Notifications Syncronously
-    assert a.notify("sync") is True
-    # Sequential send doesn't require a gather
-    assert mock_gather.call_count == 0
-    mock_gather.reset_mock()
+        # Send Notifications Syncronously
+        assert bool(a.notify("sync")) is True
+        # Sequential send doesn't require a gather
+        assert mock_gather.call_count == 0
+        mock_gather.reset_mock()
 
-    # another way of looking a our false set asset configuration
-    assert a[0].asset.async_mode is False
-    assert a[1].asset.async_mode is False
+        # another way of looking a our false set asset configuration
+        assert a[0].asset.async_mode is False
+        assert a[1].asset.async_mode is False
 
-    # Adjust 1 of the servers async_mode settings
-    a[0].asset.async_mode = True
-    assert a[0].asset.async_mode is True
+        # Adjust 1 of the services async_mode settings
+        a[0].asset.async_mode = True
+        assert a[0].asset.async_mode is True
 
-    # They all share the same object, so this gets toggled too
-    assert a[1].asset.async_mode is True
+        # They all share the same object, so this gets toggled too
+        assert a[1].asset.async_mode is True
 
-    # We'll just change this one
-    a[1].asset = AppriseAsset(async_mode=False)
-    assert a[0].asset.async_mode is True
-    assert a[1].asset.async_mode is False
+        # We'll just change this one
+        a[1].asset = AppriseAsset(async_mode=False)
+        assert a[0].asset.async_mode is True
+        assert a[1].asset.async_mode is False
 
-    # Send 1 Notification Syncronously, the other Asyncronously
-    assert a.notify("a mixed batch") is True
+        # Send 1 Notification Syncronously, the other Asyncronously
+        assert bool(a.notify("a mixed batch")) is True
 
-    # Verify we didn't use a thread pool for a single notification
-    assert mock_threadpool.call_count == 0
-    mock_threadpool.reset_mock()
+        # The single async-mode service still goes through the thread
+        # pool even though it's alone in its batch: AppriseAsset.
+        # service_timeout defaults to 60s, so a deadline applies, and
+        # only a thread-pool dispatch can abandon a service that runs
+        # past its deadline. No NEW executor is constructed though --
+        # the one from the first dispatch above is shared and reused.
+        assert mock_threadpool.call_count == 0
+
+        # Disable this service's own timeout budget entirely -- with no
+        # deadline of any kind in effect, a single async-mode service has
+        # nothing that could ever need abandoning, so the thread-pool
+        # shortcut applies again (no executor use at all, shared or not).
+        a[0].asset = AppriseAsset(async_mode=True, service_timeout=0)
+        a[1].asset = AppriseAsset(async_mode=False)
+        assert bool(a.notify("a mixed batch, no timeout")) is True
+        assert mock_threadpool.call_count == 0
+
+        # Shut down the executor constructed inside this patched block
+        # before it's discarded -- otherwise its worker threads would
+        # sit idle forever with nothing left referencing them once
+        # mock.patch restores apprise.apprise._shared_executor below.
+        import apprise.apprise as apprise_module
+
+        if apprise_module._shared_executor is not None:
+            apprise_module._shared_executor.shutdown(wait=False)
 
 
 def test_notify_matrix_dynamic_importing(tmpdir):

--- a/tests/test_apprise_asset.py
+++ b/tests/test_apprise_asset.py
@@ -61,3 +61,60 @@ def test_timezone():
 
     with pytest.raises(AttributeError):
         AppriseAsset(timezone="invalid")
+
+
+def test_service_timeout():
+    "asset: service_timeout() testing"
+
+    # Default value is 60 seconds, defined directly on AppriseAsset
+    asset = AppriseAsset()
+    assert asset._service_timeout == 60.0
+
+    # Accepts an int and stores it as a float
+    asset = AppriseAsset(service_timeout=10)
+    assert asset._service_timeout == 10.0
+    assert isinstance(asset._service_timeout, float)
+
+    # Accepts a float directly
+    asset = AppriseAsset(service_timeout=12.5)
+    assert asset._service_timeout == 12.5
+
+    # 0 is valid -- it disables the timeout entirely
+    asset = AppriseAsset(service_timeout=0)
+    assert asset._service_timeout == 0.0
+
+    # Negative values are rejected
+    with pytest.raises(ValueError):
+        AppriseAsset(service_timeout=-1)
+
+    # Non-numeric types are rejected
+    with pytest.raises(TypeError):
+        AppriseAsset(service_timeout="invalid")
+
+    # Booleans are rejected even though bool is technically an int subclass
+    with pytest.raises(TypeError):
+        AppriseAsset(service_timeout=True)
+
+    # inf might look like a second way to spell "unbounded" (0 is the
+    # documented one), but concurrent.futures.Future.result(timeout=
+    # float("inf")) raises OverflowError on some platforms, silently
+    # turning a successful notification into a reported FAILURE -- so
+    # it's rejected outright, same as any other non-finite value.
+    with pytest.raises(ValueError):
+        AppriseAsset(service_timeout=float("inf"))
+
+    with pytest.raises(ValueError):
+        AppriseAsset(service_timeout=float("-inf"))
+
+    # NaN fails every ordering comparison, so it would otherwise slip
+    # past a plain "< 0" check and silently disable the timeout as an
+    # accidental side effect of its comparison semantics.
+    with pytest.raises(ValueError):
+        AppriseAsset(service_timeout=float("nan"))
+
+    # The internal/system attribute can also be set the same way every
+    # other underscore-prefixed AppriseAsset field can: directly through
+    # the generic kwarg mechanism (bypassing the friendly named parameter
+    # and its validation).
+    asset = AppriseAsset(_service_timeout=99.0)
+    assert asset._service_timeout == 99.0

--- a/tests/test_apprise_cli.py
+++ b/tests/test_apprise_cli.py
@@ -3216,6 +3216,23 @@ def test_wait_for_abandoned_calls_exits_early_when_calls_finish():
         assert call.args[0] == cli.CLI_TIMEOUT_EXIT_POLL_INTERVAL
 
 
+def test_wait_for_abandoned_calls_finishes_right_as_grace_period_ends():
+    """A final post-loop check can catch work that just finished."""
+    with (
+        mock.patch("apprise.cli.time.sleep"),
+        mock.patch(
+            "apprise.cli._any_abandoned_calls_still_running",
+            # Four in-loop polls still report running. The final check
+            # sees that the abandoned work has just finished.
+            side_effect=[True, True, True, True, False],
+        ) as mock_still_running,
+    ):
+        result = cli._wait_for_abandoned_calls(1.0)
+
+    assert result is True
+    assert mock_still_running.call_count == 5
+
+
 def test_force_exit_sequence():
     """_force_exit() unconditionally flushes every service's
     persistent store (AUTO mode only writes on-demand, and os._exit()

--- a/tests/test_apprise_cli.py
+++ b/tests/test_apprise_cli.py
@@ -44,7 +44,14 @@ from helpers import environ
 import pytest
 import requests
 
-from apprise import NotificationManager, NotifyBase, cli
+from apprise import (
+    Apprise,
+    AppriseAsset,
+    AppriseResultStatus,
+    NotificationManager,
+    NotifyBase,
+    cli,
+)
 from apprise.locale import gettext_lazy as _
 from apprise.plugins.base import RequirementsSpec
 
@@ -2967,3 +2974,445 @@ def test_apprise_cli_runtime_env_py39_no_packages_distributions(
 
     # No dep listing -- packages_distributions unavailable on Python < 3.11
     assert not any(a[0] == "Runtime deps: %s" for a in calls)
+
+
+def test_apprise_cli_limit_option_in_help():
+    """
+    CLI: --limit (-L) appears in --help output
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli.main, ["--help"])
+    assert result.exit_code == 0
+    assert "--limit" in result.output
+    assert "-L" in result.output
+
+
+@mock.patch("requests.request")
+def test_apprise_cli_notify_runtime_stat_log(mock_request):
+    """
+    CLI: right after notify() returns, a single DEBUG line reports how
+    long it took and how the AppriseResult broke down (success/failed/
+    timeout counts, plus the overall status by name -- PARTIAL or
+    TIMEOUT show up there without needing a separate line).
+
+    Only logger.debug itself is patched (not the whole logger object) --
+    main() also reads logger.level/setLevel() during its own verbosity
+    setup, which would break against a fully mocked logger.
+    """
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = b""
+    mock_request.return_value = response
+
+    runner = CliRunner()
+    with mock.patch.object(cli.logger, "debug") as mock_debug:
+        result = runner.invoke(
+            cli.main,
+            ["-t", "title", "-b", "body", "json://good"],
+        )
+    assert result.exit_code == 0
+
+    calls = [a for a, _ in mock_debug.call_args_list]
+    assert any(
+        a[0]
+        == (
+            "Finished in %.2fs. %d service(s) tried (%s): %d sent / "
+            "%d failed / %d timed out."
+        )
+        # a[1] is the elapsed seconds float -- not asserted here, just
+        # that it's present as the first substitution.
+        and a[2:] == (1, "SUCCESS", 1, 0, 0)
+        for a in calls
+    )
+
+
+@mock.patch("apprise.cli._force_exit")
+@mock.patch("requests.request")
+def test_apprise_cli_limit_option_times_out_service(
+    mock_request, mock_force_exit
+):
+    """
+    CLI: --limit (-L) caps how long a single notification may take,
+    reporting the service as timed out and exiting 5.
+
+    _force_exit() is mocked purely as a safety net: for real it calls
+    os._exit(), which would otherwise end this test process itself --
+    CliRunner.invoke() runs main() in-process, not as a subprocess, so
+    os._exit() has no SystemExit for it to catch the way ctx.exit()
+    normally provides. In practice it's never actually reached here:
+    the service's own 0.2s delay finishes well within the default 5s
+    grace period, so _wait_for_abandoned_calls() reports success on
+    its own and main() falls through to its normal, catchable
+    ctx.exit(status) -- see the assertion below confirming this.
+    """
+    import time
+
+    def _slow_failure(*args, **kwargs):
+        """Return a delayed HTTP failure to force the CLI timeout path."""
+        time.sleep(0.2)
+        response = mock.Mock()
+        response.status_code = requests.codes.internal_server_error
+        response.content = b""
+        response.text = ""
+        return response
+
+    mock_request.side_effect = _slow_failure
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.main,
+        [
+            "-t",
+            "title",
+            "-b",
+            "body",
+            "--limit",
+            "0.05",
+            "json://good?retry=3",
+        ],
+    )
+
+    # The only service dispatched timed out (no plain failure to take
+    # priority over it -- see _aggregate_status in apprise/apprise.py),
+    # so the overall result -- and thus this exit code -- is TIMEOUT (5)
+    # rather than the generic FAILURE (1).
+    # (The "timed out" diagnostic itself goes through Python logging,
+    # not click.echo, so it isn't visible in CliRunner's captured
+    # result.output -- it's covered directly in tests/test_retry_wait.py.)
+    assert result.exit_code == AppriseResultStatus.TIMEOUT
+
+    # The abandoned call's own 0.2s delay finished naturally well
+    # within the default 5s grace period, so _wait_for_abandoned_calls()
+    # already confirmed nothing was left running -- the hard-exit path
+    # was never needed. This exit code is itself unambiguous proof the
+    # TIMEOUT branch was taken (nothing else in main() produces it).
+    mock_force_exit.assert_not_called()
+
+
+@mock.patch("apprise.cli._force_exit")
+@mock.patch("requests.request")
+def test_apprise_cli_limit_option_hard_exit_when_call_still_running(
+    mock_request, mock_force_exit
+):
+    """
+    CLI: the counterpart to test_apprise_cli_limit_option_times_out_
+    service above -- when the abandoned call is STILL genuinely running
+    after the full grace period (not just briefly delayed), main()
+    actually reaches _force_exit(), rather than falling through to a
+    normal ctx.exit().
+
+    CLI_TIMEOUT_EXIT_GRACE_SECONDS is shortened here purely so this
+    test runs quickly; the service's own delay is longer than that
+    shortened window, so _wait_for_abandoned_calls() genuinely times
+    out instead of resolving on its own. _force_exit() is mocked so
+    the real os._exit() call doesn't end this test process (see the
+    sibling test's docstring for why).
+    """
+    import time
+
+    def _slow_failure(*args, **kwargs):
+        """Return a delayed HTTP failure to force the CLI timeout path."""
+        time.sleep(0.5)
+        response = mock.Mock()
+        response.status_code = requests.codes.internal_server_error
+        response.content = b""
+        response.text = ""
+        return response
+
+    mock_request.side_effect = _slow_failure
+
+    with mock.patch("apprise.cli.CLI_TIMEOUT_EXIT_GRACE_SECONDS", 0.05):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.main,
+            [
+                "-t",
+                "title",
+                "-b",
+                "body",
+                "--limit",
+                "0.05",
+                "json://good?retry=3",
+            ],
+        )
+
+    assert result.exit_code == AppriseResultStatus.TIMEOUT
+    mock_force_exit.assert_called_once()
+    assert mock_force_exit.call_args.args[1] == AppriseResultStatus.TIMEOUT
+
+
+def test_wait_for_abandoned_calls_polls_full_grace_period():
+    """_wait_for_abandoned_calls() polls in
+    CLI_TIMEOUT_EXIT_POLL_INTERVAL increments (never a single lump
+    sleep) and returns False once the full timeout elapses with
+    _any_abandoned_calls_still_running() still reporting True
+    throughout.
+    """
+    with (
+        mock.patch("apprise.cli.time.sleep") as mock_sleep,
+        mock.patch(
+            "apprise.cli._any_abandoned_calls_still_running",
+            return_value=True,
+        ) as mock_still_running,
+    ):
+        result = cli._wait_for_abandoned_calls(
+            cli.CLI_TIMEOUT_EXIT_GRACE_SECONDS
+        )
+
+    assert result is False
+    assert mock_still_running.called
+    total_slept = sum(call.args[0] for call in mock_sleep.call_args_list)
+    assert total_slept == pytest.approx(cli.CLI_TIMEOUT_EXIT_GRACE_SECONDS)
+    for call in mock_sleep.call_args_list:
+        assert call.args[0] <= cli.CLI_TIMEOUT_EXIT_POLL_INTERVAL
+
+
+def test_wait_for_abandoned_calls_logs_service_descriptions_at_debug():
+    """_wait_for_abandoned_calls() logs which specific still-running
+    service(s) it's waiting on, once, at DEBUG level only -- so this
+    stays out of default-verbosity output even though the url() is
+    already privacy-masked by _abandoned_call_descriptions()."""
+    with (
+        mock.patch("apprise.cli.time.sleep"),
+        mock.patch(
+            "apprise.cli._any_abandoned_calls_still_running",
+            return_value=False,
+        ),
+        mock.patch(
+            "apprise.cli._abandoned_call_descriptions",
+            return_value=["dummy (dummy://masked@host)"],
+        ),
+        mock.patch("apprise.cli.logger.debug") as mock_debug,
+    ):
+        cli._wait_for_abandoned_calls(cli.CLI_TIMEOUT_EXIT_GRACE_SECONDS)
+
+    first_call_message = mock_debug.call_args_list[0].args
+    assert "dummy (dummy://masked@host)" in first_call_message
+
+
+def test_wait_for_abandoned_calls_exits_early_when_calls_finish():
+    """_wait_for_abandoned_calls() returns True as soon as
+    _any_abandoned_calls_still_running() reports False, rather than
+    always waiting out the full grace period -- the whole point of
+    polling instead of a single fixed sleep.
+    """
+    # "Still running" for the first two checks, then finished -- so
+    # only 2 short sleeps happen instead of the full grace period.
+    with (
+        mock.patch("apprise.cli.time.sleep") as mock_sleep,
+        mock.patch(
+            "apprise.cli._any_abandoned_calls_still_running",
+            side_effect=[True, True, False],
+        ) as mock_still_running,
+    ):
+        result = cli._wait_for_abandoned_calls(
+            cli.CLI_TIMEOUT_EXIT_GRACE_SECONDS
+        )
+
+    assert result is True
+    assert mock_still_running.call_count == 3
+    assert mock_sleep.call_count == 2
+    for call in mock_sleep.call_args_list:
+        assert call.args[0] == cli.CLI_TIMEOUT_EXIT_POLL_INTERVAL
+
+
+def test_force_exit_sequence():
+    """_force_exit() unconditionally flushes every service's
+    persistent store (AUTO mode only writes on-demand, and os._exit()
+    skips the garbage-collection that would normally trigger it),
+    flushes logging/stdio, and only then forces the process to end via
+    os._exit() with the given status -- no polling of any kind, since
+    _wait_for_abandoned_calls() having already reported "still running"
+    is a precondition for this being called at all.
+
+    Every external effect is mocked directly (not through the CLI) so
+    this asserts the full sequence in isolation, without actually
+    ending this test process.
+    """
+    a = Apprise()
+    services = [mock.Mock(spec=NotifyBase) for _ in range(3)]
+    for service in services:
+        a.add(service)
+
+    with (
+        mock.patch("apprise.cli.logging.shutdown") as mock_shutdown,
+        mock.patch("apprise.cli.sys.stdout.flush") as mock_stdout_flush,
+        mock.patch("apprise.cli.sys.stderr.flush") as mock_stderr_flush,
+        mock.patch("apprise.cli.os._exit") as mock_os_exit,
+    ):
+        cli._force_exit(a, AppriseResultStatus.TIMEOUT)
+
+    for service in services:
+        service.flush_store.assert_called_once()
+    mock_shutdown.assert_called_once()
+    mock_stdout_flush.assert_called_once()
+    mock_stderr_flush.assert_called_once()
+    mock_os_exit.assert_called_once_with(AppriseResultStatus.TIMEOUT)
+
+
+def test_force_exit_flush_failure_does_not_skip_others():
+    """A failing flush_store() must never prevent the hard exit below,
+    NOR stop the remaining services from getting their own chance to
+    flush -- one bad store shouldn't cost every other one its own
+    flush. The broken service is deliberately added FIRST here so its
+    failure has to happen before the good one is ever reached.
+    """
+    a = Apprise()
+    broken_service = mock.Mock(spec=NotifyBase)
+    broken_service.flush_store.side_effect = RuntimeError("disk full")
+    ok_service = mock.Mock(spec=NotifyBase)
+    a.add(broken_service)
+    a.add(ok_service)
+
+    with (
+        mock.patch("apprise.cli.logging.shutdown") as mock_shutdown,
+        mock.patch("apprise.cli.os._exit") as mock_os_exit,
+    ):
+        cli._force_exit(a, AppriseResultStatus.TIMEOUT)
+
+    # The service after the broken one in iteration order still got
+    # its own flush attempt.
+    ok_service.flush_store.assert_called_once()
+    mock_os_exit.assert_called_once_with(AppriseResultStatus.TIMEOUT)
+    # logging.shutdown() is unrelated to the failing store and should
+    # still run normally afterward.
+    mock_shutdown.assert_called_once()
+
+
+def test_force_exit_reaches_exit_despite_logging_failure():
+    """os._exit() must still run even when logging.shutdown() itself
+    raises -- there is nothing reliable left to log to at that point,
+    so the failure is swallowed rather than reported. sys.stdout/
+    stderr.flush() are independently guarded too, so logging.shutdown()
+    failing must not stop them from still being attempted.
+    """
+    a = Apprise()
+    service = mock.Mock(spec=NotifyBase)
+    a.add(service)
+
+    with (
+        mock.patch(
+            "apprise.cli.logging.shutdown",
+            side_effect=RuntimeError("logging is broken"),
+        ),
+        mock.patch("apprise.cli.sys.stdout.flush") as mock_stdout_flush,
+        mock.patch("apprise.cli.sys.stderr.flush") as mock_stderr_flush,
+        mock.patch("apprise.cli.os._exit") as mock_os_exit,
+    ):
+        cli._force_exit(a, AppriseResultStatus.TIMEOUT)
+
+    service.flush_store.assert_called_once()
+    mock_stdout_flush.assert_called_once()
+    mock_stderr_flush.assert_called_once()
+    mock_os_exit.assert_called_once_with(AppriseResultStatus.TIMEOUT)
+
+
+def test_apprise_cli_limit_option_negative_value_errors():
+    """
+    CLI: --limit (-L) rejects a negative value the same way notify()
+    and AppriseAsset(service_timeout=...) do.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.main,
+        ["-t", "title", "-b", "body", "--limit", "-5", "json://good"],
+    )
+    assert result.exit_code != 0
+
+
+def test_apprise_cli_service_limit_option_in_help():
+    """
+    CLI: --service-limit (-SL) appears in --help output
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli.main, ["--help"])
+    assert result.exit_code == 0
+    assert "--service-limit" in result.output
+    assert "-SL" in result.output
+
+
+def test_apprise_cli_service_limit_option_negative_value_errors():
+    """
+    CLI: --service-limit (-SL) rejects a negative value the same way
+    AppriseAsset(service_timeout=...) does.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.main,
+        [
+            "-t",
+            "title",
+            "-b",
+            "body",
+            "--service-limit",
+            "-5",
+            "json://good",
+        ],
+    )
+    assert result.exit_code != 0
+
+
+@mock.patch("apprise.cli.AppriseAsset")
+@mock.patch("requests.request")
+def test_apprise_cli_service_limit_option_passed_to_asset(
+    mock_request, mock_asset_cls
+):
+    """
+    CLI: --service-limit (-SL), when specified, is passed into
+    AppriseAsset(service_timeout=...) independently of --limit.
+    """
+    mock_asset_cls.side_effect = AppriseAsset
+    mock_request.return_value = requests.Request()
+    mock_request.return_value.status_code = requests.codes.ok
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.main,
+        [
+            "-t",
+            "title",
+            "-b",
+            "body",
+            "--limit",
+            "30",
+            "--service-limit",
+            "5",
+            "json://localhost",
+        ],
+    )
+    assert result.exit_code == 0
+
+    # --service-limit is independently set on the AppriseAsset, no
+    # matter what --limit was also set to.
+    assert mock_asset_cls.call_args.kwargs.get("service_timeout") == 5.0
+
+
+@mock.patch("apprise.cli.AppriseAsset")
+@mock.patch("requests.request")
+def test_apprise_cli_service_limit_option_omitted(
+    mock_request, mock_asset_cls
+):
+    """
+    CLI: when --service-limit is not specified, AppriseAsset() receives
+    service_timeout=None -- its own built-in default remains in effect,
+    even if --limit was specified.
+    """
+    mock_asset_cls.side_effect = AppriseAsset
+    mock_request.return_value = requests.Request()
+    mock_request.return_value.status_code = requests.codes.ok
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.main,
+        [
+            "-t",
+            "title",
+            "-b",
+            "body",
+            "--limit",
+            "30",
+            "json://localhost",
+        ],
+    )
+    assert result.exit_code == 0
+    assert mock_asset_cls.call_args.kwargs.get("service_timeout") is None

--- a/tests/test_apprise_config.py
+++ b/tests/test_apprise_config.py
@@ -608,7 +608,7 @@ def test_apprise_config_with_apprise_obj(tmpdir):
     assert len(a) == 1
 
     # Notify our service
-    assert a.notify(body="apprise configuration power!") is True
+    assert bool(a.notify(body="apprise configuration power!")) is True
 
     # Add our configuration object
     assert (

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -98,7 +98,7 @@ def test_apprise_asyncio_runtime_error():
         # Below, we internally will throw a RuntimeError() since there will
         # be no active event_loop in place. However internally it will be smart
         # enough to create a new event loop and continue...
-        assert a.notify(title="title", body="body") is True
+        assert bool(a.notify(title="title", body="body")) is True
 
     finally:
         # Restore our event loop (in the event the above test failed)

--- a/tests/test_attach_http.py
+++ b/tests/test_attach_http.py
@@ -480,9 +480,11 @@ def test_attach_http(mock_get, mock_request):
     assert apobj.add("xml://localhost")
     assert len(apobj) == 3
     assert (
-        apobj.notify(
-            body="one attachment split 3 times",
-            attach="http://localhost/test.gif",
+        bool(
+            apobj.notify(
+                body="one attachment split 3 times",
+                attach="http://localhost/test.gif",
+            )
         )
         is True
     )
@@ -501,9 +503,11 @@ def test_attach_http(mock_get, mock_request):
         assert apobj.add(f"xml://localhost?:entry={n}&method=post")
 
     assert (
-        apobj.notify(
-            body="one attachment split 30 times",
-            attach="http://localhost/test.gif",
+        bool(
+            apobj.notify(
+                body="one attachment split 30 times",
+                attach="http://localhost/test.gif",
+            )
         )
         is True
     )

--- a/tests/test_decorator_notify.py
+++ b/tests/test_decorator_notify.py
@@ -96,14 +96,16 @@ def test_notify_simple_decoration():
     assert len(verify_obj) == 0
 
     assert (
-        aobj.notify(
-            "Hello World",
-            title="My Title",
-            # add some attachments too
-            attach=(
-                join(TEST_VAR_DIR, "apprise-test.gif"),
-                join(TEST_VAR_DIR, "apprise-test.png"),
-            ),
+        bool(
+            aobj.notify(
+                "Hello World",
+                title="My Title",
+                # add some attachments too
+                attach=(
+                    join(TEST_VAR_DIR, "apprise-test.gif"),
+                    join(TEST_VAR_DIR, "apprise-test.png"),
+                ),
+            )
         )
         is True
     )
@@ -138,7 +140,7 @@ def test_notify_simple_decoration():
     verify_obj = {}
 
     # Send unicode
-    assert aobj.notify("ツ".encode()) is True
+    assert bool(aobj.notify("ツ".encode())) is True
     # Our content was populated after the notify() call
     assert len(verify_obj) > 0
     assert verify_obj["body"] == "ツ"  # content comes back as str (utf-8)
@@ -168,7 +170,7 @@ def test_notify_simple_decoration():
     verify_obj = {}
 
     # Send utf-8 string
-    assert aobj.notify("ツ") is True
+    assert bool(aobj.notify("ツ")) is True
 
     assert len(verify_obj) > 0
     assert verify_obj["body"] == "ツ"  # content comes back as str (utf-8)
@@ -196,16 +198,16 @@ def test_notify_simple_decoration():
 
     # Some cases that will fail internal validation:
     # - No Body
-    assert aobj.notify("") is False
+    assert bool(aobj.notify("")) is False
     # - Title only
-    assert aobj.notify("", title="hello world!") is False
+    assert bool(aobj.notify("", title="hello world!")) is False
 
     # Reset our verify object (so it can be populated again)
     verify_obj = {}
 
     # No Body but has attachment (valid)
     assert (
-        aobj.notify("", attach=(join(TEST_VAR_DIR, "apprise-test.png"),))
+        bool(aobj.notify("", attach=(join(TEST_VAR_DIR, "apprise-test.png"),)))
         is True
     )
 
@@ -240,11 +242,13 @@ def test_notify_simple_decoration():
 
     # We'll do another test now
     assert (
-        aobj.notify(
-            "Hello Another World",
-            title="My Other Title",
-            body_format=common.NotifyFormat.HTML,
-            notify_type=common.NotifyType.WARNING,
+        bool(
+            aobj.notify(
+                "Hello Another World",
+                title="My Other Title",
+                body_format=common.NotifyFormat.HTML,
+                notify_type=common.NotifyType.WARNING,
+            )
         )
         is True
     )
@@ -290,7 +294,7 @@ def test_notify_simple_decoration():
     assert aobj.add("notexc://") is True
 
     # Isn't handled
-    assert aobj.notify("Exceptions will be thrown!") is False
+    assert bool(aobj.notify("Exceptions will be thrown!")) is False
 
     # Tidy
     N_MGR.remove("utiltest", "notexc")
@@ -337,14 +341,16 @@ def test_notify_complex_decoration():
     assert len(verify_obj) == 0
 
     assert (
-        aobj.notify(
-            "Hello World",
-            title="My Title",
-            # add some attachments too
-            attach=(
-                join(TEST_VAR_DIR, "apprise-test.gif"),
-                join(TEST_VAR_DIR, "apprise-test.png"),
-            ),
+        bool(
+            aobj.notify(
+                "Hello World",
+                title="My Title",
+                # add some attachments too
+                attach=(
+                    join(TEST_VAR_DIR, "apprise-test.gif"),
+                    join(TEST_VAR_DIR, "apprise-test.png"),
+                ),
+            )
         )
         is True
     )
@@ -400,7 +406,7 @@ def test_notify_complex_decoration():
     assert len(verify_obj) == 0
 
     # Send our notification
-    assert aobj.notify("Hello World", title="My Title") is True
+    assert bool(aobj.notify("Hello World", title="My Title")) is True
 
     # Our content was populated after the notify() call
     assert len(verify_obj) > 0
@@ -495,7 +501,7 @@ def test_notify_decorator_urls_with_space():
     assert len(verify_obj) == 0
 
     # Send utf-8 characters
-    assert aobj.notify("ツ".encode(), title="My Title") is True
+    assert bool(aobj.notify("ツ".encode(), title="My Title")) is True
 
     # Service notified
     assert len(verify_obj) == 1
@@ -590,7 +596,7 @@ def test_notify_multi_instance_decoration(tmpdir):
     assert len(verify_obj) == 0
 
     # Send utf-8 characters
-    assert aobj.notify("ツ".encode(), title="My Title") is True
+    assert bool(aobj.notify("ツ".encode(), title="My Title")) is True
 
     assert len(verify_obj) == 2
 

--- a/tests/test_escapes.py
+++ b/tests/test_escapes.py
@@ -57,7 +57,7 @@ def test_apprise_interpret_escapes(mock_request):
     assert a[0].asset.interpret_escapes is False
 
     # Send notification
-    assert a.notify("ab\\ncd") is True
+    assert bool(a.notify("ab\\ncd")) is True
 
     # Test our call count
     assert mock_request.call_count == 1
@@ -71,7 +71,7 @@ def test_apprise_interpret_escapes(mock_request):
     mock_request.reset_mock()
 
     # Send notification and provide override:
-    assert a.notify("ab\\ncd", interpret_escapes=True) is True
+    assert bool(a.notify("ab\\ncd", interpret_escapes=True)) is True
 
     # Test our call count
     assert mock_request.call_count == 1
@@ -103,7 +103,7 @@ def test_apprise_interpret_escapes(mock_request):
     assert a[0].asset.interpret_escapes is True
 
     # Send notification
-    assert a.notify("ab\\ncd") is True
+    assert bool(a.notify("ab\\ncd")) is True
 
     # Test our call count
     assert mock_request.call_count == 1
@@ -117,7 +117,7 @@ def test_apprise_interpret_escapes(mock_request):
     mock_request.reset_mock()
 
     # Send notification and provide override:
-    assert a.notify("ab\\ncd", interpret_escapes=False) is True
+    assert bool(a.notify("ab\\ncd", interpret_escapes=False)) is True
 
     # Test our call count
     assert mock_request.call_count == 1
@@ -187,19 +187,23 @@ def test_apprise_escaping(mock_request):
     # Error handling
     #
     # We can't escape the content below
-    assert a.notify(title=None, body=4, interpret_escapes=True) is False
-    assert a.notify(title=4, body=None, interpret_escapes=True) is False
+    assert bool(a.notify(title=None, body=4, interpret_escapes=True)) is False
+    assert bool(a.notify(title=4, body=None, interpret_escapes=True)) is False
     assert (
-        a.notify(title=object(), body=False, interpret_escapes=True) is False
+        bool(a.notify(title=object(), body=False, interpret_escapes=True))
+        is False
     )
     assert (
-        a.notify(title=False, body=object(), interpret_escapes=True) is False
+        bool(a.notify(title=False, body=object(), interpret_escapes=True))
+        is False
     )
 
     # We support bytes
     assert (
-        a.notify(
-            title=b"byte title", body=b"byte body", interpret_escapes=True
+        bool(
+            a.notify(
+                title=b"byte title", body=b"byte body", interpret_escapes=True
+            )
         )
         is True
     )
@@ -211,7 +215,9 @@ def test_apprise_escaping(mock_request):
     # זו הודעה translates to 'This is a notification'
     title = "כותרת נפלאה".encode("ISO-8859-8")
     body = "[_[זו הודעה](http://localhost)_".encode("ISO-8859-8")
-    assert a.notify(title=title, body=body, interpret_escapes=True) is False
+    assert (
+        bool(a.notify(title=title, body=body, interpret_escapes=True)) is False
+    )
 
     # However if we let Apprise know in advance the encoding, it will handle
     # it for us
@@ -219,7 +225,9 @@ def test_apprise_escaping(mock_request):
     a = apprise.Apprise(asset=asset)
     # Create ourselves a test object to work with
     a.add("json://localhost")
-    assert a.notify(title=title, body=body, interpret_escapes=True) is True
+    assert (
+        bool(a.notify(title=title, body=body, interpret_escapes=True)) is True
+    )
 
     # We'll restore our configuration back to how it was now
     a = apprise.Apprise()
@@ -228,14 +236,25 @@ def test_apprise_escaping(mock_request):
     # The body is proessed first, so the errors thrown above get tested on
     # the body only.  Now we run similar tests but only make the title
     # bad and always mark the body good
-    assert a.notify(title=None, body="valid", interpret_escapes=True) is True
-    assert a.notify(title=4, body="valid", interpret_escapes=True) is False
     assert (
-        a.notify(title=object(), body="valid", interpret_escapes=True) is False
+        bool(a.notify(title=None, body="valid", interpret_escapes=True))
+        is True
     )
-    assert a.notify(title=False, body="valid", interpret_escapes=True) is True
+    assert (
+        bool(a.notify(title=4, body="valid", interpret_escapes=True)) is False
+    )
+    assert (
+        bool(a.notify(title=object(), body="valid", interpret_escapes=True))
+        is False
+    )
+    assert (
+        bool(a.notify(title=False, body="valid", interpret_escapes=True))
+        is True
+    )
     # Bytes are supported
     assert (
-        a.notify(title=b"byte title", body="valid", interpret_escapes=True)
+        bool(
+            a.notify(title=b"byte title", body="valid", interpret_escapes=True)
+        )
         is True
     )

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -28,6 +28,7 @@
 import asyncio
 import concurrent.futures as cf
 from datetime import datetime, timezone
+import json
 import os
 import re
 import sys
@@ -38,6 +39,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAsset, URLBase
+from apprise.common import AWARE_DATE_ISO_FORMAT
 
 # Disable logging for a cleaner testing output
 from apprise.logger import (
@@ -546,6 +548,68 @@ def test_notify_log_entry_combine_and_sort_across_calls():
     assert len(combined) == 2
     assert combined[0].message == "from service B"
     assert combined[1].message == "from service A"
+
+
+def test_notify_log_entry_ordering_notimplemented():
+    """Comparing to a non-NotifyLogEntry returns NotImplemented for
+    every relational operator."""
+    entry = NotifyLogEntry(level="WARNING", message="hi")
+
+    assert entry.__lt__("nope") is NotImplemented
+    assert entry.__le__("nope") is NotImplemented
+    assert entry.__gt__("nope") is NotImplemented
+    assert entry.__ge__("nope") is NotImplemented
+
+
+def test_notify_log_entry_asdict_json_repr():
+    """asdict(), json(), and repr() all render the entry consistently."""
+    t = datetime(2026, 1, 1, 12, 30, 0, tzinfo=timezone.utc)
+    entry = NotifyLogEntry(level="WARNING", message="hi", time=t)
+
+    d = entry.asdict()
+    assert d == {
+        "level": "WARNING",
+        "message": "hi",
+        "time": t.strftime(AWARE_DATE_ISO_FORMAT),
+    }
+
+    assert json.loads(entry.json()) == d
+
+    assert repr(entry) == (
+        f"<NotifyLogEntry level='WARNING' message='hi' time={t!r}>"
+    )
+
+
+def test_service_log_capture_max_entries_cap():
+    """Once _MAX_CAPTURED_LOG_ENTRIES is reached, further entries are
+    dropped instead of growing the buffer without bound."""
+    logging.disable(logging.NOTSET)
+
+    try:
+        service = _DummyNotify()
+        with (
+            mock.patch("apprise.logger._MAX_CAPTURED_LOG_ENTRIES", 2),
+            _ServiceLogCapture(service) as cap,
+        ):
+            service.logger.warning("one")
+            service.logger.warning("two")
+            # Dropped -- the cap was already reached.
+            service.logger.warning("three")
+    finally:
+        logging.disable(logging.CRITICAL)
+
+    assert [e.message for e in cap.entries] == ["one", "two"]
+
+
+def test_service_log_capture_exit_without_enter():
+    """__exit__ tolerates being called when __enter__ never ran, and
+    skips the contextvar reset since there is no token to restore."""
+    service = _DummyNotify()
+    cap = _ServiceLogCapture(service)
+    assert cap._token is None
+
+    # Must not raise even though __enter__ was never called.
+    cap.__exit__(None, None, None)
 
 
 def test_service_log_capture_bad_format():

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -796,7 +796,7 @@ def test_service_log_capture_async_callback_error():
         return cap
 
     try:
-        with mock.patch("apprise.logger.logger.debug") as mock_debug:
+        with mock.patch.object(logger, "debug") as mock_debug:
             cap = asyncio.run(_run())
     finally:
         logging.disable(logging.CRITICAL)
@@ -815,8 +815,8 @@ def test_service_log_capture_cancelled_callback_future():
     assert future.cancelled()
 
     with (
-        mock.patch("apprise.logger.logger.warning") as mock_warning,
-        mock.patch("apprise.logger.logger.debug") as mock_debug,
+        mock.patch.object(logger, "warning") as mock_warning,
+        mock.patch.object(logger, "debug") as mock_debug,
     ):
         # Must not raise.
         _ServiceLogCapture._log_callback_done(future)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -25,9 +25,13 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import asyncio
+import concurrent.futures as cf
+from datetime import datetime, timezone
 import os
 import re
 import sys
+import time
 from unittest import mock
 
 import pytest
@@ -36,7 +40,14 @@ import requests
 from apprise import Apprise, AppriseAsset, URLBase
 
 # Disable logging for a cleaner testing output
-from apprise.logger import LogCapture, logger, logging
+from apprise.logger import (
+    LogCapture,
+    NotifyLogEntry,
+    _ServiceLogCapture,
+    logger,
+    logging,
+)
+from apprise.plugins import NotifyBase
 
 
 def test_apprise_logger():
@@ -392,7 +403,7 @@ def test_apprise_secure_logging(mock_request):
         )
 
     # Send notification
-    assert a.notify("test") is True
+    assert bool(a.notify("test")) is True
 
     # Test our call count
     assert mock_request.call_count == 1
@@ -431,3 +442,412 @@ def test_apprise_secure_logging(mock_request):
 
     # Disable Logging
     logging.disable(logging.CRITICAL)
+
+
+class _DummyNotify(NotifyBase):
+    """Minimal plugin used to exercise _ServiceLogCapture directly."""
+
+    service_name = "dummy"
+
+    def url(self, privacy=False, *args, **kwargs):
+        """Return a stable URL for assertions that only need an identity."""
+        return "dummy://"
+
+    def send(self, *args, **kwargs):
+        """Pretend the notification was delivered successfully."""
+        return True
+
+
+def test_notify_log_entry_equality_and_hash():
+    """Two entries are equal (and hash equally) only when their time,
+    level, and message all match."""
+    t = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    a = NotifyLogEntry(level="WARNING", message="hi", time=t)
+    b = NotifyLogEntry(level="WARNING", message="hi", time=t)
+    diff_level = NotifyLogEntry(level="ERROR", message="hi", time=t)
+    diff_message = NotifyLogEntry(level="WARNING", message="bye", time=t)
+
+    assert a == b
+    assert hash(a) == hash(b)
+    assert a != diff_level
+    assert a != diff_message
+    assert a != "not a NotifyLogEntry"
+
+
+def test_notify_log_entry_ordering_by_time():
+    """Entries sort by time alone -- every relational operator is
+    defined directly against time (see the class docstring)."""
+    early = NotifyLogEntry(
+        level="WARNING",
+        message="first",
+        time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    late = NotifyLogEntry(
+        level="ERROR",
+        message="second",
+        time=datetime(2026, 1, 2, tzinfo=timezone.utc),
+    )
+
+    assert early < late
+    assert late > early
+    assert early <= late
+    assert late >= early
+    assert sorted([late, early]) == [early, late]
+
+
+def test_notify_log_entry_equal_time_ordering():
+    """Two different (unequal) entries sharing the same timestamp must
+    never both compare greater than each other.
+
+    Equality compares the full entry; ordering compares timestamps only.
+    """
+    t = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    a = NotifyLogEntry(level="WARNING", message="alpha", time=t)
+    b = NotifyLogEntry(level="ERROR", message="beta", time=t)
+
+    assert a != b
+    assert not (a > b and b > a)
+    assert not (a < b)
+    assert not (b < a)
+    assert a <= b
+    assert b <= a
+    assert a >= b
+    assert b >= a
+
+
+def test_notify_log_entry_combine_and_sort_across_calls():
+    """Entries captured across separate notify() calls (potentially for
+    different plugins) can be combined into one set and replayed back
+    in chronological order -- the scenario this supports directly."""
+    call_a = [
+        NotifyLogEntry(
+            level="WARNING",
+            message="from service A",
+            time=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        )
+    ]
+    call_b = [
+        NotifyLogEntry(
+            level="ERROR",
+            message="from service B",
+            time=datetime(2026, 1, 1, 11, 0, 0, tzinfo=timezone.utc),
+        ),
+        # A duplicate of call_a's entry -- should collapse in a set.
+        NotifyLogEntry(
+            level="WARNING",
+            message="from service A",
+            time=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        ),
+    ]
+
+    combined = sorted(set(call_a) | set(call_b))
+
+    assert len(combined) == 2
+    assert combined[0].message == "from service B"
+    assert combined[1].message == "from service A"
+
+
+def test_service_log_capture_bad_format():
+    """A plugin's own malformed logging call must not escape capture."""
+    service = _DummyNotify()
+    with _ServiceLogCapture(service) as cap:
+        # Only one arg supplied for two required by the format string --
+        # this must not raise back out of handle().
+        cap.handle(
+            logging.LogRecord(
+                name="apprise",
+                level=logging.WARNING,
+                pathname=__file__,
+                lineno=1,
+                msg="missing %s %s",
+                args=("one",),
+                exc_info=None,
+            )
+        )
+        cap.handle(
+            logging.LogRecord(
+                name="apprise",
+                level=logging.WARNING,
+                pathname=__file__,
+                lineno=2,
+                msg="a real one: %s",
+                args=("fine",),
+                exc_info=None,
+            )
+        )
+
+    assert len(cap.entries) == 1
+    assert cap.entries[0].message == "a real one: fine"
+
+
+def test_service_log_capture_async_send_warning():
+    """The default async_notify() path captures warnings logged in send()."""
+    logging.disable(logging.NOTSET)
+
+    class _WarnOnSend(_DummyNotify):
+        """Dummy service that logs during send()."""
+
+        def send(self, *args, **kwargs):
+            """Emit one warning before reporting success."""
+            self.logger.warning("a warning from send()")
+            return True
+
+    async def _run():
+        """Run async_notify() under a capture context."""
+        service = _WarnOnSend()
+        with _ServiceLogCapture(service) as cap:
+            result = await service.async_notify(body="x")
+        return result, cap.entries
+
+    try:
+        result, entries = asyncio.run(_run())
+    finally:
+        logging.disable(logging.CRITICAL)
+
+    assert result is True
+    assert len(entries) == 1
+    assert entries[0].message == "a warning from send()"
+
+
+def test_service_log_capture_async_concurrent_isolation():
+    """Concurrent async captures keep each service's logs separate."""
+    logging.disable(logging.NOTSET)
+
+    class _WarnOnSend(_DummyNotify):
+        """Dummy service that can stagger warning emission."""
+
+        def __init__(self, tag_message, delay=0.0, **kwargs):
+            """Store the warning message and optional delay."""
+            super().__init__(**kwargs)
+            self._tag_message = tag_message
+            self._delay = delay
+
+        def send(self, *args, **kwargs):
+            """Emit this service's distinct warning."""
+            if self._delay:
+                time.sleep(self._delay)
+            self.logger.warning(self._tag_message)
+            return True
+
+    async def _run_one(service):
+        """Capture one async service call."""
+        with _ServiceLogCapture(service) as cap:
+            await service.async_notify(body="x")
+        return [e.message for e in cap.entries]
+
+    async def _run():
+        """Run two captures at the same time."""
+        a = _WarnOnSend("warning from A")
+        b = _WarnOnSend("warning from B", delay=0.05)
+        return await asyncio.gather(_run_one(a), _run_one(b))
+
+    try:
+        results = asyncio.run(_run())
+    finally:
+        logging.disable(logging.CRITICAL)
+
+    assert results == [["warning from A"], ["warning from B"]]
+
+
+def test_service_log_capture_thread_isolation():
+    """Threaded captures keep each service's logs separate."""
+    logging.disable(logging.NOTSET)
+
+    class _WarnOnSend(_DummyNotify):
+        """Dummy service that can stagger warning emission in threads."""
+
+        def __init__(self, tag_message, delay=0.0, **kwargs):
+            """Store the warning message and optional delay."""
+            super().__init__(**kwargs)
+            self._tag_message = tag_message
+            self._delay = delay
+
+        def send(self, *args, **kwargs):
+            """Emit this service's distinct warning."""
+            if self._delay:
+                time.sleep(self._delay)
+            self.logger.warning(self._tag_message)
+            return True
+
+    def _run_one(service):
+        """Capture one threaded service call."""
+        with _ServiceLogCapture(service) as cap:
+            service.notify(body="x")
+        return [e.message for e in cap.entries]
+
+    try:
+        a = _WarnOnSend("warning from A")
+        b = _WarnOnSend("warning from B", delay=0.05)
+        with cf.ThreadPoolExecutor() as ex:
+            fut_a = ex.submit(_run_one, a)
+            fut_b = ex.submit(_run_one, b)
+            result_a, result_b = fut_a.result(), fut_b.result()
+    finally:
+        logging.disable(logging.CRITICAL)
+
+    assert result_a == ["warning from A"]
+    assert result_b == ["warning from B"]
+
+
+def test_service_log_capture_sync_log_callback():
+    """A plain log_callback receives each captured entry live."""
+    logging.disable(logging.NOTSET)
+    received = []
+
+    def _cb(entry, service):
+        """Record callback delivery in the order entries are emitted."""
+        received.append((service.service_name, entry.message))
+
+    try:
+        service = _DummyNotify()
+        with _ServiceLogCapture(service, log_callback=_cb) as cap:
+            service.logger.warning("first")
+            service.logger.warning("second")
+    finally:
+        logging.disable(logging.CRITICAL)
+
+    assert received == [
+        ("dummy", "first"),
+        ("dummy", "second"),
+    ]
+    assert [e.message for e in cap.entries] == ["first", "second"]
+
+
+def test_service_log_capture_callback_error():
+    """A raising log_callback must not break capture."""
+    logging.disable(logging.NOTSET)
+
+    def _broken_cb(entry, service):
+        """Raise from the callback."""
+        raise ValueError("boom")
+
+    try:
+        service = _DummyNotify()
+        with _ServiceLogCapture(service, log_callback=_broken_cb) as cap:
+            # Must not raise back out to the caller.
+            service.logger.warning("still captured")
+    finally:
+        logging.disable(logging.CRITICAL)
+
+    assert [e.message for e in cap.entries] == ["still captured"]
+
+
+def test_service_log_capture_async_callback_loop():
+    """An async log_callback is scheduled on the active event loop."""
+    logging.disable(logging.NOTSET)
+    received = []
+
+    async def _cb(entry, service):
+        """Record after yielding to the event loop."""
+        await asyncio.sleep(0.01)
+        received.append((service.service_name, entry.message))
+
+    async def _run():
+        """Schedule one async callback."""
+        service = _DummyNotify()
+        with _ServiceLogCapture(service, log_callback=_cb) as cap:
+            service.logger.warning("async entry")
+        # emit() schedules the callback but cannot await it.
+        await asyncio.sleep(0.1)
+        return cap
+
+    try:
+        cap = asyncio.run(_run())
+    finally:
+        logging.disable(logging.CRITICAL)
+
+    assert received == [("dummy", "async entry")]
+    assert [e.message for e in cap.entries] == ["async entry"]
+
+
+def test_service_log_capture_async_callback_no_loop():
+    """An async log_callback without an event loop is closed cleanly."""
+    logging.disable(logging.NOTSET)
+
+    async def _cb(entry, service):
+        """Callback that should be closed before it can run."""
+        pass  # pragma: no cover -- never actually runs
+
+    try:
+        service = _DummyNotify()
+        with _ServiceLogCapture(service, log_callback=_cb) as cap:
+            service.logger.warning("no loop available")
+    finally:
+        logging.disable(logging.CRITICAL)
+
+    assert [e.message for e in cap.entries] == ["no loop available"]
+
+
+def test_service_log_capture_async_callback_error():
+    """A scheduled async log_callback exception is logged."""
+    logging.disable(logging.NOTSET)
+
+    async def _broken_cb(entry, service):
+        """Raise inside the scheduled task."""
+        raise ValueError("boom from async callback")
+
+    async def _run():
+        """Schedule the failing callback and allow it to finish."""
+        service = _DummyNotify()
+        with _ServiceLogCapture(service, log_callback=_broken_cb) as cap:
+            service.logger.warning("still captured despite async error")
+        await asyncio.sleep(0.1)
+        return cap
+
+    try:
+        with mock.patch("apprise.logger.logger.debug") as mock_debug:
+            cap = asyncio.run(_run())
+    finally:
+        logging.disable(logging.CRITICAL)
+
+    assert [e.message for e in cap.entries] == [
+        "still captured despite async error"
+    ]
+    assert mock_debug.called
+    assert "boom from async callback" in str(mock_debug.call_args)
+
+
+def test_service_log_capture_cancelled_callback_future():
+    """_log_callback_done must swallow a cancelled callback future."""
+    future = cf.Future()
+    future.cancel()
+    assert future.cancelled()
+
+    with (
+        mock.patch("apprise.logger.logger.warning") as mock_warning,
+        mock.patch("apprise.logger.logger.debug") as mock_debug,
+    ):
+        # Must not raise.
+        _ServiceLogCapture._log_callback_done(future)
+
+    assert mock_warning.called
+    assert "cancelled" in str(mock_warning.call_args).lower()
+    assert not mock_debug.called
+
+
+def test_service_log_capture_loop_shutdown_cancel():
+    """A pending async log_callback can be cancelled at loop shutdown."""
+    logging.disable(logging.NOTSET)
+
+    async def _cb(entry, service):
+        """Remain pending until asyncio.run() teardown."""
+        # Long enough to still be pending when _run() returns.
+        await asyncio.sleep(0.2)
+
+    async def _run():
+        """Schedule one callback without waiting for it to finish."""
+        service = _DummyNotify()
+        with _ServiceLogCapture(service, log_callback=_cb) as cap:
+            service.logger.warning("cancelled before callback finishes")
+        return cap
+
+    try:
+        # No callback cancellation should propagate out of asyncio.run().
+        cap = asyncio.run(_run())
+    finally:
+        logging.disable(logging.CRITICAL)
+
+    assert [e.message for e in cap.entries] == [
+        "cancelled before callback finishes"
+    ]

--- a/tests/test_notify_base.py
+++ b/tests/test_notify_base.py
@@ -26,6 +26,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from datetime import datetime, timedelta
+import glob
 
 # Disable logging for a cleaner testing output
 import logging
@@ -476,3 +477,48 @@ def test_notify_base_runtime_deps_override():
     assert deps == ("fakelibA", "fakelibB")
     assert deps[0] == "fakelibA"
     assert deps[1] == "fakelibB"
+
+
+def test_notify_base_flush_store_noop_when_unused(tmpdir):
+    """flush_store() is a silent no-op when self.store was never
+    accessed -- it must not create a PersistentStore (or its on-disk
+    directory structure) just to immediately flush nothing."""
+    asset = AppriseAsset(storage_path=str(tmpdir))
+    obj = NotifyBase(asset=asset)
+
+    # Nothing touched .store yet -- flush_store() must not crash, and
+    # must not create any on-disk content for this service.
+    obj.flush_store()
+
+    assert len(tmpdir.listdir()) == 0
+
+
+def test_notify_base_flush_store_writes_pending_auto_mode_changes(tmpdir):
+    """flush_store() writes a service's cached changes to disk on
+    demand.  In PersistentStoreMode.AUTO (the default), set() alone
+    only updates the in-memory cache -- normally the on-disk write only
+    happens later, when the PersistentStore object is garbage
+    collected. A caller about to end the process some other way (e.g.
+    apprise/cli.py's _force_exit_after_timeout(), which calls
+    os._exit()) needs to be able to force that write immediately
+    instead."""
+    asset = AppriseAsset(storage_path=str(tmpdir))
+    obj = NotifyBase(asset=asset)
+
+    # Accessing .store alone already creates its namespace directory
+    # structure (independent of whether anything is written), so the
+    # cache file itself -- not "any file at all" -- is what actually
+    # indicates a flush occurred.
+    cache_glob = str(tmpdir.join("**", "*.psdata"))
+
+    obj.store.set("token", "abc123")
+
+    # AUTO mode: the cached change has not been written to disk yet.
+    assert glob.glob(cache_glob, recursive=True) == []
+
+    obj.flush_store()
+
+    # The cache file now exists, and the value survives a fresh
+    # PersistentStore instance reading from the same path/namespace.
+    assert glob.glob(cache_glob, recursive=True) != []
+    assert obj.store.get("token") == "abc123"

--- a/tests/test_plugin_africas_talking.py
+++ b/tests/test_plugin_africas_talking.py
@@ -174,7 +174,9 @@ def test_plugin_atalk_edge_cases(mock_post):
     )
 
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -228,7 +230,9 @@ def test_plugin_atalk_edge_cases(mock_post):
     assert len(obj) == 1
 
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 

--- a/tests/test_plugin_apprise_api.py
+++ b/tests/test_plugin_apprise_api.py
@@ -301,11 +301,13 @@ def test_notify_apprise_api_payload_check(mock_post):
     path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     attach = AppriseAttachment(path)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -329,11 +331,13 @@ def test_notify_apprise_api_payload_check(mock_post):
     assert isinstance(obj, NotifyAppriseAPI)
 
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -381,11 +385,13 @@ def test_notify_apprise_api_attachments(mock_post):
         path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
         attach = AppriseAttachment(path)
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is True
         )
@@ -395,11 +401,13 @@ def test_notify_apprise_api_attachments(mock_post):
             TEST_VAR_DIR, "/invalid/path/to/an/invalid/file.jpg"
         )
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=path,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=path,
+                )
             )
             is False
         )
@@ -419,11 +427,13 @@ def test_notify_apprise_api_attachments(mock_post):
             # We can't send the message we can't open the attachment for
             # reading
             assert (
-                obj.notify(
-                    body="body",
-                    title="title",
-                    notify_type=NotifyType.INFO,
-                    attach=attach,
+                bool(
+                    obj.notify(
+                        body="body",
+                        title="title",
+                        notify_type=NotifyType.INFO,
+                        attach=attach,
+                    )
                 )
                 is False
             )
@@ -431,11 +441,13 @@ def test_notify_apprise_api_attachments(mock_post):
         with mock.patch("requests.post", side_effect=OSError()):
             # Attachment issue
             assert (
-                obj.notify(
-                    body="body",
-                    title="title",
-                    notify_type=NotifyType.INFO,
-                    attach=attach,
+                bool(
+                    obj.notify(
+                        body="body",
+                        title="title",
+                        notify_type=NotifyType.INFO,
+                        attach=attach,
+                    )
                 )
                 is False
             )
@@ -448,11 +460,13 @@ def test_notify_apprise_api_attachments(mock_post):
         mock_post.reset_mock()
 
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is True
         )

--- a/tests/test_plugin_aprs.py
+++ b/tests/test_plugin_aprs.py
@@ -78,7 +78,7 @@ def test_plugin_aprs_urls(mock_create_connection):
     assert instance.url(privacy=True).startswith(
         "aprs://DF1JSL-15:****@D...C?"
     )
-    assert instance.notify("test") is True
+    assert bool(instance.notify("test")) is True
 
     # 1N3 callsigns
     instance = apprise.Apprise.instantiate("aprs://D1JSL-15:12345@D1ABC")
@@ -112,7 +112,7 @@ def test_plugin_aprs_urls(mock_create_connection):
     assert instance.url(privacy=True).startswith(
         "aprs://DF1JSL-15:****@D...C/D...F?"
     )
-    assert instance.notify("test") is True
+    assert bool(instance.notify("test")) is True
 
     instance = apprise.Apprise.instantiate(
         "aprs://DF1JSL-15:12345@DF1ABC-1/DF1ABC/DF1ABC-15"
@@ -121,7 +121,7 @@ def test_plugin_aprs_urls(mock_create_connection):
     assert instance.url(privacy=True).startswith(
         "aprs://DF1JSL-15:****@D...1/D...C/D...5?"
     )
-    assert instance.notify("test") is True
+    assert bool(instance.notify("test")) is True
 
     instance = apprise.Apprise.instantiate(
         "aprs://DF1JSL-15:12345@?to=DF1ABC,DF1DEF"
@@ -130,7 +130,7 @@ def test_plugin_aprs_urls(mock_create_connection):
     assert instance.url(privacy=True).startswith(
         "aprs://DF1JSL-15:****@D...C/D...F?"
     )
-    assert instance.notify("test") is True
+    assert bool(instance.notify("test")) is True
 
     # Test Locale settings
     instance = apprise.Apprise.instantiate(
@@ -142,7 +142,7 @@ def test_plugin_aprs_urls(mock_create_connection):
     )
     # we used the default locale, so no setting
     assert "locale=" not in instance.url(privacy=True)
-    assert instance.notify("test") is True
+    assert bool(instance.notify("test")) is True
 
     instance = apprise.Apprise.instantiate(
         "aprs://DF1JSL-15:12345@DF1ABC?locale=NOAM"
@@ -153,7 +153,7 @@ def test_plugin_aprs_urls(mock_create_connection):
     )
     # locale is set in URL
     assert "locale=NOAM" in instance.url(privacy=True)
-    assert instance.notify("test") is True
+    assert bool(instance.notify("test")) is True
 
     # Invalid locale
     assert (
@@ -177,7 +177,7 @@ def test_plugin_aprs_urls(mock_create_connection):
     )
 
     # But with only bad entries, we have nothing to notify
-    assert instance.notify("test") is False
+    assert bool(instance.notify("test")) is False
 
     # Enforces a close
     del instance
@@ -216,23 +216,23 @@ def test_plugin_aprs_edge_cases(mock_create_connection):
 
     # Bad data
     sobj.recv.return_value = "one line".encode("latin-1")
-    assert instance.notify(body="body", title="title") is False
+    assert bool(instance.notify(body="body", title="title")) is False
     sobj.recv.return_value = "\n\n\n".encode("latin-1")
-    assert instance.notify(body="body", title="title") is False
+    assert bool(instance.notify(body="body", title="title")) is False
     sobj.recv.return_value = "".encode("latin-1")
-    assert instance.notify(body="body", title="title") is False
+    assert bool(instance.notify(body="body", title="title")) is False
     sobj.recv.return_value = "\ndata".encode("latin-1")
-    assert instance.notify(body="body", title="title") is False
+    assert bool(instance.notify(body="body", title="title")) is False
     # Different Call-Sign then what we logged in as
     sobj.recv.return_value = "ping\npong pong DF1JSL-14 verified, pong".encode(
         "latin-1"
     )
-    assert instance.notify(body="body", title="title") is False
+    assert bool(instance.notify(body="body", title="title")) is False
     # Unverified
     sobj.recv.return_value = (
         "ping\npong pong DF1JSL-15 unverified, pong".encode("latin-1")
     )
-    assert instance.notify(body="body", title="title") is False
+    assert bool(instance.notify(body="body", title="title")) is False
 
     #
     # Test Login edge cases
@@ -293,16 +293,16 @@ def test_plugin_aprs_edge_cases(mock_create_connection):
     mock_create_connection.return_value = None
     mock_create_connection.side_effect = socket.gaierror("gaierror")
     assert instance.socket_open() is False
-    assert instance.notify("test") is False
+    assert bool(instance.notify("test")) is False
     mock_create_connection.side_effect = socket.timeout("timeout")
     assert instance.socket_open() is False
-    assert instance.notify("test") is False
+    assert bool(instance.notify("test")) is False
     mock_create_connection.side_effect = OSError("error")
     assert instance.socket_open() is False
-    assert instance.notify("test") is False
+    assert bool(instance.notify("test")) is False
     mock_create_connection.side_effect = ConnectionError("ConnectionError")
     assert instance.socket_open() is False
-    assert instance.notify("test") is False
+    assert bool(instance.notify("test")) is False
 
     # Restore our good connection
     mock_create_connection.return_value = sobj
@@ -343,11 +343,11 @@ def test_plugin_aprs_edge_cases(mock_create_connection):
     # To do this we need to have a login succeed, but the second call to send
     # to fail
     sobj.sendall.return_value = True
-    assert instance.notify("test") is True
+    assert bool(instance.notify("test")) is True
 
     sobj.sendall.return_value = None
     sobj.sendall.side_effect = (True, socket.gaierror("gaierror"))
-    assert instance.notify("test") is False
+    assert bool(instance.notify("test")) is False
 
     sobj.sendall.return_value = True
     sobj.sendall.side_effect = None

--- a/tests/test_plugin_bark.py
+++ b/tests/test_plugin_bark.py
@@ -311,9 +311,11 @@ def test_plugin_bark_html_to_markdown_format(mock_post):
     # Notify with an HTML body; the framework converts it to Markdown
     # before dispatching to the Bark plugin
     assert (
-        aobj.notify(
-            body="<b>hello</b> <i>world</i>",
-            body_format=NotifyFormat.HTML,
+        bool(
+            aobj.notify(
+                body="<b>hello</b> <i>world</i>",
+                body_format=NotifyFormat.HTML,
+            )
         )
         is True
     )

--- a/tests/test_plugin_base_formatting.py
+++ b/tests/test_plugin_base_formatting.py
@@ -3793,7 +3793,7 @@ def test_notify_emoji_general(mock_request):
     ap_obj.add("json://localhost")
     assert len(ap_obj) == 1
 
-    assert ap_obj.notify(title=title, body=body) is True
+    assert bool(ap_obj.notify(title=title, body=body)) is True
     assert mock_request.call_count == 1
 
     details = mock_request.call_args_list[0]
@@ -3815,7 +3815,7 @@ def test_notify_emoji_general(mock_request):
     ap_obj.add("json://localhost?emojis=no")
     assert len(ap_obj) == 1
 
-    assert ap_obj.notify(title=title, body=body) is True
+    assert bool(ap_obj.notify(title=title, body=body)) is True
     assert mock_request.call_count == 1
 
     details = mock_request.call_args_list[0]
@@ -3837,7 +3837,7 @@ def test_notify_emoji_general(mock_request):
     ap_obj.add("json://localhost?emojis=yes")
     assert len(ap_obj) == 1
 
-    assert ap_obj.notify(title=title, body=body) is True
+    assert bool(ap_obj.notify(title=title, body=body)) is True
     assert mock_request.call_count == 1
 
     details = mock_request.call_args_list[0]
@@ -3859,7 +3859,7 @@ def test_notify_emoji_general(mock_request):
     ap_obj.add("json://localhost?emojis=no")
     assert len(ap_obj) == 1
 
-    assert ap_obj.notify(title=title, body=body) is True
+    assert bool(ap_obj.notify(title=title, body=body)) is True
     assert mock_request.call_count == 1
 
     details = mock_request.call_args_list[0]
@@ -3886,7 +3886,7 @@ def test_notify_emoji_general(mock_request):
     ap_obj.add("json://localhost")
     assert len(ap_obj) == 1
 
-    assert ap_obj.notify(title=title, body=body) is True
+    assert bool(ap_obj.notify(title=title, body=body)) is True
     assert mock_request.call_count == 1
 
     details = mock_request.call_args_list[0]
@@ -3910,7 +3910,7 @@ def test_notify_emoji_general(mock_request):
     ap_obj.add("json://localhost?emojis=no")
     assert len(ap_obj) == 1
 
-    assert ap_obj.notify(title=title, body=body) is True
+    assert bool(ap_obj.notify(title=title, body=body)) is True
     assert mock_request.call_count == 1
 
     details = mock_request.call_args_list[0]
@@ -3934,7 +3934,7 @@ def test_notify_emoji_general(mock_request):
     ap_obj.add("json://localhost?emojis=yes")
     assert len(ap_obj) == 1
 
-    assert ap_obj.notify(title=title, body=body) is True
+    assert bool(ap_obj.notify(title=title, body=body)) is True
     assert mock_request.call_count == 1
 
     details = mock_request.call_args_list[0]
@@ -3961,7 +3961,7 @@ def test_notify_emoji_general(mock_request):
     ap_obj.add("json://localhost")
     assert len(ap_obj) == 1
 
-    assert ap_obj.notify(title=title, body=body) is True
+    assert bool(ap_obj.notify(title=title, body=body)) is True
     assert mock_request.call_count == 1
 
     details = mock_request.call_args_list[0]
@@ -3988,7 +3988,7 @@ def test_notify_emoji_general(mock_request):
     ap_obj.add("json://localhost?emojis=yes")
     assert len(ap_obj) == 1
 
-    assert ap_obj.notify(title=title, body=body) is True
+    assert bool(ap_obj.notify(title=title, body=body)) is True
     assert mock_request.call_count == 1
 
     details = mock_request.call_args_list[0]

--- a/tests/test_plugin_blink1.py
+++ b/tests/test_plugin_blink1.py
@@ -214,7 +214,7 @@ def test_plugin_blink1_device_open_failure():
 
         obj = Apprise.instantiate("blink1://ABCD1234/")
         assert obj is not None
-        assert obj.notify(body="test") is False
+        assert bool(obj.notify(body="test")) is False
 
 
 def test_plugin_blink1_device_open_failure_no_serial():
@@ -228,7 +228,7 @@ def test_plugin_blink1_device_open_failure_no_serial():
 
         obj = Apprise.instantiate("blink1://")
         assert obj is not None
-        assert obj.notify(body="test") is False
+        assert bool(obj.notify(body="test")) is False
 
 
 def test_plugin_blink1_send_feature_report_exception():
@@ -247,7 +247,7 @@ def test_plugin_blink1_send_feature_report_exception():
 
         obj = Apprise.instantiate("blink1://")
         assert obj is not None
-        assert obj.notify(body="test") is False
+        assert bool(obj.notify(body="test")) is False
 
         # close() must always be called
         assert mock_dev.close.called
@@ -268,7 +268,7 @@ def test_plugin_blink1_short_report_fails():
 
         obj = Apprise.instantiate("blink1://")
         assert obj is not None
-        assert obj.notify(body="test") is False
+        assert bool(obj.notify(body="test")) is False
 
 
 def test_plugin_blink1_notify_types():
@@ -293,7 +293,9 @@ def test_plugin_blink1_notify_types():
             NotifyType.WARNING,
             NotifyType.FAILURE,
         ):
-            assert obj.notify(body="test", notify_type=notify_type) is True
+            assert (
+                bool(obj.notify(body="test", notify_type=notify_type)) is True
+            )
 
         # Each notification sends two reports (color + off)
         assert mock_dev.send_feature_report.call_count == 8
@@ -333,7 +335,9 @@ def test_plugin_blink1_fade_rgb_args():
 
         obj = Apprise.instantiate("blink1://?fade=200&duration=100&ledn=2")
         assert obj is not None
-        assert obj.notify(body="test", notify_type=NotifyType.INFO) is True
+        assert (
+            bool(obj.notify(body="test", notify_type=NotifyType.INFO)) is True
+        )
 
         first_call_buf = mock_dev.send_feature_report.call_args_list[0][0][0]
         assert first_call_buf[1] == ord("c")  # command byte
@@ -358,7 +362,7 @@ def test_plugin_blink1_off_sent_after_duration():
 
         obj = Apprise.instantiate("blink1://?fade=500&duration=2000")
         assert obj is not None
-        assert obj.notify(body="test") is True
+        assert bool(obj.notify(body="test")) is True
 
         mock_time.sleep.assert_called_once_with(2.5)
 
@@ -389,7 +393,7 @@ def test_plugin_blink1_off_command_failure_returns_false():
 
         obj = Apprise.instantiate("blink1://")
         assert obj is not None
-        assert obj.notify(body="test") is False
+        assert bool(obj.notify(body="test")) is False
 
         # close() must still be called
         assert mock_dev.close.called

--- a/tests/test_plugin_bluesky.py
+++ b/tests/test_plugin_bluesky.py
@@ -503,11 +503,13 @@ def test_plugin_bluesky_attachments_basic(
 
     # Send our notification
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -548,6 +550,7 @@ def test_plugin_bluesky_attachments_bad_message_response(
     good_message_response,
     bad_message_response,
 ):
+    """Verify a failed message response fails attachment delivery."""
 
     mock_get.return_value = good_message_response
     mock_post.side_effect = [
@@ -562,11 +565,13 @@ def test_plugin_bluesky_attachments_bad_message_response(
 
     # Our notification will fail now since our message will error out.
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -602,6 +607,7 @@ def test_plugin_bluesky_attachments_upload_fails(
     good_media_response,
     good_message_response,
 ):
+    """Verify a failed media upload fails attachment delivery."""
 
     # Test case where upload fails.
     mock_get.return_value = good_message_response
@@ -613,11 +619,13 @@ def test_plugin_bluesky_attachments_upload_fails(
 
     # Send our notification; it will fail because of the message response.
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -653,6 +661,7 @@ def test_plugin_bluesky_attachments_invalid_attachment(
     good_message_response,
     good_media_response,
 ):
+    """Verify an invalid attachment is rejected cleanly."""
 
     mock_get.return_value = good_message_response
     mock_post.side_effect = [good_message_response, good_media_response]
@@ -665,11 +674,13 @@ def test_plugin_bluesky_attachments_invalid_attachment(
 
     # An invalid attachment will cause a failure.
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -702,6 +713,7 @@ def test_plugin_bluesky_attachments_multiple_batch(
     good_message_response,
     good_media_response,
 ):
+    """Verify multiple attachments are uploaded and sent as one batch."""
 
     mock_get.return_value = good_message_response
     mock_post.side_effect = [
@@ -730,11 +742,13 @@ def test_plugin_bluesky_attachments_multiple_batch(
     ]
 
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -806,11 +820,13 @@ def test_plugin_bluesky_attachments_multiple_batch(
     ]
 
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -861,6 +877,7 @@ def test_plugin_bluesky_auth_failure(
     good_message_response,
     bad_message_response,
 ):
+    """Verify authentication failures prevent message delivery."""
 
     mock_get.return_value = good_message_response
     mock_post.return_value = bad_message_response
@@ -869,7 +886,9 @@ def test_plugin_bluesky_auth_failure(
     obj = Apprise.instantiate(bluesky_url)
 
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
 
@@ -924,7 +943,7 @@ def test_plugin_bluesky_did_web_and_plc_resolution(
     mock_post.side_effect = [session_response, post_response]
 
     obj = Apprise.instantiate(bluesky_url)
-    assert obj.notify(body="Resolved PLC Flow") is True
+    assert bool(obj.notify(body="Resolved PLC Flow")) is True
 
     # Reset for did:web test
     identity_response = good_response({"did": "did:web:example.com"})
@@ -944,14 +963,14 @@ def test_plugin_bluesky_did_web_and_plc_resolution(
     mock_post.side_effect = [session_response, post_response]
 
     obj = Apprise.instantiate(bluesky_url)
-    assert obj.notify(body="Resolved WEB Flow") is True
+    assert bool(obj.notify(body="Resolved WEB Flow")) is True
 
     # Invalid DID scheme
     bad_did_response = good_response({"did": "did:unsupported:scheme"})
 
     mock_get.side_effect = [bad_did_response]
     obj = Apprise.instantiate(bluesky_url)
-    assert obj.notify(body="fail due to bad scheme") is False
+    assert bool(obj.notify(body="fail due to bad scheme")) is False
 
 
 @patch("requests.get")

--- a/tests/test_plugin_brevo.py
+++ b/tests/test_plugin_brevo.py
@@ -230,11 +230,13 @@ def test_plugin_brevo_attachments(mock_post):
     obj = Apprise.instantiate("brevo://abcd:user@example.com")
     assert isinstance(obj, NotifyBrevo)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -244,11 +246,13 @@ def test_plugin_brevo_attachments(mock_post):
     # Try again in a use case where we can't access the file
     with mock.patch("os.path.isfile", return_value=False):
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )
@@ -256,11 +260,13 @@ def test_plugin_brevo_attachments(mock_post):
     # Try again in a use case where we can't access the file
     with mock.patch("builtins.open", side_effect=OSError):
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )

--- a/tests/test_plugin_bulksms.py
+++ b/tests/test_plugin_bulksms.py
@@ -209,7 +209,9 @@ def test_plugin_bulksms_edge_cases(mock_post):
     )
 
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 

--- a/tests/test_plugin_bulkvs.py
+++ b/tests/test_plugin_bulkvs.py
@@ -190,7 +190,9 @@ def test_plugin_bulkvs_edge_cases(mock_post):
     )
 
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 

--- a/tests/test_plugin_burstsms.py
+++ b/tests/test_plugin_burstsms.py
@@ -230,4 +230,4 @@ def test_plugin_burstsms_edge_cases(mock_post):
     obj = NotifyBurstSMS(apikey=apikey, secret=secret, source=source)
 
     # We will fail with the above error code
-    assert obj.notify("title", "body", "info") is False
+    assert bool(obj.notify("title", "body", "info")) is False

--- a/tests/test_plugin_chime.py
+++ b/tests/test_plugin_chime.py
@@ -194,7 +194,7 @@ def test_plugin_chime_send(mock_post):
     assert isinstance(obj, NotifyChime)
 
     # Perform a successful send
-    assert obj.notify(body="Test body", title="Test title") is True
+    assert bool(obj.notify(body="Test body", title="Test title")) is True
 
     # Verify the POST was made exactly once
     assert mock_post.call_count == 1
@@ -210,43 +210,43 @@ def test_plugin_chime_send(mock_post):
 
     # A 401 response returns False
     mock_post.return_value = _mk_resp(requests.codes.unauthorized)
-    assert obj.notify(body="Test body") is False
+    assert bool(obj.notify(body="Test body")) is False
 
     mock_post.reset_mock()
 
     # A 403 response returns False
     mock_post.return_value = _mk_resp(requests.codes.forbidden)
-    assert obj.notify(body="Test body") is False
+    assert bool(obj.notify(body="Test body")) is False
 
     mock_post.reset_mock()
 
     # A 404 response returns False
     mock_post.return_value = _mk_resp(requests.codes.not_found)
-    assert obj.notify(body="Test body") is False
+    assert bool(obj.notify(body="Test body")) is False
 
     mock_post.reset_mock()
 
     # A 429 too-many-requests response returns False
     mock_post.return_value = _mk_resp(429)
-    assert obj.notify(body="Test body") is False
+    assert bool(obj.notify(body="Test body")) is False
 
     mock_post.reset_mock()
 
     # A 500 response returns False
     mock_post.return_value = _mk_resp(requests.codes.internal_server_error)
-    assert obj.notify(body="Test body") is False
+    assert bool(obj.notify(body="Test body")) is False
 
     mock_post.reset_mock()
 
     # An unknown response code returns False
     mock_post.return_value = _mk_resp(999)
-    assert obj.notify(body="Test body") is False
+    assert bool(obj.notify(body="Test body")) is False
 
     mock_post.reset_mock()
 
     # A RequestException returns False
     mock_post.side_effect = requests.RequestException("Network error")
-    assert obj.notify(body="Test body") is False
+    assert bool(obj.notify(body="Test body")) is False
 
 
 @mock.patch("requests.post")
@@ -351,7 +351,7 @@ def test_plugin_chime_native_url(mock_post):
     # The constructed object must be functional
     obj = NotifyChime(**results)
     assert isinstance(obj, NotifyChime)
-    assert obj.notify(body="Native URL test") is True
+    assert bool(obj.notify(body="Native URL test")) is True
 
     # A non-matching URL returns None
     assert (
@@ -395,14 +395,14 @@ def test_plugin_chime_apprise_integration(mock_post):
     assert isinstance(a[0], NotifyChime)
 
     # Notify succeeds
-    assert a.notify(body="Test", title="Title") is True
+    assert bool(a.notify(body="Test", title="Title")) is True
     assert mock_post.call_count == 1
 
     mock_post.reset_mock()
 
     # Test failure response
     mock_post.return_value.status_code = requests.codes.internal_server_error
-    assert a.notify(body="Test", title="Title") is False
+    assert bool(a.notify(body="Test", title="Title")) is False
 
     mock_post.reset_mock()
 
@@ -420,7 +420,7 @@ def test_plugin_chime_apprise_integration(mock_post):
     assert isinstance(a2[0], NotifyChime)
 
     mock_post.return_value.status_code = requests.codes.ok
-    assert a2.notify(body="Native test", title="Title") is True
+    assert bool(a2.notify(body="Native test", title="Title")) is True
 
 
 @mock.patch("requests.post")
@@ -461,9 +461,11 @@ def test_plugin_chime_html_to_markdown_format(mock_post):
     # Notify with an HTML body; the framework should convert it
     # to Markdown before dispatching to Chime
     assert (
-        aobj.notify(
-            body="<b>hello</b> <i>world</i>",
-            body_format=NotifyFormat.HTML,
+        bool(
+            aobj.notify(
+                body="<b>hello</b> <i>world</i>",
+                body_format=NotifyFormat.HTML,
+            )
         )
         is True
     )

--- a/tests/test_plugin_clickatell.py
+++ b/tests/test_plugin_clickatell.py
@@ -210,4 +210,4 @@ def test_plugin_clickatell_edge_cases(mock_post):
     obj = NotifyClickatell(apikey=apikey, from_phone=from_phone)
 
     # We will fail with the above error code
-    assert obj.notify("title", "body", "info") is False
+    assert bool(obj.notify("title", "body", "info")) is False

--- a/tests/test_plugin_custom_form.py
+++ b/tests/test_plugin_custom_form.py
@@ -253,11 +253,13 @@ def test_plugin_custom_form_attachments(mock_request):
     path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     attach = AppriseAttachment(path)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -265,11 +267,13 @@ def test_plugin_custom_form_attachments(mock_request):
     # Test invalid attachment
     path = os.path.join(TEST_VAR_DIR, "/invalid/path/to/an/invalid/file.jpg")
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=path,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=path,
+            )
         )
         is False
     )
@@ -278,11 +282,13 @@ def test_plugin_custom_form_attachments(mock_request):
     mock_request.side_effect = OSError()
     # We can't send the message if we can't read the attachment
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -301,11 +307,13 @@ def test_plugin_custom_form_attachments(mock_request):
     with mock.patch("builtins.open", side_effect=OSError()):
         # We can't send the message we can't open the attachment for reading
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )
@@ -314,11 +322,13 @@ def test_plugin_custom_form_attachments(mock_request):
     with mock.patch("builtins.open", side_effect=[None, OSError(), None]):
         # We can't send the message we can't open the attachment for reading
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )
@@ -327,11 +337,13 @@ def test_plugin_custom_form_attachments(mock_request):
     mock_request.return_value = None
     mock_request.side_effect = OSError()
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -353,11 +365,13 @@ def test_plugin_custom_form_attachments(mock_request):
     path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     attach = AppriseAttachment(path)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -370,11 +384,13 @@ def test_plugin_custom_form_attachments(mock_request):
     )
     attach = AppriseAttachment(path)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -410,11 +426,13 @@ def test_plugin_custom_form_attachments(mock_request):
         path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
         attach = AppriseAttachment(path)
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is True
         )
@@ -427,11 +445,13 @@ def test_plugin_custom_form_attachments(mock_request):
         )
         attach = AppriseAttachment(path)
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is True
         )

--- a/tests/test_plugin_custom_json.py
+++ b/tests/test_plugin_custom_json.py
@@ -365,11 +365,13 @@ def test_notify_json_plugin_attachments(mock_request):
     path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     attach = AppriseAttachment(path)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -377,11 +379,13 @@ def test_notify_json_plugin_attachments(mock_request):
     # Test invalid attachment
     path = os.path.join(TEST_VAR_DIR, "/invalid/path/to/an/invalid/file.jpg")
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=path,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=path,
+            )
         )
         is False
     )
@@ -400,11 +404,13 @@ def test_notify_json_plugin_attachments(mock_request):
     with mock.patch("builtins.open", side_effect=OSError()):
         # We can't send the message we can't open the attachment for reading
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )
@@ -416,11 +422,13 @@ def test_notify_json_plugin_attachments(mock_request):
     # Now send an attachment normally without issues
     mock_request.reset_mock()
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )

--- a/tests/test_plugin_custom_xml.py
+++ b/tests/test_plugin_custom_xml.py
@@ -281,11 +281,13 @@ def test_notify_xml_plugin_attachments(mock_request):
     path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     attach = AppriseAttachment(path)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -293,11 +295,13 @@ def test_notify_xml_plugin_attachments(mock_request):
     # Test invalid attachment
     path = os.path.join(TEST_VAR_DIR, "/invalid/path/to/an/invalid/file.jpg")
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=path,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=path,
+            )
         )
         is False
     )
@@ -316,11 +320,13 @@ def test_notify_xml_plugin_attachments(mock_request):
     with mock.patch("builtins.open", side_effect=OSError()):
         # We can't send the message we can't open the attachment for reading
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )
@@ -332,11 +338,13 @@ def test_notify_xml_plugin_attachments(mock_request):
     # Now send an attachment normally without issues
     mock_request.reset_mock()
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )

--- a/tests/test_plugin_dapnet.py
+++ b/tests/test_plugin_dapnet.py
@@ -209,7 +209,9 @@ def test_plugin_dapnet_edge_cases(mock_post):
     assert len(obj) == 2
 
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
     assert mock_post.call_count == 2
@@ -277,4 +279,4 @@ def test_plugin_dapnet_config_files(mock_post):
     )
 
     # Notifications work
-    assert aobj.notify(title="title", body="body") is True
+    assert bool(aobj.notify(title="title", body="body")) is True

--- a/tests/test_plugin_dbus.py
+++ b/tests/test_plugin_dbus.py
@@ -183,7 +183,7 @@ def test_plugin_dbus_send_success(mock_dbus_module, mocker):
     obj = NotifyDBus()
 
     # Send notification
-    assert obj.notify(title="Title", body="Body") is True
+    assert bool(obj.notify(title="Title", body="Body")) is True
 
     # VERIFICATION
     # Check SessionBus was called
@@ -232,7 +232,7 @@ def test_plugin_dbus_send_connection_failure(mock_dbus_module):
 
     obj = NotifyDBus()
     # Should handle exception and return False
-    assert obj.notify(title="T", body="B") is False
+    assert bool(obj.notify(title="T", body="B")) is False
 
 
 def test_plugin_dbus_send_notify_failure(mock_dbus_module):
@@ -247,7 +247,7 @@ def test_plugin_dbus_send_notify_failure(mock_dbus_module):
     mock_interface.Notify.side_effect = Exception("Generic Failure")
 
     obj = NotifyDBus()
-    assert obj.notify(title="T", body="B") is False
+    assert bool(obj.notify(title="T", body="B")) is False
 
 
 def test_plugin_dbus_image_loading_failure(mock_dbus_module, mocker):
@@ -269,7 +269,7 @@ def test_plugin_dbus_image_loading_failure(mock_dbus_module, mocker):
     spy_logger = mocker.spy(obj, "logger")
 
     # Notification should still succeed (return True), just log a warning
-    assert obj.notify(title="T", body="B") is True
+    assert bool(obj.notify(title="T", body="B")) is True
 
     # Verify the warning was logged
     spy_logger.warning.assert_called_with(
@@ -338,7 +338,7 @@ def test_plugin_dbus_send_sets_xy_meta_payload(mock_dbus_module):
     mock_interface = mock_dbus_module.Interface.return_value
     obj = NotifyDBus(x_axis=100, y_axis=200)
 
-    assert obj.notify(title="T", body="B") is True
+    assert bool(obj.notify(title="T", body="B")) is True
 
     args, _ = mock_interface.Notify.call_args
     # meta output (app, id, icon, title, body, actions, meta, timeout)
@@ -365,7 +365,7 @@ def test_plugin_dbus_send_image_condition_false_skips_pixbuf(
     # Ensure image_path is not even consulted when include_image=False
     spy_image_path = mocker.spy(obj, "image_path")
 
-    assert obj.notify(title="T", body="B") is True
+    assert bool(obj.notify(title="T", body="B")) is True
 
     assert mock_interface.Notify.called
     assert gi.repository.GdkPixbuf.Pixbuf.new_from_file.called is False

--- a/tests/test_plugin_dingtalk.py
+++ b/tests/test_plugin_dingtalk.py
@@ -162,9 +162,11 @@ def test_plugin_dingtalk_html_to_markdown_format(mock_post):
     # Notify with an HTML body; the framework converts it to Markdown
     # before dispatching to the DingTalk plugin
     assert (
-        aobj.notify(
-            body="<b>hello</b> <i>world</i>",
-            body_format=NotifyFormat.HTML,
+        bool(
+            aobj.notify(
+                body="<b>hello</b> <i>world</i>",
+                body_format=NotifyFormat.HTML,
+            )
         )
         is True
     )

--- a/tests/test_plugin_discord.py
+++ b/tests/test_plugin_discord.py
@@ -566,7 +566,9 @@ def test_plugin_discord_general(mock_sleep, mock_post):
 
     # This call includes an image with it's payload:
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -580,7 +582,9 @@ def test_plugin_discord_general(mock_sleep, mock_post):
 
     # This call includes an image with it's payload:
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -650,7 +654,9 @@ def test_plugin_discord_general(mock_sleep, mock_post):
 
     # This call includes an image with it's payload:
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -741,11 +747,13 @@ def test_plugin_discord_general(mock_sleep, mock_post):
     NotifyDiscord.discord_max_fields = 1
 
     assert (
-        a.notify(
-            body=test_markdown,
-            title="title",
-            notify_type=NotifyType.INFO,
-            body_format=NotifyFormat.TEXT,
+        bool(
+            a.notify(
+                body=test_markdown,
+                title="title",
+                notify_type=NotifyType.INFO,
+                body_format=NotifyFormat.TEXT,
+            )
         )
         is True
     )
@@ -769,8 +777,10 @@ def test_plugin_discord_general(mock_sleep, mock_post):
     )
     assert isinstance(obj, NotifyDiscord)
     assert (
-        obj.notify(
-            body=test_markdown, title="title", notify_type=NotifyType.INFO
+        bool(
+            obj.notify(
+                body=test_markdown, title="title", notify_type=NotifyType.INFO
+            )
         )
         is False
     )
@@ -801,8 +811,10 @@ def test_plugin_discord_general(mock_sleep, mock_post):
 
     # Use our test markdown string during a notification
     assert (
-        obj.notify(
-            body=test_markdown, title="title", notify_type=NotifyType.INFO
+        bool(
+            obj.notify(
+                body=test_markdown, title="title", notify_type=NotifyType.INFO
+            )
         )
         is True
     )
@@ -822,21 +834,25 @@ def test_plugin_discord_general(mock_sleep, mock_post):
 
     # This call includes an image with it's payload:
     assert (
-        a.notify(
-            body=test_markdown,
-            title="title",
-            notify_type=NotifyType.INFO,
-            body_format=NotifyFormat.TEXT,
+        bool(
+            a.notify(
+                body=test_markdown,
+                title="title",
+                notify_type=NotifyType.INFO,
+                body_format=NotifyFormat.TEXT,
+            )
         )
         is True
     )
 
     assert (
-        a.notify(
-            body=test_markdown,
-            title="title",
-            notify_type=NotifyType.INFO,
-            body_format=NotifyFormat.MARKDOWN,
+        bool(
+            a.notify(
+                body=test_markdown,
+                title="title",
+                notify_type=NotifyType.INFO,
+                body_format=NotifyFormat.MARKDOWN,
+            )
         )
         is True
     )
@@ -844,7 +860,7 @@ def test_plugin_discord_general(mock_sleep, mock_post):
     # Toggle our logo availability
     a.asset.image_url_logo = None
     assert (
-        a.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(a.notify(body="body", title="title", notify_type=NotifyType.INFO))
         is True
     )
 
@@ -860,7 +876,7 @@ def test_plugin_discord_general(mock_sleep, mock_post):
     )
 
     # This call includes an image with it's payload:
-    assert a.notify(body="test", title="title") is True
+    assert bool(a.notify(body="test", title="title")) is True
 
     assert mock_post.call_count == 1
     response = mock_post.call_args_list[0][1]
@@ -953,17 +969,19 @@ def test_plugin_discord_markdown_extra(mock_post):
 
     # This call includes an image with it's payload:
     assert (
-        a.notify(
-            body=test_markdown,
-            title="title",
-            notify_type=NotifyType.INFO,
-            body_format=NotifyFormat.TEXT,
+        bool(
+            a.notify(
+                body=test_markdown,
+                title="title",
+                notify_type=NotifyType.INFO,
+                body_format=NotifyFormat.TEXT,
+            )
         )
         is True
     )
 
     assert (
-        a.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(a.notify(body="body", title="title", notify_type=NotifyType.INFO))
         is True
     )
 
@@ -998,11 +1016,13 @@ def test_plugin_discord_attachments(mock_post):
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
 
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -1023,10 +1043,12 @@ def test_plugin_discord_attachments(mock_post):
 
     # Test notifications with mentions and attachments in it
     assert (
-        obj.notify(
-            body="Say hello to <@1234>!",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="Say hello to <@1234>!",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -1049,11 +1071,13 @@ def test_plugin_discord_attachments(mock_post):
     path = os.path.join(TEST_VAR_DIR, "/invalid/path/to/an/invalid/file.jpg")
     attach = AppriseAttachment(path)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=path,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=path,
+            )
         )
         is False
     )
@@ -1228,7 +1252,7 @@ def test_plugin_discord_attach_memory(mock_post):
         mimetype="text/html",
     )
 
-    assert obj.notify(body="Test", attach=mem) is True
+    assert bool(obj.notify(body="Test", attach=mem)) is True
     assert mock_post.call_count >= 1
 
 
@@ -1256,9 +1280,11 @@ def test_plugin_discord_html_to_markdown_format(mock_post):
     # Notify with an HTML body; the framework should convert it
     # to Markdown before dispatching to Discord
     assert (
-        aobj.notify(
-            body="<b>hello</b> <i>world</i>",
-            body_format=NotifyFormat.HTML,
+        bool(
+            aobj.notify(
+                body="<b>hello</b> <i>world</i>",
+                body_format=NotifyFormat.HTML,
+            )
         )
         is True
     )
@@ -1300,7 +1326,11 @@ def test_plugin_discord_template_content(mock_post, tmpdir):
 
     # Notification must succeed
     assert (
-        obj.notify(body="hello", title="world", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(
+                body="hello", title="world", notify_type=NotifyType.INFO
+            )
+        )
         is True
     )
     assert mock_post.called is True
@@ -1341,8 +1371,10 @@ def test_plugin_discord_template_embeds(mock_post, tmpdir):
 
     # Notification must succeed
     assert (
-        obj.notify(
-            body="my body", title="my title", notify_type=NotifyType.INFO
+        bool(
+            obj.notify(
+                body="my body", title="my title", notify_type=NotifyType.INFO
+            )
         )
         is True
     )
@@ -1453,7 +1485,7 @@ def test_plugin_discord_template_inaccessible(mock_post, tmpdir):
 
     # Notification must fail; no HTTP call should be made
     assert (
-        obj.notify(body="test", title="t", notify_type=NotifyType.INFO)
+        bool(obj.notify(body="test", title="t", notify_type=NotifyType.INFO))
         is False
     )
     assert mock_post.called is False
@@ -1486,7 +1518,9 @@ def test_plugin_discord_template_oserror(mock_post, tmpdir):
     # Patch open() to raise OSError when the template is read
     with mock.patch("builtins.open", side_effect=OSError):
         assert (
-            obj.notify(body="test", title="t", notify_type=NotifyType.INFO)
+            bool(
+                obj.notify(body="test", title="t", notify_type=NotifyType.INFO)
+            )
             is False
         )
     assert mock_post.called is False
@@ -1518,7 +1552,7 @@ def test_plugin_discord_template_invalid_json(mock_post, tmpdir):
 
     # Notification must fail due to parse error
     assert (
-        obj.notify(body="test", title="t", notify_type=NotifyType.INFO)
+        bool(obj.notify(body="test", title="t", notify_type=NotifyType.INFO))
         is False
     )
     assert mock_post.called is False
@@ -1550,7 +1584,7 @@ def test_plugin_discord_template_not_dict(mock_post, tmpdir):
 
     # Notification must fail because the root is not a dict
     assert (
-        obj.notify(body="test", title="t", notify_type=NotifyType.INFO)
+        bool(obj.notify(body="test", title="t", notify_type=NotifyType.INFO))
         is False
     )
     assert mock_post.called is False
@@ -1580,7 +1614,7 @@ def test_plugin_discord_template_payload_validation(mock_post, tmpdir):
     )
     assert isinstance(obj, NotifyDiscord)
     assert (
-        obj.notify(body="test", title="t", notify_type=NotifyType.INFO)
+        bool(obj.notify(body="test", title="t", notify_type=NotifyType.INFO))
         is False
     )
     assert mock_post.called is False
@@ -1593,7 +1627,7 @@ def test_plugin_discord_template_payload_validation(mock_post, tmpdir):
     )
     assert isinstance(obj, NotifyDiscord)
     assert (
-        obj.notify(body="test", title="t", notify_type=NotifyType.INFO)
+        bool(obj.notify(body="test", title="t", notify_type=NotifyType.INFO))
         is False
     )
 
@@ -1605,7 +1639,7 @@ def test_plugin_discord_template_payload_validation(mock_post, tmpdir):
     )
     assert isinstance(obj, NotifyDiscord)
     assert (
-        obj.notify(body="test", title="t", notify_type=NotifyType.INFO)
+        bool(obj.notify(body="test", title="t", notify_type=NotifyType.INFO))
         is False
     )
     assert mock_post.called is False
@@ -1637,7 +1671,7 @@ def test_plugin_discord_template_bad_embeds(mock_post, tmpdir):
 
     # Notification must fail because the embed entry is not a dict
     assert (
-        obj.notify(body="test", title="t", notify_type=NotifyType.INFO)
+        bool(obj.notify(body="test", title="t", notify_type=NotifyType.INFO))
         is False
     )
     assert mock_post.called is False
@@ -1667,7 +1701,7 @@ def test_plugin_discord_template_send_failure(mock_post, tmpdir):
         headers={},
     )
     assert (
-        obj.notify(body="test", title="t", notify_type=NotifyType.INFO)
+        bool(obj.notify(body="test", title="t", notify_type=NotifyType.INFO))
         is False
     )
     assert mock_post.called is True
@@ -1700,11 +1734,13 @@ def test_plugin_discord_template_with_attachments(mock_post, tmpdir):
     # Attach a test file
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
     assert (
-        obj.notify(
-            body="test",
-            title="t",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="test",
+                title="t",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )

--- a/tests/test_plugin_dot.py
+++ b/tests/test_plugin_dot.py
@@ -377,7 +377,7 @@ def test_notify_dot_auto_icon_passthrough():
 def test_notify_dot_image_mode_requires_image():
     """Explicit image mode fails without image data."""
     dot = NotifyDot(apikey="token", device_id="device", mode="image")
-    assert dot.notify(title="x", body="y") is False
+    assert bool(dot.notify(title="x", body="y")) is False
 
 
 def test_notify_dot_image_mode_with_attachment():
@@ -457,7 +457,9 @@ def test_notify_dot_image_mode_with_failed_attachment():
 
     dot = NotifyDot(apikey="token", device_id="device", mode="image")
     assert (
-        dot.notify(title="test", body="test", attach=[FailedAttachment()])
+        bool(
+            dot.notify(title="test", body="test", attach=[FailedAttachment()])
+        )
         is False
     )
 
@@ -1036,7 +1038,7 @@ def test_notify_dot_url_roundtrip_with_task_key():
 def test_notify_dot_no_device_id():
     """send() returns False when device_id is missing."""
     dot = NotifyDot(apikey="token", device_id=None)
-    assert dot.notify(title="test", body="test") is False
+    assert bool(dot.notify(title="test", body="test")) is False
     assert len(dot) == 0
 
 

--- a/tests/test_plugin_eight00com.py
+++ b/tests/test_plugin_eight00com.py
@@ -213,7 +213,7 @@ def test_plugin_eight00com_sms(mock_post):
         source="8005551234",
         targets=["5559876543"],
     )
-    assert obj.notify(body="Test", title="Title") is True
+    assert bool(obj.notify(body="Test", title="Title")) is True
     assert mock_post.call_count == 1
 
     # Verify payload
@@ -234,7 +234,7 @@ def test_plugin_eight00com_sms(mock_post):
         source="8005551234",
         targets=["5559876543", "4445551234"],
     )
-    assert obj.notify(body="Hello") is True
+    assert bool(obj.notify(body="Hello")) is True
     assert mock_post.call_count == 2
 
     mock_post.reset_mock()
@@ -246,20 +246,20 @@ def test_plugin_eight00com_sms(mock_post):
         source="8005551234",
         targets=["5559876543"],
     )
-    assert obj.notify(body="Test") is False
+    assert bool(obj.notify(body="Test")) is False
 
     mock_post.reset_mock()
 
     # Unknown status code -> failure
     response.status_code = 999
-    assert obj.notify(body="Test") is False
+    assert bool(obj.notify(body="Test")) is False
 
     mock_post.reset_mock()
 
     # RequestException -> failure
     mock_post.side_effect = requests.RequestException("Connection error")
     response.status_code = requests.codes.ok
-    assert obj.notify(body="Test") is False
+    assert bool(obj.notify(body="Test")) is False
 
     mock_post.side_effect = None
 
@@ -270,7 +270,7 @@ def test_plugin_eight00com_sms(mock_post):
         targets=["12"],
     )
     mock_post.reset_mock()
-    assert obj.notify(body="Test") is False
+    assert bool(obj.notify(body="Test")) is False
     assert mock_post.call_count == 0
 
 
@@ -374,11 +374,13 @@ def test_plugin_eight00com_attach_success(mock_post):
         os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     )
     assert (
-        obj.notify(
-            body="Test MMS",
-            title="",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="Test MMS",
+                title="",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -420,9 +422,11 @@ def test_plugin_eight00com_attach_multi(mock_post):
     attach.add(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
 
     assert (
-        obj.notify(
-            body="Multi-attachment MMS",
-            attach=attach,
+        bool(
+            obj.notify(
+                body="Multi-attachment MMS",
+                attach=attach,
+            )
         )
         is True
     )
@@ -454,7 +458,7 @@ def test_plugin_eight00com_attach_inaccessible(mock_post):
 
     # Simulate the file being inaccessible (os.path.isfile -> False)
     with mock.patch("os.path.isfile", return_value=False):
-        assert obj.notify(body="Test", attach=attach) is False
+        assert bool(obj.notify(body="Test", attach=attach)) is False
 
     # No HTTP call should have been made
     assert mock_post.call_count == 0
@@ -479,7 +483,7 @@ def test_plugin_eight00com_attach_oserror(mock_post):
     )
 
     with mock.patch("builtins.open", side_effect=OSError("IO fail")):
-        assert obj.notify(body="Test", attach=attach) is False
+        assert bool(obj.notify(body="Test", attach=attach)) is False
 
     # No HTTP call should have been made
     assert mock_post.call_count == 0
@@ -503,7 +507,7 @@ def test_plugin_eight00com_attach_http_error(mock_post):
     attach = AppriseAttachment.instantiate(
         os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     )
-    assert obj.notify(body="Test", attach=attach) is False
+    assert bool(obj.notify(body="Test", attach=attach)) is False
     assert mock_post.call_count == 1
 
 
@@ -522,7 +526,7 @@ def test_plugin_eight00com_attach_request_exception(mock_post):
     attach = AppriseAttachment.instantiate(
         os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     )
-    assert obj.notify(body="Test", attach=attach) is False
+    assert bool(obj.notify(body="Test", attach=attach)) is False
 
 
 @mock.patch("requests.post")
@@ -553,7 +557,7 @@ def test_plugin_eight00com_attach_partial_failure(mock_post):
         os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     )
     # One success and one failure -> overall False
-    assert obj.notify(body="Test", attach=attach) is False
+    assert bool(obj.notify(body="Test", attach=attach)) is False
     assert mock_post.call_count == 2
 
 
@@ -568,7 +572,7 @@ def test_plugin_eight00com_apprise_integration(mock_post):
     # Load via URL
     a = Apprise()
     assert a.add("eight00com://mytoken@8005551234/5559876543") is True
-    assert a.notify(body="Integration test") is True
+    assert bool(a.notify(body="Integration test")) is True
     assert mock_post.call_count == 1
 
     mock_post.reset_mock()
@@ -579,5 +583,5 @@ def test_plugin_eight00com_apprise_integration(mock_post):
         a2.add("eight00com://?token=mytoken&from=8005551234&to=5559876543")
         is True
     )
-    assert a2.notify(body="Integration test 2") is True
+    assert bool(a2.notify(body="Integration test 2")) is True
     assert mock_post.call_count == 1

--- a/tests/test_plugin_email.py
+++ b/tests/test_plugin_email.py
@@ -789,14 +789,18 @@ def test_plugin_email_smtplib_init_fail(mock_smtplib):
     mock_smtplib.side_effect = RuntimeError("Test")
 
     assert (
-        obj.notify(body="body", title="test", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="test", notify_type=NotifyType.INFO)
+        )
         is False
     )
 
     # A handled and expected exception
     mock_smtplib.side_effect = smtplib.SMTPException("Test")
     assert (
-        obj.notify(body="body", title="test", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="test", notify_type=NotifyType.INFO)
+        )
         is False
     )
 
@@ -818,7 +822,9 @@ def test_plugin_email_smtplib_send_okay(mock_smtplib):
     mock_smtplib.quit.return_value = True
 
     assert (
-        obj.notify(body="body", title="test", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="test", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -829,7 +835,9 @@ def test_plugin_email_smtplib_send_okay(mock_smtplib):
     assert isinstance(obj, email.NotifyEmail)
 
     assert (
-        obj.notify(body="body", title="test", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="test", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -840,32 +848,40 @@ def test_plugin_email_smtplib_send_okay(mock_smtplib):
     # Send Attachment with success
     attach = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     assert (
-        obj.notify(
-            body="body",
-            title="test",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="test",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
 
     # same results happen from our Apprise object
-    assert a.notify(body="body", title="test", attach=attach) is True
+    assert bool(a.notify(body="body", title="test", attach=attach)) is True
 
     # test using an Apprise Attachment object
     assert (
-        obj.notify(
-            body="body",
-            title="test",
-            notify_type=NotifyType.INFO,
-            attach=AppriseAttachment(attach),
+        bool(
+            obj.notify(
+                body="body",
+                title="test",
+                notify_type=NotifyType.INFO,
+                attach=AppriseAttachment(attach),
+            )
         )
         is True
     )
 
     # same results happen from our Apprise object
     assert (
-        a.notify(body="body", title="test", attach=AppriseAttachment(attach))
+        bool(
+            a.notify(
+                body="body", title="test", attach=AppriseAttachment(attach)
+            )
+        )
         is True
     )
 
@@ -874,17 +890,19 @@ def test_plugin_email_smtplib_send_okay(mock_smtplib):
 
     AttachBase.max_file_size = 1
     assert (
-        obj.notify(
-            body="body",
-            title="test",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="test",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
 
     # same results happen from our Apprise object
-    assert a.notify(body="body", title="test", attach=attach) is False
+    assert bool(a.notify(body="body", title="test", attach=attach)) is False
 
     # Restore value
     AttachBase.max_file_size = max_file_size
@@ -905,7 +923,9 @@ def test_plugin_email_smtplib_send_multiple_recipients(mock_smtplib):
     assert isinstance(obj, email.NotifyEmail)
 
     assert (
-        obj.notify(body="body", title="test", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="test", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -1085,13 +1105,15 @@ def test_plugin_email_smtplib_internationalization(mock_smtp):
 
     # Further test encoding through the message content as well
     assert (
-        obj.notify(
-            # Google Translated to Arabic:
-            #  "Let's make the world a better place."
-            title="دعونا نجعل العالم مكانا أفضل.",
-            # Google Translated to Hungarian: "One line of code at a time.'
-            body="Egy sor kódot egyszerre.",
-            notify_type=NotifyType.INFO,
+        bool(
+            obj.notify(
+                # Google Translated to Arabic:
+                #  "Let's make the world a better place."
+                title="دعونا نجعل العالم مكانا أفضل.",
+                # Google Translated to Hungarian: "One line of code at a time.'
+                body="Egy sor kódot egyszerre.",
+                notify_type=NotifyType.INFO,
+            )
         )
         is True
     )
@@ -1340,7 +1362,7 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
 
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
     assert mock_smtp.call_count == 1
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 1
@@ -1390,7 +1412,7 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
 
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 1
     assert response.starttls.call_count == 0
@@ -1440,7 +1462,7 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 0
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
     assert mock_smtp.call_count == 1
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 1
@@ -1465,7 +1487,7 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 0
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
     assert mock_smtp.call_count == 1
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 1
@@ -1492,7 +1514,7 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 0
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
     assert mock_smtp.call_count == 1
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 1
@@ -1523,7 +1545,7 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 0
-    assert obj1.notify("test") is True
+    assert bool(obj1.notify("test")) is True
     assert mock_smtp.call_count == 1
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 1
@@ -1550,7 +1572,7 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 0
-    assert obj2.notify("test") is True
+    assert bool(obj2.notify("test")) is True
     assert mock_smtp.call_count == 1
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 1
@@ -1577,7 +1599,7 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 0
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 1
     assert response.starttls.call_count == 0
@@ -1601,7 +1623,7 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 0
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
     assert mock_smtp.call_count == 1
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 1
@@ -1625,7 +1647,7 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 0
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
     assert mock_smtp.call_count == 1
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 1
@@ -1673,7 +1695,7 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 0
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 1
     assert response.starttls.call_count == 0
@@ -1707,7 +1729,7 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 0
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 1
     assert response.starttls.call_count == 0
@@ -1742,7 +1764,7 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 0
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
     assert mock_smtp.call_count == 1
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 1
@@ -1777,7 +1799,7 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 0
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
     assert mock_smtp.call_count == 1
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 1
@@ -1818,7 +1840,7 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
 
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 1
     assert response.starttls.call_count == 0
@@ -1874,7 +1896,7 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
 
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 1
     assert response.starttls.call_count == 0
@@ -1926,7 +1948,7 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
 
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 1
     assert response.starttls.call_count == 0
@@ -1982,7 +2004,7 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 0
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
     assert mock_smtp.call_count == 1
     assert response.starttls.call_count == 1
     assert mock_smtp_ssl.call_count == 0
@@ -2039,7 +2061,7 @@ def test_plugin_email_plus_in_toemail(mock_smtp, mock_smtp_ssl):
 
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
     assert mock_smtp.call_count == 1
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 1
@@ -2084,7 +2106,7 @@ def test_plugin_email_plus_in_toemail(mock_smtp, mock_smtp_ssl):
 
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
     assert mock_smtp.call_count == 1
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 1
@@ -2128,7 +2150,7 @@ def test_plugin_email_plus_in_toemail(mock_smtp, mock_smtp_ssl):
 
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
     assert mock_smtp.call_count == 1
     assert mock_smtp_ssl.call_count == 0
     assert response.starttls.call_count == 1
@@ -2286,7 +2308,7 @@ def test_plugin_email_to_handling_1356(mock_smtp, mock_smtp_ssl):
 
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
-    assert obj.notify("body", "title") is True
+    assert bool(obj.notify("body", "title")) is True
 
     assert mock_smtp.call_count == 1
     assert mock_smtp_ssl.call_count == 0
@@ -2346,7 +2368,7 @@ def test_plugin_email_variables_1334(mock_smtp, mock_smtp_ssl):
 
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
-    assert obj.notify("body", "title") is True
+    assert bool(obj.notify("body", "title")) is True
 
     assert mock_smtp.call_count == 1
     assert mock_smtp_ssl.call_count == 0
@@ -2387,7 +2409,7 @@ def test_plugin_email_variables_1334(mock_smtp, mock_smtp_ssl):
 
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
-    assert obj.notify("body", "title") is True
+    assert bool(obj.notify("body", "title")) is True
 
     assert mock_smtp.call_count == 1
     assert mock_smtp_ssl.call_count == 0
@@ -2435,7 +2457,7 @@ def test_plugin_host_detection_from_source_email(mock_smtp, mock_smtp_ssl):
 
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
-    assert obj.notify("body", "title") is True
+    assert bool(obj.notify("body", "title")) is True
 
     assert mock_smtp.call_count == 1
     assert mock_smtp_ssl.call_count == 0
@@ -2489,7 +2511,7 @@ def test_plugin_host_detection_from_source_email(mock_smtp, mock_smtp_ssl):
 
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
-    assert obj.notify("body", "title") is True
+    assert bool(obj.notify("body", "title")) is True
 
     assert mock_smtp.call_count == 1
     assert mock_smtp_ssl.call_count == 0
@@ -2566,7 +2588,7 @@ def test_plugin_host_detection_from_source_email(mock_smtp, mock_smtp_ssl):
 
     assert mock_smtp.call_count == 0
     assert mock_smtp_ssl.call_count == 0
-    assert obj.notify("body", "title") is True
+    assert bool(obj.notify("body", "title")) is True
 
     assert mock_smtp.call_count == 1
     assert mock_smtp_ssl.call_count == 0
@@ -2649,7 +2671,7 @@ def test_plugin_email_pgp(mock_smtp, mock_smtpssl, tmpdir):
     # no PGP
     obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=encrypt")
     # No PGP Support and set enabled
-    assert obj.notify("test body") is False
+    assert bool(obj.notify("test body")) is False
 
     # Return the PGP status for remaining checks
     utils.pgp.PGP_SUPPORT = True
@@ -2802,7 +2824,7 @@ def test_plugin_email_pgp(mock_smtp, mock_smtpssl, tmpdir):
 
     assert obj.pgp.public_keyfile().endswith("chris-pub.asc")
 
-    assert obj.notify("test body") is True
+    assert bool(obj.notify("test body")) is True
 
     # The private key is not needed for sending the encrypted messages
     os.unlink(os.path.join(obj.store.path, "chris-prv.asc"))
@@ -2911,7 +2933,7 @@ def test_plugin_email_pgp(mock_smtp, mock_smtpssl, tmpdir):
     with mock.patch("pgpy.PGPMessage.new", side_effect=NameError):
         assert obj.pgp.encrypt("message") is None
         # Attempts to encrypt a message
-        assert obj.notify("test-encrypt") is False
+        assert bool(obj.notify("test-encrypt")) is False
 
     # Create new keys
     assert obj.pgp.keygen() is True
@@ -2975,7 +2997,7 @@ def test_plugin_email_pgp(mock_smtp, mock_smtpssl, tmpdir):
     )
 
     # Key is corrupted
-    assert obj.notify("test") is False
+    assert bool(obj.notify("test")) is False
 
     shutil.copyfile(
         os.path.join(TEST_VAR_DIR, "apprise-test.jpeg"),
@@ -2983,7 +3005,7 @@ def test_plugin_email_pgp(mock_smtp, mock_smtpssl, tmpdir):
     )
 
     # Key is a binary image; definitely not a valid key
-    assert obj.notify("test") is False
+    assert bool(obj.notify("test")) is False
 
 
 @mock.patch("smtplib.SMTP_SSL")
@@ -3191,7 +3213,7 @@ def test_plugin_email_wkd_key_discovery(mock_smtp, mock_smtpssl, tmpdir):
 
     # Patch WKD fetch to return our generated public key
     with mock.patch.object(obj.pgp.wkd, "fetch", return_value=pub_bytes):
-        assert obj.notify("test body") is True
+        assert bool(obj.notify("test body")) is True
 
     # Clear the parsed-key cache so the second block cannot reuse the
     # key loaded above -- we need the fetch mock to be the sole source
@@ -3200,7 +3222,7 @@ def test_plugin_email_wkd_key_discovery(mock_smtp, mock_smtpssl, tmpdir):
     # WKD returning None with autogen disabled falls through gracefully
     asset.pgp_autogen = False
     with mock.patch.object(obj.pgp.wkd, "fetch", return_value=None):
-        assert obj.notify("test body") is False
+        assert bool(obj.notify("test body")) is False
 
 
 @mock.patch("smtplib.SMTP_SSL")
@@ -3301,7 +3323,7 @@ def test_plugin_email_pgp_sign_send(mock_smtp, mock_smtpssl, tmpdir):
     assert obj is not None
 
     # Notification should succeed and sendmail should be called once
-    assert obj.notify("test body") is True
+    assert bool(obj.notify("test body")) is True
     assert mock_socket.sendmail.call_count == 1
 
     # The emitted email must contain the multipart/signed structure
@@ -3409,7 +3431,7 @@ def test_plugin_email_pgp_sign_wire_content_crlf(
     with mock.patch.object(
         utils.pgp.ApprisePGPController, "sign", capturing_sign
     ):
-        assert obj.notify("test body") is True
+        assert bool(obj.notify("test body")) is True
 
     # Confirm send actually happened and our interceptor was triggered
     assert mock_socket.sendmail.call_count == 1
@@ -3450,7 +3472,7 @@ def test_plugin_email_pgp_sign_no_privkey_fails(
         asset=asset,
     )
     assert obj is not None
-    assert obj.notify("test body") is False
+    assert bool(obj.notify("test body")) is False
 
 
 @pytest.mark.skipif("pgpy" not in sys.modules, reason="Requires PGPy")
@@ -3501,7 +3523,7 @@ def test_plugin_email_pgp_sign_opportunistic_encrypt(
 
     # With WKD returning a public key: sign + encrypt
     with mock.patch.object(obj.pgp.wkd, "fetch", return_value=pub_bytes):
-        assert obj.notify("test body") is True
+        assert bool(obj.notify("test body")) is True
 
     raw = mock_socket.sendmail.call_args[0][2]
     # The outer structure is multipart/encrypted (the signed body is inside)
@@ -3513,7 +3535,7 @@ def test_plugin_email_pgp_sign_opportunistic_encrypt(
 
     # With WKD returning nothing: sign only, no failure
     with mock.patch.object(obj.pgp.wkd, "fetch", return_value=None):
-        assert obj.notify("test body") is True
+        assert bool(obj.notify("test body")) is True
 
     raw = mock_socket.sendmail.call_args[0][2]
     # No encryption this time; just a signed message
@@ -3546,7 +3568,7 @@ def test_plugin_email_pgp_sign_no_pgp_support(mock_smtp, mock_smtpssl):
     real_support = pgp_utils.PGP_SUPPORT
     pgp_utils.PGP_SUPPORT = False
     try:
-        assert obj.notify("test body") is False
+        assert bool(obj.notify("test body")) is False
     finally:
         pgp_utils.PGP_SUPPORT = real_support
 
@@ -3579,7 +3601,7 @@ def test_plugin_email_pgp_sign_encrypt_none_mode(
         asset=asset,
     )
     assert obj is not None
-    assert obj.notify("test body") is True
+    assert bool(obj.notify("test body")) is True
 
     # The email must not contain any PGP markers
     raw = mock_socket.sendmail.call_args[0][2]
@@ -3615,7 +3637,7 @@ def test_plugin_email_pgp_sign_keygen_auto(mock_smtp, mock_smtpssl, tmpdir):
     # Now send -- the auto-generated private key must be discovered.
     # With both keys present the message is sign+encrypted; the signing
     # step is the behavior under test, so we only assert success here.
-    assert obj.notify("test body") is True
+    assert bool(obj.notify("test body")) is True
 
 
 def test_plugin_email_prepare():
@@ -3734,7 +3756,7 @@ def test_plugin_email_gmx_template_lookup(mock_smtp):
         assert obj.secure is True
 
         # Send once to trigger SMTP/login behaviour
-        assert obj.notify("body", "title") is True
+        assert bool(obj.notify("body", "title")) is True
 
         # STARTTLS used
         assert response.starttls.call_count == 1
@@ -3771,7 +3793,7 @@ def test_plugin_email_tls_certificate_verification(mock_smtpssl, mock_smtp):
     )
     assert isinstance(obj, email.NotifyEmail)
     assert obj.verify_certificate is True
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
 
     assert mock_smtpssl.call_count == 1
     context = mock_smtpssl.call_args.kwargs.get("context")
@@ -3789,7 +3811,7 @@ def test_plugin_email_tls_certificate_verification(mock_smtpssl, mock_smtp):
         suppress_exceptions=False,
     )
     assert obj.verify_certificate is False
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
 
     assert mock_smtpssl.call_count == 1
     context = mock_smtpssl.call_args.kwargs.get("context")
@@ -3807,7 +3829,7 @@ def test_plugin_email_tls_certificate_verification(mock_smtpssl, mock_smtp):
         suppress_exceptions=False,
     )
     assert obj.verify_certificate is True
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
 
     assert response.starttls.call_count == 1
     context = response.starttls.call_args.kwargs.get("context")
@@ -3823,7 +3845,7 @@ def test_plugin_email_tls_certificate_verification(mock_smtpssl, mock_smtp):
         suppress_exceptions=False,
     )
     assert obj.verify_certificate is False
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
 
     assert response.starttls.call_count == 1
     context = response.starttls.call_args.kwargs.get("context")
@@ -3851,7 +3873,7 @@ def test_plugin_email_starttls_certificate_failure_handling(mock_smtp):
     )
     assert isinstance(obj, email.NotifyEmail)
 
-    assert obj.notify(body="body", title="title") is False
+    assert bool(obj.notify(body="body", title="title")) is False
     response.login.assert_not_called()
     response.sendmail.assert_not_called()
 
@@ -3895,11 +3917,13 @@ def test_plugin_email_inline_attachments(mock_smtplib):
 
     sent_messages.clear()
     assert (
-        obj.notify(
-            body="<p>hello</p>",
-            title="test",
-            notify_type=NotifyType.INFO,
-            attach=img,
+        bool(
+            obj.notify(
+                body="<p>hello</p>",
+                title="test",
+                notify_type=NotifyType.INFO,
+                attach=img,
+            )
         )
         is True
     )
@@ -3922,11 +3946,13 @@ def test_plugin_email_inline_attachments(mock_smtplib):
     # the attachment is embedded inline
     sent_messages.clear()
     assert (
-        obj.notify(
-            body="<p>no cid ref here</p>",
-            title="test",
-            notify_type=NotifyType.INFO,
-            attach=img,
+        bool(
+            obj.notify(
+                body="<p>no cid ref here</p>",
+                title="test",
+                notify_type=NotifyType.INFO,
+                attach=img,
+            )
         )
         is True
     )
@@ -3945,11 +3971,13 @@ def test_plugin_email_inline_attachments(mock_smtplib):
 
     sent_messages.clear()
     assert (
-        obj.notify(
-            body=html_with_ref,
-            title="test",
-            notify_type=NotifyType.INFO,
-            attach=img,
+        bool(
+            obj.notify(
+                body=html_with_ref,
+                title="test",
+                notify_type=NotifyType.INFO,
+                attach=img,
+            )
         )
         is True
     )
@@ -3969,11 +3997,13 @@ def test_plugin_email_inline_attachments(mock_smtplib):
 
     sent_messages.clear()
     assert (
-        obj.notify(
-            body=html_one_ref,
-            title="test",
-            notify_type=NotifyType.INFO,
-            attach=AppriseAttachment([img, img2]),
+        bool(
+            obj.notify(
+                body=html_one_ref,
+                title="test",
+                notify_type=NotifyType.INFO,
+                attach=AppriseAttachment([img, img2]),
+            )
         )
         is True
     )
@@ -3999,11 +4029,13 @@ def test_plugin_email_inline_attachments(mock_smtplib):
 
     sent_messages.clear()
     assert (
-        obj.notify(
-            body="<p>body</p>",
-            title="test",
-            notify_type=NotifyType.INFO,
-            attach=aa,
+        bool(
+            obj.notify(
+                body="<p>body</p>",
+                title="test",
+                notify_type=NotifyType.INFO,
+                attach=aa,
+            )
         )
         is True
     )
@@ -4026,11 +4058,13 @@ def test_plugin_email_inline_attachments(mock_smtplib):
 
     sent_messages.clear()
     assert (
-        obj_txt.notify(
-            body="plain text body",
-            title="test",
-            notify_type=NotifyType.INFO,
-            attach=img,
+        bool(
+            obj_txt.notify(
+                body="plain text body",
+                title="test",
+                notify_type=NotifyType.INFO,
+                attach=img,
+            )
         )
         is True
     )
@@ -4046,11 +4080,13 @@ def test_plugin_email_inline_attachments(mock_smtplib):
     # inline=True, TEXT format, non-image attachment
     sent_messages.clear()
     assert (
-        obj_txt.notify(
-            body="plain text body",
-            title="test",
-            notify_type=NotifyType.INFO,
-            attach=aa,  # application/pdf override -- not an image
+        bool(
+            obj_txt.notify(
+                body="plain text body",
+                title="test",
+                notify_type=NotifyType.INFO,
+                attach=aa,  # application/pdf override -- not an image
+            )
         )
         is True
     )
@@ -4069,11 +4105,13 @@ def test_plugin_email_inline_attachments(mock_smtplib):
 
     sent_messages.clear()
     assert (
-        obj.notify(
-            body="<p>no cid</p>",
-            title="test",
-            notify_type=NotifyType.INFO,
-            attach=aa_upper,
+        bool(
+            obj.notify(
+                body="<p>no cid</p>",
+                title="test",
+                notify_type=NotifyType.INFO,
+                attach=aa_upper,
+            )
         )
         is True
     )
@@ -4088,11 +4126,13 @@ def test_plugin_email_inline_attachments(mock_smtplib):
     # also appear, proving the case-insensitive check works in the text path
     sent_messages.clear()
     assert (
-        obj_txt.notify(
-            body="plain body",
-            title="test",
-            notify_type=NotifyType.INFO,
-            attach=aa_upper,
+        bool(
+            obj_txt.notify(
+                body="plain body",
+                title="test",
+                notify_type=NotifyType.INFO,
+                attach=aa_upper,
+            )
         )
         is True
     )
@@ -4104,11 +4144,13 @@ def test_plugin_email_inline_attachments(mock_smtplib):
     # warning is logged so the user can debug the mismatch
     with mock.patch("apprise.plugins.email.base.logger") as mock_logger:
         assert (
-            obj.notify(
-                body='<img src="cid:missing-file.jpg">',
-                title="test",
-                notify_type=NotifyType.INFO,
-                attach=img,
+            bool(
+                obj.notify(
+                    body='<img src="cid:missing-file.jpg">',
+                    title="test",
+                    notify_type=NotifyType.INFO,
+                    attach=img,
+                )
             )
             is True
         )
@@ -4125,12 +4167,14 @@ def test_plugin_email_inline_attachments(mock_smtplib):
     sent_messages.clear()
     with mock.patch("apprise.plugins.email.base.logger"):
         assert (
-            obj.notify(
-                body='<p>body <img src="cid:ghost.jpg"></p>',
-                title="test",
-                notify_type=NotifyType.INFO,
-                # application/pdf -- not an image, not named ghost.jpg
-                attach=aa,
+            bool(
+                obj.notify(
+                    body='<p>body <img src="cid:ghost.jpg"></p>',
+                    title="test",
+                    notify_type=NotifyType.INFO,
+                    # application/pdf -- not an image, not named ghost.jpg
+                    attach=aa,
+                )
             )
             is True
         )
@@ -4150,12 +4194,14 @@ def test_plugin_email_inline_attachments(mock_smtplib):
     sent_messages.clear()
     with mock.patch("apprise.plugins.email.base.logger") as mock_logger:
         assert (
-            obj.notify(
-                body=f'<p>body <embed src="cid:{pdf_attach.name}"></p>',
-                title="test",
-                notify_type=NotifyType.INFO,
-                # same PDF attachment as earlier tests
-                attach=aa,
+            bool(
+                obj.notify(
+                    body=f'<p>body <embed src="cid:{pdf_attach.name}"></p>',
+                    title="test",
+                    notify_type=NotifyType.INFO,
+                    # same PDF attachment as earlier tests
+                    attach=aa,
+                )
             )
             is True
         )
@@ -4180,11 +4226,13 @@ def test_plugin_email_inline_attachments(mock_smtplib):
     sent_messages.clear()
     with mock.patch("apprise.plugins.email.base.logger") as mock_logger:
         assert (
-            obj.notify(
-                body='<img src="cid:my%20photo.gif">',
-                title="test",
-                notify_type=NotifyType.INFO,
-                attach=aa_spaced,
+            bool(
+                obj.notify(
+                    body='<img src="cid:my%20photo.gif">',
+                    title="test",
+                    notify_type=NotifyType.INFO,
+                    attach=aa_spaced,
+                )
             )
             is True
         )
@@ -4210,11 +4258,13 @@ def test_plugin_email_inline_attachments(mock_smtplib):
 
     sent_messages.clear()
     assert (
-        obj.notify(
-            body="<p>body</p>",
-            title="test",
-            notify_type=NotifyType.INFO,
-            attach=aa_bad,
+        bool(
+            obj.notify(
+                body="<p>body</p>",
+                title="test",
+                notify_type=NotifyType.INFO,
+                attach=aa_bad,
+            )
         )
         is False  # bad attachment detected by the main loop
     )
@@ -4224,11 +4274,13 @@ def test_plugin_email_inline_attachments(mock_smtplib):
     # inline=True, TEXT format, inaccessible attachment
     sent_messages.clear()
     assert (
-        obj_txt.notify(
-            body="plain body",
-            title="test",
-            notify_type=NotifyType.INFO,
-            attach=aa_bad,
+        bool(
+            obj_txt.notify(
+                body="plain body",
+                title="test",
+                notify_type=NotifyType.INFO,
+                attach=aa_bad,
+            )
         )
         is False
     )

--- a/tests/test_plugin_emby.py
+++ b/tests/test_plugin_emby.py
@@ -123,14 +123,14 @@ def test_plugin_emby_general(
 
     obj = Apprise.instantiate("emby://l2g:l2gpass@localhost?modal=False")
     assert isinstance(obj, NotifyEmby)
-    assert obj.notify("title", "body", "info") is True
+    assert bool(obj.notify("title", "body", "info")) is True
     obj.access_token = "abc"
     obj.user_id = "123"
 
     # Test Modal support
     obj = Apprise.instantiate("emby://l2g:l2gpass@localhost?modal=True")
     assert isinstance(obj, NotifyEmby)
-    assert obj.notify("title", "body", "info") is True
+    assert bool(obj.notify("title", "body", "info")) is True
     obj.access_token = "abc"
     obj.user_id = "123"
 
@@ -139,7 +139,7 @@ def test_plugin_emby_general(
         mock_post.side_effect = exception
         mock_get.side_effect = exception
         # We'll fail to log in each time
-        assert obj.notify("title", "body", "info") is False
+        assert bool(obj.notify("title", "body", "info")) is False
 
     # Disable Exceptions
     mock_post.side_effect = None
@@ -152,12 +152,12 @@ def test_plugin_emby_general(
     # KeyError handling
     mock_post.return_value.status_code = 999
     mock_get.return_value.status_code = 999
-    assert obj.notify("title", "body", "info") is False
+    assert bool(obj.notify("title", "body", "info")) is False
 
     # General Internal Server Error
     mock_post.return_value.status_code = requests.codes.internal_server_error
     mock_get.return_value.status_code = requests.codes.internal_server_error
-    assert obj.notify("title", "body", "info") is False
+    assert bool(obj.notify("title", "body", "info")) is False
 
     mock_post.return_value.status_code = requests.codes.ok
     mock_get.return_value.status_code = requests.codes.ok
@@ -165,12 +165,12 @@ def test_plugin_emby_general(
 
     # Disable the port completely
     obj.port = None
-    assert obj.notify("title", "body", "info") is True
+    assert bool(obj.notify("title", "body", "info")) is True
 
     # An Empty return set (no query is made, but notification will still
     # succeed
     mock_sessions.return_value = {}
-    assert obj.notify("title", "body", "info") is True
+    assert bool(obj.notify("title", "body", "info")) is True
 
     # Tidy our object
     del obj

--- a/tests/test_plugin_evolution.py
+++ b/tests/test_plugin_evolution.py
@@ -223,7 +223,7 @@ def test_plugin_evolution_send(mock_post):
     )
     assert isinstance(obj, NotifyEvolution)
 
-    assert obj.notify(body="Hello World", title="Test") is True
+    assert bool(obj.notify(body="Hello World", title="Test")) is True
     assert mock_post.call_count == 1
 
     # Verify URL
@@ -255,7 +255,7 @@ def test_plugin_evolution_multiple_targets(mock_post):
     assert isinstance(obj, NotifyEvolution)
     assert len(obj) == 3
 
-    assert obj.notify(body="msg") is True
+    assert bool(obj.notify(body="msg")) is True
     assert mock_post.call_count == 3
 
     numbers = [loads(c[1]["data"])["number"] for c in mock_post.call_args_list]
@@ -281,7 +281,7 @@ def test_plugin_evolution_partial_failure(mock_post):
     obj = Apprise.instantiate(
         "evolution://key@host/inst/5511111111111/5522222222222"
     )
-    assert obj.notify(body="msg") is False
+    assert bool(obj.notify(body="msg")) is False
     assert mock_post.call_count == 2
 
 
@@ -293,7 +293,7 @@ def test_plugin_evolution_title_in_body(mock_post):
     mock_post.return_value.status_code = requests.codes.ok
 
     obj = Apprise.instantiate("evolution://key@host/inst/5511999999999")
-    assert obj.notify(body="body text", title="My Title") is True
+    assert bool(obj.notify(body="body text", title="My Title")) is True
 
     payload = loads(mock_post.call_args[1]["data"])
     assert "My Title" in payload["text"]
@@ -313,7 +313,7 @@ def test_plugin_evolution_https(mock_post):
     assert isinstance(obj, NotifyEvolution)
     assert obj.secure is True
 
-    assert obj.notify(body="secure msg") is True
+    assert bool(obj.notify(body="secure msg")) is True
     url = mock_post.call_args[0][0]
     assert url.startswith("https://")
 
@@ -329,9 +329,12 @@ def test_plugin_evolution_html_to_markdown_hardening(mock_post):
     mock_post.return_value.text = "{}"
 
     def notify(body):
+        """Send one HTML body through the configured Evolution plugin."""
         aobj = Apprise()
         assert aobj.add("evolutions://key@host/inst/5511999999999")
-        assert aobj.notify(body=body, body_format=NotifyFormat.HTML) is True
+        assert (
+            bool(aobj.notify(body=body, body_format=NotifyFormat.HTML)) is True
+        )
         payload = loads(mock_post.call_args_list[-1][1]["data"])
         mock_post.reset_mock()
         return payload["text"]
@@ -363,7 +366,7 @@ def test_plugin_evolution_html_to_markdown_hardening(mock_post):
     # Direct WhatsApp Markdown remains unchanged.
     aobj = Apprise()
     assert aobj.add("evolutions://key@host/inst/5511999999999")
-    assert aobj.notify(body="*already* whatsapp-bound markdown") is True
+    assert bool(aobj.notify(body="*already* whatsapp-bound markdown")) is True
     payload = loads(mock_post.call_args_list[-1][1]["data"])
     assert payload["text"] == "*already* whatsapp-bound markdown"
     mock_post.reset_mock()
@@ -407,10 +410,12 @@ def test_plugin_evolution_html_to_markdown_hardening(mock_post):
     aobj = Apprise()
     assert aobj.add("evolutions://key@host/inst/5511999999999")
     assert (
-        aobj.notify(
-            body="<b>hello</b>",
-            title="My Title",
-            body_format=NotifyFormat.HTML,
+        bool(
+            aobj.notify(
+                body="<b>hello</b>",
+                title="My Title",
+                body_format=NotifyFormat.HTML,
+            )
         )
         is True
     )
@@ -422,10 +427,12 @@ def test_plugin_evolution_html_to_markdown_hardening(mock_post):
     # and list characters (html_to_markdown converts "  - " to "-").
     # The heading is skipped and the title field is cleared regardless.
     assert (
-        aobj.notify(
-            body="<b>hello</b>",
-            title="  - ",
-            body_format=NotifyFormat.HTML,
+        bool(
+            aobj.notify(
+                body="<b>hello</b>",
+                title="  - ",
+                body_format=NotifyFormat.HTML,
+            )
         )
         is True
     )

--- a/tests/test_plugin_fcm.py
+++ b/tests/test_plugin_fcm.py
@@ -337,7 +337,7 @@ def test_plugin_fcm_legacy_default(mock_post_legacy):
     )
 
     # Send our notification
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
 
     # Test our call count
     assert mock_post_legacy.call_count == 1
@@ -376,7 +376,7 @@ def test_plugin_fcm_legacy_priorities(mock_post_legacy):
     assert mock_post_legacy.call_count == 0
 
     # Send our notification
-    assert obj.notify(title="title", body="body") is True
+    assert bool(obj.notify(title="title", body="body")) is True
 
     # Test our call count
     assert mock_post_legacy.call_count == 1
@@ -409,7 +409,7 @@ def test_plugin_fcm_legacy_no_colors(mock_post_legacy):
     assert mock_post_legacy.call_count == 0
 
     # Send our notification
-    assert obj.notify(title="title", body="body") is True
+    assert bool(obj.notify(title="title", body="body")) is True
 
     # Test our call count
     assert mock_post_legacy.call_count == 1
@@ -439,7 +439,7 @@ def test_plugin_fcm_legacy_colors(mock_post_legacy):
     assert mock_post_legacy.call_count == 0
 
     # Send our notification
-    assert obj.notify(title="title", body="body") is True
+    assert bool(obj.notify(title="title", body="body")) is True
 
     # Test our call count
     assert mock_post_legacy.call_count == 1
@@ -474,7 +474,7 @@ def test_plugin_fcm_oauth_default(mock_post):
     )
 
     # send our notification
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
 
     # Test our call count
     assert mock_post.call_count == 3
@@ -504,7 +504,7 @@ def test_plugin_fcm_oauth_invalid_project_id(mock_post):
     )
 
     # we'll fail as a result
-    assert obj.notify("test") is False
+    assert bool(obj.notify("test")) is False
 
     # Test our call count
     assert mock_post.call_count == 0
@@ -523,7 +523,7 @@ def test_plugin_fcm_oauth_keyfile_error(mock_post):
 
     with mock.patch("builtins.open", side_effect=OSError):
         # we'll fail as a result
-        assert obj.notify("test") is False
+        assert bool(obj.notify("test")) is False
 
     # Test our call count
     assert mock_post.call_count == 0
@@ -546,7 +546,7 @@ def test_plugin_fcm_oauth_data_parameters(mock_post):
     assert mock_post.call_count == 0
 
     # send our notification
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
 
     # Test our call count
     assert mock_post.call_count == 3
@@ -615,7 +615,7 @@ def test_plugin_fcm_oauth_priorities(mock_post):
     assert mock_post.call_count == 0
 
     # Send our notification
-    assert obj.notify(title="title", body="body") is True
+    assert bool(obj.notify(title="title", body="body")) is True
 
     # Test our call count
     assert mock_post.call_count == 2
@@ -653,7 +653,7 @@ def test_plugin_fcm_oauth_no_colors(mock_post):
     assert mock_post.call_count == 0
 
     # Send our notification
-    assert obj.notify(title="title", body="body") is True
+    assert bool(obj.notify(title="title", body="body")) is True
 
     # Test our call count
     assert mock_post.call_count == 2
@@ -688,7 +688,7 @@ def test_plugin_fcm_oauth_colors(mock_post):
     assert mock_post.call_count == 0
 
     # Send our notification
-    assert obj.notify(title="title", body="body") is True
+    assert bool(obj.notify(title="title", body="body")) is True
 
     # Test our call count
     assert mock_post.call_count == 2

--- a/tests/test_plugin_flowtriq.py
+++ b/tests/test_plugin_flowtriq.py
@@ -362,5 +362,5 @@ def test_plugin_flowtriq_apprise_integration(mock_post):
 
     app = Apprise()
     assert app.add("flowtriq://mykey@flowtriq.com/hooks/abc123") is True
-    assert app.notify(title="Title", body="Body") is True
+    assert bool(app.notify(title="Title", body="Body")) is True
     assert mock_post.call_count == 1

--- a/tests/test_plugin_fluxer.py
+++ b/tests/test_plugin_fluxer.py
@@ -752,11 +752,13 @@ def test_plugin_fluxer_general(
     try:
         NotifyFluxer.fluxer_max_fields = 1
         assert (
-            a.notify(
-                body=test_markdown,
-                title="title",
-                notify_type=NotifyType.INFO,
-                body_format=NotifyFormat.TEXT,
+            bool(
+                a.notify(
+                    body=test_markdown,
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    body_format=NotifyFormat.TEXT,
+                )
             )
             is True
         )
@@ -790,8 +792,12 @@ def test_plugin_fluxer_general(
         NotifyFluxer.fluxer_max_fields = 1
 
         assert (
-            obj.notify(
-                body=test_markdown, title="title", notify_type=NotifyType.INFO
+            bool(
+                obj.notify(
+                    body=test_markdown,
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                )
             )
             is False
         )
@@ -824,8 +830,10 @@ def test_plugin_fluxer_general(
 
     # Use our test markdown string during a notification
     assert (
-        obj.notify(
-            body=test_markdown, title="title", notify_type=NotifyType.INFO
+        bool(
+            obj.notify(
+                body=test_markdown, title="title", notify_type=NotifyType.INFO
+            )
         )
         is True
     )
@@ -845,21 +853,25 @@ def test_plugin_fluxer_general(
 
     # This call includes an image with it's payload:
     assert (
-        a.notify(
-            body=test_markdown,
-            title="title",
-            notify_type=NotifyType.INFO,
-            body_format=NotifyFormat.TEXT,
+        bool(
+            a.notify(
+                body=test_markdown,
+                title="title",
+                notify_type=NotifyType.INFO,
+                body_format=NotifyFormat.TEXT,
+            )
         )
         is True
     )
 
     assert (
-        a.notify(
-            body=test_markdown,
-            title="title",
-            notify_type=NotifyType.INFO,
-            body_format=NotifyFormat.MARKDOWN,
+        bool(
+            a.notify(
+                body=test_markdown,
+                title="title",
+                notify_type=NotifyType.INFO,
+                body_format=NotifyFormat.MARKDOWN,
+            )
         )
         is True
     )
@@ -867,7 +879,7 @@ def test_plugin_fluxer_general(
     # Toggle our logo availability
     a.asset.image_url_logo = None
     assert (
-        a.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(a.notify(body="body", title="title", notify_type=NotifyType.INFO))
         is True
     )
 
@@ -883,7 +895,7 @@ def test_plugin_fluxer_general(
     )
 
     # This call includes an image with it's payload:
-    assert a.notify(body="test", title="title") is True
+    assert bool(a.notify(body="test", title="title")) is True
 
     assert mock_post.call_count == 1
     response = mock_post.call_args_list[0][1]
@@ -959,17 +971,19 @@ def test_plugin_fluxer_markdown_extra(mock_post):
 
     # This call includes an image with it's payload:
     assert (
-        a.notify(
-            body=test_markdown,
-            title="title",
-            notify_type=NotifyType.INFO,
-            body_format=NotifyFormat.TEXT,
+        bool(
+            a.notify(
+                body=test_markdown,
+                title="title",
+                notify_type=NotifyType.INFO,
+                body_format=NotifyFormat.TEXT,
+            )
         )
         is True
     )
 
     assert (
-        a.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(a.notify(body="body", title="title", notify_type=NotifyType.INFO))
         is True
     )
 
@@ -978,6 +992,7 @@ def test_plugin_fluxer_markdown_extra(mock_post):
 def test_plugin_fluxer_markdown_attachments(
     mock_post: mock.MagicMock,
 ) -> None:
+    """Verify Markdown delivery with attachments in webhook mode."""
     # Prepare our tokens
     webhook_id, webhook_token = _tokens()
 
@@ -1003,11 +1018,13 @@ def test_plugin_fluxer_markdown_attachments(
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
 
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -1028,10 +1045,12 @@ def test_plugin_fluxer_markdown_attachments(
 
     # Test notifications with mentions and attachments in it
     assert (
-        obj.notify(
-            body="Say hello to <@1234>!",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="Say hello to <@1234>!",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -1054,11 +1073,13 @@ def test_plugin_fluxer_markdown_attachments(
     path = os.path.join(TEST_VAR_DIR, "/invalid/path/to/an/invalid/file.jpg")
     attach = AppriseAttachment(path)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=path,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=path,
+            )
         )
         is False
     )
@@ -1243,7 +1264,7 @@ def test_plugin_fluxer_threading(mock_post: mock.MagicMock) -> None:
         is True
     )
 
-    assert a.notify(body="test", title="title") is True
+    assert bool(a.notify(body="test", title="title")) is True
 
     kwargs = mock_post.call_args_list[0][1]
     assert "params" in kwargs
@@ -1367,7 +1388,7 @@ def test_plugin_fluxer_attach_memory(mock_post: mock.MagicMock) -> None:
         mimetype="text/html",
     )
 
-    assert obj.notify(body="Test", attach=mem) is True
+    assert bool(obj.notify(body="Test", attach=mem)) is True
     assert mock_post.call_count >= 1
 
 
@@ -1394,9 +1415,11 @@ def test_plugin_fluxer_html_to_markdown_format(mock_post):
     # Notify with an HTML body; the framework should convert it
     # to Markdown before dispatching to Fluxer
     assert (
-        aobj.notify(
-            body="<b>hello</b> <i>world</i>",
-            body_format=NotifyFormat.HTML,
+        bool(
+            aobj.notify(
+                body="<b>hello</b> <i>world</i>",
+                body_format=NotifyFormat.HTML,
+            )
         )
         is True
     )

--- a/tests/test_plugin_fortysixelks.py
+++ b/tests/test_plugin_fortysixelks.py
@@ -137,7 +137,9 @@ def test_plugin_46elks_edge_cases(mock_post):
 
     obj = Apprise.instantiate(f"46elks://{user}:{password}@{phone}")
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 

--- a/tests/test_plugin_glib.py
+++ b/tests/test_plugin_glib.py
@@ -116,7 +116,7 @@ def test_plugin_glib_basic_notify(enabled_glib_environment):
     """Basic notification path"""
     obj = apprise.Apprise.instantiate("glib://", suppress_exceptions=False)
     assert isinstance(obj, NotifyGLib)
-    assert obj.notify("body", title="title") is True
+    assert bool(obj.notify("body", title="title")) is True
 
 
 def test_plugin_glib_url_includes_coordinates(enabled_glib_environment):
@@ -139,7 +139,7 @@ def test_plugin_glib_icon_fails_gracefully(mocker, enabled_glib_environment):
     )
     obj = apprise.Apprise.instantiate("glib://", suppress_exceptions=False)
     spy = mocker.spy(obj, "logger")
-    assert obj.notify("msg", title="t") is True
+    assert bool(obj.notify("msg", title="t")) is True
     assert any(
         "Could not load notification icon" in str(x)
         for x in spy.warning.call_args_list
@@ -154,7 +154,7 @@ def test_plugin_glib_send_raises_glib_error(mocker, enabled_glib_environment):
         gi.repository.GLib.Error("fail")
     )
     obj = apprise.Apprise.instantiate("glib://", suppress_exceptions=False)
-    assert obj.notify("fail test") is False
+    assert bool(obj.notify("fail test")) is False
 
 
 def test_plugin_glib_send_raises_generic(mocker, enabled_glib_environment):
@@ -200,7 +200,7 @@ def test_plugin_glib_send_raises_generic(mocker, enabled_glib_environment):
 
     obj = apprise.Apprise.instantiate("glib://", suppress_exceptions=False)
     logger = mocker.spy(obj, "logger")
-    assert obj.notify("boom", title="fail") is False
+    assert bool(obj.notify("boom", title="fail")) is False
     logger.warning.assert_called_with("Failed to send GLib/Gio notification.")
 
 
@@ -208,7 +208,7 @@ def test_plugin_glib_disabled(mocker, enabled_glib_environment):
     """Test disabled plugin returns False on notify()"""
     obj = apprise.Apprise.instantiate("glib://", suppress_exceptions=False)
     obj.enabled = False
-    assert obj.notify("x") is False
+    assert bool(obj.notify("x")) is False
 
 
 def test_plugin_glib_invalid_coords():
@@ -248,7 +248,7 @@ def test_plugin_glib_xy_axis_applied_to_variant(enabled_glib_environment):
     spy_variant = Mock(wraps=gi.repository.GLib.Variant)
     gi.repository.GLib.Variant = spy_variant
 
-    assert obj.notify("Test with coords", title="xy") is True
+    assert bool(obj.notify("Test with coords", title="xy")) is True
 
     # Check x and y were added to meta_payload
     assert call("i", 5) in spy_variant.mock_calls
@@ -261,7 +261,7 @@ def test_plugin_glib_no_image_support(monkeypatch, enabled_glib_environment):
         "apprise.plugins.glib.NOTIFY_GLIB_IMAGE_SUPPORT", False
     )
     obj = apprise.Apprise.instantiate("glib://", suppress_exceptions=False)
-    assert obj.notify("no image") is True
+    assert bool(obj.notify("no image")) is True
 
 
 def test_plugin_glib_url_redaction(enabled_glib_environment):
@@ -370,7 +370,7 @@ def test_plugin_glib_notify_generic_exception(
 
     # 6. Execute notify()
     #    It should catch the exception and return False
-    assert obj.notify(title="Title", body="Body") is False
+    assert bool(obj.notify(title="Title", body="Body")) is False
 
     # 7. Verify the specific log message from glib.py
     logger_spy.warning.assert_called_with(

--- a/tests/test_plugin_gnome.py
+++ b/tests/test_plugin_gnome.py
@@ -132,15 +132,21 @@ def test_plugin_gnome_general_success(obj):
 
     # test notifications
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
 
     # test notification without a title
     assert (
-        obj.notify(title="", body="body", notify_type=apprise.NotifyType.INFO)
+        bool(
+            obj.notify(
+                title="", body="body", notify_type=apprise.NotifyType.INFO
+            )
+        )
         is True
     )
 
@@ -153,8 +159,10 @@ def test_plugin_gnome_image_success(glib_environment):
     )
     assert isinstance(obj, NotifyGnome) is True
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -164,8 +172,10 @@ def test_plugin_gnome_image_success(glib_environment):
     )
     assert isinstance(obj, NotifyGnome) is True
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -181,8 +191,10 @@ def test_plugin_gnome_priority(glib_environment):
     assert isinstance(obj, NotifyGnome) is True
     assert obj.urgency == 1
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -193,8 +205,10 @@ def test_plugin_gnome_priority(glib_environment):
     assert isinstance(obj, NotifyGnome) is True
     assert obj.urgency == 2
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -205,8 +219,10 @@ def test_plugin_gnome_priority(glib_environment):
     assert isinstance(obj, NotifyGnome) is True
     assert obj.urgency == 2
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -222,8 +238,10 @@ def test_plugin_gnome_urgency(glib_environment):
     assert obj.urgency == 1
     assert isinstance(obj, NotifyGnome) is True
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -234,8 +252,10 @@ def test_plugin_gnome_urgency(glib_environment):
     assert obj.urgency == 2
     assert isinstance(obj, NotifyGnome) is True
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -246,8 +266,10 @@ def test_plugin_gnome_urgency(glib_environment):
     assert isinstance(obj, NotifyGnome) is True
     assert obj.urgency == 2
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -338,8 +360,10 @@ def test_plugin_gnome_missing_icon(mocker, obj):
 
     logger: Mock = mocker.spy(obj, "logger")
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -347,6 +371,7 @@ def test_plugin_gnome_missing_icon(mocker, obj):
         call.warning("Could not load notification icon (%s).", ANY),
         call.debug("Gnome Exception: Something failed"),
         call.info("Sent Gnome notification."),
+        call.debug("%s send() completed in %.2fs.", ANY, ANY),
     ]
 
 
@@ -354,8 +379,10 @@ def test_plugin_gnome_disabled_plugin(obj):
     """Verify notification will not be submitted if plugin is disabled."""
     obj.enabled = False
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is False
     )
@@ -397,14 +424,17 @@ def test_plugin_gnome_notify_croaks(mocker, obj):
 
     logger: Mock = mocker.spy(obj, "logger")
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is False
     )
     assert logger.mock_calls == [
         call.warning("Failed to send Gnome notification."),
         call.debug("Gnome Exception: Something failed"),
+        call.debug("%s send() completed in %.2fs.", ANY, ANY),
     ]
 
 
@@ -433,7 +463,7 @@ def test_plugin_gnome_show_exception(mocker, obj):
 
     # 5. Execute the notification.
     #    It should crash at .show(), catch the exception, and return False.
-    assert obj.notify(title="Title", body="Body") is False
+    assert bool(obj.notify(title="Title", body="Body")) is False
 
     # 6. Verify the specific log message.
     logger_spy.warning.assert_called_with("Failed to send Gnome notification.")

--- a/tests/test_plugin_google_chat.py
+++ b/tests/test_plugin_google_chat.py
@@ -176,8 +176,10 @@ def test_plugin_google_chat_general(mock_post):
     obj = Apprise.instantiate(f"gchat://{workspace}/{key}/{token}")
     assert isinstance(obj, NotifyGoogleChat)
     assert (
-        obj.notify(
-            body="test body", title="title", notify_type=NotifyType.INFO
+        bool(
+            obj.notify(
+                body="test body", title="title", notify_type=NotifyType.INFO
+            )
         )
         is True
     )
@@ -202,8 +204,10 @@ def test_plugin_google_chat_general(mock_post):
     obj = Apprise.instantiate(f"gchat://{workspace}/{key}/{token}/{threadkey}")
     assert isinstance(obj, NotifyGoogleChat)
     assert (
-        obj.notify(
-            body="test body", title="title", notify_type=NotifyType.INFO
+        bool(
+            obj.notify(
+                body="test body", title="title", notify_type=NotifyType.INFO
+            )
         )
         is True
     )
@@ -244,9 +248,12 @@ def test_plugin_google_chat_html_to_markdown_hardening(mock_post):
     mock_post.return_value.text = "{}"
 
     def notify(body):
+        """Send one HTML body through the configured Google Chat plugin."""
         aobj = Apprise()
         assert aobj.add("gchat://workspace/key/token")
-        assert aobj.notify(body=body, body_format=NotifyFormat.HTML) is True
+        assert (
+            bool(aobj.notify(body=body, body_format=NotifyFormat.HTML)) is True
+        )
         payload = loads(mock_post.call_args_list[-1][1]["data"])
         mock_post.reset_mock()
         return payload["text"]
@@ -292,7 +299,7 @@ def test_plugin_google_chat_html_to_markdown_hardening(mock_post):
     # Direct Google Chat Markdown remains unchanged.
     aobj = Apprise()
     assert aobj.add("gchat://workspace/key/token")
-    assert aobj.notify(body="*already* chat-bound markdown") is True
+    assert bool(aobj.notify(body="*already* chat-bound markdown")) is True
     payload = loads(mock_post.call_args_list[-1][1]["data"])
     assert payload["text"] == "*already* chat-bound markdown"
     mock_post.reset_mock()
@@ -344,10 +351,12 @@ def test_plugin_google_chat_html_to_markdown_hardening(mock_post):
     aobj = Apprise()
     assert aobj.add("gchat://workspace/key/token")
     assert (
-        aobj.notify(
-            body="<b>hello</b>",
-            title="My Title",
-            body_format=NotifyFormat.HTML,
+        bool(
+            aobj.notify(
+                body="<b>hello</b>",
+                title="My Title",
+                body_format=NotifyFormat.HTML,
+            )
         )
         is True
     )
@@ -359,10 +368,12 @@ def test_plugin_google_chat_html_to_markdown_hardening(mock_post):
     # and list characters (html_to_markdown converts "  - " to "-").
     # The heading is skipped and the title field is cleared regardless.
     assert (
-        aobj.notify(
-            body="<b>hello</b>",
-            title="  - ",
-            body_format=NotifyFormat.HTML,
+        bool(
+            aobj.notify(
+                body="<b>hello</b>",
+                title="  - ",
+                body_format=NotifyFormat.HTML,
+            )
         )
         is True
     )

--- a/tests/test_plugin_gotify.py
+++ b/tests/test_plugin_gotify.py
@@ -240,9 +240,11 @@ def test_plugin_gotify_html_to_markdown_format(mock_post):
     # Notify with an HTML body; the framework should convert it
     # to Markdown before dispatching to Gotify
     assert (
-        aobj.notify(
-            body="<b>hello</b> <i>world</i>",
-            body_format=NotifyFormat.HTML,
+        bool(
+            aobj.notify(
+                body="<b>hello</b> <i>world</i>",
+                body_format=NotifyFormat.HTML,
+            )
         )
         is True
     )

--- a/tests/test_plugin_groupme.py
+++ b/tests/test_plugin_groupme.py
@@ -197,7 +197,7 @@ def test_plugin_groupme_send(mock_post):
     assert isinstance(obj, NotifyGroupMe)
 
     # Successful send
-    assert obj.notify(body="Test message") is True
+    assert bool(obj.notify(body="Test message")) is True
     assert mock_post.call_count == 1
 
     # Verify the correct URL host was used
@@ -208,49 +208,49 @@ def test_plugin_groupme_send(mock_post):
 
     # 200 OK also accepted as success
     mock_post.return_value = _mk_resp(requests.codes.ok)
-    assert obj.notify(body="Test message") is True
+    assert bool(obj.notify(body="Test message")) is True
 
     mock_post.reset_mock()
 
     # HTTP 400 returns False
     mock_post.return_value = _mk_resp(requests.codes.bad_request)
-    assert obj.notify(body="Test message") is False
+    assert bool(obj.notify(body="Test message")) is False
 
     mock_post.reset_mock()
 
     # HTTP 401 returns False
     mock_post.return_value = _mk_resp(requests.codes.unauthorized)
-    assert obj.notify(body="Test message") is False
+    assert bool(obj.notify(body="Test message")) is False
 
     mock_post.reset_mock()
 
     # HTTP 404 returns False
     mock_post.return_value = _mk_resp(requests.codes.not_found)
-    assert obj.notify(body="Test message") is False
+    assert bool(obj.notify(body="Test message")) is False
 
     mock_post.reset_mock()
 
     # HTTP 429 returns False
     mock_post.return_value = _mk_resp(429)
-    assert obj.notify(body="Test message") is False
+    assert bool(obj.notify(body="Test message")) is False
 
     mock_post.reset_mock()
 
     # HTTP 500 returns False
     mock_post.return_value = _mk_resp(requests.codes.internal_server_error)
-    assert obj.notify(body="Test message") is False
+    assert bool(obj.notify(body="Test message")) is False
 
     mock_post.reset_mock()
 
     # Unknown error code returns False
     mock_post.return_value = _mk_resp(999)
-    assert obj.notify(body="Test message") is False
+    assert bool(obj.notify(body="Test message")) is False
 
     mock_post.reset_mock()
 
     # RequestException returns False
     mock_post.side_effect = requests.RequestException("Network error")
-    assert obj.notify(body="Test message") is False
+    assert bool(obj.notify(body="Test message")) is False
 
 
 @mock.patch("requests.post")
@@ -273,7 +273,7 @@ def test_plugin_groupme_attach_no_token(mock_post):
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
 
     # Attachment send without token -- text message still succeeds
-    assert obj.notify(body="Test", attach=attach) is True
+    assert bool(obj.notify(body="Test", attach=attach)) is True
 
     # Only the bot POST is made (no upload call since no token)
     assert mock_post.call_count == 1
@@ -300,7 +300,7 @@ def test_plugin_groupme_attach_success(mock_post):
     obj = NotifyGroupMe(bot_id=TEST_BOT_ID, token=TEST_TOKEN)
 
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
-    assert obj.notify(body="Test", attach=attach) is True
+    assert bool(obj.notify(body="Test", attach=attach)) is True
 
     # Two requests: upload + bot post
     assert mock_post.call_count == 2
@@ -333,7 +333,7 @@ def test_plugin_groupme_attach_inaccessible(mock_post):
 
     # Simulate the file being inaccessible (isfile returns False)
     with mock.patch("os.path.isfile", return_value=False):
-        assert obj.notify(body="Test", attach=attach) is False
+        assert bool(obj.notify(body="Test", attach=attach)) is False
 
     # No HTTP calls should have been made
     assert mock_post.call_count == 0
@@ -358,7 +358,7 @@ def test_plugin_groupme_attach_oserror(mock_post):
 
     # Simulate an I/O error when opening the file
     with mock.patch("builtins.open", side_effect=OSError("disk error")):
-        assert obj.notify(body="Test", attach=attach) is False
+        assert bool(obj.notify(body="Test", attach=attach)) is False
 
     # No HTTP calls should have been made
     assert mock_post.call_count == 0
@@ -381,7 +381,7 @@ def test_plugin_groupme_attach_upload_http_error(mock_post):
     obj = NotifyGroupMe(bot_id=TEST_BOT_ID, token=TEST_TOKEN)
 
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
-    assert obj.notify(body="Test", attach=attach) is False
+    assert bool(obj.notify(body="Test", attach=attach)) is False
 
     # Only the upload attempt was made (bot post never called)
     assert mock_post.call_count == 1
@@ -397,7 +397,7 @@ def test_plugin_groupme_attach_upload_request_exception(mock_post):
 
     # Simulate a network error during the image upload
     mock_post.side_effect = requests.RequestException("Network error")
-    assert obj.notify(body="Test", attach=attach) is False
+    assert bool(obj.notify(body="Test", attach=attach)) is False
 
     # Only the upload attempt was made
     assert mock_post.call_count == 1
@@ -420,13 +420,13 @@ def test_plugin_groupme_attach_bad_response(mock_post):
     obj = NotifyGroupMe(bot_id=TEST_BOT_ID, token=TEST_TOKEN)
 
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
-    assert obj.notify(body="Test", attach=attach) is False
+    assert bool(obj.notify(body="Test", attach=attach)) is False
 
     mock_post.reset_mock()
 
     # Upload returns 200 but with invalid JSON
     mock_post.return_value = _mk_resp(requests.codes.ok, b"not-json")
-    assert obj.notify(body="Test", attach=attach) is False
+    assert bool(obj.notify(body="Test", attach=attach)) is False
 
 
 @mock.patch("requests.post")
@@ -450,7 +450,7 @@ def test_plugin_groupme_attach_non_image(mock_post):
     )
 
     # Non-image attachment is skipped; text message still succeeds
-    assert obj.notify(body="Test", attach=attach) is True
+    assert bool(obj.notify(body="Test", attach=attach)) is True
 
     # Only the bot POST is made (no upload attempted for non-image file)
     assert mock_post.call_count == 1
@@ -481,7 +481,7 @@ def test_plugin_groupme_attach_multi(mock_post):
     attach.add(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
     attach.add(os.path.join(TEST_VAR_DIR, "apprise-test.jpeg"))
 
-    assert obj.notify(body="Test", attach=attach) is True
+    assert bool(obj.notify(body="Test", attach=attach)) is True
 
     # 2 uploads + 1 bot post
     assert mock_post.call_count == 3
@@ -615,7 +615,7 @@ def test_plugin_groupme_apprise_integration(mock_post):
     assert len(a) == 1
     assert isinstance(a[0], NotifyGroupMe)
 
-    assert a.notify(body="Test", title="Title") is True
+    assert bool(a.notify(body="Test", title="Title")) is True
     assert mock_post.call_count == 1
 
     mock_post.reset_mock()
@@ -629,11 +629,11 @@ def test_plugin_groupme_apprise_integration(mock_post):
     assert isinstance(a2[0], NotifyGroupMe)
 
     mock_post.return_value = _mk_resp(requests.codes.accepted)
-    assert a2.notify(body="Test", title="Title") is True
+    assert bool(a2.notify(body="Test", title="Title")) is True
     assert mock_post.call_count == 1
 
     mock_post.reset_mock()
 
     # Failure response
     mock_post.return_value = _mk_resp(requests.codes.internal_server_error)
-    assert a.notify(body="Test") is False
+    assert bool(a.notify(body="Test")) is False

--- a/tests/test_plugin_growl.py
+++ b/tests/test_plugin_growl.py
@@ -94,8 +94,12 @@ def test_plugin_growl_exception_handling(mock_gntp):
         # We will fail to send the notification because our registration
         # would have failed
         assert (
-            obj.notify(
-                title="test", body="body", notify_type=apprise.NotifyType.INFO
+            bool(
+                obj.notify(
+                    title="test",
+                    body="body",
+                    notify_type=apprise.NotifyType.INFO,
+                )
             )
             is False
         )
@@ -116,8 +120,12 @@ def test_plugin_growl_exception_handling(mock_gntp):
         # We will fail to send the notification because of the underlining
         # notify() call throws an exception
         assert (
-            obj.notify(
-                title="test", body="body", notify_type=apprise.NotifyType.INFO
+            bool(
+                obj.notify(
+                    title="test",
+                    body="body",
+                    notify_type=apprise.NotifyType.INFO,
+                )
             )
             is False
         )

--- a/tests/test_plugin_httpsms.py
+++ b/tests/test_plugin_httpsms.py
@@ -173,7 +173,9 @@ def test_plugin_httpsms_edge_cases(mock_post):
     )
 
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 

--- a/tests/test_plugin_humhub.py
+++ b/tests/test_plugin_humhub.py
@@ -249,7 +249,7 @@ def test_plugin_humhub_bearer_send(mock_post):
     mock_post.return_value.content = b""
 
     obj = NotifyHumHub(user="mytoken", host="localhost", targets=["1"])
-    assert obj.notify(body="Test body") is True
+    assert bool(obj.notify(body="Test body")) is True
 
     # Confirm bearer token header was set
     assert mock_post.called
@@ -271,7 +271,7 @@ def test_plugin_humhub_basic_send(mock_post):
     obj = NotifyHumHub(
         user="admin", password="secret", host="localhost", targets=["1"]
     )
-    assert obj.notify(body="Test body") is True
+    assert bool(obj.notify(body="Test body")) is True
 
     # Confirm basic auth tuple was passed and no Authorization header
     assert mock_post.called
@@ -289,7 +289,7 @@ def test_plugin_humhub_multi_container(mock_post):
     mock_post.return_value.content = b""
 
     obj = NotifyHumHub(user="token", host="localhost", targets=["1", "2", "3"])
-    assert obj.notify(body="Hello") is True
+    assert bool(obj.notify(body="Hello")) is True
 
     # One POST per container
     assert mock_post.call_count == 3
@@ -315,7 +315,7 @@ def test_plugin_humhub_partial_failure(mock_post):
 
     obj = NotifyHumHub(user="token", host="localhost", targets=["1", "2", "3"])
     # Partial failure means overall False
-    assert obj.notify(body="msg") is False
+    assert bool(obj.notify(body="msg")) is False
     assert mock_post.call_count == 3
 
 
@@ -329,15 +329,15 @@ def test_plugin_humhub_http_errors(mock_post):
     mock_post.return_value.content = b"Unauthorized"
 
     obj = NotifyHumHub(user="token", host="localhost", targets=["1"])
-    assert obj.notify(body="msg") is False
+    assert bool(obj.notify(body="msg")) is False
 
     # HTTP 500 Internal Server Error
     mock_post.return_value.status_code = requests.codes.internal_server_error
-    assert obj.notify(body="msg") is False
+    assert bool(obj.notify(body="msg")) is False
 
     # Unknown / unexpected code
     mock_post.return_value.status_code = 999
-    assert obj.notify(body="msg") is False
+    assert bool(obj.notify(body="msg")) is False
 
 
 @mock.patch("requests.post")
@@ -347,7 +347,7 @@ def test_plugin_humhub_request_exception(mock_post):
     mock_post.side_effect = requests.RequestException("Connection refused")
 
     obj = NotifyHumHub(user="token", host="localhost", targets=["1", "2"])
-    assert obj.notify(body="msg") is False
+    assert bool(obj.notify(body="msg")) is False
     # Both containers attempted
     assert mock_post.call_count == 2
 
@@ -445,11 +445,11 @@ def test_plugin_humhub_apprise_integration(mock_post):
 
     aobj = Apprise()
     assert aobj.add("humhubs://mytoken@localhost/1")
-    assert aobj.notify(title="Title", body="Body") is True
+    assert bool(aobj.notify(title="Title", body="Body")) is True
 
     aobj2 = Apprise()
     assert aobj2.add("humhubs://user:pass@localhost/1")
-    assert aobj2.notify(title="Title", body="Body") is True
+    assert bool(aobj2.notify(title="Title", body="Body")) is True
 
 
 @mock.patch("requests.post")

--- a/tests/test_plugin_ifttt.py
+++ b/tests/test_plugin_ifttt.py
@@ -185,7 +185,9 @@ def test_plugin_ifttt_edge_cases(mock_post, mock_get):
     assert isinstance(obj, NotifyIFTTT)
 
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -210,7 +212,9 @@ def test_plugin_ifttt_edge_cases(mock_post, mock_get):
     assert isinstance(obj, NotifyIFTTT)
 
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -225,7 +229,9 @@ def test_plugin_ifttt_edge_cases(mock_post, mock_get):
     assert isinstance(obj, NotifyIFTTT)
 
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -244,7 +250,9 @@ def test_plugin_ifttt_edge_cases(mock_post, mock_get):
     assert isinstance(obj, NotifyIFTTT)
 
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 

--- a/tests/test_plugin_jira.py
+++ b/tests/test_plugin_jira.py
@@ -464,11 +464,11 @@ def test_plugin_jira_edge_case(mock_post):
     assert isinstance(instance, NotifyJira)
 
     assert len(instance.store.keys()) == 0
-    assert instance.notify("test", "key", NotifyType.FAILURE) is True
+    assert bool(instance.notify("test", "key", NotifyType.FAILURE)) is True
     assert len(instance.store.keys()) == 1
 
     # Again just causes same index to get over-written
-    assert instance.notify("test", "key", NotifyType.FAILURE) is True
+    assert bool(instance.notify("test", "key", NotifyType.FAILURE)) is True
     assert len(instance.store.keys()) == 1
     assert "a62f2225bf" in instance.store
 
@@ -477,11 +477,11 @@ def test_plugin_jira_edge_case(mock_post):
     # This causes an internal check to fail where the keys are expected to be
     # as a list (this one is now a string)
     # content self corrects and things are fine
-    assert instance.notify("test", "key", NotifyType.FAILURE) is True
+    assert bool(instance.notify("test", "key", NotifyType.FAILURE)) is True
     assert len(instance.store.keys()) == 1
 
     # new key is new index
-    assert instance.notify("test", "key2", NotifyType.FAILURE) is True
+    assert bool(instance.notify("test", "key2", NotifyType.FAILURE)) is True
     assert len(instance.store.keys()) == 2
 
 
@@ -508,18 +508,18 @@ def test_plugin_jira_mapping(mock_post):
     instance = apprise.Apprise.instantiate("jira://apikey/@user")
     assert isinstance(instance, NotifyJira)
 
-    assert instance.notify("body", "title", NotifyType.INFO) is True
+    assert bool(instance.notify("body", "title", NotifyType.INFO)) is True
     assert mock_post.call_count == 0
 
     # --- Default mapping: WARNING/FAILURE → NEW ---
     # These should POST to the base alerts URL immediately.
     mock_post.reset_mock()
-    assert instance.notify("body", "title", NotifyType.WARNING) is True
+    assert bool(instance.notify("body", "title", NotifyType.WARNING)) is True
     assert mock_post.call_count == 1
     assert mock_post.call_args[0][0] == base_url
 
     mock_post.reset_mock()
-    assert instance.notify("body", "title", NotifyType.FAILURE) is True
+    assert bool(instance.notify("body", "title", NotifyType.FAILURE)) is True
     assert mock_post.call_count == 1
     assert mock_post.call_args[0][0] == base_url
 
@@ -527,14 +527,14 @@ def test_plugin_jira_mapping(mock_post):
     # instance already has stored request IDs from the WARNING/FAILURE calls
     # above, so SUCCESS should POST to the /close endpoint.
     mock_post.reset_mock()
-    assert instance.notify("body", "title", NotifyType.SUCCESS) is True
+    assert bool(instance.notify("body", "title", NotifyType.SUCCESS)) is True
     assert mock_post.call_count >= 1
     assert mock_post.call_args[0][0].endswith("/close")
 
     # Fresh instance: SUCCESS with no stored IDs → nothing to close, no call.
     fresh = apprise.Apprise.instantiate("jira://apikey/@user")
     mock_post.reset_mock()
-    assert fresh.notify("body", "title", NotifyType.SUCCESS) is True
+    assert bool(fresh.notify("body", "title", NotifyType.SUCCESS)) is True
     assert mock_post.call_count == 0
 
     # --- Custom mapping: :info=new overrides INFO → NOTE with INFO → NEW ---
@@ -542,7 +542,7 @@ def test_plugin_jira_mapping(mock_post):
     assert isinstance(instance2, NotifyJira)
 
     mock_post.reset_mock()
-    assert instance2.notify("body", "title", NotifyType.INFO) is True
+    assert bool(instance2.notify("body", "title", NotifyType.INFO)) is True
     # A POST to the base alerts URL must have been made
     assert mock_post.call_count == 1
     assert mock_post.call_args[0][0] == base_url
@@ -558,6 +558,6 @@ def test_plugin_jira_mapping(mock_post):
     assert instance3.mapping[NotifyType.INFO] == "new"
 
     mock_post.reset_mock()
-    assert instance3.notify("body", "title", NotifyType.INFO) is True
+    assert bool(instance3.notify("body", "title", NotifyType.INFO)) is True
     assert mock_post.call_count == 1
     assert mock_post.call_args[0][0] == base_url

--- a/tests/test_plugin_join.py
+++ b/tests/test_plugin_join.py
@@ -211,7 +211,8 @@ def test_plugin_join_edge_cases(mock_post, mock_get):
     # Test notifications without a body or a title; nothing to send
     # so we return False
     assert (
-        p.notify(body=None, title=None, notify_type=NotifyType.INFO) is False
+        bool(p.notify(body=None, title=None, notify_type=NotifyType.INFO))
+        is False
     )
 
 
@@ -276,4 +277,4 @@ def test_plugin_join_config_files(mock_post):
     assert next(aobj.find(tag="join_invalid")).priority == JoinPriority.NORMAL
 
     # Notifications work
-    assert aobj.notify(title="title", body="body") is True
+    assert bool(aobj.notify(title="title", body="body")) is True

--- a/tests/test_plugin_kook.py
+++ b/tests/test_plugin_kook.py
@@ -416,7 +416,7 @@ def test_plugin_kook_webhook_send(mock_post):
     # Success
     mock_post.return_value = _mk_resp()
     obj = NotifyKook(token=WEBHOOK_KEY, mode="webhook")
-    assert obj.notify(body="hello") is True
+    assert bool(obj.notify(body="hello")) is True
     assert mock_post.call_count == 1
 
     # Verify the endpoint URL
@@ -428,15 +428,15 @@ def test_plugin_kook_webhook_send(mock_post):
     mock_post.return_value = _mk_resp(
         code=requests.codes.internal_server_error
     )
-    assert obj.notify(body="hello") is False
+    assert bool(obj.notify(body="hello")) is False
 
     # Unknown HTTP code -> False
     mock_post.return_value = _mk_resp(code=999)
-    assert obj.notify(body="hello") is False
+    assert bool(obj.notify(body="hello")) is False
 
     # API-level error (code != 0) -> False
     mock_post.return_value = _mk_resp(api_code=40001)
-    assert obj.notify(body="hello") is False
+    assert bool(obj.notify(body="hello")) is False
 
     # Unparseable JSON body is handled gracefully
     r = mock.Mock()
@@ -444,11 +444,11 @@ def test_plugin_kook_webhook_send(mock_post):
     r.content = b"not-json"
     mock_post.return_value = r
     # code defaults to 0 -> success (unparseable treated as ok)
-    assert obj.notify(body="hello") is True
+    assert bool(obj.notify(body="hello")) is True
 
     # RequestException -> False
     mock_post.side_effect = requests.RequestException("conn error")
-    assert obj.notify(body="hello") is False
+    assert bool(obj.notify(body="hello")) is False
     mock_post.side_effect = None
 
 
@@ -471,13 +471,13 @@ def test_plugin_kook_bot_send(mock_post):
     # No targets -> False without making a network call
     obj = NotifyKook(token=BOT_TOKEN)
     mock_post.reset_mock()
-    assert obj.notify(body="hello") is False
+    assert bool(obj.notify(body="hello")) is False
     assert mock_post.call_count == 0
 
     # Single channel success
     mock_post.return_value = _ok()
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
-    assert obj.notify(body="hello") is True
+    assert bool(obj.notify(body="hello")) is True
     assert mock_post.call_count == 1
 
     # Verify Authorization header
@@ -488,14 +488,14 @@ def test_plugin_kook_bot_send(mock_post):
     mock_post.return_value = _ok()
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID, CHANNEL_ID2])
     mock_post.reset_mock()
-    assert obj.notify(body="hello") is True
+    assert bool(obj.notify(body="hello")) is True
     assert mock_post.call_count == 2
 
     # DM target (uses dm_url endpoint)
     mock_post.return_value = _ok()
     obj = NotifyKook(token=BOT_TOKEN, targets=[f"@{USER_ID}"])
     mock_post.reset_mock()
-    assert obj.notify(body="hello") is True
+    assert bool(obj.notify(body="hello")) is True
     assert mock_post.call_count == 1
     call_url = mock_post.call_args[0][0]
     assert "direct-message" in call_url
@@ -504,36 +504,36 @@ def test_plugin_kook_bot_send(mock_post):
     mock_post.return_value = _ok()
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID, f"@{USER_ID}"])
     mock_post.reset_mock()
-    assert obj.notify(body="hello") is True
+    assert bool(obj.notify(body="hello")) is True
     assert mock_post.call_count == 2
 
     # HTTP 500 on one target -> has_error=True -> False
     mock_post.return_value = _err()
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
-    assert obj.notify(body="hello") is False
+    assert bool(obj.notify(body="hello")) is False
 
     # Unknown HTTP code
     mock_post.return_value = _err(code=999)
-    assert obj.notify(body="hello") is False
+    assert bool(obj.notify(body="hello")) is False
 
     # API-level error code
     r = mock.Mock()
     r.status_code = requests.codes.ok
     r.content = dumps({"code": 40001, "message": "error"}).encode()
     mock_post.return_value = r
-    assert obj.notify(body="hello") is False
+    assert bool(obj.notify(body="hello")) is False
 
     # RequestException
     mock_post.side_effect = requests.RequestException("boom")
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
-    assert obj.notify(body="hello") is False
+    assert bool(obj.notify(body="hello")) is False
     mock_post.side_effect = None
 
     # Partial failure: first channel fails, second would succeed,
     # but has_error is still True so overall False
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID, CHANNEL_ID2])
     mock_post.side_effect = [_err(), _ok()]
-    assert obj.notify(body="hello") is False
+    assert bool(obj.notify(body="hello")) is False
     mock_post.side_effect = None
 
     # ?format=text -> notify_format=TEXT -> Kook API type 1 in the payload
@@ -545,7 +545,7 @@ def test_plugin_kook_bot_send(mock_post):
     )
     obj = NotifyKook(**parsed)
     mock_post.reset_mock()
-    assert obj.notify(body="hello") is True
+    assert bool(obj.notify(body="hello")) is True
     payload = json.loads(mock_post.call_args[1]["data"])
     assert payload["type"] == 1
 
@@ -553,7 +553,7 @@ def test_plugin_kook_bot_send(mock_post):
     mock_post.return_value = _ok()
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
     mock_post.reset_mock()
-    assert obj.notify(body="hello") is True
+    assert bool(obj.notify(body="hello")) is True
     payload = json.loads(mock_post.call_args[1]["data"])
     assert payload["type"] == 9
 
@@ -579,7 +579,7 @@ def test_plugin_kook_attachments_success(mock_post):
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
 
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
-    assert obj.notify(body="hello", attach=attach) is True
+    assert bool(obj.notify(body="hello", attach=attach)) is True
     assert mock_post.call_count == 3
 
 
@@ -597,7 +597,7 @@ def test_plugin_kook_attachments_inaccessible(mock_post):
 
     with mock.patch("os.path.isfile", return_value=False):
         # Text message succeeds; attachment upload returns None -> False
-        assert obj.notify(body="hello", attach=attach) is False
+        assert bool(obj.notify(body="hello", attach=attach)) is False
 
 
 @mock.patch("requests.post")
@@ -614,7 +614,7 @@ def test_plugin_kook_attachments_oserror(mock_post):
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
 
     with mock.patch("builtins.open", side_effect=OSError("read error")):
-        assert obj.notify(body="hello", attach=attach) is False
+        assert bool(obj.notify(body="hello", attach=attach)) is False
 
 
 @mock.patch("requests.post")
@@ -634,7 +634,7 @@ def test_plugin_kook_attachments_upload_http_error(mock_post):
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
 
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
-    assert obj.notify(body="hello", attach=attach) is False
+    assert bool(obj.notify(body="hello", attach=attach)) is False
 
 
 @mock.patch("requests.post")
@@ -653,7 +653,7 @@ def test_plugin_kook_attachments_upload_no_url(mock_post):
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
 
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
-    assert obj.notify(body="hello", attach=attach) is False
+    assert bool(obj.notify(body="hello", attach=attach)) is False
 
 
 @mock.patch("requests.post")
@@ -671,7 +671,7 @@ def test_plugin_kook_attachments_upload_request_exception(mock_post):
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
 
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
-    assert obj.notify(body="hello", attach=attach) is False
+    assert bool(obj.notify(body="hello", attach=attach)) is False
 
 
 @mock.patch("requests.post")
@@ -699,7 +699,7 @@ def test_plugin_kook_attachments_post_http_error(mock_post):
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
 
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
-    assert obj.notify(body="hello", attach=attach) is False
+    assert bool(obj.notify(body="hello", attach=attach)) is False
 
 
 @mock.patch("requests.post")
@@ -727,7 +727,7 @@ def test_plugin_kook_attachments_post_request_exception(mock_post):
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
 
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
-    assert obj.notify(body="hello", attach=attach) is False
+    assert bool(obj.notify(body="hello", attach=attach)) is False
 
 
 @mock.patch("requests.post")
@@ -757,7 +757,7 @@ def test_plugin_kook_attachments_post_api_error(mock_post):
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
 
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
-    assert obj.notify(body="hello", attach=attach) is False
+    assert bool(obj.notify(body="hello", attach=attach)) is False
 
 
 @mock.patch("requests.post")
@@ -784,7 +784,7 @@ def test_plugin_kook_attachments_image_and_file(mock_post):
     attach_img = AppriseAttachment(
         os.path.join(TEST_VAR_DIR, "apprise-test.png")
     )
-    assert obj.notify(body="hello", attach=attach_img) is True
+    assert bool(obj.notify(body="hello", attach=attach_img)) is True
     attach_msg_payload = _json.loads(mock_post.call_args_list[2][1]["data"])
     assert attach_msg_payload["type"] == 2
 
@@ -795,7 +795,7 @@ def test_plugin_kook_attachments_image_and_file(mock_post):
     )
     mock_post.reset_mock()
     mock_post.side_effect = [_ok(), _ok(), _ok()]
-    assert obj.notify(body="hello", attach=attach_file) is True
+    assert bool(obj.notify(body="hello", attach=attach_file)) is True
     attach_msg_payload = _json.loads(mock_post.call_args_list[2][1]["data"])
     assert attach_msg_payload["type"] == 4
 
@@ -813,7 +813,7 @@ def test_plugin_kook_webhook_no_attachment_support(mock_post):
     obj = NotifyKook(token=WEBHOOK_KEY, mode="webhook")
     assert obj.attachment_support is False
     # Apprise framework skips attach when attachment_support=False
-    assert obj.notify(body="hello", attach=attach) is True
+    assert bool(obj.notify(body="hello", attach=attach)) is True
     # Only one POST (the webhook message itself)
     assert mock_post.call_count == 1
 
@@ -831,7 +831,7 @@ def test_plugin_kook_invalid_json_responses(mock_post):
     mock_post.return_value = r
 
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
-    assert obj.notify(body="hello") is True
+    assert bool(obj.notify(body="hello")) is True
 
     # _upload: CDN upload response with unparseable JSON
     # Text message POST returns ok with bad JSON; CDN upload also returns ok
@@ -840,7 +840,7 @@ def test_plugin_kook_invalid_json_responses(mock_post):
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
     # Text succeeds (code defaults to 0); CDN upload has no URL -> False
-    assert obj.notify(body="hello", attach=attach) is False
+    assert bool(obj.notify(body="hello", attach=attach)) is False
 
     # _send_bot: attach-message POST response with unparseable JSON
     # text OK, CDN upload OK (valid cdn_url), attach-msg POST returns bad JSON;
@@ -861,7 +861,7 @@ def test_plugin_kook_invalid_json_responses(mock_post):
     mock_post.return_value = None
     obj = NotifyKook(token=BOT_TOKEN, targets=[CHANNEL_ID])
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
-    assert obj.notify(body="hello", attach=attach) is True
+    assert bool(obj.notify(body="hello", attach=attach)) is True
     mock_post.side_effect = None
 
 
@@ -876,9 +876,9 @@ def test_plugin_kook_apprise_integration(mock_post):
     # Bot mode
     a = Apprise()
     assert a.add(f"kook://{BOT_TOKEN}/{CHANNEL_ID}") is True
-    assert a.notify(title="Test", body="Message") is True
+    assert bool(a.notify(title="Test", body="Message")) is True
 
     # Webhook mode
     a = Apprise()
     assert a.add(f"kook://{WEBHOOK_KEY}/?mode=webhook") is True
-    assert a.notify(body="webhook message") is True
+    assert bool(a.notify(body="webhook message")) is True

--- a/tests/test_plugin_macosx.py
+++ b/tests/test_plugin_macosx.py
@@ -104,15 +104,21 @@ def test_plugin_macosx_general_success(macos_notify_environment):
 
     # test notifications
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
 
     # test notification without a title
     assert (
-        obj.notify(title="", body="body", notify_type=apprise.NotifyType.INFO)
+        bool(
+            obj.notify(
+                title="", body="body", notify_type=apprise.NotifyType.INFO
+            )
+        )
         is True
     )
 
@@ -121,8 +127,10 @@ def test_plugin_macosx_general_success(macos_notify_environment):
     )
     assert isinstance(obj, NotifyMacOSX) is True
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -133,8 +141,10 @@ def test_plugin_macosx_general_success(macos_notify_environment):
     assert isinstance(obj, NotifyMacOSX) is True
     assert isinstance(obj.url(), str) is True
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -147,8 +157,10 @@ def test_plugin_macosx_general_success(macos_notify_environment):
     assert obj.sound == "default"
     assert isinstance(obj.url(), str) is True
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -161,8 +173,10 @@ def test_plugin_macosx_general_success(macos_notify_environment):
     assert obj.click == "http://google.com"
     assert isinstance(obj.url(), str) is True
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -180,8 +194,10 @@ def test_plugin_macosx_terminal_notifier_not_executable(
     os.chmod(terminal_notifier, 0o644)
 
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is False
     )
@@ -198,8 +214,10 @@ def test_plugin_macosx_terminal_notifier_invalid(macos_notify_environment):
     assert not os.path.isfile(obj.notify_path)
 
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is False
     )
@@ -217,8 +235,10 @@ def test_plugin_macosx_terminal_notifier_croaks(
     obj = apprise.Apprise.instantiate("macosx://", suppress_exceptions=False)
     assert isinstance(obj, NotifyMacOSX) is True
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is False
     )

--- a/tests/test_plugin_mailersend.py
+++ b/tests/test_plugin_mailersend.py
@@ -288,7 +288,7 @@ def test_plugin_mailersend_send(mock_post, mock_get):
         "mailersend://abcd:user@example.com/to@example.com"
     )
     assert isinstance(obj, NotifyMailerSend)
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
     assert mock_post.call_count == 1
 
     mock_post.reset_mock()
@@ -299,7 +299,7 @@ def test_plugin_mailersend_send(mock_post, mock_get):
         from_email="user@example.com",
         targets=["t1@example.com", "t2@example.com"],
     )
-    assert obj.notify(body="body") is True
+    assert bool(obj.notify(body="body")) is True
     assert mock_post.call_count == 2
 
     mock_post.reset_mock()
@@ -310,7 +310,7 @@ def test_plugin_mailersend_send(mock_post, mock_get):
         from_email="user@example.com",
         targets=["!invalid"],
     )
-    assert obj.notify(body="body") is False
+    assert bool(obj.notify(body="body")) is False
     assert mock_post.call_count == 0
 
     mock_post.reset_mock()
@@ -325,7 +325,7 @@ def test_plugin_mailersend_send(mock_post, mock_get):
         from_email="user@example.com",
         targets=["t1@example.com", "t2@example.com"],
     )
-    assert obj.notify(body="body") is False
+    assert bool(obj.notify(body="body")) is False
 
     mock_post.reset_mock()
     mock_post.side_effect = None
@@ -335,7 +335,7 @@ def test_plugin_mailersend_send(mock_post, mock_get):
     obj = Apprise.instantiate(
         "mailersend://abcd:user@example.com/to@example.com"
     )
-    assert obj.notify(body="body") is False
+    assert bool(obj.notify(body="body")) is False
 
     mock_post.side_effect = None
 
@@ -349,7 +349,7 @@ def test_plugin_mailersend_send(mock_post, mock_get):
         bcc=["bcc@example.com", "to@example.com"],
         reply_to="reply@example.com",
     )
-    assert obj.notify(body="body") is True
+    assert bool(obj.notify(body="body")) is True
     call_payload = mock_post.call_args
     assert call_payload is not None
 
@@ -359,7 +359,7 @@ def test_plugin_mailersend_send(mock_post, mock_get):
     obj = Apprise.instantiate(
         "mailersend://abcd:user@example.com/to@example.com?format=text"
     )
-    assert obj.notify(body="<p>body</p>") is True
+    assert bool(obj.notify(body="<p>body</p>")) is True
 
     # unknown response code (not 202) is treated as failure
     mock_post.reset_mock()
@@ -367,7 +367,7 @@ def test_plugin_mailersend_send(mock_post, mock_get):
     obj = Apprise.instantiate(
         "mailersend://abcd:user@example.com/to@example.com"
     )
-    assert obj.notify(body="body") is False
+    assert bool(obj.notify(body="body")) is False
 
 
 @mock.patch("requests.post")
@@ -390,11 +390,13 @@ def test_plugin_mailersend_attachments(mock_post):
     )
     assert isinstance(obj, NotifyMailerSend)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -404,11 +406,13 @@ def test_plugin_mailersend_attachments(mock_post):
     # Inaccessible file -- os.path.isfile returns False
     with mock.patch("os.path.isfile", return_value=False):
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )
@@ -418,11 +422,13 @@ def test_plugin_mailersend_attachments(mock_post):
     # OSError on open
     with mock.patch("builtins.open", side_effect=OSError):
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )
@@ -432,11 +438,13 @@ def test_plugin_mailersend_attachments(mock_post):
     # HTTP error after successful open
     mock_post.return_value = _mk_resp(requests.codes.internal_server_error)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -446,11 +454,13 @@ def test_plugin_mailersend_attachments(mock_post):
     # RequestException after successful open
     mock_post.side_effect = requests.RequestException("boom")
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -465,11 +475,13 @@ def test_plugin_mailersend_attachments(mock_post):
     ]
     multi_attach = AppriseAttachment(paths)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=multi_attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=multi_attach,
+            )
         )
         is True
     )
@@ -545,4 +557,4 @@ def test_plugin_mailersend_apprise_integration(mock_post, mock_get):
 
     a = Apprise()
     assert a.add("mailersend://abcd:user@example.com/to@example.com")
-    assert a.notify(body="body", title="title") is True
+    assert bool(a.notify(body="body", title="title")) is True

--- a/tests/test_plugin_mailgun.py
+++ b/tests/test_plugin_mailgun.py
@@ -293,11 +293,13 @@ def test_plugin_mailgun_attachments(mock_post):
     path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     attach = AppriseAttachment(path)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -305,11 +307,13 @@ def test_plugin_mailgun_attachments(mock_post):
     # Test invalid attachment
     path = os.path.join(TEST_VAR_DIR, "/invalid/path/to/an/invalid/file.jpg")
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=path,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=path,
+            )
         )
         is False
     )
@@ -318,11 +322,13 @@ def test_plugin_mailgun_attachments(mock_post):
     mock_post.side_effect = OSError()
     # We can't send the message if we can't read the attachment
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -341,11 +347,13 @@ def test_plugin_mailgun_attachments(mock_post):
     with mock.patch("builtins.open", side_effect=OSError()):
         # We can't send the message we can't open the attachment for reading
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )
@@ -355,11 +363,13 @@ def test_plugin_mailgun_attachments(mock_post):
         "builtins.open", side_effect=(mock.Mock(), mock.Mock(), OSError())
     ):
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )
@@ -371,11 +381,13 @@ def test_plugin_mailgun_attachments(mock_post):
 
         # We can't send the message we can't seek through it
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )
@@ -387,11 +399,13 @@ def test_plugin_mailgun_attachments(mock_post):
         mock_open.return_value = mock_fp
         # We can't send the message we can't seek through it
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )
@@ -415,11 +429,13 @@ def test_plugin_mailgun_attachments(mock_post):
     mock_post.reset_mock()
 
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -431,11 +447,13 @@ def test_plugin_mailgun_attachments(mock_post):
     obj.default_batch_size = 2
 
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -465,7 +483,9 @@ def test_plugin_mailgun_header_check(mock_post):
 
     # Send our notification
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -496,7 +516,9 @@ def test_plugin_mailgun_header_check(mock_post):
 
     # Send our notification
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -522,7 +544,9 @@ def test_plugin_mailgun_header_check(mock_post):
 
     # Send our notification
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -547,7 +571,9 @@ def test_plugin_mailgun_header_check(mock_post):
 
     # Send our notification
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -567,10 +593,10 @@ def test_plugin_mailgun_cc_bcc_invalid_branch():
 
     # Build a NotifyMailgun with:
     #   cc  = one valid address + one that parse_emails passes but is_email
-    #         rejects (hits the FALSE branch at line 327).
+    #         rejects, exercising the invalid-address branch.
     #         A list must be used -- parse_emails filters invalid tokens out
     #         of comma-separated strings before is_email is ever called.
-    #   bcc = same, for the FALSE branch at line 343
+    #   bcc = the same arrangement for the BCC validation branch
     obj = NotifyMailgun(
         apikey=apikey,
         targets=["user@example.com"],

--- a/tests/test_plugin_mastodon.py
+++ b/tests/test_plugin_mastodon.py
@@ -661,11 +661,13 @@ def test_plugin_mastodon_attachments(mock_get, mock_post):
 
     # Send our notification
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -723,11 +725,13 @@ def test_plugin_mastodon_attachments(mock_get, mock_post):
 
     # Send our notification
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -812,11 +816,13 @@ def test_plugin_mastodon_attachments(mock_get, mock_post):
     # adding the @caronc to the begining of the same message (since it's a
     # direct message)
     assert (
-        obj.notify(
-            body="Check this out @caronc",
-            title="Apprise",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="Check this out @caronc",
+                title="Apprise",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -882,11 +888,13 @@ def test_plugin_mastodon_attachments(mock_get, mock_post):
     mock_post.side_effect = [mr1, mr2, mr3, good_response, good_response]
     mock_get.return_value = good_whoami_response
     assert (
-        obj.notify(
-            body="Check this out @caronc",
-            title="Apprise",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="Check this out @caronc",
+                title="Apprise",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -913,11 +921,13 @@ def test_plugin_mastodon_attachments(mock_get, mock_post):
     obj = Apprise.instantiate(mastodon_url)
 
     assert (
-        obj.notify(
-            body="Check this out @caronc",
-            title="Apprise",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="Check this out @caronc",
+                title="Apprise",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -975,11 +985,13 @@ def test_plugin_mastodon_attachments(mock_get, mock_post):
         # This is the same test as above, except our error response isn't
         # parseable
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )
@@ -1017,7 +1029,11 @@ def test_plugin_mastodon_attachments(mock_get, mock_post):
         # This is the same test as above, except our error response isn't
         # parseable
         assert (
-            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+            bool(
+                obj.notify(
+                    body="body", title="title", notify_type=NotifyType.INFO
+                )
+            )
             is False
         )
 
@@ -1050,7 +1066,11 @@ def test_plugin_mastodon_attachments(mock_get, mock_post):
         # This is the same test as above, except our error response isn't
         # parseable
         assert (
-            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+            bool(
+                obj.notify(
+                    body="body", title="title", notify_type=NotifyType.INFO
+                )
+            )
             is False
         )
 
@@ -1075,11 +1095,13 @@ def test_plugin_mastodon_attachments(mock_get, mock_post):
     # An invalid attachment will cause a failure
     path = os.path.join(TEST_VAR_DIR, "/invalid/path/to/an/invalid/file.jpg")
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=path,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=path,
+            )
         )
         is False
     )
@@ -1112,11 +1134,13 @@ def test_plugin_mastodon_attachments(mock_get, mock_post):
 
     # We'll fail to send this time
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -1181,5 +1205,5 @@ def test_plugin_mastodon_apprise_tags(mock_post):
     assert len(found) == 1
 
     # A tag-filtered notify() follows the same code path
-    assert a.notify(body="test", tag="prod") is True
+    assert bool(a.notify(body="test", tag="prod")) is True
     assert mock_post.call_count == 1

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -1146,7 +1146,7 @@ def test_plugin_matrix_image_errors(mock_post, mock_get, mock_put):
 
     # Notification was successful, however we could not post image and since
     # we had post errors (of any kind) we still report a failure.
-    assert obj.notify("test", "test") is False
+    assert bool(obj.notify("test", "test")) is False
     del obj
 
     obj = NotifyMatrix(host="host", include_image=False, version="2")
@@ -1155,7 +1155,7 @@ def test_plugin_matrix_image_errors(mock_post, mock_get, mock_put):
 
     # We didn't post an image (which was set to fail) and therefore our
     # post was okay
-    assert obj.notify("test", "test") is True
+    assert bool(obj.notify("test", "test")) is True
 
     # Force a object removal (thus a logout call)
     del obj
@@ -1184,14 +1184,14 @@ def test_plugin_matrix_image_errors(mock_post, mock_get, mock_put):
     assert isinstance(obj, NotifyMatrix) is True
     assert obj.access_token is None
 
-    assert obj.notify("test", "test") is True
+    assert bool(obj.notify("test", "test")) is True
     del obj
 
     obj = NotifyMatrix(host="host", include_image=False)
     assert isinstance(obj, NotifyMatrix) is True
     assert obj.access_token is None
 
-    assert obj.notify("test", "test") is True
+    assert bool(obj.notify("test", "test")) is True
 
     # Force a object removal (thus a logout call)
     del obj
@@ -1222,11 +1222,13 @@ def test_plugin_matrix_attachments_api_v3(mock_post, mock_put):
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
 
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -1264,11 +1266,13 @@ def test_plugin_matrix_attachments_api_v3(mock_post, mock_put):
         os.path.join(TEST_VAR_DIR, "apprise-archive.zip")
     )
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -1277,11 +1281,13 @@ def test_plugin_matrix_attachments_api_v3(mock_post, mock_put):
     path = os.path.join(TEST_VAR_DIR, "/invalid/path/to/an/invalid/file.jpg")
     attach = AppriseAttachment(path)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=path,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=path,
+            )
         )
         is False
     )
@@ -1350,7 +1356,7 @@ def test_plugin_matrix_discovery_service(mock_post, mock_get, mock_put):
     obj = Apprise.instantiate(
         "matrixs://user:pass@example.com/#general?v=2&discovery=yes"
     )
-    assert obj.notify("body") is True
+    assert bool(obj.notify("body")) is True
 
     response = mock.Mock()
     response.status_code = requests.codes.unavailable
@@ -1393,7 +1399,7 @@ def test_plugin_matrix_discovery_service(mock_post, mock_get, mock_put):
     assert NotifyMatrix.discovery_identity_key not in obj.store
 
     # We fail our discovery and therefore can't send our notification
-    assert obj.notify("hello world") is False
+    assert bool(obj.notify("hello world")) is False
 
     # bad key
     resp["m.homeserver"] = {}
@@ -1421,7 +1427,7 @@ def test_plugin_matrix_discovery_service(mock_post, mock_get, mock_put):
     assert NotifyMatrix.discovery_identity_key in obj.store
 
     # Discovery passes so notifications work too
-    assert obj.notify("hello world") is True
+    assert bool(obj.notify("hello world")) is True
 
     # bad data
     resp["m.identity_server"] = "!garbage!:303"
@@ -1479,7 +1485,7 @@ def test_plugin_matrix_discovery_service(mock_post, mock_get, mock_put):
 
     # Discovery passes so notifications work too
     response.status_code = requests.codes.ok
-    assert obj.notify("hello world") is True
+    assert bool(obj.notify("hello world")) is True
 
     response.status_code = requests.codes.ok
     mock_get.return_value = None
@@ -1556,11 +1562,13 @@ def test_plugin_matrix_attachments_api_v2(mock_post, mock_get, mock_put):
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
 
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -1585,11 +1593,13 @@ def test_plugin_matrix_attachments_api_v2(mock_post, mock_get, mock_put):
     mock_put.reset_mock()
 
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -1626,11 +1636,13 @@ def test_plugin_matrix_attachments_api_v2(mock_post, mock_get, mock_put):
         os.path.join(TEST_VAR_DIR, "apprise-archive.zip")
     )
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -1639,11 +1651,13 @@ def test_plugin_matrix_attachments_api_v2(mock_post, mock_get, mock_put):
     path = os.path.join(TEST_VAR_DIR, "/invalid/path/to/an/invalid/file.jpg")
     attach = AppriseAttachment(path)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=path,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=path,
+            )
         )
         is False
     )
@@ -1706,7 +1720,9 @@ def test_plugin_matrix_attachments_api_v2(mock_post, mock_get, mock_put):
 
     # image attachment didn't succeed
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
 
@@ -1740,7 +1756,7 @@ def test_plugin_matrix_v2_compliance(mock_post, mock_put):
     obj = Apprise.instantiate("matrix://user:pass@localhost/#general?v=2")
 
     # Send a standard notification
-    assert obj.notify(body="test message") is True
+    assert bool(obj.notify(body="test message")) is True
 
     # Confirm the fix:
     # 1. Path contains the transaction ID '0'
@@ -1772,7 +1788,7 @@ def test_plugin_matrix_v2_token_mode_no_txn_increment(
     assert obj is not None
 
     # Send with image inline enabled
-    assert obj.notify(body="token mode image test") is True
+    assert bool(obj.notify(body="token mode image test")) is True
 
     # Send with an attachment
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
@@ -1802,7 +1818,7 @@ def test_plugin_matrix_hookshot_webhook(mock_post):
     )
     assert obj is not None
 
-    assert obj.notify(title="Title", body="<b>Body</b>") is True
+    assert bool(obj.notify(title="Title", body="<b>Body</b>")) is True
 
     assert mock_post.call_args.args[0] == (
         "https://hookshot.example/public-hooks/supersecret"
@@ -1829,7 +1845,7 @@ def test_plugin_matrix_hookshot_webhook_empty_title(mock_post):
     )
     assert obj is not None
 
-    assert obj.notify(body="**Body**") is True
+    assert bool(obj.notify(body="**Body**")) is True
 
     payload = loads(mock_post.call_args.kwargs["data"])
     assert payload["username"] == "apprise"
@@ -1862,7 +1878,7 @@ def test_plugin_matrix_hookshot_root_path_text(mock_post):
         "?mode=hookshot&format=text&path=%2F"
     )
     assert obj is not None
-    assert obj.notify(body="<b>Body</b>") is True
+    assert bool(obj.notify(body="<b>Body</b>")) is True
 
     assert mock_post.call_args.args[0] == (
         "https://hookshot.example/supersecret"
@@ -1907,7 +1923,11 @@ def test_plugin_matrix_transaction_ids_api_v3_no_cache(
 
         # Performs a login
         assert (
-            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+            bool(
+                obj.notify(
+                    body="body", title="title", notify_type=NotifyType.INFO
+                )
+            )
             is True
         )
         assert mock_get.call_count == 0
@@ -1934,8 +1954,10 @@ def test_plugin_matrix_transaction_ids_api_v3_no_cache(
             mock_put.reset_mock()
 
             assert (
-                obj.notify(
-                    body="body", title="title", notify_type=NotifyType.INFO
+                bool(
+                    obj.notify(
+                        body="body", title="title", notify_type=NotifyType.INFO
+                    )
                 )
                 is True
             )
@@ -2015,7 +2037,11 @@ def test_plugin_matrix_transaction_ids_api_v3_w_cache(
 
         # Performs a login
         assert (
-            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+            bool(
+                obj.notify(
+                    body="body", title="title", notify_type=NotifyType.INFO
+                )
+            )
             is True
         )
         assert mock_get.call_count == 0
@@ -2045,8 +2071,10 @@ def test_plugin_matrix_transaction_ids_api_v3_w_cache(
             mock_put.reset_mock()
 
             assert (
-                obj.notify(
-                    body="body", title="title", notify_type=NotifyType.INFO
+                bool(
+                    obj.notify(
+                        body="body", title="title", notify_type=NotifyType.INFO
+                    )
                 )
                 is True
             )
@@ -2108,7 +2136,9 @@ def test_plugin_matrix_v3_url_with_port_assembly(
     )
     # Performs a login
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -2211,7 +2241,7 @@ def test_plugin_matrix_no_room_create_on_non_not_found_join(
     ap = Apprise()
     ap.add("matrixs://user:pass@matrix.vip/#backup?discovery=no")
 
-    assert ap.notify(title="t", body="b") is False
+    assert bool(ap.notify(title="t", body="b")) is False
 
     # Cleanup explicitly to ensure __del__ executes while mocks are active.
     import gc
@@ -2286,7 +2316,7 @@ def test_plugin_matrix_room_create_on_not_found_join(
     ap = Apprise()
     ap.add("matrixs://user:pass@matrix.vip/#backup?discovery=no")
 
-    assert ap.notify(title="t", body="b") is True
+    assert bool(ap.notify(title="t", body="b")) is True
 
     import gc
 
@@ -5069,8 +5099,7 @@ def test_plugin_matrix_init_recovers_home_server_from_user_id(tmpdir):
     obj.store.flush()
 
     # Second instance with the same credentials (same url_id) reads the store.
-    # The recovery branch (lines 506-509) should derive home_server from
-    # the stored user_id.
+    # The recovery path should derive home_server from the stored user_id.
     obj2 = NotifyMatrix(
         host="h", user="u", password="pass", targets=["#r"], asset=asset
     )

--- a/tests/test_plugin_mattermost.py
+++ b/tests/test_plugin_mattermost.py
@@ -313,7 +313,7 @@ def test_plugin_mattermost_len_webhook_and_bot(
     assert isinstance(obj, NotifyMattermost)
     assert obj.mode == MattermostMode.BOT
     assert len(obj) == 2
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
     assert "mode=bot" in obj.url()
 
     # bot: channels are channel_id values -> count
@@ -322,7 +322,7 @@ def test_plugin_mattermost_len_webhook_and_bot(
     assert obj.mode == MattermostMode.BOT
     # our #chan isn't added to the list because no team was provided
     assert len(obj) == 1
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
     assert "mode=bot" in obj.url()
 
     obj = Apprise.instantiate("mmost://localhost/token?mode=bot&to=#chan")
@@ -330,7 +330,7 @@ def test_plugin_mattermost_len_webhook_and_bot(
     assert obj.mode == MattermostMode.BOT
     # No one to notify (but we always return a minimum of 1)
     assert len(obj) == 1
-    assert obj.notify("test") is False
+    assert bool(obj.notify("test")) is False
     assert "mode=bot" in obj.url()
 
     obj = Apprise.instantiate(
@@ -340,10 +340,10 @@ def test_plugin_mattermost_len_webhook_and_bot(
     assert obj.mode == MattermostMode.BOT
     assert len(obj) == 2
     # We can look up the team now
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
     assert "mode=bot" in obj.url()
     # Second call to notify() pulls from cache
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
 
     obj = Apprise.instantiate(
         "mmost://team@localhost/token?mode=bot&to=#chan,id1"
@@ -352,7 +352,7 @@ def test_plugin_mattermost_len_webhook_and_bot(
     assert obj.mode == MattermostMode.BOT
     # Invalid response
     request_get_mock.return_value.content = b"}"
-    assert obj.notify("test") is False
+    assert bool(obj.notify("test")) is False
 
     obj = Apprise.instantiate(
         "mmost://team@localhost/token?mode=bot&to=#chan,id1"
@@ -361,7 +361,7 @@ def test_plugin_mattermost_len_webhook_and_bot(
     assert obj.mode == MattermostMode.BOT
     # empty response
     request_get_mock.return_value.content = b"{}"
-    assert obj.notify("test") is False
+    assert bool(obj.notify("test")) is False
 
     obj = Apprise.instantiate(
         "mmost://team@localhost/token?mode=bot&to=#chan,id1"
@@ -370,7 +370,7 @@ def test_plugin_mattermost_len_webhook_and_bot(
     assert obj.mode == MattermostMode.BOT
     # upstream inquiry failure
     request_get_mock.side_effect = requests.RequestException
-    assert obj.notify("test") is False
+    assert bool(obj.notify("test")) is False
 
 
 def test_plugin_mattermost_channels(request_post_mock):
@@ -389,7 +389,7 @@ def test_plugin_mattermost_channels(request_post_mock):
     )
 
     assert isinstance(obj, NotifyMattermost)
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
 
     assert request_post_mock.called is True
     assert request_post_mock.call_count == 2
@@ -414,6 +414,7 @@ def test_plugin_mattermost_channels(request_post_mock):
 
 
 def test_mattermost_post_default_port(request_post_mock):
+    """Verify webhook delivery uses the default Mattermost port."""
     # Test token
     token = "token"
 
@@ -421,7 +422,7 @@ def test_mattermost_post_default_port(request_post_mock):
     obj = Apprise.instantiate(f"mmosts://mattermost.example.com/{token}")
 
     assert isinstance(obj, NotifyMattermost)
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
 
     # Make sure we don't use port if not provided
     assert request_post_mock.called is True
@@ -437,6 +438,7 @@ def test_mattermost_post_default_port(request_post_mock):
 
 
 def test_mattermost_icon_override(request_post_mock):
+    """Verify a configured icon URL is included in the webhook payload."""
     # Test token
     token = "token"
     icon_url = "http://localhost/test.png"
@@ -450,7 +452,7 @@ def test_mattermost_icon_override(request_post_mock):
     )
 
     assert isinstance(obj, NotifyMattermost)
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
 
     assert request_post_mock.called is True
     assert request_post_mock.call_count == 1
@@ -472,7 +474,7 @@ def test_plugin_mattermost_webhook_payload_variants(request_post_mock, mocker):
     obj = Apprise.instantiate("mmost://user@localhost/token?to=test")
     assert isinstance(obj, NotifyMattermost)
     assert obj.mode == MattermostMode.WEBHOOK
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
 
     posted_json = json.loads(request_post_mock.call_args_list[-1][1]["data"])
     assert posted_json["username"] == "user"
@@ -486,7 +488,7 @@ def test_plugin_mattermost_webhook_payload_variants(request_post_mock, mocker):
         "mmost://user@localhost/token?to=test&icon_url=http://x/icon.png"
     )
     assert isinstance(obj, NotifyMattermost)
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
 
     posted_json = json.loads(request_post_mock.call_args_list[0][1]["data"])
     assert posted_json["icon_url"] == "http://x/icon.png"
@@ -495,7 +497,7 @@ def test_plugin_mattermost_webhook_payload_variants(request_post_mock, mocker):
     request_post_mock.reset_mock()
     obj = Apprise.instantiate("mmost://user@localhost/token")
     assert isinstance(obj, NotifyMattermost)
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
 
     posted_json = json.loads(request_post_mock.call_args_list[0][1]["data"])
     assert "channel" not in posted_json
@@ -511,12 +513,12 @@ def test_plugin_mattermost_webhook_http_error_and_exception(
 
     # HTTP error
     request_post_mock.return_value.status_code = requests.codes.bad_request
-    assert obj.notify(body="body", title="title") is False
+    assert bool(obj.notify(body="body", title="title")) is False
 
     # Request exception
     request_post_mock.reset_mock()
     request_post_mock.side_effect = requests.RequestException("boom")
-    assert obj.notify(body="body", title="title") is False
+    assert bool(obj.notify(body="body", title="title")) is False
 
 
 def test_plugin_mattermost_bot_mode_success_and_payload(request_post_mock):
@@ -533,7 +535,7 @@ def test_plugin_mattermost_bot_mode_success_and_payload(request_post_mock):
     # Mattermost returns 201 Created for /api/v4/posts
     request_post_mock.return_value.status_code = requests.codes.created
 
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
     assert request_post_mock.called is True
     assert request_post_mock.call_count == 1
 
@@ -557,7 +559,7 @@ def test_plugin_mattermost_bot_mode_requires_channel_id(request_post_mock):
     assert obj.mode == MattermostMode.BOT
 
     request_post_mock.return_value.status_code = requests.codes.created
-    assert obj.notify(body="body", title="title") is False
+    assert bool(obj.notify(body="body", title="title")) is False
     assert request_post_mock.called is False
 
 
@@ -572,12 +574,12 @@ def test_plugin_mattermost_bot_mode_http_error_and_exception(
 
     # HTTP error (not 201)
     request_post_mock.return_value.status_code = requests.codes.unauthorized
-    assert obj.notify(body="body", title="title") is False
+    assert bool(obj.notify(body="body", title="title")) is False
 
     # Request exception
     request_post_mock.reset_mock()
     request_post_mock.side_effect = requests.RequestException("boom")
-    assert obj.notify(body="body", title="title") is False
+    assert bool(obj.notify(body="body", title="title")) is False
 
 
 def test_plugin_mattermost_bot_channel_lookup_success(
@@ -603,7 +605,7 @@ def test_plugin_mattermost_bot_channel_lookup_success(
     assert obj.mode == MattermostMode.BOT
 
     request_post_mock.return_value.status_code = requests.codes.created
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
 
     assert request_get_mock.called is True
     get_url = request_get_mock.call_args_list[0][0][0]
@@ -643,7 +645,7 @@ def test_plugin_mattermost_bot_channel_lookup_partial_success(
     assert isinstance(obj, NotifyMattermost)
     request_post_mock.return_value.status_code = requests.codes.created
 
-    assert obj.notify(body="body", title="title") is False
+    assert bool(obj.notify(body="body", title="title")) is False
     assert request_post_mock.call_count == 1
     posted_json = json.loads(request_post_mock.call_args_list[0][1]["data"])
     assert posted_json["channel_id"] == "cid-good"
@@ -659,7 +661,7 @@ def test_plugin_mattermost_webhook_attachment_warning(request_post_mock):
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
 
     # Pipeline silently drops the attachment; text message still succeeds
-    assert obj.notify(body="body", title="title", attach=attach) is True
+    assert bool(obj.notify(body="body", title="title", attach=attach)) is True
     assert request_post_mock.call_count == 1
 
     # No file upload should have been attempted
@@ -692,7 +694,7 @@ def test_plugin_mattermost_webhook_botname_in_url(request_post_mock):
 
     # Webhook payload carries username = botname
     request_post_mock.return_value.status_code = requests.codes.ok
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
     posted = json.loads(request_post_mock.call_args_list[0][1]["data"])
     assert posted["username"] == "mybot"
 
@@ -737,7 +739,7 @@ def test_plugin_mattermost_bot_attachments(request_post_mock):
     assert isinstance(obj, NotifyMattermost)
     assert obj.mode == MattermostMode.BOT
 
-    assert obj.notify(body="body", title="title", attach=attach) is True
+    assert bool(obj.notify(body="body", title="title", attach=attach)) is True
     assert request_post_mock.call_count == 2
 
     # First call is the file upload
@@ -795,7 +797,7 @@ def test_plugin_mattermost_bot_multi_attach_multi_target(request_post_mock):
         )
     )
     assert isinstance(obj, NotifyMattermost)
-    assert obj.notify(body="body", title="title", attach=attach) is True
+    assert bool(obj.notify(body="body", title="title", attach=attach)) is True
     assert request_post_mock.call_count == 6
 
     # Verify file_ids for each post
@@ -826,7 +828,7 @@ def test_plugin_mattermost_bot_attachment_upload_http_error(
         f"mmost://localhost/{bearer}?mode=bot&to={channel_id}"
     )
     assert isinstance(obj, NotifyMattermost)
-    assert obj.notify(body="body", title="title", attach=attach) is False
+    assert bool(obj.notify(body="body", title="title", attach=attach)) is False
     # Only the upload was attempted; no post was made
     assert request_post_mock.call_count == 1
     assert "/api/v4/files" in request_post_mock.call_args_list[0][0][0]
@@ -847,7 +849,7 @@ def test_plugin_mattermost_bot_attachment_request_exception(
         f"mmost://localhost/{bearer}?mode=bot&to={channel_id}"
     )
     assert isinstance(obj, NotifyMattermost)
-    assert obj.notify(body="body", title="title", attach=attach) is False
+    assert bool(obj.notify(body="body", title="title", attach=attach)) is False
     assert request_post_mock.call_count == 1
 
 
@@ -866,7 +868,10 @@ def test_plugin_mattermost_bot_attachment_ioerror(request_post_mock):
             f"mmost://localhost/{bearer}?mode=bot&to={channel_id}"
         )
         assert isinstance(obj, NotifyMattermost)
-        assert obj.notify(body="body", title="title", attach=attach) is False
+        assert (
+            bool(obj.notify(body="body", title="title", attach=attach))
+            is False
+        )
 
     # No HTTP request should have been made
     assert request_post_mock.call_count == 0
@@ -887,7 +892,10 @@ def test_plugin_mattermost_bot_attachment_valueerror(request_post_mock):
             f"mmost://localhost/{bearer}?mode=bot&to={channel_id}"
         )
         assert isinstance(obj, NotifyMattermost)
-        assert obj.notify(body="body", title="title", attach=attach) is False
+        assert (
+            bool(obj.notify(body="body", title="title", attach=attach))
+            is False
+        )
 
     assert request_post_mock.call_count == 0
 
@@ -908,7 +916,7 @@ def test_plugin_mattermost_bot_attachment_bad_response(request_post_mock):
         f"mmost://localhost/{bearer}?mode=bot&to={channel_id}"
     )
     assert isinstance(obj, NotifyMattermost)
-    assert obj.notify(body="body", title="title", attach=attach) is False
+    assert bool(obj.notify(body="body", title="title", attach=attach)) is False
     assert request_post_mock.call_count == 1
 
 
@@ -929,7 +937,7 @@ def test_plugin_mattermost_bot_attachment_no_file_id(request_post_mock):
         f"mmost://localhost/{bearer}?mode=bot&to={channel_id}"
     )
     assert isinstance(obj, NotifyMattermost)
-    assert obj.notify(body="body", title="title", attach=attach) is False
+    assert bool(obj.notify(body="body", title="title", attach=attach)) is False
 
 
 def test_plugin_mattermost_bot_attachment_invalid(request_post_mock):
@@ -943,7 +951,7 @@ def test_plugin_mattermost_bot_attachment_invalid(request_post_mock):
         f"mmost://localhost/{bearer}?mode=bot&to={channel_id}"
     )
     assert isinstance(obj, NotifyMattermost)
-    assert obj.notify(body="body", title="title", attach=attach) is False
+    assert bool(obj.notify(body="body", title="title", attach=attach)) is False
     # No upload request should be made for an invalid attachment
     assert request_post_mock.call_count == 0
 
@@ -991,7 +999,7 @@ def test_plugin_mattermost_bot_attachment_partial_target_failure(
     )
     assert isinstance(obj, NotifyMattermost)
     # One target succeeded, one failed -> overall False
-    assert obj.notify(body="body", title="title", attach=attach) is False
+    assert bool(obj.notify(body="body", title="title", attach=attach)) is False
     # 1 upload + 1 post (ch1) + 1 upload-fail (ch2) = 3 calls
     assert request_post_mock.call_count == 3
 
@@ -1053,7 +1061,9 @@ def test_plugin_mattermost_bot_attachment_memory_multi_target(
     assert isinstance(obj, NotifyMattermost)
 
     with mock.patch.object(attach.attachments[0], "open", _open_once):
-        assert obj.notify(body="body", title="title", attach=attach) is True
+        assert (
+            bool(obj.notify(body="body", title="title", attach=attach)) is True
+        )
 
     # open() was called exactly once (pre-read), not once per target
     assert open_calls[0] == 1

--- a/tests/test_plugin_mqtt.py
+++ b/tests/test_plugin_mqtt.py
@@ -276,7 +276,8 @@ def test_plugin_mqtt_tls_no_certificates_failure(mqtt_client_mock, mocker):
         call.error(
             "MQTT secure communication can not be verified, "
             "CA certificates file missing"
-        )
+        ),
+        call.debug("%s send() completed in %.2fs.", ANY, ANY),
     ]
 
 

--- a/tests/test_plugin_mqtt.py
+++ b/tests/test_plugin_mqtt.py
@@ -103,11 +103,11 @@ def test_plugin_mqtt_default_success(mqtt_client_mock):
     assert r"client_id=" not in obj.url()
 
     # Verify notification succeeds.
-    assert obj.notify(body="test=test") is True
+    assert bool(obj.notify(body="test=test")) is True
 
     # Send another notification (a new connection isn't attempted to be
     # established as one already exists)
-    assert obj.notify(body="foo=bar") is True
+    assert bool(obj.notify(body="foo=bar")) is True
 
     # Verify the right calls have been made to the MQTT client object.
     assert mqtt_client_mock.mock_calls == [
@@ -138,7 +138,7 @@ def test_plugin_mqtt_multiple_topics_success(mqtt_client_mock):
     assert obj.url().startswith("mqtt://localhost")
     assert r"my/topic" in obj.url()
     assert r"my/other/topic" in obj.url()
-    assert obj.notify(body="test=test") is True
+    assert bool(obj.notify(body="test=test")) is True
 
     # Verify the right calls have been made to the MQTT client object.
     assert mqtt_client_mock.mock_calls == [
@@ -171,7 +171,7 @@ def test_plugin_mqtt_to_success(mqtt_client_mock):
     assert re.search(r"version=v3.1.1", obj.url())
 
     # Verify notification succeeds.
-    assert obj.notify(body="test=test") is True
+    assert bool(obj.notify(body="test=test")) is True
 
 
 def test_plugin_mqtt_valid_settings_success(mqtt_client_mock):
@@ -222,7 +222,7 @@ def test_plugin_mqtt_no_topic_failure(mqtt_client_mock):
         "mqtt://localhost", suppress_exceptions=False
     )
     assert isinstance(obj, NotifyMQTT)
-    assert obj.notify(body="test=test") is False
+    assert bool(obj.notify(body="test=test")) is False
 
 
 def test_plugin_mqtt_tls_connect_success(mqtt_client_mock):
@@ -233,7 +233,7 @@ def test_plugin_mqtt_tls_connect_success(mqtt_client_mock):
     )
     assert isinstance(obj, NotifyMQTT)
     assert obj.url().startswith("mqtts://user:pass@localhost/my/topic")
-    assert obj.notify(body="test=test") is True
+    assert bool(obj.notify(body="test=test")) is True
 
     # Verify the right calls have been made to the MQTT client object.
     assert mqtt_client_mock.mock_calls == [
@@ -270,7 +270,7 @@ def test_plugin_mqtt_tls_no_certificates_failure(mqtt_client_mock, mocker):
     logger: Mock = mocker.spy(obj, "logger")
 
     # Verify notification fails w/o CA certificates.
-    assert obj.notify(body="test=test") is False
+    assert bool(obj.notify(body="test=test")) is False
 
     assert logger.mock_calls == [
         call.error(
@@ -289,7 +289,7 @@ def test_plugin_mqtt_tls_no_verify_success(mqtt_client_mock):
         suppress_exceptions=False,
     )
     assert isinstance(obj, NotifyMQTT)
-    assert obj.notify(body="test=test") is True
+    assert bool(obj.notify(body="test=test")) is True
 
     # Chain validation must be disabled via CERT_NONE (not just hostname
     # skipping via tls_insecure_set) so self-signed certs are accepted.
@@ -320,7 +320,7 @@ def test_plugin_mqtt_tls_no_verify_no_ca_success(mqtt_client_mock, mocker):
     assert isinstance(obj, NotifyMQTT)
 
     # Should succeed without CA certificates when verify is disabled
-    assert obj.notify(body="test=test") is True
+    assert bool(obj.notify(body="test=test")) is True
 
     assert (
         call.tls_set(
@@ -349,7 +349,7 @@ def test_plugin_mqtt_session_client_id_success(mqtt_client_mock):
     assert r"client_id=apprise" in obj.url()
     assert r"session=yes" in obj.url()
     assert r"retain=no" in obj.url()
-    assert obj.notify(body="test=test") is True
+    assert bool(obj.notify(body="test=test")) is True
 
 
 def test_plugin_mqtt_retain(mqtt_client_mock):
@@ -364,7 +364,7 @@ def test_plugin_mqtt_retain(mqtt_client_mock):
     assert r"my/topic" in obj.url()
     assert r"session=no" in obj.url()
     assert r"retain=yes" in obj.url()
-    assert obj.notify(body="test=test") is True
+    assert bool(obj.notify(body="test=test")) is True
 
 
 def test_plugin_mqtt_connect_failure(mqtt_client_mock):
@@ -378,7 +378,7 @@ def test_plugin_mqtt_connect_failure(mqtt_client_mock):
     )
 
     # Verify notification fails.
-    assert obj.notify(body="test=test") is False
+    assert bool(obj.notify(body="test=test")) is False
 
 
 def test_plugin_mqtt_reconnect_failure(mqtt_client_mock):
@@ -393,7 +393,7 @@ def test_plugin_mqtt_reconnect_failure(mqtt_client_mock):
     )
 
     # Verify notification fails.
-    assert obj.notify(body="test=test") is False
+    assert bool(obj.notify(body="test=test")) is False
 
 
 def test_plugin_mqtt_publish_failure(mqtt_client_mock):
@@ -408,7 +408,7 @@ def test_plugin_mqtt_publish_failure(mqtt_client_mock):
     )
 
     # Verify notification fails.
-    assert obj.notify(body="test=test") is False
+    assert bool(obj.notify(body="test=test")) is False
 
 
 def test_plugin_mqtt_exception_failure(mqtt_client_mock):
@@ -431,7 +431,7 @@ def test_plugin_mqtt_exception_failure(mqtt_client_mock):
         ValueError,
     ):
         mqtt_client_mock.connect.side_effect = side_effect
-        assert obj.notify(body="test=test") is False
+        assert bool(obj.notify(body="test=test")) is False
 
 
 def test_plugin_mqtt_not_published_failure(mqtt_client_mock, mocker):
@@ -451,7 +451,7 @@ def test_plugin_mqtt_not_published_failure(mqtt_client_mock, mocker):
     )
 
     # Verify notification fails.
-    assert obj.notify(body="test=test") is False
+    assert bool(obj.notify(body="test=test")) is False
 
 
 def test_plugin_mqtt_not_published_recovery_success(mqtt_client_mock):
@@ -468,4 +468,4 @@ def test_plugin_mqtt_not_published_recovery_success(mqtt_client_mock):
     )
 
     # Verify notification fails.
-    assert obj.notify(body="test=test") is True
+    assert bool(obj.notify(body="test=test")) is True

--- a/tests/test_plugin_nextcloud.py
+++ b/tests/test_plugin_nextcloud.py
@@ -300,7 +300,9 @@ def test_plugin_nextcloud_url_prefix(mock_post):
     )
 
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 

--- a/tests/test_plugin_nextcloudtalk.py
+++ b/tests/test_plugin_nextcloudtalk.py
@@ -216,7 +216,9 @@ def test_plugin_nextcloud_talk_url_prefix(mock_post):
     )
 
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -235,7 +237,9 @@ def test_plugin_nextcloud_talk_url_prefix(mock_post):
     )
 
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 

--- a/tests/test_plugin_notificationapi.py
+++ b/tests/test_plugin_notificationapi.py
@@ -510,7 +510,9 @@ def test_plugin_napi_template_sms_payloads(mock_post):
 
     # Send our notification
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -583,7 +585,9 @@ def test_plugin_napi_template_email_payloads(mock_post):
 
     # Send our notification
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -665,7 +669,9 @@ def test_plugin_napi_message_payloads(mock_post):
 
     # Send our notification
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -724,7 +730,9 @@ def test_plugin_napi_message_payloads(mock_post):
 
     # Send our notification
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -777,7 +785,9 @@ def test_plugin_napi_message_payloads(mock_post):
 
     # Send our notification
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 

--- a/tests/test_plugin_notifyre.py
+++ b/tests/test_plugin_notifyre.py
@@ -343,7 +343,7 @@ def test_plugin_notifyre_sms_send(mock_post):
     # Successful send
     mock_post.return_value = _mk_resp(GOOD_RESPONSE)
     obj = NotifyNotifyre(apikey=API_KEY, targets=["+15551234567"])
-    assert obj.notify(body="Hello", notify_type=NotifyType.INFO) is True
+    assert bool(obj.notify(body="Hello", notify_type=NotifyType.INFO)) is True
     assert mock_post.call_count == 1
 
     # Verify the correct endpoint was used
@@ -353,17 +353,17 @@ def test_plugin_notifyre_sms_send(mock_post):
     # HTTP error response
     mock_post.reset_mock()
     mock_post.return_value = _mk_resp({}, code=requests.codes.bad_request)
-    assert obj.notify(body="Hello", notify_type=NotifyType.INFO) is False
+    assert bool(obj.notify(body="Hello", notify_type=NotifyType.INFO)) is False
 
     # Unknown HTTP error
     mock_post.reset_mock()
     mock_post.return_value = _mk_resp({}, code=999)
-    assert obj.notify(body="Hello", notify_type=NotifyType.INFO) is False
+    assert bool(obj.notify(body="Hello", notify_type=NotifyType.INFO)) is False
 
     # API-level failure (success=false on HTTP 200)
     mock_post.reset_mock()
     mock_post.return_value = _mk_resp(FAIL_RESPONSE)
-    assert obj.notify(body="Hello", notify_type=NotifyType.INFO) is False
+    assert bool(obj.notify(body="Hello", notify_type=NotifyType.INFO)) is False
 
     # Unparseable response body on HTTP 200 is treated as success
     mock_post.reset_mock()
@@ -371,19 +371,19 @@ def test_plugin_notifyre_sms_send(mock_post):
     r.status_code = requests.codes.ok
     r.content = b"not-json"
     mock_post.return_value = r
-    assert obj.notify(body="Hello", notify_type=NotifyType.INFO) is True
+    assert bool(obj.notify(body="Hello", notify_type=NotifyType.INFO)) is True
 
     # RequestException
     mock_post.reset_mock()
     mock_post.side_effect = requests.RequestException("connection refused")
-    assert obj.notify(body="Hello", notify_type=NotifyType.INFO) is False
+    assert bool(obj.notify(body="Hello", notify_type=NotifyType.INFO)) is False
 
 
 @mock.patch("requests.post")
 def test_plugin_notifyre_sms_no_targets(mock_post):
     """SMS send with no valid targets returns False without HTTP call."""
     obj = NotifyNotifyre(apikey=API_KEY, targets=["not-valid"])
-    assert obj.notify(body="Hello", notify_type=NotifyType.INFO) is False
+    assert bool(obj.notify(body="Hello", notify_type=NotifyType.INFO)) is False
     assert mock_post.call_count == 0
 
 
@@ -403,7 +403,7 @@ def test_plugin_notifyre_sms_with_source(mock_post):
         targets=["+15551234567"],
         source="+15559876543",
     )
-    assert obj.notify(body="Hello", notify_type=NotifyType.INFO) is True
+    assert bool(obj.notify(body="Hello", notify_type=NotifyType.INFO)) is True
 
     # Verify 'from' was included in the posted payload
     posted = json.loads(mock_post.call_args[1]["data"])
@@ -428,10 +428,12 @@ def test_plugin_notifyre_sms_attachment_warning(mock_post):
 
     # Should warn but still succeed (attachments are ignored in SMS mode)
     assert (
-        obj.notify(
-            body="Hello",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="Hello",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -451,7 +453,7 @@ def test_plugin_notifyre_fax_send(mock_post):
     # Successful send (body text as only document)
     mock_post.return_value = _mk_resp(GOOD_RESPONSE)
     obj = NotifyNotifyre(apikey=API_KEY, targets=["+15551234567"], mode="fax")
-    assert obj.notify(body="Hello", notify_type=NotifyType.INFO) is True
+    assert bool(obj.notify(body="Hello", notify_type=NotifyType.INFO)) is True
     assert mock_post.call_count == 1
 
     call_url = mock_post.call_args[0][0]
@@ -460,17 +462,17 @@ def test_plugin_notifyre_fax_send(mock_post):
     # HTTP error
     mock_post.reset_mock()
     mock_post.return_value = _mk_resp({}, code=requests.codes.bad_request)
-    assert obj.notify(body="Hello", notify_type=NotifyType.INFO) is False
+    assert bool(obj.notify(body="Hello", notify_type=NotifyType.INFO)) is False
 
     # Unknown HTTP error
     mock_post.reset_mock()
     mock_post.return_value = _mk_resp({}, code=999)
-    assert obj.notify(body="Hello", notify_type=NotifyType.INFO) is False
+    assert bool(obj.notify(body="Hello", notify_type=NotifyType.INFO)) is False
 
     # API-level failure (success=false on HTTP 200)
     mock_post.reset_mock()
     mock_post.return_value = _mk_resp(FAIL_RESPONSE)
-    assert obj.notify(body="Hello", notify_type=NotifyType.INFO) is False
+    assert bool(obj.notify(body="Hello", notify_type=NotifyType.INFO)) is False
 
     # Unparseable JSON on HTTP 200 -- treated as success
     mock_post.reset_mock()
@@ -478,12 +480,12 @@ def test_plugin_notifyre_fax_send(mock_post):
     r.status_code = requests.codes.ok
     r.content = b"not-json"
     mock_post.return_value = r
-    assert obj.notify(body="Hello", notify_type=NotifyType.INFO) is True
+    assert bool(obj.notify(body="Hello", notify_type=NotifyType.INFO)) is True
 
     # RequestException
     mock_post.reset_mock()
     mock_post.side_effect = requests.RequestException("timeout")
-    assert obj.notify(body="Hello", notify_type=NotifyType.INFO) is False
+    assert bool(obj.notify(body="Hello", notify_type=NotifyType.INFO)) is False
 
 
 @mock.patch("requests.post")
@@ -503,10 +505,12 @@ def test_plugin_notifyre_fax_attachments(mock_post):
     attach = AppriseAttachment()
     attach.add(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
     assert (
-        obj.notify(
-            body="Fax body",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="Fax body",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -518,10 +522,12 @@ def test_plugin_notifyre_fax_attachments(mock_post):
     attach.add(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
     with mock.patch("os.path.isfile", return_value=False):
         assert (
-            obj.notify(
-                body="Fax body",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="Fax body",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )
@@ -533,10 +539,12 @@ def test_plugin_notifyre_fax_attachments(mock_post):
     attach.add(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
     with mock.patch("builtins.open", side_effect=OSError("perm denied")):
         assert (
-            obj.notify(
-                body="Fax body",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="Fax body",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )
@@ -552,10 +560,12 @@ def test_plugin_notifyre_fax_attachments(mock_post):
     mock_fh.read.side_effect = OSError("read error")
     with mock.patch("builtins.open", return_value=mock_fh):
         assert (
-            obj.notify(
-                body="Fax body",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="Fax body",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )
@@ -568,10 +578,12 @@ def test_plugin_notifyre_fax_attachments(mock_post):
     attach = AppriseAttachment()
     attach.add(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
     assert (
-        obj.notify(
-            body="Fax body",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="Fax body",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -582,10 +594,12 @@ def test_plugin_notifyre_fax_attachments(mock_post):
     attach = AppriseAttachment()
     attach.add(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
     assert (
-        obj.notify(
-            body="Fax body",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="Fax body",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -599,10 +613,12 @@ def test_plugin_notifyre_fax_attachments(mock_post):
     attach.add(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
     attach.add(os.path.join(TEST_VAR_DIR, "apprise-test.jpeg"))
     assert (
-        obj.notify(
-            body="Multi-page fax",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="Multi-page fax",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -783,7 +799,7 @@ def test_plugin_notifyre_sms_campaign(mock_post):
         targets=["+15551234567"],
         campaign="MyCampaign",
     )
-    assert obj.notify(body="Hello", notify_type=NotifyType.INFO) is True
+    assert bool(obj.notify(body="Hello", notify_type=NotifyType.INFO)) is True
     posted = json.loads(mock_post.call_args[1]["data"])
     assert posted["campaignName"] == "MyCampaign"
 
@@ -791,7 +807,7 @@ def test_plugin_notifyre_sms_campaign(mock_post):
     mock_post.reset_mock()
     mock_post.return_value = _mk_resp(GOOD_RESPONSE)
     obj = NotifyNotifyre(apikey=API_KEY, targets=["+15551234567"])
-    assert obj.notify(body="Hello", notify_type=NotifyType.INFO) is True
+    assert bool(obj.notify(body="Hello", notify_type=NotifyType.INFO)) is True
     posted = json.loads(mock_post.call_args[1]["data"])
     assert posted["campaignName"] == obj.app_id
 
@@ -818,7 +834,9 @@ def test_plugin_notifyre_fax_params(mock_post):
         hq=False,
         header="CONFIDENTIAL",
     )
-    assert obj.notify(body="Fax body", notify_type=NotifyType.INFO) is True
+    assert (
+        bool(obj.notify(body="Fax body", notify_type=NotifyType.INFO)) is True
+    )
     posted = json.loads(mock_post.call_args[1]["data"])
     assert posted["campaignName"] == "FaxCampaign"
     assert posted["templateName"] == "CoverTpl"
@@ -833,7 +851,7 @@ def test_plugin_notifyre_fax_params(mock_post):
     mock_post.reset_mock()
     mock_post.return_value = _mk_resp(GOOD_RESPONSE)
     obj = NotifyNotifyre(apikey=API_KEY, targets=["+15551234567"], mode="fax")
-    assert obj.notify(body="Test", notify_type=NotifyType.INFO) is True
+    assert bool(obj.notify(body="Test", notify_type=NotifyType.INFO)) is True
     posted = json.loads(mock_post.call_args[1]["data"])
     assert posted["isHighQuality"] is True
     assert posted["templateName"] == ""
@@ -857,9 +875,9 @@ def test_plugin_notifyre_apprise_integration(mock_post):
     # SMS via string URL
     app = Apprise()
     assert app.add("notifyre://{}/+15551234567".format(API_KEY))
-    assert app.notify(title="Title", body="Body") is True
+    assert bool(app.notify(title="Title", body="Body")) is True
 
     # Fax via string URL
     app = Apprise()
     assert app.add("notifyre://{}/+15551234567?mode=fax".format(API_KEY))
-    assert app.notify(title="Title", body="Body") is True
+    assert bool(app.notify(title="Title", body="Body")) is True

--- a/tests/test_plugin_ntfy.py
+++ b/tests/test_plugin_ntfy.py
@@ -472,7 +472,7 @@ def test_plugin_ntfy_attachments(mock_post):
     obj = apprise.Apprise.instantiate("ntfy://user:pass@localhost:8084/topic")
 
     # Send a good attachment
-    assert obj.notify(body="test", attach=attach) is True
+    assert bool(obj.notify(body="test", attach=attach)) is True
 
     # Test our call count; includes both image and message
     assert mock_post.call_count == 1
@@ -494,7 +494,9 @@ def test_plugin_ntfy_attachments(mock_post):
     attach.add(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
 
     # Send our attachments
-    assert obj.notify(body="test", title="wonderful", attach=attach) is True
+    assert (
+        bool(obj.notify(body="test", title="wonderful", attach=attach)) is True
+    )
 
     # Test our call count
     assert mock_post.call_count == 2
@@ -522,7 +524,7 @@ def test_plugin_ntfy_attachments(mock_post):
     # An invalid attachment will cause a failure
     path = os.path.join(TEST_VAR_DIR, "/invalid/path/to/an/invalid/file.jpg")
     attach = apprise.AppriseAttachment(path)
-    assert obj.notify(body="test", attach=attach) is False
+    assert bool(obj.notify(body="test", attach=attach)) is False
 
     # Test our call count
     assert mock_post.call_count == 0
@@ -608,8 +610,10 @@ def test_plugin_custom_ntfy_edge_cases(mock_post):
     assert "topic1" in instance.topics
 
     assert (
-        instance.notify(
-            body="body", title="title", notify_type=apprise.NotifyType.INFO
+        bool(
+            instance.notify(
+                body="body", title="title", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -634,8 +638,10 @@ def test_plugin_custom_ntfy_edge_cases(mock_post):
     instance = NotifyNtfy(**results)
 
     assert (
-        instance.notify(
-            body="body", title="title", notify_type=apprise.NotifyType.INFO
+        bool(
+            instance.notify(
+                body="body", title="title", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -871,9 +877,11 @@ def test_plugin_ntfy_html_to_markdown_format(mock_post):
     # Notify with an HTML body; the framework should convert it
     # to Markdown before dispatching to ntfy
     assert (
-        aobj.notify(
-            body="<b>hello</b> <i>world</i>",
-            body_format=NotifyFormat.HTML,
+        bool(
+            aobj.notify(
+                body="<b>hello</b> <i>world</i>",
+                body_format=NotifyFormat.HTML,
+            )
         )
         is True
     )

--- a/tests/test_plugin_office365.py
+++ b/tests/test_plugin_office365.py
@@ -412,7 +412,7 @@ def test_plugin_office365_general(mock_get, mock_post):
     assert isinstance(obj.url(), str)
 
     # Test our notification
-    assert obj.notify(title="title", body="test") is True
+    assert bool(obj.notify(title="title", body="test")) is True
 
     # Instantiate our object
     obj = Apprise.instantiate(
@@ -435,7 +435,7 @@ def test_plugin_office365_general(mock_get, mock_post):
     assert isinstance(obj.url(), str)
 
     # Test our notification
-    assert obj.notify(title="title", body="test") is True
+    assert bool(obj.notify(title="title", body="test")) is True
 
     with pytest.raises(TypeError):
         # No secret
@@ -456,7 +456,7 @@ def test_plugin_office365_general(mock_get, mock_post):
         targets=("Management abc@gmail.com", "garbage"),
     )
     # Test our notification (this will work and only notify abc@gmail.com)
-    assert obj.notify(title="title", body="test") is True
+    assert bool(obj.notify(title="title", body="test")) is True
 
     # all of the targets are invalid
     obj = NotifyOffice365(
@@ -468,7 +468,7 @@ def test_plugin_office365_general(mock_get, mock_post):
     )
 
     # Test our notification (which will fail because of no entries)
-    assert obj.notify(title="title", body="test") is False
+    assert bool(obj.notify(title="title", body="test")) is False
 
 
 @mock.patch("requests.get")
@@ -526,7 +526,7 @@ def test_plugin_office365_authentication(mock_get, mock_post):
     response.status_code = 400
 
     # We'll fail to send a notification now...
-    assert obj.notify(title="title", body="test") is False
+    assert bool(obj.notify(title="title", body="test")) is False
 
     # Expire our token
     obj.token_expiry = datetime.now()
@@ -538,7 +538,7 @@ def test_plugin_office365_authentication(mock_get, mock_post):
     assert obj.authenticate() is False
 
     # Notifications will also fail in this case
-    assert obj.notify(title="title", body="test") is False
+    assert bool(obj.notify(title="title", body="test")) is False
 
     # We will fail to authenticate with invalid data
 
@@ -627,7 +627,9 @@ def test_plugin_office365_queries(mock_post, mock_get, mock_put):
 
     # Notify must exit early since the source Object ID could not be resolved
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
 
@@ -651,7 +653,9 @@ def test_plugin_office365_queries(mock_post, mock_get, mock_put):
 
     # We can still send a notification even if we can't look up the email
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -706,7 +710,9 @@ def test_plugin_office365_queries(mock_post, mock_get, mock_put):
 
     # We can still send a notification even if we can't look up the email
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -754,11 +760,13 @@ def test_plugin_office365_attachments(mock_post, mock_get, mock_put):
     path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     attach = AppriseAttachment(path)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -801,8 +809,10 @@ def test_plugin_office365_attachments(mock_post, mock_get, mock_put):
     assert isinstance(obj, NotifyOffice365)
     # Authentication will fail
     assert (
-        obj.notify(
-            body="auth-fail", title="title", notify_type=NotifyType.INFO
+        bool(
+            obj.notify(
+                body="auth-fail", title="title", notify_type=NotifyType.INFO
+            )
         )
         is False
     )
@@ -827,11 +837,13 @@ def test_plugin_office365_attachments(mock_post, mock_get, mock_put):
     mock_post.return_value = okay_response
     path = os.path.join(TEST_VAR_DIR, "/invalid/path/to/an/invalid/file.jpg")
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=path,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=path,
+            )
         )
         is False
     )
@@ -841,11 +853,13 @@ def test_plugin_office365_attachments(mock_post, mock_get, mock_put):
     with mock.patch("base64.b64encode", side_effect=OSError()):
         # We can't send the message if we fail to parse the data
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )
@@ -933,11 +947,13 @@ def test_plugin_office365_attachments(mock_post, mock_get, mock_put):
 
     # We now have to prepare sepparate session attachments using draft emails
     assert (
-        obj.notify(
-            body="body",
-            title="title-test",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title-test",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -979,11 +995,13 @@ def test_plugin_office365_attachments(mock_post, mock_get, mock_put):
     mock_post.return_value = None
     mock_post.side_effect = (okay_response, okay_response, bad_response)
     assert (
-        obj.notify(
-            body="body",
-            title="title-test",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title-test",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -1014,11 +1032,13 @@ def test_plugin_office365_attachments(mock_post, mock_get, mock_put):
 
     # We now have to prepare sepparate session attachments using draft emails
     assert (
-        obj.notify(
-            body="body",
-            title="title-no-chunk",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title-no-chunk",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -1055,11 +1075,13 @@ def test_plugin_office365_attachments(mock_post, mock_get, mock_put):
     # We could not acquire an attachment id, so we'll fail to send our
     # notification
     assert (
-        obj.notify(
-            body="body",
-            title="title-test",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title-test",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -1076,11 +1098,13 @@ def test_plugin_office365_attachments(mock_post, mock_get, mock_put):
     # Reset attachment size
     obj.outlook_attachment_inline_max = 50 * 1024 * 1024
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -1136,7 +1160,7 @@ def test_plugin_office365_reply_to(mock_post, mock_get):
     assert "reply_to=" in url
 
     # send() adds replyTo with name to the payload
-    assert obj.notify(title="title", body="test") is True
+    assert bool(obj.notify(title="title", body="test")) is True
     assert mock_post.call_count == 2
     sent_payload = loads(mock_post.call_args_list[1][1]["data"])
     assert "replyTo" in sent_payload["message"]
@@ -1163,7 +1187,7 @@ def test_plugin_office365_reply_to(mock_post, mock_get):
     )
 
     assert isinstance(obj2, NotifyOffice365)
-    assert obj2.notify(title="t", body="b") is True
+    assert bool(obj2.notify(title="t", body="b")) is True
     sent_payload = loads(mock_post.call_args_list[1][1]["data"])
     assert "replyTo" in sent_payload["message"]
     assert "name" not in sent_payload["message"]["replyTo"][0]["emailAddress"]
@@ -1181,7 +1205,7 @@ def test_plugin_office365_reply_to(mock_post, mock_get):
     assert isinstance(obj3, NotifyOffice365)
     assert len(obj3.reply_to) == 0
     # No replyTo in payload when reply_to is empty
-    assert obj3.notify(title="t", body="b") is True
+    assert bool(obj3.notify(title="t", body="b")) is True
     sent_payload = loads(mock_post.call_args_list[1][1]["data"])
     assert "replyTo" not in sent_payload["message"]
     mock_post.reset_mock()
@@ -1312,7 +1336,7 @@ def test_plugin_office365_personal_mode(mock_post, mock_get):
         targets=["target@example.com"],
     )
     assert obj.mode == Office365Mode.PERSONAL
-    assert obj.notify(title="title", body="body") is True
+    assert bool(obj.notify(title="title", body="body")) is True
 
     # POST 0: token refresh  POST 1: sendMail
     assert mock_post.call_count == 2
@@ -1351,7 +1375,7 @@ def test_plugin_office365_personal_mode(mock_post, mock_get):
         client_id=client_id,
         secret=seed_token,
     )
-    assert obj2.notify(title="t", body="b") is False
+    assert bool(obj2.notify(title="t", body="b")) is False
     mock_post.reset_mock()
     mock_post.return_value = okay_response
 
@@ -1368,7 +1392,7 @@ def test_plugin_office365_personal_mode(mock_post, mock_get):
         client_id=client_id,
         secret=seed_token,
     )
-    assert obj3.notify(title="t", body="b") is False
+    assert bool(obj3.notify(title="t", body="b")) is False
     mock_post.reset_mock()
     mock_post.return_value = okay_response
 
@@ -1467,7 +1491,7 @@ def test_plugin_office365_personal_mode(mock_post, mock_get):
     assert "bcc=Blind%20Copy%3Abcc%40example.com" in personal_url
     assert "reply_to=Reply%20Person%3Areply%40example.org" in personal_url
 
-    assert obj7.notify(title="title", body="body") is True
+    assert bool(obj7.notify(title="title", body="body")) is True
     assert mock_post.call_count == 2
     assert (
         mock_post.call_args_list[1][0][0]
@@ -1511,7 +1535,7 @@ def test_plugin_office365_personal_mode(mock_post, mock_get):
         secret=seed_token,
         targets=["target@example.com"],
     )
-    assert obj_nr.notify(title="t", body="b") is True
+    assert bool(obj_nr.notify(title="t", body="b")) is True
     # No new token stored — seed_token still in url()
     assert obj_nr.store.get("refresh_token") is None
     mock_post.reset_mock()
@@ -1564,11 +1588,13 @@ def test_plugin_office365_personal_large_attachment(
     obj.outlook_attachment_inline_max = 50
 
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )

--- a/tests/test_plugin_opsgenie.py
+++ b/tests/test_plugin_opsgenie.py
@@ -464,11 +464,11 @@ def test_plugin_opsgenie_edge_case(mock_post):
     assert isinstance(instance, NotifyOpsgenie)
 
     assert len(instance.store.keys()) == 0
-    assert instance.notify("test", "key", NotifyType.FAILURE) is True
+    assert bool(instance.notify("test", "key", NotifyType.FAILURE)) is True
     assert len(instance.store.keys()) == 1
 
     # Again just causes same index to get over-written
-    assert instance.notify("test", "key", NotifyType.FAILURE) is True
+    assert bool(instance.notify("test", "key", NotifyType.FAILURE)) is True
     assert len(instance.store.keys()) == 1
     assert "a62f2225bf" in instance.store
 
@@ -477,9 +477,9 @@ def test_plugin_opsgenie_edge_case(mock_post):
     # This causes an internal check to fail where the keys are expected to be
     # as a list (this one is now a string)
     # content self corrects and things are fine
-    assert instance.notify("test", "key", NotifyType.FAILURE) is True
+    assert bool(instance.notify("test", "key", NotifyType.FAILURE)) is True
     assert len(instance.store.keys()) == 1
 
     # new key is new index
-    assert instance.notify("test", "key2", NotifyType.FAILURE) is True
+    assert bool(instance.notify("test", "key2", NotifyType.FAILURE)) is True
     assert len(instance.store.keys()) == 2

--- a/tests/test_plugin_pagerduty.py
+++ b/tests/test_plugin_pagerduty.py
@@ -196,6 +196,7 @@ def test_plugin_pagerduty_urls():
 
 @mock.patch("requests.post")
 def test_plugin_pagerduty_notify_type_is_string(mock_post):
+    """Verify string notification types are accepted and delivered."""
     response = mock.Mock()
     response.status_code = requests.codes.ok
     response.content = ""
@@ -205,7 +206,9 @@ def test_plugin_pagerduty_notify_type_is_string(mock_post):
     assert isinstance(obj, NotifyPagerDuty)
 
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
     assert mock_post.call_count == 1

--- a/tests/test_plugin_postmark.py
+++ b/tests/test_plugin_postmark.py
@@ -265,7 +265,7 @@ def test_plugin_postmark_send(mock_post, mock_get):
     # Basic send to self (no explicit target)
     obj = Apprise.instantiate("postmark://abcd:user@example.com")
     assert isinstance(obj, NotifyPostmark)
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
 
     # Verify the X-Postmark-Server-Token header was set
     assert mock_post.call_count == 1
@@ -282,7 +282,7 @@ def test_plugin_postmark_send(mock_post, mock_get):
     obj = Apprise.instantiate(
         "postmark://abcd:user@example.com/target@example.com"
     )
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
     posted = json.loads(mock_post.call_args[1]["data"])
     assert posted["To"] == "target@example.com"
     mock_post.reset_mock()
@@ -295,7 +295,7 @@ def test_plugin_postmark_send(mock_post, mock_get):
         cc=["cc@example.com"],
         bcc=["bcc@example.com"],
     )
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
     posted = json.loads(mock_post.call_args[1]["data"])
     assert "Cc" in posted
     assert "Bcc" in posted
@@ -307,7 +307,7 @@ def test_plugin_postmark_send(mock_post, mock_get):
         from_email="user@example.com",
         reply_to=["reply@example.com"],
     )
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
     posted = json.loads(mock_post.call_args[1]["data"])
     assert "ReplyTo" in posted
     mock_post.reset_mock()
@@ -317,7 +317,7 @@ def test_plugin_postmark_send(mock_post, mock_get):
         apikey="abcd",
         from_email="user@example.com",
     )
-    assert obj.notify(body="body", title="") is True
+    assert bool(obj.notify(body="body", title="")) is True
     posted = json.loads(mock_post.call_args[1]["data"])
     assert posted["Subject"] == NotifyPostmark.default_empty_subject
     mock_post.reset_mock()
@@ -330,7 +330,7 @@ def test_plugin_postmark_send(mock_post, mock_get):
     from apprise.common import NotifyFormat
 
     obj.notify_format = NotifyFormat.TEXT
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
     posted = json.loads(mock_post.call_args[1]["data"])
     assert "TextBody" in posted
     assert "HtmlBody" not in posted
@@ -341,17 +341,17 @@ def test_plugin_postmark_send(mock_post, mock_get):
     obj = Apprise.instantiate(
         "postmark://abcd:user@example.com/target@example.com"
     )
-    assert obj.notify(body="body", title="title") is False
+    assert bool(obj.notify(body="body", title="title")) is False
     mock_post.reset_mock()
 
     # Unknown HTTP code
     mock_post.return_value = _mk_resp(999)
-    assert obj.notify(body="body", title="title") is False
+    assert bool(obj.notify(body="body", title="title")) is False
     mock_post.reset_mock()
 
     # RequestException
     mock_post.side_effect = requests.RequestException("Connection failed")
-    assert obj.notify(body="body", title="title") is False
+    assert bool(obj.notify(body="body", title="title")) is False
     mock_post.side_effect = None
     mock_post.reset_mock()
 
@@ -362,7 +362,7 @@ def test_plugin_postmark_send(mock_post, mock_get):
         targets=["!invalid"],
     )
     mock_post.return_value = _mk_resp()
-    assert obj.notify(body="body", title="title") is False
+    assert bool(obj.notify(body="body", title="title")) is False
     assert mock_post.call_count == 0
 
     # Multiple targets -- partial failure
@@ -374,7 +374,7 @@ def test_plugin_postmark_send(mock_post, mock_get):
         from_email="user@example.com",
         targets=["t1@example.com", "t2@example.com"],
     )
-    assert obj.notify(body="body", title="title") is False
+    assert bool(obj.notify(body="body", title="title")) is False
     assert mock_post.call_count == 2
     mock_post.side_effect = None
 
@@ -397,11 +397,13 @@ def test_plugin_postmark_attachments(mock_post):
     obj = Apprise.instantiate("postmark://abcd:user@example.com")
     assert isinstance(obj, NotifyPostmark)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -418,11 +420,13 @@ def test_plugin_postmark_attachments(mock_post):
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
     attach.add(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -433,13 +437,15 @@ def test_plugin_postmark_attachments(mock_post):
     # Attachment inaccessible (file not found)
     with mock.patch("os.path.isfile", return_value=False):
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=AppriseAttachment(
-                    os.path.join(TEST_VAR_DIR, "apprise-test.gif")
-                ),
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=AppriseAttachment(
+                        os.path.join(TEST_VAR_DIR, "apprise-test.gif")
+                    ),
+                )
             )
             is False
         )
@@ -447,13 +453,15 @@ def test_plugin_postmark_attachments(mock_post):
     # Attachment read error (OSError)
     with mock.patch("builtins.open", side_effect=OSError):
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=AppriseAttachment(
-                    os.path.join(TEST_VAR_DIR, "apprise-test.gif")
-                ),
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=AppriseAttachment(
+                        os.path.join(TEST_VAR_DIR, "apprise-test.gif")
+                    ),
+                )
             )
             is False
         )

--- a/tests/test_plugin_pushbullet.py
+++ b/tests/test_plugin_pushbullet.py
@@ -274,7 +274,7 @@ def test_plugin_pushbullet_attachments(mock_post):
     obj = Apprise.instantiate(f"pbul://{access_token}/?format=markdown")
 
     # Send a good attachment
-    assert obj.notify(body="test", attach=attach) is True
+    assert bool(obj.notify(body="test", attach=attach)) is True
 
     # Test our call count
     assert mock_post.call_count == 4
@@ -306,7 +306,7 @@ def test_plugin_pushbullet_attachments(mock_post):
     attach.add(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
 
     # Send our attachments
-    assert obj.notify(body="test", attach=attach) is True
+    assert bool(obj.notify(body="test", attach=attach)) is True
 
     # Test our call count
     assert mock_post.call_count == 7
@@ -348,7 +348,7 @@ def test_plugin_pushbullet_attachments(mock_post):
     # An invalid attachment will cause a failure
     path = os.path.join(TEST_VAR_DIR, "/invalid/path/to/an/invalid/file.jpg")
     attach = AppriseAttachment(path)
-    assert obj.notify(body="test", attach=attach) is False
+    assert bool(obj.notify(body="test", attach=attach)) is False
 
     # Test our call count
     assert mock_post.call_count == 0

--- a/tests/test_plugin_pushover.py
+++ b/tests/test_plugin_pushover.py
@@ -409,7 +409,7 @@ def test_plugin_pushover_attachments(mock_post, tmpdir):
     assert isinstance(obj, NotifyPushover)
 
     # Test our attachment
-    assert obj.notify(body="test", attach=attach) is True
+    assert bool(obj.notify(body="test", attach=attach)) is True
 
     # Test our call count
     assert mock_post.call_count == 1
@@ -423,7 +423,7 @@ def test_plugin_pushover_attachments(mock_post, tmpdir):
 
     # Test multiple attachments
     assert attach.add(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
-    assert obj.notify(body="test", attach=attach) is True
+    assert bool(obj.notify(body="test", attach=attach)) is True
 
     # Test our call count
     assert mock_post.call_count == 2
@@ -443,7 +443,7 @@ def test_plugin_pushover_attachments(mock_post, tmpdir):
     image.write("a" * NotifyPushover.attach_max_size_bytes)
 
     attach = apprise.AppriseAttachment.instantiate(str(image))
-    assert obj.notify(body="test", attach=attach) is True
+    assert bool(obj.notify(body="test", attach=attach)) is True
 
     # Test our call count
     assert mock_post.call_count == 1
@@ -459,7 +459,7 @@ def test_plugin_pushover_attachments(mock_post, tmpdir):
     image.write("a" * (NotifyPushover.attach_max_size_bytes + 1))
 
     attach = apprise.AppriseAttachment.instantiate(str(image))
-    assert obj.notify(body="test", attach=attach) is False
+    assert bool(obj.notify(body="test", attach=attach)) is False
 
     # Test our call count
     assert mock_post.call_count == 0
@@ -469,7 +469,7 @@ def test_plugin_pushover_attachments(mock_post, tmpdir):
         f"file://{image!s}?cache=False"
     )
     os.unlink(str(image))
-    assert obj.notify(body="body", title="title", attach=attach) is False
+    assert bool(obj.notify(body="body", title="title", attach=attach)) is False
 
     # Test our call count
     assert mock_post.call_count == 0
@@ -480,7 +480,7 @@ def test_plugin_pushover_attachments(mock_post, tmpdir):
     attach = apprise.AppriseAttachment.instantiate(str(image))
 
     # Content is silently ignored
-    assert obj.notify(body="test", attach=attach) is True
+    assert bool(obj.notify(body="test", attach=attach)) is True
 
     # prepare our attachment
     attach = apprise.AppriseAttachment(
@@ -531,8 +531,10 @@ def test_plugin_pushover_edge_cases(mock_post):
 
     # We notify the 2 devices loaded
     assert (
-        obj.notify(
-            body="body", title="title", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                body="body", title="title", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -546,8 +548,10 @@ def test_plugin_pushover_edge_cases(mock_post):
 
     # This call succeeds because all of the devices are valid
     assert (
-        obj.notify(
-            body="body", title="title", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                body="body", title="title", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -572,8 +576,10 @@ def test_plugin_pushover_edge_cases(mock_post):
 
     # Verify notification to a group succeeds (separate API call per group)
     assert (
-        obj.notify(
-            body="body", title="title", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                body="body", title="title", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -677,14 +683,16 @@ def test_plugin_pushover_config_files(mock_post):
     # Notifications work
     # We test 'pushover_str_int' and 'low' which only matches 1 end point
     assert (
-        aobj.notify(
-            title="title", body="body", tag=[("pushover_str_int", "low")]
+        bool(
+            aobj.notify(
+                title="title", body="body", tag=[("pushover_str_int", "low")]
+            )
         )
         is True
     )
 
     # Notify everything loaded
-    assert aobj.notify(title="title", body="body") is True
+    assert bool(aobj.notify(title="title", body="body")) is True
 
 
 @mock.patch("requests.post")
@@ -793,7 +801,7 @@ def test_plugin_pushover_attach_memory(mock_post):
         mimetype="text/html",
     )
 
-    assert obj.notify(body="Test", attach=mem) is True
+    assert bool(obj.notify(body="Test", attach=mem)) is True
     assert mock_post.call_count == 1
 
 

--- a/tests/test_plugin_pushplus.py
+++ b/tests/test_plugin_pushplus.py
@@ -946,7 +946,7 @@ def test_plugin_pushplus_apprise_integration(mock_post):
     aobj = Apprise()
     assert aobj.add("pushplus://{}".format(GOOD_TOKEN))
     assert len(aobj) == 1
-    assert aobj.notify(title="Test Title", body="Test Body") is True
+    assert bool(aobj.notify(title="Test Title", body="Test Body")) is True
     assert mock_post.call_count == 1
 
     mock_post.reset_mock()
@@ -957,7 +957,7 @@ def test_plugin_pushplus_apprise_integration(mock_post):
     assert aobj2.add(
         "pushplus://{}/mygroup?format=markdown".format(GOOD_TOKEN)
     )
-    assert aobj2.notify(body="Group message") is True
+    assert bool(aobj2.notify(body="Group message")) is True
     assert mock_post.call_count == 1
     payload = loads(mock_post.call_args[1]["data"])
     # format=markdown must map to the PushPlus "markdown" template
@@ -970,6 +970,6 @@ def test_plugin_pushplus_apprise_integration(mock_post):
     # wecom:// schema alias -- channel=cp in payload
     aobj3 = Apprise()
     assert aobj3.add("wecom://{}".format(GOOD_TOKEN))
-    assert aobj3.notify(body="WeCom message") is True
+    assert bool(aobj3.notify(body="WeCom message")) is True
     payload = loads(mock_post.call_args[1]["data"])
     assert payload["channel"] == PushPlusChannel.WECOM

--- a/tests/test_plugin_pushsafer.py
+++ b/tests/test_plugin_pushsafer.py
@@ -318,11 +318,13 @@ def test_plugin_pushsafer_general(mock_post):
 
     obj = NotifyPushSafer(privatekey=privatekey)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -345,11 +347,13 @@ def test_plugin_pushsafer_general(mock_post):
     # The notify itself will still be successful
     mock_post.reset_mock()
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -364,11 +368,13 @@ def test_plugin_pushsafer_general(mock_post):
     # Invalid file path
     path = os.path.join(TEST_VAR_DIR, "/invalid/path/to/an/invalid/file.jpg")
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=path,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=path,
+            )
         )
         is False
     )

--- a/tests/test_plugin_pushward.py
+++ b/tests/test_plugin_pushward.py
@@ -196,7 +196,7 @@ def test_plugin_pushward_send(mock_post):
 
     obj = Apprise.instantiate("pushward://hlk_abc123")
     assert isinstance(obj, NotifyPushWard)
-    assert obj.notify(title="title", body="body") is True
+    assert bool(obj.notify(title="title", body="body")) is True
 
     assert mock_post.call_count == 1
     details = mock_post.call_args
@@ -227,7 +227,7 @@ def test_plugin_pushward_created(mock_post):
     mock_post.return_value = response
 
     obj = Apprise.instantiate("pushward://hlk_abc123")
-    assert obj.notify(title="title", body="body") is True
+    assert bool(obj.notify(title="title", body="body")) is True
 
 
 @mock.patch("requests.post")
@@ -242,7 +242,7 @@ def test_plugin_pushward_level_override(mock_post):
     obj = Apprise.instantiate("pushward://hlk_abc123?level=passive")
     assert isinstance(obj, NotifyPushWard)
     assert obj.level == "passive"
-    assert obj.notify(title="t", body="b") is True
+    assert bool(obj.notify(title="t", body="b")) is True
 
     payload = loads(mock_post.call_args[1]["data"])
     assert payload["level"] == "passive"
@@ -259,7 +259,8 @@ def test_plugin_pushward_notify_type_mapping(mock_post):
 
     obj = Apprise.instantiate("pushward://hlk_abc123")
     assert (
-        obj.notify(title="t", body="b", notify_type=NotifyType.WARNING) is True
+        bool(obj.notify(title="t", body="b", notify_type=NotifyType.WARNING))
+        is True
     )
 
     payload = loads(mock_post.call_args[1]["data"])
@@ -282,7 +283,7 @@ def test_plugin_pushward_critical_volume(mock_post):
     assert isinstance(obj, NotifyPushWard)
     assert obj.level == "critical"
     assert obj.volume == 0.8
-    assert obj.notify(title="t", body="b") is True
+    assert bool(obj.notify(title="t", body="b")) is True
 
     payload = loads(mock_post.call_args[1]["data"])
     assert payload["level"] == "critical"
@@ -290,7 +291,7 @@ def test_plugin_pushward_critical_volume(mock_post):
 
     # The volume is dropped when the level is not critical
     obj = Apprise.instantiate("pushward://hlk_abc123?level=active&volume=0.5")
-    assert obj.notify(title="t", body="b") is True
+    assert bool(obj.notify(title="t", body="b")) is True
     payload = loads(mock_post.call_args[1]["data"])
     assert "volume" not in payload
 
@@ -306,7 +307,7 @@ def test_plugin_pushward_no_image(mock_post):
 
     asset = AppriseAsset(image_url_mask=None)
     obj = Apprise.instantiate("pushward://hlk_abc123", asset=asset)
-    assert obj.notify(title="t", body="b") is True
+    assert bool(obj.notify(title="t", body="b")) is True
 
     payload = loads(mock_post.call_args[1]["data"])
     assert "icon_url" not in payload
@@ -323,7 +324,7 @@ def test_plugin_pushward_empty_title(mock_post):
 
     # No title provided; falls back to the asset descriptor
     obj = Apprise.instantiate("pushward://hlk_abc123")
-    assert obj.notify(body="body only") is True
+    assert bool(obj.notify(body="body only")) is True
 
     payload = loads(mock_post.call_args[1]["data"])
     assert payload["title"]
@@ -333,7 +334,7 @@ def test_plugin_pushward_empty_title(mock_post):
     # When the descriptor is also empty, fall back to the application id
     asset = AppriseAsset(app_desc="")
     obj = Apprise.instantiate("pushward://hlk_abc123", asset=asset)
-    assert obj.notify(body="body only") is True
+    assert bool(obj.notify(body="body only")) is True
 
     payload = loads(mock_post.call_args[1]["data"])
     assert payload["title"] == obj.app_id
@@ -424,11 +425,15 @@ def test_plugin_pushward_per_type_levels(mock_post):
     # Untouched types keep their defaults
     assert obj.level_map[NotifyType.WARNING] == "time-sensitive"
 
-    assert obj.notify(title="t", body="b", notify_type=NotifyType.INFO) is True
+    assert (
+        bool(obj.notify(title="t", body="b", notify_type=NotifyType.INFO))
+        is True
+    )
     assert loads(mock_post.call_args[1]["data"])["level"] == "passive"
 
     assert (
-        obj.notify(title="t", body="b", notify_type=NotifyType.FAILURE) is True
+        bool(obj.notify(title="t", body="b", notify_type=NotifyType.FAILURE))
+        is True
     )
     assert loads(mock_post.call_args[1]["data"])["level"] == "critical"
 
@@ -436,5 +441,8 @@ def test_plugin_pushward_per_type_levels(mock_post):
     obj = Apprise.instantiate(
         "pushward://hlk_abc123?level=passive&info=critical"
     )
-    assert obj.notify(title="t", body="b", notify_type=NotifyType.INFO) is True
+    assert (
+        bool(obj.notify(title="t", body="b", notify_type=NotifyType.INFO))
+        is True
+    )
     assert loads(mock_post.call_args[1]["data"])["level"] == "passive"

--- a/tests/test_plugin_resend.py
+++ b/tests/test_plugin_resend.py
@@ -270,11 +270,13 @@ def test_plugin_resend_attachments(mock_post, mock_get):
     obj = Apprise.instantiate("resend://abcd:user@example.com")
     assert isinstance(obj, NotifyResend)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -285,11 +287,13 @@ def test_plugin_resend_attachments(mock_post, mock_get):
     # Try again in a use case where we can't access the file
     with mock.patch("os.path.isfile", return_value=False):
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )
@@ -297,11 +301,13 @@ def test_plugin_resend_attachments(mock_post, mock_get):
     # Try again in a use case where we can't access the file
     with mock.patch("builtins.open", side_effect=OSError):
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )

--- a/tests/test_plugin_revolt.py
+++ b/tests/test_plugin_revolt.py
@@ -379,7 +379,9 @@ def test_plugin_revolt_general(mock_sleep, mock_post):
 
     # This call includes an image with it's payload:
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -391,7 +393,9 @@ def test_plugin_revolt_general(mock_sleep, mock_post):
 
     # This call includes an image with it's payload:
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -454,7 +458,9 @@ def test_plugin_revolt_general(mock_sleep, mock_post):
 
     # This call includes an image with it's payload:
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -468,7 +474,7 @@ def test_plugin_revolt_general(mock_sleep, mock_post):
     # Toggle our logo availability
     a.asset.image_url_logo = None
     assert (
-        a.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(a.notify(body="body", title="title", notify_type=NotifyType.INFO))
         is True
     )
 
@@ -555,17 +561,19 @@ def test_plugin_revolt_markdown_extra(mock_post):
 
     # This call includes an image with it's payload:
     assert (
-        a.notify(
-            body=test_markdown,
-            title="title",
-            notify_type=NotifyType.INFO,
-            body_format=NotifyFormat.TEXT,
+        bool(
+            a.notify(
+                body=test_markdown,
+                title="title",
+                notify_type=NotifyType.INFO,
+                body_format=NotifyFormat.TEXT,
+            )
         )
         is True
     )
 
     assert (
-        a.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(a.notify(body="body", title="title", notify_type=NotifyType.INFO))
         is True
     )
 
@@ -593,7 +601,7 @@ def test_plugin_revolt_html_to_markdown_format(mock_post):
         body="<b>hello</b> <i>world</i>",
         body_format=NotifyFormat.HTML,
     )
-    assert result is True
+    assert bool(result) is True
     assert mock_post.call_count == 1
 
     # The body must arrive inside the Markdown embed, not as

--- a/tests/test_plugin_ringcentral.py
+++ b/tests/test_plugin_ringcentral.py
@@ -432,7 +432,7 @@ def test_plugin_ringc_send_success(mock_post):
         token="password",
         targets=["15559998888"],
     )
-    assert obj.notify(body="Test message") is True
+    assert bool(obj.notify(body="Test message")) is True
     assert mock_post.call_count == 2
 
     # Second call reuses cached token (no new auth call)
@@ -440,7 +440,7 @@ def test_plugin_ringc_send_success(mock_post):
     good_sms2.status_code = requests.codes.ok
     good_sms2.content = jdumps(GOOD_RESPONSE).encode()
     mock_post.side_effect = [good_sms2]
-    assert obj.notify(body="Second message") is True
+    assert bool(obj.notify(body="Second message")) is True
     assert mock_post.call_count == 3
 
 
@@ -465,7 +465,7 @@ def test_plugin_ringc_send_multi_target(mock_post):
         token="password",
         targets=["15559998881", "15559998882"],
     )
-    assert obj.notify(body="Multi-target") is True
+    assert bool(obj.notify(body="Multi-target")) is True
     assert mock_post.call_count == 3
 
 
@@ -487,7 +487,7 @@ def test_plugin_ringc_send_loopback(mock_post):
         source=SOURCE,
         token="password",
     )
-    assert obj.notify(body="Loopback") is True
+    assert bool(obj.notify(body="Loopback")) is True
     assert mock_post.call_count == 2
 
 
@@ -505,7 +505,7 @@ def test_plugin_ringc_auth_failure(mock_post):
         source=SOURCE,
         token="password",
     )
-    assert obj.notify(body="Test") is False
+    assert bool(obj.notify(body="Test")) is False
 
 
 @mock.patch("requests.post")
@@ -524,7 +524,7 @@ def test_plugin_ringc_auth_no_access_token(mock_post):
         source=SOURCE,
         token="password",
     )
-    assert obj.notify(body="Test") is False
+    assert bool(obj.notify(body="Test")) is False
 
 
 @mock.patch("requests.post")
@@ -549,7 +549,7 @@ def test_plugin_ringc_send_http_error(mock_post):
         token="password",
         targets=["15559998888"],
     )
-    assert obj.notify(body="Test") is False
+    assert bool(obj.notify(body="Test")) is False
 
 
 @mock.patch("requests.post")
@@ -574,7 +574,7 @@ def test_plugin_ringc_send_unknown_code(mock_post):
         token="password",
         targets=["15559998888"],
     )
-    assert obj.notify(body="Test") is False
+    assert bool(obj.notify(body="Test")) is False
 
 
 @mock.patch("requests.post")
@@ -589,7 +589,7 @@ def test_plugin_ringc_request_exception(mock_post):
         token="password",
         targets=["15559998888"],
     )
-    assert obj.notify(body="Test") is False
+    assert bool(obj.notify(body="Test")) is False
 
 
 @mock.patch("requests.post")
@@ -619,7 +619,7 @@ def test_plugin_ringc_send_partial_failure(mock_post):
         token="password",
         targets=["15559998881", "15559998882"],
     )
-    assert obj.notify(body="Partial") is False
+    assert bool(obj.notify(body="Partial")) is False
 
 
 @mock.patch("requests.post")
@@ -642,7 +642,7 @@ def test_plugin_ringc_jwt_mode(mock_post):
         targets=["15559998888"],
     )
     assert obj.mode == RingCentralAuthMode.JWT
-    assert obj.notify(body="JWT test") is True
+    assert bool(obj.notify(body="JWT test")) is True
 
     # Verify the auth call used the JWT grant type
     auth_call = mock_post.call_args_list[0]
@@ -670,7 +670,7 @@ def test_plugin_ringc_sandbox_environment(mock_post):
         targets=["15559998888"],
     )
     assert obj.environment == RingCentralEnvironment.SANDBOX
-    assert obj.notify(body="Sandbox test") is True
+    assert bool(obj.notify(body="Sandbox test")) is True
 
     # Verify .devtest appears in the URL and /sms is used (no attachments)
     notify_call = mock_post.call_args_list[1]
@@ -699,7 +699,7 @@ def test_plugin_ringc_mms_attachment(mock_post):
         token="password",
         targets=["15559998888"],
     )
-    assert obj.notify(body="MMS test", attach=attach) is True
+    assert bool(obj.notify(body="MMS test", attach=attach)) is True
     assert mock_post.call_count == 2
 
     # Verify the MMS endpoint was used
@@ -713,7 +713,7 @@ def test_plugin_ringc_mms_attachment(mock_post):
         bad_attach = AppriseAttachment(
             os.path.join(TEST_VAR_DIR, "apprise-test.gif")
         )
-        assert obj.notify(body="Bad attach", attach=bad_attach) is False
+        assert bool(obj.notify(body="Bad attach", attach=bad_attach)) is False
 
     # No HTTP calls should have been made (failed at attachment check)
     assert mock_post.call_count == 0
@@ -722,7 +722,7 @@ def test_plugin_ringc_mms_attachment(mock_post):
     mock_post.reset_mock()
 
     with mock.patch("builtins.open", side_effect=OSError("disk error")):
-        assert obj.notify(body="OSError test", attach=attach) is False
+        assert bool(obj.notify(body="OSError test", attach=attach)) is False
 
     assert mock_post.call_count == 0
 
@@ -733,7 +733,7 @@ def test_plugin_ringc_mms_attachment(mock_post):
     bad_mms.content = b"{}"
     mock_post.side_effect = [bad_mms]
 
-    assert obj.notify(body="MMS HTTP fail", attach=attach) is False
+    assert bool(obj.notify(body="MMS HTTP fail", attach=attach)) is False
     assert mock_post.call_count == 1
 
 
@@ -837,7 +837,7 @@ def test_plugin_ringc_logout(mock_post):
         token="password",
         targets=["15559998888"],
     )
-    assert obj.notify(body="Test") is True
+    assert bool(obj.notify(body="Test")) is True
     assert obj._access_token is not None
 
     # Explicit logout (token is still valid, sends revoke)
@@ -892,7 +892,7 @@ def test_plugin_ringc_invalid_json_response(mock_post):
         targets=["15559998888"],
     )
     # Should succeed (status 200 regardless of body parseability)
-    assert obj.notify(body="Test") is True
+    assert bool(obj.notify(body="Test")) is True
 
 
 @mock.patch("requests.post")
@@ -930,4 +930,4 @@ def test_plugin_ringc_apprise_integration(mock_post):
         "c" * 60
     )
     assert a.add(url) is True
-    assert a.notify(body="Apprise integration test") is True
+    assert bool(a.notify(body="Apprise integration test")) is True

--- a/tests/test_plugin_rocket_chat.py
+++ b/tests/test_plugin_rocket_chat.py
@@ -382,7 +382,9 @@ def test_plugin_rocket_chat_edge_cases(mock_post, mock_get):
     # Send Notification
     #
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
     assert obj._send(payload="test", notify_type=NotifyType.INFO) is False
@@ -400,7 +402,9 @@ def test_plugin_rocket_chat_edge_cases(mock_post, mock_get):
     # Send Notification
     #
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
     assert obj._send(payload="test", notify_type=NotifyType.INFO) is False
@@ -425,7 +429,9 @@ def test_plugin_rocket_chat_edge_cases(mock_post, mock_get):
     obj.login = mock.Mock()
     obj.login.return_value = True
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
     #
@@ -450,9 +456,11 @@ def test_plugin_rocket_chat_html_to_markdown_format(mock_post):
     # Notify with an HTML body; the framework should convert it
     # to Markdown before dispatching to RocketChat
     assert (
-        aobj.notify(
-            body="<b>hello</b> <i>world</i>",
-            body_format=NotifyFormat.HTML,
+        bool(
+            aobj.notify(
+                body="<b>hello</b> <i>world</i>",
+                body_format=NotifyFormat.HTML,
+            )
         )
         is True
     )

--- a/tests/test_plugin_rsyslog.py
+++ b/tests/test_plugin_rsyslog.py
@@ -65,14 +65,14 @@ def test_plugin_rsyslog_by_url(mock_getpid, mock_socket):
     assert isinstance(obj, NotifyRSyslog)
     assert obj.url().startswith("rsyslog://localhost") is True
     assert r"logpid=yes" in obj.url()
-    assert obj.notify(body=payload) is True
+    assert bool(obj.notify(body=payload)) is True
 
     mock_connection.sendto.return_value = 18
     obj = apprise.Apprise.instantiate("rsyslog://localhost/?facility=local5")
     assert isinstance(obj, NotifyRSyslog)
     assert obj.url().startswith("rsyslog://localhost/local5") is True
     assert r"logpid=yes" in obj.url()
-    assert obj.notify(body=payload) is True
+    assert bool(obj.notify(body=payload)) is True
 
     # Invalid instantiation
     assert (
@@ -86,11 +86,11 @@ def test_plugin_rsyslog_by_url(mock_getpid, mock_socket):
     assert isinstance(obj, NotifyRSyslog)
     assert obj.url().startswith("rsyslog://localhost/daemon") is True
     assert r"logpid=yes" in obj.url()
-    assert obj.notify(body=payload) is True
+    assert bool(obj.notify(body=payload)) is True
 
     # Test bad return count
     mock_connection.sendto.return_value = 0
-    assert obj.notify(body=payload) is False
+    assert bool(obj.notify(body=payload)) is False
 
     # Test with port
     mock_connection.sendto.return_value = 17
@@ -98,11 +98,13 @@ def test_plugin_rsyslog_by_url(mock_getpid, mock_socket):
     assert isinstance(obj, NotifyRSyslog)
     assert obj.url().startswith("rsyslog://localhost:518") is True
     assert r"logpid=yes" in obj.url()
-    assert obj.notify(body=payload) is True
+    assert bool(obj.notify(body=payload)) is True
 
     # Set length to include title (for test)
     mock_connection.sendto.return_value = 39
-    assert obj.notify(body=payload, title="Testing a title entry") is True
+    assert (
+        bool(obj.notify(body=payload, title="Testing a title entry")) is True
+    )
 
     # Return length back to where it was
     mock_connection.sendto.return_value = 16
@@ -112,14 +114,14 @@ def test_plugin_rsyslog_by_url(mock_getpid, mock_socket):
     assert isinstance(obj, NotifyRSyslog)
     assert obj.url().startswith("rsyslog://localhost") is True
     assert r"logpid=yes" in obj.url()
-    assert obj.notify(body=payload) is True
+    assert bool(obj.notify(body=payload)) is True
 
     # Specify a facility
     obj = apprise.Apprise.instantiate("rsyslog://localhost/kern")
     assert isinstance(obj, NotifyRSyslog)
     assert obj.url().startswith("rsyslog://localhost/kern") is True
     assert r"logpid=yes" in obj.url()
-    assert obj.notify(body=payload) is True
+    assert bool(obj.notify(body=payload)) is True
 
     # Specify a facility requiring a lookup and having the port identified
     # resolves any ambiguity
@@ -128,7 +130,7 @@ def test_plugin_rsyslog_by_url(mock_getpid, mock_socket):
     assert obj.url().startswith("rsyslog://localhost/daemon") is True
     assert r"logpid=yes" in obj.url()
     mock_connection.sendto.return_value = 17  # daemon is one more byte in size
-    assert obj.notify(body=payload) is True
+    assert bool(obj.notify(body=payload)) is True
 
     obj = apprise.Apprise.instantiate("rsyslog://localhost:9000/d?logpid=no")
     assert isinstance(obj, NotifyRSyslog)
@@ -144,18 +146,18 @@ def test_plugin_rsyslog_by_url(mock_getpid, mock_socket):
     mock_connection.sendto.return_value = (
         len(payload) + 5 + len(str(mock_getpid.return_value))
     )
-    assert obj.notify(body=payload) is True
+    assert bool(obj.notify(body=payload)) is True
     # This only fails because the underlining sendto() will return a
     # length different then what was expected
-    assert obj.notify(body="a different payload size") is False
+    assert bool(obj.notify(body="a different payload size")) is False
 
     # Test timeouts and errors that can occur
     mock_connection.sendto.return_value = None
     mock_connection.sendto.side_effect = socket.gaierror
-    assert obj.notify(body=payload) is False
+    assert bool(obj.notify(body=payload)) is False
 
     mock_connection.sendto.side_effect = socket.timeout
-    assert obj.notify(body=payload) is False
+    assert bool(obj.notify(body=payload)) is False
 
 
 def test_plugin_rsyslog_edge_cases():

--- a/tests/test_plugin_sendgrid.py
+++ b/tests/test_plugin_sendgrid.py
@@ -244,11 +244,13 @@ def test_plugin_sendgrid_attachments(mock_post, mock_get):
     obj = Apprise.instantiate("sendgrid://abcd:user@example.com")
     assert isinstance(obj, NotifySendGrid)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -259,11 +261,13 @@ def test_plugin_sendgrid_attachments(mock_post, mock_get):
     # Try again in a use case where we can't access the file
     with mock.patch("os.path.isfile", return_value=False):
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )
@@ -271,11 +275,13 @@ def test_plugin_sendgrid_attachments(mock_post, mock_get):
     # Try again in a use case where we can't access the file
     with mock.patch("builtins.open", side_effect=OSError):
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )

--- a/tests/test_plugin_sendpulse.py
+++ b/tests/test_plugin_sendpulse.py
@@ -385,7 +385,9 @@ def test_plugin_sendpulse_edge_cases(mock_post):
     )
 
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -426,7 +428,9 @@ def test_plugin_sendpulse_edge_cases(mock_post):
     obj = Apprise.instantiate("sendpulse://user@example.com/ci/cs/?from=John")
 
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -466,7 +470,9 @@ def test_plugin_sendpulse_edge_cases(mock_post):
 
     # Second call no longer needs to authenticate
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -480,7 +486,9 @@ def test_plugin_sendpulse_edge_cases(mock_post):
     # force an exception
     mock_post.side_effect = requests.RequestException
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
 
@@ -488,7 +496,9 @@ def test_plugin_sendpulse_edge_cases(mock_post):
     mock_post.side_effect = None
     request.status_code = 403
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
 
@@ -523,7 +533,9 @@ def test_plugin_sendpulse_edge_cases(mock_post):
     mock_post.return_value = sendpulse()
 
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -590,7 +602,9 @@ def test_plugin_sendpulse_edge_cases(mock_post):
     mock_post.return_value = sendpulse()
 
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
 
@@ -645,7 +659,11 @@ def test_plugin_sendpulse_edge_cases(mock_post):
         # Instantiate our object
         obj = Apprise.instantiate("sendpulse://user@example.com/ci/cs/")
         assert (
-            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+            bool(
+                obj.notify(
+                    body="body", title="title", notify_type=NotifyType.INFO
+                )
+            )
             is True
         )
 
@@ -721,11 +739,13 @@ def test_plugin_sendpulse_attachments(mock_post):
     obj = Apprise.instantiate("sendpulse://user@example.com/aaaa/bbbb")
     assert isinstance(obj, NotifySendPulse)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -735,11 +755,13 @@ def test_plugin_sendpulse_attachments(mock_post):
     # Try again in a use case where we can't access the file
     with mock.patch("os.path.isfile", return_value=False):
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )
@@ -747,11 +769,13 @@ def test_plugin_sendpulse_attachments(mock_post):
     # Try again in a use case where we can't access the file
     with mock.patch("builtins.open", side_effect=OSError):
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )

--- a/tests/test_plugin_serwersms.py
+++ b/tests/test_plugin_serwersms.py
@@ -689,7 +689,7 @@ def test_plugin_serwersms_mms_phone_success(mock_post):
     attach = AppriseAttachment.instantiate(
         os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     )
-    assert obj.notify(body="MMS test", attach=attach) is True
+    assert bool(obj.notify(body="MMS test", attach=attach)) is True
     assert mock_post.call_count == 1
 
     # Confirm multipart files kwarg was set (MMS endpoint used)
@@ -727,7 +727,7 @@ def test_plugin_serwersms_mms_group_success(mock_post):
     attach = AppriseAttachment.instantiate(
         os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     )
-    assert obj.notify(body="Group MMS", attach=attach) is True
+    assert bool(obj.notify(body="Group MMS", attach=attach)) is True
     assert mock_post.call_count == 1
 
     # Confirm group_id was sent as a form field
@@ -757,7 +757,7 @@ def test_plugin_serwersms_mms_guard1_inaccessible(mock_post):
 
     # Simulate file being inaccessible (bool(attachment) -> False)
     with mock.patch("os.path.isfile", return_value=False):
-        assert obj.notify(body="Test", attach=attach) is False
+        assert bool(obj.notify(body="Test", attach=attach)) is False
 
     # No HTTP call should have been made
     assert mock_post.call_count == 0
@@ -783,7 +783,7 @@ def test_plugin_serwersms_mms_guard2_oserror(mock_post):
     )
 
     with mock.patch("builtins.open", side_effect=OSError("IO fail")):
-        assert obj.notify(body="Test", attach=attach) is False
+        assert bool(obj.notify(body="Test", attach=attach)) is False
 
     # No HTTP call should have been made
     assert mock_post.call_count == 0
@@ -807,7 +807,7 @@ def test_plugin_serwersms_mms_http_error(mock_post):
     attach = AppriseAttachment.instantiate(
         os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     )
-    assert obj.notify(body="Test", attach=attach) is False
+    assert bool(obj.notify(body="Test", attach=attach)) is False
     assert mock_post.call_count == 1
 
 
@@ -831,7 +831,7 @@ def test_plugin_serwersms_mms_api_failure_with_error(mock_post):
     attach = AppriseAttachment.instantiate(
         os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     )
-    assert obj.notify(body="Test", attach=attach) is False
+    assert bool(obj.notify(body="Test", attach=attach)) is False
 
 
 @mock.patch("requests.post")
@@ -852,7 +852,7 @@ def test_plugin_serwersms_mms_api_failure_no_error(mock_post):
     attach = AppriseAttachment.instantiate(
         os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     )
-    assert obj.notify(body="Test", attach=attach) is False
+    assert bool(obj.notify(body="Test", attach=attach)) is False
 
 
 @mock.patch("requests.post")
@@ -874,7 +874,7 @@ def test_plugin_serwersms_mms_bad_json(mock_post):
         os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     )
     # Bad JSON -> content = {} -> success absent -> False
-    assert obj.notify(body="Test", attach=attach) is False
+    assert bool(obj.notify(body="Test", attach=attach)) is False
 
 
 @mock.patch("requests.post")
@@ -896,7 +896,7 @@ def test_plugin_serwersms_mms_null_json(mock_post):
     attach = AppriseAttachment.instantiate(
         os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     )
-    assert obj.notify(body="Test", attach=attach) is False
+    assert bool(obj.notify(body="Test", attach=attach)) is False
 
 
 @mock.patch("requests.post")
@@ -915,4 +915,4 @@ def test_plugin_serwersms_mms_request_exception(mock_post):
     attach = AppriseAttachment.instantiate(
         os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     )
-    assert obj.notify(body="Test", attach=attach) is False
+    assert bool(obj.notify(body="Test", attach=attach)) is False

--- a/tests/test_plugin_ses.py
+++ b/tests/test_plugin_ses.py
@@ -350,7 +350,7 @@ def test_plugin_ses_edge_cases(mock_post):
     )
 
     # The object initializes properly but would not be able to send anything
-    assert obj.notify(body="test", title="test") is False
+    assert bool(obj.notify(body="test", title="test")) is False
 
     # The phone number is invalid, and without it, there is nothing
     # to notify; we
@@ -363,7 +363,7 @@ def test_plugin_ses_edge_cases(mock_post):
     )
 
     # The object initializes properly but would not be able to send anything
-    assert obj.notify(body="test", title="test") is False
+    assert bool(obj.notify(body="test", title="test")) is False
 
 
 def test_plugin_ses_url_parsing():
@@ -499,7 +499,7 @@ def test_plugin_ses_attachments(mock_post):
     )
 
     # Send a good attachment
-    assert obj.notify(body="test", attach=attach) is True
+    assert bool(obj.notify(body="test", attach=attach)) is True
 
     # Reset our mock object
     mock_post.reset_mock()
@@ -509,7 +509,7 @@ def test_plugin_ses_attachments(mock_post):
     attach.add(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
 
     # Send our attachments
-    assert obj.notify(body="test", attach=attach) is True
+    assert bool(obj.notify(body="test", attach=attach)) is True
 
     # Test our call count
     assert mock_post.call_count == 1
@@ -520,7 +520,7 @@ def test_plugin_ses_attachments(mock_post):
     # An invalid attachment will cause a failure
     path = os.path.join(TEST_VAR_DIR, "/invalid/path/to/an/invalid/file.jpg")
     attach = AppriseAttachment(path)
-    assert obj.notify(body="test", attach=attach) is False
+    assert bool(obj.notify(body="test", attach=attach)) is False
 
 
 @mock.patch("requests.post")
@@ -544,7 +544,7 @@ def test_plugin_ses_session_token(mock_post):
     assert obj.aws_session_token == TEST_SESSION_TOKEN
 
     # send() must include X-Amz-Security-Token in request headers
-    assert obj.notify(body="test") is True
+    assert bool(obj.notify(body="test")) is True
     call_kwargs = mock_post.call_args[1]
     assert "X-Amz-Security-Token" in call_kwargs["headers"]
     assert call_kwargs["headers"]["X-Amz-Security-Token"] == TEST_SESSION_TOKEN
@@ -581,7 +581,7 @@ def test_plugin_ses_session_token(mock_post):
         targets=["recipient@example.com"],
     )
     assert obj_plain.aws_session_token is None
-    assert obj_plain.notify(body="test") is True
+    assert bool(obj_plain.notify(body="test")) is True
     call_kwargs = mock_post.call_args[1]
     assert "X-Amz-Security-Token" not in call_kwargs["headers"]
 

--- a/tests/test_plugin_signal.py
+++ b/tests/test_plugin_signal.py
@@ -436,11 +436,13 @@ def test_notify_signal_plugin_attachments(request_mock):
     path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     attach = AppriseAttachment(path)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -448,11 +450,13 @@ def test_notify_signal_plugin_attachments(request_mock):
     # Test invalid attachment
     path = os.path.join(TEST_VAR_DIR, "/invalid/path/to/an/invalid/file.jpg")
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=path,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=path,
+            )
         )
         is False
     )
@@ -469,11 +473,13 @@ def test_notify_signal_plugin_attachments(request_mock):
     with mock.patch("builtins.open", side_effect=OSError()):
         # We can't send the message we can't open the attachment for reading
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )
@@ -488,11 +494,13 @@ def test_notify_signal_plugin_attachments(request_mock):
     # Now send an attachment normally without issues
     request_mock.reset_mock()
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -535,7 +543,9 @@ def test_plugin_signal_text_mode_markdown_from_library(request_mock):
         format=NotifyFormat.MARKDOWN,
     )
 
-    assert obj.notify(title="Title", body="Body **bold** _italic_") is True
+    assert (
+        bool(obj.notify(title="Title", body="Body **bold** _italic_")) is True
+    )
 
     assert request_mock.call_count == 1
     details = request_mock.call_args_list[0]

--- a/tests/test_plugin_simplepush.py
+++ b/tests/test_plugin_simplepush.py
@@ -195,4 +195,4 @@ def test_plugin_simplepush_general(mock_post):
     obj = Apprise.instantiate("spush://{}".format("Y" * 14))
 
     # Verify our content works as expected
-    assert obj.notify(title="test", body="test") is True
+    assert bool(obj.notify(title="test", body="test")) is True

--- a/tests/test_plugin_sinch.py
+++ b/tests/test_plugin_sinch.py
@@ -231,4 +231,4 @@ def test_plugin_sinch_edge_cases(mock_post):
     )
 
     # We will fail with the above error code
-    assert obj.notify("title", "body", "info") is False
+    assert bool(obj.notify("title", "body", "info")) is False

--- a/tests/test_plugin_slack.py
+++ b/tests/test_plugin_slack.py
@@ -656,11 +656,13 @@ def test_plugin_slack_oauth_access_token(mock_request):
     path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     attach = AppriseAttachment(path)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -694,11 +696,13 @@ def test_plugin_slack_oauth_access_token(mock_request):
         requests.ConnectionError(0, "requests.ConnectionError() not handled"),
     )
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -707,11 +711,13 @@ def test_plugin_slack_oauth_access_token(mock_request):
     mock_request.return_value = None
     mock_request.side_effect = (request, OSError(0, "OSError"))
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -723,11 +729,13 @@ def test_plugin_slack_oauth_access_token(mock_request):
     # Test invalid attachment
     path = os.path.join(TEST_VAR_DIR, "/invalid/path/to/an/invalid/file.jpg")
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=path,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=path,
+            )
         )
         is False
     )
@@ -751,11 +759,13 @@ def test_plugin_slack_oauth_access_token(mock_request):
     attach = AppriseAttachment(path)
     # We'll fail because of the bad 'file' response
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -812,7 +822,9 @@ def test_plugin_slack_webhook_mode(mock_request):
 
     # This call includes an image with it's payload:
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -833,7 +845,9 @@ def test_plugin_slack_webhook_mode(mock_request):
 
     # This call includes an image with it's payload:
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -856,7 +870,7 @@ def test_plugin_slack_username_payload_by_mode(mock_request):
     # Webhook mode without botname should not force username,
     # allowing Slack's configured webhook identity to be used.
     obj = NotifySlack(token_a=token_a, token_b=token_b, token_c=token_c)
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
     payload = loads(mock_request.call_args.kwargs["data"])
     assert "username" not in payload
 
@@ -868,7 +882,7 @@ def test_plugin_slack_username_payload_by_mode(mock_request):
         token_c=token_c,
         user="CustomWebhookName",
     )
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
     payload = loads(mock_request.call_args.kwargs["data"])
     assert payload.get("username") == "CustomWebhookName"
 
@@ -877,7 +891,7 @@ def test_plugin_slack_username_payload_by_mode(mock_request):
     mock_request.reset_mock()
     response.content = dumps({"ok": True, "channel": "C123456"})
     obj = NotifySlack(access_token="xoxb-1234-1234-abc124", targets="#test")
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
     payload = loads(mock_request.call_args.kwargs["data"])
     assert "username" not in payload
 
@@ -891,7 +905,7 @@ def test_plugin_slack_username_payload_by_mode(mock_request):
         token_c=token_c,
         mode=SlackMode.WEBHOOK_GOV,
     )
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
     payload = loads(mock_request.call_args.kwargs["data"])
     assert "username" not in payload
 
@@ -905,7 +919,7 @@ def test_plugin_slack_username_payload_by_mode(mock_request):
         token_c=token_c,
         use_blocks=True,
     )
-    assert obj.notify(body="body", title="title") is True
+    assert bool(obj.notify(body="body", title="title")) is True
     payload = loads(mock_request.call_args.kwargs["data"])
     assert "username" not in payload
 
@@ -939,7 +953,9 @@ def test_plugin_slack_send_by_email(mock_get, mock_request):
 
     # Send our notification
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -967,7 +983,9 @@ def test_plugin_slack_send_by_email(mock_get, mock_request):
     # Send our notification again (cached copy of user id associated with
     # email is used)
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -1008,7 +1026,9 @@ def test_plugin_slack_send_by_email(mock_get, mock_request):
     # Send our notification; it will fail because we failed to look up
     # the user id
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
 
@@ -1046,7 +1066,9 @@ def test_plugin_slack_send_by_email(mock_get, mock_request):
     # Send our notification; it will fail because we failed to look up
     # the user id
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
 
@@ -1084,7 +1106,9 @@ def test_plugin_slack_send_by_email(mock_get, mock_request):
     # Send our notification; it will fail because we failed to look up
     # the user id
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
 
@@ -1129,7 +1153,9 @@ def test_plugin_slack_send_by_email(mock_get, mock_request):
     # Send our notification; it will fail because we failed to look up
     # the user id
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
 
@@ -1233,7 +1259,9 @@ def test_plugin_slack_single_thread_reply(mock_request):
 
     # Send our notification
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -1277,7 +1305,9 @@ def test_plugin_slack_multiple_thread_reply(mock_request):
 
     # Send our notification
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -1351,11 +1381,13 @@ def test_plugin_slack_file_upload_success(mock_request):
 
     obj = NotifySlack(access_token=token, targets=["#general"])
     assert (
-        obj.notify(
-            body="Success path test",
-            title="Slack Upload OK",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="Success path test",
+                title="Slack Upload OK",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -1483,7 +1515,7 @@ def test_plugin_slack_attach_memory(mock_request):
         mimetype="text/html",
     )
 
-    assert obj.notify(body="Test", attach=mem) is True
+    assert bool(obj.notify(body="Test", attach=mem)) is True
     assert mock_request.call_count >= 1
 
 
@@ -1538,7 +1570,11 @@ def test_plugin_slack_template_blocks(mock_request, tmpdir):
 
     # Notification should succeed
     assert (
-        obj.notify(body="hello", title="world", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(
+                body="hello", title="world", notify_type=NotifyType.INFO
+            )
+        )
         is True
     )
     assert mock_request.called is True
@@ -1592,7 +1628,9 @@ def test_plugin_slack_template_blocks_implied(mock_request, tmpdir):
     # use_blocks must have been forced on by the template
     assert obj.use_blocks is True
     assert (
-        obj.notify(body="implied", title="t", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="implied", title="t", notify_type=NotifyType.INFO)
+        )
         is True
     )
     assert mock_request.called is True
@@ -1711,7 +1749,8 @@ def test_plugin_slack_template_invalid_json(mock_request, tmpdir):
 
     # Notification must fail due to bad JSON
     assert (
-        obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+        bool(obj.notify(body="x", title="y", notify_type=NotifyType.INFO))
+        is False
     )
     # No HTTP call should have been made
     assert mock_request.called is False
@@ -1734,7 +1773,8 @@ def test_plugin_slack_template_blocks_not_list(mock_request, tmpdir):
     )
     assert isinstance(obj, NotifySlack)
     assert (
-        obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+        bool(obj.notify(body="x", title="y", notify_type=NotifyType.INFO))
+        is False
     )
     assert mock_request.called is False
 
@@ -1746,7 +1786,8 @@ def test_plugin_slack_template_blocks_not_list(mock_request, tmpdir):
     )
     assert isinstance(obj2, NotifySlack)
     assert (
-        obj2.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+        bool(obj2.notify(body="x", title="y", notify_type=NotifyType.INFO))
+        is False
     )
     assert mock_request.called is False
 
@@ -1768,7 +1809,8 @@ def test_plugin_slack_template_block_missing_type(mock_request, tmpdir):
     )
     assert isinstance(obj, NotifySlack)
     assert (
-        obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+        bool(obj.notify(body="x", title="y", notify_type=NotifyType.INFO))
+        is False
     )
     assert mock_request.called is False
 
@@ -1793,7 +1835,7 @@ def test_plugin_slack_template_load_error(mock_request, tmpdir):
     with mock.patch("builtins.open", side_effect=OSError):
         # Notification must fail because the file cannot be read
         assert (
-            obj.notify(body="x", title="y", notify_type=NotifyType.INFO)
+            bool(obj.notify(body="x", title="y", notify_type=NotifyType.INFO))
             is False
         )
     assert mock_request.called is False
@@ -1879,7 +1921,8 @@ def test_plugin_slack_template_inaccessible(mock_request, tmpdir):
 
     # Template attachment resolves to falsy because the file is missing
     assert (
-        obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+        bool(obj.notify(body="x", title="y", notify_type=NotifyType.INFO))
+        is False
     )
     assert mock_request.called is False
 
@@ -1918,7 +1961,8 @@ def test_plugin_slack_template_content_not_dict(mock_request, tmpdir):
     )
     assert isinstance(obj, NotifySlack)
     assert (
-        obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+        bool(obj.notify(body="x", title="y", notify_type=NotifyType.INFO))
+        is False
     )
     assert mock_request.called is False
 
@@ -1940,7 +1984,8 @@ def test_plugin_slack_template_block_not_dict(mock_request, tmpdir):
     )
     assert isinstance(obj, NotifySlack)
     assert (
-        obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+        bool(obj.notify(body="x", title="y", notify_type=NotifyType.INFO))
+        is False
     )
     assert mock_request.called is False
 
@@ -1969,7 +2014,7 @@ def test_plugin_slack_template_none_token_value(mock_request, tmpdir):
     assert isinstance(obj, NotifySlack)
     # Must succeed -- None coerced to "" keeps the JSON valid
     assert (
-        obj.notify(body="hello", title="t", notify_type=NotifyType.INFO)
+        bool(obj.notify(body="hello", title="t", notify_type=NotifyType.INFO))
         is True
     )
     assert mock_request.called is True
@@ -2002,7 +2047,11 @@ def test_plugin_slack_workflow_default_payload(mock_request):
 
     # Notification with title
     assert (
-        obj.notify(body="hello", title="Alert", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(
+                body="hello", title="Alert", notify_type=NotifyType.INFO
+            )
+        )
         is True
     )
     assert mock_request.called is True
@@ -2018,7 +2067,9 @@ def test_plugin_slack_workflow_default_payload(mock_request):
 
     # Notification without title -- body only
     assert (
-        obj.notify(body="body only", title="", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body only", title="", notify_type=NotifyType.INFO)
+        )
         is True
     )
     posted = loads(mock_request.call_args_list[0][1]["data"])
@@ -2040,7 +2091,10 @@ def test_plugin_slack_workflow_trigger_mode(mock_request):
     assert obj.mode == "trigger"
     assert obj.workflow_path == ["T1JJ3T3L2", "XXXXXXXX", "YYYYYYYY"]
 
-    assert obj.notify(body="hi", title="", notify_type=NotifyType.INFO) is True
+    assert (
+        bool(obj.notify(body="hi", title="", notify_type=NotifyType.INFO))
+        is True
+    )
     call_url = mock_request.call_args_list[0][0][1]
     assert "hooks.slack.com/triggers/" in call_url
     assert "T1JJ3T3L2/XXXXXXXX/YYYYYYYY" in call_url
@@ -2067,7 +2121,7 @@ def test_plugin_slack_workflow_native_url(mock_request):
         "YYYYYYYY",
     ]
     assert (
-        obj.notify(body="native", title="", notify_type=NotifyType.INFO)
+        bool(obj.notify(body="native", title="", notify_type=NotifyType.INFO))
         is True
     )
     call_url = mock_request.call_args_list[0][0][1]
@@ -2082,7 +2136,9 @@ def test_plugin_slack_workflow_native_url(mock_request):
     assert isinstance(obj2, NotifySlack)
     assert obj2.mode == "trigger"
     assert (
-        obj2.notify(body="trigger", title="", notify_type=NotifyType.INFO)
+        bool(
+            obj2.notify(body="trigger", title="", notify_type=NotifyType.INFO)
+        )
         is True
     )
     call_url2 = mock_request.call_args_list[0][0][1]
@@ -2190,7 +2246,7 @@ def test_plugin_slack_workflow_template(mock_request, tmpdir):
     assert isinstance(obj, NotifySlack)
     assert obj.mode == "workflow"
     assert (
-        obj.notify(body="wf-tmpl", title="", notify_type=NotifyType.INFO)
+        bool(obj.notify(body="wf-tmpl", title="", notify_type=NotifyType.INFO))
         is True
     )
     assert mock_request.called is True
@@ -2210,7 +2266,8 @@ def test_plugin_slack_workflow_template(mock_request, tmpdir):
     )
     assert isinstance(obj2, NotifySlack)
     assert (
-        obj2.notify(body="x", title="", notify_type=NotifyType.INFO) is False
+        bool(obj2.notify(body="x", title="", notify_type=NotifyType.INFO))
+        is False
     )
     assert mock_request.call_count == 1  # no new request made
 
@@ -2236,9 +2293,11 @@ def test_plugin_slack_html_to_markdown_format(mock_request):
     # Notify with an HTML body; the framework should convert it
     # to Markdown before dispatching to Slack
     assert (
-        aobj.notify(
-            body="<b>hello</b> <i>world</i>",
-            body_format=NotifyFormat.HTML,
+        bool(
+            aobj.notify(
+                body="<b>hello</b> <i>world</i>",
+                body_format=NotifyFormat.HTML,
+            )
         )
         is True
     )
@@ -2253,9 +2312,11 @@ def test_plugin_slack_html_to_markdown_format(mock_request):
 
     # Convert CommonMark links to Slack's ``<url|text>`` syntax.
     assert (
-        aobj.notify(
-            body='<a href="https://example.com/x">click here</a>',
-            body_format=NotifyFormat.HTML,
+        bool(
+            aobj.notify(
+                body='<a href="https://example.com/x">click here</a>',
+                body_format=NotifyFormat.HTML,
+            )
         )
         is True
     )
@@ -2270,9 +2331,11 @@ def test_plugin_slack_html_to_markdown_format(mock_request):
     # '&'/'<'/'>' need Slack's HTML-entity escaping, not CommonMark's backslash
     # escaping (which Slack doesn't support for these and would otherwise.
     assert (
-        aobj.notify(
-            body="<p>2 &lt; 3 &amp; 4</p>",
-            body_format=NotifyFormat.HTML,
+        bool(
+            aobj.notify(
+                body="<p>2 &lt; 3 &amp; 4</p>",
+                body_format=NotifyFormat.HTML,
+            )
         )
         is True
     )
@@ -2282,7 +2345,9 @@ def test_plugin_slack_html_to_markdown_format(mock_request):
     mock_request.reset_mock()
 
     # Direct Slack mrkdwn input remains unchanged.
-    assert aobj.notify(body="**already** slack-bound markdown #tag") is True
+    assert (
+        bool(aobj.notify(body="**already** slack-bound markdown #tag")) is True
+    )
     payload = loads(mock_request.call_args_list[0][1]["data"])
     assert (
         payload["attachments"][0]["text"]
@@ -2302,9 +2367,12 @@ def test_plugin_slack_html_to_markdown_hardening(mock_request):
     mock_request.return_value.text = "ok"
 
     def notify(body):
+        """Send one HTML body through the configured Slack plugin."""
         aobj = Apprise()
         assert aobj.add("slack://{}/#general".format(slack_token))
-        assert aobj.notify(body=body, body_format=NotifyFormat.HTML) is True
+        assert (
+            bool(aobj.notify(body=body, body_format=NotifyFormat.HTML)) is True
+        )
         payload = loads(mock_request.call_args_list[-1][1]["data"])
         mock_request.reset_mock()
         return payload["attachments"][0]["text"]
@@ -2363,9 +2431,11 @@ def test_plugin_slack_html_to_markdown_hardening(mock_request):
     aobj = Apprise()
     assert aobj.add("slack://{}/#general?overflow=split".format(slack_token))
     assert (
-        aobj.notify(
-            body="<b>" + ("x" * 39990) + "</b>",
-            body_format=NotifyFormat.HTML,
+        bool(
+            aobj.notify(
+                body="<b>" + ("x" * 39990) + "</b>",
+                body_format=NotifyFormat.HTML,
+            )
         )
         is True
     )

--- a/tests/test_plugin_smpp.py
+++ b/tests/test_plugin_smpp.py
@@ -190,7 +190,11 @@ def test_plugin_smpp_edge_case():
 
         # Well fail to establish a connection
         assert (
-            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+            bool(
+                obj.notify(
+                    body="body", title="title", notify_type=NotifyType.INFO
+                )
+            )
             is False
         )
 
@@ -203,6 +207,10 @@ def test_plugin_smpp_edge_case():
 
         # Well fail to deliver our message
         assert (
-            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+            bool(
+                obj.notify(
+                    body="body", title="title", notify_type=NotifyType.INFO
+                )
+            )
             is False
         )

--- a/tests/test_plugin_sms_manager.py
+++ b/tests/test_plugin_sms_manager.py
@@ -164,7 +164,9 @@ def test_plugin_smsmgr_edge_cases(mock_get):
     )
 
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -210,7 +212,9 @@ def test_plugin_smsmgr_edge_cases(mock_get):
     assert len(obj) == 1
 
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 

--- a/tests/test_plugin_smsc.py
+++ b/tests/test_plugin_smsc.py
@@ -253,7 +253,7 @@ def test_plugin_smsc_send_sms(mock_post):
     mock_post.return_value = _mk_resp({"id": "1234", "cnt": 1})
 
     obj = NotifySMSC(user=LOGIN, password=PASSWORD, targets=["+71234567890"])
-    assert obj.notify(body="Hello") is True
+    assert bool(obj.notify(body="Hello")) is True
     assert mock_post.call_count == 1
 
     # Verify POST went to the SMSC endpoint
@@ -273,25 +273,25 @@ def test_plugin_smsc_send_sms(mock_post):
     mock_post.return_value = _mk_resp(
         {"error": "Invalid login", "error_code": 2}
     )
-    assert obj.notify(body="Hello") is False
+    assert bool(obj.notify(body="Hello")) is False
 
     mock_post.reset_mock()
 
     # HTTP error status
     mock_post.return_value = _mk_resp({}, code=requests.codes.bad_request)
-    assert obj.notify(body="Hello") is False
+    assert bool(obj.notify(body="Hello")) is False
 
     mock_post.reset_mock()
 
     # Unknown HTTP status
     mock_post.return_value = _mk_resp({}, code=999)
-    assert obj.notify(body="Hello") is False
+    assert bool(obj.notify(body="Hello")) is False
 
     mock_post.reset_mock()
 
     # RequestException
     mock_post.side_effect = requests.RequestException("bang")
-    assert obj.notify(body="Hello") is False
+    assert bool(obj.notify(body="Hello")) is False
 
     mock_post.reset_mock()
     mock_post.side_effect = None
@@ -302,7 +302,7 @@ def test_plugin_smsc_send_sms(mock_post):
     r.status_code = requests.codes.ok
     r.content = b"OK"
     mock_post.return_value = r
-    assert obj.notify(body="Hello") is True
+    assert bool(obj.notify(body="Hello")) is True
 
 
 @mock.patch("requests.post")
@@ -315,7 +315,7 @@ def test_plugin_smsc_no_targets(mock_post):
         targets=["notaphone"],
     )
     # notify() must return False without calling the API
-    assert obj.notify(body="Hello") is False
+    assert bool(obj.notify(body="Hello")) is False
     assert mock_post.call_count == 0
 
 
@@ -338,7 +338,7 @@ def test_plugin_smsc_sender_translit(mock_post):
         sender="MyBiz",
         translit=True,
     )
-    assert obj.notify(body="Привет") is True
+    assert bool(obj.notify(body="Привет")) is True
 
     payload = mock_post.call_args[1]["data"]
     assert payload.get("sender") == "MyBiz"
@@ -360,7 +360,7 @@ def test_plugin_smsc_send_mms_success(mock_post):
     obj = NotifySMSC(user=LOGIN, password=PASSWORD, targets=["+71234567890"])
 
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
-    assert obj.notify(body="Image", attach=attach) is True
+    assert bool(obj.notify(body="Image", attach=attach)) is True
     assert mock_post.call_count == 1
 
     # Confirm MMS flag is set in the payload
@@ -392,7 +392,7 @@ def test_plugin_smsc_mms_multi_attach(mock_post):
             os.path.join(TEST_VAR_DIR, "apprise-test.gif"),
         ]
     )
-    assert obj.notify(body="Two files", attach=attach) is True
+    assert bool(obj.notify(body="Two files", attach=attach)) is True
 
     files_arg = mock_post.call_args[1]["files"]
     assert len(files_arg) == 2
@@ -407,7 +407,7 @@ def test_plugin_smsc_mms_inaccessible(mock_post):
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
 
     with mock.patch("os.path.isfile", return_value=False):
-        assert obj.notify(body="Image", attach=attach) is False
+        assert bool(obj.notify(body="Image", attach=attach)) is False
 
     # The HTTP client must not have been called
     assert mock_post.call_count == 0
@@ -422,7 +422,7 @@ def test_plugin_smsc_mms_oserror(mock_post):
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
 
     with mock.patch("builtins.open", side_effect=OSError("disk error")):
-        assert obj.notify(body="Image", attach=attach) is False
+        assert bool(obj.notify(body="Image", attach=attach)) is False
 
     assert mock_post.call_count == 0
 
@@ -439,7 +439,7 @@ def test_plugin_smsc_mms_http_error(mock_post):
     obj = NotifySMSC(user=LOGIN, password=PASSWORD, targets=["+71234567890"])
 
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
-    assert obj.notify(body="Image", attach=attach) is False
+    assert bool(obj.notify(body="Image", attach=attach)) is False
 
 
 @mock.patch("requests.post")
@@ -456,7 +456,7 @@ def test_plugin_smsc_mms_api_error(mock_post):
     obj = NotifySMSC(user=LOGIN, password=PASSWORD, targets=["+71234567890"])
 
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
-    assert obj.notify(body="Image", attach=attach) is False
+    assert bool(obj.notify(body="Image", attach=attach)) is False
 
 
 @mock.patch("requests.post")
@@ -468,14 +468,14 @@ def test_plugin_smsc_mms_request_exception(mock_post):
     obj = NotifySMSC(user=LOGIN, password=PASSWORD, targets=["+71234567890"])
 
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
-    assert obj.notify(body="Image", attach=attach) is False
+    assert bool(obj.notify(body="Image", attach=attach)) is False
 
 
 @mock.patch("requests.post")
 def test_plugin_smsc_mms_non_json(mock_post):
     """NotifySMSC() MMS succeeds with non-JSON response body on HTTP 200."""
 
-    # The loads() exception handler branch (lines 449-450) fires here
+    # A non-JSON success body exercises the response parsing fallback.
     r = mock.Mock()
     r.status_code = requests.codes.ok
     r.content = b"OK"
@@ -484,7 +484,7 @@ def test_plugin_smsc_mms_non_json(mock_post):
     obj = NotifySMSC(user=LOGIN, password=PASSWORD, targets=["+71234567890"])
 
     attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.png"))
-    assert obj.notify(body="Image", attach=attach) is True
+    assert bool(obj.notify(body="Image", attach=attach)) is True
 
 
 @mock.patch("requests.post")

--- a/tests/test_plugin_smseagle.py
+++ b/tests/test_plugin_smseagle.py
@@ -640,7 +640,7 @@ def test_notify_smseagle_plugin_result_list(mock_post):
     assert isinstance(obj, NotifySMSEagle)
 
     # We should successfully handle the list
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
 
     # However if one of the elements in the list is bad
     okay_response.content = dumps(
@@ -656,7 +656,7 @@ def test_notify_smseagle_plugin_result_list(mock_post):
     mock_post.return_value = okay_response
 
     # We should now fail
-    assert obj.notify("test") is False
+    assert bool(obj.notify("test")) is False
 
 
 @mock.patch("requests.post")
@@ -680,11 +680,13 @@ def test_notify_smseagle_plugin_attachments(mock_post):
     path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     attach = AppriseAttachment(path)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -692,11 +694,13 @@ def test_notify_smseagle_plugin_attachments(mock_post):
     # Test invalid attachment
     path = os.path.join(TEST_VAR_DIR, "/invalid/path/to/an/invalid/file.jpg")
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=path,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=path,
+            )
         )
         is False
     )
@@ -714,11 +718,13 @@ def test_notify_smseagle_plugin_attachments(mock_post):
     with mock.patch("builtins.open", side_effect=OSError()):
         # We can't send the message we can't open the attachment for reading
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )
@@ -733,11 +739,13 @@ def test_notify_smseagle_plugin_attachments(mock_post):
     # Now send an attachment normally without issues
     mock_post.reset_mock()
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -787,11 +795,13 @@ def test_notify_smseagle_plugin_attachments(mock_post):
     # Unsupported (non image types are not sent)
     attach = os.path.join(TEST_VAR_DIR, "apprise-test.mp4")
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )

--- a/tests/test_plugin_smtp2go.py
+++ b/tests/test_plugin_smtp2go.py
@@ -243,11 +243,13 @@ def test_plugin_smtp2go_attachments(mock_post):
     path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     attach = AppriseAttachment(path)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -255,11 +257,13 @@ def test_plugin_smtp2go_attachments(mock_post):
     # Test invalid attachment
     path = os.path.join(TEST_VAR_DIR, "/invalid/path/to/an/invalid/file.jpg")
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=path,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=path,
+            )
         )
         is False
     )
@@ -268,11 +272,13 @@ def test_plugin_smtp2go_attachments(mock_post):
     mock_post.side_effect = OSError()
     # We can't send the message if we can't read the attachment
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -291,11 +297,13 @@ def test_plugin_smtp2go_attachments(mock_post):
     with mock.patch("builtins.open", side_effect=OSError()):
         # We can't send the message we can't open the attachment for reading
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )
@@ -319,11 +327,13 @@ def test_plugin_smtp2go_attachments(mock_post):
     mock_post.reset_mock()
 
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -335,11 +345,13 @@ def test_plugin_smtp2go_attachments(mock_post):
     obj.default_batch_size = 2
 
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )

--- a/tests/test_plugin_sns.py
+++ b/tests/test_plugin_sns.py
@@ -248,7 +248,7 @@ def test_plugin_sns_edge_cases(mock_post):
     )
 
     # The object initializes properly but would not be able to send anything
-    assert obj.notify(body="test", title="test") is False
+    assert bool(obj.notify(body="test", title="test")) is False
 
     # The phone number is invalid, and without it, there is nothing
     # to notify
@@ -260,7 +260,7 @@ def test_plugin_sns_edge_cases(mock_post):
     )
 
     # The object initializes properly but would not be able to send anything
-    assert obj.notify(body="test", title="test") is False
+    assert bool(obj.notify(body="test", title="test")) is False
 
     # The phone number is invalid, and without it, there is nothing
     # to notify; we
@@ -272,7 +272,7 @@ def test_plugin_sns_edge_cases(mock_post):
     )
 
     # The object initializes properly but would not be able to send anything
-    assert obj.notify(body="test", title="test") is False
+    assert bool(obj.notify(body="test", title="test")) is False
 
 
 def test_plugin_sns_url_parsing():
@@ -462,7 +462,7 @@ def test_plugin_sns_aws_topic_handling(mock_post):
     )
 
     # CreateTopic fails
-    assert a.notify(title="", body="test") is False
+    assert bool(a.notify(title="", body="test")) is False
 
     def post(url, data, **kwargs):
         """Since Publishing a token requires 2 posts, we need to return our
@@ -487,7 +487,7 @@ def test_plugin_sns_aws_topic_handling(mock_post):
     mock_post.side_effect = post
 
     # Publish fails
-    assert a.notify(title="", body="test") is False
+    assert bool(a.notify(title="", body="test")) is False
 
     # Disable our side effect
     mock_post.side_effect = None
@@ -499,14 +499,14 @@ def test_plugin_sns_aws_topic_handling(mock_post):
 
     # Assign ourselves a new function
     mock_post.return_value = robj
-    assert a.notify(title="", body="test") is False
+    assert bool(a.notify(title="", body="test")) is False
 
     # Handle case where we fails get a bad response
     robj = mock.Mock()
     robj.text = ""
     robj.status_code = requests.codes.bad_request
     mock_post.return_value = robj
-    assert a.notify(title="", body="test") is False
+    assert bool(a.notify(title="", body="test")) is False
 
     # Handle case where we get a valid response and TopicARN
     robj = mock.Mock()
@@ -514,7 +514,7 @@ def test_plugin_sns_aws_topic_handling(mock_post):
     robj.status_code = requests.codes.ok
     mock_post.return_value = robj
     # We would have failed to make Post
-    assert a.notify(title="", body="test") is True
+    assert bool(a.notify(title="", body="test")) is True
 
 
 @mock.patch("requests.post")
@@ -537,7 +537,7 @@ def test_plugin_sns_session_token(mock_post):
     assert obj.aws_session_token == TEST_SESSION_TOKEN
 
     # send() must include X-Amz-Security-Token in request headers
-    assert obj.notify(body="test") is True
+    assert bool(obj.notify(body="test")) is True
     call_kwargs = mock_post.call_args[1]
     assert "X-Amz-Security-Token" in call_kwargs["headers"]
     assert call_kwargs["headers"]["X-Amz-Security-Token"] == TEST_SESSION_TOKEN
@@ -575,7 +575,7 @@ def test_plugin_sns_session_token(mock_post):
         targets="+18001234567",
     )
     assert obj_plain.aws_session_token is None
-    assert obj_plain.notify(body="test") is True
+    assert bool(obj_plain.notify(body="test")) is True
     call_kwargs = mock_post.call_args[1]
     assert "X-Amz-Security-Token" not in call_kwargs["headers"]
 
@@ -602,7 +602,7 @@ def test_plugin_sns_session_token_via_kwarg(mock_post):
 
     obj = NotifySNS(**results)
     assert obj.aws_session_token == TEST_SESSION_TOKEN
-    assert obj.notify(body="test") is True
+    assert bool(obj.notify(body="test")) is True
 
     call_kwargs = mock_post.call_args[1]
     assert call_kwargs["headers"]["X-Amz-Security-Token"] == TEST_SESSION_TOKEN
@@ -670,7 +670,7 @@ def test_plugin_sns_detailed_failures(mocker):
     mock_post.return_value = mock_response_bad
 
     # Should return False because the SMS failed
-    assert obj_sms.notify(body="test") is False
+    assert bool(obj_sms.notify(body="test")) is False
 
     # --- Scenario 2: Topic Creation Failure ---
     obj_topic = NotifySNS(
@@ -684,7 +684,7 @@ def test_plugin_sns_detailed_failures(mocker):
     mock_post.return_value = mock_response_bad
 
     # Should return False because CreateTopic failed
-    assert obj_topic.notify(body="test") is False
+    assert bool(obj_topic.notify(body="test")) is False
 
     # --- Scenario 3: CreateTopic Success, but Publish Failure ---
     # We need a side_effect to return 200 for the first call (CreateTopic)
@@ -712,7 +712,7 @@ def test_plugin_sns_detailed_failures(mocker):
     mock_post.side_effect = side_effect
 
     # Should return False because Publish failed
-    assert obj_topic.notify(body="test") is False
+    assert bool(obj_topic.notify(body="test")) is False
 
 
 def test_plugin_sns_mode_detection():
@@ -841,14 +841,14 @@ def test_plugin_sns_topic_mode_send(mock_post):
     assert obj.mode == SNSMode.TOPIC
 
     # With title: Subject must appear in the Publish payload
-    assert obj.notify(title="My Title", body="My Body") is True
+    assert bool(obj.notify(title="My Title", body="My Body")) is True
     # urlencode() uses %20 for spaces
     assert "Subject=My%20Title" in publish_data["data"]
     assert "Message=My%20Body" in publish_data["data"]
 
     # With no title: Subject must not appear in the Publish payload
     publish_data.clear()
-    assert obj.notify(title="", body="My Body") is True
+    assert bool(obj.notify(title="", body="My Body")) is True
     assert "Subject=" not in publish_data.get("data", "")
 
 
@@ -872,7 +872,7 @@ def test_plugin_sns_topic_mode_phone_forced(mock_post):
     assert obj.mode == SNSMode.TOPIC
 
     # With a title: it must be prepended to the body in the SMS payload
-    assert obj.notify(title="My Title", body="My Body") is True
+    assert bool(obj.notify(title="My Title", body="My Body")) is True
     data = mock_post.call_args[1]["data"]
     # urlencode() uses %20 for spaces; \r\n becomes %0D%0A
     assert "My%20Title" in data
@@ -880,7 +880,7 @@ def test_plugin_sns_topic_mode_phone_forced(mock_post):
 
     # With no title: body is sent as-is without modification
     mock_post.reset_mock()
-    assert obj.notify(title="", body="My Body") is True
+    assert bool(obj.notify(title="", body="My Body")) is True
     data = mock_post.call_args[1]["data"]
     assert "My%20Body" in data
 

--- a/tests/test_plugin_sogs.py
+++ b/tests/test_plugin_sogs.py
@@ -357,12 +357,12 @@ def test_plugin_sogs_send_success(mock_post):
         targets=[ROOM],
         host="open.getsession.org",
     )
-    assert obj.notify(body="Hello SOGS") is True
+    assert bool(obj.notify(body="Hello SOGS")) is True
     assert mock_post.call_count == 1
 
     # HTTP 200 (OK) is also treated as success.
     mock_post.return_value = _mk_resp(requests.codes.ok)
-    assert obj.notify(body="Hello SOGS") is True
+    assert bool(obj.notify(body="Hello SOGS")) is True
 
 
 @pytest.mark.skipif(
@@ -387,7 +387,7 @@ def test_plugin_sogs_send_multi_room(mock_post):
         targets=[ROOM, ROOM2],
         host="open.getsession.org",
     )
-    assert obj.notify(body="Multi") is True
+    assert bool(obj.notify(body="Multi")) is True
     assert mock_post.call_count == 2
 
 
@@ -416,7 +416,7 @@ def test_plugin_sogs_send_partial_failure(mock_post):
         targets=[ROOM, ROOM2],
         host="open.getsession.org",
     )
-    assert obj.notify(body="Partial") is False
+    assert bool(obj.notify(body="Partial")) is False
     assert mock_post.call_count == 2
 
 
@@ -451,7 +451,7 @@ def test_plugin_sogs_http_error(mock_post):
     ):
         mock_post.reset_mock()
         mock_post.return_value = _mk_resp(code)
-        assert obj.notify(body="Error") is False
+        assert bool(obj.notify(body="Error")) is False
 
 
 @pytest.mark.skipif(
@@ -469,7 +469,7 @@ def test_plugin_sogs_request_exception(mock_post):
         targets=[ROOM],
         host="open.getsession.org",
     )
-    assert obj.notify(body="Error") is False
+    assert bool(obj.notify(body="Error")) is False
 
 
 @pytest.mark.skipif(
@@ -490,7 +490,7 @@ def test_plugin_sogs_http_insecure(mock_post):
 
     obj = Apprise()
     assert obj.add(f"session://{PUBLIC_KEY}:{SEED}@open.getsession.org/{ROOM}")
-    assert obj.notify(body="Plain HTTP") is True
+    assert bool(obj.notify(body="Plain HTTP")) is True
 
     # Confirm the request was sent to http:// not https://.
     url_called = mock_post.call_args[0][0]
@@ -559,7 +559,7 @@ def test_plugin_sogs_custom_port(mock_post):
         port=8443,
     )
     assert ":8443" in obj.url()
-    assert obj.notify(body="custom port") is True
+    assert bool(obj.notify(body="custom port")) is True
 
     url_called = mock_post.call_args[0][0]
     assert ":8443" in url_called
@@ -709,7 +709,7 @@ def test_plugin_sogs_auth_headers(mock_post):
         targets=[ROOM],
         host="open.getsession.org",
     )
-    assert obj.notify(body="Auth test") is True
+    assert bool(obj.notify(body="Auth test")) is True
 
     call_kwargs = mock_post.call_args[1]
     headers = call_kwargs.get("headers", {})
@@ -761,7 +761,7 @@ def test_plugin_sogs_response_unparseable_json(mock_post):
         targets=[ROOM],
         host="open.getsession.org",
     )
-    assert obj.notify(body="Hello") is True
+    assert bool(obj.notify(body="Hello")) is True
 
 
 def test_plugin_sogs_build_session_message():
@@ -818,5 +818,5 @@ def test_plugin_sogs_apprise_integration(mock_post):
 
     app = Apprise()
     assert app.add(BASE_URL)
-    assert app.notify(title="Title", body="Body") is True
+    assert bool(app.notify(title="Title", body="Body")) is True
     assert mock_post.call_count == 1

--- a/tests/test_plugin_sparkpost.py
+++ b/tests/test_plugin_sparkpost.py
@@ -401,13 +401,13 @@ def test_plugin_sparkpost_throttling(mock_post):
 
     # We'll successfully perform the notification as we're within
     # our retry limit
-    assert obj.notify("test") is True
+    assert bool(obj.notify("test")) is True
 
     mock_post.reset_mock()
     mock_post.side_effect = (retry_response, retry_response, retry_response)
 
     # Now we are less than our expected limit check so we will fail
-    assert obj.notify("test") is False
+    assert bool(obj.notify("test")) is False
 
 
 @mock.patch("requests.post")
@@ -443,11 +443,13 @@ def test_plugin_sparkpost_attachments(mock_post):
     path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
     attach = AppriseAttachment(path)
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -455,11 +457,13 @@ def test_plugin_sparkpost_attachments(mock_post):
     # Test invalid attachment
     path = os.path.join(TEST_VAR_DIR, "/invalid/path/to/an/invalid/file.jpg")
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=path,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=path,
+            )
         )
         is False
     )
@@ -467,11 +471,13 @@ def test_plugin_sparkpost_attachments(mock_post):
     with mock.patch("base64.b64encode", side_effect=OSError()):
         # We can't send the message if we fail to parse the data
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is False
         )
@@ -493,11 +499,13 @@ def test_plugin_sparkpost_attachments(mock_post):
     mock_post.reset_mock()
 
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -509,11 +517,13 @@ def test_plugin_sparkpost_attachments(mock_post):
     obj.default_batch_size = 2
 
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )

--- a/tests/test_plugin_stackfield.py
+++ b/tests/test_plugin_stackfield.py
@@ -277,5 +277,5 @@ def test_plugin_stackfield_apprise_integration(mock_post):
 
     a = Apprise()
     assert a.add(f"stackfield://{TEST_TOKEN}") is True
-    assert a.notify(title="Test", body="Integration test") is True
+    assert bool(a.notify(title="Test", body="Integration test")) is True
     assert mock_post.call_count == 1

--- a/tests/test_plugin_syslog.py
+++ b/tests/test_plugin_syslog.py
@@ -106,11 +106,11 @@ def test_plugin_syslog_by_url(openlog, syslog):
     assert r"logperror=yes" in obj.url()
 
     # Test sending a notification
-    assert obj.notify("body") is True
-    assert obj.notify(title="title", body="body") is True
+    assert bool(obj.notify("body")) is True
+    assert bool(obj.notify(title="title", body="body")) is True
 
     # Invalid Notification Type
-    assert obj.notify("body", notify_type="invalid") is False
+    assert bool(obj.notify("body", notify_type="invalid")) is False
 
     obj = apprise.Apprise.instantiate("syslog://_/?facility=local5")
     assert isinstance(obj, NotifySyslog)

--- a/tests/test_plugin_telegram.py
+++ b/tests/test_plugin_telegram.py
@@ -457,16 +457,22 @@ def test_plugin_telegram_general(mock_post):
 
     # This tests erroneous messages involving multiple chat ids
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
     assert (
-        nimg_obj.notify(
-            body="body", title="title", notify_type=NotifyType.INFO
+        bool(
+            nimg_obj.notify(
+                body="body", title="title", notify_type=NotifyType.INFO
+            )
         )
         is False
     )
@@ -477,12 +483,16 @@ def test_plugin_telegram_general(mock_post):
     nimg_obj.asset = AppriseAsset(image_path_mask=False, image_url_mask=False)
 
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
     assert (
-        nimg_obj.notify(
-            body="body", title="title", notify_type=NotifyType.INFO
+        bool(
+            nimg_obj.notify(
+                body="body", title="title", notify_type=NotifyType.INFO
+            )
         )
         is False
     )
@@ -564,8 +574,12 @@ def test_plugin_telegram_general(mock_post):
     mock_post.reset_mock()
     body = "<p>'\"This can't\t\r\nfail&nbsp;us\"'</p>"
     assert (
-        obj.notify(
-            body=body, title="special characters", notify_type=NotifyType.INFO
+        bool(
+            obj.notify(
+                body=body,
+                title="special characters",
+                notify_type=NotifyType.INFO,
+            )
         )
         is True
     )
@@ -590,22 +604,26 @@ def test_plugin_telegram_general(mock_post):
             os.path.join(TEST_VAR_DIR, "apprise-test.gif")
         )
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is True
         )
 
         # Test large messages
         assert (
-            obj.notify(
-                body="a" * (obj.telegram_caption_maxlen + 1),
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=attach,
+            bool(
+                obj.notify(
+                    body="a" * (obj.telegram_caption_maxlen + 1),
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=attach,
+                )
             )
             is True
         )
@@ -616,22 +634,26 @@ def test_plugin_telegram_general(mock_post):
         )
         attach = AppriseAttachment(path)
         assert (
-            obj.notify(
-                body="body",
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=path,
+            bool(
+                obj.notify(
+                    body="body",
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=path,
+                )
             )
             is False
         )
 
         # Test large messages
         assert (
-            obj.notify(
-                body="a" * (obj.telegram_caption_maxlen + 1),
-                title="title",
-                notify_type=NotifyType.INFO,
-                attach=path,
+            bool(
+                obj.notify(
+                    body="a" * (obj.telegram_caption_maxlen + 1),
+                    title="title",
+                    notify_type=NotifyType.INFO,
+                    attach=path,
+                )
             )
             is False
         )
@@ -640,7 +662,7 @@ def test_plugin_telegram_general(mock_post):
     # No user detected; this happens after our firsst notification
     assert len(obj.targets) == 0
 
-    assert obj.notify(title="hello", body="world") is True
+    assert bool(obj.notify(title="hello", body="world")) is True
     assert len(obj.targets) == 1
     assert obj.targets[0] == ("532389719", None)
 
@@ -656,7 +678,7 @@ def test_plugin_telegram_general(mock_post):
     obj = NotifyTelegram(bot_token=bot_token, targets=None)
     # No user detected; this happens after our firsst notification
     assert len(obj.targets) == 0
-    assert obj.notify(title="hello", body="world") is False
+    assert bool(obj.notify(title="hello", body="world")) is False
     assert len(obj.targets) == 0
 
     # Do the test again, but with ok not set to True
@@ -698,7 +720,7 @@ def test_plugin_telegram_general(mock_post):
     obj = NotifyTelegram(bot_token=bot_token, targets=None)
     # No user detected; this happens after our firsst notification
     assert len(obj.targets) == 0
-    assert obj.notify(title="hello", body="world") is False
+    assert bool(obj.notify(title="hello", body="world")) is False
     assert len(obj.targets) == 0
 
     # An edge case where no results were provided; this will probably never
@@ -713,7 +735,7 @@ def test_plugin_telegram_general(mock_post):
     obj = NotifyTelegram(bot_token=bot_token, targets=None)
     # No user detected; this happens after our firsst notification
     assert len(obj.targets) == 0
-    assert obj.notify(title="hello", body="world") is False
+    assert bool(obj.notify(title="hello", body="world")) is False
     assert len(obj.targets) == 0
     # Detect the bot with a bad response
     mock_post.return_value.content = dumps({})
@@ -725,29 +747,31 @@ def test_plugin_telegram_general(mock_post):
     # internal server error prevents notification from being sent
     obj = NotifyTelegram(bot_token=bot_token, targets=None)
     assert len(obj.targets) == 0
-    assert obj.notify(title="hello", body="world") is False
+    assert bool(obj.notify(title="hello", body="world")) is False
     assert len(obj.targets) == 0
 
     # Test our bot detection with an unmappable html error
     mock_post.return_value.status_code = 999
     NotifyTelegram(bot_token=bot_token, targets=None)
     assert len(obj.targets) == 0
-    assert obj.notify(title="hello", body="world") is False
+    assert bool(obj.notify(title="hello", body="world")) is False
     assert len(obj.targets) == 0
 
     # Do it again but this time provide a failure message
     mock_post.return_value.content = dumps({"description": "Failure Message"})
     NotifyTelegram(bot_token=bot_token, targets=None)
     assert len(obj.targets) == 0
-    assert obj.notify(title="hello", body="world") is False
+    assert bool(obj.notify(title="hello", body="world")) is False
     assert len(obj.targets) == 0
 
     # Do it again but this time provide a failure message and perform a
     # notification without a bot detection by providing at least 1 chat id
     obj = NotifyTelegram(bot_token=bot_token, targets=["@abcd"])
     assert (
-        nimg_obj.notify(
-            body="body", title="title", notify_type=NotifyType.INFO
+        bool(
+            nimg_obj.notify(
+                body="body", title="title", notify_type=NotifyType.INFO
+            )
         )
         is False
     )
@@ -758,7 +782,7 @@ def test_plugin_telegram_general(mock_post):
     # No chat_ids specified
     obj = NotifyTelegram(bot_token=bot_token, targets=None)
     assert len(obj.targets) == 0
-    assert obj.notify(title="hello", body="world") is False
+    assert bool(obj.notify(title="hello", body="world")) is False
     assert len(obj.targets) == 0
 
     # Test Telegram Group
@@ -2124,5 +2148,5 @@ def test_plugin_telegram_attach_memory(mock_post):
         mimetype="text/html",
     )
 
-    assert obj.notify(body="Test", attach=mem) is True
+    assert bool(obj.notify(body="Test", attach=mem)) is True
     assert mock_post.call_count >= 1

--- a/tests/test_plugin_twilio.py
+++ b/tests/test_plugin_twilio.py
@@ -389,4 +389,4 @@ def test_plugin_twilio_edge_cases(mock_post):
     )
 
     # We will fail with the above error code
-    assert obj.notify("title", "body", "info") is False
+    assert bool(obj.notify("title", "body", "info")) is False

--- a/tests/test_plugin_twist.py
+++ b/tests/test_plugin_twist.py
@@ -596,9 +596,11 @@ def test_plugin_twist_html_to_markdown_format(mock_post, mock_get):
     # Notify with an HTML body; the framework converts it to Markdown
     # before dispatching to the Twist plugin
     assert (
-        aobj.notify(
-            body="<b>hello</b> <i>world</i>",
-            body_format=NotifyFormat.HTML,
+        bool(
+            aobj.notify(
+                body="<b>hello</b> <i>world</i>",
+                body_format=NotifyFormat.HTML,
+            )
         )
         is True
     )

--- a/tests/test_plugin_twitter.py
+++ b/tests/test_plugin_twitter.py
@@ -660,7 +660,9 @@ def test_plugin_twitter_edge_cases():
     )
 
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
 
@@ -692,7 +694,9 @@ def test_plugin_twitter_dm_caching(
 
     # Send the first notification.
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -717,7 +721,9 @@ def test_plugin_twitter_dm_caching(
 
     # Send another notification.
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -758,11 +764,13 @@ def test_plugin_twitter_dm_attachments_basic(
 
     # Send our notification.
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -801,11 +809,13 @@ def test_plugin_twitter_dm_attachments_message_fails(
 
     # Send our notification; it will fail because of the message response.
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -836,11 +846,13 @@ def test_plugin_twitter_dm_attachments_upload_fails(
 
     # Send our notification; it will fail because of the media response.
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -868,11 +880,13 @@ def test_plugin_twitter_dm_attachments_invalid_attachment(
     )
 
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -884,6 +898,7 @@ def test_plugin_twitter_dm_attachments_invalid_attachment(
 def test_plugin_twitter_dm_attachments_multiple(
     mocker, twitter_url, good_message_response, good_media_response
 ):
+    """Verify multiple attachments are included with a direct message."""
 
     mock_post = mocker.patch("requests.post")
 
@@ -912,11 +927,13 @@ def test_plugin_twitter_dm_attachments_multiple(
     obj = Apprise.instantiate(twitter_url)
 
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -958,6 +975,7 @@ def test_plugin_twitter_dm_attachments_multiple(
 def test_plugin_twitter_dm_attachments_multiple_oserror(
     mocker, twitter_url, good_message_response, good_media_response
 ):
+    """Verify a file error during multi-attachment DM delivery is handled."""
 
     # Inject an `OSError` into the middle of the operation.
     mock_post = mocker.patch("requests.post")
@@ -976,11 +994,13 @@ def test_plugin_twitter_dm_attachments_multiple_oserror(
 
     # We'll fail to send this time
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -1011,11 +1031,13 @@ def test_plugin_twitter_tweet_attachments_basic(
 
     # Send our notification
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -1059,11 +1081,13 @@ def test_plugin_twitter_tweet_attachments_more_logging(
 
     # Send our notification
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -1082,6 +1106,7 @@ def test_plugin_twitter_tweet_attachments_more_logging(
 def test_plugin_twitter_tweet_attachments_bad_message_response(
     mock_post, twitter_url, good_media_response, bad_message_response
 ):
+    """Verify a failed tweet response fails attachment delivery."""
 
     mock_post.side_effect = [good_media_response, bad_message_response]
 
@@ -1092,11 +1117,13 @@ def test_plugin_twitter_tweet_attachments_bad_message_response(
 
     # Our notification will fail now since our tweet will error out.
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -1115,6 +1142,7 @@ def test_plugin_twitter_tweet_attachments_bad_message_response(
 def test_plugin_twitter_tweet_attachments_bad_message_response_unparseable(
     mock_post, twitter_url, good_media_response
 ):
+    """Verify an unparseable tweet failure response is handled."""
 
     bad_message_response = bad_response("")
     mock_post.side_effect = [good_media_response, bad_message_response]
@@ -1128,11 +1156,13 @@ def test_plugin_twitter_tweet_attachments_bad_message_response_unparseable(
     # This is the same test as above, except that the error response is not
     # parseable.
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -1151,6 +1181,7 @@ def test_plugin_twitter_tweet_attachments_bad_message_response_unparseable(
 def test_plugin_twitter_tweet_attachments_upload_fails(
     mock_post, twitter_url, good_media_response
 ):
+    """Verify a failed media upload prevents tweet delivery."""
 
     # Prepare a bad tweet response.
     bad_tweet_response = bad_response({})
@@ -1165,11 +1196,13 @@ def test_plugin_twitter_tweet_attachments_upload_fails(
 
     # Send our notification; it will fail because of the message response.
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -1188,6 +1221,7 @@ def test_plugin_twitter_tweet_attachments_upload_fails(
 def test_plugin_twitter_tweet_attachments_invalid_attachment(
     mock_post, twitter_url, good_message_response, good_media_response
 ):
+    """Verify an invalid tweet attachment is rejected cleanly."""
 
     mock_post.side_effect = [good_media_response, good_message_response]
 
@@ -1200,11 +1234,13 @@ def test_plugin_twitter_tweet_attachments_invalid_attachment(
 
     # An invalid attachment will cause a failure.
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -1217,6 +1253,7 @@ def test_plugin_twitter_tweet_attachments_invalid_attachment(
 def test_plugin_twitter_tweet_attachments_multiple_batch(
     mock_post, twitter_url, good_message_response, good_media_response
 ):
+    """Verify multiple tweet attachments are sent in batch mode."""
 
     mock_post.side_effect = [
         good_media_response,
@@ -1243,11 +1280,13 @@ def test_plugin_twitter_tweet_attachments_multiple_batch(
     ]
 
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -1282,6 +1321,7 @@ def test_plugin_twitter_tweet_attachments_multiple_batch(
 def test_plugin_twitter_tweet_attachments_multiple_nobatch(
     mock_post, twitter_url, good_message_response, good_media_response
 ):
+    """Verify multiple tweet attachments are sent without batch mode."""
 
     mock_post.side_effect = [
         good_media_response,
@@ -1308,11 +1348,13 @@ def test_plugin_twitter_tweet_attachments_multiple_nobatch(
     ]
 
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -1349,6 +1391,7 @@ def test_plugin_twitter_tweet_attachments_multiple_nobatch(
 def test_plugin_twitter_tweet_attachments_multiple_oserror(
     mock_post, twitter_url, good_media_response
 ):
+    """Verify file errors during multi-attachment tweets are handled."""
 
     # We have an OSError thrown in the middle of our preparation
     mock_post.side_effect = [good_media_response, OSError()]
@@ -1364,11 +1407,13 @@ def test_plugin_twitter_tweet_attachments_multiple_oserror(
     # We'll fail to send this time
     obj = Apprise.instantiate(twitter_url + "?mode=tweet")
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is False
     )
@@ -1419,11 +1464,13 @@ def test_plugin_twitter_tweet_attachments_jpeg_before_gif(
     ]
 
     assert (
-        obj.notify(
-            body="body",
-            title="title",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )

--- a/tests/test_plugin_viber.py
+++ b/tests/test_plugin_viber.py
@@ -189,9 +189,9 @@ def test_plugin_viber_http_error_and_exception(mocker):
     post.return_value.status_code = 400
     a = Apprise()
     assert a.add("viber://token/target2") is True
-    assert a.notify("test") is False
+    assert bool(a.notify("test")) is False
 
     post.side_effect = requests.RequestException("boom")
     a = Apprise()
     assert a.add("viber://token/target2") is True
-    assert a.notify("test") is False
+    assert bool(a.notify("test")) is False

--- a/tests/test_plugin_voipms.py
+++ b/tests/test_plugin_voipms.py
@@ -248,7 +248,7 @@ def test_plugin_voipms_edge_cases(mock_get):
     assert isinstance(obj, NotifyVoipms)
 
     # We will fail with the above error code
-    assert obj.notify("title", "body", "info") is False
+    assert bool(obj.notify("title", "body", "info")) is False
 
 
 @mock.patch("requests.get")
@@ -283,7 +283,7 @@ def test_plugin_voipms_non_success_status(mock_get):
     assert isinstance(obj, NotifyVoipms)
 
     # We will fail with the above error code
-    assert obj.notify("title", "body", "info") is False
+    assert bool(obj.notify("title", "body", "info")) is False
 
     response.content = "{"
     assert obj.send("title", "body") is False

--- a/tests/test_plugin_vonage.py
+++ b/tests/test_plugin_vonage.py
@@ -310,4 +310,4 @@ def test_plugin_vonage_edge_cases(mock_post):
     obj = NotifyVonage(apikey=apikey, secret=secret, source=source)
 
     # We will fail with the above error code
-    assert obj.notify("title", "body", "info") is False
+    assert bool(obj.notify("title", "body", "info")) is False

--- a/tests/test_plugin_webex_teams.py
+++ b/tests/test_plugin_webex_teams.py
@@ -598,11 +598,13 @@ def test_plugin_webex_teams_bot_attachments(mock_post):
     # Successful single attachment
     mock_post.reset_mock()
     assert (
-        obj.notify(
-            body="see attached",
-            title="",
-            notify_type=NotifyType.INFO,
-            attach=attach,
+        bool(
+            obj.notify(
+                body="see attached",
+                title="",
+                notify_type=NotifyType.INFO,
+                attach=attach,
+            )
         )
         is True
     )
@@ -673,10 +675,12 @@ def test_plugin_webex_teams_bot_attachments(mock_post):
     invalid_path = os.path.join(TEST_VAR_DIR, "/invalid/path/to/file.jpg")
     bad_attach = AppriseAttachment(invalid_path)
     assert (
-        obj.notify(
-            body="test",
-            notify_type=NotifyType.INFO,
-            attach=bad_attach,
+        bool(
+            obj.notify(
+                body="test",
+                notify_type=NotifyType.INFO,
+                attach=bad_attach,
+            )
         )
         is False
     )
@@ -696,14 +700,14 @@ def test_plugin_webex_teams_apprise_integration(mock_post):
     # Webhook mode via Apprise
     app = Apprise()
     assert app.add("wxteams://{}".format(WEBHOOK_TOKEN))
-    assert app.notify(body="webhook test") is True
+    assert bool(app.notify(body="webhook test")) is True
 
     mock_post.reset_mock()
 
     # Bot mode via Apprise
     app2 = Apprise()
     assert app2.add("wxteams://{}/{}".format(BOT_TOKEN, ROOM_ID))
-    assert app2.notify(body="bot test") is True
+    assert bool(app2.notify(body="bot test")) is True
 
 
 @mock.patch("requests.post")
@@ -721,9 +725,11 @@ def test_plugin_webex_teams_html_to_markdown_format(mock_post):
     # Notify with an HTML body; the framework should convert it
     # to Markdown before dispatching to Webex Teams
     assert (
-        aobj.notify(
-            body="<b>hello</b> <i>world</i>",
-            body_format=NotifyFormat.HTML,
+        bool(
+            aobj.notify(
+                body="<b>hello</b> <i>world</i>",
+                body_format=NotifyFormat.HTML,
+            )
         )
         is True
     )

--- a/tests/test_plugin_wechat.py
+++ b/tests/test_plugin_wechat.py
@@ -944,7 +944,7 @@ def test_plugin_wechat_apprise_integration(mock_post, mock_get):
     app = Apprise()
     url = "wechat://{}:{}@{}/@all".format(CORPID, CORPSECRET, AGENTID)
     assert app.add(url) is True
-    assert app.notify(title="T", body="B") is True
+    assert bool(app.notify(title="T", body="B")) is True
 
 
 @mock.patch("requests.get")

--- a/tests/test_plugin_whatsapp.py
+++ b/tests/test_plugin_whatsapp.py
@@ -359,7 +359,7 @@ def test_plugin_whatsapp_edge_cases(mock_post):
     )
 
     # We will fail with the above error code
-    assert obj.notify("title", "body", "info") is False
+    assert bool(obj.notify("title", "body", "info")) is False
 
 
 @mock.patch("requests.post")

--- a/tests/test_plugin_windows.py
+++ b/tests/test_plugin_windows.py
@@ -122,6 +122,21 @@ def mocked_win32_environment():
     # test files continues to point at live (non-abandoned) module dicts.
     sys.modules.update(saved_apprise)
 
+    # sys.modules.update() above only fixes the dict *keys* -- Python's
+    # import machinery separately sets each submodule as an ATTRIBUTE on
+    # its parent package too (e.g. sys.modules["apprise"].apprise), and
+    # that binding is untouched by the update. Left stale, any later
+    # `import apprise.apprise as x` anywhere else in the test session --
+    # resolved via getattr(sys.modules["apprise"], "apprise"), not a
+    # sys.modules lookup -- would silently get the module object this
+    # fixture created and already discarded above, rather than the real,
+    # restored one.
+    for name, mod in saved_apprise.items():
+        parent_name, _, attr = name.rpartition(".")
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, attr, mod)
+
 
 @pytest.mark.skipif(
     (
@@ -155,8 +170,10 @@ def test_plugin_windows_mocked(mocked_win32_environment):
 
     # test notifications
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -167,8 +184,10 @@ def test_plugin_windows_mocked(mocked_win32_environment):
     obj.duration = 0
     assert isinstance(obj.url(), str)
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -179,8 +198,10 @@ def test_plugin_windows_mocked(mocked_win32_environment):
     obj.duration = 0
     assert isinstance(obj.url(), str)
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -192,8 +213,10 @@ def test_plugin_windows_mocked(mocked_win32_environment):
     # loads okay
     assert obj.duration == 1
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -223,8 +246,10 @@ def test_plugin_windows_mocked(mocked_win32_environment):
     # notification to be sent
     win32gui.LoadImage.side_effect = AttributeError
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -234,8 +259,10 @@ def test_plugin_windows_mocked(mocked_win32_environment):
     # Test our global exception handling
     win32gui.UpdateWindow.side_effect = AttributeError
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is False
     )
@@ -246,8 +273,10 @@ def test_plugin_windows_mocked(mocked_win32_environment):
     # package has been made unavailable to us
     obj.enabled = False
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is False
     )
@@ -282,8 +311,10 @@ def test_plugin_windows_native(
 
     # test notifications
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -294,8 +325,10 @@ def test_plugin_windows_native(
     obj.duration = 0
     assert isinstance(obj.url(), str)
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -306,8 +339,10 @@ def test_plugin_windows_native(
     obj.duration = 0
     assert isinstance(obj.url(), str)
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -317,8 +352,10 @@ def test_plugin_windows_native(
     )
     assert isinstance(obj.url(), str)
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -351,8 +388,10 @@ def test_plugin_windows_native(
     # notification to be sent
     mock_loadimage.side_effect = AttributeError
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is True
     )
@@ -362,8 +401,10 @@ def test_plugin_windows_native(
     # Test our global exception handling
     mock_update_window.side_effect = AttributeError
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is False
     )
@@ -374,8 +415,10 @@ def test_plugin_windows_native(
     # package has been made unavailable to us
     obj.enabled = False
     assert (
-        obj.notify(
-            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        bool(
+            obj.notify(
+                title="title", body="body", notify_type=apprise.NotifyType.INFO
+            )
         )
         is False
     )

--- a/tests/test_plugin_workflows.py
+++ b/tests/test_plugin_workflows.py
@@ -279,7 +279,9 @@ def test_plugin_workflows_simple_test(
     obj = Apprise.instantiate(workflows_url)
     assert isinstance(obj, NotifyWorkflows)
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -338,7 +340,9 @@ def test_plugin_workflows_simple_test(
     obj = Apprise.instantiate(f"{workflows_url}?pa=yes")
     assert isinstance(obj, NotifyWorkflows)
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -441,7 +445,9 @@ def test_plugin_workflows_templating_basic_success(
 
     assert isinstance(obj, NotifyWorkflows)
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -486,7 +492,9 @@ def test_plugin_workflows_templating_invalid_json(
     assert isinstance(obj, NotifyWorkflows)
     # We will fail to preform our notifcation because the JSON is bad
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
 
@@ -508,7 +516,11 @@ def test_plugin_workflows_templating_load_json_failure(
         # we fail, but this time it's because we couldn't
         # access the cached file contents for reading
         assert (
-            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+            bool(
+                obj.notify(
+                    body="body", title="title", notify_type=NotifyType.INFO
+                )
+            )
             is False
         )
 
@@ -564,7 +576,9 @@ def test_plugin_workflows_templating_target_success(
 
     assert isinstance(obj, NotifyWorkflows)
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is True
     )
 
@@ -612,7 +626,9 @@ def test_plugin_workflows_templating_invalid_type(
     assert isinstance(obj, NotifyWorkflows)
     # Validation rejects incorrect 'type' value
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
     assert request_mock.called is False
@@ -630,7 +646,9 @@ def test_plugin_workflows_templating_missing_attachments(
     obj = Apprise.instantiate(f"{workflows_url}/?template={template!s}")
     assert isinstance(obj, NotifyWorkflows)
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
     assert request_mock.called is False
@@ -640,7 +658,11 @@ def test_plugin_workflows_templating_missing_attachments(
     obj2 = Apprise.instantiate(f"{workflows_url}/?template={template!s}")
     assert isinstance(obj2, NotifyWorkflows)
     assert (
-        obj2.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj2.notify(
+                body="body", title="title", notify_type=NotifyType.INFO
+            )
+        )
         is False
     )
     assert request_mock.called is False
@@ -658,7 +680,9 @@ def test_plugin_workflows_templating_invalid_contenttype(
     assert isinstance(obj, NotifyWorkflows)
     # An attachment without a 'contentType' string is rejected
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
     assert request_mock.called is False
@@ -731,7 +755,9 @@ def test_plugin_workflows_templating_content_not_dict(
     obj = Apprise.instantiate(f"{workflows_url}/?template={template!s}")
     assert isinstance(obj, NotifyWorkflows)
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
     assert request_mock.called is False
@@ -748,7 +774,9 @@ def test_plugin_workflows_templating_attachment_not_dict(
     obj = Apprise.instantiate(f"{workflows_url}/?template={template!s}")
     assert isinstance(obj, NotifyWorkflows)
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
     assert request_mock.called is False
@@ -777,7 +805,7 @@ def test_plugin_workflows_templating_none_token_value(
     assert isinstance(obj, NotifyWorkflows)
     # Must succeed -- None coerced to "" keeps the JSON valid
     assert (
-        obj.notify(body="hello", title="t", notify_type=NotifyType.INFO)
+        bool(obj.notify(body="hello", title="t", notify_type=NotifyType.INFO))
         is True
     )
     assert request_mock.called is True
@@ -819,7 +847,9 @@ def test_workflows_yaml_config_missing_template_filename(
 
     # However we can't send notification since the template couldn't be loaded
     assert (
-        obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        bool(
+            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+        )
         is False
     )
     assert request_mock.called is False
@@ -890,9 +920,11 @@ def test_plugin_workflows_html_to_markdown_format(mock_post):
     # Notify with an HTML body; the framework should convert it
     # to Markdown before dispatching to Workflows
     assert (
-        aobj.notify(
-            body="<b>hello</b> <i>world</i>",
-            body_format=NotifyFormat.HTML,
+        bool(
+            aobj.notify(
+                body="<b>hello</b> <i>world</i>",
+                body_format=NotifyFormat.HTML,
+            )
         )
         is True
     )
@@ -918,7 +950,7 @@ def test_plugin_workflows_mention_entities(mock_post):
     assert aobj.add("workflow://hostname/workflow1/signature1/?image=no")
 
     # Keep Teams metadata minimal when the body contains no mentions.
-    assert aobj.notify(body="Hello world", title="T") is True
+    assert bool(aobj.notify(body="Hello world", title="T")) is True
     payload = json.loads(mock_post.call_args_list[0][1]["data"])
     msteams = payload["attachments"][0]["content"]["msteams"]
     assert msteams == {"width": "full"}
@@ -926,9 +958,11 @@ def test_plugin_workflows_mention_entities(mock_post):
 
     # Add one entity for a single mention.
     assert (
-        aobj.notify(
-            body="Hello <at>foo@example.com</at>!",
-            title="T",
+        bool(
+            aobj.notify(
+                body="Hello <at>foo@example.com</at>!",
+                title="T",
+            )
         )
         is True
     )
@@ -951,11 +985,14 @@ def test_plugin_workflows_mention_entities(mock_post):
 
     # Preserve source order for distinct mentions.
     assert (
-        aobj.notify(
-            body=(
-                "Hi <at>alice@example.com</at> and <at>bob@example.com</at>!"
-            ),
-            title="T",
+        bool(
+            aobj.notify(
+                body=(
+                    "Hi <at>alice@example.com</at> and"
+                    " <at>bob@example.com</at>!"
+                ),
+                title="T",
+            )
         )
         is True
     )
@@ -968,11 +1005,14 @@ def test_plugin_workflows_mention_entities(mock_post):
 
     # Deduplicate repeated mention IDs.
     assert (
-        aobj.notify(
-            body=(
-                "<at>dup@example.com</at> and <at>dup@example.com</at> again"
-            ),
-            title="T",
+        bool(
+            aobj.notify(
+                body=(
+                    "<at>dup@example.com</at> and"
+                    " <at>dup@example.com</at> again"
+                ),
+                title="T",
+            )
         )
         is True
     )
@@ -984,9 +1024,11 @@ def test_plugin_workflows_mention_entities(mock_post):
 
     # Recover the valid inner tag from a nested opening sequence.
     assert (
-        aobj.notify(
-            body="Hi <at><at>user@example.com</at>!",
-            title="T",
+        bool(
+            aobj.notify(
+                body="Hi <at><at>user@example.com</at>!",
+                title="T",
+            )
         )
         is True
     )
@@ -998,9 +1040,11 @@ def test_plugin_workflows_mention_entities(mock_post):
 
     # Recover an inner mention when text invalidates the outer tag.
     assert (
-        aobj.notify(
-            body="<at>garbage<at>inner@example.com</at>",
-            title="T",
+        bool(
+            aobj.notify(
+                body="<at>garbage<at>inner@example.com</at>",
+                title="T",
+            )
         )
         is True
     )
@@ -1012,7 +1056,7 @@ def test_plugin_workflows_mention_entities(mock_post):
 
     # Ignore empty, whitespace-only, and unclosed mention tags.
     for bad_body in ("<at></at>", "<at>   </at>", "<at>unclosed"):
-        assert aobj.notify(body=bad_body, title="T") is True
+        assert bool(aobj.notify(body=bad_body, title="T")) is True
         payload = json.loads(mock_post.call_args_list[-1][1]["data"])
         msteams = payload["attachments"][0]["content"]["msteams"]
         assert msteams == {"width": "full"}, (
@@ -1023,9 +1067,11 @@ def test_plugin_workflows_mention_entities(mock_post):
 
     # Preserve mixed-case entity text for Teams' verbatim body match.
     assert (
-        aobj.notify(
-            body="Hi <AT>user@example.com</AT>!",
-            title="T",
+        bool(
+            aobj.notify(
+                body="Hi <AT>user@example.com</AT>!",
+                title="T",
+            )
         )
         is True
     )
@@ -1037,9 +1083,11 @@ def test_plugin_workflows_mention_entities(mock_post):
 
     # Preserve tag padding while trimming the ID used for user resolution.
     assert (
-        aobj.notify(
-            body="Hi <at>  padded@example.com  </at>!",
-            title="T",
+        bool(
+            aobj.notify(
+                body="Hi <at>  padded@example.com  </at>!",
+                title="T",
+            )
         )
         is True
     )

--- a/tests/test_plugin_wxpusher.py
+++ b/tests/test_plugin_wxpusher.py
@@ -396,4 +396,4 @@ def test_notify_wxpusher_plugin_result_list(mock_post):
     assert isinstance(obj, NotifyWxPusher)
 
     # We should now fail
-    assert obj.notify("test") is False
+    assert bool(obj.notify("test")) is False

--- a/tests/test_plugin_xmpp.py
+++ b/tests/test_plugin_xmpp.py
@@ -634,7 +634,9 @@ def test_xmpp_apprise_notify_invokes_adapter(
     apobj.add("xmpp://me:secret@example.com/a@example.com")
 
     assert (
-        apobj.notify("hello", title="subject", notify_type=NotifyType.INFO)
+        bool(
+            apobj.notify("hello", title="subject", notify_type=NotifyType.INFO)
+        )
         is True
     )
     assert captured["targets"] == [("chat", "a@example.com")]
@@ -645,7 +647,9 @@ def test_xmpp_apprise_notify_invokes_adapter(
     apobj.add("xmpp://me:secret@example.com/a@example.com?subject=yes")
 
     assert (
-        apobj.notify("hello", title="subject", notify_type=NotifyType.INFO)
+        bool(
+            apobj.notify("hello", title="subject", notify_type=NotifyType.INFO)
+        )
         is True
     )
     assert captured["targets"] == [("chat", "a@example.com")]

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1,0 +1,751 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Disable logging for a cleaner testing output
+from datetime import datetime, timezone
+from json import loads
+import logging
+
+from apprise.common import AWARE_DATE_ISO_FORMAT
+from apprise.logger import NotifyLogEntry
+from apprise.result import (
+    AppriseResult,
+    AppriseResultStatus,
+    NotifyAttempt,
+    NotifyResult,
+)
+
+logging.disable(logging.CRITICAL)
+
+
+def test_notify_log_entry():
+    """NotifyLogEntry: attributes, asdict(), json(), __str__/__repr__."""
+
+    entry = NotifyLogEntry(level="WARNING", message="HTTP 403 Forbidden")
+
+    assert entry.level == "WARNING"
+    assert entry.message == "HTTP 403 Forbidden"
+    assert entry.time.tzinfo is not None
+    assert entry.asdict() == {
+        "level": "WARNING",
+        "message": "HTTP 403 Forbidden",
+        "time": entry.time.strftime(AWARE_DATE_ISO_FORMAT),
+    }
+    assert loads(entry.json()) == entry.asdict()
+    # __str__ mirrors Python logging's own default format:
+    # "%(asctime)s - %(levelname)s - %(message)s".
+    expected_asctime = "{},{:03d}".format(
+        entry.time.strftime("%Y-%m-%d %H:%M:%S"),
+        entry.time.microsecond // 1000,
+    )
+    assert str(entry) == (f"{expected_asctime} - WARNING - HTTP 403 Forbidden")
+    assert "WARNING" in repr(entry)
+    assert "HTTP 403 Forbidden" in repr(entry)
+
+
+def test_notify_log_entry_time_defaults_to_now():
+    """NotifyLogEntry.time defaults to now() when constructed directly
+    (e.g. in tests) without an explicit time= from a real LogRecord."""
+
+    before = datetime.now(timezone.utc)
+    entry = NotifyLogEntry(level="WARNING", message="test")
+    after = datetime.now(timezone.utc)
+
+    assert before <= entry.time <= after
+
+
+def test_notify_log_entry_explicit_time():
+    """NotifyLogEntry accepts an explicit time=, as _ServiceLogCapture.emit()
+    does from the underlying LogRecord's own timestamp."""
+
+    when = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    entry = NotifyLogEntry(level="ERROR", message="test", time=when)
+
+    assert entry.time == when
+
+
+def test_notify_attempt_defaults():
+    """NotifyAttempt: default construction requires only status."""
+
+    attempt = NotifyAttempt(status=AppriseResultStatus.SUCCESS)
+
+    assert attempt.status == AppriseResultStatus.SUCCESS
+    assert attempt.elapsed == 0.0
+    assert attempt.logs == []
+    assert bool(attempt) is True
+
+
+def test_notify_attempt_bool_matches_status():
+    """NotifyAttempt.__bool__ is True only for status=SUCCESS -- raw,
+    never adjusted for optional=."""
+
+    success = NotifyAttempt(status=AppriseResultStatus.SUCCESS)
+    failure = NotifyAttempt(status=AppriseResultStatus.FAILURE)
+    timeout = NotifyAttempt(status=AppriseResultStatus.TIMEOUT)
+
+    assert bool(success) is True
+    assert bool(failure) is False
+    assert bool(timeout) is False
+
+
+def test_notify_attempt_start_end_time_match_elapsed():
+    """start_time/end_time are always populated and their difference is
+    exactly elapsed -- by construction, not by measurement, so there is
+    no separate clock to drift out of sync."""
+
+    before = datetime.now(timezone.utc)
+    attempt = NotifyAttempt(status=AppriseResultStatus.SUCCESS, elapsed=3.5)
+    after = datetime.now(timezone.utc)
+
+    assert attempt.start_time.tzinfo is not None
+    assert attempt.end_time.tzinfo is not None
+    assert (attempt.end_time - attempt.start_time).total_seconds() == 3.5
+    assert before <= attempt.end_time <= after
+    parsed = datetime.strptime(
+        attempt.asdict()["start_time"], AWARE_DATE_ISO_FORMAT
+    )
+    assert parsed == attempt.start_time
+
+
+def test_notify_attempt_iterates_logs():
+    """NotifyAttempt iterates directly over its own captured log entries."""
+
+    logs = [
+        NotifyLogEntry(level="WARNING", message="rate limited"),
+        NotifyLogEntry(level="ERROR", message="invalid token"),
+    ]
+    attempt = NotifyAttempt(
+        status=AppriseResultStatus.FAILURE, elapsed=0.2, logs=logs
+    )
+
+    assert list(attempt) == logs
+    messages = [str(entry) for entry in attempt]
+    assert " - WARNING - rate limited" in messages[0]
+    assert " - ERROR - invalid token" in messages[1]
+
+
+def test_notify_attempt_asdict_and_json():
+    """NotifyAttempt.asdict()/json() serialize every field, logs included."""
+
+    logs = [NotifyLogEntry(level="WARNING", message="HTTP 429")]
+    attempt = NotifyAttempt(
+        status=AppriseResultStatus.FAILURE, elapsed=0.5, logs=logs
+    )
+
+    expected = {
+        "status": "FAILURE",
+        "elapsed": 0.5,
+        "start_time": attempt.start_time.strftime(AWARE_DATE_ISO_FORMAT),
+        "end_time": attempt.end_time.strftime(AWARE_DATE_ISO_FORMAT),
+        "logs": [logs[0].asdict()],
+    }
+    assert attempt.asdict() == expected
+    assert loads(attempt.json()) == expected
+    assert ", " not in attempt.json()
+    assert ": " not in attempt.json()
+
+
+def test_notify_attempt_repr():
+    """NotifyAttempt.__repr__ is a compact, informative one-liner."""
+
+    attempt = NotifyAttempt(status=AppriseResultStatus.TIMEOUT, elapsed=1.2)
+    text = repr(attempt)
+
+    assert "TIMEOUT" in text
+    assert "1.2" in text
+
+
+def test_notify_result_defaults():
+    """NotifyResult: default construction requires only name/url, and
+    with no attempts given reports FAILURE (nothing ever succeeded)."""
+
+    result = NotifyResult(name="Slack", url="slack://t/ch")
+
+    assert result.name == "Slack"
+    assert result.url == "slack://t/ch"
+    assert result.url_id is None
+    assert result.tag == ()
+    assert result.status == AppriseResultStatus.FAILURE
+    assert bool(result) is False
+    assert result.optional is False
+    assert result.weight == 1
+    assert result.max_attempts == 1
+    assert result.attempts == ()
+    assert len(result) == 0
+    assert result.elapsed == 0.0
+    assert list(result.logs()) == []
+
+
+def test_notify_result_status_reflects_any_success():
+    """.status is SUCCESS if any attempt succeeded, regardless of earlier
+    failed attempts."""
+
+    result = NotifyResult(
+        name="Slack",
+        url="slack://t/ch",
+        max_attempts=3,
+        attempts=[
+            NotifyAttempt(status=AppriseResultStatus.FAILURE),
+            NotifyAttempt(status=AppriseResultStatus.SUCCESS),
+        ],
+    )
+
+    assert result.status == AppriseResultStatus.SUCCESS
+    assert bool(result) is True
+    assert len(result) == 2
+
+
+def test_notify_result_status_pure_timeout_no_failure():
+    """.status is TIMEOUT when Apprise gave up waiting without ever
+    seeing a confirmed failure from this service -- e.g. the deadline
+    had already passed before any attempt could even start, or the one
+    attempt made was abandoned mid-flight rather than completing."""
+
+    result = NotifyResult(
+        name="Slack",
+        url="slack://t/ch",
+        attempts=[NotifyAttempt(status=AppriseResultStatus.TIMEOUT)],
+    )
+
+    assert result.status == AppriseResultStatus.TIMEOUT
+    assert bool(result) is False
+
+
+def test_notify_result_status_failure_trumps_timeout():
+    """.status is FAILURE, not TIMEOUT, when at least one attempt
+    confirmed a real failure before Apprise later gave up waiting on a
+    further retry -- a confirmed failure is more informative than "ran
+    out of time" and takes priority over it."""
+
+    result = NotifyResult(
+        name="Slack",
+        url="slack://t/ch",
+        attempts=[
+            NotifyAttempt(status=AppriseResultStatus.FAILURE),
+            NotifyAttempt(status=AppriseResultStatus.TIMEOUT),
+        ],
+    )
+
+    assert result.status == AppriseResultStatus.FAILURE
+    assert bool(result) is False
+
+
+def test_notify_result_status_failure_trumps_timeout_multiple_retries():
+    """The same FAILURE-over-TIMEOUT priority holds regardless of how
+    many failed retries preceded the eventual TIMEOUT."""
+
+    result = NotifyResult(
+        name="Slack",
+        url="slack://t/ch",
+        attempts=[
+            NotifyAttempt(status=AppriseResultStatus.FAILURE),
+            NotifyAttempt(status=AppriseResultStatus.FAILURE),
+            NotifyAttempt(status=AppriseResultStatus.FAILURE),
+            NotifyAttempt(status=AppriseResultStatus.TIMEOUT),
+        ],
+    )
+
+    assert result.status == AppriseResultStatus.FAILURE
+
+
+def test_notify_result_optional_absorbs_failure_trumping_timeout():
+    """optional=True still absorbs a FAILURE-trumps-TIMEOUT outcome into
+    SUCCESS, same as it would a plain FAILURE or a plain TIMEOUT."""
+
+    result = NotifyResult(
+        name="Slack",
+        url="slack://t/ch",
+        optional=True,
+        attempts=[
+            NotifyAttempt(status=AppriseResultStatus.FAILURE),
+            NotifyAttempt(status=AppriseResultStatus.TIMEOUT),
+        ],
+    )
+
+    assert result.status == AppriseResultStatus.SUCCESS
+
+
+def test_notify_result_status_failure_when_no_timeout_no_success():
+    """.status is FAILURE when every attempt failed outright (no
+    TIMEOUT, no SUCCESS, no optional)."""
+
+    result = NotifyResult(
+        name="Slack",
+        url="slack://t/ch",
+        attempts=[NotifyAttempt(status=AppriseResultStatus.FAILURE)],
+    )
+
+    assert result.status == AppriseResultStatus.FAILURE
+
+
+def test_notify_result_optional_absorbs_failure():
+    """optional=True remaps a failed outcome's reflective .status to
+    SUCCESS, even though the underlying NotifyAttempt stays raw."""
+
+    result = NotifyResult(
+        name="Slack",
+        url="slack://t/ch",
+        optional=True,
+        attempts=[NotifyAttempt(status=AppriseResultStatus.FAILURE)],
+    )
+
+    assert result.status == AppriseResultStatus.SUCCESS
+    assert bool(result) is True
+    # The raw attempt itself is untouched by optional=.
+    assert next(iter(result)).status == AppriseResultStatus.FAILURE
+
+
+def test_notify_result_optional_absorbs_timeout():
+    """optional=True also absorbs a TIMEOUT outcome the same way it
+    absorbs a plain FAILURE."""
+
+    result = NotifyResult(
+        name="Slack",
+        url="slack://t/ch",
+        optional=True,
+        attempts=[NotifyAttempt(status=AppriseResultStatus.TIMEOUT)],
+    )
+
+    assert result.status == AppriseResultStatus.SUCCESS
+    assert next(iter(result)).status == AppriseResultStatus.TIMEOUT
+
+
+def test_notify_result_optional_does_not_mask_success():
+    """optional=True on an already-successful result is a no-op --
+    .status is still simply SUCCESS."""
+
+    result = NotifyResult(
+        name="Slack",
+        url="slack://t/ch",
+        optional=True,
+        attempts=[NotifyAttempt(status=AppriseResultStatus.SUCCESS)],
+    )
+
+    assert result.status == AppriseResultStatus.SUCCESS
+
+
+def test_notify_result_weight():
+    """.weight defaults to 1 and stores whatever value is given (e.g. a
+    plugin's own target count via len(service))."""
+
+    default = NotifyResult(name="Slack", url="slack://t/ch")
+    fanned_out = NotifyResult(name="Twilio", url="twilio://x", weight=50)
+
+    assert default.weight == 1
+    assert fanned_out.weight == 50
+
+
+def test_notify_result_max_attempts_ratio():
+    """max_attempts is the configured ceiling; len(result)/.attempts show
+    how many were actually used -- e.g. 1/3 means the first try
+    succeeded."""
+
+    result = NotifyResult(
+        name="Telegram",
+        url="tgram://bot/chat",
+        url_id="abc123",
+        max_attempts=3,
+        attempts=[NotifyAttempt(status=AppriseResultStatus.SUCCESS)],
+    )
+
+    assert result.url_id == "abc123"
+    assert result.max_attempts == 3
+    assert len(result) == 1
+    assert len(result.attempts) == 1
+
+
+def test_notify_result_start_end_time_span_all_attempts():
+    """start_time is the first attempt's start, end_time is the last
+    attempt's end, and elapsed is the difference between them -- not the
+    sum of each attempt's own elapsed."""
+
+    first = NotifyAttempt(status=AppriseResultStatus.FAILURE, elapsed=1.0)
+    second = NotifyAttempt(status=AppriseResultStatus.SUCCESS, elapsed=1.0)
+    result = NotifyResult(
+        name="Slack", url="slack://t/ch", attempts=[first, second]
+    )
+
+    assert result.start_time == first.start_time
+    assert result.end_time == second.end_time
+    assert result.elapsed == (
+        (second.end_time - first.start_time).total_seconds()
+    )
+
+
+def test_notify_result_start_end_time_default_when_no_attempts():
+    """With no attempts at all, start_time/end_time still coincide --
+    never left unset."""
+
+    result = NotifyResult(name="Slack", url="slack://t/ch")
+    assert result.start_time == result.end_time
+
+
+def test_notify_result_iterates_attempts():
+    """NotifyResult iterates over its NotifyAttempt entries, not log
+    lines directly -- use .logs() for a flattened log view."""
+
+    a1 = NotifyAttempt(status=AppriseResultStatus.FAILURE)
+    a2 = NotifyAttempt(status=AppriseResultStatus.SUCCESS)
+    result = NotifyResult(
+        name="Telegram", url="tgram://bot/chat", attempts=[a1, a2]
+    )
+
+    assert list(result) == [a1, a2]
+    assert result.attempts == (a1, a2)
+
+
+def test_notify_result_logs_flattens_every_attempt_in_order():
+    """NotifyResult.logs() yields every log entry across every attempt,
+    in call order."""
+
+    logs1 = [NotifyLogEntry(level="WARNING", message="rate limited")]
+    logs2 = [NotifyLogEntry(level="ERROR", message="invalid token")]
+    result = NotifyResult(
+        name="Telegram",
+        url="tgram://bot/chat",
+        attempts=[
+            NotifyAttempt(status=AppriseResultStatus.FAILURE, logs=logs1),
+            NotifyAttempt(status=AppriseResultStatus.SUCCESS, logs=logs2),
+        ],
+    )
+
+    assert list(result.logs()) == logs1 + logs2
+
+
+def test_notify_result_optional_and_tag():
+    """NotifyResult carries the tag tuple and optional flag through."""
+
+    result = NotifyResult(
+        name="Discord",
+        url="discord://w/t",
+        tag=("devops", "alerts"),
+        optional=True,
+        attempts=[NotifyAttempt(status=AppriseResultStatus.FAILURE)],
+    )
+
+    assert result.tag == ("devops", "alerts")
+    assert result.optional is True
+    # Absorbed by optional=True.
+    assert bool(result) is True
+
+
+def test_notify_result_asdict_and_json():
+    """NotifyResult.asdict()/json() serialize every field, with nested
+    per-attempt detail (including each attempt's own logs)."""
+
+    logs = [NotifyLogEntry(level="WARNING", message="HTTP 429")]
+    attempt = NotifyAttempt(
+        status=AppriseResultStatus.FAILURE, elapsed=0.5, logs=logs
+    )
+    result = NotifyResult(
+        name="Telegram",
+        url="tgram://bot/chat",
+        url_id="abc123",
+        tag=("alerts",),
+        optional=False,
+        weight=3,
+        max_attempts=3,
+        attempts=[attempt],
+    )
+
+    expected = {
+        "name": "Telegram",
+        "url": "tgram://bot/chat",
+        "url_id": "abc123",
+        "tag": ["alerts"],
+        "status": "FAILURE",
+        "optional": False,
+        "weight": 3,
+        "max_attempts": 3,
+        "elapsed": result.elapsed,
+        "start_time": result.start_time.strftime(AWARE_DATE_ISO_FORMAT),
+        "end_time": result.end_time.strftime(AWARE_DATE_ISO_FORMAT),
+        "attempts": [attempt.asdict()],
+    }
+    assert result.asdict() == expected
+    assert loads(result.json()) == expected
+    # json() is compact -- no space after "," or ":".
+    assert ", " not in result.json()
+    assert ": " not in result.json()
+
+
+def test_notify_result_repr():
+    """NotifyResult.__repr__ is a compact, informative one-liner."""
+
+    result = NotifyResult(
+        name="Slack",
+        url="slack://t/ch",
+        attempts=[NotifyAttempt(status=AppriseResultStatus.SUCCESS)],
+    )
+    text = repr(result)
+
+    assert "Slack" in text
+    assert "slack://t/ch" in text
+    assert "SUCCESS" in text
+
+
+def test_apprise_result_defaults():
+    """AppriseResult: default construction is an empty NOMATCH result."""
+
+    result = AppriseResult()
+
+    assert result.status == AppriseResultStatus.NOMATCH
+    assert len(result) == 0
+    assert list(result) == []
+    assert result.results == ()
+    assert result.success_count == 0
+    assert result.failed_count == 0
+    assert result.timeout_count == 0
+    assert result.elapsed == 0.0
+    assert bool(result) is False
+
+
+def test_apprise_result_elapsed_custom():
+    """AppriseResult.elapsed stores the caller-supplied wall-clock time."""
+
+    result = AppriseResult(status=AppriseResultStatus.SUCCESS, elapsed=2.5)
+    assert result.elapsed == 2.5
+
+
+def test_apprise_result_start_end_time_match_elapsed():
+    """Same start_time/end_time-derived-from-elapsed guarantee as
+    NotifyResult, at the whole-call level."""
+
+    result = AppriseResult(status=AppriseResultStatus.SUCCESS, elapsed=4.0)
+
+    assert result.start_time.tzinfo is not None
+    assert result.end_time.tzinfo is not None
+    assert (result.end_time - result.start_time).total_seconds() == 4.0
+    parsed = datetime.strptime(
+        result.asdict()["end_time"], AWARE_DATE_ISO_FORMAT
+    )
+    assert parsed == result.end_time
+
+
+def test_apprise_result_bool_success():
+    """AppriseResult.__bool__ is True only for SUCCESS."""
+
+    result = AppriseResult(status=AppriseResultStatus.SUCCESS)
+    assert bool(result) is True
+
+
+def test_apprise_result_bool_failure():
+    """AppriseResult.__bool__ is False for FAILURE."""
+
+    result = AppriseResult(status=AppriseResultStatus.FAILURE)
+    assert bool(result) is False
+
+
+def test_apprise_result_bool_nomatch():
+    """AppriseResult.__bool__ is False for NOMATCH."""
+
+    result = AppriseResult(status=AppriseResultStatus.NOMATCH)
+    assert bool(result) is False
+
+
+def test_apprise_result_bool_timeout():
+    """AppriseResult.__bool__ is False for TIMEOUT."""
+
+    result = AppriseResult(status=AppriseResultStatus.TIMEOUT)
+    assert bool(result) is False
+
+
+def test_apprise_result_status_exit_code_alignment():
+    """AppriseResultStatus values equal the CLI's historical exit codes."""
+
+    assert int(AppriseResultStatus.SUCCESS) == 0
+    assert int(AppriseResultStatus.FAILURE) == 1
+    assert int(AppriseResultStatus.NOMATCH) == 3
+    assert int(AppriseResultStatus.PARTIAL) == 4
+
+
+def test_apprise_result_timeout_status_value():
+    """TIMEOUT is the highest-numbered status value (5)."""
+
+    assert int(AppriseResultStatus.TIMEOUT) == 5
+
+
+def _notify_result(name, url, status):
+    """Test helper: build a one-attempt NotifyResult with the given
+    reflective status (SUCCESS/FAILURE/TIMEOUT), for tests that only
+    care about the aggregate outcome, not attempt-level detail."""
+
+    return NotifyResult(name=name, url=url, attempts=[NotifyAttempt(status)])
+
+
+def test_apprise_result_len_and_iter():
+    """AppriseResult.__len__/__iter__ walk the collected NotifyResults."""
+
+    r1 = _notify_result("Slack", "slack://t/ch", AppriseResultStatus.SUCCESS)
+    r2 = _notify_result(
+        "Discord", "discord://w/t", AppriseResultStatus.FAILURE
+    )
+    result = AppriseResult(
+        status=AppriseResultStatus.FAILURE, results=[r1, r2]
+    )
+
+    assert len(result) == 2
+    assert list(result) == [r1, r2]
+    assert result.results == (r1, r2)
+
+
+def test_apprise_result_success_and_failed_counts():
+    """success_count/failed_count are derived from each NotifyResult's
+    reflective .status, and timeout_count narrows failed_count down to
+    just TIMEOUT entries."""
+
+    results = [
+        _notify_result("Slack", "slack://t/ch", AppriseResultStatus.SUCCESS),
+        _notify_result(
+            "Discord", "discord://w/t", AppriseResultStatus.FAILURE
+        ),
+        _notify_result("Telegram", "tgram://b/c", AppriseResultStatus.SUCCESS),
+        _notify_result("Twilio", "twilio://x", AppriseResultStatus.TIMEOUT),
+    ]
+    result = AppriseResult(status=AppriseResultStatus.FAILURE, results=results)
+
+    assert result.success_count == 2
+    assert result.failed_count == 2
+    assert result.timeout_count == 1
+
+
+def test_apprise_result_logs_merges_and_sorts_across_services():
+    """AppriseResult.logs() combines every service's log entries into
+    one chronological timeline -- not simply service by service, since
+    services dispatched concurrently can log in any relative order to
+    each other regardless of which NotifyResult they end up attached
+    to."""
+
+    early = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    middle = datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc)
+    late = datetime(2026, 1, 1, 12, 0, 2, tzinfo=timezone.utc)
+
+    # Discord's own NotifyResult is built first, but its one log entry
+    # actually happened AFTER Slack's -- e.g. two services notified
+    # concurrently, with Discord simply finishing (and being appended
+    # to the batch) first.
+    discord = NotifyResult(
+        name="Discord",
+        url="discord://w/t",
+        attempts=[
+            NotifyAttempt(
+                status=AppriseResultStatus.SUCCESS,
+                logs=[
+                    NotifyLogEntry(
+                        level="WARNING", message="from discord", time=late
+                    )
+                ],
+            )
+        ],
+    )
+    slack = NotifyResult(
+        name="Slack",
+        url="slack://t/ch",
+        attempts=[
+            NotifyAttempt(
+                status=AppriseResultStatus.SUCCESS,
+                logs=[
+                    NotifyLogEntry(
+                        level="WARNING", message="from slack", time=early
+                    ),
+                    NotifyLogEntry(
+                        level="ERROR", message="from slack, later", time=middle
+                    ),
+                ],
+            )
+        ],
+    )
+
+    result = AppriseResult(
+        status=AppriseResultStatus.SUCCESS, results=[discord, slack]
+    )
+
+    messages = [entry.message for entry in result.logs()]
+    assert messages == ["from slack", "from slack, later", "from discord"]
+
+
+def test_apprise_result_asdict_and_json():
+    """AppriseResult.asdict()/json() serialize status, counts, and every
+    NotifyResult entry."""
+
+    results = [
+        _notify_result("Slack", "slack://t/ch", AppriseResultStatus.SUCCESS),
+        _notify_result(
+            "Discord", "discord://w/t", AppriseResultStatus.FAILURE
+        ),
+    ]
+    result = AppriseResult(
+        status=AppriseResultStatus.FAILURE, results=results, elapsed=0.75
+    )
+
+    expected = {
+        "status": "FAILURE",
+        "success_count": 1,
+        "failed_count": 1,
+        "elapsed": 0.75,
+        "start_time": result.start_time.strftime(AWARE_DATE_ISO_FORMAT),
+        "end_time": result.end_time.strftime(AWARE_DATE_ISO_FORMAT),
+        "results": [r.asdict() for r in results],
+    }
+    assert result.asdict() == expected
+    assert loads(result.json()) == expected
+    assert ", " not in result.json()
+    assert ": " not in result.json()
+
+
+def test_apprise_result_repr():
+    """AppriseResult.__repr__ reports status and entry count."""
+
+    result = AppriseResult(
+        status=AppriseResultStatus.SUCCESS,
+        results=[
+            _notify_result(
+                "Slack", "slack://t/ch", AppriseResultStatus.SUCCESS
+            )
+        ],
+    )
+    text = repr(result)
+
+    assert "SUCCESS" in text
+    assert "1" in text
+
+
+def test_apprise_result_results_is_read_only_view():
+    """.results is a snapshot tuple; mutating the input list afterwards
+    does not affect it."""
+
+    source = [
+        _notify_result("Slack", "slack://t/ch", AppriseResultStatus.SUCCESS)
+    ]
+    result = AppriseResult(status=AppriseResultStatus.SUCCESS, results=source)
+
+    source.append(
+        _notify_result("Discord", "discord://w/t", AppriseResultStatus.FAILURE)
+    )
+
+    assert len(result) == 1
+    assert len(result.results) == 1

--- a/tests/test_retry_wait.py
+++ b/tests/test_retry_wait.py
@@ -3248,3 +3248,122 @@ class TestServiceTimeout:
             assert apprise_module._any_abandoned_calls_still_running() is False
         finally:
             N_MGR.unload_modules()
+
+
+class _SlowFailNotify(NotifyBase):
+    """Fails after a configurable delay so deadlines can pass mid-attempt."""
+
+    app_id = "SlowFailApp"
+    app_desc = "Test"
+    notify_url = "slowfail://"
+    title_maxlen = 250
+    body_maxlen = 32768
+
+    def __init__(self, delay=0.0, **kwargs):
+        """Initialize the test plugin with its artificial delay."""
+        super().__init__(**kwargs)
+        self._delay = delay
+        self.calls = 0
+
+    def url(self, *args, **kwargs):
+        """Return a stable URL containing the test host."""
+        return "slowfail://{}".format(self.host)
+
+    def send(self, **kwargs):
+        """Block for the configured delay, then report failure."""
+        self.calls += 1
+        time.sleep(self._delay)
+        return False
+
+    async def async_notify(self, **kwargs):
+        """Block for the configured delay, then report failure."""
+        self.calls += 1
+        await asyncio.sleep(self._delay)
+        return False
+
+    @staticmethod
+    def parse_url(url):
+        """Parse the synthetic URL without requiring a real host."""
+        return NotifyBase.parse_url(url, verify_host=False)
+
+
+class TestDeadlineExpiresDuringAttempt:
+    """Deadline-expired retries should stop without sleeping first."""
+
+    def test_sequential_skips_wait_when_deadline_already_passed(self):
+        """Sequential retry skips its wait once the deadline has passed."""
+        N_MGR["slowfail"] = _SlowFailNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False, service_timeout=0.05)
+            service = _SlowFailNotify(
+                host="x", asset=asset, retry=1, wait=1.0, delay=0.2
+            )
+            a = Apprise(asset=asset)
+            a.add(service)
+
+            real_sleep = time.sleep
+            with mock.patch(
+                "apprise.apprise.time.sleep", side_effect=real_sleep
+            ) as mock_sleep:
+                result = a.notify(body="test")
+
+            # The first attempt failed before the retry deadline check.
+            # A confirmed failure takes priority over the later TIMEOUT.
+            assert result.status == AppriseResultStatus.FAILURE
+            # The retry loop stopped before sleeping or calling send() again.
+            assert service.calls == 1
+            mock_sleep.assert_called_once_with(pytest.approx(0.2))
+        finally:
+            N_MGR.unload_modules()
+
+    def test_asyncio_skips_wait_when_deadline_already_passed(self):
+        """Async retry skips its wait once the deadline has passed."""
+        N_MGR["slowfail"] = _SlowFailNotify
+
+        try:
+            asset = AppriseAsset(async_mode=True, service_timeout=0.05)
+            service = _SlowFailNotify(
+                host="x", asset=asset, retry=1, wait=1.0, delay=0.08
+            )
+            a = Apprise(asset=asset)
+            a.add(service)
+
+            # Keep the delay just above service_timeout so do_call() reaches
+            # its retry check before the outer abandon window takes over.
+            result = asyncio.run(a.async_notify(body="test"))
+
+            assert result.status == AppriseResultStatus.FAILURE
+            assert service.calls == 1
+        finally:
+            N_MGR.unload_modules()
+
+
+class TestSharedExecutorRace:
+    """_get_shared_executor() must reuse an executor created during locking."""
+
+    def test_inner_check_skips_creation_if_already_set(self):
+        """The inner lock check returns the executor another thread created."""
+        import apprise.apprise as apprise_module
+
+        sentinel = mock.Mock(name="already-created-executor")
+
+        class _RaceLock:
+            """Simulate another thread creating the executor first."""
+
+            def __enter__(self):
+                apprise_module._shared_executor = sentinel
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+        with (
+            mock.patch("apprise.apprise._shared_executor", None),
+            mock.patch("apprise.apprise._shared_executor_lock", _RaceLock()),
+            mock.patch("apprise.apprise.cf.ThreadPoolExecutor") as mock_pool,
+        ):
+            result = apprise_module._get_shared_executor()
+
+        assert result is sentinel
+        mock_pool.assert_not_called()

--- a/tests/test_retry_wait.py
+++ b/tests/test_retry_wait.py
@@ -27,11 +27,13 @@
 
 import asyncio
 import logging
+import threading
+import time
 from unittest import mock
 
 import pytest
 
-from apprise import Apprise, AppriseAsset
+from apprise import Apprise, AppriseAsset, AppriseResultStatus
 from apprise.common import (
     APPRISE_MAX_SERVICE_RETRY,
     APPRISE_MAX_SERVICE_WAIT,
@@ -235,53 +237,56 @@ class TestSequentialSleep:
     """time.sleep is called between retries in sequential dispatch."""
 
     def test_sleep_called_on_retry(self):
+        """A failed attempt waits once before its successful retry."""
         N_MGR["failpass"] = _FailThenSucceedNotify
 
         try:
             asset = AppriseAsset(async_mode=False)
             a = Apprise(asset=asset)
 
-            server = _FailThenSucceedNotify(
+            service = _FailThenSucceedNotify(
                 host="localhost",
                 asset=asset,
                 retry=2,
                 wait=0.3,
             )
-            a.add(server)
+            a.add(service)
 
             with mock.patch("apprise.apprise.time.sleep") as mock_sleep:
                 result = a.notify(body="test")
 
-            assert result is True
+            assert bool(result) is True
             # Failed once -> sleep once before retry
             mock_sleep.assert_called_once_with(pytest.approx(0.3))
         finally:
             N_MGR.unload_modules()
 
     def test_sleep_not_called_when_wait_zero(self):
+        """A zero wait setting retries without calling sleep."""
         N_MGR["failpass"] = _FailThenSucceedNotify
 
         try:
             asset = AppriseAsset(async_mode=False)
             a = Apprise(asset=asset)
 
-            server = _FailThenSucceedNotify(
+            service = _FailThenSucceedNotify(
                 host="localhost",
                 asset=asset,
                 retry=2,
                 wait=0.0,
             )
-            a.add(server)
+            a.add(service)
 
             with mock.patch("apprise.apprise.time.sleep") as mock_sleep:
                 result = a.notify(body="test")
 
-            assert result is True
+            assert bool(result) is True
             mock_sleep.assert_not_called()
         finally:
             N_MGR.unload_modules()
 
     def test_sleep_not_called_when_no_retry(self):
+        """A service without retries never sleeps after failure."""
         N_MGR["failpass"] = _FailThenSucceedNotify
 
         try:
@@ -290,19 +295,19 @@ class TestSequentialSleep:
 
             # retry=0 means only one attempt; with wait=1.0 sleep should
             # never fire since there are no retries
-            server = _FailThenSucceedNotify(
+            service = _FailThenSucceedNotify(
                 host="localhost",
                 asset=asset,
                 retry=0,
                 wait=1.0,
                 fail_times=0,  # always succeeds
             )
-            a.add(server)
+            a.add(service)
 
             with mock.patch("apprise.apprise.time.sleep") as mock_sleep:
                 result = a.notify(body="test")
 
-            assert result is True
+            assert bool(result) is True
             mock_sleep.assert_not_called()
         finally:
             N_MGR.unload_modules()
@@ -315,19 +320,19 @@ class TestSequentialSleep:
             asset = AppriseAsset(async_mode=False)
             a = Apprise(asset=asset)
 
-            server = _FailThenSucceedNotify(
+            service = _FailThenSucceedNotify(
                 host="localhost",
                 asset=asset,
                 retry=3,
                 wait=0.5,
                 fail_times=2,
             )
-            a.add(server)
+            a.add(service)
 
             with mock.patch("apprise.apprise.time.sleep") as mock_sleep:
                 result = a.notify(body="test")
 
-            assert result is True
+            assert bool(result) is True
             assert mock_sleep.call_count == 2
             for call in mock_sleep.call_args_list:
                 assert call == mock.call(pytest.approx(0.5))
@@ -339,15 +344,16 @@ class TestThreadPoolSleep:
     """time.sleep is called between retries in threadpool dispatch."""
 
     def test_sleep_called_in_threadpool(self):
+        """A thread-pool retry honors the configured wait interval."""
         N_MGR["failpass"] = _FailThenSucceedNotify
 
         try:
-            # async_mode=True -> uses threadpool when > 1 server;
-            # but with a single server it falls through to sequential.
-            # Use two servers so we actually hit the threadpool path.
+            # async_mode=True -> uses threadpool when > 1 service;
+            # but with a single service it falls through to sequential.
+            # Use two services so we actually hit the threadpool path.
             asset = AppriseAsset(async_mode=True)
 
-            # Two separate server objects so a threadpool is used
+            # Two separate service objects so a threadpool is used
             s1 = _FailThenSucceedNotify(
                 host="localhost",
                 asset=asset,
@@ -370,13 +376,14 @@ class TestThreadPoolSleep:
             with mock.patch("apprise.apprise.time.sleep") as mock_sleep:
                 result = a.notify(body="test")
 
-            assert result is True
+            assert bool(result) is True
             # s1 fails once -> sleep once
             mock_sleep.assert_called_once_with(pytest.approx(0.2))
         finally:
             N_MGR.unload_modules()
 
     def test_sleep_not_called_in_threadpool_when_wait_zero(self):
+        """A zero thread-pool wait retries without calling sleep."""
         N_MGR["failpass"] = _FailThenSucceedNotify
 
         try:
@@ -404,7 +411,7 @@ class TestThreadPoolSleep:
             with mock.patch("apprise.apprise.time.sleep") as mock_sleep:
                 result = a.notify(body="test")
 
-            assert result is True
+            assert bool(result) is True
             mock_sleep.assert_not_called()
         finally:
             N_MGR.unload_modules()
@@ -414,12 +421,13 @@ class TestAsyncioSleep:
     """asyncio.sleep is called between retries in async dispatch."""
 
     def test_asyncio_sleep_called(self):
+        """An asynchronous retry honors the configured wait interval."""
         N_MGR["failpass"] = _FailThenSucceedNotify
 
         try:
             asset = AppriseAsset()
 
-            server = _FailThenSucceedNotify(
+            service = _FailThenSucceedNotify(
                 host="localhost",
                 asset=asset,
                 retry=2,
@@ -428,9 +436,10 @@ class TestAsyncioSleep:
             )
 
             a = Apprise(asset=asset)
-            a.add(server)
+            a.add(service)
 
             async def run():
+                """Dispatch while capturing the asynchronous retry sleep."""
                 with mock.patch("apprise.apprise.asyncio.sleep") as mock_sleep:
                     mock_sleep.return_value = None
                     result = await a.async_notify(body="test")
@@ -438,18 +447,19 @@ class TestAsyncioSleep:
 
             result, mock_sleep = asyncio.run(run())
 
-            assert result is True
+            assert bool(result) is True
             mock_sleep.assert_called_once_with(pytest.approx(0.4))
         finally:
             N_MGR.unload_modules()
 
     def test_asyncio_sleep_not_called_when_wait_zero(self):
+        """A zero asynchronous wait retries without calling sleep."""
         N_MGR["failpass"] = _FailThenSucceedNotify
 
         try:
             asset = AppriseAsset()
 
-            server = _FailThenSucceedNotify(
+            service = _FailThenSucceedNotify(
                 host="localhost",
                 asset=asset,
                 retry=2,
@@ -458,9 +468,10 @@ class TestAsyncioSleep:
             )
 
             a = Apprise(asset=asset)
-            a.add(server)
+            a.add(service)
 
             async def run():
+                """Dispatch while checking that asyncio.sleep is unused."""
                 with mock.patch("apprise.apprise.asyncio.sleep") as mock_sleep:
                     mock_sleep.return_value = None
                     result = await a.async_notify(body="test")
@@ -468,7 +479,7 @@ class TestAsyncioSleep:
 
             result, mock_sleep = asyncio.run(run())
 
-            assert result is True
+            assert bool(result) is True
             mock_sleep.assert_not_called()
         finally:
             N_MGR.unload_modules()
@@ -506,16 +517,59 @@ class _RaisingNotify(NotifyBase):
     body_maxlen = 32768
 
     def url(self, *args, **kwargs):
+        """Return the stable URL for this raising test plugin."""
         return "raise://localhost"
 
     def send(self, **kwargs):
+        """Raise a delivery error for synchronous exception tests."""
         raise RuntimeError("plugin exploded")
 
     async def async_notify(self, **kwargs):
+        """Raise a delivery error for asynchronous exception tests."""
         raise RuntimeError("plugin exploded async")
 
     @staticmethod
     def parse_url(url):
+        """Parse the synthetic URL without requiring a real host."""
+        return NotifyBase.parse_url(url, verify_host=False)
+
+
+class _SlowNotify(NotifyBase):
+    """Plugin whose send() blocks for a configurable delay before
+    reporting success -- used to exercise AppriseAsset._service_timeout
+    and notify(timeout=...) enforcement with real wall-clock timing."""
+
+    app_id = "SlowApp"
+    app_desc = "Test"
+    notify_url = "slow://"
+    title_maxlen = 250
+    body_maxlen = 32768
+
+    def __init__(self, delay=0.0, **kwargs):
+        """Initialize the test plugin with its artificial delay."""
+        super().__init__(**kwargs)
+        self._delay = delay
+        self.calls = 0
+
+    def url(self, *args, **kwargs):
+        """Return a stable URL containing the test host."""
+        return "slow://{}".format(self.host)
+
+    def send(self, **kwargs):
+        """Simulate blocking delivery before reporting success."""
+        self.calls += 1
+        time.sleep(self._delay)
+        return True
+
+    async def async_notify(self, **kwargs):
+        """Simulate asynchronous delivery before reporting success."""
+        self.calls += 1
+        await asyncio.sleep(self._delay)
+        return True
+
+    @staticmethod
+    def parse_url(url):
+        """Parse the synthetic URL without requiring a real host."""
         return NotifyBase.parse_url(url, verify_host=False)
 
 
@@ -544,12 +598,12 @@ class TestAppriseTag:
         assert repr(AppriseTag("simple")) == "AppriseTag('simple')"
 
     def test_repr_with_priority(self):
-        """repr() includes priority= when non-zero (tag.py lines 121-122)."""
+        """repr() includes priority= when the priority is non-zero."""
         r = repr(AppriseTag("test", priority=3))
         assert "priority=3" in r
 
     def test_repr_with_retry(self):
-        """repr() includes retry= when set (tag.py lines 123-125)."""
+        """repr() includes retry= when a retry count is set."""
         r = repr(AppriseTag("test", retry=5))
         assert "retry=5" in r
 
@@ -584,13 +638,12 @@ class TestAppriseTag:
     # --- __lt__ ---
 
     def test_lt_two_apprisetags(self):
-        """__lt__ sorts by tag name (tag.py lines 159-160)."""
+        """__lt__ sorts two AppriseTag objects by tag name."""
         assert AppriseTag("abc") < AppriseTag("def")
         assert not (AppriseTag("def") < AppriseTag("abc"))
 
     def test_lt_with_string(self):
-        """AppriseTag can be less-than compared to a plain string
-        (tag.py lines 161-162)."""
+        """AppriseTag can be ordered against a plain string."""
         assert AppriseTag("abc") < "def"
         assert not (AppriseTag("zzz") < "aaa")
 
@@ -627,13 +680,13 @@ class TestStaticHelpers:
     covering the nested-list branches not reached by integration tests."""
 
     def test_extract_retry_from_nested_list(self):
-        """Retry suffix found inside a nested list entry (apprise.py:413)."""
+        """A retry suffix is found inside a nested list entry."""
         # tag = [["alerts:3"]] -- outer list, inner list as AND group
         result = Apprise._extract_filter_retry([["alerts:3"]])
         assert result == 3
 
     def test_extract_retry_from_list_of_strings(self):
-        """Retry suffix found in a plain-string list entry (apprise.py:417)."""
+        """A retry suffix is found in a plain-string list entry."""
         result = Apprise._extract_filter_retry(["alerts:3"])
         assert result == 3
 
@@ -651,29 +704,29 @@ class TestStaticHelpers:
         result = Apprise._extract_filter_retry([["alerts"]])
         assert result is None
 
-    def test_server_priority_for_tag_name_absent(self):
-        """Returns 0 when no tag in server.tags matches tag_name."""
-        server = mock.Mock()
-        server.tags = {AppriseTag("alerts", priority=3, has_priority=True)}
-        assert Apprise._server_priority_for_tag_name(server, "backup") == 0
+    def test_service_priority_for_tag_name_absent(self):
+        """Returns 0 when no tag in service.tags matches tag_name."""
+        service = mock.Mock()
+        service.tags = {AppriseTag("alerts", priority=3, has_priority=True)}
+        assert Apprise._server_priority_for_tag_name(service, "backup") == 0
 
-    def test_match_service_retry_plain_string_tag_backward_compat(self):
-        """Plain string in server.tags matched by a priority-prefixed token.
+    def test_match_service_retry_plain_string_tag(self):
+        """Plain string in service.tags matched by a priority-prefixed token.
 
-        Covers the else/str fallback inside _match_service_retry when stag is
-        not an AppriseTag instance and the name matches (lines 497-498).
+        Covers the string fallback when a matching service tag is not an
+        AppriseTag instance.
         """
-        server = mock.Mock()
-        server.tags = {"alerts"}  # plain string, not an AppriseTag
+        service = mock.Mock()
+        service.tags = {"alerts"}  # plain string, not an AppriseTag
         # "3:alerts:2" carries priority=3 + retry=2; plain "alerts" matches
-        result = Apprise._match_service_retry(server, "3:alerts:2")
+        result = Apprise._match_service_retry(service, "3:alerts:2")
         assert result == 2
 
     def test_match_service_retry_plain_string_tag_no_match(self):
-        """Plain string in server.tags that does not match returns None."""
-        server = mock.Mock()
-        server.tags = {"other"}  # plain string -- does not match "alerts"
-        result = Apprise._match_service_retry(server, "3:alerts:2")
+        """Plain string in service.tags that does not match returns None."""
+        service = mock.Mock()
+        service.tags = {"other"}  # plain string -- does not match "alerts"
+        result = Apprise._match_service_retry(service, "3:alerts:2")
         assert result is None
 
     def test_extract_retry_none_for_match_all(self):
@@ -681,37 +734,42 @@ class TestStaticHelpers:
         assert Apprise._extract_filter_retry(None) is None
 
     def test_has_priority_nested_list(self):
-        """Priority prefix found inside a nested list (apprise.py:438)."""
+        """A priority prefix is found inside a nested list."""
         assert Apprise._filter_has_explicit_priority([["2:alerts"]])
 
     def test_has_priority_list_of_strings(self):
-        """Priority prefix found in a plain-string list (apprise.py:441)."""
+        """A priority prefix is found in a plain-string list."""
         assert Apprise._filter_has_explicit_priority(["2:alerts"])
 
     def test_has_priority_false_no_prefix(self):
+        """Filters without a prefix do not carry explicit priority."""
         assert not Apprise._filter_has_explicit_priority("alerts")
         assert not Apprise._filter_has_explicit_priority(["alerts"])
 
     def test_has_priority_false_for_match_all(self):
+        """Match-all filters do not carry an explicit priority."""
         assert not Apprise._filter_has_explicit_priority(MATCH_ALL_TAG)
         assert not Apprise._filter_has_explicit_priority(None)
 
     # _notify_parallel_threadpool / _notify_parallel_asyncio zero-length -----
 
-    def test_threadpool_zero_servers_returns_true(self):
-        """Empty server list returns True immediately (apprise.py:940)."""
-        assert Apprise._notify_parallel_threadpool() is True
+    def test_threadpool_zero_services_returns_true(self):
+        """Empty service list returns (True, []) immediately."""
+        ok, results = Apprise._notify_parallel_threadpool()
+        assert ok is True
+        assert results == []
 
-    def test_asyncio_zero_servers_returns_true(self):
-        """Empty server list returns True immediately (apprise.py:1031)."""
-        result = asyncio.run(Apprise._notify_parallel_asyncio())
-        assert result is True
+    def test_asyncio_zero_services_returns_true(self):
+        """Empty service list returns (True, []) immediately."""
+        ok, results = asyncio.run(Apprise._notify_parallel_asyncio())
+        assert ok is True
+        assert results == []
 
 
 class TestDispatchIntegration:
     """End-to-end notify() tests covering the new priority/retry dispatch."""
 
-    def _make_server(self, host, priority, asset, fail_times=0):
+    def _make_service(self, host, priority, asset, fail_times=0):
         """Create a _FailThenSucceedNotify with an AppriseTag in its tags."""
         s = _FailThenSucceedNotify(
             host=host, asset=asset, fail_times=fail_times
@@ -719,47 +777,46 @@ class TestDispatchIntegration:
         # Assign a fresh instance-level set rather than mutating the
         # class-level tags set.  URLBase.tags is a class attribute (set());
         # .add() would mutate it and share state across all instances.
-        # Assignment shadows the class attribute and gives each server its
+        # Assignment shadows the class attribute and gives each service its
         # own set with the correct priority stored in the AppriseTag object.
         s.tags = {AppriseTag("alerts", priority=priority, has_priority=True)}
         return s
 
     def test_filter_retry_override_via_tag_suffix(self):
-        """tag suffix ':N' overrides per-server retry for this call only."""
+        """tag suffix ':N' overrides per-service retry for this call only."""
         N_MGR["failpass"] = _FailThenSucceedNotify
 
         try:
             asset = AppriseAsset(async_mode=False)
-            # Server's own retry=0; tag suffix of 2 should allow 3 attempts
-            server = _FailThenSucceedNotify(
+            # Service's own retry=0; tag suffix of 2 should allow 3 attempts
+            service = _FailThenSucceedNotify(
                 host="localhost",
                 asset=asset,
                 retry=0,
                 wait=0.0,
                 fail_times=2,
             )
-            # Tag the server so the filter "failpass:2" (tag name "failpass",
+            # Tag the service so the filter "failpass:2" (tag name "failpass",
             # retry override 2) can match it via is_exclusive_match.
-            server.tags = {"failpass"}
+            service.tags = {"failpass"}
             a = Apprise(asset=asset)
-            a.add(server)
+            a.add(service)
 
             # "failpass:2" -> retry override of 2 (3 total attempts)
             result = a.notify(body="test", tag="failpass:2")
-            assert result is True
-            assert server._calls == 3
+            assert bool(result) is True
+            assert service._calls == 3
         finally:
             N_MGR.unload_modules()
 
     def test_exclusive_priority_dispatch_skips_other_priorities(self):
-        """Explicit priority prefix dispatches only matching-priority services.
-        Covers apprise.py lines 556-572."""
+        """An explicit priority dispatches only matching-priority services."""
         N_MGR["failpass"] = _FailThenSucceedNotify
 
         try:
             asset = AppriseAsset(async_mode=False)
-            s1 = self._make_server("host1", priority=1, asset=asset)
-            s2 = self._make_server("host2", priority=2, asset=asset)
+            s1 = self._make_service("host1", priority=1, asset=asset)
+            s2 = self._make_service("host2", priority=2, asset=asset)
 
             a = Apprise(asset=asset)
             a.add(s1)
@@ -767,27 +824,27 @@ class TestDispatchIntegration:
 
             # "2:alerts" -> only priority-2 service fires
             result = a.notify(body="test", tag="2:alerts")
-            assert result is True
+            assert bool(result) is True
             assert s1._calls == 0  # priority-1, not contacted
             assert s2._calls == 1  # priority-2, contacted once
         finally:
             N_MGR.unload_modules()
 
-    def test_escalation_stops_when_highest_priority_group_succeeds(self):
+    def test_escalation_stops_after_priority_success(self):
         """If priority-1 group all succeed, priority-2 group is not run."""
         N_MGR["failpass"] = _FailThenSucceedNotify
 
         try:
             asset = AppriseAsset(async_mode=False)
-            s1 = self._make_server("host1", priority=1, asset=asset)
-            s2 = self._make_server("host2", priority=2, asset=asset)
+            s1 = self._make_service("host1", priority=1, asset=asset)
+            s2 = self._make_service("host2", priority=2, asset=asset)
 
             a = Apprise(asset=asset)
             a.add(s1)
             a.add(s2)
 
             result = a.notify(body="test", tag="alerts")
-            assert result is True
+            assert bool(result) is True
             assert s1._calls == 1  # priority 1 succeeded
             assert s2._calls == 0  # never escalated to
         finally:
@@ -800,46 +857,47 @@ class TestDispatchIntegration:
         try:
             asset = AppriseAsset(async_mode=False)
             # priority-1 always fails
-            s1 = self._make_server(
+            s1 = self._make_service(
                 "host1", priority=1, asset=asset, fail_times=999
             )
             # priority-2 always succeeds
-            s2 = self._make_server("host2", priority=2, asset=asset)
+            s2 = self._make_service("host2", priority=2, asset=asset)
 
             a = Apprise(asset=asset)
             a.add(s1)
             a.add(s2)
 
             result = a.notify(body="test", tag="alerts")
-            assert result is True
+            assert bool(result) is True
             assert s1._calls == 1
             assert s2._calls == 1
         finally:
             N_MGR.unload_modules()
 
     def test_async_notify_filter_retry_and_explicit_priority(self):
-        """async_notify() covers the same escalation/exclusive paths.
-        Covers apprise.py lines 630, 637-649."""
+        """async_notify() supports escalation and exclusive priority paths."""
         N_MGR["failpass"] = _FailThenSucceedNotify
 
         try:
             asset = AppriseAsset()
-            s1 = self._make_server("host1", priority=1, asset=asset)
-            s2 = self._make_server("host2", priority=2, asset=asset)
+            s1 = self._make_service("host1", priority=1, asset=asset)
+            s2 = self._make_service("host2", priority=2, asset=asset)
 
             a = Apprise(asset=asset)
             a.add(s1)
             a.add(s2)
 
             async def run_exclusive():
+                """Dispatch only the explicitly selected priority."""
                 return await a.async_notify(body="test", tag="2:alerts")
 
             async def run_escalation():
+                """Dispatch the first successful escalation group."""
                 return await a.async_notify(body="test", tag="alerts")
 
             # exclusive: only priority-2 fires
             r = asyncio.run(run_exclusive())
-            assert r is True
+            assert bool(r) is True
             assert s1._calls == 0
             assert s2._calls == 1
 
@@ -847,7 +905,7 @@ class TestDispatchIntegration:
             s1._calls = 0
             s2._calls = 0
             r = asyncio.run(run_escalation())
-            assert r is True
+            assert bool(r) is True
             assert s1._calls == 1
             assert s2._calls == 0
         finally:
@@ -886,10 +944,11 @@ class TestDispatchIntegration:
             a.add(s2)
             a.add(s3)
 
-            # Exclusive "0:family": plain "family" and "0:family" servers are
-            # both priority 0 and must both fire; priority-1 server is skipped.
+            # Exclusive "0:family": plain "family" and "0:family" services
+            # are both priority 0 and must both fire; priority-1 service is
+            # skipped.
             result = a.notify(body="test", tag="0:family")
-            assert result is True
+            assert bool(result) is True
             assert s1._calls == 1  # plain "family" matched by "0:family"
             assert s2._calls == 1  # explicit "0:family" matched
             assert s3._calls == 0  # priority 1, not priority 0 -- skipped
@@ -898,7 +957,7 @@ class TestDispatchIntegration:
             # group.  Both succeed, so s3 (priority 1) is never escalated to.
             s1._calls = s2._calls = s3._calls = 0
             result = a.notify(body="test", tag="family")
-            assert result is True
+            assert bool(result) is True
             assert s1._calls == 1  # priority-0 group
             assert s2._calls == 1  # same priority-0 group
             assert s3._calls == 0  # not escalated to
@@ -915,12 +974,12 @@ class TestExceptionHandling:
 
         try:
             asset = AppriseAsset(async_mode=False)
-            server = _RaisingNotify(host="localhost", asset=asset, retry=0)
+            service = _RaisingNotify(host="localhost", asset=asset, retry=0)
             a = Apprise(asset=asset)
-            a.add(server)
+            a.add(service)
 
             result = a.notify(body="test")
-            assert result is False
+            assert bool(result) is False
         finally:
             N_MGR.unload_modules()
 
@@ -932,7 +991,7 @@ class TestExceptionHandling:
         try:
             asset = AppriseAsset(async_mode=False)
             # Use a plugin that raises on the first attempt then succeeds
-            server = _FailThenSucceedNotify(
+            service = _FailThenSucceedNotify(
                 host="localhost", asset=asset, retry=1, wait=0.0, fail_times=1
             )
             # Patch notify to raise on the first call then succeed
@@ -944,24 +1003,23 @@ class TestExceptionHandling:
                     raise RuntimeError("transient error")
                 return True
 
-            server.send = raising_then_ok
+            service.send = raising_then_ok
             a = Apprise(asset=asset)
-            a.add(server)
+            a.add(service)
 
             result = a.notify(body="test")
-            assert result is True
+            assert bool(result) is True
             assert call_count[0] == 2
         finally:
             N_MGR.unload_modules()
 
     def test_threadpool_future_exception_caught(self):
-        """An exception escaping a thread future is caught gracefully.
-        Covers apprise.py lines 1004-1006."""
+        """An exception escaping a thread future is caught gracefully."""
         N_MGR["failpass"] = _FailThenSucceedNotify
 
         try:
             asset = AppriseAsset(async_mode=True)
-            # Need 2 servers to trigger the thread pool path
+            # Need 2 services to trigger the thread pool path
             s1 = _FailThenSucceedNotify(
                 host="host1", asset=asset, fail_times=0
             )
@@ -972,47 +1030,73 @@ class TestExceptionHandling:
             a.add(s1)
             a.add(s2)
 
-            # Patch as_completed so one future raises when .result() is called
+            # Inject one failed future so the outer safety net is exercised.
             import concurrent.futures as cf
 
-            real_as_completed = cf.as_completed
+            real_executor_cls = cf.ThreadPoolExecutor
 
-            def patched_as_completed(futures, **kw):
-                for i, f in enumerate(real_as_completed(futures, **kw)):
-                    if i == 0:
-                        # Wrap first future to raise on .result()
-                        m = mock.Mock()
-                        m.result.side_effect = RuntimeError("future boom")
-                        yield m
-                    else:
-                        yield f
+            class _PatchedExecutor:
+                """Delegate to a real executor while injecting one failure."""
 
-            with mock.patch(
-                "apprise.apprise.cf.as_completed", patched_as_completed
+                def __init__(self, *args, **kwargs):
+                    """Create the wrapped executor with the same arguments."""
+                    self._real = real_executor_cls(*args, **kwargs)
+
+                def __enter__(self):
+                    """Return this wrapper when entering the context."""
+                    return self
+
+                def __exit__(self, *exc):
+                    """Forward context cleanup to the wrapped executor."""
+                    return self._real.__exit__(*exc)
+
+                def submit(self, fn, service, kwargs):
+                    """Return a failed future for ``s1`` and submit others."""
+                    if service is s1:
+                        fut = cf.Future()
+                        fut.set_exception(RuntimeError("future boom"))
+                        return fut
+                    return self._real.submit(fn, service, kwargs)
+
+                def shutdown(self, *args, **kwargs):
+                    """Forward shutdown behavior to the wrapped executor."""
+                    return self._real.shutdown(*args, **kwargs)
+
+            # Reset the shared executor so the patched class is used here.
+            import apprise.apprise as apprise_module
+
+            with (
+                mock.patch("apprise.apprise._shared_executor", None),
+                mock.patch(
+                    "apprise.apprise.cf.ThreadPoolExecutor", _PatchedExecutor
+                ),
             ):
                 result = a.notify(body="test")
 
+                # Clean up the real executor wrapped by _PatchedExecutor.
+                apprise_module._shared_executor._real.shutdown(wait=True)
+
             # One future raised -> overall result is False
-            assert result is False
+            assert bool(result) is False
         finally:
             N_MGR.unload_modules()
 
     def test_asyncio_exception_in_do_call_treated_as_failure(self):
-        """An exception inside do_call's retry loop is caught and the
-        service is marked as failed (covers the new try/except in do_call)."""
+        """An exception inside do_call marks the service as failed."""
         N_MGR["raise"] = _RaisingNotify
 
         try:
             asset = AppriseAsset()
-            server = _RaisingNotify(host="localhost", asset=asset, retry=0)
+            service = _RaisingNotify(host="localhost", asset=asset, retry=0)
             a = Apprise(asset=asset)
-            a.add(server)
+            a.add(service)
 
             async def run():
+                """Execute async notification with the patched gather."""
                 return await a.async_notify(body="test")
 
             result = asyncio.run(run())
-            assert result is False
+            assert bool(result) is False
         finally:
             N_MGR.unload_modules()
 
@@ -1023,27 +1107,29 @@ class TestExceptionHandling:
 
         try:
             asset = AppriseAsset()
-            server = _FailThenSucceedNotify(
+            service = _FailThenSucceedNotify(
                 host="localhost", asset=asset, fail_times=0
             )
             a = Apprise(asset=asset)
-            a.add(server)
+            a.add(service)
 
             # Mock asyncio.gather to return an escaped exception object.
             # Close any unawaited coroutines passed to the mock to avoid
             # "coroutine was never awaited" RuntimeWarnings.
             async def fake_gather(*args, **kw):
+                """Return an escaped error while closing input coroutines."""
                 for arg in args:
                     if asyncio.iscoroutine(arg):
                         arg.close()
                 return [RuntimeError("escaped")]
 
             async def run():
+                """Dispatch while gather returns an escaped exception."""
                 with mock.patch("apprise.apprise.asyncio.gather", fake_gather):
                     return await a.async_notify(body="test")
 
             result = asyncio.run(run())
-            assert result is False
+            assert bool(result) is False
         finally:
             N_MGR.unload_modules()
 
@@ -1053,24 +1139,128 @@ class TestExceptionHandling:
 
         try:
             asset = AppriseAsset()
-            server = _FailThenSucceedNotify(
+            service = _FailThenSucceedNotify(
                 host="localhost", asset=asset, fail_times=0
             )
             a = Apprise(asset=asset)
-            a.add(server)
+            a.add(service)
 
             async def fake_gather(*args, **kw):
+                """Return a validation error as a gathered result."""
                 for arg in args:
                     if asyncio.iscoroutine(arg):
                         arg.close()
                 return [TypeError("validation")]
 
             async def run():
+                """Dispatch while gather returns a validation error."""
                 with mock.patch("apprise.apprise.asyncio.gather", fake_gather):
                     return await a.async_notify(body="test")
 
             result = asyncio.run(run())
-            assert result is False
+            assert bool(result) is False
+        finally:
+            N_MGR.unload_modules()
+
+    def test_sequential_raise_does_not_block_other_services(self):
+        """A raising service is marked failed but every other service in
+        the same sequential batch is still attempted and reported."""
+        N_MGR["raise"] = _RaisingNotify
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            bad = _RaisingNotify(host="bad", asset=asset)
+            good1 = _FailThenSucceedNotify(
+                host="good1", asset=asset, fail_times=0
+            )
+            good2 = _FailThenSucceedNotify(
+                host="good2", asset=asset, fail_times=0
+            )
+
+            a = Apprise(asset=asset)
+            a.add(good1)
+            a.add(bad)
+            a.add(good2)
+
+            result = a.notify(body="test")
+            assert bool(result) is False
+            assert len(result) == 3
+
+            # Order matches add() order: good1, bad, good2.
+            results = list(result)
+            assert bool(results[0]) is True
+            assert bool(results[1]) is False
+            assert bool(results[2]) is True
+            # good2 was still attempted despite bad raising before it
+            assert good2._calls == 1
+        finally:
+            N_MGR.unload_modules()
+
+    def test_threadpool_raise_does_not_block_other_services(self):
+        """Same guarantee as above, but across the thread-pool dispatch
+        path (async_mode=True, >1 service)."""
+        N_MGR["raise"] = _RaisingNotify
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=True)
+            bad = _RaisingNotify(host="bad", asset=asset)
+            good1 = _FailThenSucceedNotify(
+                host="good1", asset=asset, fail_times=0
+            )
+            good2 = _FailThenSucceedNotify(
+                host="good2", asset=asset, fail_times=0
+            )
+
+            a = Apprise(asset=asset)
+            a.add(good1)
+            a.add(bad)
+            a.add(good2)
+
+            result = a.notify(body="test")
+            assert bool(result) is False
+            assert len(result) == 3
+
+            # Threadpool dispatch preserves original submission order.
+            results = list(result)
+            assert bool(results[0]) is True
+            assert bool(results[1]) is False
+            assert bool(results[2]) is True
+            assert good2._calls == 1
+        finally:
+            N_MGR.unload_modules()
+
+    def test_asyncio_raise_does_not_block_other_services(self):
+        """Same guarantee as above, but across the asyncio dispatch path."""
+        N_MGR["raise"] = _RaisingNotify
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=True)
+            bad = _RaisingNotify(host="bad", asset=asset)
+            good1 = _FailThenSucceedNotify(
+                host="good1", asset=asset, fail_times=0
+            )
+            good2 = _FailThenSucceedNotify(
+                host="good2", asset=asset, fail_times=0
+            )
+
+            a = Apprise(asset=asset)
+            a.add(good1)
+            a.add(bad)
+            a.add(good2)
+
+            result = asyncio.run(a.async_notify(body="test"))
+            assert bool(result) is False
+            assert len(result) == 3
+
+            # asyncio dispatch preserves original submission order too.
+            results = list(result)
+            assert bool(results[0]) is True
+            assert bool(results[1]) is False
+            assert bool(results[2]) is True
+            assert good2._calls == 1
         finally:
             N_MGR.unload_modules()
 
@@ -1084,65 +1274,65 @@ class TestConfigTagRetry:
     """
 
     def test_text_rejects_retry_suffix(self):
-        """'alerts:3=json://...' is rejected; no server loaded."""
-        servers, _ = ConfigBase.config_parse_text("alerts:3=json://localhost")
-        assert servers == []
+        """'alerts:3=json://...' is rejected; no service loaded."""
+        services, _ = ConfigBase.config_parse_text("alerts:3=json://localhost")
+        assert services == []
 
     def test_text_rejects_priority_and_retry_in_tag(self):
         """'1:alerts:3=json://...' is rejected (priority + retry suffix)."""
-        servers, _ = ConfigBase.config_parse_text(
+        services, _ = ConfigBase.config_parse_text(
             "1:alerts:3=json://localhost"
         )
-        assert servers == []
+        assert services == []
 
     def test_text_accepts_priority_tag_without_retry(self):
         """'1:alerts=json://...' loads normally (priority prefix, no retry)."""
-        servers, _ = ConfigBase.config_parse_text("1:alerts=json://localhost")
-        assert len(servers) == 1
+        services, _ = ConfigBase.config_parse_text("1:alerts=json://localhost")
+        assert len(services) == 1
 
     def test_text_accepts_plain_tag(self):
         """'alerts=json://...' loads normally (no prefix, no retry)."""
-        servers, _ = ConfigBase.config_parse_text("alerts=json://localhost")
-        assert len(servers) == 1
+        services, _ = ConfigBase.config_parse_text("alerts=json://localhost")
+        assert len(services) == 1
 
     def test_yaml_rejects_retry_suffix(self):
-        """YAML 'tag: alerts:3' is rejected; no server loaded."""
-        servers, _ = ConfigBase.config_parse_yaml(
+        """YAML 'tag: alerts:3' is rejected; no service loaded."""
+        services, _ = ConfigBase.config_parse_yaml(
             "version: 1\nurls:\n  - json://localhost:\n      tag: alerts:3\n"
         )
-        assert servers == []
+        assert services == []
 
     def test_yaml_rejects_priority_and_retry_in_tag(self):
         """YAML 'tag: 1:alerts:3' is rejected (priority + retry suffix)."""
-        servers, _ = ConfigBase.config_parse_yaml(
+        services, _ = ConfigBase.config_parse_yaml(
             "version: 1\nurls:\n  - json://localhost:\n      tag: 1:alerts:3\n"
         )
-        assert servers == []
+        assert services == []
 
     def test_yaml_accepts_priority_tag_without_retry(self):
         """YAML 'tag: 1:alerts' loads normally (priority prefix, no retry)."""
-        servers, _ = ConfigBase.config_parse_yaml(
+        services, _ = ConfigBase.config_parse_yaml(
             "version: 1\nurls:\n  - json://localhost:\n      tag: 1:alerts\n"
         )
-        assert len(servers) == 1
+        assert len(services) == 1
 
     def test_yaml_accepts_plain_tag(self):
         """YAML 'tag: alerts' loads normally (no prefix, no retry)."""
-        servers, _ = ConfigBase.config_parse_yaml(
+        services, _ = ConfigBase.config_parse_yaml(
             "version: 1\nurls:\n  - json://localhost:\n      tag: alerts\n"
         )
-        assert len(servers) == 1
+        assert len(services) == 1
 
     def test_text_valid_entry_after_rejected_one_still_loads(self):
         """A valid entry that follows a rejected one is still loaded."""
-        servers, _ = ConfigBase.config_parse_text(
+        services, _ = ConfigBase.config_parse_text(
             "alerts:3=json://localhost\nalerts=json://localhost\n"
         )
-        assert len(servers) == 1
+        assert len(services) == 1
 
     def test_yaml_valid_entry_after_rejected_one_still_loads(self):
         """A valid entry that follows a rejected one is still loaded."""
-        servers, _ = ConfigBase.config_parse_yaml(
+        services, _ = ConfigBase.config_parse_yaml(
             "version: 1\n"
             "urls:\n"
             "  - json://localhost:\n"
@@ -1150,7 +1340,7 @@ class TestConfigTagRetry:
             "  - json://localhost:\n"
             "      tag: alerts\n"
         )
-        assert len(servers) == 1
+        assert len(services) == 1
 
 
 class TestMultiTagDispatch:
@@ -1173,7 +1363,7 @@ class TestMultiTagDispatch:
         return s
 
     def _make_priority_tagged(self, tag_str, asset, fail_times=0):
-        """Create a server whose tag is an explicit-priority AppriseTag."""
+        """Create a service whose tag is an explicit-priority AppriseTag."""
         ft = AppriseTag.parse(tag_str)
         s = _FailThenSucceedNotify(
             host=str(ft), asset=asset, fail_times=fail_times
@@ -1210,7 +1400,7 @@ class TestMultiTagDispatch:
             a.add(s_mgmt)
 
             result = a.notify(body="test", tag="devops:3 management:2")
-            assert result is True
+            assert bool(result) is True
             # devops: 1 initial + 3 retries = 4 total calls
             assert s_devops._calls == 4
             # management: 1 initial + 2 retries = 3 total calls
@@ -1241,7 +1431,7 @@ class TestMultiTagDispatch:
             a.add(s_mgmt)
 
             result = a.notify(body="test", tag=["devops:3", "management:2"])
-            assert result is True
+            assert bool(result) is True
             assert s_devops._calls == 4
             assert s_mgmt._calls == 3
         finally:
@@ -1251,10 +1441,10 @@ class TestMultiTagDispatch:
     # Independent escalation chains
     # ------------------------------------------------------------------
 
-    def test_independent_chains_devops_success_does_not_skip_management(self):
+    def test_independent_chains_do_not_skip(self):
         """When devops chain succeeds at priority-1, management chain still
         dispatches independently -- its priority-1 failure escalates to its
-        priority-2 server."""
+        priority-2 service."""
         N_MGR["failpass"] = _FailThenSucceedNotify
 
         try:
@@ -1296,7 +1486,7 @@ class TestMultiTagDispatch:
             a.add(s_mgmt_p2)
 
             result = a.notify(body="test", tag="devops management")
-            assert result is True
+            assert bool(result) is True
             assert s_devops_p1._calls == 1  # devops chain: p1 succeeded
             assert s_devops_p2._calls == 0  # never escalated to
             assert s_mgmt_p1._calls == 1  # management chain: p1 failed
@@ -1329,7 +1519,7 @@ class TestMultiTagDispatch:
             a.add(s_mgmt)
 
             result = a.notify(body="test", tag="devops management")
-            assert result is False
+            assert bool(result) is False
             assert s_devops._calls == 1  # its chain succeeded
             assert s_mgmt._calls == 1  # its chain failed
         finally:
@@ -1340,19 +1530,19 @@ class TestMultiTagDispatch:
     # ------------------------------------------------------------------
 
     def test_explicit_priority_list_per_service_retry(self):
-        """['1:tag:2', '2:tag:0'] flat-dispatches both servers; each gets its
-        own retry: the priority-1 server gets retry=2 and the priority-2
-        server gets retry=0 (one attempt only)."""
+        """['1:tag:2', '2:tag:0'] flat-dispatches both services; each gets its
+        own retry: the priority-1 service gets retry=2 and the priority-2
+        service gets retry=0 (one attempt only)."""
         N_MGR["failpass"] = _FailThenSucceedNotify
 
         try:
             asset = AppriseAsset(async_mode=False)
 
-            # priority-1 server: fails twice; needs retry=2 to succeed
+            # priority-1 service: fails twice; needs retry=2 to succeed
             s1 = _FailThenSucceedNotify(host="h1", asset=asset, fail_times=2)
             s1.tags = {AppriseTag("tag", priority=1, has_priority=True)}
 
-            # priority-2 server: always succeeds; retry=0 means one attempt
+            # priority-2 service: always succeeds; retry=0 means one attempt
             s2 = _FailThenSucceedNotify(host="h2", asset=asset, fail_times=0)
             s2.tags = {AppriseTag("tag", priority=2, has_priority=True)}
 
@@ -1361,7 +1551,7 @@ class TestMultiTagDispatch:
             a.add(s2)
 
             result = a.notify(body="test", tag=["1:tag:2", "2:tag:0"])
-            assert result is True
+            assert bool(result) is True
             # s1: 1 initial + 2 retries = 3 total
             assert s1._calls == 3
             # s2: retry=0 -> exactly 1 attempt
@@ -1399,7 +1589,7 @@ class TestMultiTagDispatch:
             # Simulate CLI: --tag "devops:3" --tag "management:2"
             cli_tag = [["devops:3"], ["management:2"]]
             result = a.notify(body="test", tag=cli_tag)
-            assert result is True
+            assert bool(result) is True
             assert s_devops._calls == 4  # 1 initial + 3 retries
             assert s_mgmt._calls == 3  # 1 initial + 2 retries
         finally:
@@ -1414,13 +1604,13 @@ class TestMultiTagDispatch:
         try:
             asset = AppriseAsset(async_mode=False)
 
-            # Server must carry BOTH tags to match
+            # Service must carry BOTH tags to match
             s_both = _FailThenSucceedNotify(
                 host="both", asset=asset, fail_times=0
             )
             s_both.tags = {"devops", "management"}
 
-            # Server with only "devops" -- must NOT match AND filter
+            # Service with only "devops" -- must NOT match AND filter
             s_devonly = _FailThenSucceedNotify(
                 host="devonly", asset=asset, fail_times=0
             )
@@ -1433,7 +1623,7 @@ class TestMultiTagDispatch:
             # Simulate CLI: --tag "devops, management" (AND condition)
             cli_tag = [["devops", "management"]]
             result = a.notify(body="test", tag=cli_tag)
-            assert result is True
+            assert bool(result) is True
             assert s_both._calls == 1  # has both tags -- matched
             assert s_devonly._calls == 0  # missing "management" -- not matched
         finally:
@@ -1444,24 +1634,26 @@ class TestMultiTagDispatch:
     # ------------------------------------------------------------------
 
     def test_and_filter_explicit_priority_no_match_returns_none(self):
-        """AND filter with an explicit priority that no server satisfies
-        returns None (no services dispatched at all)."""
+        """AND filter with an explicit priority that no service satisfies
+        returns AppriseResultStatus.NOMATCH (no services dispatched at
+        all)."""
         N_MGR["failpass"] = _FailThenSucceedNotify
 
         try:
             asset = AppriseAsset(async_mode=False)
 
-            # Server is tagged 'alerts' at priority 2
+            # Service is tagged 'alerts' at priority 2
             s = _FailThenSucceedNotify(host="s", asset=asset, fail_times=0)
             s.tags = {AppriseTag("alerts", priority=2, has_priority=True)}
 
             a = Apprise(asset=asset)
             a.add(s)
 
-            # Request 'alerts' at priority 1 AND 'backup' -- server has
+            # Request 'alerts' at priority 1 AND 'backup' -- service has
             # 'alerts' but at priority 2, not 1; nothing matches.
             result = a.notify(body="test", tag=[["1:alerts", "backup"]])
-            assert result is None
+            assert result.status == AppriseResultStatus.NOMATCH
+            assert len(result) == 0
             assert s._calls == 0
         finally:
             N_MGR.unload_modules()
@@ -1489,7 +1681,7 @@ class TestMultiTagDispatch:
             a.add(s_c)
 
             result = a.notify(body="test", tag=["alpha", "beta", "gamma"])
-            assert result is True
+            assert bool(result) is True
             assert s_a._calls == 1
             assert s_b._calls == 1
             assert s_c._calls == 1
@@ -1520,7 +1712,7 @@ class TestMultiTagDispatch:
             a.add(s_c)
 
             result = a.notify(body="test", tag=["alpha", "beta", "gamma"])
-            assert result is False
+            assert bool(result) is False
             assert s_a._calls == 1  # alpha succeeded
             assert s_c._calls == 1  # gamma succeeded
         finally:
@@ -1534,13 +1726,13 @@ class TestMultiTagDispatch:
         try:
             asset = AppriseAsset(async_mode=False)
 
-            # priority-0 server: always fails (no retry configured)
+            # priority-0 service: always fails (no retry configured)
             s_p0 = _FailThenSucceedNotify(
                 host="p0", asset=asset, fail_times=99
             )
             s_p0.tags = {AppriseTag("alerts", priority=0, has_priority=False)}
 
-            # priority-1 server: succeeds on first attempt
+            # priority-1 service: succeeds on first attempt
             s_p1 = _FailThenSucceedNotify(host="p1", asset=asset, fail_times=0)
             s_p1.tags = {AppriseTag("alerts", priority=1, has_priority=True)}
 
@@ -1549,7 +1741,7 @@ class TestMultiTagDispatch:
             a.add(s_p1)
 
             result = a.notify(body="test", tag="alerts")
-            assert result is True
+            assert bool(result) is True
             # priority-0 group was attempted once and failed
             assert s_p0._calls == 1
             # priority-1 group was then tried as fallback
@@ -1565,13 +1757,13 @@ class TestMultiTagDispatch:
         try:
             asset = AppriseAsset(async_mode=False)
 
-            # priority-0 server: always fails
+            # priority-0 service: always fails
             s_p0 = _FailThenSucceedNotify(
                 host="p0", asset=asset, fail_times=99
             )
             s_p0.tags = {AppriseTag("alerts", priority=0, has_priority=False)}
 
-            # priority-1 server: also always fails
+            # priority-1 service: also always fails
             s_p1 = _FailThenSucceedNotify(
                 host="p1", asset=asset, fail_times=99
             )
@@ -1582,7 +1774,7 @@ class TestMultiTagDispatch:
             a.add(s_p1)
 
             result = a.notify(body="test", tag="alerts")
-            assert result is False
+            assert bool(result) is False
             # Both groups were attempted
             assert s_p0._calls == 1
             assert s_p1._calls == 1
@@ -1593,8 +1785,8 @@ class TestMultiTagDispatch:
         """An exception escaping _run_batch is caught in the chain-dispatch
         ThreadPoolExecutor loop and treated as a delivery failure.
 
-        Covers the 'except Exception: ok = False' branch (apprise.py:788-792)
-        that is only reachable when multiple chains are active simultaneously
+        Covers the exception fallback that is only reachable when multiple
+        chains are active simultaneously
         (triggering the ThreadPoolExecutor path) and _run_batch raises.
         Uses _ExplodingAsset (raises on async_mode access) instead of
         patching a @staticmethod, which is unreliable across Python versions
@@ -1605,13 +1797,16 @@ class TestMultiTagDispatch:
         try:
             # _ExplodingAsset.async_mode raises RuntimeError.  _run_batch
             # reads s.asset.async_mode to split seq/par, so a batch with
-            # one of these servers raises and the future captures it.
+            # one of these services raises and the future captures it.
             class _ExplodingAsset(AppriseAsset):
+                """Asset whose mode lookup fails inside chain dispatch."""
+
                 @property
                 def async_mode(self):
+                    """Raise the injected failure when dispatch reads mode."""
                     raise RuntimeError("injected async_mode access")
 
-            # Two servers with distinct tags -> two independent chains so
+            # Two services with distinct tags -> two independent chains so
             # the ThreadPoolExecutor path (len(active) > 1) is taken.
             s_a = _FailThenSucceedNotify(
                 host="a", asset=_ExplodingAsset(), fail_times=0
@@ -1630,7 +1825,7 @@ class TestMultiTagDispatch:
             result = a.notify(body="test", tag=["alpha", "beta"])
 
             # Both chains raised instead of returning True -- overall False.
-            assert result is False
+            assert bool(result) is False
         finally:
             N_MGR.unload_modules()
 
@@ -1675,7 +1870,7 @@ class TestAbortOnChainFailure:
             a.add(s_c)
 
             result = a.notify(body="test", tag=["alpha", "beta", "gamma"])
-            assert result is False
+            assert bool(result) is False
             # alpha and gamma were still dispatched despite beta failing
             assert s_a._calls == 1
             assert s_b._calls == 1
@@ -1713,7 +1908,7 @@ class TestAbortOnChainFailure:
             a.add(s_b)
 
             result = a.notify(body="test", tag=["alpha", "beta"])
-            assert result is False
+            assert bool(result) is False
             # beta failed in round 1 and was exhausted -- abort triggered.
             # alpha's p1 (escalation) should NOT have been attempted.
             assert s_b._calls == 1
@@ -1753,7 +1948,7 @@ class TestAbortOnChainFailure:
             result = asyncio.run(
                 a.async_notify(body="test", tag=["alpha", "beta"])
             )
-            assert result is False
+            assert bool(result) is False
             # beta was exhausted in round 1 -- abort fires before alpha's p1
             assert s_b._calls == 1
             assert s_a_p0._calls == 1
@@ -1765,8 +1960,8 @@ class TestAbortOnChainFailure:
 class TestOptionalService:
     """optional=True silently absorbs per-service delivery failures.
 
-    The overall notify()/async_notify() result is True even when an
-    optional service cannot be reached, so callers are not penalised
+    The overall notify()/async_notify() result evaluates truthy even when
+    an optional service cannot be reached, so callers are not penalised
     for "nice to have" endpoints (e.g. home screens, debug logging).
     """
 
@@ -1807,7 +2002,7 @@ class TestOptionalService:
         assert nb_no.optional is False
 
     def test_optional_sequential_failure_absorbed(self):
-        """Sequential dispatch: failed optional server -> overall True."""
+        """Sequential dispatch: failed optional service -> overall True."""
         N_MGR["failpass"] = _FailThenSucceedNotify
 
         try:
@@ -1819,15 +2014,15 @@ class TestOptionalService:
             a.add(s)
 
             result = a.notify(body="test")
-            assert result is True
+            assert bool(result) is True
             assert s._calls == 1
         finally:
             N_MGR.unload_modules()
 
     def test_optional_threadpool_failure_absorbed(self):
-        """Thread-pool dispatch: failed optional servers -> overall True.
+        """Thread-pool dispatch: failed optional services -> overall True.
 
-        Two async_mode=True servers ensure _notify_parallel_threadpool
+        Two async_mode=True services ensure _notify_parallel_threadpool
         uses the actual thread pool (n_calls==1 falls back to sequential).
         """
         N_MGR["failpass"] = _FailThenSucceedNotify
@@ -1844,12 +2039,12 @@ class TestOptionalService:
             a.add(s2)
 
             result = a.notify(body="test")
-            assert result is True
+            assert bool(result) is True
         finally:
             N_MGR.unload_modules()
 
     def test_optional_asyncio_failure_absorbed(self):
-        """Asyncio dispatch: failed optional server -> overall True."""
+        """Asyncio dispatch: failed optional service -> overall True."""
         N_MGR["failpass"] = _FailThenSucceedNotify
 
         try:
@@ -1861,12 +2056,12 @@ class TestOptionalService:
             a.add(s)
 
             result = asyncio.run(a.async_notify(body="test"))
-            assert result is True
+            assert bool(result) is True
         finally:
             N_MGR.unload_modules()
 
     def test_optional_all_fail_all_optional_returns_true(self):
-        """When every server is optional and every server fails -> True."""
+        """When every service is optional and every service fails -> True."""
         N_MGR["failpass"] = _FailThenSucceedNotify
 
         try:
@@ -1880,12 +2075,12 @@ class TestOptionalService:
                 a.add(s)
 
             result = a.notify(body="test")
-            assert result is True
+            assert bool(result) is True
         finally:
             N_MGR.unload_modules()
 
     def test_optional_mixed_required_fails_returns_false(self):
-        """Required server failure taints result even with optional peers."""
+        """Required service failure taints result even with optional peers."""
         N_MGR["failpass"] = _FailThenSucceedNotify
 
         try:
@@ -1905,12 +2100,12 @@ class TestOptionalService:
             a.add(s_req)
 
             result = a.notify(body="test")
-            assert result is False
+            assert bool(result) is False
         finally:
             N_MGR.unload_modules()
 
     def test_optional_success_unaffected(self):
-        """An optional server that succeeds is still counted as True."""
+        """An optional service that succeeds is still counted as True."""
         N_MGR["failpass"] = _FailThenSucceedNotify
 
         try:
@@ -1922,21 +2117,162 @@ class TestOptionalService:
             a.add(s)
 
             result = a.notify(body="test")
-            assert result is True
+            assert bool(result) is True
             assert s._calls == 1
         finally:
             N_MGR.unload_modules()
 
 
+class TestPartialStatus:
+    """AppriseResultStatus.PARTIAL: a batch where at least one service
+    genuinely delivered and at least one did not, in the same call."""
+
+    def test_mixed_success_and_failure_is_partial(self):
+        """One service succeeds, one fails outright -> PARTIAL, not
+        FAILURE."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            s_ok = _FailThenSucceedNotify(host="ok", asset=asset, fail_times=0)
+            s_fail = _FailThenSucceedNotify(
+                host="fail", asset=asset, fail_times=99
+            )
+
+            a = Apprise(asset=asset)
+            a.add(s_ok)
+            a.add(s_fail)
+
+            result = a.notify(body="test")
+            assert result.status == AppriseResultStatus.PARTIAL
+            # PARTIAL is not the truthy SUCCESS value.
+            assert bool(result) is False
+        finally:
+            N_MGR.unload_modules()
+
+    def test_all_succeed_is_success_not_partial(self):
+        """Every service succeeding stays SUCCESS -- PARTIAL requires at
+        least one non-delivery in the same batch."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            s1 = _FailThenSucceedNotify(host="s1", asset=asset, fail_times=0)
+            s2 = _FailThenSucceedNotify(host="s2", asset=asset, fail_times=0)
+
+            a = Apprise(asset=asset)
+            a.add(s1)
+            a.add(s2)
+
+            result = a.notify(body="test")
+            assert result.status == AppriseResultStatus.SUCCESS
+        finally:
+            N_MGR.unload_modules()
+
+    def test_all_fail_is_failure_not_partial(self):
+        """Every service failing outright stays FAILURE -- there is no
+        genuine success in the batch to make it PARTIAL."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            s1 = _FailThenSucceedNotify(host="s1", asset=asset, fail_times=99)
+            s2 = _FailThenSucceedNotify(host="s2", asset=asset, fail_times=99)
+
+            a = Apprise(asset=asset)
+            a.add(s1)
+            a.add(s2)
+
+            result = a.notify(body="test")
+            assert result.status == AppriseResultStatus.FAILURE
+        finally:
+            N_MGR.unload_modules()
+
+    def test_optional_absorbed_failure_does_not_count_as_partial(self):
+        """A forgiven optional=yes failure does not count as a 'genuine'
+        success -- an optional service that never actually delivered,
+        paired with a required service that also failed, is still a
+        clean FAILURE, not PARTIAL."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            s_opt = _FailThenSucceedNotify(
+                host="opt", asset=asset, fail_times=99
+            )
+            s_opt.optional = True
+            s_req = _FailThenSucceedNotify(
+                host="req", asset=asset, fail_times=99
+            )
+
+            a = Apprise(asset=asset)
+            a.add(s_opt)
+            a.add(s_req)
+
+            result = a.notify(body="test")
+            assert result.status == AppriseResultStatus.FAILURE
+        finally:
+            N_MGR.unload_modules()
+
+    def test_success_plus_timeout_is_partial(self):
+        """One service succeeds, another times out with no failures at
+        all -- still a mixed outcome, so PARTIAL rather than TIMEOUT.
+
+        async_mode=True with 2+ services is required so dispatch actually
+        goes through _notify_parallel_threadpool -- only that path (and
+        the asyncio one) can genuinely abandon an in-flight call via a
+        bounded wait; _notify_sequential has no way to stop waiting on a
+        single already-blocking call, so s_slow would just eventually
+        succeed there instead of timing out.
+        """
+        N_MGR["failpass"] = _FailThenSucceedNotify
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            asset = AppriseAsset(async_mode=True, service_timeout=0.05)
+            s_ok = _FailThenSucceedNotify(host="ok", asset=asset, fail_times=0)
+            s_slow = _SlowNotify(host="slow", asset=asset, delay=0.3)
+
+            a = Apprise(asset=asset)
+            a.add(s_ok)
+            a.add(s_slow)
+
+            result = a.notify(body="test")
+            assert result.status == AppriseResultStatus.PARTIAL
+        finally:
+            N_MGR.unload_modules()
+
+    def test_async_notify_mixed_outcome_is_partial(self):
+        """The asyncio dispatch path reports PARTIAL the same way as the
+        synchronous paths."""
+        N_MGR["failpass"] = _FailThenSucceedNotify
+
+        try:
+            asset = AppriseAsset(async_mode=True)
+            s_ok = _FailThenSucceedNotify(host="ok", asset=asset, fail_times=0)
+            s_fail = _FailThenSucceedNotify(
+                host="fail", asset=asset, fail_times=99
+            )
+
+            a = Apprise(asset=asset)
+            a.add(s_ok)
+            a.add(s_fail)
+
+            result = asyncio.run(a.async_notify(body="test"))
+            assert result.status == AppriseResultStatus.PARTIAL
+        finally:
+            N_MGR.unload_modules()
+
+
 class TestCreateNotifyCalls:
-    """Cover Apprise._create_notify_calls() which splits servers into
+    """Cover Apprise._create_notify_calls() which splits services into
     sequential and parallel buckets based on their asset.async_mode flag."""
 
     def test_splits_sequential_and_parallel(self):
-        """Sequential and parallel servers are split into separate lists."""
+        """Sequential and parallel services are split into separate lists."""
         N_MGR["failpass"] = _FailThenSucceedNotify
         try:
-            # With async_mode=False all loaded servers go to the sequential
+            # With async_mode=False all loaded services go to the sequential
             # bucket; the parallel bucket remains empty.
             asset_seq = AppriseAsset(async_mode=False)
             s_seq = _FailThenSucceedNotify(
@@ -1950,7 +2286,7 @@ class TestCreateNotifyCalls:
             assert len(seq) == 1
             assert len(par) == 0
 
-            # With async_mode=True the same server is placed in the parallel
+            # With async_mode=True the same service is placed in the parallel
             # bucket instead.
             asset_par = AppriseAsset(async_mode=True)
             s_par = _FailThenSucceedNotify(
@@ -1968,22 +2304,13 @@ class TestCreateNotifyCalls:
 
 
 class TestAsyncioSafetyNet:
-    """Cover the safety-net branch in _notify_parallel_asyncio that handles
-    exceptions which escape do_call's own try/except block."""
+    """Cover async safety nets for exceptions that escape do_call."""
 
     def test_exception_outside_try_block_triggers_safety_net(self):
-        """An exception raised before the per-attempt try block (e.g. from
-        a misbehaving server.retry property) escapes do_call, is captured by
-        asyncio.gather(return_exceptions=True), and causes the batch to
-        return False via the safety-net handler.
+        """A retry-property failure is reported beside a good service."""
 
-        A second well-behaved server is included so that results contains
-        both an Exception and a bool value, exercising both branches of the
-        inner ``if isinstance(status, Exception)`` check in the loop."""
-
-        class _RaisingRetryServer:
-            """Server whose retry property raises to simulate a broken plugin
-            that fails before the per-attempt try/except in do_call."""
+        class _RaisingRetryService:
+            """Service whose retry property fails before delivery starts."""
 
             service_name = "raiser"
             asset = AppriseAsset(async_mode=True)
@@ -1991,29 +2318,933 @@ class TestAsyncioSafetyNet:
 
             @property
             def retry(self):
-                # This exception is raised when do_call evaluates
-                # getattr(server, "retry", 0), which happens OUTSIDE the
-                # per-attempt try/except.  It therefore escapes do_call
-                # entirely and is captured by asyncio.gather as a value.
+                """Raise before per-attempt handling to test the safety net."""
+                # This escapes do_call and is captured by asyncio.gather.
                 raise RuntimeError("injected: property raised outside try")
 
             async def async_notify(self, **kwargs):
+                """Represent delivery that must not be reached in this test."""
                 return True  # pragma: no cover -- never reached
 
-        class _GoodServer:
-            """Minimal well-behaved server that succeeds immediately."""
+        class _GoodService:
+            """Minimal well-behaved service that succeeds immediately."""
 
             service_name = "good"
+            asset = AppriseAsset(async_mode=True)
+            optional = False
+            tags = set()
+
+            def url(self, privacy=False):
+                """Return the stable URL used to identify this service."""
+                return "good://localhost"
+
+            def url_id(self):
+                """Return a stable identifier for result assertions."""
+                return "good-id"
+
+            def __len__(self):
+                """Report the single target represented by this service."""
+                return 1
 
             async def async_notify(self, **kwargs):
+                """Report immediate successful asynchronous delivery."""
                 return True
 
-        raiser = _RaisingRetryServer()
-        good = _GoodServer()
-        # Two servers: raiser -> Exception in results; good -> True in results.
-        # The safety-net loop therefore hits both branches of the inner
-        # ``if isinstance(status, Exception)`` check.
-        result = asyncio.run(
+        raiser = _RaisingRetryService()
+        good = _GoodService()
+        # Exercise both the escaped-exception and successful-result branches.
+        ok, results = asyncio.run(
             Apprise._notify_parallel_asyncio((raiser, {}), (good, {}))
         )
-        assert result is False
+        assert ok is False
+        assert len(results) == 2
+
+
+class TestServiceTimeout:
+    """AppriseAsset._service_timeout / notify(timeout=...) enforcement.
+
+    Real sleeps are intentional here: these tests protect threaded/async
+    deadline behaviour. Margins stay generous so slower CI hosts fail only for
+    real regressions, not ordinary timing jitter.
+    """
+
+    def test_sequential_between_attempts_timeout(self):
+        """A real failure before timeout remains a FAILURE."""
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False, service_timeout=0.5)
+            # First attempt costs 0.1s and fails, leaving ~0.4s of the
+            # 0.5s budget.  retry=5 with wait=5.0 would normally sleep
+            # five seconds between attempts, but that must be capped to
+            # the remaining budget, and no second attempt may start.
+            service = _SlowNotify(
+                host="x", asset=asset, delay=0.0, retry=5, wait=5.0
+            )
+            service.send = lambda **kw: (time.sleep(0.1), False)[1]
+            a = Apprise(asset=asset)
+            a.add(service)
+
+            t0 = time.monotonic()
+            result = a.notify(body="test")
+            wall = time.monotonic() - t0
+        finally:
+            N_MGR.unload_modules()
+
+        r0 = next(iter(result))
+        # One real attempt ran; the expired retry is recorded as TIMEOUT.
+        assert len(r0.attempts) == 2
+        assert r0.attempts[0].status == AppriseResultStatus.FAILURE
+        assert r0.attempts[-1].status == AppriseResultStatus.TIMEOUT
+        assert r0.max_attempts == 6
+        # The confirmed FAILURE outranks the trailing synthetic TIMEOUT.
+        assert r0.status == AppriseResultStatus.FAILURE
+        assert result.status == AppriseResultStatus.FAILURE
+        # The wait= sleep was capped to the remaining budget, not the
+        # full 5.0s -- confirms the cap actually applied.
+        assert wall < 3.0
+
+    def test_threadpool_between_attempts_timeout_and_sleep_cap(self):
+        """Thread-pool retry sleep is capped by the worker deadline."""
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            asset = AppriseAsset(async_mode=True, service_timeout=2.0)
+            # The failed first attempt leaves enough budget for the worker to
+            # cap wait=5.0 itself before the outer bounded wait races it.
+            slow = _SlowNotify(
+                host="slow", asset=asset, delay=0.0, retry=3, wait=5.0
+            )
+            slow.send = lambda **kw: (time.sleep(0.3), False)[1]
+            fast = _SlowNotify(host="fast", asset=asset, delay=0.0)
+            a = Apprise(asset=asset)
+            a.add(slow)
+            a.add(fast)
+
+            t0 = time.monotonic()
+            result = a.notify(body="test")
+            wall = time.monotonic() - t0
+        finally:
+            N_MGR.unload_modules()
+
+        by_host = {r.url: r for r in result}
+        slow_result = by_host["slow://slow"]
+        # Only the one over-budget attempt was made, plus the synthetic
+        # TIMEOUT attempt marking the decision to stop.
+        assert len(slow_result.attempts) == 2
+        assert slow_result.attempts[0].status == AppriseResultStatus.FAILURE
+        assert slow_result.attempts[-1].status == AppriseResultStatus.TIMEOUT
+        # The confirmed FAILURE on the first attempt outranks the
+        # synthetic TIMEOUT that follows it (see NotifyResult.__init__).
+        assert slow_result.status == AppriseResultStatus.FAILURE
+        assert by_host["slow://fast"].status == AppriseResultStatus.SUCCESS
+        # The wait= sleep was capped to the remaining budget rather than
+        # running the full 5.0s -- confirms the cap actually applied.
+        assert wall < 5.0
+
+    def test_asyncio_between_attempts_timeout_and_sleep_cap(self):
+        """Same guarantee as the thread-pool test above, for the asyncio
+        do_call() coroutine's own between-attempts deadline check."""
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            asset = AppriseAsset(async_mode=True, service_timeout=2.0)
+            slow = _SlowNotify(
+                host="slow", asset=asset, delay=0.0, retry=3, wait=5.0
+            )
+
+            async def _fail_slowly(**kw):
+                """Delay briefly, then fail so retry waiting consumes time."""
+                await asyncio.sleep(0.3)
+                return False
+
+            slow.async_notify = _fail_slowly
+            fast = _SlowNotify(host="fast", asset=asset, delay=0.0)
+            a = Apprise(asset=asset)
+            a.add(slow)
+            a.add(fast)
+
+            t0 = time.monotonic()
+            result = asyncio.run(a.async_notify(body="test"))
+            wall = time.monotonic() - t0
+        finally:
+            N_MGR.unload_modules()
+
+        by_host = {r.url: r for r in result}
+        slow_result = by_host["slow://slow"]
+        assert len(slow_result.attempts) == 2
+        assert slow_result.attempts[0].status == AppriseResultStatus.FAILURE
+        assert slow_result.attempts[-1].status == AppriseResultStatus.TIMEOUT
+        # The confirmed FAILURE on the first attempt outranks the
+        # synthetic TIMEOUT that follows it (see NotifyResult.__init__).
+        assert slow_result.status == AppriseResultStatus.FAILURE
+        assert by_host["slow://fast"].status == AppriseResultStatus.SUCCESS
+        assert wall < 5.0
+
+    def test_sequential_service_timeout_disabled(self):
+        """service_timeout=0 disables the cap -- a slow service still
+        completes normally."""
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False, service_timeout=0)
+            service = _SlowNotify(host="x", asset=asset, delay=0.05)
+            a = Apprise(asset=asset)
+            a.add(service)
+
+            result = a.notify(body="test")
+        finally:
+            N_MGR.unload_modules()
+
+        r0 = next(iter(result))
+        assert r0.status == AppriseResultStatus.SUCCESS
+        assert service.calls == 1
+
+    def test_sequential_timeout_disabled_retry_wait(self):
+        """With service_timeout=0 (no deadline at all), the retry/wait
+        loop keeps its normal uncapped wait behaviour."""
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False, service_timeout=0)
+            service = _SlowNotify(
+                host="x", asset=asset, delay=0.0, retry=1, wait=0.01
+            )
+            call_count = {"n": 0}
+
+            def _fail_then_succeed(**kw):
+                """Fail once, then succeed to exercise an uncapped retry."""
+                call_count["n"] += 1
+                return call_count["n"] >= 2
+
+            service.send = _fail_then_succeed
+            a = Apprise(asset=asset)
+            a.add(service)
+
+            result = a.notify(body="test")
+        finally:
+            N_MGR.unload_modules()
+
+        r0 = next(iter(result))
+        assert r0.status == AppriseResultStatus.SUCCESS
+        assert len(r0.attempts) == 2
+
+    def test_threadpool_outer_bound_abandons_slow_service(self):
+        """A service stuck past its deadline is abandoned by the outer
+        bounded wait; the batch returns promptly and the other service is
+        unaffected."""
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            asset = AppriseAsset(async_mode=True, service_timeout=0.5)
+            slow = _SlowNotify(host="slow", asset=asset, delay=2.0)
+            fast = _SlowNotify(host="fast", asset=asset, delay=0.0)
+            a = Apprise(asset=asset)
+            a.add(slow)
+            a.add(fast)
+
+            t0 = time.monotonic()
+            result = a.notify(body="test")
+            wall = time.monotonic() - t0
+        finally:
+            N_MGR.unload_modules()
+
+        # The whole call returned promptly -- nowhere near the slow
+        # service's 2.0s delay -- even though that thread is still
+        # running in the background because Python cannot stop the worker.
+        assert wall < 3.0
+        by_host = {r.url: r for r in result}
+        assert by_host["slow://slow"].status == (AppriseResultStatus.TIMEOUT)
+        assert by_host["slow://fast"].status == (AppriseResultStatus.SUCCESS)
+
+    def test_asyncio_outer_bound_abandons_slow_service(self):
+        """Same guarantee as the thread-pool test, for async_notify()."""
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            asset = AppriseAsset(async_mode=True, service_timeout=0.5)
+            slow = _SlowNotify(host="slow", asset=asset, delay=2.0)
+            fast = _SlowNotify(host="fast", asset=asset, delay=0.0)
+            a = Apprise(asset=asset)
+            a.add(slow)
+            a.add(fast)
+
+            t0 = time.monotonic()
+            result = asyncio.run(a.async_notify(body="test"))
+            wall = time.monotonic() - t0
+        finally:
+            N_MGR.unload_modules()
+
+        assert wall < 3.0
+        by_host = {r.url: r for r in result}
+        assert by_host["slow://slow"].status == (AppriseResultStatus.TIMEOUT)
+        assert by_host["slow://fast"].status == (AppriseResultStatus.SUCCESS)
+
+    def test_threadpool_timeout_disabled_retry_wait(self):
+        """With service_timeout=0, the thread-pool worker's retry/wait
+        loop keeps its normal uncapped wait behaviour."""
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            asset = AppriseAsset(async_mode=True, service_timeout=0)
+            call_count = {"n": 0}
+
+            def _fail_then_succeed(**kw):
+                """Fail once, then succeed in the thread-pool retry loop."""
+                call_count["n"] += 1
+                return call_count["n"] >= 2
+
+            flaky = _SlowNotify(
+                host="flaky", asset=asset, delay=0.0, retry=1, wait=0.01
+            )
+            flaky.send = _fail_then_succeed
+            other = _SlowNotify(host="other", asset=asset, delay=0.0)
+            a = Apprise(asset=asset)
+            a.add(flaky)
+            a.add(other)
+
+            result = a.notify(body="test")
+        finally:
+            N_MGR.unload_modules()
+
+        by_host = {r.url: r for r in result}
+        assert by_host["slow://flaky"].status == AppriseResultStatus.SUCCESS
+        assert len(by_host["slow://flaky"].attempts) == 2
+        assert by_host["slow://other"].status == AppriseResultStatus.SUCCESS
+
+    def test_asyncio_timeout_disabled_retry_wait(self):
+        """Same guarantee as the thread-pool test above, for the asyncio
+        do_call() coroutine's retry/wait loop."""
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            asset = AppriseAsset(async_mode=True, service_timeout=0)
+            call_count = {"n": 0}
+
+            async def _fail_then_succeed(**kw):
+                """Fail once, then succeed in the asyncio retry loop."""
+                call_count["n"] += 1
+                return call_count["n"] >= 2
+
+            flaky = _SlowNotify(
+                host="flaky", asset=asset, delay=0.0, retry=1, wait=0.01
+            )
+            flaky.async_notify = _fail_then_succeed
+            other = _SlowNotify(host="other", asset=asset, delay=0.0)
+            a = Apprise(asset=asset)
+            a.add(flaky)
+            a.add(other)
+
+            result = asyncio.run(a.async_notify(body="test"))
+        finally:
+            N_MGR.unload_modules()
+
+        by_host = {r.url: r for r in result}
+        assert by_host["slow://flaky"].status == AppriseResultStatus.SUCCESS
+        assert len(by_host["slow://flaky"].attempts) == 2
+        assert by_host["slow://other"].status == AppriseResultStatus.SUCCESS
+
+    def test_notify_timeout_overrides_longer_asset_default(self):
+        """notify(timeout=...) can cut a call short even when the asset
+        default would have allowed more time."""
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            # Asset default is generous (10s); the call-level override
+            # of 0.5s must win since it is the sooner of the two.
+            asset = AppriseAsset(async_mode=True, service_timeout=10)
+            slow1 = _SlowNotify(host="one", asset=asset, delay=2.0)
+            slow2 = _SlowNotify(host="two", asset=asset, delay=2.0)
+            a = Apprise(asset=asset)
+            a.add(slow1)
+            a.add(slow2)
+
+            t0 = time.monotonic()
+            result = a.notify(body="test", timeout=0.5)
+            wall = time.monotonic() - t0
+        finally:
+            N_MGR.unload_modules()
+
+        assert wall < 3.0
+        assert all(r.status == AppriseResultStatus.TIMEOUT for r in result)
+
+    def test_notify_timeout_keeps_stricter_asset_default(self):
+        """The reverse also holds: a short asset default still applies
+        even when notify(timeout=...) allows much more time."""
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            asset = AppriseAsset(async_mode=True, service_timeout=0.5)
+            slow1 = _SlowNotify(host="one", asset=asset, delay=2.0)
+            slow2 = _SlowNotify(host="two", asset=asset, delay=2.0)
+            a = Apprise(asset=asset)
+            a.add(slow1)
+            a.add(slow2)
+
+            t0 = time.monotonic()
+            result = a.notify(body="test", timeout=60)
+            wall = time.monotonic() - t0
+        finally:
+            N_MGR.unload_modules()
+
+        assert wall < 3.0
+        assert all(r.status == AppriseResultStatus.TIMEOUT for r in result)
+
+    def test_notify_negative_timeout_raises(self):
+        """notify(timeout=-1) is a caller error, not a silent no-op."""
+        a = Apprise()
+        a.add("json://localhost")
+        with pytest.raises(ValueError):
+            a.notify(body="test", timeout=-1)
+
+    def test_async_notify_negative_timeout_raises(self):
+        """async_notify(timeout=-1) is a caller error, not a silent
+        no-op."""
+        a = Apprise()
+        a.add("json://localhost")
+        with pytest.raises(ValueError):
+            asyncio.run(a.async_notify(body="test", timeout=-1))
+
+    def test_notify_infinite_timeout_raises(self):
+        """notify(timeout=inf) is rejected; 0 is the unbounded spelling."""
+        a = Apprise()
+        a.add("json://localhost")
+        with pytest.raises(ValueError):
+            a.notify(body="test", timeout=float("inf"))
+
+    def test_notify_nan_timeout_raises(self):
+        """notify(timeout=nan) is rejected instead of disabling the timeout."""
+        a = Apprise()
+        a.add("json://localhost")
+        with pytest.raises(ValueError):
+            a.notify(body="test", timeout=float("nan"))
+
+    def test_async_notify_infinite_timeout_raises(self):
+        """async_notify(timeout=inf) is rejected for the same reason as
+        notify(timeout=inf)."""
+        a = Apprise()
+        a.add("json://localhost")
+        with pytest.raises(ValueError):
+            asyncio.run(a.async_notify(body="test", timeout=float("inf")))
+
+    def test_notify_non_numeric_timeout_raises_typeerror(self):
+        """notify(timeout="abc") raises TypeError."""
+        a = Apprise()
+        a.add("json://localhost")
+        with pytest.raises(TypeError):
+            a.notify(body="test", timeout="abc")
+
+    def test_notify_bool_timeout_raises_typeerror(self):
+        """A bool timeout is rejected even though bool is an int subclass."""
+        a = Apprise()
+        a.add("json://localhost")
+        with pytest.raises(TypeError):
+            a.notify(body="test", timeout=True)
+
+    def test_async_notify_non_numeric_timeout_raises_typeerror(self):
+        """async_notify(timeout="abc") is a caller error (TypeError)."""
+        a = Apprise()
+        a.add("json://localhost")
+        with pytest.raises(TypeError):
+            asyncio.run(a.async_notify(body="test", timeout="abc"))
+
+    def test_notify_timeout_defaults_to_zero(self):
+        """timeout defaults to 0 (no call-level override) -- only
+        AppriseAsset._service_timeout controls the default behaviour."""
+        import inspect
+
+        signature = inspect.signature(Apprise.notify)
+        assert signature.parameters["timeout"].default == 0
+
+    def test_timeout_logs_include_error_entry(self):
+        """A TIMEOUT attempt includes a matching ERROR log entry."""
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False, service_timeout=0.5)
+            service = _SlowNotify(host="x", asset=asset, retry=5)
+            service.send = lambda **kw: (time.sleep(0.15), False)[1]
+            a = Apprise(asset=asset)
+            a.add(service)
+
+            result = a.notify(body="test")
+        finally:
+            N_MGR.unload_modules()
+
+        r0 = next(iter(result))
+        # The earlier real failures still outrank the later timeout.
+        assert r0.status == AppriseResultStatus.FAILURE
+        assert r0.attempts[-1].status == AppriseResultStatus.TIMEOUT
+        error_logs = [entry for entry in r0.logs() if entry.level == "ERROR"]
+        assert len(error_logs) == 1
+        assert "did not finish" in error_logs[0].message
+        assert r0.name in error_logs[0].message
+
+    def test_timeout_result_json_includes_start_end_time(self):
+        """A TIMEOUT NotifyResult still has start_time/end_time populated."""
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            asset = AppriseAsset(async_mode=True, service_timeout=0.5)
+            slow = _SlowNotify(host="slow", asset=asset, delay=3.0)
+            fast = _SlowNotify(host="fast", asset=asset, delay=0.0)
+            a = Apprise(asset=asset)
+            a.add(slow)
+            a.add(fast)
+
+            result = a.notify(body="test")
+        finally:
+            N_MGR.unload_modules()
+
+        by_host = {r.url: r for r in result}
+        r0 = by_host["slow://slow"]
+        assert r0.status == AppriseResultStatus.TIMEOUT
+        assert r0.start_time is not None
+        assert r0.end_time is not None
+        # Datetime arithmetic can differ from float elapsed by tiny rounding.
+        assert (r0.end_time - r0.start_time).total_seconds() == pytest.approx(
+            r0.elapsed, abs=1e-5
+        )
+
+    def test_weight_reflects_service_len(self):
+        """NotifyResult.weight mirrors len(service) (the plugin's own
+        target count)."""
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            service = _SlowNotify(host="x", asset=asset, delay=0.0)
+            a = Apprise(asset=asset)
+            a.add(service)
+
+            result = a.notify(body="test")
+        finally:
+            N_MGR.unload_modules()
+
+        # _SlowNotify has no targets/list -- NotifyBase.__len__ always
+        # reports at least 1.
+        assert next(iter(result)).weight == len(service) == 1
+
+    def test_log_capture_records_warning_message(self):
+        """A service WARNING is captured in NotifyResult.logs()."""
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            service = _SlowNotify(host="x", asset=asset, delay=0.0)
+
+            def _fail_with_warning(**kw):
+                """Emit a warning before reporting a delivery failure."""
+                service.logger.warning("HTTP 429 Too Many Requests")
+                return False
+
+            service.send = _fail_with_warning
+            a = Apprise(asset=asset)
+            a.add(service)
+
+            logging.disable(logging.NOTSET)
+            try:
+                result = a.notify(body="test")
+            finally:
+                logging.disable(logging.CRITICAL)
+        finally:
+            N_MGR.unload_modules()
+
+        r0 = next(iter(result))
+        assert r0.status == AppriseResultStatus.FAILURE
+        logs = list(r0.logs())
+        assert len(logs) == 1
+        assert logs[0].level == "WARNING"
+        assert "429" in logs[0].message
+        assert "429" in str(logs[0])
+
+    def test_log_capture_preserves_preexisting_instance_logger(self):
+        """_ServiceLogCapture does not replace a service's logger."""
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            service = _SlowNotify(host="x", asset=asset, delay=0.0)
+            custom_logger = logging.getLogger("apprise.test.custom")
+            service.logger = custom_logger
+
+            a = Apprise(asset=asset)
+            a.add(service)
+            a.notify(body="test")
+        finally:
+            N_MGR.unload_modules()
+
+        assert "logger" in service.__dict__
+        assert service.__dict__["logger"] is custom_logger
+
+    def test_notify_log_callback_default_from_apprise_instance(self):
+        """A log_callback given to Apprise() applies to every notify()
+        call made with that instance, firing live with (entry, service)
+        for each captured entry."""
+        N_MGR["slow"] = _SlowNotify
+        received = []
+
+        def _cb(entry, service):
+            """Collect the instance-level callback's service/message pair."""
+            received.append((service.service_name, entry.message))
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            service = _SlowNotify(host="x", asset=asset, delay=0.0)
+
+            def _fail_with_warning(**kw):
+                """Emit a warning and report a failed delivery attempt."""
+                service.logger.warning("HTTP 429 Too Many Requests")
+                return False
+
+            service.send = _fail_with_warning
+            a = Apprise(asset=asset, log_callback=_cb)
+            a.add(service)
+
+            logging.disable(logging.NOTSET)
+            try:
+                a.notify(body="test")
+            finally:
+                logging.disable(logging.CRITICAL)
+        finally:
+            N_MGR.unload_modules()
+
+        assert received == [
+            (service.service_name, "HTTP 429 Too Many Requests")
+        ]
+
+    def test_notify_log_callback_call_override(self):
+        """log_callback passed directly to notify() takes priority over
+        the Apprise instance's own default for that one call only."""
+        N_MGR["slow"] = _SlowNotify
+        default_received = []
+        override_received = []
+
+        def _default_cb(entry, service):
+            """Collect entries delivered to the instance default callback."""
+            default_received.append(entry.message)
+
+        def _override_cb(entry, service):
+            """Collect entries delivered to the per-call override callback."""
+            override_received.append(entry.message)
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            service = _SlowNotify(host="x", asset=asset, delay=0.0)
+
+            def _fail_with_warning(**kw):
+                """Emit a warning and report a failed delivery attempt."""
+                service.logger.warning("overridden call")
+                return False
+
+            service.send = _fail_with_warning
+            a = Apprise(asset=asset, log_callback=_default_cb)
+            a.add(service)
+
+            logging.disable(logging.NOTSET)
+            try:
+                a.notify(body="test", log_callback=_override_cb)
+            finally:
+                logging.disable(logging.CRITICAL)
+        finally:
+            N_MGR.unload_modules()
+
+        assert default_received == []
+        assert override_received == ["overridden call"]
+
+    def test_async_notify_log_callback(self):
+        """log_callback works for a plugin's native async_notify()."""
+        N_MGR["slow"] = _SlowNotify
+        received = []
+
+        def _cb(entry, service):
+            """Collect callback entries produced by async_notify()."""
+            received.append((service.service_name, entry.message))
+
+        try:
+            asset = AppriseAsset(async_mode=True)
+            service = _SlowNotify(host="x", asset=asset, delay=0.0)
+
+            async def _fail_with_warning(**kw):
+                """Emit a warning from the native async_notify override."""
+                service.logger.warning("async 429")
+                return False
+
+            service.async_notify = _fail_with_warning
+            a = Apprise(asset=asset, log_callback=_cb)
+            a.add(service)
+
+            logging.disable(logging.NOTSET)
+            try:
+                asyncio.run(a.async_notify(body="test"))
+            finally:
+                logging.disable(logging.CRITICAL)
+        finally:
+            N_MGR.unload_modules()
+
+        assert received == [(service.service_name, "async 429")]
+
+    def test_notify_log_callback_thread_attribution(self):
+        """Concurrent log callbacks are attributed to the right service."""
+        N_MGR["slow"] = _SlowNotify
+        received = []
+        lock = threading.Lock()
+
+        def _cb(entry, service):
+            """Append callback data under a lock."""
+            with lock:
+                received.append((service.host, entry.message))
+
+        def _make_send(service):
+            """Build a send() replacement bound to one service instance."""
+
+            def _send(**kw):
+                """Emit a host-specific warning from the bound service."""
+                service.logger.warning("warning from %s", service.host)
+                return True
+
+            return _send
+
+        try:
+            asset = AppriseAsset(async_mode=True)
+            a = Apprise(asset=asset, log_callback=_cb)
+            services = []
+            for i in range(6):
+                service = _SlowNotify(host=f"host{i}", asset=asset, delay=0.02)
+                service.send = _make_send(service)
+                services.append(service)
+                a.add(service)
+
+            logging.disable(logging.NOTSET)
+            try:
+                a.notify(body="test")
+            finally:
+                logging.disable(logging.CRITICAL)
+        finally:
+            N_MGR.unload_modules()
+
+        assert sorted(received) == sorted(
+            (s.host, f"warning from {s.host}") for s in services
+        )
+
+    def test_timeout_result_defensive_on_malformed_service(self):
+        """Timeout metadata falls back when service helpers are missing."""
+
+        class _MalformedSlowService:
+            """A service missing url()/url_id()/__len__ that never finishes
+            in time, exercising _timeout_result's defensive except paths.
+            """
+
+            service_name = "malformed"
+            asset = AppriseAsset(async_mode=True, service_timeout=0.1)
+            optional = False
+            tags: set = set()
+            retry = 0
+            wait = 0.0
+
+            async def async_notify(self, **kwargs):
+                """Remain active long enough to exceed the test deadline."""
+                await asyncio.sleep(1.0)
+                return True  # pragma: no cover -- never reached in time
+
+        good = _SlowNotify(
+            host="good", asset=AppriseAsset(async_mode=True), delay=0.0
+        )
+        malformed = _MalformedSlowService()
+
+        ok, results = asyncio.run(
+            Apprise._notify_parallel_asyncio(
+                (malformed, {}),
+                (good, {}),
+            )
+        )
+
+        assert ok is False
+        by_url = {r.url: r for r in results}
+        # No url()/url_id()/__len__ on the malformed service -- defensive
+        # fallbacks kick in rather than raising.
+        assert by_url["unknown://"].status == AppriseResultStatus.TIMEOUT
+        assert by_url["unknown://"].url_id is None
+        assert by_url["unknown://"].weight == 1
+        assert by_url["slow://good"].status == AppriseResultStatus.SUCCESS
+
+    def test_notify_result_tag_is_sorted(self):
+        """NotifyResult.tag is sorted for stable output."""
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            service = _SlowNotify(
+                host="x",
+                asset=AppriseAsset(async_mode=False),
+                delay=0.0,
+                tag=["zeta", "alpha", "middle", "beta"],
+            )
+            a = Apprise()
+            a.add(service)
+            result = a.notify(body="test")
+        finally:
+            N_MGR.unload_modules()
+
+        r0 = next(iter(result))
+        assert r0.tag == ("alpha", "beta", "middle", "zeta")
+
+    def test_threadpool_queued_futures_cancelled(self):
+        """A service still queued behind other work in a size-limited
+        thread pool must not execute later after timeout."""
+        N_MGR["slow"] = _SlowNotify
+
+        # More services than the default ThreadPoolExecutor can run at once,
+        # so some work is guaranteed to still be queued at the deadline.
+        n_services = 40
+        started: list[int] = []
+        finished: list[int] = []
+        lock = threading.Lock()
+
+        def _slow_send(idx):
+            """Build a send() replacement that records start and finish."""
+
+            def _send(**kwargs):
+                """Simulate slow work so queued futures can be cancelled."""
+                with lock:
+                    started.append(idx)
+                time.sleep(0.3)
+                with lock:
+                    finished.append(idx)
+                return True
+
+            return _send
+
+        try:
+            asset = AppriseAsset(async_mode=True, service_timeout=0.05)
+            a = Apprise(asset=asset)
+            services = []
+            for i in range(n_services):
+                service = _SlowNotify(host=f"host{i}", asset=asset, delay=0.0)
+                service.send = _slow_send(i)
+                services.append(service)
+                a.add(service)
+
+            result = a.notify(body="test")
+            assert result.status == AppriseResultStatus.TIMEOUT
+
+            with lock:
+                started_at_return = len(started)
+
+            # Give uncancelled queued work enough time to reveal itself.
+            time.sleep(1.0)
+            with lock:
+                started_later = len(started)
+                finished_later = len(finished)
+        finally:
+            N_MGR.unload_modules()
+
+        # Some work stayed queued because the pool is size-limited.
+        assert 0 < started_at_return < n_services
+        # And none of the ones that hadn't started yet ever did.
+        assert started_later == started_at_return
+        assert finished_later == started_at_return
+
+    def test_threadpool_shared_across_notify_calls(self):
+        """Separate notify() calls reuse the shared executor."""
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            import apprise.apprise as apprise_module
+
+            # Force this test to observe executor construction.
+            with mock.patch("apprise.apprise._shared_executor", None):
+                executors_seen = set()
+                for i in range(3):
+                    asset = AppriseAsset(async_mode=True, service_timeout=0.05)
+                    a = Apprise(asset=asset)
+                    service = _SlowNotify(
+                        host=f"host{i}", asset=asset, delay=1.0
+                    )
+                    a.add(service)
+                    result = a.notify(body="test")
+                    assert result.status == AppriseResultStatus.TIMEOUT
+                    executors_seen.add(id(apprise_module._shared_executor))
+
+                # All three notify() calls reused the same executor.
+                assert len(executors_seen) == 1
+
+                # Clean up the temporary executor before mock.patch restores.
+                apprise_module._shared_executor.shutdown(wait=False)
+        finally:
+            N_MGR.unload_modules()
+
+    def test_abandoned_calls_reflect_running_state(self):
+        """Tracked abandoned calls clear once their background work ends."""
+        import apprise.apprise as apprise_module
+
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            asset = AppriseAsset(async_mode=True, service_timeout=0.05)
+            a = Apprise(asset=asset)
+            service = _SlowNotify(host="host", asset=asset, delay=0.5)
+            a.add(service)
+
+            result = a.notify(body="test")
+            assert result.status == AppriseResultStatus.TIMEOUT
+
+            # The 0.5s send() is still running in the background --
+            # notify() only gave up waiting on it, it did not stop it.
+            assert apprise_module._any_abandoned_calls_still_running() is True
+
+            # Give it a generous window to actually finish.
+            time.sleep(0.7)
+            assert apprise_module._any_abandoned_calls_still_running() is False
+        finally:
+            N_MGR.unload_modules()
+
+    def test_abandoned_call_descriptions_clear(self):
+        """Abandoned-call descriptions clear once the service finishes."""
+        import apprise.apprise as apprise_module
+
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            asset = AppriseAsset(async_mode=True, service_timeout=0.05)
+            a = Apprise(asset=asset)
+            service = _SlowNotify(
+                host="descriptionhost", asset=asset, delay=0.5
+            )
+            a.add(service)
+
+            result = a.notify(body="test")
+            assert result.status == AppriseResultStatus.TIMEOUT
+
+            descriptions = apprise_module._abandoned_call_descriptions()
+            assert len(descriptions) == 1
+            assert "slow://descriptionhost" in descriptions[0]
+
+            # Once the service finishes, its abandoned-call description clears.
+            time.sleep(0.7)
+            assert apprise_module._abandoned_call_descriptions() == []
+        finally:
+            N_MGR.unload_modules()
+
+    def test_abandoned_calls_false_when_only_queued(self):
+        """Cancelled queued work does not count as still running."""
+        import apprise.apprise as apprise_module
+
+        N_MGR["slow"] = _SlowNotify
+
+        n_services = 40
+        try:
+            asset = AppriseAsset(async_mode=True, service_timeout=0.05)
+            a = Apprise(asset=asset)
+            for i in range(n_services):
+                service = _SlowNotify(host=f"host{i}", asset=asset, delay=0.3)
+                a.add(service)
+
+            result = a.notify(body="test")
+            assert result.status == AppriseResultStatus.TIMEOUT
+
+            # Queued futures are cancelled before they ever touch the tracked
+            # abandoned-call list; any running work should settle quickly.
+            time.sleep(0.5)
+            assert apprise_module._any_abandoned_calls_still_running() is False
+        finally:
+            N_MGR.unload_modules()


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1611 & #1632

*Note:* This is a breaking feature and for this reason it will be moved to Apprise v2.

This PR changes how Apprise reports notification results.

`notify()` and `async_notify()` now return a richer result object instead of a simple yes/no value. This gives apps more useful details about what happened, such as whether a notification worked, failed, matched no services, partially worked, or timed out.

```python
from apprise import AppriseResultStatus

result = apobj.notify(body="Hello")

if result:                                            # Still works
    ...

if result.status == AppriseResultStatus.NOMATCH:      # Replaces `result is None`
    ...
```

To further this...

```python
result = apobj.notify(body="Nightly backup finished")

print(bool(result))               # True/False -- same meaning as before
print(result.status.name)         # SUCCESS, FAILURE, NOMATCH, PARTIAL, or TIMEOUT
print(len(result))                # how many services were actually contacted
print(result.success_count)       # how many of those succeeded
print(result.failed_count)        # how many of those did not
```

`result.status` is one of five values. The numbers match the Apprise CLI exit codes, so scripts checking `$?` can use the same meanings:

| Status    | Exit code | Meaning                                                                                                                                              |
| :-------- | :-------- | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
| `SUCCESS` | `0`       | Every matched service was notified successfully.                                                                                                     |
| `FAILURE` | `1`       | Every matched service failed (none of them genuinely delivered), or the notification could not start.                                                |
| `NOMATCH` | `3`       | Nothing matched the tag or priority filter, so no service was attempted.                                                                             |
| `PARTIAL` | `4`       | Some services delivered and some did not -- see [Mixed Service Results](#mixed-service-results) below.                                               |
| `TIMEOUT` | `5`       | Nothing delivered, but the only problem was that services ran out of time -- see [Per-Service Timeouts](/library/tag-routing/#per-service-timeouts). |

```python
from apprise import AppriseResultStatus

# An exclusive priority filter that matches nothing gives back a
# result that evaluates as False with a NOMATCH status. This means
# there was no matching service to notify.
result = apobj.notify(body="Deploy finished", tag="2:alerts")

if result.status == AppriseResultStatus.NOMATCH:
    print("No service matched that tag/priority combination")
```

It also adds timeout controls so users can stop waiting on slow services:
- Set a default time limit for each service.
- Set a time limit for one whole notification run.
- Use new CLI options to control both from the command line.

The CLI is also safer when a service gets stuck. If Apprise has to stop waiting, it now makes a best effort to save pending service data and flush output before exiting.

Other cleanup in this PR improves reliability around logging, async behavior, shared JSON formatting, and test isolation.

Logging improvement example (now live streaming support:
```python
# example:
recent_logs = []

def collect_log(entry, service):
    # Save just enough information for your app's own status page.
    recent_logs.append(
        {
            "service": service.name,
            "level": entry.level,
            "message": entry.message,
        }
    )

apobj = apprise.Apprise()
apobj.add("mailto://user:pass@example.com")

# Use this callback only for this one notification.
result = apobj.notify(
    body="Backup finished",
    log_callback=collect_log,
```

If your app already uses `asyncio`, the callback may also return a coroutine.
Use it with `async_notify()` so Apprise has an event loop to schedule it on:

```python
async def publish_log(entry, service):
    await websocket.send_json(
        {
            "service": service.name,
            "level": entry.level,
            "message": entry.message,
        }
    )

apobj = apprise.Apprise(log_callback=publish_log)
apobj.add("discord://webhook_id/webhook_token")

result = await apobj.async_notify(body="Deploy started")
```

## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/102](https://github.com/caronc/apprise-docs/pull/102)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (`tox -e lint` passes clean: ruff check + ruff format --check).
* [x] Test coverage added or updated (`tox -e qa`) 

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1611-improved-response

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    -L 10 -SL 5 \
    <apprise url related to this change>
```
