### PR TITLE
fix issue causing in memory email attachments to fail

### DIFF
--- a/apprise/plugins/email/base.py
+++ b/apprise/plugins/email/base.py
@@ -1416,7 +1416,7 @@ class NotifyEmail(NotifyBase):
                         )
                     )
 
-                    with open(attachment.path, "rb") as abody:
+                    with attachment.open() as abody:
                         app = MIMEApplication(abody.read())
                         app.set_type(attachment.mimetype)
 

--- a/tests/test_plugin_email.py
+++ b/tests/test_plugin_email.py
@@ -49,6 +49,7 @@ from apprise import (
     PersistentStoreMode,
     utils,
 )
+from apprise.attachment.memory import AttachMemory
 from apprise.config import ConfigBase
 from apprise.exception import AppriseException
 from apprise.plugins import email
@@ -868,6 +869,28 @@ def test_plugin_email_smtplib_send_okay(mock_smtplib):
         a.notify(body="body", title="test", attach=AppriseAttachment(attach))
         is True
     )
+
+    # test using an Apprise in memory attachement object
+    attachment = AppriseAttachment()
+    attachment.add(
+        AttachMemory(
+            content="attachment",
+            name="attached.txt",
+            mimetype="text/plain",
+        )
+    )
+    assert (
+        obj.notify(
+            body="body",
+            title="test",
+            notify_type=NotifyType.INFO,
+            attach=attachment,
+        )
+        is True
+    )
+
+    # same results happen from our Apprise object
+    assert a.notify(body="body", title="test", attach=attachment) is True
 
     max_file_size = AttachBase.max_file_size
     # Now do a case where the file can't be sent


### PR DESCRIPTION
## Fix in-memory attachments for the email plugin

In the documentation, attaching data can be done in memory (https://appriseit.com/library/attachments/#tab-panel-201) with an instance of AttachMemory. When this is done with the email plugin, a bug is exposed in the email plugin's base implementation. The base implementation always tries to open the `attachment.path`, which may not exist, and fails with the error:

`Socket Exception: [Errno 2] No such file or directory: ...`

Reproduce with:
```python
from apprise import Apprise
from apprise.attachment.memory import AttachMemory

obj = Apprise.instantiate("mailto://user:pass@gmail.com")
am = AttachMemory(
    content="attachment",
    name="attached.txt",
    mimetype="text/plain")
obj.notify(
    body="body", 
    title="test", 
    attach=am)
```
\
**Fix:** is to simply change to using the attachments open method, the same as #1553.
\
**Test:** added test case for in memory attachement to`test_plugin_email.py`.
