### PR TITLE
fix(docs): CLI file attachments feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,10 +368,12 @@ apprise -vv -t "Alert" --config=~/apprise.yml -g "2:alerts"
 
 # With retry override: retry each matched service up to 3 times
 apprise -vv -t "Alert" --config=~/apprise.yml -g "alerts:3"
+```
 
 ## CLI File Attachments
 
 Apprise also supports file attachments too! Specify as many attachments to a notification as you want.
+
 ```bash
 # Send a funny image you found on the internet to a colleague:
 apprise -vv --title 'Agile Joke' \


### PR DESCRIPTION
Simple README fix. I stumbled upon this while reading the "priority prefix and retry suffix" section.

By the way, why isn't this included in the [official configuration docs](https://appriseit.com/getting-started/configuration/)?