### PR TITLE
Proxy documentation added to man page

### DIFF
--- a/packaging/man/apprise.1
+++ b/packaging/man/apprise.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "APPRISE" "1" "May 2026" "Chris Caron <lead2gold@gmail.com>"
+.TH "APPRISE" "1" "August 2026" "Chris Caron <lead2gold@gmail.com>"
 .SH "NAME"
 \fBapprise\fR \- Push Notifications that work with just about every platform!
 .SH "SYNOPSIS"
@@ -315,6 +315,8 @@ $ apprise \-vv \-\-title "Will Be Late Getting Home" \e
 \fBAPPRISE_PLUGIN_PATH\fR: Explicitly specify the custom plugin search path to use (overriding the default)\. Use a semi\-colon (\fB;\fR), line\-feed (\fB\en\fR), and/or carriage return (\fB\er\fR) to delimit multiple entries\.
 .P
 \fBAPPRISE_STORAGE_PATH\fR: Explicitly specify the persistent storage path to use (overriding the default)\.
+.P
+\fBHTTP_PROXY\fR, \fBHTTPS_PROXY\fR, \fBNO_PROXY\fR: Standard proxy variables honored by the underlying \fBrequests\fR library (not Apprise\-specific)\. Set \fBHTTP_PROXY\fR/\fBHTTPS_PROXY\fR to route outbound notifications through a proxy, and \fBNO_PROXY\fR to exempt specific hosts\. SOCKS proxies (\fBsocks5h://\|\.\|\.\|\.\fR) additionally require the optional \fBPySocks\fR package (\fBpip install pysocks\fR) to be installed\.
 .SH "BUGS"
 If you find any bugs, please make them known at: \fIhttps://github\.com/caronc/apprise/issues\fR
 .SH "DONATIONS"

--- a/packaging/man/apprise.1.html
+++ b/packaging/man/apprise.1.html
@@ -467,6 +467,13 @@ configuration that you want and only specifically notify a subset of them:</p>
 <p><code>APPRISE_STORAGE_PATH</code>:
   Explicitly specify the persistent storage path to use (overriding the default).</p>
 
+<p><code>HTTP_PROXY</code>, <code>HTTPS_PROXY</code>, <code>NO_PROXY</code>:
+  Standard proxy variables honored by the underlying <code>requests</code> library (not
+  Apprise-specific). Set <code>HTTP_PROXY</code>/<code>HTTPS_PROXY</code> to route outbound
+  notifications through a proxy, and <code>NO_PROXY</code> to exempt specific hosts.
+  SOCKS proxies (<code>socks5h://...</code>) additionally require the optional
+  <code>PySocks</code> package (<code>pip install pysocks</code>) to be installed.</p>
+
 <h2 id="BUGS">BUGS</h2>
 
 <p>If you find any bugs, please make them known at:
@@ -481,7 +488,7 @@ configuration that you want and only specifically notify a subset of them:</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>Chris Caron &lt;lead2gold@gmail.com&gt;</li>
-    <li class='tc'>May 2026</li>
+    <li class='tc'>August 2026</li>
     <li class='tr'>apprise(1)</li>
   </ol>
 

--- a/packaging/man/apprise.md
+++ b/packaging/man/apprise.md
@@ -355,6 +355,13 @@ configuration that you want and only specifically notify a subset of them:
   `APPRISE_STORAGE_PATH`:
   Explicitly specify the persistent storage path to use (overriding the default).
 
+  `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`:
+  Standard proxy variables honored by the underlying `requests` library (not
+  Apprise-specific). Set `HTTP_PROXY`/`HTTPS_PROXY` to route outbound
+  notifications through a proxy, and `NO_PROXY` to exempt specific hosts.
+  SOCKS proxies (`socks5h://...`) additionally require the optional
+  `PySocks` package (`pip install pysocks`) to be installed.
+
 ## BUGS
 
 If you find any bugs, please make them known at:


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #554

Added documentation to support how to leverage proxy support using Apprise.

## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/117](https://github.com/caronc/apprise-docs/pull/117)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
_Not required; man page updated only in this PR_
