### PR TITLE
Improved handling matrix message splitting

### DIFF
--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -50,6 +50,9 @@ from ...common import (
     NotifyType,
     PersistentStoreMode,
 )
+
+# Convert confirmed HTML into Matrix's required plain-text fallback.
+from ...conversion import html_to_text
 from ...exception import AppriseException
 from ...locale import gettext_lazy as _
 from ...url import PrivacyMode
@@ -168,6 +171,21 @@ MATRIX_WEBHOOK_MODES = (
     MatrixWebhookMode.HOOKSHOT,
 )
 
+# Matrix rejects complete events larger than 65,536 bytes. This hard ceiling
+# includes message content, metadata, and federation signatures.
+# https://spec.matrix.org/v1.6/client-server-api/#size-limits
+MATRIX_EVENT_BYTE_LIMIT = 65536
+
+# Reserve 4,000 bytes for IDs, timestamps, sender details, and signatures
+# that the homeserver adds after Apprise submits the message content.
+MATRIX_EVENT_SAFETY_MARGIN = 4000
+
+# Limit Apprise-controlled JSON to the hard ceiling minus server overhead.
+# Direct and encrypted send paths both use this final safety allowance.
+MATRIX_CONTENT_BYTE_LIMIT = (
+    MATRIX_EVENT_BYTE_LIMIT - MATRIX_EVENT_SAFETY_MARGIN
+)
+
 
 class NotifyMatrix(NotifyBase):
     """A wrapper for Matrix Notifications."""
@@ -193,15 +211,22 @@ class NotifyMatrix(NotifyBase):
     # Allows the user to specify the NotifyImageSize object
     image_size = NotifyImageSize.XY_32
 
-    # The maximum allowable characters allowed in the body per message
-    # https://spec.matrix.org/v1.6/client-server-api/#size-limits
-    # The complete event MUST NOT be larger than 65536 bytes, when formatted
-    # with the federation event format, including any signatures, and encoded
-    # as Canonical JSON.
-    #
-    # To gracefully allow for some overhead' we'll define a max body length
-    # of just slighty lower then the limit of the full message itself.
-    body_maxlen = 65000
+    # These character limits let the framework split or truncate the body
+    # before Matrix builds and measures the completed JSON payload.
+    # A 60,000-character one-byte body leaves room for JSON and the title.
+    body_maxlen_default = 60000
+
+    # Two 29,000-character one-byte bodies leave room for JSON and the title.
+    body_maxlen_formatted = 29000
+
+    # Keep one-byte plaintext near 40,000 before encryption expands it.
+    body_maxlen_e2ee = 40000
+
+    # Two one-byte 19,000-character bodies leave room for encryption growth.
+    body_maxlen_e2ee_formatted = 19000
+
+    # Webhooks do not create direct room events, so retain v1's 65,000 limit.
+    body_maxlen_webhook = 65000
 
     # Throttle a wee-bit to avoid thrashing
     request_rate_per_sec = 0.5
@@ -552,9 +577,18 @@ class NotifyMatrix(NotifyBase):
                 with contextlib.suppress(Exception):
                     self._e2ee_account = MatrixOlmAccount.from_dict(acct_data)
 
-    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+    def send(
+        self,
+        body,
+        title="",
+        notify_type=NotifyType.INFO,
+        body_format=None,
+        **kwargs,
+    ):
         """Perform Matrix Notification."""
 
+        # Keep the caller's input format available to the selected sender.
+        # A value of None retains the legacy v1 pass-through behavior.
         # Call the _send_ function applicable to whatever mode we're in
         # - calls _send_webhook_notification if the mode variable is set
         # - calls _send_server_notification if the mode variable is not set
@@ -565,10 +599,80 @@ class NotifyMatrix(NotifyBase):
                 if self.mode != MatrixWebhookMode.DISABLED
                 else "server"
             ),
-        )(body=body, title=title, notify_type=notify_type, **kwargs)
+        )(
+            body=body,
+            title=title,
+            notify_type=notify_type,
+            body_format=body_format,
+            **kwargs,
+        )
+
+    def _matrix_plain_fallback(self, body, body_format=None):
+        """Build the fallback shown by clients without rich-text support."""
+        # A missing input format is v1's pass-through signal.
+        if body_format is None or self.notify_format != NotifyFormat.HTML:
+            # Preserve unknown or non-HTML content exactly as supplied.
+            return body
+
+        # Strip confirmed HTML for clients that only display plain text.
+        return html_to_text(body)
+
+    @staticmethod
+    def _matrix_enforce_byte_budget(payload, byte_budget, keys):
+        """Shrink selected fields until the JSON payload fits its byte
+        budget."""
+        # Measure after JSON encoding because escaping changes the byte count.
+        while True:
+            # Match the compact Unicode representation used for delivery.
+            encoded_len = len(
+                dumps(payload, ensure_ascii=False).encode(
+                    "utf-8", errors="replace"
+                )
+            )
+
+            # A negative or zero overage means the payload is ready to send.
+            overage = encoded_len - byte_budget
+            if overage <= 0:
+                break
+
+            # Prefer the largest body so both representations retain content.
+            target_key = max(
+                # Ignore missing and already-empty candidate fields.
+                (k for k in keys if payload.get(k)),
+                # Compare encoded size because characters have varying widths.
+                key=lambda k: len(
+                    payload[k].encode("utf-8", errors="replace")
+                ),
+                default=None,
+            )
+            if target_key is None:
+                # Fixed payload fields alone exceed the requested budget.
+                break
+
+            # Estimate how many characters account for the excess bytes.
+            text = payload[target_key]
+            bytes_per_char = len(text.encode("utf-8", errors="replace")) / len(
+                text
+            )
+
+            # Always remove at least one character so the loop progresses.
+            chars_to_drop = max(1, int(overage / bytes_per_char) + 1)
+
+            # Empty the field when the calculated reduction consumes it all.
+            payload[target_key] = (
+                text[:-chars_to_drop] if chars_to_drop < len(text) else ""
+            )
+
+        # Return the same payload object for convenient use by callers.
+        return payload
 
     def _send_webhook_notification(
-        self, body, title="", notify_type=NotifyType.INFO, **kwargs
+        self,
+        body,
+        title="",
+        notify_type=NotifyType.INFO,
+        body_format=None,
+        **kwargs,
     ):
         """Perform Matrix Notification as a webhook."""
 
@@ -614,9 +718,13 @@ class NotifyMatrix(NotifyBase):
                 token=access_token,
             )
 
-        # Retrieve our payload
+        # Forward the original format so webhook fallbacks remain accurate.
         payload = getattr(self, f"_{self.mode}_webhook_payload")(
-            body=body, title=title, notify_type=notify_type, **kwargs
+            body=body,
+            title=title,
+            notify_type=notify_type,
+            body_format=body_format,
+            **kwargs,
         )
 
         self.logger.debug(
@@ -632,7 +740,11 @@ class NotifyMatrix(NotifyBase):
         try:
             r = requests.post(
                 url,
-                data=dumps(payload),
+                # Keep Unicode compact instead of expanding it to \u escapes.
+                # Replace invalid code points before requests encodes the body.
+                data=dumps(payload, ensure_ascii=False)
+                .encode("utf-8", errors="replace")
+                .decode("utf-8"),
                 headers=headers,
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
@@ -795,7 +907,17 @@ class NotifyMatrix(NotifyBase):
         }
 
         if self.notify_format == NotifyFormat.HTML:
-            payload["text"] = body if not title else f"{title}\r\n{body}"
+            # Build the value used by clients that ignore Hookshot's HTML.
+            plain_body = self._matrix_plain_fallback(
+                body, kwargs.get("body_format")
+            )
+
+            # Keep the title readable in the plain fallback.
+            payload["text"] = (
+                plain_body if not title else f"{title}\r\n{plain_body}"
+            )
+
+            # Place the original markup in Hookshot's rich HTML field.
             payload["html"] = "{title}{body}".format(
                 title=(
                     ""
@@ -830,6 +952,7 @@ class NotifyMatrix(NotifyBase):
         title="",
         notify_type=NotifyType.INFO,
         attach=None,
+        body_format=None,
         **kwargs,
     ):
         """Perform Direct Matrix Server Notification (no webhook)"""
@@ -926,9 +1049,9 @@ class NotifyMatrix(NotifyBase):
                 continue
 
             if e2ee_capable and self._e2ee_room_encrypted(room_id):
-                # E2EE path: encrypt message and any attachments
+                # Pass format provenance into the encrypted message builder.
                 if not self._e2ee_send_to_room(
-                    room_id, body, title, notify_type
+                    room_id, body, title, notify_type, body_format
                 ):
                     has_error = True
                     continue
@@ -1024,12 +1147,15 @@ class NotifyMatrix(NotifyBase):
                         has_error = True
                         continue
 
-            # Define our payload
+            # Build the fallback that Matrix clients always expect.
+            plain_body = self._matrix_plain_fallback(body, body_format)
+
+            # Start with the fields shared by every Matrix text message.
             payload = {
                 "msgtype": f"m.{self.msgtype}",
                 "body": "{title}{body}".format(
                     title="" if not title else f"# {title}\r\n",
-                    body=body,
+                    body=plain_body,
                 ),
             }
 
@@ -1068,7 +1194,15 @@ class NotifyMatrix(NotifyBase):
                     }
                 )
 
-            # Post our content
+            # Character splitting cannot predict the cost of emoji or escapes.
+            # Apply the byte limit to the completed Matrix content as a guard.
+            self._matrix_enforce_byte_budget(
+                payload,
+                MATRIX_CONTENT_BYTE_LIMIT,
+                keys=("formatted_body", "body"),
+            )
+
+            # Submit only after both character and byte limits are applied.
             postokay, _, _ = self._fetch(path, payload=payload, method="PUT")
 
             # Increment the transaction ID to avoid future messages being
@@ -1852,7 +1986,15 @@ class NotifyMatrix(NotifyBase):
             try:
                 r = fn(
                     url,
-                    data=dumps(payload) if not attachment else payload,
+                    # Keep Unicode compact instead of expanding it to escapes.
+                    # Replace invalid code points before sending JSON text.
+                    data=(
+                        dumps(payload, ensure_ascii=False)
+                        .encode("utf-8", errors="replace")
+                        .decode("utf-8")
+                        if not attachment
+                        else payload
+                    ),
                     params=params if params else None,
                     headers=headers,
                     verify=self.verify_certificate,
@@ -2633,7 +2775,9 @@ class NotifyMatrix(NotifyBase):
 
         return True
 
-    def _e2ee_send_to_room(self, room_id, body, title, notify_type):
+    def _e2ee_send_to_room(
+        self, room_id, body, title, notify_type, body_format=None
+    ):
         """Encrypt and send one message to *room_id* via MegOLM.
 
         Shares the MegOLM session key with room members when the
@@ -2678,12 +2822,15 @@ class NotifyMatrix(NotifyBase):
                 session.session_id[:12],
             )
 
-        # Build the inner plaintext event
+        # Build the fallback before placing content inside the encrypted event.
+        plain_body = self._matrix_plain_fallback(body, body_format)
+
+        # Start the plaintext content that MegOLM will encrypt.
         msg_content = {
             "msgtype": "m.{}".format(self.msgtype),
             "body": "{title}{body}".format(
                 title="" if not title else "# {}\r\n".format(title),
-                body=body,
+                body=plain_body,
             ),
         }
 
@@ -2719,13 +2866,22 @@ class NotifyMatrix(NotifyBase):
                 }
             )
 
+        # Bound the inner content before encryption increases its wire size.
+        self._matrix_enforce_byte_budget(
+            msg_content, self.body_maxlen_e2ee, keys=("formatted_body", "body")
+        )
+
+        # MegOLM encrypts a complete room event, not only the message body.
         inner_event = {
             "type": "m.room.message",
             "content": msg_content,
             "room_id": room_id,
         }
 
+        # Encrypt with the room's current outbound group session.
         ciphertext = session.encrypt(inner_event)
+
+        # Persist the advanced message counter so it is never reused.
         self._e2ee_save_megolm(room_id, session)
 
         self.logger.trace(
@@ -2740,6 +2896,7 @@ class NotifyMatrix(NotifyBase):
         path = "/rooms/{}/send/m.room.encrypted/{}".format(
             NotifyMatrix.quote(room_id), self.transaction_id
         )
+        # Wrap the ciphertext with the identifiers Matrix clients require.
         encrypted_payload = {
             "algorithm": "m.megolm.v1.aes-sha2",
             "ciphertext": ciphertext,
@@ -2748,6 +2905,23 @@ class NotifyMatrix(NotifyBase):
             "device_id": self.device_id or "",
         }
 
+        # Server-provided identifiers may be longer than our initial estimate.
+        # Measure the finished envelope because it is the actual wire content.
+        encrypted_bytes = len(
+            dumps(encrypted_payload, ensure_ascii=False).encode(
+                "utf-8", errors="replace"
+            )
+        )
+
+        # Avoid a predictable homeserver rejection when the envelope is large.
+        if encrypted_bytes > MATRIX_CONTENT_BYTE_LIMIT:
+            self.logger.warning(
+                "Matrix E2EE event for room %s exceeds the safe byte limit.",
+                room_id,
+            )
+            return False
+
+        # The completed encrypted payload is now within the safe allowance.
         postokay, _, _ = self._fetch(
             path, payload=encrypted_payload, method="PUT"
         )
@@ -3047,6 +3221,37 @@ class NotifyMatrix(NotifyBase):
         # Best-effort cleanup only
         with contextlib.suppress(Exception):
             self._logout()
+
+    @property
+    def body_maxlen(self):
+        """Return a conservative limit for the configured Matrix format."""
+        # Webhooks are not sent as direct Matrix room events.
+        if self.mode != MatrixWebhookMode.DISABLED:
+            # Preserve their historical v1 character allowance.
+            return self.body_maxlen_webhook
+
+        # Rich messages send both formatted and fallback representations.
+        is_formatted = self.notify_format in (
+            NotifyFormat.HTML,
+            NotifyFormat.MARKDOWN,
+        )
+
+        # v1 must choose a split size before inspecting individual rooms.
+        e2ee_capable = self.e2ee and self.secure and MATRIX_E2EE_SUPPORT
+        if e2ee_capable:
+            # Reserve encryption room even if a later room is unencrypted.
+            return (
+                self.body_maxlen_e2ee_formatted
+                if is_formatted
+                else self.body_maxlen_e2ee
+            )
+
+        # Unencrypted messages only need normal Matrix event headroom.
+        return (
+            self.body_maxlen_formatted
+            if is_formatted
+            else self.body_maxlen_default
+        )
 
     @property
     def url_identifier(self):

--- a/apprise/plugins/matrix/e2ee.py
+++ b/apprise/plugins/matrix/e2ee.py
@@ -826,7 +826,11 @@ class MatrixMegOlmSession:
 
         Reference: MegOLM spec, Section 4.
         """
-        plaintext = dumps(payload_dict).encode("utf-8")
+        # Keep Unicode compact so encryption does not carry JSON escape bloat.
+        # Replace invalid code points before converting plaintext to bytes.
+        plaintext = dumps(payload_dict, ensure_ascii=False).encode(
+            "utf-8", errors="replace"
+        )
         aes_key, mac_key, iv = self._message_keys()
 
         ct_bytes = _aes_cbc_encrypt(aes_key, iv, plaintext)

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -41,10 +41,18 @@ from apprise import (
     Apprise,
     AppriseAsset,
     AppriseAttachment,
+    NotifyFormat,
     NotifyType,
+    OverflowMode,
     PersistentStoreMode,
 )
 from apprise.plugins.matrix import MatrixDiscoveryException, NotifyMatrix
+
+# Use Matrix's internal limit and mode names for exact boundary assertions.
+from apprise.plugins.matrix.base import (
+    MATRIX_CONTENT_BYTE_LIMIT,
+    MatrixWebhookMode,
+)
 
 logging.disable(logging.CRITICAL)
 
@@ -1810,6 +1818,7 @@ def test_plugin_matrix_hookshot_webhook(mock_post):
 
     payload = loads(mock_post.call_args.kwargs["data"])
     assert payload["username"] == "apprise"
+    # An omitted input format preserves v1's pass-through behavior.
     assert payload["text"] == "Title\r\n<b>Body</b>"
     assert payload["html"] == "<h1>Title</h1><b>Body</b>"
 
@@ -5189,3 +5198,344 @@ def test_plugin_matrix_room_id_returns_none_without_home_server():
 
     result = obj._room_id("#bare_alias")
     assert result is None
+
+
+def test_plugin_matrix_enforce_byte_budget():
+    """The byte budget shrinks Unicode without looping on empty text."""
+
+    # Give both Matrix body representations the same emoji-heavy content.
+    payload = {
+        "body": "\U0001f600" * 1000,
+        "formatted_body": "\U0001f600" * 1000,
+    }
+    # Apply a deliberately small budget so both fields must shrink.
+    NotifyMatrix._matrix_enforce_byte_budget(
+        payload, 500, keys=("formatted_body", "body")
+    )
+
+    # Measure the JSON exactly as Matrix serializes it.
+    assert len(dumps(payload, ensure_ascii=False).encode("utf-8")) <= 500
+
+    # Empty candidates exercise the helper's no-progress exit path.
+    empty_payload = {"body": "", "formatted_body": ""}
+
+    # A tiny impossible budget must return instead of looping forever.
+    result = NotifyMatrix._matrix_enforce_byte_budget(
+        empty_payload, 10, keys=("formatted_body", "body")
+    )
+    assert result == {"body": "", "formatted_body": ""}
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_emoji_byte_budget(mock_post, mock_get, mock_put):
+    """Emoji-heavy messages remain within Matrix's byte limit."""
+
+    # Reuse a successful Matrix response for login, lookup, and room joins.
+    response_obj = {
+        "room_id": "!abc123:localhost",
+        "room_alias": "#abc123:localhost",
+        "joined_rooms": ["!abc123:localhost"],
+        "access_token": "abcd1234",
+        "home_server": "localhost",
+    }
+    # Every mocked Matrix request receives the same successful response.
+    request = mock.Mock()
+    request.content = dumps(response_obj)
+    request.status_code = requests.codes.ok
+
+    # Cover each HTTP verb used by the direct Matrix send path.
+    mock_get.return_value = request
+    mock_post.return_value = request
+    mock_put.return_value = request
+
+    # Configure rich output so the payload contains two body fields.
+    kwargs = NotifyMatrix.parse_url(
+        "matrix://user:passwd@hostname/#abcd?format=html"
+    )
+    obj = NotifyMatrix(**kwargs)
+
+    # Send directly to exercise the byte-budget safety net.
+    assert obj.send(body="\U0001f600" * 20000) is True
+
+    # Inspect the final room event submitted through PUT.
+    payload = loads(mock_put.call_args.kwargs["data"])
+
+    # Confirm the wire representation stays inside Matrix's safe allowance.
+    encoded_len = len(dumps(payload, ensure_ascii=False).encode("utf-8"))
+    assert encoded_len <= MATRIX_CONTENT_BYTE_LIMIT
+
+    # Invalid Unicode is replaced instead of raising during serialization.
+    assert obj.send(body="\ud800") is True
+    # The invalid code point becomes a valid placeholder in the JSON body.
+    wire_payload = mock_put.call_args.kwargs["data"]
+    assert loads(wire_payload)["body"] == "?"
+
+
+def test_plugin_matrix_e2ee_body_limit():
+    """Matrix selects limits for formatting, encryption, and webhooks."""
+
+    # Begin with an explicitly unencrypted direct Matrix connection.
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=False,
+        secure=True,
+    )
+    # Plain output receives the larger single-body allowance.
+    assert obj.e2ee is False
+    assert obj.body_maxlen == obj.body_maxlen_default
+
+    # Rich text carries a plain fallback beside its formatted body.
+    obj.notify_format = NotifyFormat.HTML
+    assert obj.body_maxlen == obj.body_maxlen_formatted
+
+    # Non-TLS connections cannot use encryption even when requested.
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+        secure=False,
+    )
+    # The setting remains visible, but the normal formatted limit is used.
+    assert obj.e2ee is True
+    obj.notify_format = NotifyFormat.HTML
+    assert obj.body_maxlen == obj.body_maxlen_formatted
+
+    # A secure connection may use E2EE when crypto support is installed.
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+        secure=True,
+    )
+    assert obj.e2ee is True
+    obj.notify_format = NotifyFormat.HTML
+
+    # Installed crypto support activates the smaller encrypted rich limit.
+    if CRYPTOGRAPHY_AVAILABLE:
+        assert obj.body_maxlen == obj.body_maxlen_e2ee_formatted
+        assert obj.body_maxlen < obj.body_maxlen_formatted
+
+        # Plain encrypted content only needs one Matrix body field.
+        obj.notify_format = NotifyFormat.TEXT
+        assert obj.body_maxlen == obj.body_maxlen_e2ee
+    else:
+        # Encryption also requires the optional cryptography package.
+        assert obj.body_maxlen == obj.body_maxlen_formatted
+
+    # Webhooks keep the original limit regardless of output format.
+    obj.mode = MatrixWebhookMode.HOOKSHOT
+    assert obj.body_maxlen == obj.body_maxlen_webhook
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_html_plain_fallback(mock_post, mock_get, mock_put):
+    """HTML messages include plain text without repeating their markup."""
+
+    # Supply the minimum successful responses needed for a direct room send.
+    response_obj = {
+        "room_id": "!abc123:localhost",
+        "room_alias": "#abc123:localhost",
+        "joined_rooms": ["!abc123:localhost"],
+        "access_token": "abcd1234",
+        "home_server": "localhost",
+    }
+    # Return success for each mocked Matrix endpoint.
+    request = mock.Mock()
+    request.content = dumps(response_obj)
+    request.status_code = requests.codes.ok
+
+    mock_get.return_value = request
+    mock_post.return_value = request
+    mock_put.return_value = request
+
+    # Select HTML as Matrix's single configured v1 output format.
+    kwargs = NotifyMatrix.parse_url(
+        "matrix://user:passwd@hostname/#abcd?format=html"
+    )
+    obj = NotifyMatrix(**kwargs)
+
+    # Known input provenance allows Matrix to build a plain fallback.
+    assert (
+        obj.send(
+            title="Title",
+            body="<b>Bold</b> text",
+            body_format=NotifyFormat.HTML,
+        )
+        is True
+    )
+
+    # Read the unencrypted Matrix event submitted to the room.
+    payload = loads(mock_put.call_args.kwargs["data"])
+
+    # Preserve the original markup in Matrix's formatted representation.
+    assert payload["formatted_body"] == "<h1>Title</h1><b>Bold</b> text"
+    # The plain-text fallback must not carry the raw markup a second time.
+    assert "<b>" not in payload["body"]
+    assert "Bold text" in payload["body"]
+
+    # No input format is v1's pass-through signal.
+    assert obj.send(body="<b>Upstream HTML</b>") is True
+
+    # Re-read the most recent PUT to verify pass-through behavior.
+    payload = loads(mock_put.call_args.kwargs["data"])
+    assert payload["body"] == "<b>Upstream HTML</b>"
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_html_split_preserves_body(
+    mock_post, mock_get, mock_put
+):
+    """HTML overflow splits before payload sizing so content is preserved."""
+
+    # Make login, discovery, and room operations succeed for every chunk.
+    response_obj = {
+        "room_id": "!abc123:localhost",
+        "room_alias": "#abc123:localhost",
+        "joined_rooms": ["!abc123:localhost"],
+        "access_token": "abcd1234",
+        "home_server": "localhost",
+    }
+    # Share one stable mock response across all Matrix HTTP methods.
+    request = mock.Mock()
+    request.content = dumps(response_obj)
+    request.status_code = requests.codes.ok
+
+    mock_get.return_value = request
+    mock_post.return_value = request
+    mock_put.return_value = request
+
+    # Disable E2EE so this test targets the unencrypted HTML tier.
+    kwargs = NotifyMatrix.parse_url(
+        "matrix://user:passwd@hostname/#abcd?format=html&e2ee=no"
+    )
+    # Build a body that requires exactly three framework chunks.
+    obj = NotifyMatrix(**kwargs)
+    body = "x" * (obj.body_maxlen * 2 + 100)
+
+    # Use the normal notification path so the framework performs the split.
+    assert (
+        obj.notify(
+            body=body,
+            body_format=NotifyFormat.HTML,
+            overflow=OverflowMode.SPLIT,
+        )
+        is True
+    )
+
+    # Every original character remains across the resulting Matrix events.
+    payloads = [loads(call.kwargs["data"]) for call in mock_put.call_args_list]
+    # The conservative formatted limit should produce three events.
+    assert len(payloads) == 3
+
+    # Joining the formatted bodies must recreate the original input.
+    assert "".join(payload["formatted_body"] for payload in payloads) == body
+
+    # Each individual room event must remain within the byte allowance.
+    assert all(
+        len(dumps(payload, ensure_ascii=False).encode("utf-8"))
+        <= MATRIX_CONTENT_BYTE_LIMIT
+        for payload in payloads
+    )
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_e2ee_html_plain_fallback(mock_post, mock_get, mock_put):
+    """Encrypted HTML messages also provide a plain-text fallback."""
+    from apprise.common import NotifyFormat
+    from apprise.plugins.matrix.e2ee import (
+        MatrixMegOlmSession,
+        MatrixOlmAccount,
+    )
+
+    def _mk_resp(d):
+        # Build a successful Matrix response with JSON content.
+        r = mock.Mock()
+        r.status_code = requests.codes.ok
+        r.content = dumps(d).encode()
+        return r
+
+    # Room sends only need an empty successful response body here.
+    mock_put.return_value = _mk_resp({})
+
+    # Prepare a logged-in Matrix object with E2EE enabled.
+    obj = NotifyMatrix(
+        host="h", user="u", password="pass", targets=["#r"], e2ee=True
+    )
+    # Force the rich-output branch being exercised by this regression.
+    obj.notify_format = NotifyFormat.HTML
+
+    # Populate the identifiers normally learned during Matrix login.
+    obj.access_token = "tok"
+    obj.home_server = "h"
+    obj.user_id = "@u:h"
+    obj.device_id = "DEV"
+    # Supply an Olm account so the outer event has a sender key.
+    obj._e2ee_account = MatrixOlmAccount()
+
+    # Seed a MegOLM session that has already been shared with the room.
+    session = MatrixMegOlmSession()
+    obj.store.set("e2ee_megolm_!r:h", session.to_dict())
+    obj.store.set("e2ee_key_shared_!r:h", session.session_id)
+
+    # Capture the event before encryption so its fallback can be checked.
+    captured = {}
+    # Retain the real encryption function after capturing its input.
+    original_encrypt = MatrixMegOlmSession.encrypt
+
+    def _spy_encrypt(self, event):
+        # Save the plaintext event immediately before MegOLM encryption.
+        captured["event"] = event
+        return original_encrypt(self, event)
+
+    with mock.patch.object(MatrixMegOlmSession, "encrypt", _spy_encrypt):
+        assert (
+            obj._e2ee_send_to_room(
+                "!r:h",
+                "<b>Bold</b> text",
+                "Title",
+                NotifyType.INFO,
+                NotifyFormat.HTML,
+            )
+            is True
+        )
+
+    # Inspect both representations inside the captured plaintext event.
+    msg_content = captured["event"]["content"]
+
+    # The rich representation retains all supplied HTML.
+    assert msg_content["formatted_body"] == "<h1>Title</h1><b>Bold</b> text"
+
+    # The fallback remains readable without carrying duplicate markup.
+    assert "<b>" not in msg_content["body"]
+    assert "Bold text" in msg_content["body"]
+
+    # Reject unexpected envelope growth before the homeserver returns a 413.
+    # Record network activity before introducing an oversized device ID.
+    put_count = mock_put.call_count
+
+    # Simulate unexpected server metadata that consumes the entire budget.
+    obj.device_id = "d" * MATRIX_CONTENT_BYTE_LIMIT
+    assert (
+        obj._e2ee_send_to_room(
+            "!r:h", "Body", "", NotifyType.INFO, NotifyFormat.HTML
+        )
+        is False
+    )
+    # Rejection must happen locally without another room request.
+    assert mock_put.call_count == put_count


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1682

Backports a focused Matrix message-sizing workaround to Apprise v1.

Matrix limits complete events to 65,536 bytes. Formatted messages can exceed this limit because Matrix carries both a formatted body and a plain fallback. This change:

This intentionally remains simpler than the content-aware sizing provided by Apprise v2 (see #1686)

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
- [x] Documentation ticket created (if applicable): [apprise-docs/111](https://github.com/caronc/apprise-docs/pull/111)
- [x] The change is tested and works locally.
- [x] No commented-out code in this PR.
- [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
- [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:

```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the v1 backport branch
pip install git+https://github.com/caronc/apprise.git@1682-matrix-message-sizes

# Send a formatted Matrix notification
apprise -vv --input-format html \
    -t "Matrix HTML Test" \
    -b "<p>This is a <strong>formatted Matrix message</strong>.</p>" \
    "matrixs://user:password@hostname/#room?format=html&e2ee=no"

# If you have cloned the branch and have tox available:
tox -e apprise -- -vv --input-format html \
    -t "Matrix HTML Test" \
    -b "<p>This is a <strong>formatted Matrix message</strong>.</p>" \
    "matrixs://user:password@hostname/#room?format=html&e2ee=no"
```

To exercise message splitting with a larger HTML body:

```bash
python3 - <<'PY' > /tmp/apprise-matrix-test.html
print("<p>" + ("Long Matrix message content. " * 4000) + "</p>")
PY

apprise -vv --input-format html \
    -t "Matrix Overflow Test" \
    -b "$(cat /tmp/apprise-matrix-test.html)" \
    "matrixs://user:password@hostname/#room?format=html&overflow=split&e2ee=no"
```