### PR TITLE
Fixed warnings emitted while running test suite

### DIFF
--- a/apprise/attachment/base.py
+++ b/apprise/attachment/base.py
@@ -342,9 +342,11 @@ class AttachBase(URLBase):
           - detected_mimetype: Should identify mimetype of content
         """
 
-        # Remove all open pointers
+        # Close every tracked pointer without letting cleanup errors escape
+        # from invalidate() or __del__().
         while self.__pointers:
-            self.__pointers.pop().close()
+            with contextlib.suppress(OSError):
+                self.__pointers.pop().close()
 
         self.detected_name = None
         self.download_path = None

--- a/apprise/attachment/http.py
+++ b/apprise/attachment/http.py
@@ -297,7 +297,9 @@ class AttachHTTP(AttachBase):
         """Close our temporary file."""
         if self._temp_file:
             self.logger.trace("Attachment cleanup of %s", self._temp_file.name)
-            self._temp_file.close()
+            # Do not let temporary-file cleanup errors escape from __del__().
+            with contextlib.suppress(OSError):
+                self._temp_file.close()
 
             with contextlib.suppress(OSError):
                 # Ensure our file is removed (if it exists)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -367,7 +367,14 @@ builtins-ignorelist = ["_"]
 addopts = "-ra"
 testpaths = ["tests"]
 python_files = ["test_*.py", "tests/test_*.py"]
-filterwarnings = ["once::Warning"]
+filterwarnings = [
+    "once::Warning",
+    # Ignore warnings from PGPy's dependencies and unfinished checks, which
+    # Apprise cannot resolve.
+    "ignore::Warning:pgpy(\\.|$)",
+    # PGPy reports this internal encryption warning from Apprise's call site.
+    "ignore:^Selected compression algorithm not in key preferences$:UserWarning",
+]
 
 [tool.coverage.run]
 branch = true

--- a/tests/test_persistent_store.py
+++ b/tests/test_persistent_store.py
@@ -34,6 +34,7 @@ import logging
 import os
 import shutil
 import sys
+import tempfile
 import time
 from unittest import mock
 import zlib
@@ -53,6 +54,27 @@ logging.disable(logging.CRITICAL)
 
 # Attachment Directory
 TEST_VAR_DIR = os.path.join(os.path.dirname(__file__), "var")
+
+
+# Keep the real close method so simulated failures do not leak file handles.
+_real_ntf_close = tempfile._TemporaryFileWrapper.close
+
+
+def _flaky_close(always=False):
+    """Mock close errors while still releasing the real file handle.
+
+    Raise on every call when ``always`` is true; otherwise, raise only once.
+    """
+    state = {"calls": 0}
+
+    def _close(self, *args, **kwargs):
+        # Perform the real close regardless of the simulated outcome
+        _real_ntf_close(self)
+        state["calls"] += 1
+        if always or state["calls"] == 1:
+            raise OSError()
+
+    return _close
 
 
 def test_persistent_storage_asset(tmpdir):
@@ -750,21 +772,25 @@ def test_persistent_storage_corruption_handling(tmpdir):
     with (
         mock.patch(
             "tempfile._TemporaryFileWrapper.close",
-            side_effect=(OSError(), None),
+            autospec=True,
+            side_effect=_flaky_close(),
         ),
         mock.patch("os.unlink", side_effect=(OSError())),
     ):
         assert not pc.flush(force=True)
 
     with mock.patch(
-        "tempfile._TemporaryFileWrapper.close", side_effect=OSError()
+        "tempfile._TemporaryFileWrapper.close",
+        autospec=True,
+        side_effect=_flaky_close(always=True),
     ):
         assert not pc.flush(force=True)
 
     with (
         mock.patch(
             "tempfile._TemporaryFileWrapper.close",
-            side_effect=(OSError(), None),
+            autospec=True,
+            side_effect=_flaky_close(),
         ),
         mock.patch("os.unlink", side_effect=OSError()),
     ):
@@ -773,7 +799,8 @@ def test_persistent_storage_corruption_handling(tmpdir):
     with (
         mock.patch(
             "tempfile._TemporaryFileWrapper.close",
-            side_effect=(OSError(), None),
+            autospec=True,
+            side_effect=_flaky_close(),
         ),
         mock.patch("os.unlink", side_effect=FileNotFoundError()),
     ):
@@ -1126,7 +1153,9 @@ def test_persistent_custom_io(tmpdir):
 
     pc.delete()
     with mock.patch(
-        "tempfile._TemporaryFileWrapper.close", side_effect=OSError()
+        "tempfile._TemporaryFileWrapper.close",
+        autospec=True,
+        side_effect=_flaky_close(always=True),
     ):
         assert pc.write(b"test") is False
 
@@ -1134,7 +1163,8 @@ def test_persistent_custom_io(tmpdir):
     with (
         mock.patch(
             "tempfile._TemporaryFileWrapper.close",
-            side_effect=(OSError(), None),
+            autospec=True,
+            side_effect=_flaky_close(),
         ),
         mock.patch("os.unlink", side_effect=OSError()),
     ):
@@ -1144,7 +1174,8 @@ def test_persistent_custom_io(tmpdir):
     with (
         mock.patch(
             "tempfile._TemporaryFileWrapper.close",
-            side_effect=(OSError(), None),
+            autospec=True,
+            side_effect=_flaky_close(),
         ),
         mock.patch("os.unlink", side_effect=FileNotFoundError()),
     ):

--- a/tests/test_plugin_xmpp.py
+++ b/tests/test_plugin_xmpp.py
@@ -3388,13 +3388,10 @@ def test_adapter_keepalive_runner_finally_loop_none(
 
 
 @pytest.mark.skipif(not SLIXMPP_AVAILABLE, reason="Requires slixmpp")
-def test_adapter_keepalive_runner_finally_stop_close_exceptions_suppressed(
+def test_adapter_runner_suppresses_cleanup_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """
-    Cover adapter.py where loop.stop() and loop.close() raise,
-    and exceptions are swallowed.
-    """
+    """Ensure event-loop cleanup errors do not escape the runner."""
     install_fake_slixmpp(monkeypatch)
 
     cfg = xmpp_adapter.XMPPConfig(
@@ -3429,19 +3426,20 @@ def test_adapter_keepalive_runner_finally_stop_close_exceptions_suppressed(
             loop, "run_forever", run_forever_boom, raising=True
         )
 
-        # Make stop/close raise to exercise both except blocks
-        monkeypatch.setattr(
-            loop,
-            "stop",
-            lambda: (_ for _ in ()).throw(RuntimeError("boom-stop")),
-            raising=True,
-        )
-        monkeypatch.setattr(
-            loop,
-            "close",
-            lambda: (_ for _ in ()).throw(RuntimeError("boom-close")),
-            raising=True,
-        )
+        # Raise after real cleanup so the event loop does not leak resources.
+        real_stop = loop.stop
+        real_close = loop.close
+
+        def stop_boom() -> None:
+            real_stop()
+            raise RuntimeError("boom-stop")
+
+        def close_boom() -> None:
+            real_close()
+            raise RuntimeError("boom-close")
+
+        monkeypatch.setattr(loop, "stop", stop_boom, raising=True)
+        monkeypatch.setattr(loop, "close", close_boom, raising=True)
 
         return loop
 


### PR DESCRIPTION
## Description
**Related issue (if applicable):** n/a

Fixed/cleaned up all of the warnings emitted during unit test runs.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [ ] Documentation ticket created (if applicable): n/a
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@test-warning-cleanup

# Run test suite
tox -e qa
```
