### PR TITLE
feat(bark): add AES-GCM encryption

### DIFF
--- a/apprise/plugins/bark.py
+++ b/apprise/plugins/bark.py
@@ -28,9 +28,19 @@
 #
 # API: https://github.com/Finb/bark-server/blob/master/docs/API_V2.md#python
 #
+import base64
 import json
+import secrets
 
 import requests
+
+try:
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+    BARK_AESGCM_SUPPORT = True
+
+except ImportError:
+    BARK_AESGCM_SUPPORT = False
 
 from ..common import NotifyFormat, NotifyImageSize, NotifyType
 from ..locale import gettext_lazy as _
@@ -95,12 +105,20 @@ BARK_LEVELS = (
     NotifyBarkLevel.CRITICAL,
 )
 
+BARK_AES_KEY_LENGTHS = frozenset({16, 24, 32})
+BARK_GCM_IV_RANDOM_BYTES = 9
+BARK_GCM_IV_LENGTH = 12
+
 
 class NotifyBark(NotifyBase):
     """A wrapper for Notify Bark Notifications."""
 
     # The default descriptive name associated with the Notification
     service_name = "Bark"
+
+    requirements = {
+        "packages_recommended": "cryptography",
+    }
 
     # The services URL
     service_url = "https://github.com/Finb/Bark"
@@ -154,11 +172,13 @@ class NotifyBark(NotifyBase):
                 "name": _("Target Device"),
                 "type": "string",
                 "map_to": "targets",
+                "private": True,
             },
             "targets": {
                 "name": _("Targets"),
                 "type": "list:string",
                 "required": True,
+                "private": True,
             },
         },
     )
@@ -215,6 +235,12 @@ class NotifyBark(NotifyBase):
                 "type": "bool",
                 "default": False,
             },
+            "key": {
+                "name": _("Encryption Key"),
+                "type": "string",
+                "private": True,
+                "map_to": "encryption_key",
+            },
             "to": {
                 "alias_of": "targets",
             },
@@ -234,6 +260,7 @@ class NotifyBark(NotifyBase):
         volume=None,
         icon=None,
         call=None,
+        encryption_key=None,
         **kwargs,
     ):
         """Initialize Notify Bark Object."""
@@ -314,6 +341,39 @@ class NotifyBark(NotifyBase):
 
         # Call
         self.call = parse_bool(call)
+
+        self.encryption_key = None
+        self._cipher = None
+        if encryption_key:
+            try:
+                encryption_key_bytes = encryption_key.encode("ascii")
+
+            except (AttributeError, UnicodeEncodeError):
+                msg = (
+                    "The Bark encryption key must contain only ASCII "
+                    "characters."
+                )
+                self.logger.warning(msg)
+                raise TypeError(msg) from None
+
+            if len(encryption_key_bytes) not in BARK_AES_KEY_LENGTHS:
+                msg = (
+                    "The Bark encryption key must contain exactly 16, 24, or "
+                    "32 ASCII characters."
+                )
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
+            if not BARK_AESGCM_SUPPORT:
+                msg = (
+                    "Bark encryption requires the 'cryptography' package. "
+                    "Install Apprise with the 'all-plugins' extra."
+                )
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
+            self.encryption_key = encryption_key
+            self._cipher = AESGCM(encryption_key_bytes)
 
         # Icon URL
         self.icon = icon if isinstance(icon, str) else None
@@ -418,20 +478,46 @@ class NotifyBark(NotifyBase):
         while len(targets) > 0:
             # Retrieve our device key
             target = targets.pop()
+            private_target = self.pprint(
+                target,
+                privacy=True,
+                mode=PrivacyMode.Secret,
+                safe="",
+            )
 
-            payload["device_key"] = target
+            request_payload = {"device_key": target, **payload}
+            if self._cipher is not None:
+                try:
+                    ciphertext, iv = self._encrypt_payload(payload)
+                    request_payload = {
+                        "device_key": target,
+                        "ciphertext": ciphertext,
+                        "iv": iv,
+                    }
+
+                except Exception as e:
+                    self.logger.warning("Failed to encrypt Bark notification.")
+                    self.logger.debug(
+                        "Bark encryption failed with %s.", type(e).__name__
+                    )
+                    has_error = True
+                    continue
+
             self.logger.debug(
                 "Bark POST URL:"
-                f" {self.notify_url} (cert_verify={self.verify_certificate!r})"
+                f" {self.notify_url} "
+                f"(cert_verify={self.verify_certificate!r}, "
+                f"encrypted={self._cipher is not None!r})"
             )
-            self.logger.debug(f"Bark Payload: {payload!s}")
+            if self._cipher is None:
+                self.logger.debug(f"Bark Payload: {request_payload!s}")
 
             # Always call throttle before any remote server i/o is made
             self.throttle()
             try:
                 r = requests.post(
                     self.notify_url,
-                    data=json.dumps(payload),
+                    data=json.dumps(request_payload),
                     headers=headers,
                     auth=auth,
                     verify=self.verify_certificate,
@@ -447,36 +533,59 @@ class NotifyBark(NotifyBase):
                     self.logger.warning(
                         "Failed to send Bark notification to {}: "
                         "{}{}error={}.".format(
-                            target,
+                            private_target,
                             status_str,
                             ", " if status_str else "",
                             r.status_code,
                         )
                     )
 
-                    self.logger.debug(
-                        "Response Details:\r\n%r", (r.content or b"")[:2000]
-                    )
+                    if self._cipher is None:
+                        self.logger.debug(
+                            "Response Details:\r\n%r",
+                            (r.content or b"")[:2000],
+                        )
 
                     # Mark our failure
                     has_error = True
                     continue
 
                 else:
-                    self.logger.info(f"Sent Bark notification to {target}.")
+                    self.logger.info(
+                        f"Sent Bark notification to {private_target}."
+                    )
 
             except requests.RequestException as e:
                 self.logger.warning(
                     "A Connection error occurred sending Bark "
-                    f"notification to {target}."
+                    f"notification to {private_target}."
                 )
-                self.logger.debug(f"Socket Exception: {e!s}")
+                if self._cipher is None:
+                    self.logger.debug(f"Socket Exception: {e!s}")
 
                 # Mark our failure
                 has_error = True
                 continue
 
         return not has_error
+
+    def _encrypt_payload(self, payload):
+        """Encrypt one Bark parameter object with a fresh AES-GCM IV."""
+        iv = secrets.token_urlsafe(BARK_GCM_IV_RANDOM_BYTES)
+        if len(iv) != BARK_GCM_IV_LENGTH or not iv.isascii():
+            raise ValueError("Bark generated an incompatible AES-GCM IV")
+
+        plaintext = json.dumps(
+            payload,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        ciphertext = self._cipher.encrypt(
+            iv.encode("ascii"),
+            plaintext,
+            None,
+        )
+        return base64.b64encode(ciphertext).decode("ascii"), iv
 
     @property
     def url_identifier(self):
@@ -491,6 +600,7 @@ class NotifyBark(NotifyBase):
             self.password,
             self.host,
             self.port,
+            self.encryption_key,
         )
 
     def url(self, privacy=False, *args, **kwargs):
@@ -528,6 +638,14 @@ class NotifyBark(NotifyBase):
         if self.call:
             params["call"] = "yes"
 
+        if self.encryption_key:
+            params["key"] = self.pprint(
+                self.encryption_key,
+                privacy,
+                mode=PrivacyMode.Secret,
+                safe="",
+            )
+
         # Extend our parameters
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
 
@@ -556,7 +674,17 @@ class NotifyBark(NotifyBase):
                 if self.port is None or self.port == default_port
                 else f":{self.port}"
             ),
-            targets="/".join([NotifyBark.quote(f"{x}") for x in self.targets]),
+            targets="/".join(
+                [
+                    self.pprint(
+                        f"{x}",
+                        privacy,
+                        mode=PrivacyMode.Secret,
+                        safe="",
+                    )
+                    for x in self.targets
+                ]
+            ),
             params=NotifyBark.urlencode(params),
         )
 
@@ -637,4 +765,15 @@ class NotifyBark(NotifyBase):
         # Call
         results["call"] = parse_bool(results["qsd"].get("call", False))
 
+        # Encryption Key
+        if "key" in results["qsd"] and results["qsd"]["key"]:
+            results["encryption_key"] = NotifyBark.unquote(
+                results["qsd"]["key"]
+            )
+
         return results
+
+    @staticmethod
+    def runtime_deps():
+        """Return optional runtime dependency package names."""
+        return ("cryptography",)

--- a/apprise/plugins/bark.py
+++ b/apprise/plugins/bark.py
@@ -342,9 +342,12 @@ class NotifyBark(NotifyBase):
         # Call
         self.call = parse_bool(call)
 
+        # Encryption is off unless an encryption key was explicitly given
         self.encryption_key = None
         self._cipher = None
         if encryption_key:
+            # The Bark app expects a raw ASCII key, so reject anything
+            # that can't be represented as one up front
             try:
                 encryption_key_bytes = encryption_key.encode("ascii")
 
@@ -356,6 +359,7 @@ class NotifyBark(NotifyBase):
                 self.logger.warning(msg)
                 raise TypeError(msg) from None
 
+            # AES-GCM only accepts 128/192/256-bit (16/24/32 byte) keys
             if len(encryption_key_bytes) not in BARK_AES_KEY_LENGTHS:
                 msg = (
                     "The Bark encryption key must contain exactly 16, 24, or "
@@ -364,6 +368,8 @@ class NotifyBark(NotifyBase):
                 self.logger.warning(msg)
                 raise TypeError(msg)
 
+            # Fail closed; never fall back to sending plaintext when the
+            # caller asked for encryption but the library isn't available
             if not BARK_AESGCM_SUPPORT:
                 msg = (
                     "Bark encryption requires the 'cryptography' package. "
@@ -372,6 +378,7 @@ class NotifyBark(NotifyBase):
                 self.logger.warning(msg)
                 raise TypeError(msg)
 
+            # We're ready to encrypt every outbound payload with this key
             self.encryption_key = encryption_key
             self._cipher = AESGCM(encryption_key_bytes)
 
@@ -485,8 +492,10 @@ class NotifyBark(NotifyBase):
                 safe="",
             )
 
-            request_payload = {"device_key": target, **payload}
             if self._cipher is not None:
+                # Encrypt the payload; on success this replaces the
+                # plaintext fields with a device_key/ciphertext/iv wire
+                # payload for this target
                 try:
                     ciphertext, iv = self._encrypt_payload(payload)
                     request_payload = {
@@ -496,12 +505,18 @@ class NotifyBark(NotifyBase):
                     }
 
                 except Exception as e:
+                    # Fail closed; never fall back to sending this
+                    # target's notification as plaintext
                     self.logger.warning("Failed to encrypt Bark notification.")
                     self.logger.debug(
                         "Bark encryption failed with %s.", type(e).__name__
                     )
                     has_error = True
                     continue
+
+            else:
+                # Plaintext payload; just tag on this target's device key
+                request_payload = {"device_key": target, **payload}
 
             self.logger.debug(
                 "Bark POST URL:"
@@ -510,6 +525,7 @@ class NotifyBark(NotifyBase):
                 f"encrypted={self._cipher is not None!r})"
             )
             if self._cipher is None:
+                # Never log ciphertext/iv; there's nothing readable in it
                 self.logger.debug(f"Bark Payload: {request_payload!s}")
 
             # Always call throttle before any remote server i/o is made
@@ -541,6 +557,8 @@ class NotifyBark(NotifyBase):
                     )
 
                     if self._cipher is None:
+                        # The response body is only safe to log when we
+                        # sent a plaintext request in the first place
                         self.logger.debug(
                             "Response Details:\r\n%r",
                             (r.content or b"")[:2000],
@@ -561,6 +579,8 @@ class NotifyBark(NotifyBase):
                     f"notification to {private_target}."
                 )
                 if self._cipher is None:
+                    # Suppress low-level exception text once encryption
+                    # is active; it may echo back request fragments
                     self.logger.debug(f"Socket Exception: {e!s}")
 
                 # Mark our failure
@@ -571,20 +591,30 @@ class NotifyBark(NotifyBase):
 
     def _encrypt_payload(self, payload):
         """Encrypt one Bark parameter object with a fresh AES-GCM IV."""
+
+        # Generate a fresh IV for every request; Bark's client rebuilds
+        # this string as raw bytes, so it must land on exactly 12 ASCII
+        # characters (a 96-bit GCM nonce)
         iv = secrets.token_urlsafe(BARK_GCM_IV_RANDOM_BYTES)
         if len(iv) != BARK_GCM_IV_LENGTH or not iv.isascii():
             raise ValueError("Bark generated an incompatible AES-GCM IV")
 
+        # Bark decrypts a compact JSON object back into its parameters
         plaintext = json.dumps(
             payload,
             ensure_ascii=False,
             separators=(",", ":"),
         ).encode("utf-8")
+
+        # No additional authenticated data; tag is appended to the
+        # ciphertext automatically (GCM "combined" mode)
         ciphertext = self._cipher.encrypt(
             iv.encode("ascii"),
             plaintext,
             None,
         )
+
+        # Bark expects the ciphertext base64-encoded and the IV as-is
         return base64.b64encode(ciphertext).decode("ascii"), iv
 
     @property

--- a/tests/test_plugin_bark.py
+++ b/tests/test_plugin_bark.py
@@ -26,14 +26,18 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 # Disable logging for a cleaner testing output
+import base64
 import json
 import logging
+import re
 from unittest import mock
 
 from helpers import AppriseURLTester
+import pytest
 import requests
 
 from apprise import Apprise, NotifyFormat
+import apprise.plugins.bark as bark_module
 from apprise.plugins.bark import NotifyBark
 
 logging.disable(logging.CRITICAL)
@@ -232,7 +236,7 @@ apprise_url_tests = (
             "response": False,
             "requests_response_code": 999,
             # Our expected url(privacy=True) startswith() response:
-            "privacy_url": "barks://192.168.0.7/device_key",
+            "privacy_url": "barks://192.168.0.7/****",
         },
     ),
     (
@@ -322,3 +326,349 @@ def test_plugin_bark_html_to_markdown_format(mock_post):
     # The body must arrive as Markdown, not stripped plain text
     payload = json.loads(mock_post.call_args_list[0][1]["data"])
     assert payload["markdown"] == "**hello** *world*"
+
+
+@pytest.mark.parametrize(
+    ("key", "expected_ciphertext"),
+    (
+        (
+            "k" * 16,
+            "M31imDGJqdEEszZWcWfgiMTooJniyhmvnRIIrUSrWDVi3FxcD9cl1Dyre2wQ8a5I2bhFyBrGPeMEwp1+Uw==",
+        ),
+        (
+            "k" * 24,
+            "QyuvztP2Yktq2khUWXw6hYrjLnhuc+kC44lyGOaVYBRJC4vsYaB6RewayvX+4ZKjUUIifRWDtIiVFq/KgA==",
+        ),
+        (
+            "k" * 32,
+            "a9CkBbe9d0qkskyAzKyb4pV/WjH6D1J/JLm0EOUTMcoTpJEs10gqANkkLKaOPqVXL0yo0AaxElYjmLmynw==",
+        ),
+    ),
+)
+def test_plugin_bark_aesgcm_wire_format(
+    key,
+    expected_ciphertext,
+    monkeypatch,
+):
+    """NotifyBark() matches Bark's AES-GCM combined wire format."""
+    pytest.importorskip("cryptography")
+    monkeypatch.setattr(
+        bark_module.secrets,
+        "token_urlsafe",
+        lambda length: "fixed-iv-123",
+    )
+    instance = NotifyBark(
+        host="localhost",
+        targets=("device-key",),
+        secure=True,
+        encryption_key=key,
+    )
+
+    ciphertext, iv = instance._encrypt_payload(
+        {"body": "Encrypted weather", "level": "active"}
+    )
+
+    assert iv == "fixed-iv-123"
+    assert ciphertext == expected_ciphertext
+
+
+@pytest.mark.parametrize(
+    "key",
+    (
+        pytest.param("short", id="too-short"),
+        pytest.param("k" * 17, id="unsupported-length"),
+        pytest.param("🔒" * 16, id="non-ascii-unicode-probe"),
+        pytest.param(b"k" * 16, id="non-string"),
+    ),
+)
+def test_plugin_bark_rejects_invalid_encryption_keys(key):
+    """NotifyBark() rejects keys Bark cannot use as raw AES keys."""
+    with pytest.raises(TypeError, match="Bark encryption key"):
+        NotifyBark(
+            host="localhost",
+            targets=("device-key",),
+            secure=True,
+            encryption_key=key,
+        )
+
+
+def test_plugin_bark_encryption_fails_closed_without_cryptography(monkeypatch):
+    """NotifyBark() never downgrades requested encryption to plaintext."""
+    monkeypatch.setattr(bark_module, "BARK_AESGCM_SUPPORT", False)
+
+    with pytest.raises(TypeError, match="requires the 'cryptography' package"):
+        NotifyBark(
+            host="localhost",
+            targets=("device-key",),
+            secure=True,
+            encryption_key="k" * 32,
+        )
+
+    instance = NotifyBark(
+        host="localhost",
+        targets=("device-key",),
+        secure=True,
+    )
+    assert instance.encryption_key is None
+
+
+def test_plugin_bark_encryption_url_roundtrip_and_privacy():
+    """NotifyBark() preserves encryption config without exposing secrets."""
+    pytest.importorskip("cryptography")
+    device_key = "private-device-key"
+    encryption_key = "k" * 32
+    instance = NotifyBark(
+        host="localhost",
+        targets=(device_key,),
+        secure=True,
+        encryption_key=encryption_key,
+    )
+
+    generated_url = instance.url(privacy=False)
+    assert device_key in generated_url
+    assert encryption_key in generated_url
+
+    private_url = instance.url(privacy=True)
+    assert device_key not in private_url
+    assert encryption_key not in private_url
+    assert private_url.startswith("barks://localhost/****?")
+    assert "key=" in private_url
+
+    parsed = NotifyBark.parse_url(generated_url)
+    rebuilt = NotifyBark(**parsed)
+    assert rebuilt.encryption_key == encryption_key
+    assert rebuilt.targets == [device_key]
+    assert rebuilt.url_identifier == instance.url_identifier
+
+    different_key = NotifyBark(
+        host="localhost",
+        targets=(device_key,),
+        secure=True,
+        encryption_key="x" * 32,
+    )
+    assert different_key.url_identifier != instance.url_identifier
+
+
+@mock.patch("requests.post")
+def test_plugin_bark_encrypts_complete_payload_with_fresh_iv_per_target(
+    mock_post,
+    monkeypatch,
+):
+    """NotifyBark() encrypts all parameters and rotates IVs per request."""
+    aesgcm = pytest.importorskip(
+        "cryptography.hazmat.primitives.ciphers.aead"
+    ).AESGCM
+    generated_ivs = iter(("abcdefghijkl", "mnopqrstuvwx"))
+    token_urlsafe = mock.Mock(side_effect=lambda length: next(generated_ivs))
+    monkeypatch.setattr(
+        bark_module.secrets,
+        "token_urlsafe",
+        token_urlsafe,
+    )
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+    key = "k" * 32
+    private_body = "Private encrypted body"
+    private_title = "Private encrypted title"
+    targets = ("private-device-one", "private-device-two")
+    instance = NotifyBark(
+        host="localhost",
+        targets=targets,
+        secure=True,
+        encryption_key=key,
+        include_image=False,
+        sound="alarm",
+        category="private-category",
+        group="private-group",
+        level="active",
+        click="https://private.example.invalid",
+        badge=3,
+        volume=4,
+        icon="https://private.example.invalid/icon.png",
+        call=True,
+    )
+    instance.logger = mock.Mock()
+
+    assert instance.send(body=private_body, title=private_title) is True
+    assert mock_post.call_count == 2
+
+    request_payloads = [
+        json.loads(call.kwargs["data"]) for call in mock_post.call_args_list
+    ]
+    assert {payload["device_key"] for payload in request_payloads} == set(
+        targets
+    )
+    assert [payload["iv"] for payload in request_payloads] == [
+        "abcdefghijkl",
+        "mnopqrstuvwx",
+    ]
+    assert token_urlsafe.call_args_list == [
+        mock.call(bark_module.BARK_GCM_IV_RANDOM_BYTES),
+        mock.call(bark_module.BARK_GCM_IV_RANDOM_BYTES),
+    ]
+    assert all(
+        re.fullmatch(r"[A-Za-z0-9_-]{12}", payload["iv"])
+        for payload in request_payloads
+    )
+    assert all(
+        set(payload) == {"device_key", "ciphertext", "iv"}
+        for payload in request_payloads
+    )
+
+    expected_parameters = {
+        "title": private_title,
+        "body": private_body,
+        "sound": "alarm.caf",
+        "url": "https://private.example.invalid",
+        "badge": 3,
+        "level": "active",
+        "category": "private-category",
+        "group": "private-group",
+        "volume": 4,
+        "icon": "https://private.example.invalid/icon.png",
+        "call": 1,
+    }
+    for request_payload in request_payloads:
+        plaintext = aesgcm(key.encode("ascii")).decrypt(
+            request_payload["iv"].encode("ascii"),
+            base64.b64decode(request_payload["ciphertext"]),
+            None,
+        )
+        assert json.loads(plaintext) == expected_parameters
+
+    logged = repr(instance.logger.method_calls)
+    for private_value in (
+        key,
+        private_body,
+        private_title,
+        *targets,
+        "private-category",
+        "private-group",
+        "private.example.invalid",
+    ):
+        assert private_value not in logged
+
+
+@mock.patch("requests.post")
+def test_plugin_bark_encrypts_markdown_payload(mock_post, monkeypatch):
+    """NotifyBark() encrypts Markdown and does not add a plaintext body."""
+    aesgcm = pytest.importorskip(
+        "cryptography.hazmat.primitives.ciphers.aead"
+    ).AESGCM
+    monkeypatch.setattr(
+        bark_module.secrets,
+        "token_urlsafe",
+        lambda length: "fixed-iv-123",
+    )
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+    key = "k" * 32
+    instance = NotifyBark(
+        host="localhost",
+        targets=("device-key",),
+        secure=True,
+        encryption_key=key,
+        include_image=False,
+        format=NotifyFormat.MARKDOWN,
+    )
+
+    assert instance.send(body="**encrypted**", title="Title") is True
+
+    request_payload = json.loads(mock_post.call_args.kwargs["data"])
+    plaintext = aesgcm(key.encode("ascii")).decrypt(
+        request_payload["iv"].encode("ascii"),
+        base64.b64decode(request_payload["ciphertext"]),
+        None,
+    )
+    assert json.loads(plaintext) == {
+        "title": "Title",
+        "markdown": "**encrypted**",
+    }
+
+
+@mock.patch("requests.post")
+def test_plugin_bark_rotates_iv_across_repeated_sends(
+    mock_post,
+    monkeypatch,
+):
+    """NotifyBark() generates a fresh IV for every repeated request."""
+    pytest.importorskip("cryptography")
+    generated_ivs = iter(("abcdefghijkl", "mnopqrstuvwx"))
+    monkeypatch.setattr(
+        bark_module.secrets,
+        "token_urlsafe",
+        lambda length: next(generated_ivs),
+    )
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+    instance = NotifyBark(
+        host="localhost",
+        targets=("device-key",),
+        secure=True,
+        encryption_key="k" * 32,
+        include_image=False,
+    )
+
+    assert instance.send(body="same body", title="same title") is True
+    assert instance.send(body="same body", title="same title") is True
+
+    payloads = [
+        json.loads(call.kwargs["data"]) for call in mock_post.call_args_list
+    ]
+    assert [payload["iv"] for payload in payloads] == [
+        "abcdefghijkl",
+        "mnopqrstuvwx",
+    ]
+    assert payloads[0]["ciphertext"] != payloads[1]["ciphertext"]
+
+
+def test_plugin_bark_rejects_incompatible_generated_iv(monkeypatch):
+    """NotifyBark() rejects RNG output Bark cannot decrypt."""
+    pytest.importorskip("cryptography")
+    monkeypatch.setattr(
+        bark_module.secrets,
+        "token_urlsafe",
+        lambda length: "too-short",
+    )
+    instance = NotifyBark(
+        host="localhost",
+        targets=("device-key",),
+        secure=True,
+        encryption_key="k" * 32,
+    )
+
+    with pytest.raises(ValueError, match="incompatible AES-GCM IV"):
+        instance._encrypt_payload({"body": "private body"})
+
+
+@mock.patch("requests.post")
+def test_plugin_bark_encryption_failure_prevents_network_io(mock_post):
+    """NotifyBark() fails closed when payload encryption fails."""
+    pytest.importorskip("cryptography")
+    instance = NotifyBark(
+        host="localhost",
+        targets=("private-device",),
+        secure=True,
+        encryption_key="k" * 32,
+        include_image=False,
+    )
+    instance.logger = mock.Mock()
+    instance._encrypt_payload = mock.Mock(
+        side_effect=ValueError("private encryption detail")
+    )
+
+    assert instance.send(body="private body", title="private title") is False
+    mock_post.assert_not_called()
+    logged = repr(instance.logger.method_calls)
+    assert "private encryption detail" not in logged
+    assert "private body" not in logged
+    assert "private title" not in logged
+    assert "private-device" not in logged
+
+
+def test_plugin_bark_runtime_dependencies():
+    """NotifyBark() declares its optional cryptography dependency."""
+    assert NotifyBark.runtime_deps() == ("cryptography",)

--- a/tests/test_plugin_bark.py
+++ b/tests/test_plugin_bark.py
@@ -669,6 +669,75 @@ def test_plugin_bark_encryption_failure_prevents_network_io(mock_post):
     assert "private-device" not in logged
 
 
+@mock.patch("requests.post")
+def test_plugin_bark_encrypted_send_http_error(mock_post, monkeypatch):
+    """NotifyBark() suppresses response details when encrypted."""
+    pytest.importorskip("cryptography")
+    monkeypatch.setattr(
+        bark_module.secrets,
+        "token_urlsafe",
+        lambda length: "fixed-iv-123",
+    )
+    response = mock.Mock()
+    response.status_code = requests.codes.internal_server_error
+    response.content = b"private response body"
+    mock_post.return_value = response
+    instance = NotifyBark(
+        host="localhost",
+        targets=("private-device",),
+        secure=True,
+        encryption_key="k" * 32,
+        include_image=False,
+    )
+    instance.logger = mock.Mock()
+
+    assert instance.send(body="private body", title="private title") is False
+    # The encrypted request still went out; it's the server's response
+    # that failed, not the encryption step
+    assert mock_post.call_count == 1
+
+    # A failure warning must still surface, just without the response
+    # body attached to it
+    instance.logger.warning.assert_called_once()
+    logged = repr(instance.logger.method_calls)
+    assert "private response body" not in logged
+    assert "private body" not in logged
+    assert "private title" not in logged
+    assert "private-device" not in logged
+
+
+@mock.patch("requests.post")
+def test_plugin_bark_encrypted_send_connection_error(mock_post, monkeypatch):
+    """NotifyBark() suppresses socket exception details when encrypted."""
+    pytest.importorskip("cryptography")
+    monkeypatch.setattr(
+        bark_module.secrets,
+        "token_urlsafe",
+        lambda length: "fixed-iv-123",
+    )
+    mock_post.side_effect = requests.RequestException("private socket detail")
+    instance = NotifyBark(
+        host="localhost",
+        targets=("private-device",),
+        secure=True,
+        encryption_key="k" * 32,
+        include_image=False,
+    )
+    instance.logger = mock.Mock()
+
+    assert instance.send(body="private body", title="private title") is False
+    assert mock_post.call_count == 1
+
+    # A failure warning must still surface, just without the raw
+    # exception text attached to it
+    instance.logger.warning.assert_called_once()
+    logged = repr(instance.logger.method_calls)
+    assert "private socket detail" not in logged
+    assert "private body" not in logged
+    assert "private title" not in logged
+    assert "private-device" not in logged
+
+
 def test_plugin_bark_runtime_dependencies():
     """NotifyBark() declares its optional cryptography dependency."""
     assert NotifyBark.runtime_deps() == ("cryptography",)


### PR DESCRIPTION
Bark supports AES-GCM encrypted notifications, while the current Apprise plugin only sends plaintext. This path has been exercised in another project for about a month. Supporting it in Apprise avoids requiring a permanently maintained parallel Bark publisher.

This change:

- accepts an optional private `key` for 16-, 24-, or 32-byte AES keys;
- encrypts the complete Bark parameter object with AES-GCM and a fresh Bark-compatible IV for every target request;
- fails closed when encryption is requested but unavailable or unsuccessful;
- keeps plaintext Bark behavior available without the optional `cryptography` dependency;
- protects encryption and device keys in rendered private URLs and encrypted-path logs; and
- adds interoperability, IV rotation, dependency, URL privacy, and plaintext regression coverage.
