### PR TITLE
Added Pinglet Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The table below identifies the services this tool supports and some example serv
 | [PagerDuty](https://appriseit.com/services/pagerduty/) | pagerduty:// | (TCP) 443 | pagerduty://IntegrationKey@ApiKey<br/>pagerduty://IntegrationKey@ApiKey/Source/Component
 | [PagerTree](https://appriseit.com/services/pagertree/) | pagertree:// | (TCP) 443 | pagertree://integration_id
 | [ParsePlatform](https://appriseit.com/services/parseplatform/) | parsep:// or parseps:// | (TCP) 80 or 443 | parsep://AppID:MasterKey@Hostname<br/>parseps://AppID:MasterKey@Hostname
+| [Pinglet](https://appriseit.com/services/pinglet/) | pinglet:// or pinglets:// | (TCP) 80 or 443 | pinglets://apikey@hostname/namespace/topic<br/>pinglets://apikey@hostname:port/namespace/topic
 | [Postmark](https://appriseit.com/services/postmark/) | postmark://  | (TCP) 443   | postmark://APIToken:FromEmail/<br />postmark://APIToken:FromEmail/ToEmail<br />postmark://APIToken:FromEmail/ToEmail1/ToEmail2/ToEmailN/
 | [Prowl](https://appriseit.com/services/prowl/) | prowl://   | (TCP) 443    | prowl://apikey<br />prowl://apikey/providerkey
 | [PushBullet](https://appriseit.com/services/pushbullet/) | pbul://    | (TCP) 443    | pbul://accesstoken<br />pbul://accesstoken/#channel<br/>pbul://accesstoken/A_DEVICE_ID<br />pbul://accesstoken/email@address.com<br />pbul://accesstoken/#channel/#channel2/email@address.net/DEVICE

--- a/apprise/plugins/pinglet.py
+++ b/apprise/plugins/pinglet.py
@@ -1,0 +1,499 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Pinglet - Push notifications with topic feeds
+# Website: https://pinglet.co.uk
+#
+# Notifications are published to a topic within a namespace:
+#   POST https://{host}/{namespace}/{topic}
+#   Authorization: Bearer {apikey}
+#   {"title": "...", "message": "...", "priority": "normal",
+#    "level": "success", "badges": {...}, "data": {...}}
+#
+# Apprise URL examples:
+#   pinglets://{apikey}@app.pinglet.co.uk/{namespace}/{topic}
+#   pinglets://{apikey}@app.pinglet.co.uk/acme/deploys?priority=urgent
+#   pinglets://{apikey}@my.host/acme/deploys?:CPU=95%25&+region=eu-west
+
+from json import dumps
+
+import requests
+
+from ..common import NotifyType
+from ..locale import gettext_lazy as _
+from ..url import PrivacyMode
+from ..utils.parse import validate_regex
+from .base import NotifyBase
+
+
+# Priorities (delivery intrusiveness; separate from the display level)
+class PingletPriority:
+    SILENT = "silent"
+    NORMAL = "normal"
+    URGENT = "urgent"
+
+
+PINGLET_PRIORITIES = (
+    PingletPriority.SILENT,
+    PingletPriority.NORMAL,
+    PingletPriority.URGENT,
+)
+
+PINGLET_PRIORITY_MAP = {
+    # Maps against string 'silent'
+    "s": PingletPriority.SILENT,
+    # Maps against string 'normal'
+    "n": PingletPriority.NORMAL,
+    # Maps against string 'urgent'
+    "u": PingletPriority.URGENT,
+}
+
+# Maps the Apprise notification type to Pinglet's display-only level
+PINGLET_LEVEL_MAP = {
+    NotifyType.INFO.value: "info",
+    NotifyType.SUCCESS.value: "success",
+    NotifyType.WARNING.value: "warning",
+    NotifyType.FAILURE.value: "error",
+}
+
+
+class NotifyPinglet(NotifyBase):
+    """A wrapper for Pinglet Notifications."""
+
+    # The default descriptive name associated with the Notification
+    service_name = "Pinglet"
+
+    # The services URL
+    service_url = "https://pinglet.co.uk/"
+
+    # The default protocol
+    protocol = "pinglet"
+
+    # The default secure protocol
+    secure_protocol = "pinglets"
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = "https://appriseit.com/services/pinglet/"
+
+    # Pinglet API keys are limited to 120 requests/min
+    request_rate_per_sec = 0.5
+
+    # Pinglet rejects payloads larger then 4KB (title, message, badges,
+    # metadata and envelope combined); leave head-room for everything
+    # that is not the message body
+    body_maxlen = 3000
+
+    # Pinglet renders at most 3 badges (pills) per notification; keys and
+    # values that exceed the below lengths are rejected by the server, so
+    # they are truncated client-side instead
+    max_badge_count = 3
+    max_badge_key_len = 24
+    max_badge_value_len = 32
+
+    # Metadata (data) key/value length limits
+    max_data_key_len = 64
+    max_data_value_len = 256
+
+    # Define object templates
+    templates = (
+        "{schema}://{token}@{host}/{namespace}/{topic}",
+        "{schema}://{token}@{host}:{port}/{namespace}/{topic}",
+        "{schema}://{token}@{host}{path}{namespace}/{topic}",
+        "{schema}://{token}@{host}:{port}{path}{namespace}/{topic}",
+    )
+
+    # Define our template tokens
+    template_tokens = dict(
+        NotifyBase.template_tokens,
+        **{
+            "token": {
+                "name": _("API Key"),
+                "type": "string",
+                "private": True,
+                "required": True,
+            },
+            "host": {
+                "name": _("Hostname"),
+                "type": "string",
+                "required": True,
+            },
+            "port": {
+                "name": _("Port"),
+                "type": "int",
+                "min": 1,
+                "max": 65535,
+            },
+            "path": {
+                "name": _("Path"),
+                "type": "string",
+                "map_to": "fullpath",
+                "default": "/",
+            },
+            "namespace": {
+                "name": _("Namespace"),
+                "type": "string",
+                "required": True,
+            },
+            "topic": {
+                "name": _("Topic"),
+                "type": "string",
+                "required": True,
+            },
+        },
+    )
+
+    # Define our template arguments
+    template_args = dict(
+        NotifyBase.template_args,
+        **{
+            "priority": {
+                "name": _("Priority"),
+                "type": "choice:string",
+                "values": PINGLET_PRIORITIES,
+                "default": PingletPriority.NORMAL,
+            },
+            "token": {
+                "alias_of": "token",
+            },
+        },
+    )
+
+    # Define any kwargs we're using
+    template_kwargs = {
+        "badges": {
+            "name": _("Badges"),
+            "prefix": ":",
+        },
+        "data": {
+            "name": _("Metadata"),
+            "prefix": "+",
+        },
+    }
+
+    def __init__(
+        self,
+        token,
+        namespace,
+        topic,
+        priority=None,
+        badges=None,
+        data=None,
+        **kwargs,
+    ):
+        """Initialize Pinglet Object."""
+        super().__init__(**kwargs)
+
+        # Our API Key
+        self.token = validate_regex(token)
+        if not self.token:
+            msg = f"An invalid Pinglet API Key ({token}) was specified."
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # The Namespace the topic resides in
+        self.namespace = validate_regex(namespace)
+        if not self.namespace:
+            msg = f"An invalid Pinglet Namespace ({namespace}) was specified."
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # The Topic to publish to (auto-created on first publish)
+        self.topic = validate_regex(topic)
+        if not self.topic:
+            msg = f"An invalid Pinglet Topic ({topic}) was specified."
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # prepare our fullpath
+        self.fullpath = kwargs.get("fullpath")
+        if not isinstance(self.fullpath, str) or not self.fullpath:
+            self.fullpath = "/"
+
+        # The Priority of the message
+        self.priority = (
+            NotifyPinglet.template_args["priority"]["default"]
+            if priority is None
+            else next(
+                (
+                    v
+                    for k, v in PINGLET_PRIORITY_MAP.items()
+                    if str(priority).lower().startswith(k)
+                ),
+                NotifyPinglet.template_args["priority"]["default"],
+            )
+        )
+
+        # Badges (pills rendered on the feed card); the server rejects
+        # over-length keys/values outright, so truncate to keep the
+        # notification deliverable
+        self.badges = {}
+        if badges:
+            for key, value in badges.items():
+                if len(self.badges) >= self.max_badge_count:
+                    self.logger.warning(
+                        "Pinglet renders at most %d badges; "
+                        "additional entries were ignored.",
+                        self.max_badge_count,
+                    )
+                    break
+
+                if (
+                    len(key) > self.max_badge_key_len
+                    or len(str(value)) > self.max_badge_value_len
+                ):
+                    self.logger.warning("Pinglet badge %s was truncated.", key)
+
+                self.badges[key[: self.max_badge_key_len]] = str(value)[
+                    : self.max_badge_value_len
+                ]
+
+        # Metadata key/value pairs (shown on the detail sheet)
+        self.data = {}
+        if data:
+            for key, value in data.items():
+                if (
+                    len(key) > self.max_data_key_len
+                    or len(str(value)) > self.max_data_value_len
+                ):
+                    self.logger.warning(
+                        "Pinglet metadata %s was truncated.", key
+                    )
+
+                self.data[key[: self.max_data_key_len]] = str(value)[
+                    : self.max_data_value_len
+                ]
+
+        return
+
+    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+        """Perform Pinglet Notification."""
+
+        schema = "https" if self.secure else "http"
+        url = f"{schema}://{self.host}"
+        if self.port:
+            url += f":{self.port}"
+
+        # Append our namespace/topic path
+        url += f"{self.fullpath}{self.namespace}/{self.topic}"
+
+        # Prepare Pinglet Object
+        payload = {
+            "message": body,
+            "priority": self.priority,
+            "level": PINGLET_LEVEL_MAP.get(
+                notify_type.value
+                if isinstance(notify_type, NotifyType)
+                else str(notify_type),
+                "info",
+            ),
+        }
+
+        if title:
+            payload["title"] = title
+
+        if self.badges:
+            payload["badges"] = self.badges
+
+        if self.data:
+            payload["data"] = self.data
+
+        # Our headers
+        headers = {
+            "User-Agent": self.app_id,
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.token}",
+        }
+
+        self.logger.debug(
+            "Pinglet POST URL:"
+            f" {url} (cert_verify={self.verify_certificate!r})"
+        )
+        self.logger.debug(f"Pinglet Payload: {payload!s}")
+
+        # Always call throttle before the requests are made
+        self.throttle()
+
+        try:
+            r = requests.post(
+                url,
+                data=dumps(payload),
+                headers=headers,
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+                allow_redirects=self.redirects,
+            )
+            if r.status_code < 200 or r.status_code >= 300:
+                # We had a problem
+                status_str = NotifyPinglet.http_response_code_lookup(
+                    r.status_code
+                )
+
+                self.logger.warning(
+                    "Failed to send Pinglet notification: "
+                    "{}{}error={}.".format(
+                        status_str, ", " if status_str else "", r.status_code
+                    )
+                )
+
+                self.logger.debug(
+                    "Response Details:\r\n%r", (r.content or b"")[:2000]
+                )
+
+                # Mark our failure
+                return False
+
+            else:
+                self.logger.info("Sent Pinglet notification.")
+
+        except requests.RequestException as e:
+            self.logger.warning(
+                "A Connection error occurred sending Pinglet "
+                f"notification to {self.host}."
+            )
+            self.logger.debug(f"Socket Exception: {e!s}")
+
+            # Mark our failure
+            return False
+
+        return True
+
+    @property
+    def url_identifier(self):
+        """Returns all of the identifiers that make this URL unique from
+        another simliar one.
+
+        Targets or end points should never be identified here.
+        """
+        return (
+            self.secure_protocol if self.secure else self.protocol,
+            self.token,
+            self.host,
+            self.port if self.port else (443 if self.secure else 80),
+            self.fullpath.rstrip("/"),
+            self.namespace,
+            self.topic,
+        )
+
+    def url(self, privacy=False, *args, **kwargs):
+        """Returns the URL built dynamically based on specified arguments."""
+
+        # Define any URL parameters
+        params = {
+            "priority": self.priority,
+        }
+
+        # Append our badges into our parameters
+        params.update({f":{k}": v for k, v in self.badges.items()})
+
+        # Append our metadata into our parameters
+        params.update({f"+{k}": v for k, v in self.data.items()})
+
+        # Extend our parameters
+        params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
+
+        # Our default port
+        default_port = 443 if self.secure else 80
+        return (
+            "{schema}://{token}@{hostname}{port}{fullpath}"
+            "{namespace}/{topic}/?{params}".format(
+                schema=self.secure_protocol if self.secure else self.protocol,
+                token=self.pprint(
+                    self.token, privacy, mode=PrivacyMode.Secret, safe=""
+                ),
+                # never encode hostname since we're expecting it to be valid
+                hostname=self.host,
+                port=(
+                    ""
+                    if self.port is None or self.port == default_port
+                    else f":{self.port}"
+                ),
+                fullpath=NotifyPinglet.quote(self.fullpath, safe="/"),
+                namespace=NotifyPinglet.quote(self.namespace, safe=""),
+                topic=NotifyPinglet.quote(self.topic, safe=""),
+                params=NotifyPinglet.urlencode(params),
+            )
+        )
+
+    @staticmethod
+    def parse_url(url):
+        """Parses the URL and returns enough arguments that can allow us to re-
+        instantiate this object."""
+        results = NotifyBase.parse_url(url)
+        if not results:
+            # We're done early
+            return results
+
+        # Retrieve our escaped entries found on the fullpath
+        entries = NotifyBase.split_path(results["fullpath"])
+
+        # The last two entries are our namespace/topic
+        try:
+            results["topic"] = entries.pop()
+
+        except IndexError:
+            results["topic"] = None
+
+        try:
+            results["namespace"] = entries.pop()
+
+        except IndexError:
+            results["namespace"] = None
+
+        # Re-assemble our full path (anything left is a path prefix such
+        # as a reverse-proxy mount point)
+        results["fullpath"] = (
+            "/" if not entries else "/{}/".format("/".join(entries))
+        )
+
+        # Our API Key is the user component of the URL...
+        results["token"] = (
+            NotifyPinglet.unquote(results["user"]) if results["user"] else None
+        )
+
+        # ... but it can also be provided as ?token=
+        if "token" in results["qsd"] and len(results["qsd"]["token"]):
+            results["token"] = NotifyPinglet.unquote(results["qsd"]["token"])
+
+        # Set our priority
+        if "priority" in results["qsd"] and len(results["qsd"]["priority"]):
+            results["priority"] = NotifyPinglet.unquote(
+                results["qsd"]["priority"]
+            )
+
+        # Store our badges (:key=value)
+        results["badges"] = {
+            NotifyPinglet.unquote(x): NotifyPinglet.unquote(y)
+            for x, y in results["qsd:"].items()
+        }
+
+        # Store our metadata (+key=value)
+        results["data"] = {
+            NotifyPinglet.unquote(x): NotifyPinglet.unquote(y)
+            for x, y in results["qsd+"].items()
+        }
+
+        return results

--- a/apprise/plugins/pinglet.py
+++ b/apprise/plugins/pinglet.py
@@ -39,7 +39,10 @@
 #   pinglets://{apikey}@app.pinglet.co.uk/acme/deploys?priority=urgent
 #   pinglets://{apikey}@my.host/acme/deploys?:CPU=95%25&+region=eu-west
 
+from __future__ import annotations
+
 from json import dumps
+from typing import Any, Optional
 
 import requests
 
@@ -196,14 +199,14 @@ class NotifyPinglet(NotifyBase):
 
     def __init__(
         self,
-        token,
-        namespace,
-        topic,
-        priority=None,
-        badges=None,
-        data=None,
-        **kwargs,
-    ):
+        token: str,
+        namespace: str,
+        topic: str,
+        priority: Optional[str] = None,
+        badges: Optional[dict[str, Any]] = None,
+        data: Optional[dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
         """Initialize Pinglet Object."""
         super().__init__(**kwargs)
 
@@ -261,13 +264,17 @@ class NotifyPinglet(NotifyBase):
                     )
                     break
 
+                # Cast the value to a string once so the length check
+                # below and the stored value always agree
+                value = str(value)
                 if (
                     len(key) > self.max_badge_key_len
-                    or len(str(value)) > self.max_badge_value_len
+                    or len(value) > self.max_badge_value_len
                 ):
                     self.logger.warning("Pinglet badge %s was truncated.", key)
 
-                self.badges[key[: self.max_badge_key_len]] = str(value)[
+                # Store the (possibly truncated) badge
+                self.badges[key[: self.max_badge_key_len]] = value[
                     : self.max_badge_value_len
                 ]
 
@@ -275,23 +282,34 @@ class NotifyPinglet(NotifyBase):
         self.data = {}
         if data:
             for key, value in data.items():
+                # Cast the value to a string once so the length check
+                # below and the stored value always agree
+                value = str(value)
                 if (
                     len(key) > self.max_data_key_len
-                    or len(str(value)) > self.max_data_value_len
+                    or len(value) > self.max_data_value_len
                 ):
                     self.logger.warning(
                         "Pinglet metadata %s was truncated.", key
                     )
 
-                self.data[key[: self.max_data_key_len]] = str(value)[
+                # Store the (possibly truncated) metadata entry
+                self.data[key[: self.max_data_key_len]] = value[
                     : self.max_data_value_len
                 ]
 
         return
 
-    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+    def send(
+        self,
+        body: str,
+        title: str = "",
+        notify_type: NotifyType = NotifyType.INFO,
+        **kwargs: Any,
+    ) -> bool:
         """Perform Pinglet Notification."""
 
+        # Prepare our URL
         schema = "https" if self.secure else "http"
         url = f"{schema}://{self.host}"
         if self.port:
@@ -304,20 +322,18 @@ class NotifyPinglet(NotifyBase):
         payload = {
             "message": body,
             "priority": self.priority,
-            "level": PINGLET_LEVEL_MAP.get(
-                notify_type.value
-                if isinstance(notify_type, NotifyType)
-                else str(notify_type),
-                "info",
-            ),
+            "level": PINGLET_LEVEL_MAP.get(notify_type.value, "info"),
         }
 
+        # A title is only included when one was actually provided
         if title:
             payload["title"] = title
 
+        # Include our badges if any were defined
         if self.badges:
             payload["badges"] = self.badges
 
+        # Include our metadata if any was defined
         if self.data:
             payload["data"] = self.data
 
@@ -346,7 +362,7 @@ class NotifyPinglet(NotifyBase):
                 timeout=self.request_timeout,
                 allow_redirects=self.redirects,
             )
-            if r.status_code < 200 or r.status_code >= 300:
+            if r.status_code != requests.codes.ok:
                 # We had a problem
                 status_str = NotifyPinglet.http_response_code_lookup(
                     r.status_code
@@ -382,7 +398,7 @@ class NotifyPinglet(NotifyBase):
         return True
 
     @property
-    def url_identifier(self):
+    def url_identifier(self) -> tuple[Any, ...]:
         """Returns all of the identifiers that make this URL unique from
         another simliar one.
 
@@ -398,11 +414,11 @@ class NotifyPinglet(NotifyBase):
             self.topic,
         )
 
-    def url(self, privacy=False, *args, **kwargs):
+    def url(self, privacy: bool = False, *args: Any, **kwargs: Any) -> str:
         """Returns the URL built dynamically based on specified arguments."""
 
         # Define any URL parameters
-        params = {
+        params: dict[str, Any] = {
             "priority": self.priority,
         }
 
@@ -439,7 +455,7 @@ class NotifyPinglet(NotifyBase):
         )
 
     @staticmethod
-    def parse_url(url):
+    def parse_url(url: str) -> Optional[dict[str, Any]]:
         """Parses the URL and returns enough arguments that can allow us to re-
         instantiate this object."""
         results = NotifyBase.parse_url(url)

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -76,7 +76,7 @@ notification services. It supports sending alerts to platforms such as: \
 `NextcloudTalk`, `Notica`, `NotificationAPI`, `Notifiarr`, `Notifico`, \
 `Notifyre`, \
 `ntfy`, `Octopush`, `Office365`, `OneSignal`, `Opsgenie`, `PagerDuty`, \
-`PagerTree`, `ParsePlatform`, `Plivo`, `Prowl`, \
+`PagerTree`, `ParsePlatform`, `Pinglet`, `Plivo`, `Prowl`, \
 `Postmark`, `Pushalot`, `PushBullet`, \
 `Pushjet`, `PushMe`, `Pushover`, `Pushplus`, `PushSafer`, `PushWard`, \
 `Pushy`, `PushDeer`, \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ keywords = [
     "PagerDuty",
     "PagerTree",
     "ParsePlatform",
+    "Pinglet",
     "Plivo",
     "Postmark",
     "Power Automate",

--- a/tests/test_plugin_pinglet.py
+++ b/tests/test_plugin_pinglet.py
@@ -1,0 +1,310 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Disable logging for a cleaner testing output
+from json import loads
+import logging
+from unittest import mock
+
+from helpers import AppriseURLTester
+import pytest
+import requests
+
+import apprise
+from apprise import NotifyType
+from apprise.plugins.pinglet import NotifyPinglet, PingletPriority
+
+logging.disable(logging.CRITICAL)
+
+# Our Testing URLs
+apprise_url_tests = (
+    (
+        "pinglet://",
+        {
+            "instance": None,
+        },
+    ),
+    # An invalid url
+    (
+        "pinglet://:@/",
+        {
+            "instance": None,
+        },
+    ),
+    # No API Key specified
+    (
+        "pinglet://hostname/acme/deploys",
+        {
+            "instance": TypeError,
+        },
+    ),
+    # No namespace and/or topic specified
+    (
+        "pinglet://token@hostname",
+        {
+            "instance": TypeError,
+        },
+    ),
+    (
+        "pinglet://token@hostname/deploys",
+        {
+            "instance": TypeError,
+        },
+    ),
+    # Provide an API Key, namespace, and topic
+    (
+        "pinglet://abc123@hostname/acme/deploys",
+        {
+            "instance": NotifyPinglet,
+            # Our expected url(privacy=True) startswith() response:
+            "privacy_url": "pinglet://****@hostname/acme/deploys",
+        },
+    ),
+    # Secure protocol
+    (
+        "pinglets://abc123@hostname/acme/deploys",
+        {
+            "instance": NotifyPinglet,
+            "privacy_url": "pinglets://****@hostname/acme/deploys",
+        },
+    ),
+    # API Key as a query argument
+    (
+        "pinglets://hostname/acme/deploys?token=abc123",
+        {
+            "instance": NotifyPinglet,
+            "privacy_url": "pinglets://****@hostname/acme/deploys",
+        },
+    ),
+    # A path prefix (such as a reverse-proxy mount point)
+    (
+        "pinglet://abc123@hostname/prefix/acme/deploys",
+        {
+            "instance": NotifyPinglet,
+            "privacy_url": "pinglet://****@hostname/prefix/acme/deploys",
+        },
+    ),
+    # Host with a port
+    (
+        "pinglet://abc123@hostname:8080/acme/deploys",
+        {
+            "instance": NotifyPinglet,
+            "privacy_url": "pinglet://****@hostname:8080/acme/deploys",
+        },
+    ),
+    # Provide a priority
+    (
+        "pinglet://abc123@hostname/acme/deploys?priority=urgent",
+        {
+            "instance": NotifyPinglet,
+        },
+    ),
+    # Priorities support prefix matching (s => silent)
+    (
+        "pinglet://abc123@hostname/acme/deploys?priority=s",
+        {
+            "instance": NotifyPinglet,
+        },
+    ),
+    # An invalid priority takes on the default (normal)
+    (
+        "pinglet://abc123@hostname/acme/deploys?priority=invalid",
+        {
+            "instance": NotifyPinglet,
+        },
+    ),
+    # Badges (:key=value) and metadata (+key=value)
+    (
+        "pinglet://abc123@hostname/acme/deploys?:CPU=95%25&+region=eu-west",
+        {
+            "instance": NotifyPinglet,
+        },
+    ),
+    (
+        "pinglet://abc123@hostname/acme/deploys",
+        {
+            "instance": NotifyPinglet,
+            # force a failure
+            "response": False,
+            "requests_response_code": requests.codes.internal_server_error,
+        },
+    ),
+    (
+        "pinglets://abc123@localhost/acme/deploys",
+        {
+            "instance": NotifyPinglet,
+            # throw a bizarre code forcing us to fail to look it up
+            "response": False,
+            "requests_response_code": 999,
+        },
+    ),
+    (
+        "pinglet://abc123@localhost/acme/deploys",
+        {
+            "instance": NotifyPinglet,
+            # Throws a series of i/o exceptions with this flag
+            # is set and tests that we gracefully handle them
+            "test_requests_exceptions": True,
+        },
+    ),
+)
+
+
+def test_plugin_pinglet_urls():
+    """NotifyPinglet() Apprise URLs."""
+
+    # Run our general tests
+    AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+def test_plugin_pinglet_edge_cases():
+    """NotifyPinglet() Edge Cases."""
+    # Initializes the plugin with an invalid token
+    with pytest.raises(TypeError):
+        NotifyPinglet(token=None, namespace="acme", topic="deploys")
+    # Whitespace also acts as an invalid token value
+    with pytest.raises(TypeError):
+        NotifyPinglet(token="   ", namespace="acme", topic="deploys")
+
+    # Missing namespace and/or topic
+    with pytest.raises(TypeError):
+        NotifyPinglet(token="abc123", namespace=None, topic="deploys")
+    with pytest.raises(TypeError):
+        NotifyPinglet(token="abc123", namespace="acme", topic=None)
+
+
+@mock.patch("requests.post")
+def test_plugin_pinglet_payload(mock_post):
+    """NotifyPinglet() Payload Construction."""
+
+    # Prepare Mock
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    aobj = apprise.Apprise()
+    assert aobj.add(
+        "pinglets://mykey@app.pinglet.co.uk/acme/deploys"
+        "?priority=urgent&:CPU=95%25&:Host=web-1&+region=eu-west"
+    )
+
+    assert (
+        aobj.notify(
+            title="Hello",
+            body="It works",
+            notify_type=NotifyType.FAILURE,
+        )
+        is True
+    )
+
+    assert mock_post.call_count == 1
+    assert (
+        mock_post.call_args_list[0][0][0]
+        == "https://app.pinglet.co.uk/acme/deploys"
+    )
+
+    headers = mock_post.call_args_list[0][1]["headers"]
+    assert headers["Authorization"] == "Bearer mykey"
+
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+    assert payload["title"] == "Hello"
+    assert payload["message"] == "It works"
+    assert payload["priority"] == PingletPriority.URGENT
+    # The FAILURE notification type maps to Pinglet's 'error' level
+    assert payload["level"] == "error"
+    assert payload["badges"] == {"CPU": "95%", "Host": "web-1"}
+    assert payload["data"] == {"region": "eu-west"}
+
+
+@mock.patch("requests.post")
+def test_plugin_pinglet_payload_defaults(mock_post):
+    """NotifyPinglet() Payload Defaults."""
+
+    # Prepare Mock
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    aobj = apprise.Apprise()
+    assert aobj.add("pinglet://mykey@hostname/acme/deploys")
+
+    assert aobj.notify(body="It works") is True
+
+    assert mock_post.call_count == 1
+    assert mock_post.call_args_list[0][0][0] == "http://hostname/acme/deploys"
+
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+    # An empty title is omitted entirely
+    assert "title" not in payload
+    # No badges/metadata were specified so they are omitted
+    assert "badges" not in payload
+    assert "data" not in payload
+    assert payload["priority"] == PingletPriority.NORMAL
+    # The INFO notification type maps to Pinglet's 'info' level
+    assert payload["level"] == "info"
+
+
+def test_plugin_pinglet_limits():
+    """NotifyPinglet() Badge and Metadata Limits."""
+
+    # Badges are capped at 3 entries; keys are truncated to 24
+    # characters, and values to 32
+    obj = apprise.Apprise.instantiate(
+        "pinglet://abc123@hostname/acme/deploys"
+        "?:{}={}&:b=2&:c=3&:d=4&:e=5".format("k" * 30, "v" * 40)
+    )
+    assert isinstance(obj, NotifyPinglet)
+    assert len(obj.badges) == 3
+    assert "k" * 24 in obj.badges
+    assert obj.badges["k" * 24] == "v" * 32
+
+    # Metadata keys are truncated to 64 characters, and values to 256
+    obj = apprise.Apprise.instantiate(
+        "pinglet://abc123@hostname/acme/deploys?+{}={}".format(
+            "k" * 70, "v" * 300
+        )
+    )
+    assert isinstance(obj, NotifyPinglet)
+    assert obj.data == {"k" * 64: "v" * 256}
+
+
+def test_plugin_pinglet_priorities():
+    """NotifyPinglet() Priority Handling."""
+
+    for priority, expected in (
+        ("silent", PingletPriority.SILENT),
+        ("s", PingletPriority.SILENT),
+        ("NORMAL", PingletPriority.NORMAL),
+        ("urgent", PingletPriority.URGENT),
+        ("u", PingletPriority.URGENT),
+        # Invalid entries take on the default
+        ("invalid", PingletPriority.NORMAL),
+        ("", PingletPriority.NORMAL),
+    ):
+        obj = apprise.Apprise.instantiate(
+            f"pinglet://abc123@hostname/acme/deploys?priority={priority}"
+        )
+        assert isinstance(obj, NotifyPinglet)
+        assert obj.priority == expected, f"priority={priority}"

--- a/tests/test_plugin_pinglet.py
+++ b/tests/test_plugin_pinglet.py
@@ -196,6 +196,10 @@ def test_plugin_pinglet_edge_cases():
     with pytest.raises(TypeError):
         NotifyPinglet(token="abc123", namespace="acme", topic=None)
 
+    # Direct instantiation without a fullpath defaults to "/"
+    obj = NotifyPinglet(token="abc123", namespace="acme", topic="deploys")
+    assert obj.fullpath == "/"
+
 
 @mock.patch("requests.post")
 def test_plugin_pinglet_payload(mock_post):


### PR DESCRIPTION
## Description
**Related issue (if applicable):** N/A

Adds `pinglet://` / `pinglets://` notification support for [Pinglet](https://pinglet.co.uk), a push notification service built around topic feeds within a namespace. Notifications can optionally carry short "badge" pills and key/value metadata alongside the message body. Companion documentation PR: caronc/apprise-docs#<PR number once opened>.

## Pinglet Notifications
* **Source**: https://pinglet.co.uk
* **Image Support**: No
* **Message Format**: Plain Text
* **Message Limit**: 3000 characters

Pinglet delivers notifications to a topic within a namespace via a simple authenticated POST. Topics are auto-created on first publish.

## Account Setup
1. Sign up at https://pinglet.co.uk and sign in to your account.
2. Create (or note) the namespace and topic you want to publish to.
3. Generate your API key from the account/API section and copy it.

## Syntax

Valid syntax is as follows:
- `pinglet://{token}@{host}/{namespace}/{topic}`
- `pinglets://{token}@{host}/{namespace}/{topic}`
- `pinglets://{token}@{host}:{port}/{namespace}/{topic}`
- `pinglets://{token}@{host}{path}{namespace}/{topic}` (reverse-proxy path prefix)

## Parameter Breakdown

| Variable  | Required | Description   |
|-----------|----------|----------------|
| token     | Yes      | Your Pinglet API key (can also be passed as `?token=`) |
| host      | Yes      | Hostname of your Pinglet instance |
| port      | No       | Port, if not the default 80/443 |
| namespace | Yes      | The namespace the topic resides in |
| topic     | Yes      | The topic to publish to |
| priority  | No       | Delivery priority: `silent`, `normal` (default), or `urgent` |
| `:key=value` | No | Badge (pill) rendered on the notification card, up to 3 |
| `+key=value` | No | Metadata shown on the detail sheet |

## Examples

Sends a simple example:
```bash
apprise -vv -t "Title" -b "Message content" \
    pinglets://apikey@app.pinglet.co.uk/acme/deploys
```

Sends with a priority, a badge, and metadata:
```bash
apprise -vv -t "Deploy Complete" -b "Build #482 shipped to production" \
    "pinglets://apikey@app.pinglet.co.uk/acme/deploys?priority=urgent&:Host=web-1&+region=eu-west"
```

## New Service Completion Status
* [x] apprise/plugins/pinglet.py
* [x] pyproject.toml
    - Update keywords section to identify the new service (alphabetically).
* [x] README.md
    - Add entry for the new service (quick reference only).
* [x] packaging/redhat/python-apprise.spec
    - add new service into the `%global common_description`

## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/107](https://github.com/caronc/apprise-docs/pull/107)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/TheGlenn88/apprise.git@add-pinglet-support

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    pinglets://apikey@app.pinglet.co.uk/acme/deploys
```
