### PR TITLE
Support for Telegram rich message support

### DIFF
--- a/apprise/plugins/telegram.py
+++ b/apprise/plugins/telegram.py
@@ -52,11 +52,13 @@
 # Development API Reference::
 #  - https://core.telegram.org/bots/api
 from json import dumps, loads
+from json.decoder import JSONDecodeError
 import os
 import re
 
 import requests
 
+from ..apprise_attachment import AppriseAttachment
 from ..attachment.base import AttachBase
 from ..common import (
     NotifyFormat,
@@ -72,6 +74,7 @@ from ..conversion import (
 )
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_bool, parse_list, validate_regex
+from ..utils.templates import TemplateType, apply_template
 from .base import NotifyBase
 
 TELEGRAM_IMAGE_XY = NotifyImageSize.XY_256
@@ -170,6 +173,10 @@ class NotifyTelegram(NotifyBase):
 
     # Telegram is limited to sending a maximum of 100 requests per second.
     request_rate_per_sec = 0.001
+
+    # There is no reason we should exceed 35KB when reading in a Rich
+    # Message template file.
+    max_telegram_template_size = 35000
 
     # Our default is to no not use persistent storage beyond in-memory
     # reference
@@ -416,8 +423,21 @@ class NotifyTelegram(NotifyBase):
                 "values": TELEGRAM_CONTENT_PLACEMENT,
                 "default": TelegramContentPlacement.BEFORE,
             },
+            "template": {
+                "name": _("Rich Message Template Path"),
+                "type": "string",
+                "private": True,
+            },
         },
     )
+
+    # Define our template kwargs
+    template_kwargs = {
+        "tokens": {
+            "name": _("Template Tokens"),
+            "prefix": ":",
+        },
+    }
 
     def __init__(
         self,
@@ -430,6 +450,8 @@ class NotifyTelegram(NotifyBase):
         topic=None,
         content=None,
         mdv=None,
+        template=None,
+        tokens=None,
         **kwargs,
     ):
         """Initialize Telegram Object."""
@@ -544,6 +566,38 @@ class NotifyTelegram(NotifyBase):
         # Track whether or not we want to send an image with our notification
         # or not.
         self.include_image = include_image
+
+        # Our Rich Message template is just an AppriseAttachment object
+        self.template = AppriseAttachment(asset=self.asset)
+        if template:
+            # Add our definition to our template
+            self.template.add(template)
+            if not len(self.template):
+                # We could not add our template; this occurs if the
+                # AppriseAttachment object could not load/parse the entry
+                # we just provided it.
+                msg = (
+                    f"The Telegram Rich Message template ({template!r})"
+                    " could not be loaded."
+                )
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
+            # Enforce a maximum file size on our template
+            self.template[0].max_file_size = self.max_telegram_template_size
+
+        # Rich Message template token substitutions
+        self.tokens = {}
+        if isinstance(tokens, dict):
+            self.tokens.update(tokens)
+
+        elif tokens:
+            msg = (
+                "The specified Telegram Rich Message Template Tokens"
+                f" ({tokens}) are not identified as a dictionary."
+            )
+            self.logger.warning(msg)
+            raise TypeError(msg)
 
     def send_media(self, target, notify_type, payload=None, attach=None):
         """Sends a sticker based on the specified notify type."""
@@ -1243,6 +1297,26 @@ class NotifyTelegram(NotifyBase):
         Pending Telegram entity state is carried between generated calls.
         """
 
+        if self.template:
+            # A Rich Message template defines its own structure -- body
+            # and title are only substitution tokens for it, not text to
+            # be amalgamated, format-converted, or length-split the way a
+            # normal message is.
+            attach = kwargs.pop("attach", None)
+            if attach is not None and not isinstance(
+                attach, AppriseAttachment
+            ):
+                attach = AppriseAttachment(attach, asset=self.asset)
+
+            yield {
+                "body": body if body else "",
+                "title": title if title else "",
+                "body_format": body_format,
+                "attach": attach,
+                **kwargs,
+            }
+            return
+
         if not (
             self.notify_format == NotifyFormat.MARKDOWN
             and body_format == NotifyFormat.HTML
@@ -1297,6 +1371,13 @@ class NotifyTelegram(NotifyBase):
         if len(self.targets) == 0:
             self.logger.warning("There were not Telegram chat_ids to notify.")
             return False
+
+        if self.template:
+            # A Rich Message template bypasses our normal text/markdown/HTML
+            # handling entirely -- the template itself defines the content.
+            return self._send_rich_message(
+                body, title, notify_type=notify_type, attach=attach
+            )
 
         headers = {
             "User-Agent": self.app_id,
@@ -1530,6 +1611,214 @@ class NotifyTelegram(NotifyBase):
 
         return not has_error
 
+    def _gen_rich_payload(self, body, title, notify_type):
+        """Generates and validates our Rich Message 'blocks' content from
+        our configured template.
+
+        Returns the parsed InputRichMessage dictionary, or False if the
+        template could not be loaded, read, parsed, or validated.
+        """
+
+        # Acquire our template attachment
+        template = self.template[0]
+        if not template:
+            # We could not access the attachment
+            self.logger.warning(
+                "Could not access Telegram Rich Message template"
+                f" {template.url(privacy=True)}."
+            )
+            return False
+
+        # Take a copy of our token dictionary
+        tokens = self.tokens.copy()
+
+        # Apply some defaults template values
+        tokens["app_body"] = body
+        tokens["app_title"] = title
+        tokens["app_type"] = notify_type.value
+        tokens["app_id"] = self.app_id
+        tokens["app_desc"] = self.app_desc
+        tokens["app_color"] = self.color(notify_type)
+        # app_color_hex is an explicit alias for app_color so templates
+        # can reference the hex variant by a self-documenting name
+        tokens["app_color_hex"] = self.color(notify_type)
+        tokens["app_image_url"] = (
+            self.image_url(notify_type) if self.include_image else None
+        )
+        tokens["app_url"] = self.app_url
+
+        # Templates are always Rich Message JSON; enforce JSON escaping
+        tokens["app_mode"] = TemplateType.JSON
+
+        # Stringify substitutions before JSON escaping; preserve app_mode.
+        safe_tokens = {
+            k: (
+                v
+                if k == "app_mode" or isinstance(v, str)
+                else ("" if v is None else str(v))
+            )
+            for k, v in tokens.items()
+        }
+
+        try:
+            with open(template.path) as fp:
+                content = apply_template(fp.read(), **safe_tokens)
+
+        except OSError:
+            self.logger.warning(
+                "Telegram Rich Message template"
+                f" {template.url(privacy=True)} could not be read."
+            )
+            return False
+
+        # Parse and validate as JSON
+        try:
+            content = loads(content)
+
+        except JSONDecodeError as e:
+            self.logger.warning(
+                "Telegram Rich Message template"
+                f" {template.url(privacy=True)} contains invalid JSON."
+            )
+            self.logger.debug(f"JSONDecodeError: {e}")
+            return False
+
+        # Template must parse to a JSON object, not an array or scalar
+        if not isinstance(content, dict):
+            self.logger.warning(
+                "Telegram Rich Message template"
+                f" {template.url(privacy=True)} must be a JSON object"
+                f" (got {type(content).__name__})."
+            )
+            return False
+
+        # 'blocks' must be a non-empty list (Rich Message requirement)
+        if (
+            not isinstance(content.get("blocks"), list)
+            or not content["blocks"]
+        ):
+            self.logger.warning(
+                "Telegram Rich Message template"
+                f" {template.url(privacy=True)} must contain"
+                " a non-empty 'blocks' list."
+            )
+            return False
+
+        # Every block must be a dict with a 'type' string
+        if not all(
+            isinstance(b, dict) and isinstance(b.get("type"), str)
+            for b in content["blocks"]
+        ):
+            self.logger.warning(
+                "Telegram Rich Message template"
+                f" {template.url(privacy=True)} contains"
+                " a block missing a 'type' string."
+            )
+            return False
+
+        # Return the validated Rich Message content
+        return content
+
+    def _send_rich_message(self, body, title, notify_type, attach=None):
+        """Sends a Telegram Rich Message (built from our configured
+        template) to every target, followed by any attachments exactly as
+        they would be sent for a normal notification."""
+
+        # Generate our payload once; its content does not vary by target
+        rich_message = self._gen_rich_payload(body, title, notify_type)
+        if rich_message is False:
+            return False
+
+        headers = {
+            "User-Agent": self.app_id,
+            "Content-Type": "application/json",
+        }
+
+        url = "{}{}/{}".format(
+            self.notify_url, self.bot_token, "sendRichMessage"
+        )
+
+        has_error = False
+        for target in self.targets:
+            chat_id, topic = target
+
+            # Printable chat_id details
+            pchat_id = f"{chat_id}" if not topic else f"{chat_id}:{topic}"
+
+            payload = {"chat_id": chat_id, "rich_message": rich_message}
+            if topic:
+                payload["message_thread_id"] = topic
+            if not self.preview:
+                payload["link_preview_options"] = {"is_disabled": True}
+
+            self.throttle()
+
+            self.logger.debug(
+                f"Telegram POST URL: {url} "
+                f"(cert_verify={self.verify_certificate!r})"
+            )
+            self.logger.debug(f"Telegram Payload: {payload!s}")
+
+            try:
+                r = requests.post(
+                    url,
+                    data=dumps(payload),
+                    headers=headers,
+                    verify=self.verify_certificate,
+                    timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
+                )
+
+                if r.status_code != requests.codes.ok:
+                    status_str = NotifyTelegram.http_response_code_lookup(
+                        r.status_code
+                    )
+
+                    try:
+                        error_msg = loads(r.content).get(
+                            "description", "unknown"
+                        )
+
+                    except (AttributeError, TypeError, ValueError):
+                        error_msg = None
+
+                    self.logger.warning(
+                        "Failed to send Telegram Rich Message to"
+                        f" {pchat_id}: "
+                        f"{error_msg if error_msg else status_str}, "
+                        f"error={r.status_code}."
+                    )
+                    self.logger.debug(f"Response Details:\r\n{r.content}")
+
+                    has_error = True
+                    continue
+
+            except requests.RequestException as e:
+                self.logger.warning(
+                    "A connection error occurred sending a Telegram"
+                    f" Rich Message to {pchat_id}."
+                )
+                self.logger.debug(f"Socket Exception: {e!s}")
+
+                has_error = True
+                continue
+
+            self.logger.info("Sent Telegram Rich Message.")
+
+            # Attachments are untouched by Rich Message mode -- they are
+            # always sent afterward, exactly as a normal notification
+            # would send them.
+            if (
+                attach
+                and self.attachment_support
+                and not self._send_attachments(
+                    target=target, notify_type=notify_type, attach=attach
+                )
+            ):
+                has_error = True
+
+        return not has_error
+
     @property
     def url_identifier(self):
         """Returns all of the identifiers that make this URL unique from
@@ -1555,8 +1844,16 @@ class NotifyTelegram(NotifyBase):
         if self.topic:
             params["topic"] = self.topic
 
+        if self.template:
+            params["template"] = NotifyTelegram.quote(
+                self.template[0].url(), safe=""
+            )
+
         # Extend our parameters
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
+
+        # Store any Rich Message template token entries if specified
+        params.update({f":{k}": v for k, v in self.tokens.items()})
 
         targets = []
         for chat_id, topic_ in self.targets:
@@ -1697,5 +1994,14 @@ class NotifyTelegram(NotifyBase):
         results["detect_owner"] = parse_bool(
             results["qsd"].get("detect", not results["targets"])
         )
+
+        # Rich Message Template Handling
+        if "template" in results["qsd"] and results["qsd"]["template"]:
+            results["template"] = NotifyTelegram.unquote(
+                results["qsd"]["template"]
+            )
+
+        # Store our Rich Message template tokens
+        results["tokens"] = results["qsd:"]
 
         return results

--- a/tests/test_plugin_telegram.py
+++ b/tests/test_plugin_telegram.py
@@ -25,6 +25,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from inspect import cleandoc
 from json import dumps, loads
 
 # Disable logging for a cleaner testing output
@@ -2126,3 +2127,519 @@ def test_plugin_telegram_attach_memory(mock_post):
 
     assert obj.notify(body="Test", attach=mem) is True
     assert mock_post.call_count >= 1
+
+
+@mock.patch("requests.post")
+def test_plugin_telegram_template_blocks(mock_post, tmpdir):
+    """NotifyTelegram() - Rich Message template mode."""
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = dumps({"ok": True})
+    mock_post.return_value = response
+
+    # Write a minimal Rich Message JSON template to disk
+    template = tmpdir.join("blocks.json")
+    template.write(
+        cleandoc("""
+        {
+          "blocks": [
+            {
+              "type": "section_heading",
+              "text": "{{app_title}}"
+            },
+            {
+              "type": "paragraph",
+              "text": "{{app_body}}"
+            }
+          ]
+        }
+        """)
+    )
+
+    obj = Apprise.instantiate(
+        "tgram://123456789:abcdefg_hijklmnop/lead2gold/"
+        "?template={}&:mykey=myval".format(str(template))
+    )
+    assert isinstance(obj, NotifyTelegram)
+
+    # Verify tokens and template were parsed correctly
+    assert "mykey" in obj.tokens
+    assert obj.tokens["mykey"] == "myval"
+    assert obj.template
+
+    assert (
+        obj.notify(body="hello", title="world", notify_type=NotifyType.INFO)
+        is True
+    )
+    assert mock_post.called is True
+
+    # Inspect the posted URL and payload
+    posted_url = mock_post.call_args_list[0][0][0]
+    assert posted_url.endswith("/sendRichMessage")
+
+    posted = loads(mock_post.call_args_list[0][1]["data"])
+    assert posted["chat_id"] == "@lead2gold"
+    assert "rich_message" in posted
+    blocks = posted["rich_message"]["blocks"]
+    assert any(b.get("type") == "section_heading" for b in blocks)
+    assert any(b.get("type") == "paragraph" for b in blocks)
+
+    heading = next(b for b in blocks if b.get("type") == "section_heading")
+    assert heading["text"] == "world"
+    paragraph = next(b for b in blocks if b.get("type") == "paragraph")
+    assert paragraph["text"] == "hello"
+
+
+@mock.patch("requests.post")
+def test_plugin_telegram_template_invalid_json(mock_post, tmpdir):
+    """NotifyTelegram() - Rich Message template with invalid JSON fails."""
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = dumps({"ok": True})
+    mock_post.return_value = response
+
+    template = tmpdir.join("bad.json")
+    template.write("{ not valid json }")
+
+    obj = Apprise.instantiate(
+        "tgram://123456789:abcdefg_hijklmnop/lead2gold/?template={}".format(
+            str(template)
+        )
+    )
+    assert isinstance(obj, NotifyTelegram)
+
+    assert (
+        obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+    )
+    assert mock_post.called is False
+
+
+@mock.patch("requests.post")
+def test_plugin_telegram_template_blocks_not_list(mock_post, tmpdir):
+    """NotifyTelegram() - 'blocks' missing/not-a-list/empty is rejected."""
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = dumps({"ok": True})
+    mock_post.return_value = response
+
+    # 'blocks' key entirely missing
+    template = tmpdir.join("missing_blocks.json")
+    template.write('{"text": "no blocks here"}')
+
+    obj = Apprise.instantiate(
+        "tgram://123456789:abcdefg_hijklmnop/lead2gold/?template={}".format(
+            str(template)
+        )
+    )
+    assert isinstance(obj, NotifyTelegram)
+    assert (
+        obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+    )
+    assert mock_post.called is False
+
+    # 'blocks' present but not a list
+    template.write('{"blocks": "not-a-list"}')
+    obj2 = Apprise.instantiate(
+        "tgram://123456789:abcdefg_hijklmnop/lead2gold/?template={}".format(
+            str(template)
+        )
+    )
+    assert isinstance(obj2, NotifyTelegram)
+    assert (
+        obj2.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+    )
+    assert mock_post.called is False
+
+    # Empty list is also rejected
+    template.write('{"blocks": []}')
+    obj3 = Apprise.instantiate(
+        "tgram://123456789:abcdefg_hijklmnop/lead2gold/?template={}".format(
+            str(template)
+        )
+    )
+    assert isinstance(obj3, NotifyTelegram)
+    assert (
+        obj3.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+    )
+    assert mock_post.called is False
+
+
+@mock.patch("requests.post")
+def test_plugin_telegram_template_block_missing_type(mock_post, tmpdir):
+    """NotifyTelegram() - a block dict without 'type' is rejected."""
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = dumps({"ok": True})
+    mock_post.return_value = response
+
+    template = tmpdir.join("no_type.json")
+    template.write('{"blocks": [{"text": "hi"}]}')
+
+    obj = Apprise.instantiate(
+        "tgram://123456789:abcdefg_hijklmnop/lead2gold/?template={}".format(
+            str(template)
+        )
+    )
+    assert isinstance(obj, NotifyTelegram)
+    assert (
+        obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+    )
+    assert mock_post.called is False
+
+
+@mock.patch("requests.post")
+def test_plugin_telegram_template_content_not_dict(mock_post, tmpdir):
+    """NotifyTelegram() - template that parses to a JSON array is
+    rejected."""
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = dumps({"ok": True})
+    mock_post.return_value = response
+
+    template = tmpdir.join("array.json")
+    template.write('[{"type": "paragraph"}]')
+
+    obj = Apprise.instantiate(
+        "tgram://123456789:abcdefg_hijklmnop/lead2gold/?template={}".format(
+            str(template)
+        )
+    )
+    assert isinstance(obj, NotifyTelegram)
+    assert (
+        obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+    )
+    assert mock_post.called is False
+
+
+@mock.patch("requests.post")
+def test_plugin_telegram_template_block_not_dict(mock_post, tmpdir):
+    """NotifyTelegram() - non-dict entry in blocks list is rejected."""
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = dumps({"ok": True})
+    mock_post.return_value = response
+
+    template = tmpdir.join("bad_block.json")
+    template.write('{"blocks": ["not-a-dict"]}')
+
+    obj = Apprise.instantiate(
+        "tgram://123456789:abcdefg_hijklmnop/lead2gold/?template={}".format(
+            str(template)
+        )
+    )
+    assert isinstance(obj, NotifyTelegram)
+    assert (
+        obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+    )
+    assert mock_post.called is False
+
+
+@mock.patch("requests.post")
+def test_plugin_telegram_template_load_error(mock_post, tmpdir):
+    """NotifyTelegram() - template OSError during read fails gracefully."""
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = dumps({"ok": True})
+    mock_post.return_value = response
+
+    # Write an empty file so the attachment resolves but open() can be
+    # mocked to fail
+    template = tmpdir.join("empty.json")
+    template.write("")
+
+    obj = Apprise.instantiate(
+        "tgram://123456789:abcdefg_hijklmnop/lead2gold/?template={}".format(
+            str(template)
+        )
+    )
+    assert isinstance(obj, NotifyTelegram)
+
+    with mock.patch("builtins.open", side_effect=OSError):
+        assert (
+            obj.notify(body="x", title="y", notify_type=NotifyType.INFO)
+            is False
+        )
+    assert mock_post.called is False
+
+
+def test_plugin_telegram_template_bad_tokens():
+    """NotifyTelegram() - invalid tokens type raises TypeError."""
+    with pytest.raises(TypeError):
+        NotifyTelegram(
+            bot_token="123456789:abcdefg_hijklmnop",
+            targets="lead2gold",
+            tokens="not-a-dict",
+        )
+
+
+def test_plugin_telegram_template_add_failure():
+    """NotifyTelegram() - TypeError when AppriseAttachment.add() drops
+    entry."""
+    with mock.patch("apprise.plugins.telegram.AppriseAttachment") as mock_cls:
+        inst = mock.MagicMock()
+        inst.__len__ = mock.Mock(return_value=0)
+        mock_cls.return_value = inst
+
+        with pytest.raises(TypeError):
+            NotifyTelegram(
+                bot_token="123456789:abcdefg_hijklmnop",
+                targets="lead2gold",
+                template="file:///some/template.json",
+            )
+
+
+@mock.patch("requests.post")
+def test_plugin_telegram_template_inaccessible(mock_post, tmpdir):
+    """NotifyTelegram() - template attachment that cannot be accessed
+    fails."""
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = dumps({"ok": True})
+    mock_post.return_value = response
+
+    # Point to a template file that does not exist
+    missing = str(tmpdir.join("missing.json"))
+
+    obj = Apprise.instantiate(
+        "tgram://123456789:abcdefg_hijklmnop/lead2gold/?template={}".format(
+            missing
+        )
+    )
+    assert isinstance(obj, NotifyTelegram)
+    assert (
+        obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+    )
+    assert mock_post.called is False
+
+
+@mock.patch("requests.post")
+def test_plugin_telegram_template_none_token_value(mock_post, tmpdir):
+    """NotifyTelegram() - a None token value (e.g. app_image_url) is
+    coerced to an empty string before JSON-escaping."""
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = dumps({"ok": True})
+    mock_post.return_value = response
+
+    # Template references app_image_url which will be None when
+    # include_image=False
+    template = tmpdir.join("img.json")
+    template.write(
+        '{"blocks": [{"type": "paragraph",'
+        ' "text": "{{app_body}} img={{app_image_url}}"}]}'
+    )
+
+    obj = Apprise.instantiate(
+        "tgram://123456789:abcdefg_hijklmnop/lead2gold/"
+        "?image=no&template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifyTelegram)
+    assert (
+        obj.notify(body="hi", title="y", notify_type=NotifyType.INFO) is True
+    )
+    posted = loads(mock_post.call_args_list[0][1]["data"])
+    paragraph = posted["rich_message"]["blocks"][0]
+    assert paragraph["text"] == "hi img="
+
+
+@mock.patch("requests.post")
+def test_plugin_telegram_template_url_roundtrip(mock_post, tmpdir):
+    """NotifyTelegram() - template + tokens survive url()/parse_url()
+    round-trip."""
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = dumps({"ok": True})
+    mock_post.return_value = response
+
+    template = tmpdir.join("rt.json")
+    template.write(
+        cleandoc("""
+        {
+          "blocks": [
+            {"type": "paragraph", "text": "{{app_body}}"}
+          ]
+        }
+        """)
+    )
+
+    obj1 = NotifyTelegram(
+        bot_token="123456789:abcdefg_hijklmnop",
+        targets="lead2gold",
+        template=str(template),
+        tokens={"key1": "val1", "key2": "val2"},
+    )
+
+    url = obj1.url()
+    result = NotifyTelegram.parse_url(url)
+    assert result is not None
+
+    obj2 = NotifyTelegram(**result)
+    assert isinstance(obj2, NotifyTelegram)
+
+    # Connection identity must be preserved
+    assert obj1.url_identifier == obj2.url_identifier
+
+    # Tokens must survive the round-trip
+    assert obj2.tokens.get("key1") == "val1"
+    assert obj2.tokens.get("key2") == "val2"
+
+    # Template must be present after round-trip
+    assert obj2.template
+
+
+@mock.patch("requests.post")
+def test_plugin_telegram_template_multi_target(mock_post, tmpdir):
+    """NotifyTelegram() - Rich Message is POSTed once per target."""
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = dumps({"ok": True})
+    mock_post.return_value = response
+
+    template = tmpdir.join("multi.json")
+    template.write('{"blocks": [{"type": "paragraph", "text": "hi"}]}')
+
+    obj = Apprise.instantiate(
+        "tgram://123456789:abcdefg_hijklmnop/12345/67890:55/"
+        "?template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifyTelegram)
+    assert len(obj.targets) == 2
+
+    assert obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is True
+    assert mock_post.call_count == 2
+
+    posted_1 = loads(mock_post.call_args_list[0][1]["data"])
+    posted_2 = loads(mock_post.call_args_list[1][1]["data"])
+    assert posted_1["chat_id"] == 12345
+    assert "message_thread_id" not in posted_1
+    assert posted_2["chat_id"] == 67890
+    assert posted_2["message_thread_id"] == 55
+
+
+@mock.patch("requests.post")
+def test_plugin_telegram_template_with_attachment(mock_post, tmpdir):
+    """NotifyTelegram() - attachments remain untouched in template mode,
+    sent separately after the Rich Message."""
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = dumps({"ok": True})
+    mock_post.return_value = response
+
+    template = tmpdir.join("attach.json")
+    template.write('{"blocks": [{"type": "paragraph", "text": "hi"}]}')
+
+    obj = Apprise.instantiate(
+        "tgram://123456789:abcdefg_hijklmnop/lead2gold/?template={}".format(
+            str(template)
+        )
+    )
+    assert isinstance(obj, NotifyTelegram)
+
+    # Pass a raw (not pre-wrapped) attachment path; template mode must
+    # still normalize it into an AppriseAttachment internally.
+    path = os.path.join(TEST_VAR_DIR, "apprise-test.gif")
+
+    assert obj.notify(body="hi", title="y", attach=path) is True
+
+    # First call is the Rich Message itself
+    first_url = mock_post.call_args_list[0][0][0]
+    assert first_url.endswith("/sendRichMessage")
+
+    # Second call is the attachment, sent via the normal send_media() path
+    second_url = mock_post.call_args_list[1][0][0]
+    assert not second_url.endswith("/sendRichMessage")
+
+
+@mock.patch("requests.post")
+def test_plugin_telegram_template_attachment_failure(mock_post, tmpdir):
+    """NotifyTelegram() - a failed attachment send flags an overall
+    failure in Rich Message mode."""
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = dumps({"ok": True})
+    mock_post.return_value = response
+
+    template = tmpdir.join("attach_fail.json")
+    template.write('{"blocks": [{"type": "paragraph", "text": "hi"}]}')
+
+    obj = Apprise.instantiate(
+        "tgram://123456789:abcdefg_hijklmnop/lead2gold/?template={}".format(
+            str(template)
+        )
+    )
+    assert isinstance(obj, NotifyTelegram)
+
+    # Point to an attachment that cannot be accessed
+    attach = AppriseAttachment("file:///path/does/not/exist.gif")
+
+    assert obj.notify(body="hi", title="y", attach=attach) is False
+
+
+@mock.patch("requests.post")
+def test_plugin_telegram_template_preview_enabled(mock_post, tmpdir):
+    """NotifyTelegram() - preview=yes omits link_preview_options."""
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = dumps({"ok": True})
+    mock_post.return_value = response
+
+    template = tmpdir.join("preview.json")
+    template.write('{"blocks": [{"type": "paragraph", "text": "hi"}]}')
+
+    obj = Apprise.instantiate(
+        "tgram://123456789:abcdefg_hijklmnop/lead2gold/"
+        "?preview=yes&template={}".format(str(template))
+    )
+    assert isinstance(obj, NotifyTelegram)
+    assert obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is True
+    posted = loads(mock_post.call_args_list[0][1]["data"])
+    assert "link_preview_options" not in posted
+
+
+@mock.patch("requests.post")
+def test_plugin_telegram_template_http_error(mock_post, tmpdir):
+    """NotifyTelegram() - Rich Message HTTP error is handled gracefully."""
+    response = mock.Mock()
+    response.status_code = requests.codes.internal_server_error
+    response.content = dumps({"description": "failure"})
+    mock_post.return_value = response
+
+    template = tmpdir.join("err.json")
+    template.write('{"blocks": [{"type": "paragraph", "text": "hi"}]}')
+
+    obj = Apprise.instantiate(
+        "tgram://123456789:abcdefg_hijklmnop/lead2gold/?template={}".format(
+            str(template)
+        )
+    )
+    assert isinstance(obj, NotifyTelegram)
+    assert (
+        obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+    )
+
+    # Also cover the case where the error response body itself is not
+    # parsable JSON (falls back to the generic HTTP status string)
+    response.content = b"not-json"
+    assert (
+        obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+    )
+
+
+@mock.patch("requests.post")
+def test_plugin_telegram_template_request_exception(mock_post, tmpdir):
+    """NotifyTelegram() - Rich Message RequestException is handled
+    gracefully."""
+    mock_post.side_effect = requests.RequestException()
+
+    template = tmpdir.join("exc.json")
+    template.write('{"blocks": [{"type": "paragraph", "text": "hi"}]}')
+
+    obj = Apprise.instantiate(
+        "tgram://123456789:abcdefg_hijklmnop/lead2gold/?template={}".format(
+            str(template)
+        )
+    )
+    assert isinstance(obj, NotifyTelegram)
+    assert (
+        obj.notify(body="x", title="y", notify_type=NotifyType.INFO) is False
+    )


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1662

- `tgram://` can now send Telegram's new **Rich Messages** (Bot API 10.1's `sendRichMessage`) using a `?template=` JSON file, the same pattern already used by Slack (Block Kit) and Workflows (Adaptive Cards).
- Point `?template=` at a JSON file containing a non-empty `"blocks"` list; Apprise substitutes `{{app_title}}`, `{{app_body}}`, and other tokens into it and posts it as a structured Rich Message instead of the normal text/Markdown/HTML message.
- Custom tokens can be injected with the `:key=value` URL prefix (e.g. `?:env=production`), same convention as Slack/Workflows.

## Checklist
* [x] Documentation ticket created (if applicable): https://github.com/caronc/apprise-docs/pull/116
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (`tox -e lint` and `tox -e format` both clean).
* [x] Test coverage added or updated

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1662-telegram-rich-message-support

# Save a Rich Message template, e.g. /tmp/blocks.json:
# {"blocks": [{"type": "section_heading", "text": "{{app_title}}"}, {"type": "paragraph", "text": "{{app_body}}"}]}

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "tgram://{bot_token}/{chat_id}/?template=/tmp/blocks.json"
```
