### PR TITLE
Allow RFC 3986 path characters that are safe to leave unencoded

### DIFF
--- a/apprise/attachment/http.py
+++ b/apprise/attachment/http.py
@@ -36,6 +36,7 @@ import requests
 from ..common import ContentLocation
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
+from ..utils.parse import URL_PATH_SAFE_CHARS
 from .base import AttachBase
 
 
@@ -366,7 +367,7 @@ class AttachHTTP(AttachBase):
                 if self.port is None or self.port == default_port
                 else f":{self.port}"
             ),
-            fullpath=self.quote(self.fullpath, safe="/"),
+            fullpath=self.quote(self.fullpath, safe=URL_PATH_SAFE_CHARS),
             params=self.urlencode(params, safe="/"),
         )
 

--- a/apprise/config/http.py
+++ b/apprise/config/http.py
@@ -32,6 +32,7 @@ import requests
 from ..common import ConfigFormat, ContentIncludeMode
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
+from ..utils.parse import URL_PATH_SAFE_CHARS
 from .base import ConfigBase
 
 # Support YAML formats
@@ -139,7 +140,7 @@ class ConfigHTTP(ConfigBase):
                 if self.port is None or self.port == default_port
                 else f":{self.port}"
             ),
-            fullpath=self.quote(self.fullpath, safe="/"),
+            fullpath=self.quote(self.fullpath, safe=URL_PATH_SAFE_CHARS),
             params=self.urlencode(params),
         )
 

--- a/apprise/plugins/apprise_api.py
+++ b/apprise/plugins/apprise_api.py
@@ -35,7 +35,7 @@ from .. import exception
 from ..common import NotifyType
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
-from ..utils.parse import parse_list, validate_regex
+from ..utils.parse import URL_PATH_SAFE_CHARS, parse_list, validate_regex
 from ..utils.sanitize import sanitize_payload
 from .base import NotifyBase
 
@@ -243,7 +243,11 @@ class NotifyAppriseAPI(NotifyBase):
                     else f":{self.port}"
                 ),
                 fullpath=(
-                    "/{}/".format(NotifyAppriseAPI.quote(fullpath, safe="/"))
+                    "/{}/".format(
+                        NotifyAppriseAPI.quote(
+                            fullpath, safe=URL_PATH_SAFE_CHARS
+                        )
+                    )
                     if fullpath
                     else "/"
                 ),

--- a/apprise/plugins/custom_form.py
+++ b/apprise/plugins/custom_form.py
@@ -32,6 +32,7 @@ import requests
 from ..common import NotifyImageSize, NotifyType
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
+from ..utils.parse import URL_PATH_SAFE_CHARS
 from .base import NotifyBase
 
 
@@ -524,7 +525,7 @@ class NotifyForm(NotifyBase):
                 else f":{self.port}"
             ),
             fullpath=(
-                NotifyForm.quote(self.fullpath, safe="/")
+                NotifyForm.quote(self.fullpath, safe=URL_PATH_SAFE_CHARS)
                 if self.fullpath
                 else "/"
             ),

--- a/apprise/plugins/custom_json.py
+++ b/apprise/plugins/custom_json.py
@@ -34,6 +34,7 @@ from .. import exception
 from ..common import NotifyImageSize, NotifyType
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
+from ..utils.parse import URL_PATH_SAFE_CHARS
 from ..utils.sanitize import sanitize_payload
 from .base import NotifyBase
 
@@ -421,7 +422,7 @@ class NotifyJSON(NotifyBase):
                 else f":{self.port}"
             ),
             fullpath=(
-                NotifyJSON.quote(self.fullpath, safe="/")
+                NotifyJSON.quote(self.fullpath, safe=URL_PATH_SAFE_CHARS)
                 if self.fullpath
                 else "/"
             ),

--- a/apprise/plugins/custom_xml.py
+++ b/apprise/plugins/custom_xml.py
@@ -34,6 +34,7 @@ from .. import exception
 from ..common import NotifyImageSize, NotifyType
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
+from ..utils.parse import URL_PATH_SAFE_CHARS
 from ..utils.sanitize import sanitize_payload
 from .base import NotifyBase
 
@@ -511,7 +512,7 @@ class NotifyXML(NotifyBase):
                 else f":{self.port}"
             ),
             fullpath=(
-                NotifyXML.quote(self.fullpath, safe="/")
+                NotifyXML.quote(self.fullpath, safe=URL_PATH_SAFE_CHARS)
                 if self.fullpath
                 else "/"
             ),

--- a/apprise/plugins/enigma2.py
+++ b/apprise/plugins/enigma2.py
@@ -40,6 +40,7 @@ import requests
 from ..common import NotifyType
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
+from ..utils.parse import URL_PATH_SAFE_CHARS
 from .base import NotifyBase
 
 
@@ -239,7 +240,9 @@ class NotifyEnigma2(NotifyBase):
                 if self.port is None or self.port == default_port
                 else f":{self.port}"
             ),
-            fullpath=NotifyEnigma2.quote(self.fullpath, safe="/"),
+            fullpath=NotifyEnigma2.quote(
+                self.fullpath, safe=URL_PATH_SAFE_CHARS
+            ),
             params=NotifyEnigma2.urlencode(params),
         )
 

--- a/apprise/plugins/flowtriq.py
+++ b/apprise/plugins/flowtriq.py
@@ -62,7 +62,7 @@ import requests
 
 from ..common import NotifyType
 from ..locale import gettext_lazy as _
-from ..utils.parse import validate_regex
+from ..utils.parse import URL_PATH_SAFE_CHARS, validate_regex
 from .base import NotifyBase
 
 # Map Apprise notification types to Flowtriq severity levels
@@ -284,7 +284,9 @@ class NotifyFlowtriq(NotifyBase):
                 if self.port is None or self.port == default_port
                 else ":{}".format(self.port)
             ),
-            path=NotifyFlowtriq.quote(self.webhook_path, safe="/"),
+            path=NotifyFlowtriq.quote(
+                self.webhook_path, safe=URL_PATH_SAFE_CHARS
+            ),
             params=NotifyFlowtriq.urlencode(params),
         )
 

--- a/apprise/plugins/gotify.py
+++ b/apprise/plugins/gotify.py
@@ -36,7 +36,7 @@ import requests
 
 from ..common import NotifyFormat, NotifyType
 from ..locale import gettext_lazy as _
-from ..utils.parse import validate_regex
+from ..utils.parse import URL_PATH_SAFE_CHARS, validate_regex
 from .base import NotifyBase
 
 
@@ -316,7 +316,9 @@ class NotifyGotify(NotifyBase):
                 if self.port is None or self.port == default_port
                 else f":{self.port}"
             ),
-            fullpath=NotifyGotify.quote(self.fullpath, safe="/"),
+            fullpath=NotifyGotify.quote(
+                self.fullpath, safe=URL_PATH_SAFE_CHARS
+            ),
             token=self.pprint(self.token, privacy, safe=""),
             params=NotifyGotify.urlencode(params),
         )

--- a/apprise/plugins/home_assistant.py
+++ b/apprise/plugins/home_assistant.py
@@ -39,6 +39,7 @@ from ..common import NotifyType
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import (
+    URL_PATH_SAFE_CHARS,
     is_domain_service_target,
     parse_bool,
     parse_domain_service_targets,
@@ -493,7 +494,8 @@ class NotifyHomeAssistant(NotifyBase):
                 if not self.fullpath
                 else "/{}/".format(
                     NotifyHomeAssistant.quote(
-                        self.fullpath.strip("/"), safe="/"
+                        self.fullpath.strip("/"),
+                        safe=URL_PATH_SAFE_CHARS,
                     )
                 )
             ),

--- a/apprise/plugins/mattermost.py
+++ b/apprise/plugins/mattermost.py
@@ -64,7 +64,12 @@ import requests
 
 from ..common import NotifyImageSize, NotifyType, PersistentStoreMode
 from ..locale import gettext_lazy as _
-from ..utils.parse import parse_bool, parse_list, validate_regex
+from ..utils.parse import (
+    URL_PATH_SAFE_CHARS,
+    parse_bool,
+    parse_list,
+    validate_regex,
+)
 from .base import NotifyBase
 
 # Some Reference Locations:
@@ -781,7 +786,9 @@ class NotifyMattermost(NotifyBase):
                     "/"
                     if not self.fullpath
                     else "{}/".format(
-                        NotifyMattermost.quote(self.fullpath, safe="/")
+                        NotifyMattermost.quote(
+                            self.fullpath, safe=URL_PATH_SAFE_CHARS
+                        )
                     )
                 ),
                 token=self.pprint(self.token, privacy, safe=""),

--- a/apprise/plugins/notica.py
+++ b/apprise/plugins/notica.py
@@ -46,7 +46,7 @@ import requests
 from ..common import NotifyType
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
-from ..utils.parse import validate_regex
+from ..utils.parse import URL_PATH_SAFE_CHARS, validate_regex
 from .base import NotifyBase
 
 
@@ -335,7 +335,9 @@ class NotifyNotica(NotifyBase):
                 if self.port is None or self.port == default_port
                 else f":{self.port}"
             ),
-            fullpath=NotifyNotica.quote(self.fullpath, safe="/"),
+            fullpath=NotifyNotica.quote(
+                self.fullpath, safe=URL_PATH_SAFE_CHARS
+            ),
             token=self.pprint(self.token, privacy, safe=""),
             params=NotifyNotica.urlencode(params),
         )

--- a/apprise/plugins/parseplatform.py
+++ b/apprise/plugins/parseplatform.py
@@ -32,7 +32,7 @@ import requests
 
 from ..common import NotifyType
 from ..locale import gettext_lazy as _
-from ..utils.parse import validate_regex
+from ..utils.parse import URL_PATH_SAFE_CHARS, validate_regex
 from .base import NotifyBase
 
 # Used to break path apart into list of targets
@@ -314,7 +314,9 @@ class NotifyParsePlatform(NotifyBase):
                     if self.port is None or self.port == default_port
                     else f":{self.port}"
                 ),
-                fullpath=NotifyParsePlatform.quote(self.fullpath, safe="/"),
+                fullpath=NotifyParsePlatform.quote(
+                    self.fullpath, safe=URL_PATH_SAFE_CHARS
+                ),
                 params=NotifyParsePlatform.urlencode(params),
             )
         )

--- a/apprise/plugins/synology.py
+++ b/apprise/plugins/synology.py
@@ -32,6 +32,7 @@ import requests
 from ..common import NotifyType
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
+from ..utils.parse import URL_PATH_SAFE_CHARS
 from .base import NotifyBase
 
 # For API Details see:
@@ -220,7 +221,9 @@ class NotifySynology(NotifyBase):
                 ),
                 token=self.pprint(self.token, privacy, safe=""),
                 fullpath=(
-                    NotifySynology.quote(self.fullpath, safe="/")
+                    NotifySynology.quote(
+                        self.fullpath, safe=URL_PATH_SAFE_CHARS
+                    )
                     if self.fullpath
                     else "/"
                 ),

--- a/apprise/url.py
+++ b/apprise/url.py
@@ -38,6 +38,7 @@ from .locale import gettext_lazy as _
 from .logger import logger
 from .tag import AppriseTag
 from .utils.parse import (
+    URL_PATH_SAFE_CHARS,
     parse_bool,
     parse_list,
     parse_phone_no,
@@ -401,7 +402,7 @@ class URLBase:
                 else f":{self.port}"
             ),
             fullpath=(
-                URLBase.quote(self.fullpath, safe="/")
+                URLBase.quote(self.fullpath, safe=URL_PATH_SAFE_CHARS)
                 if self.fullpath
                 else "/"
             ),

--- a/apprise/utils/parse.py
+++ b/apprise/utils/parse.py
@@ -737,7 +737,9 @@ def parse_url(
 
     # Parse results
     result["host"] = parsed[1].strip()
-    result["fullpath"] = quote(unquote(tidy_path(parsed[2].strip())))
+    result["fullpath"] = quote(
+        unquote(tidy_path(parsed[2].strip())), safe="/@"
+    )
 
     try:
         # Handle trailing slashes removed by tidy_path

--- a/apprise/utils/parse.py
+++ b/apprise/utils/parse.py
@@ -43,6 +43,15 @@ VALID_URL_RE = re.compile(
 )
 VALID_QUERY_RE = re.compile(r"^(?P<path>.*[/\\])(?P<query>[^/\\]+)?$")
 
+# RFC 3986 path characters that are safe to leave unencoded when we
+# quote() a URL path. This is the pchar sub-delims set minus comma and
+# semicolon, which Apprise reserves as its own list delimiters. Shared by
+# parse_url() below and by every url() implementation that re-quotes a
+# previously parsed fullpath, so a literal path character (such as the
+# '@' in a jsDelivr version selector) is never re-percent-encoded when a
+# URL is reconstructed.
+URL_PATH_SAFE_CHARS = "/:@!$&'()*+="
+
 # delimiters used to separate values when content is passed in by string.
 # This is useful when turning a string into a list
 STRING_DELIMITERS = r"[\[\]\;,\s]+"
@@ -741,7 +750,7 @@ def parse_url(
     # Keep commas and semicolons encoded because Apprise uses them as
     # delimiters.
     result["fullpath"] = quote(
-        unquote(tidy_path(parsed[2].strip())), safe="/:@!$&'()*+="
+        unquote(tidy_path(parsed[2].strip())), safe=URL_PATH_SAFE_CHARS
     )
 
     try:

--- a/apprise/utils/parse.py
+++ b/apprise/utils/parse.py
@@ -737,8 +737,10 @@ def parse_url(
 
     # Parse results
     result["host"] = parsed[1].strip()
+    # Preserve RFC 3986 path characters used literally by some services.
+    # Keep commas and semicolons encoded because Apprise uses them as delimiters.
     result["fullpath"] = quote(
-        unquote(tidy_path(parsed[2].strip())), safe="/@"
+        unquote(tidy_path(parsed[2].strip())), safe="/:@!$&'()*+="
     )
 
     try:

--- a/apprise/utils/parse.py
+++ b/apprise/utils/parse.py
@@ -738,7 +738,8 @@ def parse_url(
     # Parse results
     result["host"] = parsed[1].strip()
     # Preserve RFC 3986 path characters used literally by some services.
-    # Keep commas and semicolons encoded because Apprise uses them as delimiters.
+    # Keep commas and semicolons encoded because Apprise uses them as
+    # delimiters.
     result["fullpath"] = quote(
         unquote(tidy_path(parsed[2].strip())), safe="/:@!$&'()*+="
     )

--- a/tests/test_apprise_utils.py
+++ b/tests/test_apprise_utils.py
@@ -815,6 +815,12 @@ def test_parse_url_general():
     assert "-token" in result["qsd"]
     assert result["qsd-"]["token"] == "ab cdefg"
 
+    # Testing Defect 1672 - reserved characters in URL paths
+    url = "https://cdn.jsdelivr.net/gh/Cleanuparr/Cleanuparr@main/Logo/256.png"
+    result = utils.parse.parse_url(url)
+    assert result["fullpath"] == "/gh/Cleanuparr/Cleanuparr@main/Logo/256.png"
+    assert result["url"] == url
+
 
 def test_parse_url_simple():
     "utils: parse_url() testing"

--- a/tests/test_apprise_utils.py
+++ b/tests/test_apprise_utils.py
@@ -829,8 +829,9 @@ def test_parse_url_general():
     assert result["url"] == url
 
     # Keep commas and semicolons encoded because Apprise uses them as path/list
-    # delimiters. Otherwise path data such as a Home Assistant target list could
-    # become extra segments. Related regressions have dedicated plugin tests.
+    # delimiters. Otherwise path data such as a Home Assistant target list
+    # could become extra segments. Related regressions have dedicated plugin
+    # tests.
     result = utils.parse.parse_url("https://example.com/a,b;c/file.txt")
     assert result["fullpath"] == "/a%2Cb%3Bc/file.txt"
 

--- a/tests/test_apprise_utils.py
+++ b/tests/test_apprise_utils.py
@@ -821,6 +821,43 @@ def test_parse_url_general():
     assert result["fullpath"] == "/gh/Cleanuparr/Cleanuparr@main/Logo/256.png"
     assert result["url"] == url
 
+    # RFC 3986 path characters must survive a parse_url() round trip because
+    # some services distinguish literal characters from encoded ones.
+    url = "https://example.com/a:b@c!d$e&f'g(h)i*j+k=n/file.txt"
+    result = utils.parse.parse_url(url)
+    assert result["fullpath"] == "/a:b@c!d$e&f'g(h)i*j+k=n/file.txt"
+    assert result["url"] == url
+
+    # Keep commas and semicolons encoded because Apprise uses them as path/list
+    # delimiters. Otherwise path data such as a Home Assistant target list could
+    # become extra segments. Related regressions have dedicated plugin tests.
+    result = utils.parse.parse_url("https://example.com/a,b;c/file.txt")
+    assert result["fullpath"] == "/a%2Cb%3Bc/file.txt"
+
+    # Characters outside an RFC 3986 path segment must remain encoded when the
+    # safe list is expanded.
+    result = utils.parse.parse_url("https://example.com/a b/c[1]#/file.txt")
+    assert "%20" in result["fullpath"]
+    assert "[" not in result["fullpath"]
+    assert "]" not in result["fullpath"]
+
+
+def test_parse_url_path_no_redos():
+    "utils: parse_url() does not regress into slow/backtracking behavior"
+
+    # Escaping uses linear-time table lookups. This guards against a future
+    # regex-based implementation backtracking on untrusted paths.
+    segment = "%40%3A%21%24%26%27%28%29%2A%2B%2C%3B%3D-a" * 5000
+    url = f"https://example.com/{segment}/file.txt?foo=bar"
+
+    start = time.time()
+    result = utils.parse.parse_url(url)
+    elapsed = time.time() - start
+
+    assert result is not None
+    # The generous limit allows slower CI while catching nonlinear behavior.
+    assert elapsed < 5.0
+
 
 def test_parse_url_simple():
     "utils: parse_url() testing"


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1672

`parse_url()` percent-encoded `@` in paths, so jsDelivr attachment URLs reached the CDN with `%40` and returned HTTP 400. Preserve `@` as a path-safe character while continuing to encode spaces and other unsafe characters.

<!--
  -- Have anything else to describe?
  -- Define it here; this helps build the documentation site later
-->

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): N/A — no documentation change.
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
python -m pytest -q tests/test_apprise_utils.py::test_parse_url_general
```
