### PR TITLE
v2 - Improved handling matrix message splitting

### DIFF
--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -50,6 +50,7 @@ from ...common import (
     NotifyType,
     PersistentStoreMode,
 )
+from ...conversion import html_to_text
 from ...exception import AppriseException
 from ...locale import gettext_lazy as _
 from ...url import PrivacyMode
@@ -67,6 +68,14 @@ from .e2ee import (
     encrypt_attachment,
     verify_device_keys,
     verify_signed_otk,
+)
+from .sizing import (
+    MATRIX_EVENT_BYTE_LIMIT,
+    MATRIX_EVENT_SAFETY_MARGIN,
+    body_char_limit as _matrix_body_char_limit,
+    effective_body_maxlen as _matrix_effective_body_maxlen_var,
+    payload_preview as _matrix_payload_preview,
+    sanitize_text as _matrix_sanitize_text,
 )
 
 # Define default path
@@ -190,8 +199,20 @@ class NotifyMatrix(NotifyBase):
     # A URL that takes you to the setup/help of the specific protocol
     setup_url = "https://appriseit.com/services/matrix/"
 
+    # Matrix supports plain text, HTML, and Markdown (rendered to HTML).
+    # TEXT remains the default to preserve existing URLs' behavior.
+    notify_format = (
+        NotifyFormat.TEXT,
+        NotifyFormat.HTML,
+        NotifyFormat.MARKDOWN,
+    )
+
     # Allows the user to specify the NotifyImageSize object
     image_size = NotifyImageSize.XY_32
+
+    # Matrix sizing accounts for titles separately from body chunks.
+    title_maxlen = 250
+    overflow_amalgamate_title = False
 
     # The maximum allowable characters allowed in the body per message
     # https://spec.matrix.org/v1.6/client-server-api/#size-limits
@@ -199,9 +220,14 @@ class NotifyMatrix(NotifyBase):
     # with the federation event format, including any signatures, and encoded
     # as Canonical JSON.
     #
-    # To gracefully allow for some overhead' we'll define a max body length
-    # of just slighty lower then the limit of the full message itself.
-    body_maxlen = 65000
+    # These are fallback values used outside content-aware message preparation.
+    # They leave room for event structure when body_maxlen is read before a
+    # message is prepared or while a webhook uses its own payload shape.
+    body_maxlen_default = 65000
+
+    # Encrypted events use a lower fallback limit because encryption and its
+    # JSON wrapper increase the final message size.
+    body_maxlen_e2ee = 40000
 
     # Throttle a wee-bit to avoid thrashing
     request_rate_per_sec = 0.5
@@ -552,8 +578,64 @@ class NotifyMatrix(NotifyBase):
                 with contextlib.suppress(Exception):
                     self._e2ee_account = MatrixOlmAccount.from_dict(acct_data)
 
-    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+    def _build_send_calls(
+        self, body=None, title=None, body_format=None, **kwargs
+    ):
+        """Choose a content-aware limit before normal framework splitting.
+
+        A normalized preview sizes direct events without changing the values
+        passed to the framework. This preserves its trimming behavior and
+        warnings while accounting for JSON, rich text, titles, and E2EE.
+        """
+        if self.mode == MatrixWebhookMode.DISABLED:
+            # Build a bounded preview without changing framework inputs.
+            preview_body, preview_title = _matrix_payload_preview(
+                self.asset, body, title
+            )
+
+            # Resolve the actual format used by this individual send.
+            resolved_format = self.resolve_format(body_format)
+
+            # Encryption is possible only with TLS and optional E2EE support.
+            e2ee_capable = self.e2ee and self.secure and MATRIX_E2EE_SUPPORT
+
+            # Keep concurrent calls from sharing temporary sizing state.
+            token = _matrix_effective_body_maxlen_var.set(
+                _matrix_body_char_limit(
+                    preview_body,
+                    preview_title[: self.title_maxlen],
+                    resolved_format,
+                    e2ee_capable,
+                    self.device_id,
+                    self.escape_html,
+                )
+            )
+        else:
+            token = None
+
+        try:
+            # Split and repair the original values through the framework.
+            yield from super()._build_send_calls(
+                body=body, title=title, body_format=body_format, **kwargs
+            )
+        finally:
+            # Restore the previous value after this generator finishes.
+            if token is not None:
+                _matrix_effective_body_maxlen_var.reset(token)
+
+    def send(
+        self,
+        body,
+        title="",
+        notify_type=NotifyType.INFO,
+        body_format=None,
+        **kwargs,
+    ):
         """Perform Matrix Notification."""
+
+        # Sanitize each bounded chunk before any delivery mode serializes it.
+        body = _matrix_sanitize_text(body)
+        title = _matrix_sanitize_text(title)
 
         # Call the _send_ function applicable to whatever mode we're in
         # - calls _send_webhook_notification if the mode variable is set
@@ -565,7 +647,46 @@ class NotifyMatrix(NotifyBase):
                 if self.mode != MatrixWebhookMode.DISABLED
                 else "server"
             ),
-        )(body=body, title=title, notify_type=notify_type, **kwargs)
+        )(
+            body=body,
+            title=title,
+            notify_type=notify_type,
+            body_format=body_format,
+            **kwargs,
+        )
+
+    def dialect_convert(self, body, body_format=None, *args, **kwargs):
+        """Render CommonMark as HTML for Matrix's rich-text fields.
+
+        Slack webhooks keep CommonMark for Slack to render.
+        """
+        # Non-Markdown bodies need no dialect conversion.
+        if body_format != NotifyFormat.MARKDOWN:
+            return body
+
+        # Slack expects the original CommonMark source.
+        if self.mode == MatrixWebhookMode.SLACK:
+            return body
+
+        # Other Matrix paths receive rendered HTML.
+        return markdown(body)
+
+    def _matrix_plain_fallback(self, body, body_format, body_passthrough):
+        """Build Matrix's plain-text fallback.
+
+        Strip confirmed HTML or Markdown. Preserve plain and passthrough
+        content because its source format is unknown.
+        """
+        # Preserve undeclared content because its source format is unknown.
+        if body_passthrough:
+            return body
+
+        # Plain text already is its own fallback.
+        if body_format not in (NotifyFormat.HTML, NotifyFormat.MARKDOWN):
+            return body
+
+        # Strip markup for clients that cannot display formatted content.
+        return html_to_text(body)
 
     def _send_webhook_notification(
         self, body, title="", notify_type=NotifyType.INFO, **kwargs
@@ -614,7 +735,7 @@ class NotifyMatrix(NotifyBase):
                 token=access_token,
             )
 
-        # Retrieve our payload
+        # Build the payload for the configured webhook mode.
         payload = getattr(self, f"_{self.mode}_webhook_payload")(
             body=body, title=title, notify_type=notify_type, **kwargs
         )
@@ -632,7 +753,9 @@ class NotifyMatrix(NotifyBase):
         try:
             r = requests.post(
                 url,
-                data=dumps(payload),
+                # ensure_ascii=False avoids inflating multi-byte content
+                # (emoji, non-Latin text) into \uXXXX escapes.
+                data=dumps(payload, ensure_ascii=False),
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
@@ -674,7 +797,12 @@ class NotifyMatrix(NotifyBase):
         return True
 
     def _slack_webhook_payload(
-        self, body, title="", notify_type=NotifyType.INFO, **kwargs
+        self,
+        body,
+        title="",
+        notify_type=NotifyType.INFO,
+        body_format=None,
+        **kwargs,
     ):
         """Format the payload for a Slack based message."""
 
@@ -707,11 +835,11 @@ class NotifyMatrix(NotifyBase):
             body,
         )
 
-        # prepare JSON Object
+        # Build Slack's attachment-style JSON payload.
         payload = {
             "username": self.user if self.user else self.app_id,
-            # Use Markdown language
-            "mrkdwn": self.notify_format == NotifyFormat.MARKDOWN,
+            # Slack renders the CommonMark body itself.
+            "mrkdwn": body_format == NotifyFormat.MARKDOWN,
             "attachments": [
                 {
                     "title": title,
@@ -726,19 +854,26 @@ class NotifyMatrix(NotifyBase):
         return payload
 
     def _matrix_webhook_payload(
-        self, body, title="", notify_type=NotifyType.INFO, **kwargs
+        self,
+        body,
+        title="",
+        notify_type=NotifyType.INFO,
+        body_format=None,
+        **kwargs,
     ):
         """Format the payload for a Matrix based message."""
 
+        # Tell the bridge whether the supplied text is plain or HTML.
         payload = {
             "displayName": self.user if self.user else self.app_id,
             "format": (
-                "plain" if self.notify_format == NotifyFormat.TEXT else "html"
+                "plain" if body_format == NotifyFormat.TEXT else "html"
             ),
             "text": "",
         }
 
-        if self.notify_format == NotifyFormat.HTML:
+        # Declared Markdown is already HTML; passthrough content is unchanged.
+        if body_format in (NotifyFormat.HTML, NotifyFormat.MARKDOWN):
             payload["text"] = "{title}{body}".format(
                 title=(
                     ""
@@ -746,16 +881,6 @@ class NotifyMatrix(NotifyBase):
                     else f"<h1>{NotifyMatrix.escape_html(title)}</h1>"
                 ),
                 body=body,
-            )
-
-        elif self.notify_format == NotifyFormat.MARKDOWN:
-            payload["text"] = "{title}{body}".format(
-                title=(
-                    ""
-                    if not title
-                    else f"<h1>{NotifyMatrix.escape_html(title)}</h1>"
-                ),
-                body=markdown(body),
             )
 
         else:  # NotifyFormat.TEXT
@@ -785,17 +910,31 @@ class NotifyMatrix(NotifyBase):
         return payload
 
     def _hookshot_webhook_payload(
-        self, body, title="", notify_type=NotifyType.INFO, **kwargs
+        self,
+        body,
+        title="",
+        notify_type=NotifyType.INFO,
+        body_format=None,
+        body_passthrough=None,
+        **kwargs,
     ):
         """Format the payload for a matrix-hookshot webhook."""
 
+        # Hookshot accepts a plain fallback and optional formatted HTML.
         payload = {
             "username": self.user if self.user else self.app_id,
             "text": "",
         }
 
-        if self.notify_format == NotifyFormat.HTML:
-            payload["text"] = body if not title else f"{title}\r\n{body}"
+        # Declared Markdown is already HTML; passthrough content is unchanged.
+        if body_format in (NotifyFormat.HTML, NotifyFormat.MARKDOWN):
+            # Keep confirmed markup out of the plain-text fallback.
+            plain_body = self._matrix_plain_fallback(
+                body, body_format, body_passthrough
+            )
+            payload["text"] = (
+                plain_body if not title else f"{title}\r\n{plain_body}"
+            )
             payload["html"] = "{title}{body}".format(
                 title=(
                     ""
@@ -803,17 +942,6 @@ class NotifyMatrix(NotifyBase):
                     else f"<h1>{NotifyMatrix.escape_html(title)}</h1>"
                 ),
                 body=body,
-            )
-
-        elif self.notify_format == NotifyFormat.MARKDOWN:
-            payload["text"] = body if not title else f"{title}\r\n{body}"
-            payload["html"] = "{title}{body}".format(
-                title=(
-                    ""
-                    if not title
-                    else f"<h1>{NotifyMatrix.escape_html(title)}</h1>"
-                ),
-                body=markdown(body),
             )
 
         else:  # NotifyFormat.TEXT
@@ -830,6 +958,8 @@ class NotifyMatrix(NotifyBase):
         title="",
         notify_type=NotifyType.INFO,
         attach=None,
+        body_format=None,
+        body_passthrough=None,
         **kwargs,
     ):
         """Perform Direct Matrix Server Notification (no webhook)"""
@@ -846,16 +976,9 @@ class NotifyMatrix(NotifyBase):
             # We need to register
             return False
 
-        # Resolve user_id (and device_id / home_server as a side-effect) via
-        # /whoami whenever user_id is still absent after login/token setup.
-        # This covers all paths where the server does not return user_id:
-        #   - raw access-token auth (no /login flow at all)
-        #   - username + ?token= (password treated as token, not a login)
-        #   - servers that omit optional /login response fields
-        # Without user_id the m.direct lookup is skipped and
-        # each send creates a fresh orphan DM room instead of reusing the
-        # existing one.  home_server is recovered from user_id inside
-        # _whoami(); the fallback at handles any remaining gap.
+        # Fetch identity values omitted by raw-token or incomplete login paths.
+        # Without a user ID, direct-message lookup may create duplicate rooms.
+        # _whoami also derives the home server when possible.
         if not self.user_id:
             self._whoami()
 
@@ -928,7 +1051,12 @@ class NotifyMatrix(NotifyBase):
             if e2ee_capable and self._e2ee_room_encrypted(room_id):
                 # E2EE path: encrypt message and any attachments
                 if not self._e2ee_send_to_room(
-                    room_id, body, title, notify_type
+                    room_id,
+                    body,
+                    title,
+                    notify_type,
+                    body_format,
+                    body_passthrough,
                 ):
                     has_error = True
                     continue
@@ -1024,47 +1152,38 @@ class NotifyMatrix(NotifyBase):
                         has_error = True
                         continue
 
+            # Matrix clients use this fallback when they cannot display HTML.
+            plain_body = self._matrix_plain_fallback(
+                body, body_format, body_passthrough
+            )
+
             # Define our payload
             payload = {
                 "msgtype": f"m.{self.msgtype}",
                 "body": "{title}{body}".format(
                     title="" if not title else f"# {title}\r\n",
-                    body=body,
+                    body=plain_body,
                 ),
             }
 
-            # Update our payload advance formatting for the services that
-            # support them.
-            if self.notify_format == NotifyFormat.HTML:
-                payload.update(
-                    {
-                        "format": "org.matrix.custom.html",
-                        "formatted_body": "{title}{body}".format(
-                            title=("" if not title else f"<h1>{title}</h1>"),
-                            body=body,
-                        ),
-                    }
-                )
-
-            elif self.notify_format == NotifyFormat.MARKDOWN:
-                title_ = (
+            # HTML and rendered Markdown share a formatted body. HTML titles
+            # remain trusted, while Markdown titles are escaped.
+            if body_format in (NotifyFormat.HTML, NotifyFormat.MARKDOWN):
+                title_html = (
                     ""
                     if not title
                     else (
-                        "<h1>{}".format(
+                        f"<h1>{title}</h1>"
+                        if body_format == NotifyFormat.HTML
+                        else "<h1>{}</h1>".format(
                             NotifyMatrix.escape_html(title, whitespace=False)
                         )
-                        + "</h1>"
                     )
                 )
-
                 payload.update(
                     {
                         "format": "org.matrix.custom.html",
-                        "formatted_body": "{title}{body}".format(
-                            title=title_,
-                            body=markdown(body),
-                        ),
+                        "formatted_body": f"{title_html}{body}",
                     }
                 )
 
@@ -1336,11 +1455,8 @@ class NotifyMatrix(NotifyBase):
     def _whoami(self):
         """Resolve user_id, device_id, and home_server via GET /account/whoami.
 
-        Called when a raw access token is supplied (no login flow), so
-        the server never returned these identifiers directly.  Results
-        are cached in the persistent store for future calls.
-
-        Returns True on success, False otherwise.
+        Raw access tokens skip login, so this fetches the missing identity
+        values and caches them. Returns ``True`` on success.
         """
         ok, response, _ = self._fetch(
             "/account/whoami", payload=None, method="GET"
@@ -1852,7 +1968,13 @@ class NotifyMatrix(NotifyBase):
             try:
                 r = fn(
                     url,
-                    data=dumps(payload) if not attachment else payload,
+                    # ensure_ascii=False avoids inflating multi-byte
+                    # content (emoji, non-Latin text) into \uXXXX escapes.
+                    data=(
+                        dumps(payload, ensure_ascii=False)
+                        if not attachment
+                        else payload
+                    ),
                     params=params if params else None,
                     headers=headers,
                     verify=self.verify_certificate,
@@ -1993,12 +2115,8 @@ class NotifyMatrix(NotifyBase):
     def _e2ee_setup(self):
         """Ensure the E2EE device account exists and keys are uploaded.
 
-        Creates a new :class:`MatrixOlmAccount` if one does not yet
-        exist in the persistent store, then calls
-        :meth:`_e2ee_upload_keys` if the server has not yet received
-        our device keys for the current access token.
-
-        Returns ``True`` on success, ``False`` on failure.
+        Restores or creates the local account, then uploads device keys when
+        the current server identity has not received them. Returns a boolean.
         """
         if self._e2ee_account is None:
             acct_data = self.store.get("e2ee_account")
@@ -2633,7 +2751,15 @@ class NotifyMatrix(NotifyBase):
 
         return True
 
-    def _e2ee_send_to_room(self, room_id, body, title, notify_type):
+    def _e2ee_send_to_room(
+        self,
+        room_id,
+        body,
+        title,
+        notify_type,
+        body_format=None,
+        body_passthrough=None,
+    ):
         """Encrypt and send one message to *room_id* via MegOLM.
 
         Shares the MegOLM session key with room members when the
@@ -2678,44 +2804,38 @@ class NotifyMatrix(NotifyBase):
                 session.session_id[:12],
             )
 
+        # Matrix clients use this fallback when they cannot display HTML.
+        plain_body = self._matrix_plain_fallback(
+            body, body_format, body_passthrough
+        )
+
         # Build the inner plaintext event
         msg_content = {
             "msgtype": "m.{}".format(self.msgtype),
             "body": "{title}{body}".format(
                 title="" if not title else "# {}\r\n".format(title),
-                body=body,
+                body=plain_body,
             ),
         }
 
-        if self.notify_format == NotifyFormat.HTML:
-            msg_content.update(
-                {
-                    "format": "org.matrix.custom.html",
-                    "formatted_body": "{title}{body}".format(
-                        title=(
-                            "" if not title else "<h1>{}</h1>".format(title)
-                        ),
-                        body=body,
-                    ),
-                }
+        # HTML and rendered Markdown share a formatted body. HTML titles
+        # remain trusted, while Markdown titles are escaped.
+        if body_format in (NotifyFormat.HTML, NotifyFormat.MARKDOWN):
+            title_html = (
+                ""
+                if not title
+                else (
+                    "<h1>{}</h1>".format(title)
+                    if body_format == NotifyFormat.HTML
+                    else "<h1>{}</h1>".format(
+                        NotifyMatrix.escape_html(title, whitespace=False)
+                    )
+                )
             )
-
-        elif self.notify_format == NotifyFormat.MARKDOWN:
             msg_content.update(
                 {
                     "format": "org.matrix.custom.html",
-                    "formatted_body": "{title}{body}".format(
-                        title=(
-                            ""
-                            if not title
-                            else "<h1>{}</h1>".format(
-                                NotifyMatrix.escape_html(
-                                    title, whitespace=False
-                                )
-                            )
-                        ),
-                        body=markdown(body),
-                    ),
+                    "formatted_body": f"{title_html}{body}",
                 }
             )
 
@@ -2747,6 +2867,26 @@ class NotifyMatrix(NotifyBase):
             "session_id": session.session_id,
             "device_id": self.device_id or "",
         }
+
+        # A device ID learned after sizing may exceed the fallback.
+        # Measure the finished encrypted content before sending it.
+        encrypted_bytes = len(
+            dumps(encrypted_payload, ensure_ascii=False).encode("utf-8")
+        )
+
+        # Prepare budget
+        safe_byte_budget = MATRIX_EVENT_BYTE_LIMIT - MATRIX_EVENT_SAFETY_MARGIN
+        if encrypted_bytes > safe_byte_budget:
+            self.logger.warning(
+                "Matrix E2EE: encrypted event for room %s is %d bytes, "
+                "over the safe %d-byte budget (device_id is %d "
+                "characters); message not sent.",
+                room_id,
+                encrypted_bytes,
+                safe_byte_budget,
+                len(self.device_id or ""),
+            )
+            return False
 
         postokay, _, _ = self._fetch(
             path, payload=encrypted_payload, method="PUT"
@@ -3047,6 +3187,30 @@ class NotifyMatrix(NotifyBase):
         # Best-effort cleanup only
         with contextlib.suppress(Exception):
             self._logout()
+
+    @property
+    def body_maxlen(self):
+        """Return the body character limit for the current message.
+
+        Direct sends use the content-aware value while chunks are prepared.
+        Reads outside preparation use the normal encrypted fallback, while
+        webhook modes always retain their standard flat limit.
+        """
+        # Use the temporary content-aware value during message preparation.
+        # Context-local state isolates concurrent notification calls.
+        effective = _matrix_effective_body_maxlen_var.get()
+        if effective is not None:
+            return effective
+
+        # Webhook payloads retain their normal flat limit.
+        if self.mode != MatrixWebhookMode.DISABLED:
+            return self.body_maxlen_default
+
+        # Direct sends use the encrypted fallback only when E2EE is possible.
+        e2ee_capable = self.e2ee and self.secure and MATRIX_E2EE_SUPPORT
+        return (
+            self.body_maxlen_e2ee if e2ee_capable else self.body_maxlen_default
+        )
 
     @property
     def url_identifier(self):

--- a/apprise/plugins/matrix/e2ee.py
+++ b/apprise/plugins/matrix/e2ee.py
@@ -115,6 +115,22 @@ def _b64dec(s):
     return base64.b64decode(s)
 
 
+def _b64_unpadded_len(byte_count):
+    """Return the unpadded base64 length without encoding the data.
+
+    This mirrors ``_b64enc`` after its trailing padding is removed.
+    """
+    # Count complete three-byte base64 groups and the remainder.
+    full_groups, remainder = divmod(byte_count, 3)
+
+    # Complete groups need no stripped padding adjustment.
+    if remainder == 0:
+        return full_groups * 4
+
+    # Partial groups retain two or three characters after padding is removed.
+    return full_groups * 4 + remainder + 1
+
+
 def _hmac_sha256(key, data):
     """32-byte HMAC-SHA-256 of *data* keyed by *key*."""
     h = _hmac_mod.HMAC(key, hashes.SHA256(), backend=default_backend())
@@ -160,6 +176,16 @@ def _varint(n):
     return bytes(out)
 
 
+def _varint_len(n):
+    """Return ``len(_varint(n))`` without building the varint itself."""
+    # Zero still requires one encoded byte.
+    if n == 0:
+        return 1
+
+    # Each varint byte carries seven value bits.
+    return (n.bit_length() + 6) // 7
+
+
 def _pb_bytes(field_num, data):
     """Protobuf wire-type 2 (length-delimited bytes) field."""
     tag = _varint((field_num << 3) | 2)
@@ -170,6 +196,32 @@ def _pb_varint_field(field_num, value):
     """Protobuf wire-type 0 (varint) field."""
     tag = _varint((field_num << 3) | 0)
     return tag + _varint(value)
+
+
+def predict_megolm_ciphertext_len(plaintext_len, counter=0):
+    """Predict MegOLM's base64 ciphertext length without encrypting.
+
+    The calculation mirrors the padding, protobuf framing, authentication,
+    and signature added by ``MatrixMegOlmSession.encrypt()``. It uses
+    arithmetic only, keeping memory use constant for large candidates.
+    """
+    # AES-256-CBC with PKCS7 padding always adds 1-16 bytes.
+    padded_len = (plaintext_len // 16 + 1) * 16
+
+    # These field tags are one byte; only their encoded values vary in size.
+    counter_field_len = 1 + _varint_len(counter)
+
+    # Include the ciphertext tag, encoded length, and padded bytes.
+    ciphertext_field_len = 1 + _varint_len(padded_len) + padded_len
+
+    # The MegOLM version byte precedes both protobuf fields.
+    body_len = 1 + counter_field_len + ciphertext_field_len
+
+    # Add the truncated HMAC and Ed25519 signature.
+    total = body_len + 8 + 64
+
+    # The final Matrix field contains unpadded base64.
+    return _b64_unpadded_len(total)
 
 
 def _canonical_json(obj):
@@ -827,7 +879,8 @@ class MatrixMegOlmSession:
 
         Reference: MegOLM spec, Section 4.
         """
-        plaintext = dumps(payload_dict).encode("utf-8")
+        # Preserve Unicode as UTF-8 instead of expanding it into JSON escapes.
+        plaintext = dumps(payload_dict, ensure_ascii=False).encode("utf-8")
         aes_key, mac_key, iv = self._message_keys()
 
         ct_bytes = _aes_cbc_encrypt(aes_key, iv, plaintext)

--- a/apprise/plugins/matrix/sizing.py
+++ b/apprise/plugins/matrix/sizing.py
@@ -1,0 +1,392 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Matrix event sizing helpers."""
+
+import contextvars
+from json import dumps
+
+from ...common import NotifyFormat
+from .e2ee import predict_megolm_ciphertext_len
+
+# Matrix's hard event-size ceiling.
+# https://spec.matrix.org/v1.11/client-server-api/#size-limits
+MATRIX_EVENT_BYTE_LIMIT = 65536
+
+# Reserve room for fields Apprise doesn't control: homeserver-added event
+# metadata (event_id, origin_server_ts, sender, age, unsigned, and -- once
+# federated -- signatures) and small JSON punctuation slop. The title and
+# device_id are measured exactly elsewhere, not guessed here.
+MATRIX_EVENT_SAFETY_MARGIN = 4000
+
+# Allow for the JSON fields around plaintext or encrypted message content.
+MATRIX_CONTENT_JSON_OVERHEAD = 200
+
+# sender_key/session_id are always the unpadded base64 of a 32-byte
+# Curve25519/Ed25519 key -- exactly 43 characters regardless of value.
+MATRIX_E2EE_KEY_LEN = 43
+
+# device_id has no length limit in the Matrix spec and is server-assigned,
+# so it cannot be measured before the first login on a fresh connection.
+# This generous fallback covers any realistic device_id when its real
+# value isn't known yet at sizing time; a known device_id is measured
+# exactly instead (see device_id_overhead_bytes()).
+MATRIX_DEVICE_ID_FALLBACK_BYTES = 512
+
+# Exact JSON structural overhead of an m.room.encrypted payload's
+# fixed-shape fields, excluding the ciphertext and device_id values --
+# both measured separately since they vary per send. Computed once here
+# instead of guessed, using a placeholder of the guaranteed key length.
+MATRIX_E2EE_ENVELOPE_STRUCTURAL_BYTES = len(
+    dumps(
+        {
+            "algorithm": "m.megolm.v1.aes-sha2",
+            "ciphertext": "",
+            "sender_key": "x" * MATRIX_E2EE_KEY_LEN,
+            "session_id": "x" * MATRIX_E2EE_KEY_LEN,
+            "device_id": "",
+        },
+        ensure_ascii=False,
+    ).encode("utf-8")
+)
+
+# Share the calculated limit with the framework's body_maxlen property.
+# Context-local storage keeps concurrent notifications isolated.
+effective_body_maxlen = contextvars.ContextVar(
+    "matrix_effective_body_maxlen", default=None
+)
+
+
+def utf8_char_len(ch):
+    """Return the UTF-8 byte length of a single character."""
+    # Use the code point range to determine its encoded width.
+    cp = ord(ch)
+
+    # ASCII occupies one byte.
+    if cp <= 0x7F:
+        return 1
+
+    # Extended Latin and similar characters occupy two bytes.
+    if cp <= 0x7FF:
+        return 2
+
+    # Characters in the basic multilingual plane occupy three bytes.
+    if cp <= 0xFFFF:
+        return 3
+
+    # Supplementary characters such as emoji occupy four bytes.
+    return 4
+
+
+def sanitize_text(text):
+    """Replace lone UTF-16 surrogates so text can be UTF-8 encoded.
+
+    Sanitizing before sizing keeps the calculation aligned with delivery.
+    """
+    # Preserve empty and absent values without allocating a new string.
+    if not text:
+        return text
+
+    # Replace invalid code points while preserving normal Unicode.
+    return text.encode("utf-8", errors="replace").decode("utf-8")
+
+
+def rstrip_end(text):
+    """Find the end of ``text.rstrip()`` without copying the input."""
+    # Walk backward until the last meaningful character is found.
+    end = len(text)
+    while end > 0 and text[end - 1].isspace():
+        end -= 1
+
+    # The caller can safely slice up to this position.
+    return end
+
+
+def strip_bounds(text):
+    """Find the bounds of ``text.strip()`` without copying the input."""
+    # Find the first non-whitespace character.
+    length = len(text)
+    start = 0
+    while start < length and text[start].isspace():
+        start += 1
+
+    # Find the last non-whitespace character.
+    end = length
+    while end > start and text[end - 1].isspace():
+        end -= 1
+
+    # These indexes describe the same result as text.strip().
+    return start, end
+
+
+def json_char_bytes(ch):
+    """Return a character's UTF-8 cost after JSON string escaping."""
+    # Quotes and backslashes gain a leading escape character.
+    if ch in ('"', "\\"):
+        return 2
+
+    # Common control characters use their short escapes.
+    if ch in ("\b", "\f", "\n", "\r", "\t"):
+        return 2
+
+    # Remaining control characters use the six-byte Unicode form.
+    if ord(ch) < 0x20:
+        return 6
+
+    # All other characters retain their normal UTF-8 width.
+    return utf8_char_len(ch)
+
+
+def max_byte_budget(cost_fn, byte_budget, ceiling):
+    """Find the largest input accepted by a non-decreasing cost function."""
+    # Stop when the fixed event structure is already too large.
+    if cost_fn(0) > byte_budget:
+        return 0
+
+    # Search the permitted raw-byte range.
+    low, high = 0, ceiling
+    while low < high:
+        # Bias upward so a two-value range continues to make progress.
+        middle = (low + high + 1) // 2
+
+        # Keep fitting values and discard values that exceed the budget.
+        if cost_fn(middle) <= byte_budget:
+            low = middle
+        else:
+            high = middle - 1
+
+    # Both bounds now identify the largest fitting value.
+    return low
+
+
+def fit_char_limit(body, byte_budget, cost_fn):
+    """Return a character limit safe for every chunk in ``body``.
+
+    A linear sliding window protects dense regions rather than averages.
+    """
+    # Empty messages still need a positive framework limit.
+    length = len(body)
+    if length == 0:
+        return 1
+
+    # This ceiling covers rich representations and encryption growth.
+    ceiling = byte_budget * 16 + 1024
+    raw_byte_target = max_byte_budget(cost_fn, byte_budget, ceiling)
+
+    # Track the JSON-escaped window and its left edge.
+    window_sum = 0
+    left = 0
+    shortest_over = None
+
+    for right, ch in enumerate(body):
+        # Add the next character to the active window.
+        window_sum += json_char_bytes(ch)
+
+        # Shrink until the active window fits again.
+        while window_sum > raw_byte_target:
+            window_length = right - left + 1
+
+            # The shortest overflowing window defines the safe limit.
+            if shortest_over is None or window_length < shortest_over:
+                shortest_over = window_length
+
+            # Remove the leftmost character before advancing the window.
+            window_sum -= json_char_bytes(body[left])
+            left += 1
+
+    # No window overflow means the complete body already fits.
+    if shortest_over is None:
+        return length
+
+    # One less than the shortest overflow is safe for every chunk.
+    return max(1, shortest_over - 1)
+
+
+def payload_budget(asset, title_len, body_len):
+    """Mirror the asset payload cap using lengths only.
+
+    The asset still applies the authoritative cap to the original strings.
+    """
+    # Read the optional combined title and body limit from the asset.
+    cap = asset._payload_max_size
+
+    # A disabled cap leaves both inputs untouched.
+    if not cap:
+        return title_len, body_len
+
+    # Content already within the cap needs no allocation.
+    total = title_len + body_len
+    if total <= cap:
+        return title_len, body_len
+
+    # Give the full budget to the only nonempty side.
+    if not title_len:
+        return 0, cap
+
+    if not body_len:
+        return cap, 0
+
+    # Short inputs may be preserved when the other side keeps enough room.
+    threshold = asset._payload_buffer_threshold
+    min_buffer = asset._payload_min_buffer
+
+    # Keep a short title whole when the body retains its minimum allowance.
+    if title_len <= threshold:
+        body_reserve = min(body_len, min_buffer)
+        if title_len + body_reserve <= cap:
+            return title_len, cap - title_len
+
+    # Apply the same preference when the body is the short side.
+    if body_len <= threshold:
+        title_reserve = min(title_len, min_buffer)
+        if body_len + title_reserve <= cap:
+            return cap - body_len, body_len
+
+    # Otherwise divide the cap in proportion to the original lengths.
+    title_budget = (title_len * cap) // total
+    body_budget = cap - title_budget
+
+    # Preserve at least one title character when the cap permits it.
+    if not title_budget and body_budget > 0:
+        title_budget = 1
+        body_budget -= 1
+
+    # Both budgets always add back up to the configured cap.
+    return title_budget, body_budget
+
+
+def payload_preview(asset, body, title):
+    """Build the bounded, normalized preview used for event sizing."""
+    # Locate trim boundaries without copying large inputs.
+    title_start, title_end = strip_bounds(title) if title else (0, 0)
+    title_len = title_end - title_start
+    body_len = rstrip_end(body) if body else 0
+
+    # Match the asset's cap allocation before materializing either slice.
+    title_limit, body_limit = payload_budget(asset, title_len, body_len)
+    preview_title = (
+        "" if not title else title[title_start : title_start + title_limit]
+    )
+    preview_body = "" if not body else body[:body_limit]
+
+    # Sanitize only the bounded copies used by the sizing scan.
+    return sanitize_text(preview_body), sanitize_text(preview_title)
+
+
+def device_id_overhead_bytes(device_id):
+    """Return a device ID's JSON byte cost or a conservative fallback."""
+    # Fresh logins do not expose the device ID until after initial sizing.
+    if not device_id:
+        return MATRIX_DEVICE_ID_FALLBACK_BYTES
+
+    # Include any JSON escaping required by the known ID.
+    return sum(json_char_bytes(ch) for ch in device_id)
+
+
+def title_overhead_bytes(title, body_format, escape_html):
+    """Return the JSON byte cost added by Matrix title wrappers."""
+    # An absent title adds no wrapper or content bytes.
+    if not title:
+        return 0
+
+    # Plain messages include the title once.
+    plain_wrapper = f"# {title}\r\n"
+    plain_bytes = sum(json_char_bytes(ch) for ch in plain_wrapper)
+
+    # Plain messages do not carry a second title representation.
+    if body_format not in (NotifyFormat.HTML, NotifyFormat.MARKDOWN):
+        return plain_bytes
+
+    # Rich messages include a second HTML title.
+    title_html = (
+        title
+        if body_format == NotifyFormat.HTML
+        else escape_html(title, whitespace=False)
+    )
+    formatted_wrapper = f"<h1>{title_html}</h1>"
+
+    # Rich messages pay for both the plain and formatted titles.
+    return plain_bytes + sum(json_char_bytes(ch) for ch in formatted_wrapper)
+
+
+def wire_cost(
+    content_bytes,
+    body_format,
+    e2ee_capable,
+    title_bytes,
+    device_id,
+):
+    """Estimate a chunk's final Matrix event size."""
+    # Rich messages carry both plain and formatted representations.
+    multiplier = (
+        2 if body_format in (NotifyFormat.HTML, NotifyFormat.MARKDOWN) else 1
+    )
+
+    # Combine message representations, title wrappers, and fixed JSON fields.
+    inner_bytes = (
+        content_bytes * multiplier + title_bytes + MATRIX_CONTENT_JSON_OVERHEAD
+    )
+
+    # Unencrypted events stop at the inner content estimate.
+    if not e2ee_capable:
+        return inner_bytes
+
+    # E2EE adds MegOLM growth and the outer encrypted-event fields.
+    return (
+        predict_megolm_ciphertext_len(inner_bytes)
+        + MATRIX_E2EE_ENVELOPE_STRUCTURAL_BYTES
+        + device_id_overhead_bytes(device_id)
+    )
+
+
+def body_char_limit(
+    body,
+    title,
+    body_format,
+    e2ee_capable,
+    device_id,
+    escape_html,
+):
+    """Calculate the safe Matrix body limit for one notification."""
+    # Measure the title once because every candidate chunk shares it.
+    title_bytes = title_overhead_bytes(title, body_format, escape_html)
+
+    # Convert each possible content size into its final event estimate.
+    def cost_fn(content_bytes):
+        return wire_cost(
+            content_bytes,
+            body_format,
+            e2ee_capable,
+            title_bytes,
+            device_id,
+        )
+
+    # Leave room for metadata added after Apprise submits the content.
+    byte_budget = MATRIX_EVENT_BYTE_LIMIT - MATRIX_EVENT_SAFETY_MARGIN
+
+    # Find the character count that keeps every body chunk within budget.
+    return fit_char_limit(body, byte_budget, cost_fn)

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -1826,6 +1826,7 @@ def test_plugin_matrix_hookshot_webhook(mock_post):
 
     payload = loads(mock_post.call_args.kwargs["data"])
     assert payload["username"] == "apprise"
+    # Undeclared passthrough content remains untouched.
     assert payload["text"] == "Title\r\n<b>Body</b>"
     assert payload["html"] == "<h1>Title</h1><b>Body</b>"
 
@@ -1833,6 +1834,7 @@ def test_plugin_matrix_hookshot_webhook(mock_post):
 @mock.patch("requests.post")
 def test_plugin_matrix_hookshot_webhook_empty_title(mock_post):
     """Hookshot webhook mode avoids extra separators for empty titles."""
+    from apprise.common import NotifyFormat
 
     response = mock.Mock()
     response.status_code = requests.codes.ok
@@ -1845,12 +1847,43 @@ def test_plugin_matrix_hookshot_webhook_empty_title(mock_post):
     )
     assert obj is not None
 
-    assert bool(obj.notify(body="**Body**")) is True
+    # Declaring Markdown enables HTML rendering.
+    assert (
+        bool(obj.notify(body="**Body**", body_format=NotifyFormat.MARKDOWN))
+        is True
+    )
 
     payload = loads(mock_post.call_args.kwargs["data"])
     assert payload["username"] == "apprise"
-    assert payload["text"] == "**Body**"
+    # The text fallback comes from the rendered HTML.
+    assert payload["text"] == "Body"
     assert payload["html"] == "<p><strong>Body</strong></p>"
+
+
+@mock.patch("requests.post")
+def test_plugin_matrix_slack_webhook_markdown_untouched(mock_post):
+    """Slack webhooks forward CommonMark for Slack to render."""
+    from apprise.common import NotifyFormat
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = b"{}"
+    mock_post.return_value = response
+
+    obj = Apprise.instantiate(
+        "matrixs://apprise:supersecret@slack.example?mode=slack&format=markdown"
+    )
+    assert obj is not None
+
+    assert (
+        bool(obj.notify(body="**Body**", body_format=NotifyFormat.MARKDOWN))
+        is True
+    )
+
+    payload = loads(mock_post.call_args.kwargs["data"])
+    assert payload["mrkdwn"] is True
+    # Slack receives the original CommonMark.
+    assert payload["attachments"][0]["text"] == "**Body**"
 
 
 def test_plugin_matrix_hookshot_path_normalization():
@@ -2574,15 +2607,9 @@ def test_plugin_matrix_e2ee_olm_session():
 def test_plugin_matrix_e2ee_olm_roundtrip():
     """Full Olm round-trip: Alice encrypts, Bob manually decrypts.
 
-    This test implements the Bob (inbound) side of the Olm X3DH and
-    message-decryption protocol using the same cryptography primitives,
-    verifying that our Alice-side implementation produces wire bytes that
-    a conformant receiver can decrypt.
-
-    Critical invariant verified: the outer base-key (pre-key field 2)
-    equals the inner ratchet-key (normal-message field 1).  They MUST be
-    the same ephemeral key E_A or the receiver cannot reconstruct the
-    session and decryption fails.
+    The receiver-side reconstruction verifies compatible X3DH output.
+    It also confirms the outer base key matches the inner ratchet key,
+    which receivers need to reconstruct the session.
     """
     import hmac as _hmac_stdlib
 
@@ -5218,3 +5245,1173 @@ def test_plugin_matrix_room_id_returns_none_without_home_server():
 
     result = obj._room_id("#bare_alias")
     assert result is None
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_html_plain_fallback(mock_post, mock_get, mock_put):
+    """Declared HTML receives a plain-text fallback."""
+    from apprise.common import NotifyFormat
+
+    response_obj = {
+        "room_id": "!abc123:localhost",
+        "room_alias": "#abc123:localhost",
+        "joined_rooms": ["!abc123:localhost"],
+        "access_token": "abcd1234",
+        "home_server": "localhost",
+    }
+    request = mock.Mock()
+    request.content = dumps(response_obj)
+    request.status_code = requests.codes.ok
+
+    mock_get.return_value = request
+    mock_post.return_value = request
+    mock_put.return_value = request
+
+    kwargs = NotifyMatrix.parse_url(
+        "matrix://user:passwd@hostname/#abcd?format=html"
+    )
+    obj = NotifyMatrix(**kwargs)
+
+    # Declaring the source confirms that the content is HTML.
+    assert (
+        bool(
+            obj.notify(
+                title="Title",
+                body="<b>Bold</b> text",
+                body_format=NotifyFormat.HTML,
+            )
+        )
+        is True
+    )
+
+    payload = loads(mock_put.call_args.kwargs["data"])
+    assert payload["formatted_body"] == "<h1>Title</h1><b>Bold</b> text"
+    # The plain-text fallback must not carry the raw markup a second time.
+    assert "<b>" not in payload["body"]
+    assert "Bold text" in payload["body"]
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_html_passthrough_untouched(
+    mock_post, mock_get, mock_put
+):
+    """Undeclared content remains unchanged when routed as rich text."""
+
+    response_obj = {
+        "room_id": "!abc123:localhost",
+        "room_alias": "#abc123:localhost",
+        "joined_rooms": ["!abc123:localhost"],
+        "access_token": "abcd1234",
+        "home_server": "localhost",
+    }
+    request = mock.Mock()
+    request.content = dumps(response_obj)
+    request.status_code = requests.codes.ok
+
+    mock_get.return_value = request
+    mock_post.return_value = request
+    mock_put.return_value = request
+
+    kwargs = NotifyMatrix.parse_url(
+        "matrix://user:passwd@hostname/#abcd?format=html"
+    )
+    obj = NotifyMatrix(**kwargs)
+
+    # No body_format declared: a passthrough source.
+    assert bool(obj.notify(title="Title", body="<b>Bold</b> text")) is True
+
+    payload = loads(mock_put.call_args.kwargs["data"])
+    assert payload["formatted_body"] == "<h1>Title</h1><b>Bold</b> text"
+    # Preserve the source when its format is unknown.
+    assert payload["body"] == "# Title\r\n<b>Bold</b> text"
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_e2ee_html_plain_fallback(mock_post, mock_get, mock_put):
+    """Encrypted HTML also receives a plain-text fallback."""
+    from apprise.common import NotifyFormat
+    from apprise.plugins.matrix.e2ee import (
+        MatrixMegOlmSession,
+        MatrixOlmAccount,
+    )
+
+    def _mk_resp(d):
+        r = mock.Mock()
+        r.status_code = requests.codes.ok
+        r.content = dumps(d).encode()
+        return r
+
+    mock_put.return_value = _mk_resp({})
+
+    obj = NotifyMatrix(
+        host="h", user="u", password="pass", targets=["#r"], e2ee=True
+    )
+    obj.access_token = "tok"
+    obj.home_server = "h"
+    obj.user_id = "@u:h"
+    obj.device_id = "DEV"
+    obj._e2ee_account = MatrixOlmAccount()
+
+    session = MatrixMegOlmSession()
+    obj.store.set("e2ee_megolm_!r:h", session.to_dict())
+    obj.store.set("e2ee_key_shared_!r:h", session.session_id)
+
+    # Capture the event before encryption.
+    captured = {}
+    original_encrypt = MatrixMegOlmSession.encrypt
+
+    def _spy_encrypt(self, event):
+        captured["event"] = event
+        return original_encrypt(self, event)
+
+    with mock.patch.object(MatrixMegOlmSession, "encrypt", _spy_encrypt):
+        assert (
+            obj._e2ee_send_to_room(
+                "!r:h",
+                "<b>Bold</b> text",
+                "Title",
+                NotifyType.INFO,
+                body_format=NotifyFormat.HTML,
+                body_passthrough=False,
+            )
+            is True
+        )
+
+    msg_content = captured["event"]["content"]
+    assert msg_content["formatted_body"] == "<h1>Title</h1><b>Bold</b> text"
+    assert "<b>" not in msg_content["body"]
+    assert "Bold text" in msg_content["body"]
+
+
+def test_plugin_matrix_e2ee_body_limit():
+    """Encrypted messages use a smaller limit when E2EE is available."""
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=False,
+        secure=True,
+    )
+    assert obj.e2ee is False
+    assert obj.body_maxlen == obj.body_maxlen_default
+
+    # Non-TLS connections cannot use encryption.
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+        secure=False,
+    )
+    assert obj.e2ee is True
+    assert obj.body_maxlen == obj.body_maxlen_default
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+        secure=True,
+    )
+    assert obj.e2ee is True
+
+    if CRYPTOGRAPHY_AVAILABLE:
+        assert obj.body_maxlen == obj.body_maxlen_e2ee
+        assert obj.body_maxlen < obj.body_maxlen_default
+    else:
+        # Encryption also requires the optional cryptography package.
+        assert obj.body_maxlen == obj.body_maxlen_default
+
+
+def test_plugin_matrix_webhook_mode_body_maxlen_unaffected():
+    """Webhook modes keep their flat limit for their distinct payloads."""
+    from apprise.common import NotifyFormat, OverflowMode
+    from apprise.plugins.matrix import base as matrix_base
+    from apprise.plugins.matrix.base import MatrixWebhookMode
+
+    for mode in (
+        MatrixWebhookMode.SLACK,
+        MatrixWebhookMode.MATRIX,
+        MatrixWebhookMode.HOOKSHOT,
+    ):
+        obj = NotifyMatrix(
+            host="h", user="u", token="tok", mode=mode, secure=True
+        )
+        # Webhooks ignore the default E2EE setting.
+        assert obj.e2ee is True
+        assert obj.body_maxlen == obj.body_maxlen_default
+
+        list(
+            obj._build_send_calls(
+                body="hello world " * 20,
+                title="",
+                body_format=NotifyFormat.HTML,
+                overflow=OverflowMode.SPLIT,
+            )
+        )
+        # Webhook preparation does not activate content-aware sizing.
+        assert matrix_base._matrix_effective_body_maxlen_var.get() is None
+        assert obj.body_maxlen == obj.body_maxlen_default
+
+
+def test_plugin_matrix_body_maxlen_content_aware():
+    """Direct sends choose a content-aware limit while preparing chunks."""
+    from apprise.common import OverflowMode
+    from apprise.plugins.matrix import base as matrix_base
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        secure=True,
+        e2ee=False,
+    )
+
+    # No send in progress: fall back to the flat default.
+    assert matrix_base._matrix_effective_body_maxlen_var.get() is None
+    assert obj.body_maxlen == obj.body_maxlen_default
+
+    observed = {}
+
+    # Capture the computed limit while the generator is active.
+    original_property = NotifyMatrix.body_maxlen.fget
+
+    def _spy_body_maxlen(self):
+        observed["body_maxlen"] = (
+            matrix_base._matrix_effective_body_maxlen_var.get()
+        )
+        return original_property(self)
+
+    with mock.patch.object(
+        NotifyMatrix, "body_maxlen", property(_spy_body_maxlen)
+    ):
+        list(
+            obj._build_send_calls(
+                # This length makes UTF-8 density determine the limit.
+                body="\U0001f600" * 20000,
+                title="",
+                overflow=OverflowMode.SPLIT,
+            )
+        )
+
+    # Emoji require four UTF-8 bytes and therefore a smaller limit.
+    emoji_limit = observed["body_maxlen"]
+    assert emoji_limit < obj.body_maxlen_default
+
+    # Restored after the call completes.
+    assert matrix_base._matrix_effective_body_maxlen_var.get() is None
+
+    with mock.patch.object(
+        NotifyMatrix, "body_maxlen", property(_spy_body_maxlen)
+    ):
+        list(
+            obj._build_send_calls(
+                body="hello world " * 10000,
+                title="",
+                overflow=OverflowMode.SPLIT,
+            )
+        )
+
+    # Plain ASCII content allows a much larger character limit.
+    assert observed["body_maxlen"] > emoji_limit
+    assert matrix_base._matrix_effective_body_maxlen_var.get() is None
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_concentrated_density_split(
+    mock_post, mock_get, mock_put
+):
+    """Dense Unicode regions must fit even when ASCII lowers the average."""
+    from apprise.common import OverflowMode
+
+    response_obj = {
+        "room_id": "!abc123:localhost",
+        "room_alias": "#abc123:localhost",
+        "joined_rooms": ["!abc123:localhost"],
+        "access_token": "abcd1234",
+        "home_server": "localhost",
+    }
+    request = mock.Mock()
+    request.content = dumps(response_obj)
+    request.status_code = requests.codes.ok
+
+    mock_get.return_value = request
+    mock_post.return_value = request
+    mock_put.return_value = request
+
+    obj = NotifyMatrix(host="hostname", user="user", password="passwd")
+
+    original_body = ("\U0001f600" * 20000) + ("a" * 80000)
+    assert (
+        bool(obj.notify(body=original_body, overflow=OverflowMode.SPLIT))
+        is True
+    )
+
+    assert mock_put.call_count > 1
+    reconstructed = ""
+    for call in mock_put.call_args_list:
+        payload = loads(call.kwargs["data"])
+        encoded_len = len(dumps(payload, ensure_ascii=False).encode("utf-8"))
+        assert encoded_len <= 65536
+        reconstructed += payload["body"]
+
+    # No content was dropped or duplicated across the split events.
+    assert reconstructed == original_body
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_json_escape_heavy_split(mock_post, mock_get, mock_put):
+    """Backslash-heavy bodies must fit after JSON escape expansion."""
+    from apprise.common import OverflowMode
+
+    response_obj = {
+        "room_id": "!abc123:localhost",
+        "room_alias": "#abc123:localhost",
+        "joined_rooms": ["!abc123:localhost"],
+        "access_token": "abcd1234",
+        "home_server": "localhost",
+    }
+    request = mock.Mock()
+    request.content = dumps(response_obj)
+    request.status_code = requests.codes.ok
+
+    mock_get.return_value = request
+    mock_post.return_value = request
+    mock_put.return_value = request
+
+    obj = NotifyMatrix(host="hostname", user="user", password="passwd")
+
+    original_body = "\\" * 70000
+    assert (
+        bool(obj.notify(body=original_body, overflow=OverflowMode.SPLIT))
+        is True
+    )
+
+    assert mock_put.call_count > 1
+    reconstructed = ""
+    for call in mock_put.call_args_list:
+        payload = loads(call.kwargs["data"])
+        encoded_len = len(dumps(payload, ensure_ascii=False).encode("utf-8"))
+        assert encoded_len <= 65536
+        reconstructed += payload["body"]
+
+    assert reconstructed == original_body
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_mixed_escape_and_unicode_split(
+    mock_post, mock_get, mock_put
+):
+    """Mixed JSON escapes and Unicode must remain within the byte limit."""
+    from apprise.common import OverflowMode
+
+    response_obj = {
+        "room_id": "!abc123:localhost",
+        "room_alias": "#abc123:localhost",
+        "joined_rooms": ["!abc123:localhost"],
+        "access_token": "abcd1234",
+        "home_server": "localhost",
+    }
+    request = mock.Mock()
+    request.content = dumps(response_obj)
+    request.status_code = requests.codes.ok
+
+    mock_get.return_value = request
+    mock_post.return_value = request
+    mock_put.return_value = request
+
+    obj = NotifyMatrix(host="hostname", user="user", password="passwd")
+
+    # Include escapes, a non-whitespace control, CJK, and emoji characters.
+    # Whitespace controls are avoided because chunk splitting may trim them.
+    cluster = '"\\\x01中\U0001f600'
+    original_body = cluster * 15000
+    assert (
+        bool(obj.notify(body=original_body, overflow=OverflowMode.SPLIT))
+        is True
+    )
+
+    assert mock_put.call_count > 1
+    reconstructed = ""
+    for call in mock_put.call_args_list:
+        payload = loads(call.kwargs["data"])
+        encoded_len = len(dumps(payload, ensure_ascii=False).encode("utf-8"))
+        assert encoded_len <= 65536
+        reconstructed += payload["body"]
+
+    assert reconstructed == original_body
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_html_dual_representation_split(
+    mock_post, mock_get, mock_put
+):
+    """HTML events fit with both plain and formatted representations."""
+    from apprise.common import NotifyFormat, OverflowMode
+
+    response_obj = {
+        "room_id": "!abc123:localhost",
+        "room_alias": "#abc123:localhost",
+        "joined_rooms": ["!abc123:localhost"],
+        "access_token": "abcd1234",
+        "home_server": "localhost",
+    }
+    request = mock.Mock()
+    request.content = dumps(response_obj)
+    request.status_code = requests.codes.ok
+
+    mock_get.return_value = request
+    mock_post.return_value = request
+    mock_put.return_value = request
+
+    obj = NotifyMatrix(host="hostname", user="user", password="passwd")
+
+    body = ("word " * 12999) + "end"
+    assert (
+        bool(
+            obj.notify(
+                body=body,
+                body_format=NotifyFormat.HTML,
+                overflow=OverflowMode.SPLIT,
+            )
+        )
+        is True
+    )
+
+    assert mock_put.call_count > 1
+    for call in mock_put.call_args_list:
+        payload = loads(call.kwargs["data"])
+        assert "formatted_body" in payload
+        encoded_len = len(dumps(payload, ensure_ascii=False).encode("utf-8"))
+        assert encoded_len <= 65536
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_e2ee_html_split(mock_post, mock_get, mock_put):
+    """Encrypted HTML chunks fit after formatting and MegOLM expansion."""
+    from apprise.common import NotifyFormat, OverflowMode
+    from apprise.plugins.matrix.e2ee import MatrixMegOlmSession
+
+    def _mk_resp(d):
+        r = mock.Mock()
+        r.status_code = requests.codes.ok
+        r.content = dumps(d).encode()
+        return r
+
+    login_resp = {
+        "access_token": "tok",
+        "user_id": "@u:h",
+        "home_server": "h",
+        "device_id": "DEV",
+    }
+    mock_post.side_effect = [
+        _mk_resp(login_resp),
+        _mk_resp({}),  # keys/upload
+        _mk_resp({"room_id": "!r:h"}),  # join
+        _mk_resp({}),  # logout
+    ]
+    mock_get.return_value = _mk_resp({})
+    mock_put.return_value = _mk_resp({})
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["!r:h"],
+        e2ee=True,
+        secure=True,
+        discovery=False,
+    )
+    # Pre-seed encryption state so the test only sends message events.
+    session = MatrixMegOlmSession()
+    obj.store.set("e2ee_room_enc_!r:h", True)
+    obj.store.set("e2ee_megolm_!r:h", session.to_dict())
+    obj.store.set("e2ee_key_shared_!r:h", session.session_id)
+
+    body = ("<b>hello world this is a test</b> " * 2000).strip()
+    assert (
+        bool(
+            obj.notify(
+                body=body,
+                body_format=NotifyFormat.HTML,
+                overflow=OverflowMode.SPLIT,
+            )
+        )
+        is True
+    )
+
+    assert mock_put.call_count > 1
+    for call in mock_put.call_args_list:
+        payload = loads(call.kwargs["data"])
+        assert payload["algorithm"] == "m.megolm.v1.aes-sha2"
+        encoded_len = len(dumps(payload, ensure_ascii=False).encode("utf-8"))
+        assert encoded_len <= 65536
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+@pytest.mark.parametrize("device_id_len", [3, 128, 255, 1000])
+def test_plugin_matrix_e2ee_long_device_id_and_title(
+    mock_post, mock_get, mock_put, device_id_len
+):
+    """Long device IDs and escaped titles must fit encrypted events.
+
+    Both values are measured because neither raw character counts nor a
+    fixed envelope estimate represent their final JSON byte cost.
+    """
+    from apprise.common import NotifyFormat, OverflowMode
+    from apprise.plugins.matrix.e2ee import MatrixMegOlmSession
+
+    def _mk_resp(d):
+        r = mock.Mock()
+        r.status_code = requests.codes.ok
+        r.content = dumps(d).encode()
+        return r
+
+    mock_get.return_value = _mk_resp({})
+    mock_put.return_value = _mk_resp({})
+    mock_post.return_value = _mk_resp({})
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["!r:h"],
+        e2ee=True,
+        secure=True,
+        discovery=False,
+    )
+    session = MatrixMegOlmSession()
+    obj.store.set("e2ee_room_enc_!r:h", True)
+    obj.store.set("e2ee_megolm_!r:h", session.to_dict())
+    obj.store.set("e2ee_key_shared_!r:h", session.session_id)
+    obj.access_token = "tok"
+    obj.home_server = "h"
+    obj.user_id = "@u:h"
+    # A known device_id (as if cached from a prior login) is measured
+    # exactly rather than falling back to the generous default.
+    obj.device_id = "D" * device_id_len
+
+    title = "\x01" * 250  # near title_maxlen, maximal 6-byte JSON escape
+    body = "\x01" * 200000
+
+    assert (
+        bool(
+            obj.notify(
+                body=body,
+                title=title,
+                body_format=NotifyFormat.HTML,
+                overflow=OverflowMode.SPLIT,
+            )
+        )
+        is True
+    )
+
+    assert mock_put.call_count > 1
+    for call in mock_put.call_args_list:
+        payload = loads(call.kwargs["data"])
+        assert payload["algorithm"] == "m.megolm.v1.aes-sha2"
+        encoded_len = len(dumps(payload, ensure_ascii=False).encode("utf-8"))
+        assert encoded_len <= 65536
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_e2ee_rejects_late_oversize():
+    """Refuse a first-login event that becomes too large after sizing.
+
+    The fallback covers normal unknown device IDs. The final check must
+    reject content that eats into the reserved MATRIX_EVENT_SAFETY_MARGIN
+    -- not just content that exceeds the full MATRIX_EVENT_BYTE_LIMIT
+    outright -- since that margin exists specifically to leave room for
+    homeserver-added event metadata this payload doesn't include.
+    Comparing against the full ceiling would let a late device ID
+    silently consume that reserved room without ever tripping the guard.
+    """
+    from apprise.common import NotifyFormat, OverflowMode
+    from apprise.plugins.matrix.base import (
+        MATRIX_EVENT_BYTE_LIMIT,
+        MATRIX_EVENT_SAFETY_MARGIN,
+    )
+    from apprise.plugins.matrix.e2ee import (
+        MatrixMegOlmSession,
+        MatrixOlmAccount,
+    )
+
+    safe_byte_budget = MATRIX_EVENT_BYTE_LIMIT - MATRIX_EVENT_SAFETY_MARGIN
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["!r:h"],
+        e2ee=True,
+        secure=True,
+        discovery=False,
+    )
+    obj.access_token = "tok"
+    obj.home_server = "h"
+    obj.user_id = "@u:h"
+    # Unknown at sizing time: _build_send_calls() uses the fallback.
+    obj.device_id = None
+    obj._e2ee_account = MatrixOlmAccount()
+
+    # A small, fixed body/title: content isn't what's under test here,
+    # device_id's contribution is. device_id sits outside the encrypted
+    # ciphertext (a plain sibling JSON field), so every extra character
+    # added to it adds exactly one byte to the final encrypted payload,
+    # letting the boundary below be targeted precisely.
+    calls = list(
+        obj._build_send_calls(
+            body="hello", title="", overflow=OverflowMode.SPLIT
+        )
+    )
+    first = calls[0]
+
+    session = MatrixMegOlmSession()
+    obj.store.set("e2ee_room_enc_!r:h", True)
+    obj.store.set("e2ee_megolm_!r:h", session.to_dict())
+    obj.store.set("e2ee_key_shared_!r:h", session.session_id)
+
+    def send_with_device_id(device_id_len):
+        # The real device_id becomes known only now, as if login
+        # happened after sizing already ran.
+        obj.device_id = "D" * device_id_len
+        with (
+            mock.patch.object(obj, "_e2ee_share_room_key", return_value=True),
+            mock.patch.object(
+                obj, "_fetch", return_value=(True, {}, 200)
+            ) as mock_fetch,
+        ):
+            result = obj._e2ee_send_to_room(
+                "!r:h",
+                first["body"],
+                first["title"],
+                NotifyType.INFO,
+                NotifyFormat.HTML,
+                False,
+            )
+        sent = mock_fetch.call_count > 0
+        assert result is sent
+        if sent:
+            payload = mock_fetch.call_args.kwargs["payload"]
+            return len(dumps(payload, ensure_ascii=False).encode("utf-8"))
+        return None
+
+    # Measure this content's baseline (device_id excluded) once.
+    baseline_bytes = send_with_device_id(0)
+
+    # Exactly at the safe budget: still accepted.
+    at_budget_len = safe_byte_budget - baseline_bytes
+    assert send_with_device_id(at_budget_len) == safe_byte_budget
+
+    # One byte into the reserved margin -- between the safe budget and
+    # the hard ceiling, previously accepted by mistake -- must now be
+    # refused.
+    past_budget_len = at_budget_len + 1
+    assert send_with_device_id(past_budget_len) is None
+
+    # Comfortably past the full ceiling: also refused.
+    assert send_with_device_id(MATRIX_EVENT_BYTE_LIMIT) is None
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_surrogate_sanitized_end_to_end(
+    mock_post, mock_get, mock_put
+):
+    """A lone UTF-16 surrogate in the body/title must not crash delivery
+    on any send path -- direct-server, E2EE, or webhook."""
+    from apprise.common import NotifyFormat
+    from apprise.plugins.matrix.base import MatrixWebhookMode
+    from apprise.plugins.matrix.e2ee import MatrixMegOlmSession
+
+    def _mk_resp(d):
+        r = mock.Mock()
+        r.status_code = requests.codes.ok
+        r.content = dumps(d).encode()
+        return r
+
+    lone_surrogate_body = "hello " + chr(0xD800) + " world"
+    lone_surrogate_title = "t" + chr(0xDC00) + "t"
+
+    # Direct-server plaintext path.
+    response_obj = {
+        "room_id": "!abc:localhost",
+        "room_alias": "#abc:localhost",
+        "joined_rooms": ["!abc:localhost"],
+        "access_token": "abcd1234",
+        "home_server": "localhost",
+    }
+    mock_get.return_value = _mk_resp(response_obj)
+    mock_post.return_value = _mk_resp(response_obj)
+    mock_put.return_value = _mk_resp({})
+    obj = NotifyMatrix(host="hostname", user="user", password="passwd")
+    assert bool(obj.notify(body=lone_surrogate_body)) is True
+    payload = loads(mock_put.call_args.kwargs["data"])
+    # The lone surrogate is replaced, never crashing serialization.
+    payload["body"].encode("utf-8")
+
+    # E2EE path.
+    mock_get.return_value = _mk_resp({})
+    mock_put.return_value = _mk_resp({})
+    mock_post.return_value = _mk_resp({})
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["!r:h"],
+        e2ee=True,
+        secure=True,
+        discovery=False,
+    )
+    session = MatrixMegOlmSession()
+    obj.store.set("e2ee_room_enc_!r:h", True)
+    obj.store.set("e2ee_megolm_!r:h", session.to_dict())
+    obj.store.set("e2ee_key_shared_!r:h", session.session_id)
+    obj.access_token = "tok"
+    obj.home_server = "h"
+    obj.user_id = "@u:h"
+    obj.device_id = "DEV"
+    assert (
+        bool(
+            obj.notify(
+                body="hello",
+                title=lone_surrogate_title,
+                body_format=NotifyFormat.HTML,
+            )
+        )
+        is True
+    )
+
+    # Webhook (Slack-compatible) path.
+    mock_post.return_value = _mk_resp({})
+    obj = NotifyMatrix(
+        host="h", user="u", token="tok", mode=MatrixWebhookMode.SLACK
+    )
+    assert bool(obj.notify(body=lone_surrogate_body)) is True
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_caps_before_scanning_density(
+    mock_post, mock_get, mock_put
+):
+    """The payload cap is applied before UTF-8 density is scanned."""
+    from apprise.asset import AppriseAsset
+    from apprise.common import OverflowMode
+
+    response_obj = {
+        "room_id": "!abc123:localhost",
+        "room_alias": "#abc123:localhost",
+        "joined_rooms": ["!abc123:localhost"],
+        "access_token": "abcd1234",
+        "home_server": "localhost",
+    }
+    request = mock.Mock()
+    request.content = dumps(response_obj)
+    request.status_code = requests.codes.ok
+
+    mock_get.return_value = request
+    mock_post.return_value = request
+    mock_put.return_value = request
+
+    asset = AppriseAsset(payload_max_size=100)
+    obj = NotifyMatrix(
+        host="hostname", user="user", password="passwd", asset=asset
+    )
+
+    # Only the capped 100 characters should be scanned.
+    huge_body = "a" * 10_000_000
+    assert (
+        bool(obj.notify(body=huge_body, overflow=OverflowMode.SPLIT)) is True
+    )
+
+    # Capped to 100 characters up front, so a single small event is sent.
+    assert mock_put.call_count == 1
+    payload = loads(mock_put.call_args.kwargs["data"])
+    assert len(payload["body"]) <= 100
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_caps_before_sanitizing(mock_post, mock_get, mock_put):
+    """Apply the payload cap before scanning text for invalid surrogates.
+
+    Webhook mode isolates the cap performed by ``_build_send_calls()``.
+    """
+    from apprise.asset import AppriseAsset
+    from apprise.plugins.matrix.base import MatrixWebhookMode
+
+    request = mock.Mock()
+    request.content = dumps({})
+    request.status_code = requests.codes.ok
+    mock_post.return_value = request
+
+    asset = AppriseAsset(payload_max_size=100)
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        token="tok",
+        mode=MatrixWebhookMode.SLACK,
+        asset=asset,
+    )
+
+    seen_lengths = []
+    from apprise.plugins.matrix import (
+        base as matrix_base,
+        sizing as matrix_sizing,
+    )
+
+    real_sanitize_fn = matrix_sizing.sanitize_text
+
+    def spy_sanitize(text):
+        seen_lengths.append(len(text) if text else 0)
+        return real_sanitize_fn(text)
+
+    huge_body = "a" * 10_000_000
+    with (
+        mock.patch.object(matrix_sizing, "sanitize_text", spy_sanitize),
+        mock.patch.object(matrix_base, "_matrix_sanitize_text", spy_sanitize),
+    ):
+        assert bool(obj.notify(body=huge_body)) is True
+
+    # Every call into the sanitizer saw only the already-capped text, never
+    # the original 10,000,000-character body.
+    assert seen_lengths
+    assert max(seen_lengths) <= 100
+
+
+def test_plugin_matrix_preview_avoids_extra_full_strip():
+    """Avoid stripping and copying a large input during sizing.
+
+    The framework performs the one required full-input strip. The sizing
+    preview finds trim boundaries without making another full-size copy.
+    """
+    from apprise.asset import AppriseAsset
+    from apprise.common import OverflowMode
+
+    calls = []
+
+    class _TrackingStr(str):
+        def rstrip(self, *args, **kwargs):
+            calls.append(("rstrip", len(self)))
+            return super().rstrip(*args, **kwargs)
+
+        def strip(self, *args, **kwargs):
+            calls.append(("strip", len(self)))
+            return super().strip(*args, **kwargs)
+
+    asset = AppriseAsset(payload_max_size=100)
+    obj = NotifyMatrix(
+        host="h", user="u", password="pass", targets=["#r"], asset=asset
+    )
+
+    huge_body = _TrackingStr("a" * 10_000_000 + " ")
+    huge_title = _TrackingStr(" " * 10_000_000 + "hi")
+
+    list(
+        obj._build_send_calls(
+            body=huge_body,
+            title=huge_title,
+            overflow=OverflowMode.SPLIT,
+        )
+    )
+
+    full_length_rstrip_calls = [
+        c for c in calls if c == ("rstrip", len(huge_body))
+    ]
+    full_length_strip_calls = [
+        c for c in calls if c == ("strip", len(huge_title))
+    ]
+    assert len(full_length_rstrip_calls) == 1
+    assert len(full_length_strip_calls) == 1
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_whitespace_title_does_not_steal_cap(
+    mock_post, mock_get, mock_put
+):
+    """Whitespace-only titles must not consume the payload cap.
+
+    The sizing preview follows the framework's strip-then-cap order so the
+    useful body receives the space vacated by the title.
+    """
+    from apprise.asset import AppriseAsset
+    from apprise.common import OverflowMode
+
+    response_obj = {
+        "room_id": "!abc123:localhost",
+        "room_alias": "#abc123:localhost",
+        "joined_rooms": ["!abc123:localhost"],
+        "access_token": "abcd1234",
+        "home_server": "localhost",
+    }
+    request = mock.Mock()
+    request.content = dumps(response_obj)
+    request.status_code = requests.codes.ok
+    mock_get.return_value = request
+    mock_post.return_value = request
+    mock_put.return_value = request
+
+    asset = AppriseAsset(payload_max_size=300)
+    obj = NotifyMatrix(
+        host="hostname", user="user", password="passwd", asset=asset
+    )
+
+    title = " " * 250
+    body = "x" * 300
+
+    assert bool(
+        obj.notify(body=body, title=title, overflow=OverflowMode.SPLIT)
+    )
+    payload = loads(mock_put.call_args_list[0].kwargs["data"])
+    # The whitespace-only title contributes nothing once stripped, so the
+    # full body -- not a truncated fragment -- fits within the cap.
+    assert payload["body"] == body
+
+
+def test_plugin_matrix_title_leading_whitespace_past_cap():
+    """Keep meaningful title text beyond leading whitespace.
+
+    The preview must follow the framework's trim-then-cap behavior so title
+    overhead is measured correctly.
+    """
+    from apprise.asset import AppriseAsset
+    from apprise.common import NotifyFormat, OverflowMode
+
+    asset = AppriseAsset(payload_max_size=100)
+    obj = NotifyMatrix(
+        host="h", user="u", password="pass", targets=["#r"], asset=asset
+    )
+
+    # More leading whitespace than the cap, followed by an escape-heavy
+    # meaningful title (each char costs 6 JSON-escaped bytes).
+    title = (" " * 150) + ("\x01" * 50)
+    body = "hello world"
+
+    from apprise.plugins.matrix import sizing as matrix_sizing
+
+    observed = {}
+    real_overhead_fn = matrix_sizing.title_overhead_bytes
+
+    def spy_title_overhead(title_arg, body_format, escape_html):
+        observed["title_arg"] = title_arg
+        return real_overhead_fn(title_arg, body_format, escape_html)
+
+    with mock.patch.object(
+        matrix_sizing, "title_overhead_bytes", spy_title_overhead
+    ):
+        list(
+            obj._build_send_calls(
+                body=body,
+                title=title,
+                body_format=NotifyFormat.HTML,
+                overflow=OverflowMode.SPLIT,
+            )
+        )
+
+    # The preview must have seen the real, meaningful title content --
+    # not an empty string produced by slicing into the leading whitespace.
+    assert observed["title_arg"] == "\x01" * 50
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_truncation_warning_fires(mock_post, mock_get, mock_put):
+    """A genuinely oversized payload must still log the framework's normal
+    truncation warning -- sizing this content-aware must not suppress it
+    by pre-trimming before the framework's own check ever runs."""
+    from apprise.asset import AppriseAsset
+    from apprise.common import OverflowMode
+
+    response_obj = {
+        "room_id": "!abc123:localhost",
+        "room_alias": "#abc123:localhost",
+        "joined_rooms": ["!abc123:localhost"],
+        "access_token": "abcd1234",
+        "home_server": "localhost",
+    }
+    request = mock.Mock()
+    request.content = dumps(response_obj)
+    request.status_code = requests.codes.ok
+    mock_get.return_value = request
+    mock_post.return_value = request
+    mock_put.return_value = request
+
+    asset = AppriseAsset(payload_max_size=100)
+    obj = NotifyMatrix(
+        host="hostname", user="user", password="passwd", asset=asset
+    )
+
+    with mock.patch.object(obj, "logger") as mock_logger:
+        assert bool(
+            obj.notify(
+                body="x" * 300, title="Alert", overflow=OverflowMode.SPLIT
+            )
+        )
+        assert any(
+            "trimmed" in call.args[0]
+            for call in mock_logger.warning.call_args_list
+        )
+
+
+def test_plugin_matrix_body_limit_thread_isolation():
+    """Keep content-aware body limits isolated across threads.
+
+    The context variable is exercised directly so the test is deterministic
+    and does not depend on reproducing a timing-sensitive race.
+    """
+    import threading
+
+    from apprise.plugins.matrix import base as matrix_base
+
+    obj = NotifyMatrix(
+        host="h", user="u", password="pass", targets=["#r"], secure=True
+    )
+
+    # Sizing state lives in a context var, not on the instance itself.
+    assert "_matrix_effective_body_maxlen" not in obj.__dict__
+
+    var = matrix_base._matrix_effective_body_maxlen_var
+    seen_in_other_thread = {}
+
+    def set_and_check_from_other_thread():
+        token = var.set(999)
+        try:
+            seen_in_other_thread["value"] = var.get()
+        finally:
+            var.reset(token)
+
+    token = var.set(111)
+    try:
+        t = threading.Thread(target=set_and_check_from_other_thread)
+        t.start()
+        t.join(timeout=5)
+
+        # The other thread's write must not have leaked into this one.
+        assert var.get() == 111
+    finally:
+        var.reset(token)
+
+    # And this thread's write must not have leaked into the other one.
+    assert seen_in_other_thread["value"] == 999
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_emoji_split_preserves_content(
+    mock_post, mock_get, mock_put
+):
+    """Emoji splitting preserves content within the byte limit."""
+    from apprise.common import OverflowMode
+
+    response_obj = {
+        "room_id": "!abc123:localhost",
+        "room_alias": "#abc123:localhost",
+        "joined_rooms": ["!abc123:localhost"],
+        "access_token": "abcd1234",
+        "home_server": "localhost",
+    }
+    request = mock.Mock()
+    request.content = dumps(response_obj)
+    request.status_code = requests.codes.ok
+
+    mock_get.return_value = request
+    mock_post.return_value = request
+    mock_put.return_value = request
+
+    obj = NotifyMatrix(host="hostname", user="user", password="passwd")
+
+    original_body = "\U0001f600" * 20000
+    assert (
+        bool(obj.notify(body=original_body, overflow=OverflowMode.SPLIT))
+        is True
+    )
+
+    # Each event must independently fit Matrix's byte limit.
+    assert mock_put.call_count > 1
+    reconstructed = ""
+    for call in mock_put.call_args_list:
+        payload = loads(call.kwargs["data"])
+        encoded_len = len(dumps(payload, ensure_ascii=False).encode("utf-8"))
+        assert encoded_len <= 65536
+        reconstructed += payload["body"]
+
+    # No emoji was dropped or duplicated across the split events.
+    assert reconstructed == original_body
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_emoji_split_counters(mock_post, mock_get, mock_put):
+    """Emoji split counters match the number of events sent."""
+    from apprise.common import OverflowMode
+
+    response_obj = {
+        "room_id": "!abc123:localhost",
+        "room_alias": "#abc123:localhost",
+        "joined_rooms": ["!abc123:localhost"],
+        "access_token": "abcd1234",
+        "home_server": "localhost",
+    }
+    request = mock.Mock()
+    request.content = dumps(response_obj)
+    request.status_code = requests.codes.ok
+
+    mock_get.return_value = request
+    mock_post.return_value = request
+    mock_put.return_value = request
+
+    obj = NotifyMatrix(host="hostname", user="user", password="passwd")
+
+    assert (
+        bool(
+            obj.notify(
+                title="Title",
+                body="\U0001f600" * 20000,
+                overflow=OverflowMode.SPLIT,
+            )
+        )
+        is True
+    )
+
+    total = mock_put.call_count
+    assert total > 1
+
+    # Counters use the framework's zero-padded width.
+    digits = len(str(total))
+    last_payload = loads(mock_put.call_args_list[-1].kwargs["data"])
+    assert f"[{total:0{digits}d}/{total:0{digits}d}]" in last_payload["body"]

--- a/tests/test_plugin_matrix_sizing.py
+++ b/tests/test_plugin_matrix_sizing.py
@@ -1,0 +1,194 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import random
+
+from apprise.asset import AppriseAsset
+from apprise.common import NotifyFormat
+from apprise.plugins.matrix import NotifyMatrix, sizing
+
+
+def test_plugin_matrix_utf8_char_len():
+    """Calculate UTF-8 widths without encoding each character."""
+    assert sizing.utf8_char_len("a") == 1
+    assert sizing.utf8_char_len("é") == 2
+    assert sizing.utf8_char_len("中") == 3
+    assert sizing.utf8_char_len("\U0001f600") == 4
+
+
+def test_plugin_matrix_json_char_bytes():
+    """Include JSON escaping in each character's byte cost."""
+    assert sizing.json_char_bytes("a") == 1
+    assert sizing.json_char_bytes('"') == 2
+    assert sizing.json_char_bytes("\\") == 2
+
+    # Short control escapes use two bytes.
+    for ch in ("\b", "\f", "\n", "\r", "\t"):
+        assert sizing.json_char_bytes(ch) == 2
+
+    # Other control characters use the six-byte Unicode form.
+    assert sizing.json_char_bytes("\x00") == 6
+    assert sizing.json_char_bytes("\x1f") == 6
+    assert sizing.json_char_bytes("é") == 2
+    assert sizing.json_char_bytes("中") == 3
+    assert sizing.json_char_bytes("\U0001f600") == 4
+
+
+def test_plugin_matrix_max_byte_budget():
+    """Find the largest input accepted by the event cost model."""
+    assert sizing.max_byte_budget(lambda value: value + 10, 110, 1000) == 100
+    assert sizing.max_byte_budget(lambda value: value + 1000, 10, 1000) == 0
+
+
+def test_plugin_matrix_sanitize_text():
+    """Replace lone surrogates while preserving regular text."""
+    assert sizing.sanitize_text(None) is None
+    assert sizing.sanitize_text("") == ""
+    assert sizing.sanitize_text("hello") == "hello"
+
+    sanitized = sizing.sanitize_text("a" + chr(0xD800) + "b")
+    assert sanitized == "a?b"
+    sanitized.encode("utf-8")
+
+
+def test_plugin_matrix_trim_bounds():
+    """Find normal strip boundaries without copying the input."""
+    assert sizing.rstrip_end("hello") == len("hello")
+    assert sizing.rstrip_end("hello   ") == len("hello")
+    assert sizing.rstrip_end("   ") == 0
+    assert sizing.rstrip_end("") == 0
+
+    assert sizing.strip_bounds("hello") == (0, len("hello"))
+    text = "   hello   "
+    start, end = sizing.strip_bounds(text)
+    assert text[start:end] == "hello"
+
+    start, end = sizing.strip_bounds("   ")
+    assert start == end
+    assert sizing.strip_bounds("") == (0, 0)
+
+
+def test_plugin_matrix_payload_budget():
+    """Match every branch of the asset's payload-cap allocation."""
+    assert sizing.payload_budget(AppriseAsset(), 500, 500) == (500, 500)
+
+    asset = AppriseAsset(payload_max_size=100)
+    assert sizing.payload_budget(asset, 10, 10) == (10, 10)
+    assert sizing.payload_budget(asset, 0, 5000) == (0, 100)
+    assert sizing.payload_budget(asset, 5000, 0) == (100, 0)
+    assert sizing.payload_budget(asset, 5, 5000) == (5, 95)
+    assert sizing.payload_budget(asset, 5000, 5) == (95, 5)
+    assert sizing.payload_budget(asset, 5000, 5000) == (50, 50)
+
+    # A local generator avoids changing randomness for unrelated tests.
+    generator = random.Random(2026)
+    for _ in range(500):
+        cap = generator.choice([0, 1, 5, 25, 50, 100, 300])
+        threshold = generator.choice([1, 5, 10, 20])
+        min_buffer = generator.choice([1, 5, 25, 50])
+        title_len = generator.choice([0, 1, 5, 10, 50, 100, 500])
+        body_len = generator.choice([0, 1, 5, 10, 50, 100, 500, 5000])
+
+        asset = AppriseAsset(
+            payload_max_size=cap,
+            payload_buffer_threshold=threshold,
+            payload_min_buffer=min_buffer,
+        )
+        real_title, real_body = asset.enforce_payload_max_size(
+            "T" * title_len, "B" * body_len
+        )
+        assert sizing.payload_budget(asset, title_len, body_len) == (
+            len(real_title),
+            len(real_body),
+        )
+
+
+def test_plugin_matrix_title_overhead_bytes():
+    """Measure title wrappers exactly as Matrix embeds them."""
+
+    def json_bytes(value):
+        return sum(sizing.json_char_bytes(ch) for ch in value)
+
+    escape_html = NotifyMatrix.escape_html
+    assert sizing.title_overhead_bytes("", NotifyFormat.TEXT, escape_html) == 0
+
+    plain = sizing.title_overhead_bytes("hi", NotifyFormat.TEXT, escape_html)
+    assert plain == json_bytes("# hi\r\n")
+
+    html = sizing.title_overhead_bytes("hi", NotifyFormat.HTML, escape_html)
+    assert html == json_bytes("# hi\r\n") + json_bytes("<h1>hi</h1>")
+
+    markdown = sizing.title_overhead_bytes(
+        "<b>", NotifyFormat.MARKDOWN, escape_html
+    )
+    escaped = escape_html("<b>", whitespace=False)
+    assert markdown == json_bytes("# <b>\r\n") + json_bytes(
+        f"<h1>{escaped}</h1>"
+    )
+
+    heavy = sizing.title_overhead_bytes(
+        "\x01" * 10, NotifyFormat.TEXT, escape_html
+    )
+    assert heavy == json_bytes("# \r\n") + 10 * 6
+
+
+def test_plugin_matrix_device_id_overhead_bytes():
+    """Measure known device IDs and use a fallback for unknown IDs."""
+    assert (
+        sizing.device_id_overhead_bytes(None)
+        == sizing.MATRIX_DEVICE_ID_FALLBACK_BYTES
+    )
+    assert sizing.device_id_overhead_bytes("ABCDEFGHIJ") == 10
+    assert sizing.device_id_overhead_bytes("D" * 500) == 500
+
+
+def test_plugin_matrix_title_sizing_stays_separate():
+    """Keep Matrix title sizing independent from body chunk lengths."""
+    assert NotifyMatrix.title_maxlen == 250
+    assert NotifyMatrix.overflow_amalgamate_title is False
+
+
+def test_plugin_matrix_fit_limit_performance(monkeypatch):
+    """Keep the sizing scan linear for large messages."""
+
+    def cost_fn(window_bytes):
+        return window_bytes + 200
+
+    length = 1_000_000
+    body = "a" * length
+    calls = {"count": 0}
+    real_json_char_bytes = sizing.json_char_bytes
+
+    def counting_json_char_bytes(ch):
+        calls["count"] += 1
+        return real_json_char_bytes(ch)
+
+    monkeypatch.setattr(sizing, "json_char_bytes", counting_json_char_bytes)
+    result = sizing.fit_char_limit(body, 61536, cost_fn)
+
+    assert result > 0
+    assert calls["count"] <= length * 3


### PR DESCRIPTION
## Description

**Related issue (if applicable):** #1682

Improves Matrix message sizing so notifications remain within Matrix’s 65,536-byte event limit.

## Checklist

- [x] Documentation ticket created (if applicable): [apprise-docs/110](https://github.com/caronc/apprise-docs/pull/110)
- [x] The change is tested and works locally.
- [x] No commented-out code in this PR.
- [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
- [x] Test coverage added or updated (use `tox -e qa`).

## Testing

Anyone can help test as follows:

```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@v2-1682-matrix-message-sizes

# Send a large Unicode message to test content-aware splitting
apprise -vv -t "Matrix Size Test" \
    -b "$(python3 -c 'print("😀" * 20000)')" \
    "matrixs://user:password@matrix.example.com/#room"

# Test Markdown rendering and its plain-text fallback
apprise -vv -t "Markdown Test" -f markdown \
    -b "**Bold text** with a [link](https://example.com)" \
    "matrixs://user:password@matrix.example.com/#room"

# Explicitly test an unencrypted room
apprise -vv -t "Unencrypted Test" \
    -b "$(python3 -c 'print("Matrix message " * 10000)')" \
    "matrixs://user:password@matrix.example.com/#room?e2ee=no"

# Run the Matrix test coverage from a cloned checkout
python -m pytest -q \
    tests/test_plugin_matrix.py \
    tests/test_plugin_matrix_sizing.py

# Run the project checks with tox
tox -e lint
tox -e qa
```