### PR TITLE
v2 - Multi-format support: services can declare and auto-select multiple output formats

### DIFF
--- a/apprise/apprise.py
+++ b/apprise/apprise.py
@@ -1491,13 +1491,25 @@ class Apprise:
             # was set to None), or we did define a tag and the logic above
             # determined we need to notify the service it's associated with
 
+            # Resolve this server's actual per-call rendering target.
+            # Single-format servers always resolve to their one declared
+            # format. Multi-format servers may resolve differently per
+            # call depending on ?format= or this notify() call's
+            # body_format.
+            target_format = server.resolve_format(body_format)
+
             # First we need to generate a key we will use to determine if we
             # need to build our data out.  Entries without are merged with
-            # the body at this stage.
+            # the body at this stage. Keying off the resolved target
+            # keeps conversion caching about the actual rendered format,
+            # not the plugin's raw notify_format declaration. Two
+            # servers that both resolve to HTML still share one converted
+            # body even if one of them declared multiple supported
+            # formats.
             key = (
-                server.notify_format
+                target_format
                 if server.title_maxlen > 0
-                else f"_{server.notify_format}"
+                else f"_{target_format}"
             )
 
             if server.interpret_emojis:
@@ -1514,13 +1526,13 @@ class Apprise:
                 if conversion_title_map[key] and server.title_maxlen <= 0:
                     conversion_title_map[key] = convert_between(
                         body_format,
-                        server.notify_format,
+                        target_format,
                         content=conversion_title_map[key],
                     )
 
                 # Our body is always converted no matter what
                 conversion_body_map[key] = convert_between(
-                    body_format, server.notify_format, content=body
+                    body_format, target_format, content=body
                 )
 
                 if interpret_escapes:
@@ -1566,7 +1578,11 @@ class Apprise:
                 "title": conversion_title_map[key],
                 "notify_type": notify_type,
                 "attach": attach,
-                "body_format": body_format,
+                # Pass the resolved target format; downstream notify()
+                # calls use it directly without resolving again.
+                # Preserve whether the caller declared a source format.
+                "body_format": target_format,
+                "format_controlled": body_format is not None,
             }
             yield (server, kwargs)
 

--- a/apprise/apprise.py
+++ b/apprise/apprise.py
@@ -72,9 +72,9 @@ ServerCall = tuple[NotifyBase, dict[str, Any]]
 # Extra seconds of patience for notify() calls.
 _ABANDON_GRACE_SECONDS = 0.1
 
-# Shared thread pool for _notify_parallel_threadpool(). One pool for the
-# whole process -- a fresh one per call would leak a thread every time a
-# service hangs.
+# Shared thread pool for _notify_sequential() and
+# _notify_parallel_threadpool(). One pool for the whole process -- a
+# fresh one per call would leak a thread every time a service hangs.
 _shared_executor: Optional[cf.ThreadPoolExecutor] = None
 _shared_executor_lock = threading.Lock()
 
@@ -293,6 +293,123 @@ def _attempt_status(success: bool) -> AppriseResultStatus:
     return (
         AppriseResultStatus.SUCCESS if success else AppriseResultStatus.FAILURE
     )
+
+
+def _call_with_retry(
+    service: NotifyBase,
+    kwargs: dict[str, Any],
+    call_deadline: Optional[float],
+) -> tuple[bool, NotifyResult]:
+    """Run one service with retries, waits, logging, and deadlines.
+
+    Shared by sequential and thread-pool dispatch so both paths report
+    the same NotifyResult shape.
+    """
+    # Pop the per-call overrides so they stay internal.
+    retry = kwargs.pop("_retry_override", getattr(service, "retry", 0))
+    wait = getattr(service, "wait", 0.0)
+    log_callback = kwargs.pop("_log_callback", None)
+
+    # Start the service budget when work actually begins.
+    deadline = _compute_deadline(service, call_deadline)
+    attempts: list[NotifyAttempt] = []
+    for attempt in range(retry + 1):
+        if deadline is not None and time.monotonic() >= deadline:
+            # Record that no further attempt was started.
+            logger.trace(
+                "Deadline already passed for '%s'; skipping attempt %d/%d.",
+                service.service_name,
+                attempt + 1,
+                retry + 1,
+            )
+            attempts.append(
+                NotifyAttempt(
+                    status=AppriseResultStatus.TIMEOUT,
+                    logs=[_timeout_log_entry(service.service_name, 0.0)],
+                )
+            )
+            break
+
+        attempt_start = time.monotonic()
+        logger.trace(
+            "Starting attempt %d/%d for '%s'.",
+            attempt + 1,
+            retry + 1,
+            service.service_name,
+        )
+        # Treat validation errors and plugin crashes as retriable failures.
+        with _ServiceLogCapture(service, log_callback=log_callback) as capture:
+            try:
+                result = service.notify(**kwargs)
+            except TypeError:
+                result = False
+            except Exception as e:
+                logger.warning(
+                    "Notification service '%s' raised an exception.",
+                    service.service_name,
+                )
+                logger.debug("Notification Exception: %s", str(e))
+                result = False
+
+        attempt_elapsed = time.monotonic() - attempt_start
+        logger.trace(
+            "Attempt %d/%d for '%s' finished in %.3fs: %s.",
+            attempt + 1,
+            retry + 1,
+            service.service_name,
+            attempt_elapsed,
+            "success" if result else "failure",
+        )
+        attempts.append(
+            NotifyAttempt(
+                status=_attempt_status(result),
+                elapsed=attempt_elapsed,
+                logs=capture.entries,
+            )
+        )
+
+        if result:
+            break
+
+        if attempt < retry:
+            logger.warning(
+                "Attempt %d/%d for '%s' failed; trying again.",
+                attempt + 1,
+                retry,
+                service.service_name,
+            )
+            if wait > 0:
+                sleep_for = wait
+                if deadline is not None:
+                    sleep_for = min(
+                        wait, max(0.0, deadline - time.monotonic())
+                    )
+                if sleep_for > 0:
+                    time.sleep(sleep_for)
+
+    # Optional services can fail quietly, but keep a log breadcrumb.
+    optional = getattr(service, "optional", False)
+    succeeded = any(a.status == AppriseResultStatus.SUCCESS for a in attempts)
+    if not succeeded and optional:
+        logger.info(
+            "Optional service '%s' did not send successfully; continuing.",
+            service.service_name,
+        )
+
+    # Metadata helpers belong to plugins and may raise.
+    name, url, url_id, tag, weight = _service_metadata(service)
+    notify_result = NotifyResult(
+        name=name,
+        url=url,
+        url_id=url_id,
+        tag=tag,
+        optional=optional,
+        weight=weight,
+        max_attempts=retry + 1,
+        attempts=attempts,
+    )
+
+    return bool(notify_result), notify_result
 
 
 class Apprise:
@@ -1590,156 +1707,86 @@ class Apprise:
     def _notify_sequential(
         *services_kwargs: ServerCall, call_deadline: Optional[float] = None
     ) -> tuple[bool, list[NotifyResult]]:
-        """Process a list of notify() calls sequentially and synchronously.
+        """Process a list of notify() calls one at a time, in order.
 
-        Retries, wait times, per-call retry overrides, and deadlines are all
-        handled here. A blocking in-flight call cannot be preempted.
+        Calls with deadlines use the shared executor so Apprise can stop
+        waiting on a blocked service while preserving result order.
         """
 
         success = True
         results: list[NotifyResult] = []
 
         for service, kwargs in services_kwargs:
-            # Pop the per-call overrides before forwarding kwargs to the
-            # plugin so it never sees these internal keys.
-            retry = kwargs.pop("_retry_override", getattr(service, "retry", 0))
-            wait = getattr(service, "wait", 0.0)
-            log_callback = kwargs.pop("_log_callback", None)
-
-            # The deadline is computed fresh right as this service's own
-            # dispatch begins, per-service, not from when notify() was
-            # first called.
+            # The outer wait needs a deadline before submission.
             deadline = _compute_deadline(service, call_deadline)
-            attempts: list[NotifyAttempt] = []
-            for attempt in range(retry + 1):
-                if deadline is not None and time.monotonic() >= deadline:
-                    # Out of time -- do not start another attempt.  Record
-                    # a zero-elapsed TIMEOUT attempt marking the decision
-                    # to stop, with its own diagnostic log entry, rather
-                    # than silently dropping it.
-                    logger.trace(
-                        "Deadline already passed for '%s'; skipping "
-                        "attempt %d/%d.",
-                        service.service_name,
-                        attempt + 1,
-                        retry + 1,
-                    )
-                    attempts.append(
-                        NotifyAttempt(
-                            status=AppriseResultStatus.TIMEOUT,
-                            logs=[
-                                _timeout_log_entry(service.service_name, 0.0)
-                            ],
-                        )
-                    )
-                    break
 
-                # monotonic() avoids wall-clock jumps while timing an attempt.
-                attempt_start = time.monotonic()
-                logger.trace(
-                    "Starting attempt %d/%d for '%s'.",
-                    attempt + 1,
-                    retry + 1,
-                    service.service_name,
+            if deadline is None:
+                ok, notify_result = _call_with_retry(
+                    service, kwargs, call_deadline
                 )
-                # Isolate this attempt's log output so it can be
-                # attributed to exactly this call in the NotifyAttempt
-                # built below (see _ServiceLogCapture).
-                with _ServiceLogCapture(
-                    service, log_callback=log_callback
-                ) as capture:
-                    # Treat validation and plugin exceptions as failed
-                    # attempts.
-                    try:
-                        result = service.notify(**kwargs)
-                    except TypeError:
-                        result = False
-                    except Exception as e:
-                        logger.warning(
-                            "Notification service '%s' raised an exception.",
-                            service.service_name,
-                        )
-                        logger.debug("Notification Exception: %s", str(e))
-                        result = False
+                success = success and ok
+                results.append(notify_result)
+                continue
 
-                attempt_elapsed = time.monotonic() - attempt_start
-                logger.trace(
-                    "Attempt %d/%d for '%s' finished in %.3fs: %s.",
-                    attempt + 1,
-                    retry + 1,
-                    service.service_name,
-                    attempt_elapsed,
-                    "success" if result else "failure",
-                )
-                attempts.append(
-                    NotifyAttempt(
-                        status=_attempt_status(result),
-                        elapsed=attempt_elapsed,
-                        logs=capture.entries,
-                    )
-                )
+            # Allow a small grace window before abandoning the wait.
+            abandon_at = deadline + _ABANDON_GRACE_SECONDS
+            wait_start = time.monotonic()
+            wait_for = max(0.0, abandon_at - wait_start)
 
-                if result:
-                    # Delivered successfully; no need to retry this service.
-                    break
-
-                if attempt < retry:
-                    # Delivery failed and retries remain.  Log the attempt
-                    # number and pause before the next try.
-                    logger.warning(
-                        "Attempt %d/%d for '%s' failed; trying again.",
-                        attempt + 1,
-                        retry,
-                        service.service_name,
-                    )
-                    if wait > 0:
-                        # Never sleep past the deadline -- the top-of-loop
-                        # check above will report the timeout on the next
-                        # iteration once we wake up.
-                        sleep_for = wait
-                        if deadline is not None:
-                            sleep_for = min(
-                                wait, max(0.0, deadline - time.monotonic())
-                            )
-                        if sleep_for > 0:
-                            time.sleep(sleep_for)
-
-            # Optional-service check after all retries have completed.
-            # NotifyResult reflects optional failures/timeouts as SUCCESS;
-            # this log only records that the underlying delivery failed.
-            #
-            # Optional services still use every retry; only the final status
-            # is interpreted differently.
-            optional = getattr(service, "optional", False)
-            succeeded = any(
-                a.status == AppriseResultStatus.SUCCESS for a in attempts
+            logger.trace(
+                "Waiting up to %.3fs for '%s'.",
+                wait_for,
+                service.service_name,
             )
-            if not succeeded and optional:
-                logger.info(
-                    "Optional service '%s' did not send successfully; "
-                    "continuing.",
+
+            executor = _get_shared_executor()
+            future = executor.submit(
+                _call_with_retry, service, kwargs, call_deadline
+            )
+            try:
+                # Keep a final guard for unexpected executor failures.
+                ok, notify_result = future.result(timeout=wait_for)
+                logger.trace(
+                    "'%s' finished after %.3fs: %s.",
                     service.service_name,
+                    time.monotonic() - wait_start,
+                    "success" if ok else "failure",
                 )
 
-            # Gathered defensively -- see _service_metadata() -- so a
-            # plugin whose url()/url_id()/__len__ raises can never crash
-            # this call or discard a delivery that already succeeded.
-            name, url, url_id, tag, weight = _service_metadata(service)
-            notify_result = NotifyResult(
-                name=name,
-                url=url,
-                url_id=url_id,
-                tag=tag,
-                optional=optional,
-                weight=weight,
-                max_attempts=retry + 1,
-                attempts=attempts,
-            )
-            results.append(notify_result)
+            except cf.TimeoutError:
+                # The service took too long; report TIMEOUT and move on.
+                wait_elapsed = time.monotonic() - wait_start
+
+                # Track only work that already started and cannot be cancelled.
+                cancelled = future.cancel()
+                if not cancelled:
+                    name, url, _, _, _ = _service_metadata(service)
+                    _track_abandoned_future(future, name, url)
+                logger.trace(
+                    "Stopped waiting for '%s' after %.3fs (%s).",
+                    service.service_name,
+                    wait_elapsed,
+                    "it was still queued and has been cancelled"
+                    if cancelled
+                    else "its worker thread may still be running in the "
+                    "background",
+                )
+                notify_result = _timeout_result(service, wait_elapsed)
+                ok = bool(notify_result)
+
+            except Exception as e:
+                logger.warning(
+                    "Notification service '%s' raised an exception.",
+                    service.service_name,
+                )
+                logger.debug("Notification Exception: %s", str(e))
+                notify_result = _safe_error_result(service)
+                ok = bool(notify_result)
 
             # One required failure means the whole batch cannot succeed.
             # Optional failures already count as SUCCESS in NotifyResult.
-            success = success and bool(notify_result)
+            success = success and ok
+            results.append(notify_result)
 
         return success, results
 
@@ -1774,143 +1821,6 @@ class Apprise:
             "Notifying %d service(s) with threads.", len(services_kwargs)
         )
 
-        def _call_with_retry(
-            service: NotifyBase, kwargs: dict[str, Any]
-        ) -> tuple[bool, NotifyResult]:
-            """Execute one service's notify() with retry/wait logic.
-
-            Runs inside a worker thread.  Pops ``_retry_override`` from
-            kwargs so it is never forwarded to the plugin's notify() call.
-            Exceptions are caught and treated as failures so the retry
-            loop continues even when a plugin raises unexpectedly.
-
-            Returns (bool, NotifyResult) -- the bool is this service's
-            contribution to the batch's aggregate success value (mirrors
-            the NotifyResult's own reflective status, already adjusted
-            for optional=); the NotifyResult also carries every raw,
-            unadjusted NotifyAttempt for the caller's AppriseResult.
-            """
-            # Pop the per-call overrides so they stay internal.
-            retry = kwargs.pop("_retry_override", getattr(service, "retry", 0))
-            wait = getattr(service, "wait", 0.0)
-            log_callback = kwargs.pop("_log_callback", None)
-
-            # The deadline is computed here, right as this worker actually
-            # begins running -- not at submission time -- so time spent
-            # queued behind other work in the pool never counts against
-            # this service's own budget.
-            deadline = _compute_deadline(service, call_deadline)
-            attempts: list[NotifyAttempt] = []
-            for attempt in range(retry + 1):
-                if deadline is not None and time.monotonic() >= deadline:
-                    # Out of time -- record a zero-elapsed TIMEOUT attempt
-                    # marking the decision to stop, and do not start
-                    # another one.
-                    logger.trace(
-                        "Deadline already passed for '%s'; skipping "
-                        "attempt %d/%d.",
-                        service.service_name,
-                        attempt + 1,
-                        retry + 1,
-                    )
-                    attempts.append(
-                        NotifyAttempt(
-                            status=AppriseResultStatus.TIMEOUT,
-                            logs=[
-                                _timeout_log_entry(service.service_name, 0.0)
-                            ],
-                        )
-                    )
-                    break
-
-                attempt_start = time.monotonic()
-                logger.trace(
-                    "Starting attempt %d/%d for '%s'.",
-                    attempt + 1,
-                    retry + 1,
-                    service.service_name,
-                )
-                # Same exception handling as _notify_sequential: TypeError
-                # from Apprise validation and bare Exception for buggy or
-                # third-party plugins both map to a retriable failure.
-                with _ServiceLogCapture(
-                    service, log_callback=log_callback
-                ) as capture:
-                    try:
-                        result = service.notify(**kwargs)
-                    except TypeError:
-                        result = False
-                    except Exception as e:
-                        logger.warning(
-                            "Notification service '%s' raised an exception.",
-                            service.service_name,
-                        )
-                        logger.debug("Notification Exception: %s", str(e))
-                        result = False
-
-                attempt_elapsed = time.monotonic() - attempt_start
-                logger.trace(
-                    "Attempt %d/%d for '%s' finished in %.3fs: %s.",
-                    attempt + 1,
-                    retry + 1,
-                    service.service_name,
-                    attempt_elapsed,
-                    "success" if result else "failure",
-                )
-                attempts.append(
-                    NotifyAttempt(
-                        status=_attempt_status(result),
-                        elapsed=attempt_elapsed,
-                        logs=capture.entries,
-                    )
-                )
-
-                if result:
-                    break
-
-                if attempt < retry:
-                    logger.warning(
-                        "Attempt %d/%d for '%s' failed; trying again.",
-                        attempt + 1,
-                        retry,
-                        service.service_name,
-                    )
-                    if wait > 0:
-                        sleep_for = wait
-                        if deadline is not None:
-                            sleep_for = min(
-                                wait, max(0.0, deadline - time.monotonic())
-                            )
-                        if sleep_for > 0:
-                            time.sleep(sleep_for)
-
-            # Optional services can fail quietly, but keep a log breadcrumb.
-            optional = getattr(service, "optional", False)
-            succeeded = any(
-                a.status == AppriseResultStatus.SUCCESS for a in attempts
-            )
-            if not succeeded and optional:
-                logger.info(
-                    "Optional service '%s' did not send successfully; "
-                    "continuing.",
-                    service.service_name,
-                )
-
-            # Build result metadata defensively; plugin helpers may raise.
-            name, url, url_id, tag, weight = _service_metadata(service)
-            notify_result = NotifyResult(
-                name=name,
-                url=url,
-                url_id=url_id,
-                tag=tag,
-                optional=optional,
-                weight=weight,
-                max_attempts=retry + 1,
-                attempts=attempts,
-            )
-
-            return bool(notify_result), notify_result
-
         # Keep output ordered by input, though threads finish out of order.
         # This is the shared, process-wide pool (see _get_shared_executor()),
         # not a fresh one per call -- never shut down here, it persists for
@@ -1927,7 +1837,9 @@ class Apprise:
             for service, kwargs in services_kwargs
         ]
         future_to_idx: dict[cf.Future, int] = {
-            executor.submit(_call_with_retry, service, kwargs): i
+            executor.submit(
+                _call_with_retry, service, kwargs, call_deadline
+            ): i
             for i, (service, kwargs) in enumerate(services_kwargs)
         }
 
@@ -2032,8 +1944,9 @@ class Apprise:
             so the retry loop continues even when a plugin raises
             unexpectedly (e.g. a third-party @notify-decorated coroutine).
 
-            Returns (bool, NotifyResult) -- see _call_with_retry in
-            _notify_parallel_threadpool for the equivalent contract.
+            Returns (bool, NotifyResult) -- see the module-level
+            _call_with_retry() for the equivalent contract used by the
+            sequential and thread-pool dispatch styles.
             """
             # Pop the per-call overrides so they stay internal.
             retry = kwargs.pop("_retry_override", getattr(service, "retry", 0))
@@ -2041,7 +1954,7 @@ class Apprise:
             log_callback = kwargs.pop("_log_callback", None)
 
             # Computed fresh as this coroutine actually starts running,
-            # same rationale as _notify_parallel_threadpool's worker.
+            # same rationale as the module-level _call_with_retry().
             deadline = _compute_deadline(service, call_deadline)
             attempts: list[NotifyAttempt] = []
             for attempt in range(retry + 1):

--- a/apprise/conversion.py
+++ b/apprise/conversion.py
@@ -90,6 +90,7 @@ def convert_between(from_format, to_format, content):
         (NotifyFormat.TEXT, NotifyFormat.HTML): text_to_html,
         (NotifyFormat.HTML, NotifyFormat.TEXT): html_to_text,
         (NotifyFormat.HTML, NotifyFormat.MARKDOWN): html_to_markdown,
+        (NotifyFormat.TEXT, NotifyFormat.MARKDOWN): text_to_markdown,
     }
 
     # Fetch the converter registered for this format pair.
@@ -114,6 +115,21 @@ def text_to_html(content):
 
     # First eliminate any carriage returns
     return URLBase.escape_html(content, convert_new_lines=True)
+
+
+# CommonMark syntax characters, including backslash itself.
+# Plain text has no escape state, so escape every occurrence.
+_COMMONMARK_ESCAPABLE_RE = re.compile(r"([\\_*\[\]()~`>#+=|{}.!-])")
+
+
+def text_to_markdown(content):
+    """Converts specified content from plain text to CommonMark.
+
+    Escapes CommonMark-significant characters, including backslashes, so
+    plain text renders literally in Markdown destinations.
+    """
+
+    return _COMMONMARK_ESCAPABLE_RE.sub(r"\\\1", content)
 
 
 def html_to_text(content):

--- a/apprise/decorators/base.py
+++ b/apprise/decorators/base.py
@@ -72,10 +72,14 @@ class CustomNotifyPlugin(NotifyBase):
         return f"{self.secure_protocol}://"
 
     @staticmethod
-    def instantiate_plugin(url, send_func, name=None):
+    def instantiate_plugin(url, send_func, name=None, body_format=None):
         """The function used to add a new notification plugin based on the
         schema parsed from the provided URL into our supported matrix
-        structure."""
+        structure.
+
+        ``body_format`` declares the destination format(s) this wrapper
+        accepts. When omitted, the wrapper passes every format through.
+        """
 
         if not isinstance(url, str):
             msg = (
@@ -129,6 +133,18 @@ class CustomNotifyPlugin(NotifyBase):
 
             # Store our matched schema
             secure_protocol = schema
+
+            # Explicit body_format= declares this wrapper's destination.
+            # Without one, accept every format as pass-through input.
+            notify_format = (
+                body_format
+                if body_format is not None
+                else (
+                    common.NotifyFormat.TEXT,
+                    common.NotifyFormat.HTML,
+                    common.NotifyFormat.MARKDOWN,
+                )
+            )
 
             requirements = {
                 # Define our required packaging in order to work

--- a/apprise/decorators/notify.py
+++ b/apprise/decorators/notify.py
@@ -28,7 +28,7 @@
 from .base import CustomNotifyPlugin
 
 
-def notify(on, name=None):
+def notify(on, name=None, body_format=None):
     """
     @notify decorator allows you to map functions you've defined to be loaded
     as a regular notify by Apprise.  You must identify a protocol that
@@ -42,6 +42,13 @@ def notify(on, name=None):
     is what calling functions via the API will receive.
 
         @notify(on="foobar", name="My Foobar Process")
+        def your_action(body, title, notify_type, meta, *args, **kwargs):
+            ...
+
+    You can optionally declare the prepared body format(s) your function
+    accepts. Without this, all formats pass through unconverted.
+
+        @notify(on="foobar", body_format=NotifyFormat.MARKDOWN)
         def your_action(body, title, notify_type, meta, *args, **kwargs):
             ...
 
@@ -59,8 +66,9 @@ def notify(on, name=None):
       body:        The message body associated with the notification
       title:       The message title associated with the notification
       notify_type: The message type (info, success, warning, and failure)
-      body_format: The format of the incoming notification body. This is
-                   either text, html, or markdown.
+      body_format: The resolved format delivered to your function.
+      format_controlled:
+                   True if the caller declared a source format.
       meta:        Combines the URL arguments specified on the `on` call
                    with the ones loaded from a users configuration. This
                    is a dictionary that presents itself like this:
@@ -94,8 +102,9 @@ def notify(on, name=None):
 
       attach:      An array AppriseAttachment objects (if any were provided)
 
-      body_format: Defaults to the expected format output; By default this
-                   will be TEXT unless over-ridden in the Apprise URL
+      @notify body_format:
+                   Declares the prepared body format(s) your wrapper
+                   accepts; omitted means pass-through for every format.
 
 
     If you don't intend on using all of the parameters, your @notify() call
@@ -118,7 +127,7 @@ def notify(on, name=None):
 
         # Generate
         CustomNotifyPlugin.instantiate_plugin(
-            url=on, send_func=func, name=name
+            url=on, send_func=func, name=name, body_format=body_format
         )
 
         return func

--- a/apprise/plugins/__init__.py
+++ b/apprise/plugins/__init__.py
@@ -321,6 +321,25 @@ def details(plugin):
                 # We only nee to remove this key
                 del template_args[key]["_exists_if"]
 
+    # notify_format may be one NotifyFormat or a tuple of supported
+    # formats. `values` stays the broad three-item set because ?format=
+    # remains a standard Apprise URL parameter on every plugin. The
+    # additive `supported` field tells newer consumers which destination
+    # formats this plugin actually renders natively, with index 0 as the
+    # default. Keeping older `values`/`default` consumers working avoids
+    # making the service metadata update a breaking change.
+    # sort=False preserves declaration order because parse_list() sorts
+    # alphabetically by default, which would change the fallback format.
+    if "format" in template_args:
+        formats = parse_list(plugin.notify_format, sort=False)
+        template_args["format"]["supported"] = formats
+        if len(formats) > 1:
+            # A single-format plugin's default was already correctly
+            # resolved above via _lookup_default; only a multi-format
+            # plugin needs correcting here (that mechanism would
+            # otherwise leave the raw tuple in place).
+            template_args["format"]["default"] = formats[0]
+
     return {
         "templates": templates,
         "tokens": template_tokens,

--- a/apprise/plugins/apprise_api.py
+++ b/apprise/plugins/apprise_api.py
@@ -32,7 +32,7 @@ import re
 import requests
 
 from .. import exception
-from ..common import NotifyType
+from ..common import NotifyFormat, NotifyType
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import parse_list, validate_regex
@@ -73,6 +73,14 @@ class NotifyAppriseAPI(NotifyBase):
 
     # Support attachments
     attachment_support = True
+
+    # Relay every format unchanged; the downstream Apprise API instance
+    # performs its own format handling.
+    notify_format = (
+        NotifyFormat.TEXT,
+        NotifyFormat.HTML,
+        NotifyFormat.MARKDOWN,
+    )
 
     # Depending on the number of transactions/notifications taking place, this
     # could take a while. 30 seconds should be enough to perform the task
@@ -258,6 +266,8 @@ class NotifyAppriseAPI(NotifyBase):
         title="",
         notify_type=NotifyType.INFO,
         attach=None,
+        body_format=None,
+        format_controlled=None,
         **kwargs,
     ):
         """Perform Apprise API Notification."""
@@ -335,8 +345,12 @@ class NotifyAppriseAPI(NotifyBase):
             "title": title,
             "body": body,
             "type": notify_type.value,
-            "format": self.notify_format.value,
         }
+
+        if format_controlled:
+            # Relay format only when the caller declared one; otherwise
+            # let the downstream Apprise API server choose its default.
+            payload["format"] = body_format.value
 
         if self.method == AppriseAPIMethod.JSON:
             headers["Content-Type"] = "application/json"

--- a/apprise/plugins/base.py
+++ b/apprise/plugins/base.py
@@ -761,14 +761,14 @@ class NotifyBase(URLBase):
 
             # The requested destination is not one this plugin declared.
             # Fall through to input alignment/default instead of failing
-            # delivery, but log why the override could not be honored.
-            # The actual fallback (input alignment vs formats[0]) is
-            # decided below, so it is not named here.
-            self.logger.warning(
-                "%s does not support format %s; ignoring override.",
-                self.service_name,
-                self._format_override.value,
-            )
+            # delivery. The actual fallback (input alignment vs
+            # formats[0]) is decided below, so it is not named here.
+            if body_format is not None:
+                self.logger.debug(
+                    "%s does not support format %s; ignoring override.",
+                    self.service_name,
+                    self._format_override.value,
+                )
 
         if body_format in formats:
             # body_format may arrive as a plain string (e.g. from the

--- a/apprise/plugins/base.py
+++ b/apprise/plugins/base.py
@@ -52,7 +52,7 @@ from ..locale import Translatable, gettext_lazy as _
 from ..persistent_store import PersistentStore
 from ..url import URLBase
 from ..utils.format import smart_split
-from ..utils.parse import parse_bool
+from ..utils.parse import parse_bool, parse_list
 from ..utils.time import zoneinfo
 
 
@@ -321,6 +321,12 @@ class NotifyBase(URLBase):
             "format": {
                 "name": _("Notify Format"),
                 "type": "choice:string",
+                # ?format= is accepted for any of the 3 values on every
+                # plugin. Single-format plugins force the requested
+                # value directly; multi-format plugins decide later
+                # whether to honor it. plugins.details() exposes the
+                # plugin's native subset through the additive
+                # format.supported field.
                 "values": NOTIFY_FORMATS,
                 # Provide a default
                 "default": notify_format,
@@ -576,10 +582,17 @@ class NotifyBase(URLBase):
                 )
             )
 
+        # Store an explicit ?format= request for multi-format plugins.
+        # Those plugins keep their declared notify_format tuple intact,
+        # then resolve the one active destination later for each send.
+        # Single-format plugins still force self.notify_format directly,
+        # preserving the established URL override behavior.
+        self._format_override: Optional[NotifyFormat] = None
+
         if "format" in kwargs:
             value = kwargs["format"]
             try:
-                self.notify_format = (
+                requested = (
                     value
                     if isinstance(value, NotifyFormat)
                     else NotifyFormat(value.lower())
@@ -591,6 +604,16 @@ class NotifyBase(URLBase):
                 )
                 self.logger.warning(err)
                 raise TypeError(err) from None
+
+            if len(self._formats()) == 1:
+                # Single-format plugin: force the requested destination
+                # directly onto self.notify_format.
+                self.notify_format = requested
+
+            else:
+                # Multi-format plugin: remember the request and validate
+                # it during per-send resolution.
+                self._format_override = requested
 
         if "tz" in kwargs:
             value = kwargs["tz"]
@@ -699,14 +722,81 @@ class NotifyBase(URLBase):
             notify_type=notify_type,
         )
 
+    def _formats(self) -> tuple[NotifyFormat, ...]:
+        """Supported notify formats as a tuple.
+
+        ``notify_format`` may be declared as a single ``NotifyFormat`` or
+        as a tuple/list of them. This mirrors the string-or-iterable
+        tolerance already used for protocol/secure_protocol. Index 0 is
+        the default/native format used when no override or input format
+        picks a different one.
+        """
+        # Preserve declaration order because the first entry is the
+        # default. parse_list() sorts alphabetically by default, which
+        # would silently choose the wrong fallback format here.
+        return tuple(
+            NotifyFormat(f) for f in parse_list(self.notify_format, sort=False)
+        )
+
+    def resolve_format(
+        self, body_format: Optional[NotifyFormat] = None
+    ) -> NotifyFormat:
+        """Resolve which format this send should actually render as.
+
+        Resolution order:
+        - A single-format plugin always uses its one declared format.
+        - A multi-format plugin honors an explicit ?format= override,
+          when that override is one of its declared formats.
+        - Otherwise, if the caller's body_format matches a declared
+          format, align to it directly (no conversion needed).
+        - Otherwise, fall back to the plugin's default, formats[0].
+        """
+        formats = self._formats()
+        if len(formats) == 1:
+            return formats[0]
+
+        if self._format_override is not None:
+            if self._format_override in formats:
+                return self._format_override
+
+            # The requested destination is not one this plugin declared.
+            # Fall through to input alignment/default instead of failing
+            # delivery, but log why the override could not be honored.
+            self.logger.warning(
+                "%s does not support format %s; using %s instead.",
+                self.service_name,
+                self._format_override.value,
+                formats[0].value,
+            )
+
+        if body_format in formats:
+            # body_format may arrive as a plain string (e.g. from the
+            # CLI) rather than a NotifyFormat; normalize to the actual
+            # matched member so callers can always rely on .value etc.
+            return (
+                body_format
+                if isinstance(body_format, NotifyFormat)
+                else NotifyFormat(body_format)
+            )
+
+        return formats[0]
+
     def _timed_send(self, **kwargs2: Any) -> bool:
         """Call send() once, logging how long it took at DEBUG.
 
         Shared by notify() and async_notify() so every attempt is timed
-        the same way.
+        the same way. Dispatches to a type-specific send_text()/
+        send_html()/send_markdown() when the plugin defines one for the
+        resolved format, falling back to the generic send() otherwise.
+
+        _build_send_calls() yields an already-resolved body_format.
         """
+        resolved = kwargs2.get("body_format")
+        fn = getattr(self, f"send_{resolved.value}", None)
+        send_fn = fn if callable(fn) else self.send
+
         send_start = time.monotonic()
-        result = self.send(**kwargs2)
+        result = send_fn(**kwargs2)
         self.logger.debug(
             "%s send() completed in %.2fs.",
             self.service_name,
@@ -773,10 +863,17 @@ class NotifyBase(URLBase):
         overflow: Optional[Union[str, OverflowMode]] = None,
         attach: Optional[Union[list[str], AppriseAttachment]] = None,
         body_format: Optional[NotifyFormat] = None,
+        format_controlled: Optional[bool] = None,
         **kwargs: Any,
     ) -> Generator[dict[str, Any], None, None]:
         """Get a list of dictionaries that can be used to call send() or (in
         the future) async_send()."""
+
+        # Direct plugin calls bypass Apprise's per-server resolution, so
+        # resolve here and remember whether a source format was declared.
+        if format_controlled is None:
+            format_controlled = body_format is not None
+            body_format = self.resolve_format(body_format)
 
         if not self.enabled:
             # Deny notifications issued to services that are disabled
@@ -835,7 +932,11 @@ class NotifyBase(URLBase):
 
         # Apply our overflow (if defined)
         for chunk in self._apply_overflow(
-            body=body, title=title, overflow=overflow, body_format=body_format
+            body=body,
+            title=title,
+            overflow=overflow,
+            body_format=body_format,
+            format_controlled=format_controlled,
         ):
             # Send notification
             yield {
@@ -844,6 +945,7 @@ class NotifyBase(URLBase):
                 "notify_type": notify_type,
                 "attach": attach_,
                 "body_format": body_format,
+                "format_controlled": format_controlled,
             }
 
     def _apply_overflow(
@@ -852,6 +954,7 @@ class NotifyBase(URLBase):
         title: Optional[str] = None,
         overflow: Optional[Union[str, OverflowMode]] = None,
         body_format: Optional[NotifyFormat] = None,
+        format_controlled: Optional[bool] = None,
     ) -> list[dict[str, str]]:
         """
         Apply overflow behaviour (UPSTREAM, TRUNCATE, SPLIT) to title/body.
@@ -859,6 +962,10 @@ class NotifyBase(URLBase):
         Takes the message body and title as input.  This function then
         applies any defined overflow restrictions associated with the
         notification service and may alter the message if/as required.
+
+        ``body_format`` is the resolved render target for this send.
+        ``format_controlled`` tracks whether the caller declared a source
+        format; standalone calls resolve both here as a fallback.
 
         The function will always return a list object in the following
         structure:
@@ -883,29 +990,22 @@ class NotifyBase(URLBase):
         if overflow is None:
             overflow = self.overflow_mode
 
-        # Default effective body format
-        if body_format is None:
-            body_format = self.notify_format
+        if format_controlled is None:
+            format_controlled = body_format is not None
+            body_format = self.resolve_format(body_format)
 
         # If the service does not support a title, amalgamate into body
         if self.title_maxlen <= 0 and len(title) > 0:
-            if self.notify_format == NotifyFormat.HTML:
+            if body_format == NotifyFormat.HTML:
                 body = (
                     f"<{self.default_html_tag_id}>{title}"
                     f"</{self.default_html_tag_id}>"
                     f"<br />\r\n{body}"
                 )
 
-            elif (
-                self.notify_format == NotifyFormat.MARKDOWN
-                and body_format
-                in (
-                    NotifyFormat.TEXT,
-                    NotifyFormat.HTML,
-                )
-            ):
-                # Body was plain text or HTML converted to CommonMark;
-                # render the title as a Markdown heading.
+            elif body_format == NotifyFormat.MARKDOWN and format_controlled:
+                # Declared Markdown/CommonMark can receive a heading.
+                # Undeclared content falls through unchanged below.
                 title = title.lstrip("\r\n \t\v\f#-")
                 if title:
                     body = f"# {title}\n{body}"
@@ -1161,10 +1261,18 @@ class NotifyBase(URLBase):
         function in all defined plugin services.
         """
 
-        params = {
-            "format": self.notify_format.value,
-            "overflow": self.overflow_mode.value,
-        }
+        params = {"overflow": self.overflow_mode.value}
+
+        # Single-format plugins always serialize their effective format.
+        # Multi-format plugins only serialize format= when the user asked
+        # for an explicit override. Omitting it keeps plain multi-format
+        # URLs flexible on a round trip, so the next send can still align
+        # to that call's body_format.
+        formats = self._formats()
+        if len(formats) == 1:
+            params["format"] = formats[0].value
+        elif self._format_override is not None:
+            params["format"] = self._format_override.value
 
         # Timezone Information (if ZoneInfo)
         if self.__tzinfo and isinstance(self.__tzinfo, ZoneInfo):

--- a/apprise/plugins/base.py
+++ b/apprise/plugins/base.py
@@ -762,11 +762,12 @@ class NotifyBase(URLBase):
             # The requested destination is not one this plugin declared.
             # Fall through to input alignment/default instead of failing
             # delivery, but log why the override could not be honored.
+            # The actual fallback (input alignment vs formats[0]) is
+            # decided below, so it is not named here.
             self.logger.warning(
-                "%s does not support format %s; using %s instead.",
+                "%s does not support format %s; ignoring override.",
                 self.service_name,
                 self._format_override.value,
-                formats[0].value,
             )
 
         if body_format in formats:

--- a/apprise/plugins/brevo.py
+++ b/apprise/plugins/brevo.py
@@ -127,8 +127,9 @@ class NotifyBrevo(NotifyBase):
     # A URL that takes you to the setup/help of the specific protocol
     setup_url = "https://appriseit.com/services/brevo/"
 
-    # Default to markdown
-    notify_format = NotifyFormat.HTML
+    # Brevo can accept either HTML or plain text as the main message
+    # body. HTML remains the default.
+    notify_format = (NotifyFormat.HTML, NotifyFormat.TEXT)
 
     # The default Email API URL to use
     notify_url = "https://api.brevo.com/v3/smtp/email"
@@ -358,6 +359,7 @@ class NotifyBrevo(NotifyBase):
         title="",
         notify_type=NotifyType.INFO,
         attach=None,
+        body_format=None,
         **kwargs,
     ):
         """Perform Brevo Notification."""
@@ -388,17 +390,22 @@ class NotifyBrevo(NotifyBase):
             "to": [{"email": None}],
             "subject": title if title else self.default_empty_subject,
         }
-        # Body selection
-        use_html = self.notify_format == NotifyFormat.HTML
+        # Resolve the requested delivery representation for this send.
+        # Brevo still wants both htmlContent and textContent, so the
+        # resolved format decides which one is the original body and
+        # which one is derived from it.
+        use_html = self.resolve_format(body_format) == NotifyFormat.HTML
 
         if use_html:
-            # body already normalised; keep your existing logic
+            # HTML is the caller-selected representation; derive the
+            # plain-text alternative for Brevo's companion field.
             payload_["htmlContent"] = body
             payload_["textContent"] = convert_between(
                 NotifyFormat.HTML, NotifyFormat.TEXT, body
             )
         else:
-            # Plain text requested, but Brevo still wants HTML
+            # Plain text is the caller-selected representation; derive
+            # the HTML alternative so the payload remains complete.
             payload_["textContent"] = body
             payload_["htmlContent"] = convert_between(
                 NotifyFormat.TEXT, NotifyFormat.HTML, body

--- a/apprise/plugins/custom_form.py
+++ b/apprise/plugins/custom_form.py
@@ -29,7 +29,7 @@ import re
 
 import requests
 
-from ..common import NotifyImageSize, NotifyType
+from ..common import NotifyFormat, NotifyImageSize, NotifyType
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from .base import NotifyBase
@@ -96,6 +96,14 @@ class NotifyForm(NotifyBase):
 
     # Support attachments
     attachment_support = True
+
+    # Pass-through Notify Formats. The endpoint receives whichever body
+    # representation Apprise resolved for this send.
+    notify_format = (
+        NotifyFormat.TEXT,
+        NotifyFormat.HTML,
+        NotifyFormat.MARKDOWN,
+    )
 
     # Allows the user to specify the NotifyImageSize object
     image_size = NotifyImageSize.XY_128

--- a/apprise/plugins/custom_json.py
+++ b/apprise/plugins/custom_json.py
@@ -31,7 +31,7 @@ import logging
 import requests
 
 from .. import exception
-from ..common import NotifyImageSize, NotifyType
+from ..common import NotifyFormat, NotifyImageSize, NotifyType
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.sanitize import sanitize_payload
@@ -78,6 +78,14 @@ class NotifyJSON(NotifyBase):
 
     # Support attachments
     attachment_support = True
+
+    # Pass-through Notify Formats. The endpoint receives whichever body
+    # representation Apprise resolved for this send.
+    notify_format = (
+        NotifyFormat.TEXT,
+        NotifyFormat.HTML,
+        NotifyFormat.MARKDOWN,
+    )
 
     # Allows the user to specify the NotifyImageSize object
     image_size = NotifyImageSize.XY_128

--- a/apprise/plugins/custom_xml.py
+++ b/apprise/plugins/custom_xml.py
@@ -31,7 +31,7 @@ import re
 import requests
 
 from .. import exception
-from ..common import NotifyImageSize, NotifyType
+from ..common import NotifyFormat, NotifyImageSize, NotifyType
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.sanitize import sanitize_payload
@@ -77,6 +77,14 @@ class NotifyXML(NotifyBase):
 
     # Support attachments
     attachment_support = True
+
+    # Pass-through Notify Formats. The endpoint receives whichever body
+    # representation Apprise resolved for this send.
+    notify_format = (
+        NotifyFormat.TEXT,
+        NotifyFormat.HTML,
+        NotifyFormat.MARKDOWN,
+    )
 
     # Allows the user to specify the NotifyImageSize object
     image_size = NotifyImageSize.XY_128

--- a/apprise/plugins/discord.py
+++ b/apprise/plugins/discord.py
@@ -85,6 +85,10 @@ class NotifyDiscord(NotifyBase):
     # Discord Webhook
     notify_url = "https://discord.com/api/webhooks"
 
+    # Discord supports plain text and Markdown-style embeds. Plain text
+    # remains the default.
+    notify_format = (NotifyFormat.TEXT, NotifyFormat.MARKDOWN)
+
     # Support attachments
     attachment_support = True
 
@@ -504,9 +508,12 @@ class NotifyDiscord(NotifyBase):
         title: str = "",
         notify_type: NotifyType = NotifyType.INFO,
         attach: list[AttachBase] | None = None,
+        body_format: NotifyFormat | None = None,
         **kwargs: Any,
     ) -> bool:
         """Perform Discord Notification."""
+
+        # body_format arrives as the resolved render target.
 
         payload: dict[str, Any] = {
             "tts": self.tts,
@@ -537,11 +544,9 @@ class NotifyDiscord(NotifyBase):
         # Template mode bypasses ping detection and embed construction;
         # the template defines the complete payload content.
         if not self.template:
-            # Ping handling rules:
-            # - If ping= is set, it is an additive if in MARKDOWN mode
-            #   otherwise it is explicit for TEXT/HTML formats.
-            # - Otherwise, ping detection only happens in MARKDOWN mode
-            if self.notify_format == NotifyFormat.MARKDOWN:
+            # Markdown can detect pings; ping= is additive there and
+            # explicit for text/HTML.
+            if body_format == NotifyFormat.MARKDOWN:
                 if self.ping:
                     payload.update(
                         self.ping_payload(body, " ".join(self.ping))
@@ -549,7 +554,7 @@ class NotifyDiscord(NotifyBase):
                 else:
                     payload.update(self.ping_payload(body))
 
-            # TEXT/HTML: no body parsing, ping= is exclusive
+            # TEXT destination: no body parsing, ping= is exclusive.
             elif self.ping:
                 payload.update(self.ping_payload(" ".join(self.ping)))
 
@@ -576,7 +581,7 @@ class NotifyDiscord(NotifyBase):
             # Track extra embed fields (if used)
             fields: list[dict[str, str]] = []
 
-            if self.notify_format == NotifyFormat.MARKDOWN:
+            if body_format == NotifyFormat.MARKDOWN:
                 # Use embeds for payload
                 payload["embeds"] = [
                     {

--- a/apprise/plugins/email/base.py
+++ b/apprise/plugins/email/base.py
@@ -112,8 +112,8 @@ class NotifyEmail(NotifyBase):
     # reference; this allows us to auto-generate our config if needed
     storage_mode = PersistentStoreMode.AUTO
 
-    # Default Notify Format
-    notify_format = NotifyFormat.HTML
+    # Email can send either HTML or plain text. HTML remains the default.
+    notify_format = (NotifyFormat.HTML, NotifyFormat.TEXT)
 
     # Default SMTP Timeout (in seconds)
     socket_connect_timeout = 15
@@ -649,8 +649,10 @@ class NotifyEmail(NotifyBase):
         title="",
         notify_type=NotifyType.INFO,
         attach=None,
+        body_format=None,
         **kwargs,
     ):
+        """Perform Email Notification."""
 
         if not self.targets:
             # There is no one to email; we're done
@@ -709,12 +711,13 @@ class NotifyEmail(NotifyBase):
             }
             headers.update(self.headers)
 
-            # Iterate over our email messages we can generate and then
-            # send them off.
+            # Resolve the active representation once for each prepared
+            # message. prepare_emails() then decides whether to build an
+            # HTML multipart message or a plain text message.
             for message in NotifyEmail.prepare_emails(
                 subject=title,
                 body=body,
-                notify_format=self.notify_format,
+                notify_format=self.resolve_format(body_format),
                 from_addr=self.from_addr,
                 to=self.targets,
                 cc=self.cc,

--- a/apprise/plugins/evolution.py
+++ b/apprise/plugins/evolution.py
@@ -326,22 +326,31 @@ class NotifyEvolution(NotifyBase):
         return "".join(out)
 
     def _build_send_calls(
-        self, body=None, title=None, body_format=None, **kwargs
+        self,
+        body=None,
+        title=None,
+        body_format=None,
+        format_controlled=None,
+        **kwargs,
     ):
-        """Convert HTML-derived CommonMark before splitting for WhatsApp.
+        """Convert declared CommonMark to WhatsApp Markdown before split.
 
-        Direct Markdown and other source formats pass through unchanged.
+        Undeclared sources are left untouched, even if the resolved
+        target is Markdown.
         """
 
-        # Only adapt HTML-derived Markdown; pass other formats through.
-        if not (
-            self.notify_format == NotifyFormat.MARKDOWN
-            and body_format == NotifyFormat.HTML
-        ):
+        # Direct plugin calls bypass Apprise's format resolution.
+        if format_controlled is None:
+            format_controlled = body_format is not None
+            body_format = self.resolve_format(body_format)
+
+        # Only adapt a declared source; pass an undeclared one through.
+        if not (body_format == NotifyFormat.MARKDOWN and format_controlled):
             yield from super()._build_send_calls(
                 body=body,
                 title=title,
                 body_format=body_format,
+                format_controlled=format_controlled,
                 **kwargs,
             )
             return
@@ -357,16 +366,15 @@ class NotifyEvolution(NotifyBase):
             # Clear the title so the base class does not send it separately.
             title = ""
 
-        # Apply the WhatsApp dialect adapter to convert CommonMark constructs
-        # (backslash escapes, links, emphasis, code spans) to WhatsApp syntax.
+        # Translate CommonMark constructs to WhatsApp syntax.
         body = self._commonmark_to_whatsapp(body)
 
-        # Tell the base splitter that the body is now WhatsApp Markdown so
-        # that split heuristics protect link and code-span constructs.
+        # Split as Markdown so links and code spans stay intact.
         yield from super()._build_send_calls(
             body=body,
             title=title,
             body_format=NotifyFormat.MARKDOWN,
+            format_controlled=format_controlled,
             **kwargs,
         )
 

--- a/apprise/plugins/google_chat.py
+++ b/apprise/plugins/google_chat.py
@@ -376,22 +376,31 @@ class NotifyGoogleChat(NotifyBase):
         return "\n".join(result)
 
     def _build_send_calls(
-        self, body=None, title=None, body_format=None, **kwargs
+        self,
+        body=None,
+        title=None,
+        body_format=None,
+        format_controlled=None,
+        **kwargs,
     ):
-        """Convert HTML-derived CommonMark before splitting for Chat.
+        """Convert declared CommonMark to Google Chat syntax before split.
 
-        Direct Markdown and other source formats pass through unchanged.
+        Undeclared sources are left untouched, even if the resolved
+        target is Markdown.
         """
 
-        # Only adapt HTML-derived Markdown; pass other formats through.
-        if not (
-            self.notify_format == NotifyFormat.MARKDOWN
-            and body_format == NotifyFormat.HTML
-        ):
+        # Direct plugin calls bypass Apprise's format resolution.
+        if format_controlled is None:
+            format_controlled = body_format is not None
+            body_format = self.resolve_format(body_format)
+
+        # Only adapt a declared source; pass an undeclared one through.
+        if not (body_format == NotifyFormat.MARKDOWN and format_controlled):
             yield from super()._build_send_calls(
                 body=body,
                 title=title,
                 body_format=body_format,
+                format_controlled=format_controlled,
                 **kwargs,
             )
             return
@@ -400,16 +409,15 @@ class NotifyGoogleChat(NotifyBase):
         if self.title_maxlen <= 0 and title:
             body, title = commonmark_prepend_title(body, title)
 
-        # Apply the Chat dialect adapter to convert CommonMark constructs
-        # (backslash escapes, links, emphasis) into Chat-native syntax.
+        # Translate CommonMark constructs to Chat-native syntax.
         body = self._commonmark_to_google_chat(body)
 
-        # Tell the base splitter that the body is now Chat Markdown so that
-        # the split heuristics protect link and code-span constructs.
+        # Split as Markdown so links and code spans stay intact.
         yield from super()._build_send_calls(
             body=body,
             title=title,
             body_format=NotifyFormat.MARKDOWN,
+            format_controlled=format_controlled,
             **kwargs,
         )
 

--- a/apprise/plugins/mailersend.py
+++ b/apprise/plugins/mailersend.py
@@ -99,8 +99,9 @@ class NotifyMailerSend(NotifyBase):
     # The MailerSend Email API endpoint
     notify_url = "https://api.mailersend.com/v1/email"
 
-    # Default to HTML notifications
-    notify_format = NotifyFormat.HTML
+    # MailerSend can accept either HTML or plain text as the main
+    # message body. HTML remains the default.
+    notify_format = (NotifyFormat.HTML, NotifyFormat.TEXT)
 
     # Support attachments
     attachment_support = True
@@ -329,6 +330,7 @@ class NotifyMailerSend(NotifyBase):
         title="",
         notify_type=NotifyType.INFO,
         attach=None,
+        body_format=None,
         **kwargs,
     ):
         """Perform MailerSend Notification."""
@@ -348,8 +350,10 @@ class NotifyMailerSend(NotifyBase):
             "Authorization": "Bearer {}".format(self.apikey),
         }
 
-        # Determine whether the body is HTML or plain text
-        use_html = self.notify_format == NotifyFormat.HTML
+        # Resolve the requested delivery representation for this send.
+        # MailerSend accepts both html and text fields, so the resolved
+        # format decides which field receives the original body.
+        use_html = self.resolve_format(body_format) == NotifyFormat.HTML
 
         # Build a base payload template reused per recipient
         payload_ = {
@@ -361,7 +365,8 @@ class NotifyMailerSend(NotifyBase):
             "subject": title if title else self.default_empty_subject,
         }
 
-        # Assign body fields; provide both html and text
+        # Assign both body fields so MailerSend has an HTML part and a
+        # plain-text alternative regardless of the selected source.
         if use_html:
             payload_["html"] = body
             payload_["text"] = convert_between(

--- a/apprise/plugins/notificationapi.py
+++ b/apprise/plugins/notificationapi.py
@@ -134,6 +134,10 @@ class NotifyNotificationAPI(NotifyBase):
     # A URL that takes you to the setup/help of the specific protocol
     setup_url = "https://appriseit.com/services/notificationapi/"
 
+    # NotificationAPI can send plain text or HTML depending on the
+    # selected channel. Plain text remains the default.
+    notify_format = (NotifyFormat.TEXT, NotifyFormat.HTML)
+
     # If no NotificationAPI Message Type is specified, then the following is
     # used
     default_message_type = "apprise"
@@ -660,10 +664,18 @@ class NotifyNotificationAPI(NotifyBase):
         return max(1, len(self.targets))
 
     def gen_payload(
-        self, body, title="", notify_type=NotifyType.INFO, **kwargs
+        self,
+        body,
+        title="",
+        notify_type=NotifyType.INFO,
+        body_format=None,
+        **kwargs,
     ):
-        """
-        generates our NotificationAPI payload
+        """Generate one or more NotificationAPI payloads.
+
+        ``body_format`` carries the caller's original source format so
+        this helper can resolve whether the already-prepared body should
+        be treated as the HTML original or the text original.
         """
 
         payload_ = {
@@ -691,10 +703,16 @@ class NotifyNotificationAPI(NotifyBase):
             )
 
         else:
-            # Acquire text version of body if provided
+            # Resolve once for both SMS and Email channel branches.
+            # Direct gen_payload()/send() calls may arrive unresolved.
+            body_format = self.resolve_format(body_format)
+
+            # SMS always needs text. If the resolved body is HTML, derive
+            # a text companion from it; otherwise the body already is the
+            # text representation.
             text_body = (
                 convert_between(NotifyFormat.HTML, NotifyFormat.TEXT, body)
-                if self.notify_format == NotifyFormat.HTML
+                if body_format == NotifyFormat.HTML
                 else body
             )
 
@@ -714,11 +732,14 @@ class NotifyNotificationAPI(NotifyBase):
                     )
 
                 elif channel == NotificationAPIChannel.EMAIL:
+                    # Email always needs HTML. If the resolved body is
+                    # text, derive the HTML companion from it; otherwise
+                    # the body already is the HTML representation.
                     html_body = (
                         convert_between(
                             NotifyFormat.TEXT, NotifyFormat.HTML, body
                         )
-                        if self.notify_format != NotifyFormat.HTML
+                        if body_format != NotifyFormat.HTML
                         else body
                     )
 
@@ -831,10 +852,15 @@ class NotifyNotificationAPI(NotifyBase):
 
             yield payload
 
-    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
-        """
-        Perform NotificationAPI Notification
-        """
+    def send(
+        self,
+        body,
+        title="",
+        notify_type=NotifyType.INFO,
+        body_format=None,
+        **kwargs,
+    ):
+        """Perform NotificationAPI Notification."""
 
         # error tracking (used for function return)
         has_error = False
@@ -859,7 +885,11 @@ class NotifyNotificationAPI(NotifyBase):
         }
 
         for payload in self.gen_payload(
-            body, title=title, notify_type=notify_type, **kwargs
+            body,
+            title=title,
+            notify_type=notify_type,
+            body_format=body_format,
+            **kwargs,
         ):
             # Perform our post
             self.logger.debug(

--- a/apprise/plugins/pushover.py
+++ b/apprise/plugins/pushover.py
@@ -197,6 +197,14 @@ class NotifyPushover(NotifyBase):
     # Pushover uses the http protocol with JSON requests
     notify_url = "https://api.pushover.net/1/messages.json"
 
+    # Pushover can send plain text, HTML, or Markdown-derived HTML.
+    # Plain text remains the default.
+    notify_format = (
+        NotifyFormat.TEXT,
+        NotifyFormat.HTML,
+        NotifyFormat.MARKDOWN,
+    )
+
     # Support attachments
     attachment_support = True
 
@@ -514,6 +522,8 @@ class NotifyPushover(NotifyBase):
         title="",
         notify_type=NotifyType.INFO,
         attach=None,
+        body_format=None,
+        format_controlled=None,
         **kwargs,
     ):
         """Perform Pushover Notification."""
@@ -552,11 +562,13 @@ class NotifyPushover(NotifyBase):
         if self.supplemental_url_title:
             base_payload["url_title"] = self.supplemental_url_title
 
-        if self.notify_format == NotifyFormat.HTML:
+        if body_format == NotifyFormat.HTML:
             # https://pushover.net/api#html
             base_payload["html"] = 1
 
-        elif self.notify_format == NotifyFormat.MARKDOWN:
+        elif body_format == NotifyFormat.MARKDOWN and format_controlled:
+            # Pushover has no native Markdown; convert declared Markdown
+            # to HTML and leave undeclared sources untouched.
             base_payload["message"] = convert_between(
                 NotifyFormat.MARKDOWN, NotifyFormat.HTML, body
             )

--- a/apprise/plugins/sendpulse.py
+++ b/apprise/plugins/sendpulse.py
@@ -62,8 +62,9 @@ class NotifySendPulse(NotifyBase):
     # A URL that takes you to the setup/help of the specific protocol
     setup_url = "https://appriseit.com/services/sendpulse/"
 
-    # Default to markdown
-    notify_format = NotifyFormat.HTML
+    # SendPulse can send either HTML or plain text. HTML remains the
+    # default.
+    notify_format = (NotifyFormat.HTML, NotifyFormat.TEXT)
 
     # The default Email API URL to use
     notify_email_url = "https://api.sendpulse.com/smtp/emails"
@@ -498,6 +499,7 @@ class NotifySendPulse(NotifyBase):
         title="",
         notify_type=NotifyType.INFO,
         attach=None,
+        body_format=None,
         **kwargs,
     ):
         """
@@ -527,9 +529,12 @@ class NotifySendPulse(NotifyBase):
             }
         }
 
-        # Prepare Email Message
-        if self.notify_format == NotifyFormat.HTML:
-            # HTML
+        # Resolve the requested delivery representation for this send.
+        # HTML mode includes a derived plain-text alternative; TEXT mode
+        # sends the plain body only.
+        if self.resolve_format(body_format) == NotifyFormat.HTML:
+            # HTML is the caller-selected representation; derive the
+            # plain-text companion field for mail clients that need it.
             payload_["email"].update(
                 {
                     "text": convert_between(

--- a/apprise/plugins/slack.py
+++ b/apprise/plugins/slack.py
@@ -189,8 +189,8 @@ class NotifySlack(NotifyBase):
     # If it is more than this, then it is not accepted
     max_slack_template_size = 35000
 
-    # Default Notification Format
-    notify_format = NotifyFormat.MARKDOWN
+    # Slack supports mrkdwn and plain text. mrkdwn remains the default.
+    notify_format = (NotifyFormat.MARKDOWN, NotifyFormat.TEXT)
 
     # Bot's do not have default channels to notify; so #general
     # becomes the default channel in BOT mode
@@ -863,38 +863,6 @@ class NotifySlack(NotifyBase):
         # Return the validated attachment content dict
         return content
 
-    def _build_send_calls(
-        self, body=None, title=None, body_format=None, **kwargs
-    ):
-        """Split HTML-derived CommonMark before Slack conversion.
-
-        Markdown-aware splitting protects links; ``send()`` then converts each
-        chunk to independently valid ``mrkdwn``.
-        """
-
-        # Only adapt HTML-derived Markdown; pass other formats through.
-        if not (
-            self.notify_format == NotifyFormat.MARKDOWN
-            and body_format == NotifyFormat.HTML
-        ):
-            yield from super()._build_send_calls(
-                body=body,
-                title=title,
-                body_format=body_format,
-                **kwargs,
-            )
-            return
-
-        # Split as Markdown to protect links, then restore HTML provenance.
-        # Each resulting chunk is converted independently by ``send()``.
-        for chunk in super()._build_send_calls(
-            body=body,
-            title=title,
-            body_format=NotifyFormat.MARKDOWN,
-            **kwargs,
-        ):
-            yield {**chunk, "body_format": NotifyFormat.HTML}
-
     def send(
         self,
         body,
@@ -902,6 +870,7 @@ class NotifySlack(NotifyBase):
         notify_type=NotifyType.INFO,
         attach=None,
         body_format=None,
+        format_controlled=None,
         **kwargs,
     ):
         """Perform Slack Notification."""
@@ -909,10 +878,9 @@ class NotifySlack(NotifyBase):
         # error tracking (used for function return)
         has_error = False
 
-        if self.notify_format == NotifyFormat.MARKDOWN and (
-            body_format == NotifyFormat.HTML
-        ):
-            # Adapt converted CommonMark; direct mrkdwn input is unchanged.
+        if body_format == NotifyFormat.MARKDOWN and format_controlled:
+            # Declared Markdown targets are treated as CommonMark first,
+            # then translated to Slack's mrkdwn dialect.
             body = self._commonmark_to_slack(body)
 
         #
@@ -966,7 +934,7 @@ class NotifySlack(NotifyBase):
                 # Our slack format
                 slack_format = (
                     "mrkdwn"
-                    if self.notify_format == NotifyFormat.MARKDOWN
+                    if body_format == NotifyFormat.MARKDOWN
                     else "plain_text"
                 )
 
@@ -1036,10 +1004,10 @@ class NotifySlack(NotifyBase):
             #
             # Legacy API Formatting
             #
-            # Apply legacy formatting only to direct Slack mrkdwn input.
-            if self.notify_format == NotifyFormat.MARKDOWN and (
-                body_format != NotifyFormat.HTML
-            ):
+            # _commonmark_to_slack() above already entity-escapes &, <,
+            # and > for any declared source; only escape here for an
+            # undeclared source, to avoid double-escaping.
+            if body_format == NotifyFormat.MARKDOWN and not format_controlled:
                 body = self._re_formatting_rules.sub(  # pragma: no branch
                     lambda x: self._re_formatting_map[x.group()],
                     body,
@@ -1097,7 +1065,7 @@ class NotifySlack(NotifyBase):
             # Prepare JSON Object (applicable to both WEBHOOK and BOT mode)
             payload = {
                 # Use Markdown language
-                "mrkdwn": self.notify_format == NotifyFormat.MARKDOWN,
+                "mrkdwn": body_format == NotifyFormat.MARKDOWN,
                 "attachments": [
                     {
                         "title": title,

--- a/apprise/plugins/telegram.py
+++ b/apprise/plugins/telegram.py
@@ -145,8 +145,8 @@ class NotifyTelegram(NotifyBase):
     # A URL that takes you to the setup/help of the specific protocol
     setup_url = "https://appriseit.com/services/telegram/"
 
-    # Default Notify Format
-    notify_format = NotifyFormat.HTML
+    # Telegram supports HTML and Markdown. HTML remains the default.
+    notify_format = (NotifyFormat.HTML, NotifyFormat.MARKDOWN)
 
     # Telegram uses the http protocol with JSON requests
     notify_url = "https://api.telegram.org/bot"
@@ -1236,19 +1236,31 @@ class NotifyTelegram(NotifyBase):
         return "".join(out), new_pending
 
     def _build_send_calls(
-        self, body=None, title=None, body_format=None, **kwargs
+        self,
+        body=None,
+        title=None,
+        body_format=None,
+        format_controlled=None,
+        **kwargs,
     ):
-        """Convert HTML-derived CommonMark and repair each split chunk.
+        """Convert declared CommonMark to Telegram syntax before split.
 
-        Pending Telegram entity state is carried between generated calls.
+        Undeclared sources are left untouched. Pending Telegram entity
+        state is carried between generated calls.
         """
 
-        if not (
-            self.notify_format == NotifyFormat.MARKDOWN
-            and body_format == NotifyFormat.HTML
-        ):
+        # Direct plugin calls bypass Apprise's format resolution.
+        if format_controlled is None:
+            format_controlled = body_format is not None
+            body_format = self.resolve_format(body_format)
+
+        if not (body_format == NotifyFormat.MARKDOWN and format_controlled):
             yield from super()._build_send_calls(
-                body=body, title=title, body_format=body_format, **kwargs
+                body=body,
+                title=title,
+                body_format=body_format,
+                format_controlled=format_controlled,
+                **kwargs,
             )
             return
 
@@ -1264,8 +1276,9 @@ class NotifyTelegram(NotifyBase):
         for kwargs2 in super()._build_send_calls(
             body=body,
             title=title,
-            # Use Markdown-aware splitting on the translated body.
+            # Already Markdown; kept explicit for readability.
             body_format=NotifyFormat.MARKDOWN,
+            format_controlled=format_controlled,
             **kwargs,
         ):
             kwargs2["body"], pending = self._repair_split_chunk(
@@ -1280,6 +1293,7 @@ class NotifyTelegram(NotifyBase):
         notify_type=NotifyType.INFO,
         attach=None,
         body_format=None,
+        format_controlled=None,
         **kwargs,
     ):
         """Perform Telegram Notification."""
@@ -1316,20 +1330,8 @@ class NotifyTelegram(NotifyBase):
         }
 
         # Prepare Message Body
-        if self.notify_format == NotifyFormat.MARKDOWN:
-            if (
-                body_format == NotifyFormat.TEXT
-                and self.markdown_ver == TelegramMarkdownVersion.TWO
-            ):
-                # Escape MarkdownV2-only reserved characters in plain text.
-                # See: https://stackoverflow.com/a/69892704/355584
-                # Also: https://core.telegram.org/bots/api#markdownv2-style
-                # HTML bodies were already escaped during dialect adaptation.
-                body = re.sub(r"(?<!\\)([_*[\]()~`>#+=|{}.!-])", r"\\\1", body)
-
-            # HTML was converted to Telegram Markdown before splitting so no
-            # further transformation is required here; direct Telegram Markdown
-            # input is left unchanged regardless of version.
+        if body_format == NotifyFormat.MARKDOWN:
+            # Markdown bodies were already translated in _build_send_calls().
             payload_["parse_mode"] = self.markdown_ver
             payload_["text"] = body
 
@@ -1338,14 +1340,8 @@ class NotifyTelegram(NotifyBase):
             payload_["parse_mode"] = "HTML"
             for r, v, m in self.__telegram_escape_html_entries:
                 if "html" in m:
-                    # Handle special cases where we need to alter new lines for
-                    # presentation purposes
-                    v = v.format(
-                        m["html"]
-                        if body_format
-                        in (NotifyFormat.HTML, NotifyFormat.MARKDOWN)
-                        else ""
-                    )
+                    # Add heading padding only for declared HTML sources.
+                    v = v.format(m["html"] if format_controlled else "")
 
                 body = r.sub(v, body)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1345,7 +1345,7 @@ def test_apprise_multi_format_resolution(caplog):
     API: multi-format notify_format resolution
 
     """
-    caplog.set_level(logging.WARNING, logger=LOGGER_NAME)
+    caplog.set_level(logging.DEBUG, logger=LOGGER_NAME)
 
     class SingleFormatNotification(NotifyBase):
         """Test plugin that resolves to one fixed format."""
@@ -1402,7 +1402,7 @@ def test_apprise_multi_format_resolution(caplog):
     )
 
     # Multi-format plugin, ?format= override NOT in the declared set falls
-    # back through to input alignment, then default, with a warning
+    # back through to input alignment, then default, with a debug message.
     multi_bad_override = MultiFormatNotification(
         host="localhost", format="text"
     )
@@ -1412,10 +1412,13 @@ def test_apprise_multi_format_resolution(caplog):
         NotifyFormat.MARKDOWN
     )
     assert "does not support format" in caplog.text
+    assert "DEBUG" in caplog.text
 
+    # No declared source format: same fallback, but silent -- matches
+    # the historical no-noise conversion behavior.
     caplog.clear()
     assert multi_bad_override.resolve_format(None) == NotifyFormat.HTML
-    assert "does not support format" in caplog.text
+    assert "does not support format" not in caplog.text
 
     # send_{type}() dispatch: send_markdown() defined, used when resolved
     multi.received.clear()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -43,6 +43,8 @@ import pytest
 import requests
 
 from apprise import (
+    LOGGER_NAME,
+    NOTIFY_FORMATS,
     Apprise,
     AppriseAsset,
     AppriseAttachment,
@@ -55,6 +57,7 @@ from apprise import (
     PrivacyMode,
     URLBase,
     __version__,
+    plugins,
 )
 from apprise.locale import LazyTranslation, gettext_lazy as _
 from apprise.plugins.base import RequirementsSpec
@@ -1337,6 +1340,194 @@ def test_apprise_notify_formats():
     )
 
 
+def test_apprise_multi_format_resolution(caplog):
+    """
+    API: multi-format notify_format resolution
+
+    """
+    caplog.set_level(logging.WARNING, logger=LOGGER_NAME)
+
+    class SingleFormatNotification(NotifyBase):
+        """Test plugin that resolves to one fixed format."""
+
+        # Single-format plugins always use their declared format.
+        notify_format = NotifyFormat.HTML
+
+        def send(self, body, title="", notify_type=None, **kwargs):
+            """Accept the prepared body without doing network work."""
+            return True
+
+    class MultiFormatNotification(NotifyBase):
+        """Test plugin that can render either HTML or Markdown."""
+
+        # Declares more than one supported format, index[0] is default
+        notify_format = (NotifyFormat.HTML, NotifyFormat.MARKDOWN)
+
+        received = []
+
+        def send(self, body, title="", notify_type=None, **kwargs):
+            """Record fallback sends that do not have format-specific hooks."""
+            self.received.append(("send", body))
+            return True
+
+        def send_markdown(self, body, title="", notify_type=None, **kwargs):
+            """Record Markdown-specific dispatch."""
+            self.received.append(("send_markdown", body))
+            return True
+
+    # Single-format plugin: _formats()/resolve_format() resolve to the
+    # one declared format no matter what is passed in.
+    single = SingleFormatNotification(host="localhost")
+    assert single._formats() == (NotifyFormat.HTML,)
+    assert single.resolve_format(None) == NotifyFormat.HTML
+    assert single.resolve_format(NotifyFormat.TEXT) == NotifyFormat.HTML
+    assert single.resolve_format(NotifyFormat.MARKDOWN) == NotifyFormat.HTML
+
+    # Multi-format plugin, no override, no matching input: default wins
+    multi = MultiFormatNotification(host="localhost")
+    assert multi._formats() == (NotifyFormat.HTML, NotifyFormat.MARKDOWN)
+    assert multi.resolve_format(None) == NotifyFormat.HTML
+    assert multi.resolve_format(NotifyFormat.TEXT) == NotifyFormat.HTML
+
+    # Multi-format plugin, no override, input aligns to a declared format
+    assert multi.resolve_format(NotifyFormat.MARKDOWN) == NotifyFormat.MARKDOWN
+
+    # Multi-format plugin, explicit ?format= override in the declared set
+    multi_override = MultiFormatNotification(
+        host="localhost", format="markdown"
+    )
+    assert multi_override._format_override == NotifyFormat.MARKDOWN
+    assert multi_override.resolve_format(NotifyFormat.HTML) == (
+        NotifyFormat.MARKDOWN
+    )
+
+    # Multi-format plugin, ?format= override NOT in the declared set falls
+    # back through to input alignment, then default, with a warning
+    multi_bad_override = MultiFormatNotification(
+        host="localhost", format="text"
+    )
+    assert multi_bad_override._format_override == NotifyFormat.TEXT
+    caplog.clear()
+    assert multi_bad_override.resolve_format(NotifyFormat.MARKDOWN) == (
+        NotifyFormat.MARKDOWN
+    )
+    assert "does not support format" in caplog.text
+
+    caplog.clear()
+    assert multi_bad_override.resolve_format(None) == NotifyFormat.HTML
+    assert "does not support format" in caplog.text
+
+    # send_{type}() dispatch: send_markdown() defined, used when resolved
+    multi.received.clear()
+    assert multi.notify(body="# hi", body_format=NotifyFormat.MARKDOWN) is True
+    assert multi.received == [("send_markdown", "# hi")]
+
+    # send_{type}() dispatch: no send_html() defined, falls back to send()
+    multi.received.clear()
+    assert multi.notify(body="hi", body_format=NotifyFormat.HTML) is True
+    assert multi.received == [("send", "hi")]
+
+
+def test_apprise_multi_format_conversion_cache():
+    """
+    API: multi-format resolution reuses one converted body per resolved
+    target, same as the existing single-format conversion cache.
+
+    """
+    asset = AppriseAsset(async_mode=False)
+    a = Apprise(asset=asset)
+
+    class HtmlOnlyNotification(NotifyBase):
+        """Test plugin that resolves to HTML."""
+
+        notify_format = NotifyFormat.HTML
+
+        def send(self, body, title="", notify_type=None, **kwargs):
+            """Accept the prepared body without doing network work."""
+            return True
+
+    class MultiFormatNotification(NotifyBase):
+        """Test plugin that also resolves to HTML by default."""
+
+        # Resolves to HTML by default, same target as HtmlOnlyNotification
+        notify_format = (NotifyFormat.HTML, NotifyFormat.MARKDOWN)
+
+        def send(self, body, title="", notify_type=None, **kwargs):
+            """Accept the prepared body without doing network work."""
+            return True
+
+    N_MGR["htmlonly"] = HtmlOnlyNotification
+    N_MGR["multi"] = MultiFormatNotification
+
+    assert a.add("htmlonly://localhost") is True
+    assert a.add("multi://localhost") is True
+    assert len(a) == 2
+
+    with mock.patch(
+        "apprise.apprise.convert_between",
+        side_effect=lambda *a, **k: "converted",
+    ) as mock_convert:
+        assert (
+            bool(a.notify(body="hello", body_format=NotifyFormat.TEXT)) is True
+        )
+        # Both servers resolve to HTML; the body should only be converted
+        # once and reused, exactly like the single-format cache today.
+        assert mock_convert.call_count == 1
+
+
+def test_apprise_multi_format_details():
+    """
+    API: Apprise() Details reflect a plugin's real supported formats
+
+    """
+
+    class SingleFormatNotification(NotifyBase):
+        """Test plugin whose public details should stay broad."""
+
+        service_name = "Single Format Testing"
+        protocol = "singlefmt"
+        notify_format = NotifyFormat.HTML
+
+        templates = ("{schema}://{host}",)
+
+        def send(self, body, title="", notify_type=None, **kwargs):
+            """Accept the prepared body without doing network work."""
+            return True
+
+    class MultiFormatNotification(NotifyBase):
+        """Test plugin whose public details expose supported formats."""
+
+        service_name = "Multi Format Testing"
+        protocol = "multifmtdetails"
+        # Declaration order matters: markdown is the default (index[0])
+        notify_format = (NotifyFormat.MARKDOWN, NotifyFormat.HTML)
+
+        templates = ("{schema}://{host}",)
+
+        def send(self, body, title="", notify_type=None, **kwargs):
+            """Accept the prepared body without doing network work."""
+            return True
+
+    # values/default remain broad for every plugin so consumers that only
+    # know those fields keep seeing the standard Apprise ?format= choices.
+    # The additive `supported` field carries the narrower native subset.
+    single_details = plugins.details(SingleFormatNotification)
+    assert single_details["args"]["format"]["values"] == NOTIFY_FORMATS
+    assert single_details["args"]["format"]["default"] == "html"
+    # `supported` names the subset this plugin actually renders natively:
+    # one entry for a single-format plugin.
+    assert single_details["args"]["format"]["supported"] == ["html"]
+
+    multi_details = plugins.details(MultiFormatNotification)
+    assert multi_details["args"]["format"]["values"] == NOTIFY_FORMATS
+    assert multi_details["args"]["format"]["default"] == "markdown"
+    # Declaration order preserved, not alphabetically re-sorted
+    assert multi_details["args"]["format"]["supported"] == [
+        "markdown",
+        "html",
+    ]
+
+
 def test_apprise_asset(tmpdir):
     """
     API: AppriseAsset() object
@@ -1979,6 +2170,10 @@ def test_apprise_details_plugin_verification():
         "required",
         "type",
         "values",
+        # The subset of `values` this specific plugin actually renders
+        # natively; only meaningfully narrower than `values` for a
+        # multi-format plugin. See NotifyBase.resolve_format().
+        "supported",
         "min",
         "max",
         "regex",
@@ -2344,6 +2539,67 @@ def test_apprise_details_plugin_raw_template_tokens():
                     " Expected one of: string, bool, int, float,"
                     " choice:string, list:string, etc."
                 )
+
+
+def test_apprise_send_format_handlers_match_notify_format():
+    """
+    API: send_text()/send_html()/send_markdown() vs notify_format sanity
+
+    A format-specific send_<format>() method must be reachable through
+    the plugin's notify_format declaration.
+    """
+
+    for plugin in N_MGR.plugins():
+        label = plugin.__name__
+
+        # Only consider format-specific methods defined directly on this
+        # class (not merely inherited), so a subclass that narrows
+        # notify_format isn't blamed for a handler its parent defined.
+        declared_handlers = {
+            fmt for fmt in NOTIFY_FORMATS if f"send_{fmt}" in vars(plugin)
+        }
+
+        if not declared_handlers:
+            continue
+
+        # notify_format may be a single NotifyFormat or a tuple; resolve
+        # it the same way NotifyBase._formats() does.
+        supported = set(parse_list(plugin.notify_format, sort=False))
+
+        missing = declared_handlers - supported
+        assert not missing, (
+            f"{label} defines send_{next(iter(missing))}() but "
+            f"{next(iter(missing))!r} is not declared in its "
+            f"notify_format {plugin.notify_format!r}; the handler can "
+            "never be reached."
+        )
+
+
+def test_apprise_multi_format_plugins_no_scalar_comparison():
+    """Multi-format plugins must resolve before scalar comparisons."""
+
+    scalar_compare_re = re.compile(r"self\.notify_format\s*==")
+
+    for plugin in N_MGR.plugins():
+        formats = parse_list(plugin.notify_format, sort=False)
+        if len(formats) <= 1:
+            # Single-format plugins can compare their scalar directly.
+            continue
+
+        try:
+            source = inspect.getsource(plugin)
+        except (OSError, TypeError):
+            # Dynamic plugins have no source file to inspect.
+            continue
+
+        assert not scalar_compare_re.search(source), (
+            f"{plugin.__name__} declares a multi-format notify_format "
+            f"{plugin.notify_format!r} but compares self.notify_format "
+            "directly somewhere in its source; use "
+            "self.resolve_format(body_format) instead, since a tuple "
+            "never equals a scalar and the comparison can never be "
+            "True."
+        )
 
 
 @mock.patch("requests.request")

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -42,6 +42,7 @@ from apprise.conversion import (
     build_backtick_run_index,
     convert_between,
     find_unescaped_run,
+    markdown_to_html,
 )
 
 logging.disable(logging.CRITICAL)
@@ -1742,6 +1743,47 @@ def test_conversion_text_to():
         response
         == "&lt;title&gt;Test&nbsp;Message&lt;/title&gt;&lt;body&gt;Body&lt;"
         "/body&gt;"
+    )
+
+
+def test_conversion_text_to_markdown():
+    """conversion: Test Text to Markdown"""
+
+    def to_markdown(body):
+        """Convert plain text through the public dispatcher."""
+        return convert_between(NotifyFormat.TEXT, NotifyFormat.MARKDOWN, body)
+
+    # CommonMark-significant characters are escaped so they read as
+    # literal text instead of being misread as formatting.
+    response = to_markdown("Some *text* with _markdown_ looking chars.")
+    assert response == "Some \\*text\\* with \\_markdown\\_ looking chars\\."
+
+    # Text without Markdown-significant characters is unchanged.
+    assert to_markdown("hello world") == "hello world"
+
+    # Every Markdown-significant punctuation character gets escaped.
+    response = to_markdown("_*[]()~`>#+=|{}.!-")
+    assert response == "\\_\\*\\[\\]\\(\\)\\~\\`\\>\\#\\+\\=\\|\\{\\}\\.\\!\\-"
+
+    # Plain text has no escape state, so a literal backslash is escaped.
+    response = to_markdown("already \\* escaped")
+    assert response == "already \\\\\\* escaped"
+    assert markdown_to_html(response) == "<p>already \\* escaped</p>"
+
+    # Windows-style paths survive CommonMark rendering unchanged.
+    response = to_markdown("C:\\Users\\foo")
+    assert response == "C:\\\\Users\\\\foo"
+    assert markdown_to_html(response) == "<p>C:\\Users\\foo</p>"
+
+    # Backslash-plus-syntax is still literal plain text.
+    response = to_markdown("\\# heading")
+    assert response == "\\\\\\# heading"
+    assert markdown_to_html(response) == "<p>\\# heading</p>"
+
+    # The generic dispatcher resolves the same conversion pair.
+    assert (
+        convert_between(NotifyFormat.TEXT, NotifyFormat.MARKDOWN, "hello")
+        == "hello"
     )
 
 

--- a/tests/test_decorator_notify.py
+++ b/tests/test_decorator_notify.py
@@ -35,6 +35,7 @@ from apprise import (
     AppriseAttachment,
     AppriseConfig,
     NotificationManager,
+    NotifyFormat,
     common,
 )
 from apprise.decorators import notify
@@ -118,9 +119,11 @@ def test_notify_simple_decoration():
     assert isinstance(verify_obj["attach"], AppriseAttachment)
     assert len(verify_obj["attach"]) == 2
 
-    # No format was defined
+    # Undeclared input resolves to the wrapper default and remains marked
+    # uncontrolled.
     assert "body_format" in verify_obj["kwargs"]
-    assert verify_obj["kwargs"]["body_format"] is None
+    assert verify_obj["kwargs"]["body_format"] == common.NotifyFormat.TEXT
+    assert verify_obj["kwargs"]["format_controlled"] is False
 
     # The meta argument allows us to further parse the URL parameters
     # specified
@@ -148,9 +151,11 @@ def test_notify_simple_decoration():
     assert verify_obj["notify_type"] == common.NotifyType.INFO
     assert verify_obj["attach"] is None
 
-    # No format was defined
+    # Undeclared input resolves to the wrapper default and remains
+    # uncontrolled.
     assert "body_format" in verify_obj["kwargs"]
-    assert verify_obj["kwargs"]["body_format"] is None
+    assert verify_obj["kwargs"]["body_format"] == common.NotifyFormat.TEXT
+    assert verify_obj["kwargs"]["format_controlled"] is False
 
     # The meta argument allows us to further parse the URL parameters
     # specified
@@ -178,9 +183,11 @@ def test_notify_simple_decoration():
     assert verify_obj["notify_type"] == common.NotifyType.INFO
     assert verify_obj["attach"] is None
 
-    # No format was defined
+    # Undeclared input resolves to the wrapper default and remains marked
+    # uncontrolled.
     assert "body_format" in verify_obj["kwargs"]
-    assert verify_obj["kwargs"]["body_format"] is None
+    assert verify_obj["kwargs"]["body_format"] == common.NotifyFormat.TEXT
+    assert verify_obj["kwargs"]["format_controlled"] is False
 
     # The meta argument allows us to further parse the URL parameters
     # specified
@@ -219,9 +226,11 @@ def test_notify_simple_decoration():
     assert isinstance(verify_obj["attach"], AppriseAttachment)
     assert len(verify_obj["attach"]) == 1
 
-    # No format was defined
+    # Undeclared input resolves to the wrapper default and remains marked
+    # uncontrolled.
     assert "body_format" in verify_obj["kwargs"]
-    assert verify_obj["kwargs"]["body_format"] is None
+    assert verify_obj["kwargs"]["body_format"] == common.NotifyFormat.TEXT
+    assert verify_obj["kwargs"]["format_controlled"] is False
 
     # The meta argument allows us to further parse the URL parameters
     # specified
@@ -261,9 +270,10 @@ def test_notify_simple_decoration():
     # We have no attachments
     assert verify_obj["attach"] is None
 
-    # No format was defined
+    # Declared HTML resolves directly and is marked controlled.
     assert "body_format" in verify_obj["kwargs"]
     assert verify_obj["kwargs"]["body_format"] == common.NotifyFormat.HTML
+    assert verify_obj["kwargs"]["format_controlled"] is True
 
     # The meta argument allows us to further parse the URL parameters
     # specified
@@ -298,6 +308,90 @@ def test_notify_simple_decoration():
 
     # Tidy
     N_MGR.remove("utiltest", "notexc")
+
+
+def test_notify_decorator_body_format():
+    """decorators: Test @notify body_format support."""
+
+    assert "multifmt" not in N_MGR
+
+    received = []
+
+    @notify(
+        on="multifmt",
+        name="Apprise @notify Multi-Format Testing",
+        body_format=(NotifyFormat.HTML, NotifyFormat.MARKDOWN),
+    )
+    def my_multi_format_wrapper(body, title, notify_type, *args, **kwargs):
+        """Record the body and original body_format passed to the wrapper."""
+        received.append((body, kwargs.get("body_format")))
+
+    assert "multifmt" in N_MGR
+    assert N_MGR["multifmt"].notify_format == (
+        NotifyFormat.HTML,
+        NotifyFormat.MARKDOWN,
+    )
+
+    aobj = Apprise()
+    assert aobj.add("multifmt://") is True
+
+    # No override and no matching input body_format resolves to the
+    # declared default, HTML at index 0.
+    assert bool(aobj.notify(body="hello")) is True
+    assert received[-1][1] == NotifyFormat.HTML
+
+    # Markdown input aligns directly to the declared Markdown support.
+    assert (
+        bool(aobj.notify(body="# hi", body_format=NotifyFormat.MARKDOWN))
+        is True
+    )
+    assert received[-1][0] == "# hi"
+    assert received[-1][1] == NotifyFormat.MARKDOWN
+
+    # Tidy
+    N_MGR.remove("multifmt")
+
+
+def test_notify_decorator_default_is_pass_through():
+    """decorators: @notify() with no body_format= never converts."""
+
+    assert "passthru" not in N_MGR
+
+    received = []
+
+    @notify(on="passthru")
+    def passthru_wrapper(body, title, notify_type, *args, **kwargs):
+        received.append((body, kwargs.get("body_format")))
+
+    assert N_MGR["passthru"].notify_format == (
+        NotifyFormat.TEXT,
+        NotifyFormat.HTML,
+        NotifyFormat.MARKDOWN,
+    )
+
+    aobj = Apprise()
+    assert aobj.add("passthru://") is True
+
+    # Undeclared input passes through, then reports the wrapper default.
+    assert bool(aobj.notify(body="<b>hi</b>")) is True
+    assert received[-1] == ("<b>hi</b>", NotifyFormat.TEXT)
+
+    # Declared HTML still passes through unchanged.
+    assert (
+        bool(aobj.notify(body="<b>hi</b>", body_format=NotifyFormat.HTML))
+        is True
+    )
+    assert received[-1] == ("<b>hi</b>", NotifyFormat.HTML)
+
+    # Markdown declared: also unchanged.
+    assert (
+        bool(aobj.notify(body="*hi*", body_format=NotifyFormat.MARKDOWN))
+        is True
+    )
+    assert received[-1] == ("*hi*", NotifyFormat.MARKDOWN)
+
+    # Tidy
+    N_MGR.remove("passthru")
 
 
 def test_notify_complex_decoration():
@@ -363,9 +457,11 @@ def test_notify_complex_decoration():
     assert isinstance(verify_obj["attach"], AppriseAttachment)
     assert len(verify_obj["attach"]) == 2
 
-    # No format was defined
+    # Undeclared input resolves to the wrapper default and remains marked
+    # uncontrolled.
     assert "body_format" in verify_obj["kwargs"]
-    assert verify_obj["kwargs"]["body_format"] is None
+    assert verify_obj["kwargs"]["body_format"] == common.NotifyFormat.TEXT
+    assert verify_obj["kwargs"]["format_controlled"] is False
 
     # The meta argument allows us to further parse the URL parameters
     # specified
@@ -415,9 +511,11 @@ def test_notify_complex_decoration():
     assert verify_obj["notify_type"] == common.NotifyType.INFO
     assert verify_obj["attach"] is None
 
-    # No format was defined
+    # Undeclared input resolves to the wrapper default and remains marked
+    # uncontrolled.
     assert "body_format" in verify_obj["kwargs"]
-    assert verify_obj["kwargs"]["body_format"] is None
+    assert verify_obj["kwargs"]["body_format"] == common.NotifyFormat.TEXT
+    assert verify_obj["kwargs"]["format_controlled"] is False
 
     # The meta argument allows us to further parse the URL parameters
     # specified
@@ -515,7 +613,10 @@ def test_notify_decorator_urls_with_space():
     assert obj.get("attach") is None
     assert isinstance(obj.get("args"), tuple)
     assert len(obj.get("args")) == 0
-    assert obj.get("kwargs") == {"body_format": None}
+    assert obj.get("kwargs") == {
+        "body_format": NotifyFormat.TEXT,
+        "format_controlled": False,
+    }
     meta = obj.get("meta")
     assert isinstance(meta, dict)
 
@@ -614,9 +715,11 @@ def test_notify_multi_instance_decoration(tmpdir):
     meta = obj["meta"]
     assert isinstance(meta, dict)
 
-    # No format was defined
+    # Undeclared input resolves to the wrapper default and remains marked
+    # uncontrolled.
     assert "body_format" in obj["kwargs"]
-    assert obj["kwargs"]["body_format"] is None
+    assert obj["kwargs"]["body_format"] == common.NotifyFormat.TEXT
+    assert obj["kwargs"]["format_controlled"] is False
 
     # The meta argument allows us to further parse the URL parameters
     # specified
@@ -653,9 +756,11 @@ def test_notify_multi_instance_decoration(tmpdir):
     meta = obj["meta"]
     assert isinstance(meta, dict)
 
-    # No format was defined
+    # Undeclared input resolves to the wrapper default and remains marked
+    # uncontrolled.
     assert "body_format" in obj["kwargs"]
-    assert obj["kwargs"]["body_format"] is None
+    assert obj["kwargs"]["body_format"] == common.NotifyFormat.TEXT
+    assert obj["kwargs"]["format_controlled"] is False
 
     # The meta argument allows us to further parse the URL parameters
     # specified

--- a/tests/test_plugin_apprise_api.py
+++ b/tests/test_plugin_apprise_api.py
@@ -34,7 +34,7 @@ from unittest import mock
 from helpers import AppriseURLTester
 import requests
 
-from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise import Apprise, AppriseAttachment, NotifyFormat, NotifyType
 from apprise.plugins.apprise_api import NotifyAppriseAPI
 
 logging.disable(logging.CRITICAL)
@@ -314,11 +314,11 @@ def test_notify_apprise_api_payload_check(mock_post):
 
     details = mock_post.call_args_list[0]
     assert details[0][0] == "http://localhost/notify/mytoken1"
+    # Undeclared input relays no format; the downstream server chooses.
     assert details[1]["data"] == {
         "title": "title",
         "body": "body",
         "type": "info",
-        "format": "text",
     }
     assert "X-Apprise-ID" in details[1]["headers"]
     assert details[1]["headers"].get("User-Agent") == "Apprise"
@@ -351,16 +351,71 @@ def test_notify_apprise_api_payload_check(mock_post):
 
     # Remove our attachment to make the next assert easier
     del data["attachments"]
+    # Undeclared input relays no format.
     assert data == {
         "title": "title",
         "body": "body",
         "type": "info",
-        "format": "text",
     }
     assert "X-Apprise-ID" in details[1]["headers"]
     assert details[1]["headers"].get("User-Agent") == "Apprise"
     assert details[1]["headers"].get("Accept") == "application/json"
     assert details[1]["headers"].get("X-Apprise-Recursion-Count") == "1"
+
+
+@mock.patch("requests.post")
+def test_notify_apprise_api_relays_declared_format(mock_post):
+    """NotifyAppriseAPI() relays only caller-declared formats."""
+
+    okay_response = requests.Request()
+    okay_response.status_code = requests.codes.ok
+    okay_response.content = ""
+    mock_post.return_value = okay_response
+
+    obj = Apprise.instantiate("apprise://user@localhost/mytoken1/")
+    assert isinstance(obj, NotifyAppriseAPI)
+
+    # A declared source is relayed onward as-is
+    assert (
+        bool(
+            obj.notify(
+                body="# hi",
+                title="title",
+                notify_type=NotifyType.INFO,
+                body_format=NotifyFormat.MARKDOWN,
+            )
+        )
+        is True
+    )
+
+    details = mock_post.call_args_list[0]
+    assert details[1]["data"] == {
+        "title": "title",
+        "body": "# hi",
+        "type": "info",
+        "format": "markdown",
+    }
+
+    mock_post.reset_mock()
+
+    # Undeclared input relays no format, despite the internal default.
+    assert (
+        bool(
+            obj.notify(
+                body="body",
+                title="title",
+                notify_type=NotifyType.INFO,
+            )
+        )
+        is True
+    )
+
+    details = mock_post.call_args_list[0]
+    assert details[1]["data"] == {
+        "title": "title",
+        "body": "body",
+        "type": "info",
+    }
 
 
 @mock.patch("requests.post")

--- a/tests/test_plugin_base_formatting.py
+++ b/tests/test_plugin_base_formatting.py
@@ -3762,6 +3762,23 @@ def test_notify_markdown_general():
     assert body.lstrip("\r\n\x0b\x0c").rstrip() == chunks[0].get("body")
     assert chunks[0].get("title") == ""
 
+    # Declared Markdown turns a real title into a heading.
+    real_title = "My Title"
+    chunks = obj._apply_overflow(
+        body=body,
+        title=real_title,
+        body_format=NotifyFormat.MARKDOWN,
+    )
+    assert len(chunks) == 1
+    assert chunks[0].get("body") == f"# {real_title}\n{body}"
+    assert chunks[0].get("title") == ""
+
+    # Undeclared input keeps the title literal.
+    chunks = obj._apply_overflow(body=body, title=real_title)
+    assert len(chunks) == 1
+    assert chunks[0].get("body") == f"{real_title}\r\n{body}"
+    assert chunks[0].get("title") == ""
+
 
 @mock.patch("requests.request")
 def test_notify_emoji_general(mock_request):

--- a/tests/test_plugin_custom_form.py
+++ b/tests/test_plugin_custom_form.py
@@ -33,7 +33,7 @@ from unittest import mock
 from helpers import AppriseURLTester
 import requests
 
-from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise import Apprise, AppriseAttachment, NotifyFormat, NotifyType
 from apprise.plugins.custom_form import NotifyForm
 
 logging.disable(logging.CRITICAL)
@@ -233,6 +233,40 @@ def test_plugin_custom_form_urls():
 
     # Run our general tests
     AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+@mock.patch("requests.request")
+def test_plugin_custom_form_multi_format(mock_request):
+    """NotifyForm() supports all 3 notify formats as a pass-through."""
+
+    response = requests.Request()
+    response.status_code = requests.codes.ok
+    mock_request.return_value = response
+
+    assert NotifyForm.notify_format == (
+        NotifyFormat.TEXT,
+        NotifyFormat.HTML,
+        NotifyFormat.MARKDOWN,
+    )
+
+    a = Apprise()
+    assert a.add("form://localhost") is True
+
+    # Markdown input aligns directly to the pass-through Markdown path,
+    # so no conversion should alter it.
+    assert (
+        bool(a.notify(body="# hello", body_format=NotifyFormat.MARKDOWN))
+        is True
+    )
+    payload = mock_request.call_args_list[-1][1]["data"]
+    assert payload["message"] == "# hello"
+
+    # ?format=html forces the resolved target regardless of input format.
+    a = Apprise()
+    assert a.add("form://localhost/?format=html") is True
+    assert bool(a.notify(body="a < b", body_format=NotifyFormat.TEXT)) is True
+    payload = mock_request.call_args_list[-1][1]["data"]
+    assert payload["message"] == "a&nbsp;&lt;&nbsp;b"
 
 
 @mock.patch("requests.request")

--- a/tests/test_plugin_custom_json.py
+++ b/tests/test_plugin_custom_json.py
@@ -35,7 +35,7 @@ from unittest import mock
 from helpers import AppriseURLTester
 import requests
 
-from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise import Apprise, AppriseAttachment, NotifyFormat, NotifyType
 from apprise.plugins.custom_json import NotifyJSON
 
 logging.disable(logging.CRITICAL)
@@ -229,6 +229,41 @@ def test_plugin_custom_json_urls():
 
     # Run our general tests
     AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+@mock.patch("requests.request")
+def test_plugin_custom_json_multi_format(mock_request):
+    """NotifyJSON() supports all 3 notify formats as a pass-through."""
+
+    response = requests.Request()
+    response.status_code = requests.codes.ok
+    mock_request.return_value = response
+
+    assert NotifyJSON.notify_format == (
+        NotifyFormat.TEXT,
+        NotifyFormat.HTML,
+        NotifyFormat.MARKDOWN,
+    )
+
+    a = Apprise()
+    assert a.add("json://localhost") is True
+
+    # Markdown input aligns directly to the plugin's supported markdown
+    # format; no conversion should alter the content.
+    assert (
+        bool(a.notify(body="# hello", body_format=NotifyFormat.MARKDOWN))
+        is True
+    )
+    payload = json.loads(mock_request.call_args_list[-1][1]["data"])
+    assert payload["message"] == "# hello"
+
+    # ?format=html forces the resolved target regardless of the caller's
+    # input format.
+    a = Apprise()
+    assert a.add("json://localhost/?format=html") is True
+    assert bool(a.notify(body="a < b", body_format=NotifyFormat.TEXT)) is True
+    payload = json.loads(mock_request.call_args_list[-1][1]["data"])
+    assert payload["message"] == "a&nbsp;&lt;&nbsp;b"
 
 
 @mock.patch("requests.request")

--- a/tests/test_plugin_custom_xml.py
+++ b/tests/test_plugin_custom_xml.py
@@ -34,7 +34,7 @@ from unittest import mock
 from helpers import AppriseURLTester
 import requests
 
-from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise import Apprise, AppriseAttachment, NotifyFormat, NotifyType
 from apprise.plugins.custom_xml import NotifyXML
 
 logging.disable(logging.CRITICAL)
@@ -261,6 +261,43 @@ def test_plugin_custom_xml_urls():
 
     # Run our general tests
     AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+@mock.patch("requests.request")
+def test_plugin_custom_xml_multi_format(mock_request):
+    """NotifyXML() supports all 3 notify formats as a pass-through."""
+
+    response = requests.Request()
+    response.status_code = requests.codes.ok
+    mock_request.return_value = response
+
+    assert NotifyXML.notify_format == (
+        NotifyFormat.TEXT,
+        NotifyFormat.HTML,
+        NotifyFormat.MARKDOWN,
+    )
+
+    a = Apprise()
+    assert a.add("xml://localhost") is True
+
+    # Markdown input aligns directly to the pass-through Markdown path,
+    # so no conversion should alter it.
+    assert (
+        bool(a.notify(body="# hello", body_format=NotifyFormat.MARKDOWN))
+        is True
+    )
+    payload = mock_request.call_args_list[-1][1]["data"]
+    assert "# hello" in payload
+
+    # ?format=html forces the resolved target regardless of input format.
+    a = Apprise()
+    assert a.add("xml://localhost/?format=html") is True
+    assert bool(a.notify(body="a < b", body_format=NotifyFormat.TEXT)) is True
+    payload = mock_request.call_args_list[-1][1]["data"]
+    # The body was HTML-converted first (< -> &lt;), then XML-escaped a
+    # second time on top (& -> &amp;), proving format=html was honored
+    # rather than the plain-text default.
+    assert "&amp;lt;" in payload
 
 
 @mock.patch("requests.request")

--- a/tests/test_plugin_discord.py
+++ b/tests/test_plugin_discord.py
@@ -343,7 +343,10 @@ def test_plugin_discord_notifications(mock_post):
     instance = NotifyDiscord(**results)
     assert isinstance(instance, NotifyDiscord)
 
-    response = instance.send(body=body)
+    # Direct send() bypasses notify(), so pass the URL-resolved format.
+    response = instance.send(
+        body=body, body_format=instance.resolve_format(None)
+    )
     assert response is True
     assert mock_post.call_count == 1
 
@@ -1131,7 +1134,8 @@ def test_plugin_discord_markdown_fields_batches_exactly(mock_post):
     )
     assert isinstance(obj, NotifyDiscord)
 
-    assert obj.send(body=body) is True
+    # Direct send() bypasses notify(), so pass the URL-resolved format.
+    assert obj.send(body=body, body_format=obj.resolve_format(None)) is True
 
     # H1, H2, H3 => 3 fields => 3 posts (since max_fields=1)
     assert mock_post.call_count == 3
@@ -1153,7 +1157,8 @@ def test_plugin_discord_markdown_ping_is_additive(mock_post):
     )
     obj = NotifyDiscord(**results)
 
-    assert obj.send(body=body) is True
+    # Direct send() bypasses notify(), so pass the URL-resolved format.
+    assert obj.send(body=body, body_format=obj.resolve_format(None)) is True
     assert mock_post.call_count == 1
 
     payload = loads(mock_post.call_args_list[0][1]["data"])
@@ -1203,7 +1208,11 @@ def test_plugin_discord_markdown_no_mentions_has_no_allow_mentions(mock_post):
     )
     obj = NotifyDiscord(**results)
 
-    assert obj.send(body="Hello world") is True
+    # Direct send() bypasses notify(), so pass the URL-resolved format.
+    assert (
+        obj.send(body="Hello world", body_format=obj.resolve_format(None))
+        is True
+    )
     payload = loads(mock_post.call_args_list[0][1]["data"])
 
     assert "allow_mentions" not in payload

--- a/tests/test_plugin_email.py
+++ b/tests/test_plugin_email.py
@@ -45,6 +45,7 @@ from apprise import (
     AppriseAttachment,
     AttachBase,
     NotifyBase,
+    NotifyFormat,
     NotifyType,
     PersistentStoreMode,
     utils,
@@ -3638,6 +3639,46 @@ def test_plugin_email_pgp_sign_keygen_auto(mock_smtp, mock_smtpssl, tmpdir):
     # With both keys present the message is sign+encrypted; the signing
     # step is the behavior under test, so we only assert success here.
     assert bool(obj.notify("test body")) is True
+
+
+@mock.patch("smtplib.SMTP")
+def test_plugin_email_multi_format(mock_smtp):
+    """NotifyEmail() declares HTML+TEXT and resolves per-call."""
+
+    assert email.NotifyEmail.notify_format == (
+        NotifyFormat.HTML,
+        NotifyFormat.TEXT,
+    )
+
+    instance = mock_smtp.return_value
+
+    aobj = Apprise()
+    assert aobj.add("mailto://user:pass@example.com") is True
+
+    # Default (no body_format): still builds a multipart/alternative
+    # message with both an HTML and a derived plain-text part.
+    assert bool(aobj.notify(body="<b>Bold HTML</b> body")) is True
+    msg = instance.sendmail.call_args_list[-1][0][2]
+    assert "multipart" in msg
+    assert "text/plain" in msg
+    assert "text/html" in msg
+
+    # body_format=TEXT aligns directly to TEXT mode (no HTML round
+    # trip); the exact original text is sent, unescaped and unchanged.
+    assert (
+        bool(
+            aobj.notify(
+                body="Plain text with <literal> angle brackets.",
+                body_format=NotifyFormat.TEXT,
+            )
+        )
+        is True
+    )
+    msg = instance.sendmail.call_args_list[-1][0][2]
+    assert "multipart" not in msg
+    assert "text/plain" in msg
+    assert "text/html" not in msg
+    assert "Plain text with <literal> angle brackets." in msg
 
 
 def test_plugin_email_prepare():

--- a/tests/test_plugin_evolution.py
+++ b/tests/test_plugin_evolution.py
@@ -439,3 +439,29 @@ def test_plugin_evolution_html_to_markdown_hardening(mock_post):
     payload = loads(mock_post.call_args_list[-1][1]["data"])
     assert payload["text"] == "*hello*"
     mock_post.reset_mock()
+
+
+@mock.patch("requests.post")
+def test_plugin_evolution_declared_markdown_gets_dialect_completion(
+    mock_post,
+):
+    """Declared Markdown gets WhatsApp dialect completion."""
+
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+    mock_post.return_value.content = b"{}"
+
+    aobj = Apprise()
+    assert aobj.add("evolution://key@host/inst/5511999999999")
+
+    assert (
+        bool(
+            aobj.notify(
+                body="*bold* [click here](<https://example.com/x>)",
+                body_format=NotifyFormat.MARKDOWN,
+            )
+        )
+        is True
+    )
+    payload = loads(mock_post.call_args_list[-1][1]["data"])
+    assert payload["text"] == "_bold_ click here (https://example.com/x)"

--- a/tests/test_plugin_google_chat.py
+++ b/tests/test_plugin_google_chat.py
@@ -379,4 +379,30 @@ def test_plugin_google_chat_html_to_markdown_hardening(mock_post):
     )
     payload = loads(mock_post.call_args_list[-1][1]["data"])
     assert payload["text"] == "*hello*"
+
+
+@mock.patch("requests.post")
+def test_plugin_google_chat_declared_markdown_gets_dialect_completion(
+    mock_post,
+):
+    """Declared Markdown gets Google Chat dialect completion."""
+
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+    mock_post.return_value.content = b"{}"
+
+    aobj = Apprise()
+    assert aobj.add("gchat://workspace/key/token")
+
+    assert (
+        bool(
+            aobj.notify(
+                body="*bold* [click here](<https://example.com/x>)",
+                body_format=NotifyFormat.MARKDOWN,
+            )
+        )
+        is True
+    )
+    payload = loads(mock_post.call_args_list[-1][1]["data"])
+    assert payload["text"] == "_bold_ <https://example.com/x|click here>"
     mock_post.reset_mock()

--- a/tests/test_plugin_pushover.py
+++ b/tests/test_plugin_pushover.py
@@ -618,6 +618,43 @@ def test_plugin_pushover_edge_cases(mock_post):
 
 
 @mock.patch("requests.post")
+def test_plugin_pushover_multi_format(mock_post):
+    """NotifyPushover() multi-format resolution."""
+
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    token = "a" * 30
+    user_key = "u" * 30
+
+    obj = NotifyPushover(user_key=user_key, token=token)
+
+    # HTML: declared source aligns directly, html flag set, body as-is.
+    mock_post.reset_mock()
+    assert obj.notify(body="<b>hi</b>", body_format=apprise.NotifyFormat.HTML)
+    sent = mock_post.call_args[1]["data"]
+    assert sent["html"] == 1
+    assert sent["message"] == "<b>hi</b>"
+
+    # Markdown is converted to HTML because Pushover has no Markdown mode.
+    mock_post.reset_mock()
+    assert obj.notify(body="*hi*", body_format=apprise.NotifyFormat.MARKDOWN)
+    sent = mock_post.call_args[1]["data"]
+    assert sent["html"] == 1
+    assert sent["message"] != "*hi*"
+
+    # Undeclared input stays unconverted, even with a Markdown override.
+    mock_post.reset_mock()
+    obj_override = NotifyPushover(
+        user_key=user_key, token=token, format="markdown"
+    )
+    assert obj_override.notify(body="*hi*")
+    sent = mock_post.call_args[1]["data"]
+    assert "html" not in sent
+    assert sent["message"] == "*hi*"
+
+
+@mock.patch("requests.post")
 def test_plugin_pushover_config_files(mock_post):
     """NotifyPushover() Config File Cases."""
     content = """

--- a/tests/test_plugin_slack.py
+++ b/tests/test_plugin_slack.py
@@ -2356,6 +2356,39 @@ def test_plugin_slack_html_to_markdown_format(mock_request):
 
 
 @mock.patch("requests.request")
+def test_plugin_slack_markdown_dialect_requires_declared_source(
+    mock_request,
+):
+    """Slack dialect conversion requires a declared source format."""
+
+    slack_token = "T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ"
+
+    mock_request.return_value = requests.Request()
+    mock_request.return_value.status_code = requests.codes.ok
+    mock_request.return_value.content = b"ok"
+    mock_request.return_value.text = "ok"
+
+    aobj = Apprise()
+    assert aobj.add("slack://{}/#general?blocks=yes".format(slack_token))
+
+    body = "**hello** &amp; <world>"
+
+    def block_text(payload):
+        return payload["attachments"][0]["blocks"][0]["text"]["text"]
+
+    # Declared Markdown is translated to Slack mrkdwn.
+    assert bool(aobj.notify(body=body, body_format=NotifyFormat.MARKDOWN))
+    payload = loads(mock_request.call_args_list[0][1]["data"])
+    assert block_text(payload) == "*hello* &amp;amp; <world>"
+    mock_request.reset_mock()
+
+    # Undeclared input remains byte-for-byte unchanged.
+    assert bool(aobj.notify(body=body))
+    payload = loads(mock_request.call_args_list[0][1]["data"])
+    assert block_text(payload) == body
+
+
+@mock.patch("requests.request")
 def test_plugin_slack_html_to_markdown_hardening(mock_request):
     """Test edge cases in the CommonMark-to-Slack dialect adaptation."""
 

--- a/tests/test_plugin_telegram.py
+++ b/tests/test_plugin_telegram.py
@@ -961,11 +961,11 @@ def test_plugin_telegram_formatting(mock_post):
 
     payload = loads(mock_post.call_args_list[1][1]["data"])
 
-    # Test that everything is escaped properly in a HTML mode
+    # Declared Markdown gets the same MarkdownV2 dialect completion.
     assert (
-        payload["text"] == "# 🚨 Change detected for _Apprise Test Title_\r\n"
+        payload["text"] == "\\# 🚨 Change detected for _Apprise Test Title_\n"
         "_[Apprise Body Title](http://localhost)_ had "
-        "[a change](http://127.0.0.1)"
+        "[a change](http://127\\.0\\.0\\.1)"
     )
 
     # Reset our values
@@ -1000,9 +1000,9 @@ def test_plugin_telegram_formatting(mock_post):
 
     payload = loads(mock_post.call_args_list[1][1]["data"])
 
-    # Test that everything is escaped properly in a HTML mode
+    # v1 (non-strict) recognizes a narrower escape set than v2 does.
     assert (
-        payload["text"] == "# 🚨 Change detected for _Apprise Test Title_\r\n"
+        payload["text"] == "# 🚨 Change detected for _Apprise Test Title_\n"
         "_[Apprise Body Title](http://localhost)_ had "
         "[a change](http://127.0.0.1)"
     )
@@ -1087,8 +1087,13 @@ def test_plugin_telegram_formatting(mock_post):
 
     payload = loads(mock_post.call_args_list[1][1]["data"])
 
-    # Test that everything is escaped properly in a MARKDOWN mode
-    assert payload["text"] == body
+    # Declared text resolved to Markdown gets title merging and dialect
+    # completion.
+    assert payload["text"] == (
+        "# # \n"
+        r"\_\[Apprise Body Title\](http://localhost)\_"
+        r" had \[a change\](http://127.0.0.2)"
+    )
 
     # Reset our values
     mock_post.reset_mock()
@@ -1116,11 +1121,12 @@ def test_plugin_telegram_formatting(mock_post):
 
     payload = loads(mock_post.call_args_list[1][1]["data"])
 
-    # Test that everything is escaped properly in a MARKDOWN mode
-    assert (
-        payload["text"]
-        == "\\_\\[Apprise Body Title\\]\\(http://localhost\\)\\_ had \\"
-        "[a change\\]\\(http://127\\.0\\.0\\.2\\)"
+    # v2 (strict) keeps every reserved character escaped, same title
+    # doubling as the v1 case above.
+    assert payload["text"] == (
+        "\\# \\# \n"
+        r"\_\[Apprise Body Title\]\(http://localhost\)\_"
+        r" had \[a change\]\(http://127\.0\.0\.2\)"
     )
 
     # Reset our values
@@ -1156,11 +1162,12 @@ def test_plugin_telegram_formatting(mock_post):
 
     payload = loads(mock_post.call_args_list[1][1]["data"])
 
-    # Test that everything is escaped properly in a MARKDOWN mode
-    assert (
-        payload["text"] == "# A Great Title\n"
-        "_[Apprise Body Title](http://localhost)_ had "
-        "[a change](http://127.0.0.2)"
+    # v1's narrower escape set un-escapes what the framework's baseline
+    # text-to-markdown pass added, since v1 does not require it.
+    assert payload["text"] == (
+        "# # A Great Title\n"
+        r"\_\[Apprise Body Title\](http://localhost)\_"
+        r" had \[a change\](http://127.0.0.2)"
     )
 
     # Reset our values
@@ -1189,18 +1196,18 @@ def test_plugin_telegram_formatting(mock_post):
 
     payload = loads(mock_post.call_args_list[1][1]["data"])
 
-    # Test that everything is escaped properly in a MARKDOWN mode
-    assert (
-        payload["text"] == "\\# A Great Title\n"
-        "\\_\\[Apprise Body Title\\]\\(http://localhost\\)\\_ had "
-        "\\[a change\\]\\(http://127\\.0\\.0\\.2\\)"
+    # MarkdownV2 runs its completion pass over the already-amalgamated
+    # title+body, so the literal leading hash is escaped too.
+    assert payload["text"] == (
+        "\\# \\# A Great Title\n"
+        r"\_\[Apprise Body Title\]\(http://localhost\)\_"
+        r" had \[a change\]\(http://127\.0\.0\.2\)"
     )
 
     # Reset our values
     mock_post.reset_mock()
 
-    # If input is markdown and output is v2, it is expected the user knows
-    # what he is doing... no esaping takes place
+    # Declared Markdown gets MarkdownV2 dialect completion.
     assert aobj.notify(
         title=title, body=body, body_format=NotifyFormat.MARKDOWN
     )
@@ -1215,11 +1222,11 @@ def test_plugin_telegram_formatting(mock_post):
 
     payload = loads(mock_post.call_args_list[0][1]["data"])
 
-    # No escaping in this circumstance
-    assert (
-        payload["text"] == "# A Great Title\r\n"
+    # MarkdownV2 escapes the leading hash and URL dots.
+    assert payload["text"] == (
+        "\\# A Great Title\n"
         "_[Apprise Body Title](http://localhost)_ had "
-        "[a change](http://127.0.0.2)"
+        "[a change](http://127\\.0\\.0\\.2)"
     )
 
     # Reset our values
@@ -1250,7 +1257,8 @@ def test_plugin_telegram_formatting(mock_post):
     mock_post.reset_mock()
 
     #
-    # Now test that <br/> is correctly escaped
+    # Markdown input aligns directly, then gets title merging and v1
+    # dialect completion without an HTML round trip.
     #
     title = "Test Message Title"
     body = "Test Message Body <br/> ok</br>"
@@ -1273,10 +1281,9 @@ def test_plugin_telegram_formatting(mock_post):
 
     payload = loads(mock_post.call_args_list[0][1]["data"])
 
-    # Test that everything is escaped properly in a HTML mode
-    assert (
-        payload["text"]
-        == "<b>Test Message Title\r\n</b>\r\nTest Message Body\r\nok\r\n"
+    # v1 keeps "#" and HTML-looking body text unescaped.
+    assert payload["text"] == (
+        "# Test Message Title\nTest Message Body <br/> ok</br>"
     )
 
     # Reset our values
@@ -1451,6 +1458,33 @@ def test_plugin_telegram_html_formatting(mock_post):
         "<b>Heading 6</b>\r\nA set of text\r\n"
         "Another line after the set of text\r\nMore text\r\nlabel"
     )
+
+
+@mock.patch("requests.post")
+def test_plugin_telegram_html_heading_padding_requires_declared_source(
+    mock_post,
+):
+    """HTML heading padding requires a declared source format."""
+
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+    mock_post.return_value.content = "{}"
+
+    body = "<h1>Heading</h1>Body text here"
+
+    aobj = Apprise()
+    assert aobj.add("tgram://123456789:abcdefg_hijklmnop/12345678")
+
+    # Declared HTML: heading gets padded on both sides.
+    assert aobj.notify(body=body, body_format=NotifyFormat.HTML)
+    payload = loads(mock_post.call_args_list[-1][1]["data"])
+    assert payload["text"] == "\r\n<b>Heading</b>\r\nBody text here"
+    mock_post.reset_mock()
+
+    # Undeclared input resolves to HTML but remains unpadded.
+    assert aobj.notify(body=body)
+    payload = loads(mock_post.call_args_list[-1][1]["data"])
+    assert payload["text"] == "<b>Heading</b>Body text here"
 
 
 @mock.patch("requests.post")
@@ -1915,6 +1949,46 @@ def test_plugin_telegram_overflow_split_repair(mock_post):
 
 
 @mock.patch("requests.post")
+def test_plugin_telegram_overflow_split_repair_declared_markdown(mock_post):
+    """Declared Markdown uses the same split repair as converted HTML."""
+
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+    mock_post.return_value.content = dumps({"ok": True, "result": True})
+
+    def notify_split(body, body_format):
+        aobj = Apprise()
+        aobj.add(
+            "tgram://123456789:abcdefg_hijklmnop/12345"
+            "?format=markdown&mdv=2&overflow=split"
+        )
+        assert len(aobj) == 1
+        assert aobj.notify(body=body, body_format=body_format)
+        texts = [loads(c[1]["data"])["text"] for c in mock_post.call_args_list]
+        mock_post.reset_mock()
+        return texts
+
+    # Force a split after a long bold span.
+    body = "**" + ("x" * 4990) + "**" + "TAIL SHOULD NOT BE BOLD"
+    texts_html = notify_split(
+        "<b>" + ("x" * 4990) + "</b>" + "TAIL SHOULD NOT BE BOLD",
+        NotifyFormat.HTML,
+    )
+    texts_md = notify_split(body, NotifyFormat.MARKDOWN)
+
+    # Declared Markdown matches HTML-derived Markdown chunk repair.
+    assert texts_md == texts_html
+
+    # Short declared Markdown still gets dialect completion.
+    texts = notify_split("**short** _text_", NotifyFormat.MARKDOWN)
+    assert texts == ["*short* _text_"]
+
+    # Undeclared input skips dialect completion and repair.
+    texts = notify_split("**short** _text_", None)
+    assert texts == ["**short** _text_"]
+
+
+@mock.patch("requests.post")
 def test_plugin_telegram_threads(mock_post):
     """NotifyTelegram() Threads/Topics."""
     # Prepare Mock
@@ -2081,10 +2155,10 @@ def test_plugin_telegram_markdown_v2(mock_post):
     assert mock_post.call_count == 2
     payload = loads(mock_post.call_args_list[1][1]["data"])
 
-    # Our content is escapped properly
+    # Literal backslashes are escaped along with MarkdownV2 syntax.
     assert (
         payload["text"] == "\\# my message\r\n"
-        "\\#\\# more content\r\n\\# already escaped hashtag"
+        "\\#\\# more content\r\n\\\\\\# already escaped hashtag"
     )
 
     mock_post.reset_mock()
@@ -2119,10 +2193,10 @@ def test_plugin_telegram_markdown_v2(mock_post):
         assert mock_post.call_count == 1
         payload = loads(mock_post.call_args_list[0][1]["data"])
 
-        # Our content is escapped properly
+        # The literal backslash before the second occurrence is escaped too.
         assert (
             payload["text"]
-            == f"bad character: \\{c}, and already escapped \\{c}"
+            == f"bad character: \\{c}, and already escapped \\\\\\{c}"
         )
 
         mock_post.reset_mock()

--- a/tests/test_retry_wait.py
+++ b/tests/test_retry_wait.py
@@ -1050,13 +1050,15 @@ class TestExceptionHandling:
                     """Forward context cleanup to the wrapped executor."""
                     return self._real.__exit__(*exc)
 
-                def submit(self, fn, service, kwargs):
+                def submit(self, fn, service, kwargs, call_deadline):
                     """Return a failed future for ``s1`` and submit others."""
                     if service is s1:
                         fut = cf.Future()
                         fut.set_exception(RuntimeError("future boom"))
                         return fut
-                    return self._real.submit(fn, service, kwargs)
+                    return self._real.submit(
+                        fn, service, kwargs, call_deadline
+                    )
 
                 def shutdown(self, *args, **kwargs):
                     """Forward shutdown behavior to the wrapped executor."""
@@ -1077,6 +1079,64 @@ class TestExceptionHandling:
                 apprise_module._shared_executor._real.shutdown(wait=True)
 
             # One future raised -> overall result is False
+            assert bool(result) is False
+        finally:
+            N_MGR.unload_modules()
+
+    def test_sequential_future_exception_caught(self):
+        """An exception escaping a sequential dispatch's thread future is
+        caught by the outer safety net, same as the thread-pool path."""
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False, service_timeout=0.05)
+            service = _SlowNotify(host="x", asset=asset, delay=0.0)
+            a = Apprise(asset=asset)
+            a.add(service)
+
+            import concurrent.futures as cf
+
+            real_executor_cls = cf.ThreadPoolExecutor
+
+            class _PatchedExecutor:
+                """Delegate to a real executor while always failing."""
+
+                def __init__(self, *args, **kwargs):
+                    """Create the wrapped executor with the same args."""
+                    self._real = real_executor_cls(*args, **kwargs)
+
+                def __enter__(self):
+                    """Return this wrapper when entering the context."""
+                    return self
+
+                def __exit__(self, *exc):
+                    """Forward context cleanup to the wrapped executor."""
+                    return self._real.__exit__(*exc)
+
+                def submit(self, fn, service, kwargs, call_deadline):
+                    """Return a future that raises instead of running."""
+                    fut = cf.Future()
+                    fut.set_exception(RuntimeError("future boom"))
+                    return fut
+
+                def shutdown(self, *args, **kwargs):
+                    """Forward shutdown behavior to the wrapped executor."""
+                    return self._real.shutdown(*args, **kwargs)
+
+            # Reset the shared executor so the patched class is used here.
+            import apprise.apprise as apprise_module
+
+            with (
+                mock.patch("apprise.apprise._shared_executor", None),
+                mock.patch(
+                    "apprise.apprise.cf.ThreadPoolExecutor", _PatchedExecutor
+                ),
+            ):
+                result = a.notify(body="test")
+
+                # Clean up the real executor wrapped by _PatchedExecutor.
+                apprise_module._shared_executor._real.shutdown(wait=True)
+
             assert bool(result) is False
         finally:
             N_MGR.unload_modules()
@@ -3144,6 +3204,46 @@ class TestServiceTimeout:
         assert started_later == started_at_return
         assert finished_later == started_at_return
 
+    def test_sequential_queued_future_cancelled(self):
+        """A sequential service whose future never got a chance to start
+        (still queued behind other work in a size-limited pool) is
+        cancelled outright at the deadline -- nothing is left running,
+        so it is never tracked as abandoned."""
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            import concurrent.futures as cf
+
+            import apprise.apprise as apprise_module
+
+            release = threading.Event()
+
+            with mock.patch(
+                "apprise.apprise._shared_executor",
+                cf.ThreadPoolExecutor(max_workers=1),
+            ):
+                executor = apprise_module._shared_executor
+                # Occupy the pool's only worker so the service's own
+                # future stays queued until its deadline has passed.
+                blocker = executor.submit(release.wait, 2.0)
+
+                asset = AppriseAsset(async_mode=False, service_timeout=0.05)
+                service = _SlowNotify(host="x", asset=asset, delay=0.0)
+                a = Apprise(asset=asset)
+                a.add(service)
+
+                result = a.notify(body="test")
+
+                release.set()
+                blocker.result(timeout=2.0)
+                executor.shutdown(wait=True)
+        finally:
+            N_MGR.unload_modules()
+
+        assert result.status == AppriseResultStatus.TIMEOUT
+        # Still queued when abandoned -- it never actually got to run.
+        assert service.calls == 0
+
     def test_threadpool_shared_across_notify_calls(self):
         """Separate notify() calls reuse the shared executor."""
         N_MGR["slow"] = _SlowNotify
@@ -3290,8 +3390,8 @@ class _SlowFailNotify(NotifyBase):
 class TestDeadlineExpiresDuringAttempt:
     """Deadline-expired retries should stop without sleeping first."""
 
-    def test_sequential_skips_wait_when_deadline_already_passed(self):
-        """Sequential retry skips its wait once the deadline has passed."""
+    def test_sequential_abandons_service_that_blocks_past_deadline(self):
+        """A blocking sync service is abandoned once its deadline passes."""
         N_MGR["slowfail"] = _SlowFailNotify
 
         try:
@@ -3302,18 +3402,15 @@ class TestDeadlineExpiresDuringAttempt:
             a = Apprise(asset=asset)
             a.add(service)
 
-            real_sleep = time.sleep
-            with mock.patch(
-                "apprise.apprise.time.sleep", side_effect=real_sleep
-            ) as mock_sleep:
-                result = a.notify(body="test")
+            t0 = time.monotonic()
+            result = a.notify(body="test")
+            wall = time.monotonic() - t0
 
-            # The first attempt failed before the retry deadline check.
-            # A confirmed failure takes priority over the later TIMEOUT.
-            assert result.status == AppriseResultStatus.FAILURE
-            # The retry loop stopped before sleeping or calling send() again.
+            # The result returns before the full blocking send() delay.
+            assert wall < 0.2
+            assert result.status == AppriseResultStatus.TIMEOUT
+            # The first attempt started, but no retry was launched.
             assert service.calls == 1
-            mock_sleep.assert_called_once_with(pytest.approx(0.2))
         finally:
             N_MGR.unload_modules()
 

--- a/tests/test_retry_wait.py
+++ b/tests/test_retry_wait.py
@@ -3397,7 +3397,7 @@ class TestDeadlineExpiresDuringAttempt:
         try:
             asset = AppriseAsset(async_mode=False, service_timeout=0.05)
             service = _SlowFailNotify(
-                host="x", asset=asset, retry=1, wait=1.0, delay=0.2
+                host="x", asset=asset, retry=1, wait=1.0, delay=1.0
             )
             a = Apprise(asset=asset)
             a.add(service)
@@ -3406,8 +3406,10 @@ class TestDeadlineExpiresDuringAttempt:
             result = a.notify(body="test")
             wall = time.monotonic() - t0
 
-            # The result returns before the full blocking send() delay.
-            assert wall < 0.2
+            # The result returns nowhere near the full blocking send()
+            # delay -- generous slack here for loaded CI runners, since
+            # only the *relative* gap to the 1.0s delay matters.
+            assert wall < 0.6
             assert result.status == AppriseResultStatus.TIMEOUT
             # The first attempt started, but no retry was launched.
             assert service.calls == 1


### PR DESCRIPTION
## Description

**Related issue (if applicable):** #1600

This PR is a behind-the-scenes cleanup of how Apprise figures out what "format" your message is (plain text, Markdown, or HTML), plus a few real bugs it turned up along the way. 

This is 100% a breaking change as plugins now can support more than one format.  Cases like Email supported both HTML and TEXT, but we had to just pick one to tell users.  Now services can support all or some services and just relay accordingly.  For example Telegram supports HTML and Markdown.   Now you can more easily toggle between the two automaticaly.   This also breaks systems that depended on the `Apprise.details()`  as the supported format went from a single string ('markdown,', 'text', or 'html') to a list of strings.  The first item in the list is always the default value used if you send an unsupported format type along.
You can always provide `?format=type` on the URL to force a plugin that supports more than one output to always use one over another.  If Apprise needs to convert the body to accomodate this, it will .  This is similar to the behaviour of Apprise v1.0

This change is breaking, so it will not appear until Apprise v2.

The system now alings what you send it... for example, while HTML is the default for telegram, if you pass along `markdown` (also supported by Telegram), it no longer converts the data to HTML, it just leverages the supported Markdown output instead.

In addition to this, the following was also fixed:

- Fixed a bug in the `apprise://` relay plugin - (used when one Apprise server forwards a notification to another Apprise API server). It was always telling the receiving server "treat this as plain text," even if you never said that yourself. Now it only passes along a format when you've actually told Apprise what format your message is in — otherwise the receiving server is left to use its own judgment, just like it would if you'd contacted it directly.
- Fixed a message-corruption bug affecting plain text sent to Markdown-only services. -  If your message contained a literal backslash character — for example a Windows file path like `C:\Users\name`, or anything else with a `\` in it — that backslash could silently disappear when Apprise converted your plain text into Markdown for a service that needs it. Backslashes are now preserved correctly.
- Cleaned up how several plugins decide what to do when you haven't told Apprise your message's format. -  Telegram, Slack, and Pushover previously had a couple of edge cases where declaring your content as Markdown vs. leaving it unspecified could produce a slightly different (and sometimes wrong) result. This is now handled consistently across all of them.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/104(https://github.com/caronc/apprise-docs/pull/104)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1600-multi-upstream-format-support

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    tgram://bottoken/ChatID
```
