### PR TITLE
small bugfix in splunk entity_id handling on url

### DIFF
--- a/apprise/plugins/splunk.py
+++ b/apprise/plugins/splunk.py
@@ -433,7 +433,9 @@ class NotifySplunk(NotifyBase):
             schema=self.secure_protocol[0],
             routing_key=self.routing_key,
             entity_id=(
-                "" if self.entity_id == self.routing_key else self.entity_id
+                ""
+                if self.entity_id == self.routing_key
+                else NotifySplunk.quote(self.entity_id, safe="/")
             ),
             apikey=self.pprint(self.apikey, privacy, safe=""),
             params=NotifySplunk.urlencode(params),

--- a/tests/test_plugin_splunk.py
+++ b/tests/test_plugin_splunk.py
@@ -89,6 +89,19 @@ apprise_url_tests = (
             "instance": NotifySplunk,
         },
     ),
+    (
+        # An entity_id containing characters that are reserved in a URL
+        # (?, #, %, /) must survive a url() round-trip without being
+        # truncated or corrupted.
+        "splunk://route@abc123/?entity_id=a%3Fb%23c%25d%2Fe",
+        {
+            # We're good
+            "instance": NotifySplunk,
+            # Our privacy url confirms the entity_id was quoted (not
+            # dropped) when the url() was re-assembled
+            "privacy_url": "splunk://route@a...3/a%3Fb%23c%25d/e",
+        },
+    ),
     # Support legacy URL
     (
         (


### PR DESCRIPTION
## Description
**Related issue (if applicable):** n/a

`NotifySplunk.url()` was interpolating `entity_id` directly into the URL string with no percent-encoding at all. An `entity_id` containing `?`, `#`, or `%` (all valid in a Splunk On-Call / VictorOps entity ID) would get silently truncated or corrupted the next time that URL was reloaded.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): N/A — no documentation change.
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@splunk-small-bugfix

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "splunk://routing_key@apikey/?entity_id=a%3Fb%23c%25d%2Fe"
```
