### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,12 +49,12 @@ git clone https://github.com/caronc/apprise.git
 cd apprise
 
 # Install all runtime + dev dependencies
-pip install .[dev]
+pip install '.[dev]'
 ```
 
 (Optional, but recommended if actively developing):
 ```bash
-pip install -e .[dev]
+pip install -e '.[dev]'
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `CONTRIBUTING.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`