### PR TITLE
Synchronous log callback handling

### DIFF
--- a/apprise/apprise.py
+++ b/apprise/apprise.py
@@ -482,7 +482,7 @@ class Apprise:
         location: Optional[ContentLocation] = None,
         debug: bool = False,
         log_callback: Optional[
-            Callable[[NotifyLogEntry, NotifyBase], Any]
+            Callable[[NotifyLogEntry, NotifyBase], None]
         ] = None,
     ) -> None:
         """Loads a set of server urls while applying the Asset() module to each
@@ -493,8 +493,24 @@ class Apprise:
         Optionally specify a global ContentLocation for a more strict means of
         handling Attachments.
 
-        log_callback, when given, fires on every warning/error a service
-        logs. Applies to every notify() call unless overridden per-call.
+        log_callback receives each service warning or error as
+        ``log_callback(entry, service)``. It runs inline, so use a short
+        synchronous function and schedule any async work from there.
+        Keep each task referenced until it finishes because the event loop
+        holds only a weak reference:
+
+            loop = asyncio.get_running_loop()
+            background_tasks = set()
+
+            def _schedule(entry, service):
+                task = loop.create_task(
+                    my_async_handler(entry, service)
+                )
+                background_tasks.add(task)
+                task.add_done_callback(background_tasks.discard)
+
+            def log_callback(entry, service):
+                loop.call_soon_threadsafe(_schedule, entry, service)
         """
 
         # Initialize a server list of URLs
@@ -1134,7 +1150,7 @@ class Apprise:
         interpret_escapes: Optional[bool] = None,
         timeout: Union[int, float] = 0,
         log_callback: Optional[
-            Callable[[NotifyLogEntry, NotifyBase], Any]
+            Callable[[NotifyLogEntry, NotifyBase], None]
         ] = None,
     ) -> AppriseResult:
         """Send a notification to all the plugins previously loaded.
@@ -1195,7 +1211,8 @@ class Apprise:
         non-numeric values raise TypeError, exactly like
         AppriseAsset(service_timeout=...) itself.
 
-        log_callback overrides the instance default for this call only.
+        log_callback overrides the instance default for this call. It must be
+        synchronous; see ``Apprise.__init__()`` for an async-work example.
         """
         timeout = _validate_timeout(timeout)
         effective_log_callback = (
@@ -1395,9 +1412,9 @@ class Apprise:
         timeout: Union[int, float] = _validate_timeout(
             kwargs.pop("timeout", 0)
         )
-        log_callback: Optional[Callable[[NotifyLogEntry, NotifyBase], Any]] = (
-            kwargs.pop("log_callback", None)
-        )
+        log_callback: Optional[
+            Callable[[NotifyLogEntry, NotifyBase], None]
+        ] = kwargs.pop("log_callback", None)
         effective_log_callback = (
             log_callback if log_callback is not None else self._log_callback
         )

--- a/apprise/apprise.py
+++ b/apprise/apprise.py
@@ -493,24 +493,10 @@ class Apprise:
         Optionally specify a global ContentLocation for a more strict means of
         handling Attachments.
 
-        log_callback receives each service warning or error as
-        ``log_callback(entry, service)``. It runs inline, so use a short
-        synchronous function and schedule any async work from there.
-        Keep each task referenced until it finishes because the event loop
-        holds only a weak reference:
-
-            loop = asyncio.get_running_loop()
-            background_tasks = set()
-
-            def _schedule(entry, service):
-                task = loop.create_task(
-                    my_async_handler(entry, service)
-                )
-                background_tasks.add(task)
-                task.add_done_callback(background_tasks.discard)
-
-            def log_callback(entry, service):
-                loop.call_soon_threadsafe(_schedule, entry, service)
+        log_callback receives captured service warnings and errors as
+        ``log_callback(entry, service)``. It runs inline and must be a short,
+        synchronous function. Schedule async work from the callback when
+        needed.
         """
 
         # Initialize a server list of URLs
@@ -1212,7 +1198,7 @@ class Apprise:
         AppriseAsset(service_timeout=...) itself.
 
         log_callback overrides the instance default for this call. It must be
-        synchronous; see ``Apprise.__init__()`` for an async-work example.
+        synchronous; schedule any async work from inside the callback.
         """
         timeout = _validate_timeout(timeout)
         effective_log_callback = (

--- a/apprise/logger.py
+++ b/apprise/logger.py
@@ -28,7 +28,6 @@
 from __future__ import annotations
 
 import asyncio
-import concurrent.futures as cf
 import contextlib
 import contextvars
 from datetime import datetime, timezone
@@ -179,15 +178,15 @@ class NotifyLogEntry:
 class _ServiceLogCapture(logging.Handler):
     """Capture one service's warning and error messages in isolation.
 
-    It attaches one extra handler for a single attempt. ``log_callback``,
-    when provided, receives each captured (entry, service) live.
+    A temporary handler stores one attempt's entries. ``log_callback`` receives
+    them live and must return promptly; it can schedule async work if needed.
     """
 
     def __init__(
         self,
         service: NotifyBase,
         log_callback: Optional[
-            Callable[[NotifyLogEntry, NotifyBase], Any]
+            Callable[[NotifyLogEntry, NotifyBase], None]
         ] = None,
     ) -> None:
         """Prepare an isolated WARNING-level handler for ``service``."""
@@ -203,14 +202,6 @@ class _ServiceLogCapture(logging.Handler):
         # Kept only so log_callback can identify the service.
         self._service = service
         self._log_callback = log_callback
-
-        # support for async log_callback.
-        try:
-            self._loop: Optional[asyncio.AbstractEventLoop] = (
-                asyncio.get_running_loop()
-            )
-        except RuntimeError:
-            self._loop = None
 
         # Set on __enter__, used to restore _active_capture on __exit__.
         self._token: Optional[contextvars.Token] = None
@@ -277,12 +268,11 @@ class _ServiceLogCapture(logging.Handler):
     def _invoke_log_callback(
         self,
         entry: NotifyLogEntry,
-        callback: Callable[[NotifyLogEntry, NotifyBase], Any],
+        callback: Callable[[NotifyLogEntry, NotifyBase], None],
     ) -> None:
-        """Call log_callback(entry, service) for one captured entry.
+        """Call ``log_callback(entry, service)``.
 
-        The returned value tells us whether it was plain sync work or an
-        async coroutine that still needs scheduling.
+        Its return value is ignored.
         """
         try:
             result = callback(entry, self._service)
@@ -292,37 +282,14 @@ class _ServiceLogCapture(logging.Handler):
             logger.debug("log_callback Exception: %s", str(e))
             return
 
-        if not asyncio.iscoroutine(result):
-            return
-
-        if self._loop is None:
-            # No loop is available; close the coroutine to avoid a warning.
+        if asyncio.iscoroutine(result):
+            # Close unsupported async callbacks without leaking a warning.
             result.close()
             logger.warning(
-                "The log_callback returned async work, but no asyncio event "
-                "loop is running; this live log update was skipped: %s",
-                entry,
+                "The log_callback function must be synchronous; its "
+                "returned coroutine was ignored. Schedule async work "
+                "from inside the callback instead."
             )
-            return
-
-        # This is safe from worker threads and the loop's own thread.
-        future = asyncio.run_coroutine_threadsafe(result, self._loop)
-        future.add_done_callback(self._log_callback_done)
-
-    @staticmethod
-    def _log_callback_done(future: cf.Future[Any]) -> None:
-        """Surface any exception from a scheduled async log_callback."""
-        if future.cancelled():
-            logger.warning(
-                "A log_callback update was cancelled before it completed. "
-                "The log entry was still saved normally."
-            )
-            return
-
-        exc = future.exception()
-        if exc is not None:
-            logger.warning("The log_callback function raised an exception.")
-            logger.debug("log_callback Exception: %s", str(exc))
 
     @property
     def entries(self) -> list[NotifyLogEntry]:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -806,121 +806,22 @@ def test_service_log_capture_callback_error():
     assert [e.message for e in cap.entries] == ["still captured"]
 
 
-def test_service_log_capture_async_callback_loop():
-    """An async log_callback is scheduled on the active event loop."""
+def test_service_log_capture_rejects_async_callback(caplog):
+    """Reject an async callback without losing the captured warning."""
+    # Older pytest releases may leave logging disabled after another test.
     logging.disable(logging.NOTSET)
-    received = []
+    caplog.set_level(logging.WARNING, logger=logger.name)
 
     async def _cb(entry, service):
-        """Record after yielding to the event loop."""
-        await asyncio.sleep(0.01)
-        received.append((service.service_name, entry.message))
-
-    async def _run():
-        """Schedule one async callback."""
-        service = _DummyNotify()
-        with _ServiceLogCapture(service, log_callback=_cb) as cap:
-            service.logger.warning("async entry")
-        # emit() schedules the callback but cannot await it.
-        await asyncio.sleep(0.1)
-        return cap
-
-    try:
-        cap = asyncio.run(_run())
-    finally:
-        logging.disable(logging.CRITICAL)
-
-    assert received == [("dummy", "async entry")]
-    assert [e.message for e in cap.entries] == ["async entry"]
-
-
-def test_service_log_capture_async_callback_no_loop():
-    """An async log_callback without an event loop is closed cleanly."""
-    logging.disable(logging.NOTSET)
-
-    async def _cb(entry, service):
-        """Callback that should be closed before it can run."""
-        pass  # pragma: no cover -- never actually runs
+        """A callback mistakenly defined as async; body never runs."""
+        pass  # pragma: no cover -- the coroutine is closed, not awaited
 
     try:
         service = _DummyNotify()
         with _ServiceLogCapture(service, log_callback=_cb) as cap:
-            service.logger.warning("no loop available")
+            service.logger.warning("service warning")
     finally:
         logging.disable(logging.CRITICAL)
 
-    assert [e.message for e in cap.entries] == ["no loop available"]
-
-
-def test_service_log_capture_async_callback_error():
-    """A scheduled async log_callback exception is logged."""
-    logging.disable(logging.NOTSET)
-
-    async def _broken_cb(entry, service):
-        """Raise inside the scheduled task."""
-        raise ValueError("boom from async callback")
-
-    async def _run():
-        """Schedule the failing callback and allow it to finish."""
-        service = _DummyNotify()
-        with _ServiceLogCapture(service, log_callback=_broken_cb) as cap:
-            service.logger.warning("still captured despite async error")
-        await asyncio.sleep(0.1)
-        return cap
-
-    try:
-        with mock.patch.object(logger, "debug") as mock_debug:
-            cap = asyncio.run(_run())
-    finally:
-        logging.disable(logging.CRITICAL)
-
-    assert [e.message for e in cap.entries] == [
-        "still captured despite async error"
-    ]
-    assert mock_debug.called
-    assert "boom from async callback" in str(mock_debug.call_args)
-
-
-def test_service_log_capture_cancelled_callback_future():
-    """_log_callback_done must swallow a cancelled callback future."""
-    future = cf.Future()
-    future.cancel()
-    assert future.cancelled()
-
-    with (
-        mock.patch.object(logger, "warning") as mock_warning,
-        mock.patch.object(logger, "debug") as mock_debug,
-    ):
-        # Must not raise.
-        _ServiceLogCapture._log_callback_done(future)
-
-    assert mock_warning.called
-    assert "cancelled" in str(mock_warning.call_args).lower()
-    assert not mock_debug.called
-
-
-def test_service_log_capture_loop_shutdown_cancel():
-    """A pending async log_callback can be cancelled at loop shutdown."""
-    logging.disable(logging.NOTSET)
-
-    async def _cb(entry, service):
-        """Remain pending until asyncio.run() teardown."""
-        # Long enough to still be pending when _run() returns.
-        await asyncio.sleep(0.2)
-
-    async def _run():
-        """Schedule one callback without waiting for it to finish."""
-        service = _DummyNotify()
-        with _ServiceLogCapture(service, log_callback=_cb) as cap:
-            service.logger.warning("cancelled before callback finishes")
-        return cap
-
-    try:
-        # No callback cancellation should propagate out of asyncio.run().
-        cap = asyncio.run(_run())
-    finally:
-        logging.disable(logging.CRITICAL)
-
-    assert [e.message for e in cap.entries] == [
-        "cancelled before callback finishes"
-    ]
+    assert [e.message for e in cap.entries] == ["service warning"]
+    assert "must be synchronous" in caplog.text


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1666 
## Description

- `log_callback` is now strictly synchronous
- Removed the internal machinery that scheduled an async `log_callback` onto the running event loop

### Standard Simple Example
```python
import apprise


def on_log(entry, service):
    # A plain synchronous callback
    print(f"[{service.service_name}] {entry}")


aobj = apprise.Apprise(log_callback=on_log)
aobj.add("slack://tokenA/tokenB/tokenC")
aobj.add("discord://webhook_id/webhook_token")

# on_log() will now fire per log entry
aobj.notify(body="Deploying new release")
```

### Async Example
```python
import asyncio
import apprise


async def my_async_handler(entry, service):
    # An async  callback
    print(f"[{service.service_name}] {entry}")


async def main():
    loop = asyncio.get_running_loop()
    background_tasks = set()

    def _schedule(entry, service):
        # Runs on the loop thread
        task = loop.create_task(my_async_handler(entry, service))
        # Enforce a strong reference
        background_tasks.add(task)
        task.add_done_callback(background_tasks.discard)

    def log_callback(entry, service):
        # log_callback itself may run on any thread
        loop.call_soon_threadsafe(_schedule, entry, service)

    aobj = apprise.Apprise(log_callback=log_callback)
    aobj.add("slack://tokenA/tokenB/tokenC")

    # Send notification which will call my_async_handler() per log entry
    await aobj.async_notify(body="Deploying new release")


asyncio.run(main())
```

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/109](https://github.com/caronc/apprise-docs/pull/109)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@log-callback-sync-refactor

# Run the affected test files directly
python -m pytest tests/test_logger.py tests/test_retry_wait.py -q
```