### PR TITLE
Fix Microsoft Workflows CU-routed webhooks

### DIFF
--- a/apprise/plugins/workflows.py
+++ b/apprise/plugins/workflows.py
@@ -222,6 +222,7 @@ class NotifyWorkflows(NotifyBase):
         signature,
         include_image=None,
         power_automate=None,
+        routing_id=None,
         version=None,
         template=None,
         tokens=None,
@@ -260,6 +261,9 @@ class NotifyWorkflows(NotifyBase):
             if power_automate is not None
             else self.template_args["pa"]["default"]
         )
+
+        # Microsoft may provide a routing ID in native Power Automate URLs
+        self.routing_id = routing_id
 
         # Wrap Text
         self.wrap = bool(
@@ -536,6 +540,8 @@ class NotifyWorkflows(NotifyBase):
         path = (
             "/powerautomate/automations/direct" if self.power_automate else ""
         )
+        if path and self.routing_id:
+            path += f"/cu/{self.routing_id}"
 
         notify_url = (
             "https://{host}{port}{path}/workflows/{workflow}/"
@@ -774,7 +780,9 @@ class NotifyWorkflows(NotifyBase):
             r"^https?://(?P<host>[A-Z0-9_.-]+)"
             r"(?P<port>:[1-9][0-9]{0,5})?"
             # The new URL structure includes /powerautomate/automations/direct
-            r"(?P<power_automate>/powerautomate/automations/direct)?"
+            # and may include a CU routing ID before /workflows
+            r"(?P<power_automate>/powerautomate/automations/direct"
+            r"(?:/cu/(?P<routing_id>[0-9]+))?)?"
             r"/workflows/"
             r"(?P<workflow>[A-Z0-9_-]+)"
             r"/triggers/manual/paths/invoke/?"
@@ -790,7 +798,7 @@ class NotifyWorkflows(NotifyBase):
             )
 
             # Construct our URL
-            return NotifyWorkflows.parse_url(
+            results = NotifyWorkflows.parse_url(
                 "{schema}://{host}{port}/{workflow}/{params}{pa}".format(
                     schema=NotifyWorkflows.secure_protocol[0],
                     host=result.group("host"),
@@ -804,4 +812,6 @@ class NotifyWorkflows(NotifyBase):
                     pa=power_automate,
                 )
             )
+            results["routing_id"] = result.group("routing_id")
+            return results
         return None

--- a/apprise/plugins/workflows.py
+++ b/apprise/plugins/workflows.py
@@ -184,6 +184,13 @@ class NotifyWorkflows(NotifyBase):
                 "map_to": "power_automate",
             },
             "powerautomate": {"alias_of": "pa"},
+            "route": {
+                "name": _("Power Automate Routing ID"),
+                "type": "string",
+                "regex": (r"^[0-9]+$", ""),
+                "map_to": "routing_id",
+            },
+            "routeid": {"alias_of": "route"},
             "wrap": {
                 "name": _("Wrap Text"),
                 "type": "bool",
@@ -263,7 +270,9 @@ class NotifyWorkflows(NotifyBase):
         )
 
         # Microsoft may provide a routing ID in native Power Automate URLs
-        self.routing_id = routing_id
+        self.routing_id = (
+            None if routing_id is None else str(routing_id).strip()
+        ) or None
 
         # Wrap Text
         self.wrap = bool(
@@ -630,6 +639,7 @@ class NotifyWorkflows(NotifyBase):
             self.port,
             self.workflow,
             self.signature,
+            self.routing_id,
         )
 
     def url(self, privacy=False, *args, **kwargs):
@@ -641,6 +651,9 @@ class NotifyWorkflows(NotifyBase):
             "wrap": "yes" if self.wrap else "no",
             "pa": "yes" if self.power_automate else "no",
         }
+
+        if self.routing_id:
+            params["route"] = self.routing_id
 
         if self.template:
             params["template"] = NotifyWorkflows.quote(
@@ -703,6 +716,17 @@ class NotifyWorkflows(NotifyBase):
                 ),
             )
         )
+
+        # Power Automate CU routing ID
+        if "route" in results["qsd"] and results["qsd"]["route"]:
+            results["routing_id"] = NotifyWorkflows.unquote(
+                results["qsd"]["route"]
+            )
+
+        elif "routeid" in results["qsd"] and results["qsd"]["routeid"]:
+            results["routing_id"] = NotifyWorkflows.unquote(
+                results["qsd"]["routeid"]
+            )
 
         # Wrap Text?
         results["wrap"] = parse_bool(
@@ -812,6 +836,7 @@ class NotifyWorkflows(NotifyBase):
                     pa=power_automate,
                 )
             )
-            results["routing_id"] = result.group("routing_id")
+            if result.group("routing_id"):
+                results["routing_id"] = result.group("routing_id")
             return results
         return None

--- a/apprise/plugins/workflows.py
+++ b/apprise/plugins/workflows.py
@@ -270,9 +270,18 @@ class NotifyWorkflows(NotifyBase):
         )
 
         # Microsoft may provide a routing ID in native Power Automate URLs
-        self.routing_id = (
-            None if routing_id is None else str(routing_id).strip()
-        ) or None
+        self.routing_id = None
+        if routing_id is not None:
+            self.routing_id = validate_regex(
+                routing_id, *self.template_args["route"]["regex"]
+            )
+            if not self.routing_id:
+                msg = (
+                    "An invalid Workflows Routing ID"
+                    f" ({routing_id}) was specified."
+                )
+                self.logger.warning(msg)
+                raise TypeError(msg)
 
         # Wrap Text
         self.wrap = bool(

--- a/tests/test_plugin_workflows.py
+++ b/tests/test_plugin_workflows.py
@@ -875,6 +875,27 @@ def test_plugin_workflows_azure_webhooks(request_mock):
     assert obj.api_version == "2016-06-01"
 
 
+@pytest.mark.parametrize("routing_id", (123456789, 987654321))
+def test_plugin_workflows_power_automate_cu_webhooks(request_mock, routing_id):
+    """NotifyWorkflows() preserves Power Automate CU routing IDs."""
+    url = (
+        "https://default.environment.api.powerplatform.com:443"
+        f"/powerautomate/automations/direct/cu/{routing_id}"
+        "/workflows/3XXX5/triggers/manual/paths/invoke"
+        "?api-version=2022-03-01-preview&"
+        "sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=iXXXU"
+    )
+
+    obj = Apprise.instantiate(url)
+    assert isinstance(obj, NotifyWorkflows)
+    assert obj.notify(body="body", title="title") is True
+    assert request_mock.call_args.args[0] == (
+        "https://default.environment.api.powerplatform.com:443"
+        f"/powerautomate/automations/direct/cu/{routing_id}"
+        "/workflows/3XXX5/triggers/manual/paths/invoke"
+    )
+
+
 @mock.patch("requests.post")
 def test_plugin_workflows_html_to_markdown_format(mock_post):
     """NotifyWorkflows(): HTML body is converted to Markdown."""

--- a/tests/test_plugin_workflows.py
+++ b/tests/test_plugin_workflows.py
@@ -923,6 +923,23 @@ def test_plugin_workflows_routing_id_parse_url(key):
     assert "route=" not in obj.url()
 
 
+def test_plugin_workflows_routing_id_invalid():
+    """NotifyWorkflows() rejects a non-numeric routing ID."""
+
+    with pytest.raises(TypeError):
+        NotifyWorkflows(
+            workflow="3XXX5", signature="iXXXU", routing_id="1/../evil"
+        )
+
+    # Confirmed unusable (and therefore never reflected) via a full URL too
+    assert (
+        Apprise.instantiate(
+            "workflow://host/3XXX5/iXXXU/?pa=yes&route=1/../evil"
+        )
+        is None
+    )
+
+
 def test_plugin_workflows_routing_id_round_trip(request_mock):
     """NotifyWorkflows() round-trips the routing ID through url()."""
 

--- a/tests/test_plugin_workflows.py
+++ b/tests/test_plugin_workflows.py
@@ -895,6 +895,61 @@ def test_plugin_workflows_power_automate_cu_webhooks(request_mock, routing_id):
         "/workflows/3XXX5/triggers/manual/paths/invoke"
     )
 
+    # Our routing ID is tracked and advertised in the Apprise URL
+    assert obj.routing_id == str(routing_id)
+    assert f"route={routing_id}" in obj.url()
+
+
+@pytest.mark.parametrize("key", ("route", "routeid"))
+def test_plugin_workflows_routing_id_parse_url(key):
+    """NotifyWorkflows() parses the routing ID from an Apprise URL."""
+
+    results = NotifyWorkflows.parse_url(
+        f"workflow://host/3XXX5/iXXXU/?pa=yes&{key}=123456789"
+    )
+    assert isinstance(results, dict)
+    assert results["routing_id"] == "123456789"
+
+    obj = Apprise.instantiate(
+        f"workflow://host/3XXX5/iXXXU/?pa=yes&{key}=123456789"
+    )
+    assert isinstance(obj, NotifyWorkflows)
+    assert obj.routing_id == "123456789"
+
+    # No routing ID provided; nothing is set and nothing is advertised
+    obj = Apprise.instantiate("workflow://host/3XXX5/iXXXU/?pa=yes")
+    assert isinstance(obj, NotifyWorkflows)
+    assert obj.routing_id is None
+    assert "route=" not in obj.url()
+
+
+def test_plugin_workflows_routing_id_round_trip(request_mock):
+    """NotifyWorkflows() round-trips the routing ID through url()."""
+
+    obj = Apprise.instantiate(
+        "https://default.environment.api.powerplatform.com:443"
+        "/powerautomate/automations/direct/cu/123456789"
+        "/workflows/3XXX5/triggers/manual/paths/invoke"
+        "?api-version=2022-03-01-preview&"
+        "sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=iXXXU"
+    )
+    assert isinstance(obj, NotifyWorkflows)
+    assert obj.routing_id == "123456789"
+
+    # Re-instantiate ourselves from our own generated URL
+    obj_copy = Apprise.instantiate(obj.url())
+    assert isinstance(obj_copy, NotifyWorkflows)
+    assert obj_copy.routing_id == obj.routing_id
+    assert obj_copy.url() == obj.url()
+
+    # The routed endpoint survives the round trip
+    assert obj_copy.notify(body="body", title="title") is True
+    assert request_mock.call_args.args[0] == (
+        "https://default.environment.api.powerplatform.com:443"
+        "/powerautomate/automations/direct/cu/123456789"
+        "/workflows/3XXX5/triggers/manual/paths/invoke"
+    )
+
 
 @mock.patch("requests.post")
 def test_plugin_workflows_html_to_markdown_format(mock_post):


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1675

Microsoft Workflows now emits some Power Automate webhook URLs with a `cu/<routing-id>` segment before `/workflows`. Apprise rejected those native URLs because its parser only recognized the older direct route.

This preserves the numeric routing ID during native URL parsing and includes it when constructing the outbound request. Existing legacy and `/powerautomate/automations/direct/workflows/` URLs keep their current behavior.

## Checklist
* [x] Documentation ticket created (if applicable): Not applicable; this is native URL compatibility.
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (`ruff check` and `ruff format --check`).
* [x] Test coverage added or updated.

## Testing
```bash
pytest -q tests/test_plugin_workflows.py
ruff check apprise/plugins/workflows.py tests/test_plugin_workflows.py
ruff format --check apprise/plugins/workflows.py tests/test_plugin_workflows.py
```

The plugin test file passes with 20 tests passed and 1 version-specific skip. The new parametrized regression covers two routing IDs and verifies the exact outbound webhook URL.
