### PR TITLE
Return None from parse_url() on malformed authority content (#1693)

### DIFF
--- a/apprise/utils/parse.py
+++ b/apprise/utils/parse.py
@@ -742,7 +742,14 @@ def parse_url(
     # Now do a proper extraction of data; http:// is just substitued in place
     # to allow urlparse() to function as expected, we'll swap this back to the
     # expected schema after.
-    parsed = urlparse(f"http://{host}")
+    try:
+        parsed = urlparse(f"http://{host}")
+
+    except ValueError:
+        # urlparse() raises ValueError on malformed authority content such
+        # as an unmatched '[' from Markdown link syntax ("Invalid IPv6
+        # URL"). Honor the documented contract and treat it as unparseable.
+        return None
 
     # Parse results
     result["host"] = parsed[1].strip()

--- a/tests/test_apprise_utils.py
+++ b/tests/test_apprise_utils.py
@@ -843,6 +843,21 @@ def test_parse_url_general():
     assert "]" not in result["fullpath"]
 
 
+def test_parse_url_markdown_content():
+    """
+    utils: parse_url() with unmatched-bracket content (GH#1693)
+    """
+    # Content whose host portion carries an unmatched '[' (for example from
+    # Markdown link syntax) makes the underlying urlparse() raise
+    # "Invalid IPv6 URL". parse_url() documents that it returns None when
+    # content cannot be extracted, so that ValueError must not propagate.
+    assert (
+        utils.parse.parse_url("**bold** and [link](https://example.com)")
+        is None
+    )
+    assert utils.parse.parse_url("text with [unclosed bracket") is None
+
+
 def test_parse_url_path_no_redos():
     "utils: parse_url() does not regress into slow/backtracking behavior"
 


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1693

`parse_url()` documents that it returns `None` when content cannot be extracted, but the underlying `urlparse(f"http://{host}")` call was unguarded. When `host` carries an unmatched `[` (for example from Markdown link syntax like `[link](https://example.com)`), Python's `urlparse()` raises `ValueError: Invalid IPv6 URL`, which propagates to callers instead of the documented `None`. This aborts `reddit://` notifications whose body contains a Markdown link (breaks `--input-format=html`), as reported in #1693.

Minimal repro:

```python
>>> from apprise.utils.parse import parse_url
>>> parse_url("**bold** and [link](https://example.com)")
ValueError: Invalid IPv6 URL
```

**Fix:** wrap the `urlparse()` call in `try/except ValueError` and return `None`, matching the function's existing "content could not be extracted -> return None" behavior. The empty/normal paths are unchanged.

**Test:** added `test_parse_url_markdown_content` asserting `parse_url()` returns `None` for content with an unmatched `[`. Verified red before the fix (it raised `ValueError`) and green after. `pytest tests/test_apprise_utils.py` (34 passed), `ruff check`, and `ruff format --check` all pass locally.

---

Disclosure: developed with the assistance of Claude Code (AI); reviewed and verified by me.
