### PR TITLE
Additional refactoring of asynchronous logging

### DIFF
--- a/apprise/apprise.py
+++ b/apprise/apprise.py
@@ -1989,9 +1989,7 @@ class Apprise:
                 )
 
         logger.debug("Threaded notification mode")
-        logger.info(
-            "Notifying %d service(s).", len(services_kwargs)
-        )
+        logger.info("Notifying %d service(s).", len(services_kwargs))
 
         # Keep output ordered by input, though threads finish out of order.
         # This is the shared, process-wide pool (see _get_shared_executor()),
@@ -2113,9 +2111,7 @@ class Apprise:
             return True, []
 
         logger.debug("Asynchronous notification mode")
-        logger.info(
-            "Notifying %d service(s).", len(services_kwargs)
-        )
+        logger.info("Notifying %d service(s).", len(services_kwargs))
 
         async def do_call(
             service: NotifyBase,

--- a/apprise/apprise.py
+++ b/apprise/apprise.py
@@ -245,7 +245,11 @@ def _compute_deadline(
     return deadline
 
 
-def _timeout_result(server: NotifyBase, elapsed: float) -> NotifyResult:
+def _timeout_result(
+    server: NotifyBase,
+    elapsed: float,
+    max_attempts: int,
+) -> NotifyResult:
     """Build the result for a service that exceeded the outer wait.
 
     The worker may still be running. Record only what Apprise knows here:
@@ -260,7 +264,8 @@ def _timeout_result(server: NotifyBase, elapsed: float) -> NotifyResult:
         tag=tag,
         optional=getattr(server, "optional", False),
         weight=weight,
-        max_attempts=1,
+        # Preserve the configured retry count even when the outer wait wins.
+        max_attempts=max_attempts,
         attempts=[
             NotifyAttempt(
                 status=AppriseResultStatus.TIMEOUT,
@@ -335,6 +340,19 @@ def _resolve_retry_count(service: NotifyBase, kwargs: dict[str, Any]) -> int:
         # Not a usable number; treat it the same as "no override".
         retry = getattr(service, "retry", 0)
     return max(0, min(retry, APPRISE_MAX_SERVICE_RETRY))
+
+
+def _configured_max_attempts(
+    service: NotifyBase, kwargs: dict[str, Any]
+) -> int:
+    """Return the attempt limit without consuming a call override."""
+    try:
+        # Resolve a copy so the worker receives the original private override.
+        return _resolve_retry_count(service, dict(kwargs)) + 1
+
+    except Exception:
+        # Let the worker's safety net report invalid plugin metadata.
+        return 1
 
 
 def _attempt_status(success: bool) -> AppriseResultStatus:
@@ -1868,6 +1886,9 @@ class Apprise:
             # The outer wait needs a deadline before submission.
             deadline = _compute_deadline(service, call_deadline)
 
+            # Preserve retry metadata before the worker consumes its override.
+            max_attempts = _configured_max_attempts(service, kwargs)
+
             if deadline is None:
                 ok, notify_result = _call_with_retry(service, kwargs, None)
                 success = success and ok
@@ -1917,7 +1938,11 @@ class Apprise:
                     else "its worker thread may still be running in the "
                     "background",
                 )
-                notify_result = _timeout_result(service, wait_elapsed)
+                notify_result = _timeout_result(
+                    service,
+                    wait_elapsed,
+                    max_attempts,
+                )
                 ok = bool(notify_result)
 
             except Exception as e:
@@ -1982,6 +2007,12 @@ class Apprise:
             _compute_deadline(service, call_deadline)
             for service, kwargs in services_kwargs
         ]
+
+        # Preserve retry metadata before workers consume private overrides.
+        max_attempts = [
+            _configured_max_attempts(service, kwargs)
+            for service, kwargs in services_kwargs
+        ]
         future_to_idx: dict[cf.Future, int] = {
             _submit_with_context(
                 executor, _call_with_retry, service, kwargs, deadlines[i]
@@ -2040,7 +2071,11 @@ class Apprise:
                     else "its worker thread may still be running in the "
                     "background",
                 )
-                notify_result = _timeout_result(service, wait_elapsed)
+                notify_result = _timeout_result(
+                    service,
+                    wait_elapsed,
+                    max_attempts[idx],
+                )
                 ok = bool(notify_result)
 
             except Exception as e:
@@ -2187,6 +2222,7 @@ class Apprise:
             service: NotifyBase,
             kwargs: dict[str, Any],
             deadline: Optional[float],
+            max_attempts: int,
         ) -> tuple[bool, NotifyResult]:
             """Apply an outer asyncio timeout to one service call.
 
@@ -2239,7 +2275,11 @@ class Apprise:
                     service.service_name,
                     wait_elapsed,
                 )
-                notify_result = _timeout_result(service, wait_elapsed)
+                notify_result = _timeout_result(
+                    service,
+                    wait_elapsed,
+                    max_attempts,
+                )
                 return bool(notify_result), notify_result
 
         # Snapshot outer wait deadlines before launching the async workers;
@@ -2249,10 +2289,21 @@ class Apprise:
             for service, kwargs in services_kwargs
         ]
 
+        # Preserve retry metadata before coroutines consume private overrides.
+        max_attempts = [
+            _configured_max_attempts(service, kwargs)
+            for service, kwargs in services_kwargs
+        ]
+
         # Run all coroutines concurrently.  return_exceptions=True ensures
         # one escaped exception is reported without cancelling other services.
         cors = (
-            do_call_bounded(service, kwargs, deadlines[i])
+            do_call_bounded(
+                service,
+                kwargs,
+                deadlines[i],
+                max_attempts[i],
+            )
             for i, (service, kwargs) in enumerate(services_kwargs)
         )
         gathered = await asyncio.gather(*cors, return_exceptions=True)

--- a/apprise/apprise.py
+++ b/apprise/apprise.py
@@ -1988,8 +1988,9 @@ class Apprise:
                     services_kwargs[0], call_deadline=call_deadline
                 )
 
+        logger.debug("Threaded notification mode")
         logger.info(
-            "Notifying %d service(s) with threads.", len(services_kwargs)
+            "Notifying %d service(s).", len(services_kwargs)
         )
 
         # Keep output ordered by input, though threads finish out of order.
@@ -2111,8 +2112,9 @@ class Apprise:
         if n_calls == 0:
             return True, []
 
+        logger.debug("Asynchronous notification mode")
         logger.info(
-            "Notifying %d service(s) asynchronously.", len(services_kwargs)
+            "Notifying %d service(s).", len(services_kwargs)
         )
 
         async def do_call(

--- a/apprise/apprise.py
+++ b/apprise/apprise.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Iterator
 import concurrent.futures as cf
+import contextvars
 from functools import partial
 from itertools import chain
 import json
@@ -108,6 +109,15 @@ def _get_coordinator_executor() -> cf.ThreadPoolExecutor:
             if _coordinator_executor is None:
                 _coordinator_executor = cf.ThreadPoolExecutor()
     return _coordinator_executor
+
+
+def _submit_with_context(
+    executor: cf.Executor, function: Callable, *args: Any
+) -> cf.Future:
+    """Submit work with a copy of the caller's logging context."""
+    # The copied context lets worker logs find the current call capture.
+    context = contextvars.copy_context()
+    return executor.submit(context.run, function, *args)
 
 
 # Services abandoned on timeout that are still genuinely running. Lets
@@ -485,7 +495,7 @@ class Apprise:
         location: Optional[ContentLocation] = None,
         debug: bool = False,
         log_callback: Optional[
-            Callable[[NotifyLogEntry, NotifyBase], None]
+            Callable[[NotifyLogEntry, Optional[NotifyBase]], None]
         ] = None,
         log_level: Optional[int] = None,
     ) -> None:
@@ -497,15 +507,12 @@ class Apprise:
         Optionally specify a global ContentLocation for a more strict means of
         handling Attachments.
 
-        log_callback receives captured service warnings and errors as
-        ``log_callback(entry, service)``. It runs inline and must be a short,
-        synchronous function. Schedule async work from the callback when
-        needed.
+        log_callback receives captured entries as ``callback(entry, service)``.
+        ``service`` is ``None`` for orchestration entries returned by
+        ``AppriseResult.call_logs()``. The callback must be synchronous.
 
-        log_level sets the minimum severity captured per service attempt
-        (as NotifyLogEntry objects on each NotifyAttempt). Defaults to
-        logging.WARNING; pass a finer level such as logging.INFO or
-        logging.DEBUG to also capture informational/debug chatter..
+        log_level controls captured service and call-level entries. It defaults
+        to WARNING, or INFO when a log_callback is configured.
         """
 
         # Initialize a server list of URLs
@@ -959,14 +966,28 @@ class Apprise:
 
     @staticmethod
     def _inject_log_level(all_calls, log_level):
-        """Inject _log_level into every call's kwargs. No-op if
-        log_level is None."""
-        if log_level is None:
-            return all_calls
+        """Add the chosen capture level to every service call."""
         return [
             (service, dict(kwargs, _log_level=log_level))
             for service, kwargs in all_calls
         ]
+
+    @staticmethod
+    def _resolve_call_level(
+        effective_log_level: Optional[int],
+        effective_log_callback: Optional[
+            Callable[[NotifyLogEntry, Optional[NotifyBase]], None]
+        ],
+    ) -> int:
+        """Resolve the explicit level or the callback-aware default."""
+        # A level supplied by the caller always takes priority.
+        if effective_log_level is not None:
+            return effective_log_level
+        # Live callbacks usually need progress messages as well as warnings.
+        if effective_log_callback is not None:
+            return logging.INFO
+        # Preserve the quieter result-only default when no callback is active.
+        return logging.WARNING
 
     @staticmethod
     def _build_tag_chains(all_calls, tag):
@@ -1121,6 +1142,7 @@ class Apprise:
         seq_future = (
             loop.run_in_executor(
                 executor,
+                contextvars.copy_context().run,
                 partial(
                     Apprise._notify_sequential,
                     *[(s, k) for _, s, k in sequential],
@@ -1161,7 +1183,7 @@ class Apprise:
         interpret_escapes: Optional[bool] = None,
         timeout: Union[int, float] = 0,
         log_callback: Optional[
-            Callable[[NotifyLogEntry, NotifyBase], None]
+            Callable[[NotifyLogEntry, Optional[NotifyBase]], None]
         ] = None,
         log_level: Optional[int] = None,
     ) -> AppriseResult:
@@ -1183,6 +1205,9 @@ class Apprise:
             result = apobj.notify(body="hello")
             for service_result in result:
                 print(service_result.name, bool(service_result))
+
+        ``result.logs()`` combines service and orchestration entries in time
+        order. Orchestration-only entries are also available in ``call_logs``.
 
         A filter tag may carry an optional priority prefix and/or retry suffix:
 
@@ -1215,13 +1240,12 @@ class Apprise:
 
         log_callback overrides the instance default for this call. It must be
         synchronous; schedule any async work from inside the callback.
+        ``service`` is ``None`` for a call-level entry (see
+        ``result.call_logs()`` above).
 
-        log_level overrides the instance default for this call, setting the
-        minimum severity captured per service attempt (as NotifyLogEntry
-        objects on each NotifyAttempt). Defaults to logging.WARNING, the
-        level at which plugins themselves report delivery failures; pass a
-        finer level such as logging.INFO or logging.DEBUG to also capture
-        informational/debug chatter the same way command-line verbosity does.
+        log_level overrides the capture level for this call. It defaults to
+        WARNING, or INFO when a log_callback is active. Use DEBUG or TRACE for
+        more detail.
         """
         timeout = _validate_timeout(timeout)
         effective_log_callback = (
@@ -1230,186 +1254,206 @@ class Apprise:
         effective_log_level = (
             log_level if log_level is not None else self._log_level
         )
+        call_level = Apprise._resolve_call_level(
+            effective_log_level, effective_log_callback
+        )
 
         # Wall-clock start for AppriseResult.elapsed -- covers the entire
         # call, including argument validation, not just service dispatch.
         start = time.monotonic()
 
-        # An absolute time.monotonic() ceiling for the whole call, or None
-        # when no override was given (each service still has its own
-        # AppriseAsset._service_timeout budget -- see _compute_deadline()).
+        # Apply the call timeout without replacing each service's own limit.
         call_deadline: Optional[float] = (
             time.monotonic() + timeout if timeout else None
         )
 
-        try:
-            all_calls = list(
-                self._create_notify_gen(
-                    body,
-                    title,
-                    notify_type=notify_type,
-                    body_format=body_format,
-                    tag=tag,
-                    match_always=match_always,
-                    attach=attach,
-                    interpret_escapes=interpret_escapes,
+        # Capture orchestration logs not owned by a service attempt.
+        # The capture reads its limits from the asset already held by Apprise.
+        with _ServiceLogCapture(
+            service=None,
+            log_callback=effective_log_callback,
+            level=call_level,
+            memory_size=self.asset.result_log_memory_size,
+            disk_size=self.asset.result_log_disk_size,
+        ) as call_capture:
+            try:
+                all_calls = list(
+                    self._create_notify_gen(
+                        body,
+                        title,
+                        notify_type=notify_type,
+                        body_format=body_format,
+                        tag=tag,
+                        match_always=match_always,
+                        attach=attach,
+                        interpret_escapes=interpret_escapes,
+                    )
                 )
-            )
 
-        except TypeError:
-            # Invalid notify() arguments -- no service was ever attempted.
-            return AppriseResult(
-                status=AppriseResultStatus.FAILURE,
-                results=[],
-                elapsed=time.monotonic() - start,
-            )
-
-        if not all_calls:
-            # Tag filter matched nothing, or no servers are loaded at all.
-            return AppriseResult(
-                status=AppriseResultStatus.NOMATCH,
-                results=[],
-                elapsed=time.monotonic() - start,
-            )
-
-        # Apply the first matching retry suffix to each service.
-        all_calls = Apprise._inject_per_service_retries(all_calls, tag)
-        all_calls = Apprise._inject_log_callback(
-            all_calls, effective_log_callback
-        )
-        all_calls = Apprise._inject_log_level(all_calls, effective_log_level)
-
-        if Apprise._filter_has_explicit_priority(tag):
-            # An explicit priority sends one flat batch without escalation.
-            ok, results = Apprise._split_and_dispatch(
-                all_calls, call_deadline=call_deadline
-            )
-            return AppriseResult(
-                status=_aggregate_status(ok, results),
-                results=results,
-                elapsed=time.monotonic() - start,
-            )
-
-        # Without an explicit priority:
-        # - Each OR tag becomes an independent chain.
-        # - Each chain starts at its highest priority.
-        # - A failed group advances only its own chain.
-        # - Active chains run concurrently.
-        chains = Apprise._build_tag_chains(all_calls, tag)
-
-        # Per-chain state: priorities (sorted), groups dict, current index,
-        # and a flag marking whether a successful group has been found.
-        chain_states = {
-            key: {
-                "priorities": sorted(groups),
-                "groups": groups,
-                "idx": 0,
-                "succeeded": False,
-            }
-            for key, groups in chains.items()
-        }
-
-        # Every NotifyResult actually dispatched across every chain and
-        # every priority-group attempt, in the order each batch was run.
-        all_results = []
-
-        while True:
-            # When abort_on_chain_failure is enabled, stop as soon as any
-            # chain has exhausted all its priority groups without success.
-            # With the default (False) all chains run to completion even if
-            # one has already failed, so every defined URL gets an attempt.
-            if self.asset.abort_on_chain_failure and any(
-                not st["succeeded"] and st["idx"] >= len(st["priorities"])
-                for st in chain_states.values()
-            ):
+            except TypeError:
+                # Invalid notify() arguments -- no service was ever attempted.
                 return AppriseResult(
-                    status=_aggregate_status(False, all_results),
-                    results=all_results,
+                    status=AppriseResultStatus.FAILURE,
+                    results=[],
                     elapsed=time.monotonic() - start,
+                    call_logs=call_capture.entries,
                 )
 
-            # Collect chains that still need to try their next priority group.
-            active = [
-                (key, st)
-                for key, st in chain_states.items()
-                if not st["succeeded"] and st["idx"] < len(st["priorities"])
-            ]
-            if not active:
-                break  # every chain has either succeeded or been exhausted
-
-            if len(active) == 1:
-                # Single active chain: dispatch directly, no thread overhead.
-                key, st = active[0]
-                priority = st["priorities"][st["idx"]]
-                batch = st["groups"][priority]
-                ok, batch_results = Apprise._split_and_dispatch(
-                    batch, call_deadline=call_deadline
+            if not all_calls:
+                # Tag filter matched nothing, or no servers are loaded at all.
+                return AppriseResult(
+                    status=AppriseResultStatus.NOMATCH,
+                    results=[],
+                    elapsed=time.monotonic() - start,
+                    call_logs=call_capture.entries,
                 )
-                all_results.extend(batch_results)
-                if ok:
-                    logger.trace(
-                        "Chain '%s' priority group %s succeeded.",
-                        key,
-                        priority,
-                    )
-                    st["succeeded"] = True
-                else:
-                    logger.trace(
-                        "Chain '%s' priority group %s failed; escalating.",
-                        key,
-                        priority,
-                    )
-                    st["idx"] += 1  # escalate to next priority
-            else:
-                # Multiple active chains: run their current-priority batches
-                # concurrently so independent chains don't block each other.
-                # Use the coordinator pool because each batch may await leaf
-                # service calls from the other executor.
-                executor = _get_coordinator_executor()
-                future_map = {
-                    executor.submit(
-                        Apprise._split_and_dispatch,
-                        st["groups"][st["priorities"][st["idx"]]],
-                        call_deadline,
-                    ): (key, st)
-                    for key, st in active
+
+            # Apply the first matching retry suffix to each service.
+            all_calls = Apprise._inject_per_service_retries(all_calls, tag)
+            all_calls = Apprise._inject_log_callback(
+                all_calls, effective_log_callback
+            )
+            all_calls = Apprise._inject_log_level(all_calls, call_level)
+
+            if Apprise._filter_has_explicit_priority(tag):
+                # An explicit priority sends one flat batch without escalation.
+                ok, results = Apprise._split_and_dispatch(
+                    all_calls, call_deadline=call_deadline
+                )
+                return AppriseResult(
+                    status=_aggregate_status(ok, results),
+                    results=results,
+                    elapsed=time.monotonic() - start,
+                    call_logs=call_capture.entries,
+                )
+
+            # Without an explicit priority:
+            # - Each OR tag becomes an independent chain.
+            # - Each chain starts at its highest priority.
+            # - A failed group advances only its own chain.
+            # - Active chains run concurrently.
+            chains = Apprise._build_tag_chains(all_calls, tag)
+
+            # Per-chain state: priorities (sorted), groups dict, current
+            # index, and a flag marking whether a successful group has
+            # been found.
+            chain_states = {
+                key: {
+                    "priorities": sorted(groups),
+                    "groups": groups,
+                    "idx": 0,
+                    "succeeded": False,
                 }
-                # Collect in submission order so results are stable even
-                # when chains finish in a different order.
-                for future, (key, st) in future_map.items():
-                    try:
-                        ok, batch_results = future.result()
-                    except Exception as e:
-                        logger.warning(
-                            "Notification chain '%s' priority group %s "
-                            "raised an exception.",
-                            key,
-                            st["priorities"][st["idx"]],
-                        )
-                        logger.debug("Notification Exception: %s", str(e))
-                        ok, batch_results = False, []
+                for key, groups in chains.items()
+            }
+
+            # Every NotifyResult actually dispatched across every chain and
+            # every priority-group attempt, in the order each batch was run.
+            all_results = []
+
+            while True:
+                # When abort_on_chain_failure is enabled, stop as soon as any
+                # chain has exhausted all its priority groups without
+                # success. With the default (False) all chains run to
+                # completion even if one has already failed, so every
+                # defined URL gets an attempt.
+                if self.asset.abort_on_chain_failure and any(
+                    not st["succeeded"] and st["idx"] >= len(st["priorities"])
+                    for st in chain_states.values()
+                ):
+                    return AppriseResult(
+                        status=_aggregate_status(False, all_results),
+                        results=all_results,
+                        elapsed=time.monotonic() - start,
+                        call_logs=call_capture.entries,
+                    )
+
+                # Collect chains that still need to try their next
+                # priority group.
+                active = [
+                    (key, st)
+                    for key, st in chain_states.items()
+                    if not st["succeeded"]
+                    and st["idx"] < len(st["priorities"])
+                ]
+                if not active:
+                    break  # every chain has either succeeded or been exhausted
+
+                if len(active) == 1:
+                    # Single active chain: dispatch directly, no thread
+                    # overhead.
+                    key, st = active[0]
+                    priority = st["priorities"][st["idx"]]
+                    batch = st["groups"][priority]
+                    ok, batch_results = Apprise._split_and_dispatch(
+                        batch, call_deadline=call_deadline
+                    )
                     all_results.extend(batch_results)
                     if ok:
                         logger.trace(
                             "Chain '%s' priority group %s succeeded.",
                             key,
-                            st["priorities"][st["idx"]],
+                            priority,
                         )
                         st["succeeded"] = True
                     else:
                         logger.trace(
                             "Chain '%s' priority group %s failed; escalating.",
                             key,
-                            st["priorities"][st["idx"]],
+                            priority,
                         )
                         st["idx"] += 1  # escalate to next priority
+                else:
+                    # Run active chains in the coordinator pool so their
+                    # service calls can use the shared worker pool.
+                    executor = _get_coordinator_executor()
+                    future_map = {
+                        _submit_with_context(
+                            executor,
+                            Apprise._split_and_dispatch,
+                            st["groups"][st["priorities"][st["idx"]]],
+                            call_deadline,
+                        ): (key, st)
+                        for key, st in active
+                    }
+                    # Collect in submission order so results are stable
+                    # even when chains finish in a different order.
+                    for future, (key, st) in future_map.items():
+                        try:
+                            ok, batch_results = future.result()
+                        except Exception as e:
+                            logger.warning(
+                                "Notification chain '%s' priority group "
+                                "%s raised an exception.",
+                                key,
+                                st["priorities"][st["idx"]],
+                            )
+                            logger.debug("Notification Exception: %s", str(e))
+                            ok, batch_results = False, []
+                        all_results.extend(batch_results)
+                        if ok:
+                            logger.trace(
+                                "Chain '%s' priority group %s succeeded.",
+                                key,
+                                st["priorities"][st["idx"]],
+                            )
+                            st["succeeded"] = True
+                        else:
+                            logger.trace(
+                                "Chain '%s' priority group %s failed; "
+                                "escalating.",
+                                key,
+                                st["priorities"][st["idx"]],
+                            )
+                            st["idx"] += 1  # escalate to next priority
 
-        success = all(st["succeeded"] for st in chain_states.values())
-        return AppriseResult(
-            status=_aggregate_status(success, all_results),
-            results=all_results,
-            elapsed=time.monotonic() - start,
-        )
+            success = all(st["succeeded"] for st in chain_states.values())
+            return AppriseResult(
+                status=_aggregate_status(success, all_results),
+                results=all_results,
+                elapsed=time.monotonic() - start,
+                call_logs=call_capture.entries,
+            )
 
     async def async_notify(self, *args: Any, **kwargs: Any) -> AppriseResult:
         """Asynchronously notify all loaded plugins.
@@ -1424,7 +1468,7 @@ class Apprise:
             kwargs.pop("timeout", 0)
         )
         log_callback: Optional[
-            Callable[[NotifyLogEntry, NotifyBase], None]
+            Callable[[NotifyLogEntry, Optional[NotifyBase]], None]
         ] = kwargs.pop("log_callback", None)
         effective_log_callback = (
             log_callback if log_callback is not None else self._log_callback
@@ -1432,6 +1476,9 @@ class Apprise:
         log_level: Optional[int] = kwargs.pop("log_level", None)
         effective_log_level = (
             log_level if log_level is not None else self._log_level
+        )
+        call_level = Apprise._resolve_call_level(
+            effective_log_level, effective_log_callback
         )
 
         # Wall-clock start for AppriseResult.elapsed -- see notify().
@@ -1442,132 +1489,146 @@ class Apprise:
             time.monotonic() + timeout if timeout else None
         )
 
-        try:
-            all_calls = list(self._create_notify_gen(*args, **kwargs))
+        # Capture orchestration logs not owned by a service attempt.
+        # The capture reads its limits from the asset already held by Apprise.
+        with _ServiceLogCapture(
+            service=None,
+            log_callback=effective_log_callback,
+            level=call_level,
+            memory_size=self.asset.result_log_memory_size,
+            disk_size=self.asset.result_log_disk_size,
+        ) as call_capture:
+            try:
+                all_calls = list(self._create_notify_gen(*args, **kwargs))
 
-        except TypeError:
-            # Invalid notify() arguments -- no service was ever attempted.
-            return AppriseResult(
-                status=AppriseResultStatus.FAILURE,
-                results=[],
-                elapsed=time.monotonic() - start,
-            )
-
-        if not all_calls:
-            # Tag filter matched nothing, or no servers are loaded at all.
-            return AppriseResult(
-                status=AppriseResultStatus.NOMATCH,
-                results=[],
-                elapsed=time.monotonic() - start,
-            )
-
-        # Inject per-service call-time retry overrides (same logic as notify).
-        all_calls = Apprise._inject_per_service_retries(all_calls, tag)
-        all_calls = Apprise._inject_log_callback(
-            all_calls, effective_log_callback
-        )
-        all_calls = Apprise._inject_log_level(all_calls, effective_log_level)
-
-        if Apprise._filter_has_explicit_priority(tag):
-            # Explicit priority prefix: flat dispatch, no escalation.
-            ok, results = await Apprise._split_and_dispatch_async(
-                all_calls, call_deadline=call_deadline
-            )
-            return AppriseResult(
-                status=_aggregate_status(ok, results),
-                results=results,
-                elapsed=time.monotonic() - start,
-            )
-
-        # Use the same independent escalation chains as notify(). Active
-        # groups run together; only a failed chain advances.
-        chains = Apprise._build_tag_chains(all_calls, tag)
-
-        chain_states = {
-            key: {
-                "priorities": sorted(groups),
-                "groups": groups,
-                "idx": 0,
-                "succeeded": False,
-            }
-            for key, groups in chains.items()
-        }
-
-        # Every NotifyResult actually dispatched across every chain and
-        # every priority-group attempt, in the order each batch was run.
-        all_results = []
-
-        while True:
-            # Same abort_on_chain_failure guard as notify().
-            if self.asset.abort_on_chain_failure and any(
-                not st["succeeded"] and st["idx"] >= len(st["priorities"])
-                for st in chain_states.values()
-            ):
+            except TypeError:
+                # Invalid notify() arguments -- no service was ever attempted.
                 return AppriseResult(
-                    status=_aggregate_status(False, all_results),
-                    results=all_results,
+                    status=AppriseResultStatus.FAILURE,
+                    results=[],
                     elapsed=time.monotonic() - start,
+                    call_logs=call_capture.entries,
                 )
 
-            active = [
-                (key, st)
-                for key, st in chain_states.items()
-                if not st["succeeded"] and st["idx"] < len(st["priorities"])
-            ]
-            if not active:
-                break  # every chain has either succeeded or been exhausted
+            if not all_calls:
+                # Tag filter matched nothing, or no servers are loaded at all.
+                return AppriseResult(
+                    status=AppriseResultStatus.NOMATCH,
+                    results=[],
+                    elapsed=time.monotonic() - start,
+                    call_logs=call_capture.entries,
+                )
 
-            # Run all active chains' current-priority batches concurrently.
-            # asyncio.gather() interleaves coroutines so async services across
-            # different chains can pipeline their I/O simultaneously.
-            # return_exceptions=True prevents one failing batch from cancelling
-            # the others; exceptions are treated as delivery failures below.
-            gathered = await asyncio.gather(
-                *(
-                    Apprise._split_and_dispatch_async(
-                        st["groups"][st["priorities"][st["idx"]]],
-                        call_deadline=call_deadline,
-                    )
-                    for _, st in active
-                ),
-                return_exceptions=True,
+            # Inject per-service call-time retry overrides (same logic as
+            # notify).
+            all_calls = Apprise._inject_per_service_retries(all_calls, tag)
+            all_calls = Apprise._inject_log_callback(
+                all_calls, effective_log_callback
             )
+            all_calls = Apprise._inject_log_level(all_calls, call_level)
 
-            for (key, st), item in zip(active, gathered):
-                if isinstance(item, Exception):
-                    # Escaped exception -- safety net; treat as failure.
-                    logger.warning(
-                        "Notification chain '%s' priority group %s raised "
-                        "an exception.",
-                        key,
-                        st["priorities"][st["idx"]],
+            if Apprise._filter_has_explicit_priority(tag):
+                # Explicit priority prefix: flat dispatch, no escalation.
+                ok, results = await Apprise._split_and_dispatch_async(
+                    all_calls, call_deadline=call_deadline
+                )
+                return AppriseResult(
+                    status=_aggregate_status(ok, results),
+                    results=results,
+                    elapsed=time.monotonic() - start,
+                    call_logs=call_capture.entries,
+                )
+
+            # Use the same independent escalation chains as notify(). Active
+            # groups run together; only a failed chain advances.
+            chains = Apprise._build_tag_chains(all_calls, tag)
+
+            chain_states = {
+                key: {
+                    "priorities": sorted(groups),
+                    "groups": groups,
+                    "idx": 0,
+                    "succeeded": False,
+                }
+                for key, groups in chains.items()
+            }
+
+            # Every NotifyResult actually dispatched across every chain and
+            # every priority-group attempt, in the order each batch was run.
+            all_results = []
+
+            while True:
+                # Same abort_on_chain_failure guard as notify().
+                if self.asset.abort_on_chain_failure and any(
+                    not st["succeeded"] and st["idx"] >= len(st["priorities"])
+                    for st in chain_states.values()
+                ):
+                    return AppriseResult(
+                        status=_aggregate_status(False, all_results),
+                        results=all_results,
+                        elapsed=time.monotonic() - start,
+                        call_logs=call_capture.entries,
                     )
-                    logger.debug("Notification Exception: %s", str(item))
-                    st["idx"] += 1
-                else:
-                    ok, batch_results = item
-                    all_results.extend(batch_results)
-                    if ok:
-                        logger.trace(
-                            "Chain '%s' priority group %s succeeded.",
-                            key,
-                            st["priorities"][st["idx"]],
-                        )
-                        st["succeeded"] = True
-                    else:
-                        logger.trace(
-                            "Chain '%s' priority group %s failed; escalating.",
-                            key,
-                            st["priorities"][st["idx"]],
-                        )
-                        st["idx"] += 1  # escalate to next priority group
 
-        success = all(st["succeeded"] for st in chain_states.values())
-        return AppriseResult(
-            status=_aggregate_status(success, all_results),
-            results=all_results,
-            elapsed=time.monotonic() - start,
-        )
+                active = [
+                    (key, st)
+                    for key, st in chain_states.items()
+                    if not st["succeeded"]
+                    and st["idx"] < len(st["priorities"])
+                ]
+                if not active:
+                    break  # every chain has either succeeded or been exhausted
+
+                # Run active chains together. Keep one failure from cancelling
+                # the others, then handle each result below.
+                gathered = await asyncio.gather(
+                    *(
+                        Apprise._split_and_dispatch_async(
+                            st["groups"][st["priorities"][st["idx"]]],
+                            call_deadline=call_deadline,
+                        )
+                        for _, st in active
+                    ),
+                    return_exceptions=True,
+                )
+
+                for (key, st), item in zip(active, gathered):
+                    if isinstance(item, Exception):
+                        # Escaped exception -- safety net; treat as failure.
+                        logger.warning(
+                            "Notification chain '%s' priority group %s "
+                            "raised an exception.",
+                            key,
+                            st["priorities"][st["idx"]],
+                        )
+                        logger.debug("Notification Exception: %s", str(item))
+                        st["idx"] += 1
+                    else:
+                        ok, batch_results = item
+                        all_results.extend(batch_results)
+                        if ok:
+                            logger.trace(
+                                "Chain '%s' priority group %s succeeded.",
+                                key,
+                                st["priorities"][st["idx"]],
+                            )
+                            st["succeeded"] = True
+                        else:
+                            logger.trace(
+                                "Chain '%s' priority group %s failed; "
+                                "escalating.",
+                                key,
+                                st["priorities"][st["idx"]],
+                            )
+                            st["idx"] += 1  # escalate to next priority group
+
+            success = all(st["succeeded"] for st in chain_states.values())
+            return AppriseResult(
+                status=_aggregate_status(success, all_results),
+                results=all_results,
+                elapsed=time.monotonic() - start,
+                call_logs=call_capture.entries,
+            )
 
     def _create_notify_calls(self, *args, **kwargs):
         """Creates notifications for all the plugins loaded.
@@ -1825,8 +1886,8 @@ class Apprise:
             )
 
             executor = _get_shared_executor()
-            future = executor.submit(
-                _call_with_retry, service, kwargs, deadline
+            future = _submit_with_context(
+                executor, _call_with_retry, service, kwargs, deadline
             )
             try:
                 # Keep a final guard for unexpected executor failures.
@@ -1922,7 +1983,9 @@ class Apprise:
             for service, kwargs in services_kwargs
         ]
         future_to_idx: dict[cf.Future, int] = {
-            executor.submit(_call_with_retry, service, kwargs, deadlines[i]): i
+            _submit_with_context(
+                executor, _call_with_retry, service, kwargs, deadlines[i]
+            ): i
             for i, (service, kwargs) in enumerate(services_kwargs)
         }
 

--- a/apprise/asset.py
+++ b/apprise/asset.py
@@ -257,6 +257,14 @@ class AppriseAsset:
     # share the cap proportionally.
     _payload_min_buffer = 25
 
+    # Keep result logs in memory unless disk-backed capture is configured.
+    # Apprise reads this setting from its existing asset when it notifies.
+    _result_log_memory_size = 0
+
+    # A zero disk allowance preserves the existing memory-only behavior.
+    # When enabled, both limits cover the complete notification call.
+    _result_log_disk_size = 0
+
     def __init__(
         self,
         plugin_paths: Optional[list[str]] = None,
@@ -269,6 +277,8 @@ class AppriseAsset:
         payload_max_size: Optional[int] = None,
         payload_buffer_threshold: Optional[int] = None,
         payload_min_buffer: Optional[int] = None,
+        result_log_memory_size: Optional[int] = None,
+        result_log_disk_size: Optional[int] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize shared settings and delivery limits.
@@ -276,8 +286,9 @@ class AppriseAsset:
         Zero disables ``service_timeout`` and ``payload_max_size``.
         ``payload_buffer_threshold`` and ``payload_min_buffer`` control how a
         capped payload is shared between title and body; see
-        ``enforce_payload_max_size()``. ``None`` keeps the class default for
-        each setting.
+        ``enforce_payload_max_size()``. Result logs use disk after their memory
+        allowance; a zero disk size keeps them in memory. ``None`` keeps each
+        class default.
         """
         # Assign default arguments if specified
         for key, value in kwargs.items():
@@ -412,6 +423,38 @@ class AppriseAsset:
                 )
 
             self._payload_min_buffer = payload_min_buffer
+
+        if result_log_memory_size is not None:
+            # Booleans are integers in Python, but are not valid byte limits.
+            if not isinstance(result_log_memory_size, int) or isinstance(
+                result_log_memory_size, bool
+            ):
+                raise TypeError(
+                    "AppriseAsset result_log_memory_size must be an int."
+                )
+
+            if result_log_memory_size < 0:
+                raise ValueError(
+                    "AppriseAsset result_log_memory_size must be >= 0."
+                )
+
+            self._result_log_memory_size = result_log_memory_size
+
+        if result_log_disk_size is not None:
+            # Keep this strict so later storage calculations are predictable.
+            if not isinstance(result_log_disk_size, int) or isinstance(
+                result_log_disk_size, bool
+            ):
+                raise TypeError(
+                    "AppriseAsset result_log_disk_size must be an int."
+                )
+
+            if result_log_disk_size < 0:
+                raise ValueError(
+                    "AppriseAsset result_log_disk_size must be >= 0."
+                )
+
+            self._result_log_disk_size = result_log_disk_size
 
         if storage_salt is not None:
             # Define the number of characters utilized from our namespace lengh
@@ -699,6 +742,16 @@ class AppriseAsset:
         """Return the persistent storage id length."""
 
         return self.__storage_idlen
+
+    @property
+    def result_log_memory_size(self) -> int:
+        """Return the result-log memory allowance in bytes."""
+        return self._result_log_memory_size
+
+    @property
+    def result_log_disk_size(self) -> int:
+        """Return the result-log disk allowance in bytes."""
+        return self._result_log_disk_size
 
     @property
     def tzinfo(self) -> tzinfo:

--- a/apprise/logger.py
+++ b/apprise/logger.py
@@ -28,6 +28,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterator
 import contextlib
 import contextvars
 from datetime import datetime, timezone
@@ -35,7 +36,10 @@ from io import StringIO
 import json
 import logging
 import os
-from typing import TYPE_CHECKING, Any, Callable, Optional
+import struct
+import tempfile
+import threading
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 from .common import AWARE_DATE_ISO_FORMAT, JSON_COMPACT_SEPARATORS
 
@@ -47,14 +51,14 @@ if TYPE_CHECKING:
 # The root identifier needed to monitor 'apprise' logging
 LOGGER_NAME = "apprise"
 
-# Upper bound on WARNING+ entries captured for one attempt.
-# This caps memory use if a plugin logs repeatedly in a large batch.
-_MAX_CAPTURED_LOG_ENTRIES = 5000
-
-# Tracks which capture owns logs from the current execution context.
-# ContextVar also survives async-to-thread handoffs when copied explicitly.
+# Tracks the service capture active in the current execution context.
 _active_capture: contextvars.ContextVar[Optional[_ServiceLogCapture]] = (
     contextvars.ContextVar("apprise_active_log_capture", default=None)
+)
+
+# Keeps call-level logs isolated when notifications run concurrently.
+_active_call_capture: contextvars.ContextVar[Optional[_ServiceLogCapture]] = (
+    contextvars.ContextVar("apprise_active_call_log_capture", default=None)
 )
 
 
@@ -92,8 +96,17 @@ logging.Logger.deprecate = deprecate
 logger = logging.getLogger(LOGGER_NAME)
 
 
+def _safe_internal_log(level: int, message: str, *args: Any) -> None:
+    """Report a capture problem without letting logging handlers raise."""
+    # Logging is best-effort while the original notification continues.
+    with contextlib.suppress(Exception):
+        # Capture handlers already block their own re-entry. This guard also
+        # contains failures raised by application-provided handlers.
+        logger.log(level, message, *args)
+
+
 class NotifyLogEntry:
-    """A single log line captured while one service was being notified."""
+    """A log entry captured during notification processing."""
 
     def __init__(
         self, level: str, message: str, time: Optional[datetime] = None
@@ -175,136 +188,611 @@ class NotifyLogEntry:
         )
 
 
-class _ServiceLogCapture(logging.Handler):
-    """Capture one service's log messages in isolation.
+class _LogCaptureBudget:
+    """Share result-log memory and disk limits across one notify call."""
 
-    A temporary handler stores one attempt's entries. ``log_callback`` receives
-    them live and must return promptly; it can schedule async work if needed.
+    # Store each entry's size and the next entry in this capture.
+    _HEADER = struct.Struct("!QQ")
+
+    # Update only the next-entry location when linking records.
+    _LINK = struct.Struct("!Q")
+
+    # This value marks the last record in one capture's disk chain.
+    _END = (1 << 64) - 1
+
+    # This message is retained when the configured disk allowance is full.
+    _LIMIT_MESSAGE = (
+        "Result log storage is full; additional entries were not retained."
+    )
+
+    # This message is retained when temporary storage stops working.
+    _DISK_MESSAGE = (
+        "Result log disk storage failed; additional entries may be missing."
+    )
+
+    def __init__(self, memory_size: int = 0, disk_size: int = 0) -> None:
+        """Set byte limits; a zero disk limit keeps memory unbounded."""
+        # Maximum memory shared by all captures in this notification call.
+        self.memory_size = memory_size
+
+        # Maximum temporary disk space shared by the same captures.
+        self.disk_size = disk_size
+
+        # Memory currently reserved by captured entries.
+        self.memory_used = 0
+
+        # Disk space currently reserved by captured entries.
+        self.disk_used = 0
+
+        # Stop further writes after the first disk error.
+        self.disk_failed = False
+
+        # Open the temporary file only when an entry spills to disk.
+        self._disk: Optional[Any] = None
+
+        # The final store to close releases the shared temporary file.
+        self._store_count = 0
+
+        # Report each storage problem once per notification call.
+        self._reported_warnings: set[str] = set()
+
+        # Protect shared limits and disk access across service threads.
+        self._lock = threading.RLock()
+
+    def register_store(self) -> None:
+        """Keep shared disk storage open for one capture store."""
+        with self._lock:
+            # Every active store receives one ownership count.
+            self._store_count += 1
+
+    def reserve_memory(self, size: int) -> bool:
+        """Reserve memory for one entry before it spills to disk."""
+        with self._lock:
+            # No disk allowance preserves the original all-memory behavior.
+            if not self.disk_size:
+                return True
+
+            # Spill the complete entry rather than splitting it across stores.
+            if self.memory_used + size > self.memory_size:
+                return False
+
+            # Reserve the entry's bytes before another thread can claim them.
+            self.memory_used += size
+
+            return True
+
+    def claim_warning(self, message: str) -> bool:
+        """Return true once for each storage warning in this notify call."""
+        with self._lock:
+            # A warning already claimed by another capture is not repeated.
+            if message in self._reported_warnings:
+                return False
+
+            # Remember the warning before its caller writes to the logger.
+            self._reported_warnings.add(message)
+
+            return True
+
+    def write(
+        self, payload: bytes, previous: Optional[int]
+    ) -> tuple[Optional[int], Optional[str]]:
+        """Write one entry and return its offset or a safe warning."""
+        # Disk accounting includes the record header and its log content.
+        size = self._HEADER.size + len(payload)
+
+        with self._lock:
+            # A failed or full disk store cannot accept another record.
+            if self.disk_failed or self.disk_used + size > self.disk_size:
+                return (
+                    None,
+                    self._DISK_MESSAGE
+                    if self.disk_failed
+                    else self._LIMIT_MESSAGE,
+                )
+
+            # Reserve space first so parallel captures cannot exceed the cap.
+            self.disk_used += size
+
+            try:
+                if self._disk is None:
+                    # Share one anonymous file across this notification.
+                    self._disk = tempfile.TemporaryFile(  # noqa: SIM115
+                        mode="w+b"
+                    )
+
+                # Append new content without disturbing earlier records.
+                self._disk.seek(0, os.SEEK_END)
+
+                # New records always begin at the current end of the file.
+                offset = self._disk.tell()
+
+                # New records begin as the final item in their capture.
+                header = self._HEADER.pack(len(payload), self._END)
+
+                # A short write means the record cannot be trusted later.
+                if self._disk.write(header) != len(header):
+                    raise OSError("short result log header write")
+
+                # Write the complete log entry immediately after its header.
+                if self._disk.write(payload) != len(payload):
+                    raise OSError("short result log entry write")
+
+                if previous is not None:
+                    # Link this capture's entries across the shared file.
+                    self._disk.seek(previous + self._LINK.size)
+
+                    # Point the prior record at the new record's location.
+                    link = self._LINK.pack(offset)
+
+                    if self._disk.write(link) != len(link):
+                        raise OSError("short result log link write")
+
+                # Make completed writes available to result readers.
+                self._disk.flush()
+
+                return offset, None
+
+            except Exception as e:
+                # Return unused space after a failed write.
+                self.disk_used -= size
+
+                if self.claim_warning(self._DISK_MESSAGE):
+                    # Keep the main warning concise and details at debug level.
+                    _safe_internal_log(logging.WARNING, self._DISK_MESSAGE)
+                    _safe_internal_log(
+                        logging.DEBUG,
+                        "Result log storage exception: %s",
+                        str(e),
+                    )
+
+                # Future entries skip disk instead of repeating the failure.
+                self.disk_failed = True
+
+                return None, self._DISK_MESSAGE
+
+    def read(self, offset: int) -> tuple[bytes, int]:
+        """Read and validate one serialized entry at an owned offset."""
+        with self._lock:
+            # A closed result no longer has disk content to replay.
+            if self._disk is None:
+                raise OSError("result log storage is closed")
+
+            # Move directly to the record owned by this capture.
+            self._disk.seek(offset)
+
+            # Read the fixed-size details that describe the stored entry.
+            header = self._disk.read(self._HEADER.size)
+
+            # Reject partial records before decoding their content.
+            if len(header) != self._HEADER.size:
+                raise OSError("truncated result log header")
+
+            # Recover the content length and the next record location.
+            size, next_offset = self._HEADER.unpack(header)
+
+            # A record cannot be larger than the complete disk allowance.
+            if size > self.disk_size:
+                raise OSError("invalid result log entry size")
+
+            # Read only the number of bytes declared by this record.
+            payload = self._disk.read(size)
+
+            # Do not pass incomplete content to the JSON decoder.
+            if len(payload) != size:
+                raise OSError("truncated result log entry")
+
+            return payload, next_offset
+
+    def release_store(self) -> None:
+        """Close shared disk storage after its final capture is released."""
+        with self._lock:
+            # This store no longer needs access to the shared file.
+            self._store_count -= 1
+
+            # Another store still needs the file, or no file was opened.
+            if self._store_count or self._disk is None:
+                return
+
+            try:
+                # The last store owns final cleanup of temporary storage.
+                self._disk.close()
+
+            except Exception as e:
+                # Report cleanup errors while still clearing the file below.
+                _safe_internal_log(
+                    logging.WARNING,
+                    "Result log storage could not be closed.",
+                )
+                _safe_internal_log(
+                    logging.DEBUG,
+                    "Result log close exception: %s",
+                    str(e),
+                )
+
+            finally:
+                # Never leave a closed or failed handle available for reuse.
+                self._disk = None
+
+
+class _NotifyLogStore:
+    """Keep captured entries in memory, spilling later entries to disk."""
+
+    # Reuse the shared message when the configured allowance is full.
+    _LIMIT_MESSAGE = _LogCaptureBudget._LIMIT_MESSAGE
+
+    # Reuse the shared message when temporary storage stops working.
+    _DISK_MESSAGE = _LogCaptureBudget._DISK_MESSAGE
+
+    # Return a safe entry when retained disk content cannot be replayed.
+    _READ_MESSAGE = "Stored result logs could not be read."
+
+    def __init__(self, budget: _LogCaptureBudget) -> None:
+        """Create an empty store using the call's shared byte budget."""
+        # Register first so the shared file stays open for this store.
+        self._budget = budget
+        self._budget.register_store()
+
+        # Memory always holds the oldest retained entries.
+        self._memory: list[NotifyLogEntry] = []
+
+        # This is where the first disk-backed entry can be found.
+        self._first_offset: Optional[int] = None
+
+        # This is where the newest disk-backed entry can be found.
+        self._last_offset: Optional[int] = None
+
+        # Count the disk entries this store can read.
+        self._disk_count = 0
+
+        # A final notice explains why later entries are missing.
+        self._notice: Optional[NotifyLogEntry] = None
+
+        # Closed stores ignore late entries and no longer read from disk.
+        self._closed = False
+
+        # Iteration and appends can occur from different worker threads.
+        self._lock = threading.RLock()
+
+    @staticmethod
+    def _encode(entry: NotifyLogEntry) -> bytes:
+        """Serialize an entry for length-prefixed disk storage."""
+        return entry.json().encode("utf-8")
+
+    @staticmethod
+    def _decode(payload: bytes) -> NotifyLogEntry:
+        """Restore an entry read from disk."""
+        # Convert the stored JSON text back into its plain fields.
+        data = json.loads(payload.decode("utf-8"))
+
+        # Rebuild the same public entry type used by in-memory logs.
+        return NotifyLogEntry(
+            level=data["level"],
+            message=data["message"],
+            time=datetime.strptime(data["time"], AWARE_DATE_ISO_FORMAT),
+        )
+
+    def append(self, entry: NotifyLogEntry) -> None:
+        """Append an entry without allowing storage errors to escape."""
+        # Measure the encoded entry before choosing memory or disk.
+        payload = self._encode(entry)
+
+        # Include the small disk header in all shared byte accounting.
+        size = self._budget._HEADER.size + len(payload)
+
+        with self._lock:
+            # Late messages cannot reopen a completed result.
+            if self._closed:
+                return
+
+            # After data is lost, keep its warning as the final entry.
+            if self._notice is not None:
+                return
+
+            if self._budget.reserve_memory(size):
+                # Fill memory before using slower disk storage.
+                self._memory.append(entry)
+
+                return
+
+            # The last offset joins this entry to only this store's chain.
+            offset, warning = self._budget.write(payload, self._last_offset)
+
+            if offset is None:
+                # Keep a readable explanation in place of discarded entries.
+                self._set_notice(
+                    warning or self._DISK_MESSAGE,
+                    log=self._budget.claim_warning(
+                        warning or self._DISK_MESSAGE
+                    ),
+                )
+
+                return
+
+            if self._first_offset is None:
+                # Remember where replay for this store begins.
+                self._first_offset = offset
+
+            # This entry is now the final item in this store's disk chain.
+            self._last_offset = offset
+
+            # Count only entries that completed their disk write.
+            self._disk_count += 1
+
+    def _set_notice(self, message: str, log: bool = True) -> None:
+        """Retain one bounded warning when entries must be discarded."""
+        if self._notice is None:
+            # The notice becomes the final entry returned to the caller.
+            self._notice = NotifyLogEntry("WARNING", message)
+
+            if log:
+                # Also tell the application when this warning is first owned.
+                _safe_internal_log(logging.WARNING, message)
+
+    def __iter__(self) -> Iterator[NotifyLogEntry]:
+        """Yield retained entries in capture order."""
+        with self._lock:
+            # Memory comes first because it contains the oldest entries.
+            yield from self._memory
+
+            if self._first_offset is not None:
+                try:
+                    # Follow only this store's entries in the shared file.
+                    offset = self._first_offset
+
+                    for index in range(self._disk_count):
+                        # Read and restore one entry at its known location.
+                        payload, next_offset = self._budget.read(offset)
+                        yield self._decode(payload)
+
+                        if (
+                            next_offset == self._budget._END
+                            and index + 1 < self._disk_count
+                        ):
+                            # The entry chain ended sooner than expected.
+                            raise OSError("truncated result log chain")
+
+                        # Continue from the location saved in this record.
+                        offset = next_offset
+
+                except Exception as e:
+                    # Replace unreadable content with one useful warning.
+                    _safe_internal_log(logging.WARNING, self._READ_MESSAGE)
+                    _safe_internal_log(
+                        logging.DEBUG,
+                        "Result log read exception: %s",
+                        str(e),
+                    )
+                    yield NotifyLogEntry("WARNING", self._READ_MESSAGE)
+
+            if self._notice is not None:
+                # This stays last because later entries were discarded.
+                yield self._notice
+
+    def __len__(self) -> int:
+        """Return the number of retained entries and any storage warning."""
+        with self._lock:
+            return (
+                len(self._memory)
+                + self._disk_count
+                + (self._notice is not None)
+            )
+
+    def __getitem__(
+        self, index: Union[int, slice]
+    ) -> Union[NotifyLogEntry, list[NotifyLogEntry]]:
+        """Return an entry or slice using normal sequence behavior."""
+        return list(self)[index]
+
+    def __eq__(self, other: object) -> bool:
+        """Compare retained entries with another iterable."""
+        if isinstance(other, _NotifyLogStore):
+            return list(self) == list(other)
+
+        if isinstance(other, (list, tuple)):
+            return list(self) == list(other)
+
+        return NotImplemented
+
+    def close(self) -> None:
+        """Release any temporary file owned by this store."""
+        with self._lock:
+            if not self._closed:
+                # Clear locations so a closed store cannot replay disk data.
+                self._closed = True
+
+                self._first_offset = None
+
+                self._last_offset = None
+
+                self._disk_count = 0
+
+                # Release this store's ownership of shared temporary storage.
+                self._budget.release_store()
+
+    def __del__(self) -> None:
+        """Best-effort cleanup when callers do not close the result."""
+        with contextlib.suppress(Exception):
+            # Interpreter shutdown may already have cleared module globals.
+            self.close()
+
+
+class _ServiceLogCapture(logging.Handler):
+    """Capture logs for one service or one notification call.
+
+    The capture mode depends on ``service``:
+
+    - A service captures entries from its current notification attempt.
+    - ``service=None`` captures orchestration entries for the whole call.
+
+    ``log_callback`` receives entries live and should return promptly.
     """
 
     def __init__(
         self,
-        service: NotifyBase,
+        service: Optional[NotifyBase] = None,
         log_callback: Optional[
-            Callable[[NotifyLogEntry, NotifyBase], None]
+            Callable[[NotifyLogEntry, Optional[NotifyBase]], None]
         ] = None,
         level: int = logging.WARNING,
+        memory_size: int = 0,
+        disk_size: int = 0,
     ) -> None:
-        """Prepare an isolated handler for ``service``."""
+        """Prepare a service-level or call-level log handler."""
         super().__init__(level=level)
-        self._entries: list[NotifyLogEntry] = []
 
-        # Reuse the service's logger; this capture is just another listener.
+        # A service capture can reuse the budget owned by its enclosing call.
+        call_capture = _active_call_capture.get()
+
+        # Standalone and call-level captures create their own shared budget.
+        self._budget = (
+            call_capture._budget
+            if service is not None and call_capture is not None
+            else _LogCaptureBudget(memory_size, disk_size)
+        )
+
+        # Each handler owns one ordered view into that shared budget.
+        self._entries = _NotifyLogStore(self._budget)
+
+        # Call-level orchestration messages use the shared logger.
         self._logger = getattr(service, "logger", logger)
 
-        # Kept only so log_callback can identify the service.
+        # None identifies a call-level entry to the callback.
         self._service = service
+
+        # The optional callback receives entries as they are captured.
         self._log_callback = log_callback
 
-        # Set on __enter__, used to restore _active_capture on __exit__.
+        # This token restores an enclosing service capture on exit.
         self._token: Optional[contextvars.Token] = None
 
-        # prevent reoccurrance of emit() calls from the same thread.
+        # This token restores an enclosing call capture on exit.
+        self._call_token: Optional[contextvars.Token] = None
+
+        # Prevent a callback from logging recursively through this handler.
         self._in_emit = False
 
     def emit(self, record: logging.LogRecord) -> None:
-        """Wrap and store one captured logging.LogRecord.
-
-        Ignores any record produced on behalf of another service
-        dispatched concurrently -- see _active_capture's own docstring.
-        """
+        """Store a record owned by this capture."""
+        # Ignore logging triggered by this handler's own callback or warnings.
         if self._in_emit:
             return
+
+        # Set the guard before formatting or invoking user callback code.
         self._in_emit = True
+
         try:
             self._emit(record)
+
         finally:
+            # Always allow the next independent record through.
             self._in_emit = False
 
     def _emit(self, record: logging.LogRecord) -> None:
-        """The actual body of emit(), guarded against re-entrancy by the
-        wrapper above."""
+        """Process a record after the reentrancy check."""
         try:
-            if _active_capture.get() is not self:
-                return
+            if self._service is not None:
+                # Per-service: only the exact active capture accepts.
+                if _active_capture.get() is not self:
+                    return
 
-            if len(self._entries) >= _MAX_CAPTURED_LOG_ENTRIES:
-                # A plugin can log once per item while processing a large
-                # or malformed batch (bulk recipients, malformed config
-                # entries, etc.) -- cap growth instead of buffering an
-                # unbounded number of entries for the lifetime of the
-                # result.
-                return
+            else:
+                # Accept only unclaimed records from this notification call.
+                if (
+                    _active_call_capture.get() is not self
+                    or _active_capture.get() is not None
+                ):
+                    return
 
             entry = NotifyLogEntry(
                 level=record.levelname,
-                # record.getMessage() re-applies %-style formatting
-                # (msg % args) every time it's called, so a plugin's
-                # own malformed logging call (e.g. too few args for
-                # its format string) raises here, exactly as it would
-                # for any other handler -- self.handleError() is the
-                # standard library's own convention for this (see
-                # logging.StreamHandler.emit()), so the caller's
-                # original self.logger.warning(...) call still
-                # returns normally instead of raising through it.
+                # Preserve normal logging behavior for formatted messages.
+                # The outer handler catches malformed format strings.
                 message=record.getMessage(),
-                # record.created is a Unix timestamp (seconds since
-                # the epoch); logging itself is timezone-agnostic,
-                # but every other timestamp Apprise reports is an
-                # aware UTC datetime, so this is converted to match.
+                # Match the UTC-aware timestamps used by other results.
                 time=datetime.fromtimestamp(record.created, tz=timezone.utc),
             )
+
+            # Retain the entry before notifying a live callback.
             self._entries.append(entry)
 
+            # Copy the reference in case application code later replaces it.
             callback = self._log_callback
+
             if callback is not None:
                 self._invoke_log_callback(entry, callback)
 
         except Exception:
+            # Use logging's normal error path for formatting or storage errors.
             self.handleError(record)
 
     def _invoke_log_callback(
         self,
         entry: NotifyLogEntry,
-        callback: Callable[[NotifyLogEntry, NotifyBase], None],
+        callback: Callable[[NotifyLogEntry, Optional[NotifyBase]], None],
     ) -> None:
         """Call ``log_callback(entry, service)``.
 
-        Its return value is ignored.
+        ``service`` is ``None`` for call-level entries. The return value is
+        ignored.
         """
         try:
             result = callback(entry, self._service)
 
         except Exception as e:
-            logger.warning("The log_callback function raised an exception.")
-            logger.debug("log_callback Exception: %s", str(e))
+            _safe_internal_log(
+                logging.WARNING,
+                "The log_callback function raised an exception.",
+            )
+            _safe_internal_log(
+                logging.DEBUG,
+                "log_callback Exception: %s",
+                str(e),
+            )
             return
 
         if asyncio.iscoroutine(result):
             # Close unsupported async callbacks without leaking a warning.
             result.close()
-            logger.warning(
+
+            _safe_internal_log(
+                logging.WARNING,
                 "The log_callback function must be synchronous; its "
                 "returned coroutine was ignored. Schedule async work "
-                "from inside the callback instead."
+                "from inside the callback instead.",
             )
 
     @property
-    def entries(self) -> list[NotifyLogEntry]:
-        """Return every WARNING+ entry captured during this attempt."""
+    def entries(self) -> _NotifyLogStore:
+        """Return entries captured at or above this handler's level."""
         return self._entries
 
     def __enter__(self) -> _ServiceLogCapture:
-        """Attach as an extra handler without disturbing existing ones."""
+        """Attach the handler and mark its capture context."""
+        # Begin receiving records from the logger owned by this capture.
         self._logger.addHandler(self)
-        self._token = _active_capture.set(self)
+
+        if self._service is not None:
+            # Mark this as the active capture for one service attempt.
+            self._token = _active_capture.set(self)
+
+        else:
+            # Mark this as the active capture for the complete notify call.
+            self._call_token = _active_call_capture.set(self)
+
         return self
 
     def __exit__(self, *_: object) -> None:
-        """Detach the handler."""
+        """Detach the handler and restore the enclosing capture."""
+        # Stop receiving records before changing the active context.
         self._logger.removeHandler(self)
+
         if self._token is not None:
+            # Restore any service capture that surrounded this one.
             _active_capture.reset(self._token)
+
+        if self._call_token is not None:
+            # Restore any call capture that surrounded this one.
+            _active_call_capture.reset(self._call_token)
 
 
 class LogCapture:

--- a/apprise/logger.py
+++ b/apprise/logger.py
@@ -488,7 +488,10 @@ class _NotifyLogStore:
             if self._notice is not None:
                 return
 
-            if self._budget.reserve_memory(size):
+            # Once this store spills, keep every later entry behind it on disk.
+            if self._first_offset is None and self._budget.reserve_memory(
+                size
+            ):
                 # Fill memory before using slower disk storage.
                 self._memory.append(entry)
 

--- a/apprise/result.py
+++ b/apprise/result.py
@@ -43,14 +43,21 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from datetime import datetime, timedelta, timezone
 from enum import IntEnum
+import heapq
 import json
-from typing import Any, Optional
+from typing import Optional, TextIO
 
 from .common import AWARE_DATE_ISO_FORMAT, JSON_COMPACT_SEPARATORS
-from .logger import NotifyLogEntry
+from .logger import NotifyLogEntry, _NotifyLogStore
+
+
+def _write_json(stream: TextIO, chunks: Iterable[str]) -> None:
+    """Write JSON chunks immediately without joining them in memory."""
+    for chunk in chunks:
+        stream.write(chunk)
 
 
 class AppriseResultStatus(IntEnum):
@@ -91,7 +98,7 @@ class NotifyAttempt:
         self,
         status: AppriseResultStatus,
         elapsed: float = 0.0,
-        logs: Optional[list[NotifyLogEntry]] = None,
+        logs: Optional[Iterable[NotifyLogEntry]] = None,
     ) -> None:
         """Initialize the outcome, duration, and logs for one attempt."""
         # The raw outcome of this one call: SUCCESS, FAILURE, or TIMEOUT.
@@ -105,22 +112,59 @@ class NotifyAttempt:
         self.end_time = datetime.now(timezone.utc)
         self.start_time = self.end_time - timedelta(seconds=self.elapsed)
 
-        # Every WARNING+ message the plugin logged during this one call.
-        self.logs = list(logs) if logs else []
+        # Read disk-backed logs as needed; copy ordinary iterables.
+        self.logs = (
+            logs
+            if isinstance(logs, _NotifyLogStore)
+            else list(logs)
+            if logs is not None
+            else []
+        )
 
-    def asdict(self) -> dict[str, Any]:
-        """Return this attempt as a plain, JSON-serializable dict."""
-        return {
-            "status": self.status.name,
-            "elapsed": self.elapsed,
-            "start_time": self.start_time.strftime(AWARE_DATE_ISO_FORMAT),
-            "end_time": self.end_time.strftime(AWARE_DATE_ISO_FORMAT),
-            "logs": [entry.asdict() for entry in self.logs],
-        }
+    def iter_json(self) -> Iterator[str]:
+        """Yield this attempt as bounded JSON chunks.
 
-    def json(self) -> str:
-        """Return this attempt as a JSON string."""
-        return json.dumps(self.asdict(), separators=JSON_COMPACT_SEPARATORS)
+        Logs are read one at a time, including entries retained on disk.
+        """
+        # Write the small fixed fields before walking captured logs.
+        yield '{{"status":{}'.format(
+            json.dumps(self.status.name, separators=JSON_COMPACT_SEPARATORS)
+        )
+
+        yield ',"elapsed":{}'.format(
+            json.dumps(self.elapsed, separators=JSON_COMPACT_SEPARATORS)
+        )
+
+        yield ',"start_time":{}'.format(
+            json.dumps(
+                self.start_time.strftime(AWARE_DATE_ISO_FORMAT),
+                separators=JSON_COMPACT_SEPARATORS,
+            )
+        )
+
+        yield ',"end_time":{}'.format(
+            json.dumps(
+                self.end_time.strftime(AWARE_DATE_ISO_FORMAT),
+                separators=JSON_COMPACT_SEPARATORS,
+            )
+        )
+
+        # Open the log array without first copying its entries into a list.
+        yield ',"logs":['
+
+        separator = ""
+        for entry in self.logs:
+            # Prefix every entry after the first with the JSON separator.
+            yield separator
+            yield entry.json()
+            separator = ","
+
+        # Close both the log array and this attempt object.
+        yield "]}"
+
+    def write_json(self, stream: TextIO) -> None:
+        """Write this attempt to a text stream without joining its logs."""
+        _write_json(stream, self.iter_json())
 
     def __bool__(self) -> bool:
         """Return ``True`` only when this attempt succeeded."""
@@ -230,26 +274,50 @@ class NotifyResult:
         for attempt in self._attempts:
             yield from attempt.logs
 
-    def asdict(self) -> dict[str, Any]:
-        """Return this result as a plain, JSON-serializable dict."""
-        return {
-            "name": self.name,
-            "url": self.url,
-            "url_id": self.url_id,
-            "tag": list(self.tag),
-            "status": self.status.name,
-            "optional": self.optional,
-            "weight": self.weight,
-            "max_attempts": self.max_attempts,
-            "elapsed": self.elapsed,
-            "start_time": self.start_time.strftime(AWARE_DATE_ISO_FORMAT),
-            "end_time": self.end_time.strftime(AWARE_DATE_ISO_FORMAT),
-            "attempts": [a.asdict() for a in self._attempts],
-        }
+    def iter_json(self) -> Iterator[str]:
+        """Yield this service result as bounded JSON chunks."""
+        # Service details are small and safe to encode one field at a time.
+        fields = (
+            ("name", self.name),
+            ("url", self.url),
+            ("url_id", self.url_id),
+            ("tag", list(self.tag)),
+            ("status", self.status.name),
+            ("optional", self.optional),
+            ("weight", self.weight),
+            ("max_attempts", self.max_attempts),
+            ("elapsed", self.elapsed),
+            ("start_time", self.start_time.strftime(AWARE_DATE_ISO_FORMAT)),
+            ("end_time", self.end_time.strftime(AWARE_DATE_ISO_FORMAT)),
+        )
 
-    def json(self) -> str:
-        """Return this result as a JSON string."""
-        return json.dumps(self.asdict(), separators=JSON_COMPACT_SEPARATORS)
+        yield "{"
+
+        separator = ""
+        for name, value in fields:
+            # Encode both names and values so escaping follows normal JSON.
+            yield "{}{}:{}".format(
+                separator,
+                json.dumps(name, separators=JSON_COMPACT_SEPARATORS),
+                json.dumps(value, separators=JSON_COMPACT_SEPARATORS),
+            )
+            separator = ","
+
+        # Attempts can contain disk-backed logs, so stream each nested object.
+        yield ',"attempts":['
+
+        separator = ""
+        for attempt in self._attempts:
+            yield separator
+            yield from attempt.iter_json()
+            separator = ","
+
+        # Close both the attempts array and this service object.
+        yield "]}"
+
+    def write_json(self, stream: TextIO) -> None:
+        """Write this service result to a text stream in bounded chunks."""
+        _write_json(stream, self.iter_json())
 
     def __bool__(self) -> bool:
         """Return ``True`` when this service result is successful."""
@@ -271,6 +339,13 @@ class NotifyResult:
             self.name, self.url, self.status.name
         )
 
+    def close(self) -> None:
+        """Release temporary log storage held by this service result."""
+        for attempt in self._attempts:
+            # List-backed attempts have no temporary resource to release.
+            if isinstance(attempt.logs, _NotifyLogStore):
+                attempt.logs.close()
+
 
 class AppriseResult:
     """The overall outcome of one Apprise.notify() / async_notify() call.
@@ -284,6 +359,7 @@ class AppriseResult:
         status: AppriseResultStatus = AppriseResultStatus.NOMATCH,
         results: Optional[list[NotifyResult]] = None,
         elapsed: float = 0.0,
+        call_logs: Optional[Iterable[NotifyLogEntry]] = None,
     ) -> None:
         """Initialize the overall status and ordered service results."""
         # Dispatch computes this because priority escalation affects outcome.
@@ -297,6 +373,15 @@ class AppriseResult:
         # priority group, escalation round, and chain.
         self.elapsed = elapsed
 
+        # Read disk-backed call logs as needed; copy ordinary iterables.
+        self._call_logs = (
+            call_logs
+            if isinstance(call_logs, _NotifyLogStore)
+            else list(call_logs)
+            if call_logs is not None
+            else []
+        )
+
         # Derive start_time from end_time and elapsed so they always agree.
         self.end_time = datetime.now(timezone.utc)
         self.start_time = self.end_time - timedelta(seconds=self.elapsed)
@@ -305,6 +390,10 @@ class AppriseResult:
     def results(self) -> tuple[NotifyResult, ...]:
         """Read-only view of every NotifyResult collected this call."""
         return tuple(self._results)
+
+    def call_logs(self) -> Iterator[NotifyLogEntry]:
+        """Yield orchestration logs without loading disk entries at once."""
+        yield from self._call_logs
 
     @property
     def success_count(self) -> int:
@@ -330,31 +419,67 @@ class AppriseResult:
         )
 
     def logs(self) -> Iterator[NotifyLogEntry]:
-        """Yield every log entry captured across every service and every
-        attempt made this call, in chronological order.
+        """Yield all service and call-level logs in chronological order.
 
-        Concurrent service logs are sorted back into one timeline.
+        Each capture is already ordered, so merge them without copying every
+        entry into a second list.
         """
-        all_entries = (
-            entry for result in self._results for entry in result.logs()
+        # Merge the already ordered sources without building another list.
+        streams = [result.logs() for result in self._results]
+        # Call entries belong in the same timeline as service entries.
+        streams.append(iter(self._call_logs))
+        yield from heapq.merge(*streams)
+
+    def iter_json(self) -> Iterator[str]:
+        """Yield the complete result as bounded JSON chunks.
+
+        Service and call logs remain lazy while the iterator is consumed.
+        Keep the result open until iteration finishes.
+        """
+        # Encode the fixed summary without touching any captured logs.
+        fields = (
+            ("status", self.status.name),
+            ("success_count", self.success_count),
+            ("failed_count", self.failed_count),
+            ("elapsed", self.elapsed),
+            ("start_time", self.start_time.strftime(AWARE_DATE_ISO_FORMAT)),
+            ("end_time", self.end_time.strftime(AWARE_DATE_ISO_FORMAT)),
         )
-        yield from sorted(all_entries)
 
-    def asdict(self) -> dict[str, Any]:
-        """Return this result as a plain, JSON-serializable dict."""
-        return {
-            "status": self.status.name,
-            "success_count": self.success_count,
-            "failed_count": self.failed_count,
-            "elapsed": self.elapsed,
-            "start_time": self.start_time.strftime(AWARE_DATE_ISO_FORMAT),
-            "end_time": self.end_time.strftime(AWARE_DATE_ISO_FORMAT),
-            "results": [r.asdict() for r in self._results],
-        }
+        yield "{"
 
-    def json(self) -> str:
-        """Return this result as a JSON string."""
-        return json.dumps(self.asdict(), separators=JSON_COMPACT_SEPARATORS)
+        separator = ""
+        for name, value in fields:
+            yield "{}{}:{}".format(
+                separator,
+                json.dumps(name, separators=JSON_COMPACT_SEPARATORS),
+                json.dumps(value, separators=JSON_COMPACT_SEPARATORS),
+            )
+            separator = ","
+
+        # Stream each service and its attempts before moving to call logs.
+        yield ',"results":['
+
+        separator = ""
+        for result in self._results:
+            yield separator
+            yield from result.iter_json()
+            separator = ","
+
+        yield '],"call_logs":['
+
+        separator = ""
+        for entry in self._call_logs:
+            yield separator
+            yield entry.json()
+            separator = ","
+
+        # Close the call-log array and the overall result object.
+        yield "]}"
+
+    def write_json(self, stream: TextIO) -> None:
+        """Write the complete result to a text stream in bounded chunks."""
+        _write_json(stream, self.iter_json())
 
     def __bool__(self) -> bool:
         """Return ``True`` only when the overall notification succeeded."""
@@ -374,3 +499,20 @@ class AppriseResult:
         return "<AppriseResult status={!r} count={}>".format(
             self.status.name, len(self._results)
         )
+
+    def close(self) -> None:
+        """Release temporary files used by captured result logs."""
+        # Each service closes the stores owned by its attempts.
+        for result in self._results:
+            result.close()
+        # The call capture can share the same temporary file.
+        if isinstance(self._call_logs, _NotifyLogStore):
+            self._call_logs.close()
+
+    def __enter__(self) -> AppriseResult:
+        """Return this result for use as a context manager."""
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        """Release temporary result-log files on context exit."""
+        self.close()

--- a/tests/test_apprise_asset.py
+++ b/tests/test_apprise_asset.py
@@ -203,6 +203,28 @@ def test_payload_buffer_threshold_and_min_buffer():
         AppriseAsset(_payload_min_buffer=7)
 
 
+def test_result_log_storage_sizes():
+    """Result-log storage accepts non-negative byte limits."""
+    asset = AppriseAsset()
+    assert asset.result_log_memory_size == 0
+    assert asset.result_log_disk_size == 0
+
+    asset = AppriseAsset(
+        result_log_memory_size=2048, result_log_disk_size=4096
+    )
+    assert asset.result_log_memory_size == 2048
+    assert asset.result_log_disk_size == 4096
+
+    for name in ("result_log_memory_size", "result_log_disk_size"):
+        with pytest.raises(ValueError):
+            AppriseAsset(**{name: -1})
+        for value in (True, 1.5, "1024"):
+            with pytest.raises(TypeError):
+                AppriseAsset(**{name: value})
+        with pytest.raises(AttributeError):
+            AppriseAsset(**{"_{}".format(name): 1})
+
+
 def test_enforce_payload_max_size():
     "asset: enforce_payload_max_size() testing"
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -27,12 +27,14 @@
 
 import asyncio
 import concurrent.futures as cf
+import contextvars
 from datetime import datetime, timezone
-import importlib
+import io
 import json
 import os
 import re
 import sys
+import threading
 import time
 from unittest import mock
 
@@ -46,6 +48,10 @@ from apprise.common import AWARE_DATE_ISO_FORMAT
 from apprise.logger import (
     LogCapture,
     NotifyLogEntry,
+    _active_call_capture,
+    _active_capture,
+    _LogCaptureBudget,
+    _NotifyLogStore,
     _ServiceLogCapture,
     logger,
     logging,
@@ -581,33 +587,397 @@ def test_notify_log_entry_asdict_json_repr():
     )
 
 
-def test_service_log_capture_max_entries_cap():
-    """Once _MAX_CAPTURED_LOG_ENTRIES is reached, further entries are
-    dropped instead of growing the buffer without bound."""
+def test_service_log_capture_keeps_all_entries():
+    """Captures remain complete beyond the former 5,000-entry boundary."""
+    service = _DummyNotify()
+    with _ServiceLogCapture(service) as cap:
+        for index in range(5001):
+            record = logging.LogRecord(
+                "apprise",
+                logging.WARNING,
+                __file__,
+                0,
+                "entry %d",
+                (index,),
+                None,
+            )
+            cap.handle(record)
+
+    assert len(cap.entries) == 5001
+    assert cap.entries[-1].message == "entry 5000"
+
+
+def test_result_log_store_spills_to_disk_in_order():
+    """A bounded capture reads disk-backed entries in their original order."""
+    budget = _LogCaptureBudget(memory_size=1, disk_size=4096)
+    store = _NotifyLogStore(budget)
+    entries = [
+        NotifyLogEntry("WARNING", "first"),
+        NotifyLogEntry("ERROR", "second"),
+    ]
+
+    for entry in entries:
+        store.append(entry)
+
+    assert store._memory == []
+    assert store._disk_count == 2
+    assert len(store) == 2
+    assert store == entries
+    assert store[0] == entries[0]
+    assert store[:] == entries
+    store.close()
+    assert budget._disk is None
+
+
+def test_result_log_store_uses_unbounded_memory_without_disk():
+    """The library default retains all logs in memory without a temp file."""
+    store = _NotifyLogStore(_LogCaptureBudget(memory_size=1, disk_size=0))
+    entry = NotifyLogEntry("WARNING", "kept in memory")
+
+    store.append(entry)
+
+    assert list(store) == [entry]
+    assert store._budget._disk is None
+
+
+def test_result_log_stores_share_one_temporary_file():
+    """All captures in one notification share a single temporary file."""
+    budget = _LogCaptureBudget(memory_size=4096, disk_size=4096)
+    memory_store = _NotifyLogStore(budget)
+    disk_store = _NotifyLogStore(budget)
+
+    memory_store.append(NotifyLogEntry("WARNING", "memory"))
+    budget.memory_used = budget.memory_size
+    disk_store.append(NotifyLogEntry("WARNING", "disk"))
+
+    assert len(memory_store._memory) == 1
+    assert disk_store._disk_count == 1
+    disk = budget._disk
+    memory_store.close()
+    assert budget._disk is disk
+    disk_store.close()
+    assert budget._disk is None
+
+
+def test_result_log_store_reports_capacity_once(caplog):
+    """A full store adds one warning while live callbacks remain unaffected."""
     logging.disable(logging.NOTSET)
+    caplog.set_level(logging.WARNING, logger=logger.name)
+    received = []
 
     try:
-        service = _DummyNotify()
-        # apprise.__init__ imports the "logger" object out of the
-        # apprise.logger submodule under the same name, which shadows
-        # the submodule reference on the apprise package. Resolve the
-        # real submodule via importlib rather than a dotted string
-        # path, since older unittest.mock versions (Python 3.9) walk
-        # that path with getattr() and land on the shadowed Logger
-        # instance instead of the module.
-        logger_module = importlib.import_module("apprise.logger")
-        with (
-            mock.patch.object(logger_module, "_MAX_CAPTURED_LOG_ENTRIES", 2),
-            _ServiceLogCapture(service) as cap,
-        ):
-            service.logger.warning("one")
-            service.logger.warning("two")
-            # Dropped -- the cap was already reached.
-            service.logger.warning("three")
+        with _ServiceLogCapture(
+            service=None,
+            log_callback=lambda entry, service: received.append(entry),
+            memory_size=0,
+            disk_size=1,
+        ) as cap:
+            logger.warning("first")
+            logger.warning("second")
     finally:
         logging.disable(logging.CRITICAL)
 
-    assert [e.message for e in cap.entries] == ["one", "two"]
+    assert [entry.message for entry in received] == ["first", "second"]
+    assert [entry.message for entry in cap.entries] == [
+        _NotifyLogStore._LIMIT_MESSAGE
+    ]
+    assert caplog.text.count(_NotifyLogStore._LIMIT_MESSAGE) == 1
+
+
+def test_result_log_store_handles_disk_failure(caplog):
+    """Temporary-file failures are logged and contained."""
+    logging.disable(logging.NOTSET)
+    caplog.set_level(logging.DEBUG, logger=logger.name)
+    store = _NotifyLogStore(_LogCaptureBudget(memory_size=0, disk_size=1024))
+
+    try:
+        with mock.patch(
+            "apprise.logger.tempfile.TemporaryFile",
+            side_effect=OSError("no space"),
+        ):
+            store.append(NotifyLogEntry("ERROR", "delivery failed"))
+    finally:
+        logging.disable(logging.CRITICAL)
+
+    assert [entry.message for entry in store] == [
+        _NotifyLogStore._DISK_MESSAGE
+    ]
+    assert "no space" in caplog.text
+
+
+def test_result_log_store_contains_logging_failure_on_write():
+    """A broken handler cannot expose a result-log write failure."""
+    store = _NotifyLogStore(_LogCaptureBudget(memory_size=0, disk_size=1024))
+
+    with (
+        mock.patch(
+            "apprise.logger.tempfile.TemporaryFile",
+            side_effect=OSError("no space"),
+        ),
+        mock.patch.object(
+            logger,
+            "log",
+            side_effect=RuntimeError("broken handler"),
+        ),
+    ):
+        # The storage warning remains available even when it cannot be logged.
+        store.append(NotifyLogEntry("ERROR", "delivery failed"))
+
+    assert [entry.message for entry in store] == [
+        _NotifyLogStore._DISK_MESSAGE
+    ]
+    store.close()
+
+
+@pytest.mark.parametrize("failed_write", (1, 2, 5))
+def test_result_log_store_handles_short_writes(failed_write):
+    """Short header, entry, and link writes are contained."""
+
+    class ShortWriteFile(io.BytesIO):
+        """Return one short write at the requested call."""
+
+        def __init__(self):
+            super().__init__()
+            self.calls = 0
+
+        def write(self, value):
+            self.calls += 1
+            if self.calls == failed_write:
+                super().write(value[:-1])
+                return len(value) - 1
+            return super().write(value)
+
+    budget = _LogCaptureBudget(memory_size=0, disk_size=4096)
+    store = _NotifyLogStore(budget)
+    with mock.patch(
+        "apprise.logger.tempfile.TemporaryFile",
+        return_value=ShortWriteFile(),
+    ):
+        # The first record covers header and payload writes.
+        store.append(NotifyLogEntry("WARNING", "first"))
+        if failed_write == 5:
+            # A second record reaches the write that links both records.
+            store.append(NotifyLogEntry("WARNING", "second"))
+
+    assert store._notice.message == _NotifyLogStore._DISK_MESSAGE
+    assert budget.disk_failed is True
+    store.close()
+
+
+@pytest.mark.parametrize("corruption", ("header", "size", "payload", "chain"))
+def test_result_log_store_handles_unreadable_data(corruption, caplog):
+    """Corrupt temporary data is logged instead of escaping iteration."""
+    logging.disable(logging.NOTSET)
+    caplog.set_level(logging.WARNING, logger=logger.name)
+    budget = _LogCaptureBudget(memory_size=0, disk_size=4096)
+    store = _NotifyLogStore(budget)
+    store.append(NotifyLogEntry("WARNING", "first"))
+    if corruption == "chain":
+        store.append(NotifyLogEntry("WARNING", "second"))
+
+    disk = budget._disk
+    if corruption == "header":
+        # Leave too few bytes to form a complete record header.
+        disk.seek(0)
+        disk.truncate(1)
+    elif corruption == "size":
+        # Claim a size that can never fit within this capture's limit.
+        disk.seek(0)
+        disk.write(budget._HEADER.pack(budget.disk_size + 1, budget._END))
+    elif corruption == "payload":
+        # Keep the header but remove most of the promised content.
+        disk.seek(0)
+        disk.truncate(budget._HEADER.size + 1)
+    else:
+        # End the chain while the store still expects another record.
+        disk.seek(budget._LINK.size)
+        disk.write(budget._LINK.pack(budget._END))
+
+    try:
+        list(store)
+    finally:
+        logging.disable(logging.CRITICAL)
+        store.close()
+
+    assert "could not be read" in caplog.text
+
+
+def test_result_log_store_contains_logging_failure_on_read():
+    """A broken handler cannot expose a result-log read failure."""
+    budget = _LogCaptureBudget(memory_size=0, disk_size=4096)
+    store = _NotifyLogStore(budget)
+    store.append(NotifyLogEntry("WARNING", "first"))
+
+    # Leave too little data for a complete disk record.
+    budget._disk.seek(0)
+    budget._disk.truncate(1)
+
+    with mock.patch.object(
+        logger,
+        "log",
+        side_effect=RuntimeError("broken handler"),
+    ):
+        entries = list(store)
+
+    # Iteration still returns a useful warning to the caller.
+    assert [entry.message for entry in entries] == [
+        _NotifyLogStore._READ_MESSAGE
+    ]
+    store.close()
+
+
+def test_result_log_store_handles_close_failure(caplog):
+    """Temporary-file close failures are logged and contained."""
+
+    class CloseFailFile(io.BytesIO):
+        """Raise when temporary storage is closed."""
+
+        failed = False
+
+        def close(self):
+            if not self.failed:
+                self.failed = True
+                raise OSError("close failed")
+            super().close()
+
+    logging.disable(logging.NOTSET)
+    caplog.set_level(logging.DEBUG, logger=logger.name)
+    budget = _LogCaptureBudget(memory_size=0, disk_size=4096)
+    store = _NotifyLogStore(budget)
+    with mock.patch(
+        "apprise.logger.tempfile.TemporaryFile", return_value=CloseFailFile()
+    ):
+        store.append(NotifyLogEntry("WARNING", "entry"))
+
+    try:
+        store.close()
+        store.append(NotifyLogEntry("WARNING", "ignored after close"))
+        with pytest.raises(OSError):
+            budget.read(0)
+    finally:
+        logging.disable(logging.CRITICAL)
+
+    assert "close failed" in caplog.text
+
+
+def test_result_log_store_contains_logging_failure_on_close():
+    """A broken handler cannot expose a result-log cleanup failure."""
+
+    class CloseFailFile(io.BytesIO):
+        """Fail the first close request, like a temporary-file error."""
+
+        failed = False
+
+        def close(self):
+            if not self.failed:
+                self.failed = True
+                raise OSError("close failed")
+
+            super().close()
+
+    budget = _LogCaptureBudget(memory_size=0, disk_size=4096)
+    store = _NotifyLogStore(budget)
+
+    with mock.patch(
+        "apprise.logger.tempfile.TemporaryFile",
+        return_value=CloseFailFile(),
+    ):
+        store.append(NotifyLogEntry("WARNING", "entry"))
+
+    with mock.patch.object(
+        logger,
+        "log",
+        side_effect=RuntimeError("broken handler"),
+    ):
+        # Cleanup remains safe even when its warning cannot be logged.
+        store.close()
+
+    assert budget._disk is None
+
+
+def test_result_log_store_sequence_and_repeat_failure_paths():
+    """Sequence comparisons and repeated storage failures stay safe."""
+    budget = _LogCaptureBudget(memory_size=0, disk_size=4096)
+    first = _NotifyLogStore(budget)
+    second = _NotifyLogStore(budget)
+    entry = NotifyLogEntry("WARNING", "entry")
+    first.append(entry)
+    second.append(entry)
+
+    assert budget.claim_warning("one warning") is True
+    assert budget.claim_warning("one warning") is False
+    assert first == second
+    assert first.__eq__(object()) is NotImplemented
+    first._set_notice("first warning", log=False)
+    first._set_notice("ignored warning", log=False)
+    assert first._notice.message == "first warning"
+    first.close()
+    second.close()
+
+    class ConcurrentFailFile(io.BytesIO):
+        """Simulate another writer reporting the same disk failure first."""
+
+        def write(self, value):
+            budget.disk_failed = True
+            raise OSError("shared failure")
+
+    budget = _LogCaptureBudget(memory_size=0, disk_size=4096)
+    store = _NotifyLogStore(budget)
+    budget.claim_warning(_NotifyLogStore._DISK_MESSAGE)
+    with mock.patch(
+        "apprise.logger.tempfile.TemporaryFile",
+        return_value=ConcurrentFailFile(),
+    ):
+        store.append(entry)
+    assert store._notice.message == _NotifyLogStore._DISK_MESSAGE
+    store.close()
+
+
+def test_service_captures_share_call_log_budget():
+    """Service captures draw from their enclosing call's storage budget."""
+    service = _DummyNotify()
+    with (
+        _ServiceLogCapture(
+            service=None, memory_size=0, disk_size=4096
+        ) as call_cap,
+        _ServiceLogCapture(service) as service_cap,
+    ):
+        assert service_cap._budget is call_cap._budget
+
+
+def test_notify_uses_asset_result_log_limits():
+    """Sync and async notifications apply their asset's shared log limits."""
+    logging.disable(logging.NOTSET)
+
+    class _WarnNotify(_DummyNotify):
+        """Emit one retained warning during delivery."""
+
+        def send(self, *args, **kwargs):
+            """Log a warning and report success."""
+            self.logger.warning("stored on disk")
+            return True
+
+    try:
+        for use_async in (False, True):
+            asset = AppriseAsset(
+                result_log_memory_size=0, result_log_disk_size=4096
+            )
+            instance = Apprise(asset=asset)
+            assert instance.add(_WarnNotify(asset=asset))
+
+            result = (
+                asyncio.run(instance.async_notify("body"))
+                if use_async
+                else instance.notify("body")
+            )
+            attempt_logs = result.results[0].attempts[0].logs
+            assert attempt_logs._disk_count == 1
+            assert [entry.message for entry in result.logs()] == [
+                "stored on disk"
+            ]
+            result.close()
+    finally:
+        logging.disable(logging.CRITICAL)
 
 
 def test_service_log_capture_exit_without_enter():
@@ -761,6 +1131,181 @@ def test_service_log_capture_thread_isolation():
 
     assert result_a == ["warning from A"]
     assert result_b == ["warning from B"]
+
+
+def test_call_capture_uses_separate_context():
+    """Call and service captures use separate context markers."""
+    with _ServiceLogCapture(service=None) as cap:
+        assert _active_capture.get() is None
+        assert _active_call_capture.get() is cap
+        assert cap._token is None
+
+
+def test_call_capture_records_shared_logs():
+    """A call capture stores unclaimed shared-logger records."""
+    logging.disable(logging.NOTSET)
+
+    try:
+        with _ServiceLogCapture(service=None) as cap:
+            logger.warning("no services to notify")
+    finally:
+        logging.disable(logging.CRITICAL)
+
+    assert [e.message for e in cap.entries] == ["no services to notify"]
+
+
+def test_call_capture_defers_to_service():
+    """A call capture ignores records owned by a service capture."""
+    logging.disable(logging.NOTSET)
+    service = _DummyNotify()
+
+    try:
+        with _ServiceLogCapture(service=None) as call_cap:
+            logger.warning("before service window")
+
+            with _ServiceLogCapture(service) as svc_cap:
+                service.logger.warning("during service window")
+
+            logger.warning("after service window")
+    finally:
+        logging.disable(logging.CRITICAL)
+
+    assert [e.message for e in call_cap.entries] == [
+        "before service window",
+        "after service window",
+    ]
+    assert [e.message for e in svc_cap.entries] == ["during service window"]
+
+
+def test_call_capture_callback_has_no_service():
+    """Call-level callbacks receive ``service=None``."""
+    logging.disable(logging.NOTSET)
+    received = []
+
+    def _cb(entry, service):
+        """Record the (message, service) pair delivered live."""
+        received.append((entry.message, service))
+
+    try:
+        with _ServiceLogCapture(service=None, log_callback=_cb) as cap:
+            logger.warning("orchestration message")
+    finally:
+        logging.disable(logging.CRITICAL)
+
+    assert received == [("orchestration message", None)]
+    assert [e.message for e in cap.entries] == ["orchestration message"]
+
+
+def test_call_capture_keeps_concurrent_logs():
+    """A call capture keeps concurrent entries without loss."""
+    logging.disable(logging.NOTSET)
+
+    n_per_thread = 200
+    barrier = threading.Barrier(4)
+
+    def _hammer(tag):
+        """Log many messages from one thread, all starting together."""
+        barrier.wait()
+        for i in range(n_per_thread):
+            logger.warning("%s-%d", tag, i)
+
+    try:
+        with (
+            _ServiceLogCapture(service=None) as cap,
+            cf.ThreadPoolExecutor(max_workers=4) as ex,
+        ):
+            futures = [
+                ex.submit(contextvars.copy_context().run, _hammer, tag)
+                for tag in ("A", "B", "C", "D")
+            ]
+            for future in futures:
+                future.result()
+    finally:
+        logging.disable(logging.CRITICAL)
+
+    messages = sorted(e.message for e in cap.entries)
+    expected = sorted(
+        f"{tag}-{i}"
+        for tag in ("A", "B", "C", "D")
+        for i in range(n_per_thread)
+    )
+    assert messages == expected
+
+
+def test_call_capture_blocks_recursive_callback():
+    """A callback cannot recursively capture its own log message."""
+    logging.disable(logging.NOTSET)
+    received = []
+
+    def _reentrant_cb(entry, service):
+        """Try to log again through the same handler while still
+        inside the first entry's own callback."""
+        received.append(entry.message)
+        if entry.message == "first":
+            logger.warning("triggered from callback")
+
+    try:
+        with _ServiceLogCapture(
+            service=None, log_callback=_reentrant_cb
+        ) as cap:
+            logger.warning("first")
+    finally:
+        logging.disable(logging.CRITICAL)
+
+    # The reentrant call is swallowed by _in_emit, not processed as a
+    # second entry or a second callback invocation.
+    assert [e.message for e in cap.entries] == ["first"]
+    assert received == ["first"]
+
+
+def test_callback_error_contains_logging_failure():
+    """A broken handler cannot expose a callback failure."""
+    logging.disable(logging.NOTSET)
+
+    def _broken_callback(_entry, _service):
+        """Represent application callback code that unexpectedly fails."""
+        raise RuntimeError("callback failed")
+
+    try:
+        with (
+            mock.patch.object(
+                logger,
+                "log",
+                side_effect=RuntimeError("broken handler"),
+            ),
+            _ServiceLogCapture(
+                service=None,
+                log_callback=_broken_callback,
+            ) as cap,
+        ):
+            # The original log call and notification flow both continue.
+            logger.warning("first")
+
+    finally:
+        logging.disable(logging.CRITICAL)
+
+    assert [entry.message for entry in cap.entries] == ["first"]
+
+
+def test_call_captures_are_thread_isolated():
+    """Concurrent call captures do not receive each other's entries."""
+    logging.disable(logging.NOTSET)
+    barrier = threading.Barrier(2)
+
+    def _capture(message):
+        with _ServiceLogCapture(service=None) as cap:
+            barrier.wait()
+            logger.warning(message)
+            return [entry.message for entry in cap.entries]
+
+    try:
+        with cf.ThreadPoolExecutor(max_workers=2) as executor:
+            first = executor.submit(_capture, "first")
+            second = executor.submit(_capture, "second")
+            assert first.result() == ["first"]
+            assert second.result() == ["second"]
+    finally:
+        logging.disable(logging.CRITICAL)
 
 
 def test_service_log_capture_sync_log_callback():

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -634,6 +634,31 @@ def test_result_log_store_spills_to_disk_in_order():
     assert budget._disk is None
 
 
+def test_result_log_store_stays_on_disk_after_large_entry():
+    """A smaller entry cannot move ahead of one already stored on disk."""
+    entries = [
+        NotifyLogEntry("WARNING", "first " + ("x" * 256)),
+        NotifyLogEntry("ERROR", "second"),
+    ]
+
+    # Only the second entry fits in memory when considered by itself.
+    memory_size = _LogCaptureBudget._HEADER.size + len(
+        entries[1].json().encode("utf-8")
+    )
+    budget = _LogCaptureBudget(memory_size=memory_size, disk_size=4096)
+    store = _NotifyLogStore(budget)
+
+    for entry in entries:
+        store.append(entry)
+
+    # Once the first entry spills, later entries remain behind it on disk.
+    assert store._memory == []
+    assert store._disk_count == 2
+    assert list(store) == entries
+    store.close()
+    assert budget._disk is None
+
+
 def test_result_log_store_uses_unbounded_memory_without_disk():
     """The library default retains all logs in memory without a temp file."""
     store = _NotifyLogStore(_LogCaptureBudget(memory_size=1, disk_size=0))

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -29,6 +29,7 @@ import asyncio
 import concurrent.futures as cf
 import contextvars
 from datetime import datetime, timezone
+from importlib import import_module
 import io
 import json
 import os
@@ -57,6 +58,10 @@ from apprise.logger import (
     logging,
 )
 from apprise.plugins import NotifyBase
+
+# Import the module directly because ``apprise.logger`` is also a public
+# package attribute containing the shared Logger instance.
+_LOGGER_MODULE = import_module("apprise.logger")
 
 
 def test_apprise_logger():
@@ -691,8 +696,9 @@ def test_result_log_store_handles_disk_failure(caplog):
     store = _NotifyLogStore(_LogCaptureBudget(memory_size=0, disk_size=1024))
 
     try:
-        with mock.patch(
-            "apprise.logger.tempfile.TemporaryFile",
+        with mock.patch.object(
+            _LOGGER_MODULE.tempfile,
+            "TemporaryFile",
             side_effect=OSError("no space"),
         ):
             store.append(NotifyLogEntry("ERROR", "delivery failed"))
@@ -710,8 +716,9 @@ def test_result_log_store_contains_logging_failure_on_write():
     store = _NotifyLogStore(_LogCaptureBudget(memory_size=0, disk_size=1024))
 
     with (
-        mock.patch(
-            "apprise.logger.tempfile.TemporaryFile",
+        mock.patch.object(
+            _LOGGER_MODULE.tempfile,
+            "TemporaryFile",
             side_effect=OSError("no space"),
         ),
         mock.patch.object(
@@ -749,8 +756,9 @@ def test_result_log_store_handles_short_writes(failed_write):
 
     budget = _LogCaptureBudget(memory_size=0, disk_size=4096)
     store = _NotifyLogStore(budget)
-    with mock.patch(
-        "apprise.logger.tempfile.TemporaryFile",
+    with mock.patch.object(
+        _LOGGER_MODULE.tempfile,
+        "TemporaryFile",
         return_value=ShortWriteFile(),
     ):
         # The first record covers header and payload writes.
@@ -844,8 +852,10 @@ def test_result_log_store_handles_close_failure(caplog):
     caplog.set_level(logging.DEBUG, logger=logger.name)
     budget = _LogCaptureBudget(memory_size=0, disk_size=4096)
     store = _NotifyLogStore(budget)
-    with mock.patch(
-        "apprise.logger.tempfile.TemporaryFile", return_value=CloseFailFile()
+    with mock.patch.object(
+        _LOGGER_MODULE.tempfile,
+        "TemporaryFile",
+        return_value=CloseFailFile(),
     ):
         store.append(NotifyLogEntry("WARNING", "entry"))
 
@@ -878,8 +888,9 @@ def test_result_log_store_contains_logging_failure_on_close():
     budget = _LogCaptureBudget(memory_size=0, disk_size=4096)
     store = _NotifyLogStore(budget)
 
-    with mock.patch(
-        "apprise.logger.tempfile.TemporaryFile",
+    with mock.patch.object(
+        _LOGGER_MODULE.tempfile,
+        "TemporaryFile",
         return_value=CloseFailFile(),
     ):
         store.append(NotifyLogEntry("WARNING", "entry"))
@@ -924,8 +935,9 @@ def test_result_log_store_sequence_and_repeat_failure_paths():
     budget = _LogCaptureBudget(memory_size=0, disk_size=4096)
     store = _NotifyLogStore(budget)
     budget.claim_warning(_NotifyLogStore._DISK_MESSAGE)
-    with mock.patch(
-        "apprise.logger.tempfile.TemporaryFile",
+    with mock.patch.object(
+        _LOGGER_MODULE.tempfile,
+        "TemporaryFile",
         return_value=ConcurrentFailFile(),
     ):
         store.append(entry)

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -27,6 +27,7 @@
 
 # Disable logging for a cleaner testing output
 from datetime import datetime, timezone
+from io import StringIO
 from json import loads
 import logging
 
@@ -40,6 +41,11 @@ from apprise.result import (
 )
 
 logging.disable(logging.CRITICAL)
+
+
+def _json_data(value):
+    """Decode one result object's bounded JSON iterator for assertions."""
+    return loads("".join(value.iter_json()))
 
 
 def test_notify_log_entry():
@@ -126,7 +132,7 @@ def test_notify_attempt_start_end_time_match_elapsed():
     assert (attempt.end_time - attempt.start_time).total_seconds() == 3.5
     assert before <= attempt.end_time <= after
     parsed = datetime.strptime(
-        attempt.asdict()["start_time"], AWARE_DATE_ISO_FORMAT
+        _json_data(attempt)["start_time"], AWARE_DATE_ISO_FORMAT
     )
     assert parsed == attempt.start_time
 
@@ -148,8 +154,8 @@ def test_notify_attempt_iterates_logs():
     assert " - ERROR - invalid token" in messages[1]
 
 
-def test_notify_attempt_asdict_and_json():
-    """NotifyAttempt.asdict()/json() serialize every field, logs included."""
+def test_notify_attempt_iter_json_and_write_json():
+    """Attempt JSON streams every field and can write to a text stream."""
 
     logs = [NotifyLogEntry(level="WARNING", message="HTTP 429")]
     attempt = NotifyAttempt(
@@ -163,10 +169,47 @@ def test_notify_attempt_asdict_and_json():
         "end_time": attempt.end_time.strftime(AWARE_DATE_ISO_FORMAT),
         "logs": [logs[0].asdict()],
     }
-    assert attempt.asdict() == expected
-    assert loads(attempt.json()) == expected
-    assert ", " not in attempt.json()
-    assert ": " not in attempt.json()
+    output = "".join(attempt.iter_json())
+    assert loads(output) == expected
+    assert ", " not in output
+    assert ": " not in output
+
+    # write_json consumes the same bounded chunks without joining them first.
+    stream = StringIO()
+    attempt.write_json(stream)
+    assert stream.getvalue() == output
+
+
+def test_notify_attempt_json_reads_disk_logs_lazily():
+    """Creating and starting JSON output does not preload disk-backed logs."""
+    from apprise.logger import _LogCaptureBudget, _NotifyLogStore
+
+    budget = _LogCaptureBudget(memory_size=0, disk_size=4096)
+    logs = _NotifyLogStore(budget)
+    logs.append(NotifyLogEntry(level="WARNING", message="from disk"))
+
+    reads = 0
+    original_read = budget.read
+
+    def tracked_read(offset):
+        """Count actual disk reads while preserving normal behavior."""
+        nonlocal reads
+        reads += 1
+        return original_read(offset)
+
+    budget.read = tracked_read
+    attempt = NotifyAttempt(AppriseResultStatus.FAILURE, logs=logs)
+    chunks = attempt.iter_json()
+
+    # Fixed fields are emitted before iteration reaches the disk log array.
+    first_chunk = next(chunks)
+    assert first_chunk.startswith('{"status":')
+    assert reads == 0
+
+    output = first_chunk + "".join(chunks)
+    assert loads(output)["logs"][0]["message"] == "from disk"
+    assert reads == 1
+    logs.close()
 
 
 def test_notify_attempt_repr():
@@ -453,9 +496,8 @@ def test_notify_result_optional_and_tag():
     assert bool(result) is True
 
 
-def test_notify_result_asdict_and_json():
-    """NotifyResult.asdict()/json() serialize every field, with nested
-    per-attempt detail (including each attempt's own logs)."""
+def test_notify_result_iter_json_and_write_json():
+    """Service JSON streams every field and its nested attempts."""
 
     logs = [NotifyLogEntry(level="WARNING", message="HTTP 429")]
     attempt = NotifyAttempt(
@@ -484,13 +526,16 @@ def test_notify_result_asdict_and_json():
         "elapsed": result.elapsed,
         "start_time": result.start_time.strftime(AWARE_DATE_ISO_FORMAT),
         "end_time": result.end_time.strftime(AWARE_DATE_ISO_FORMAT),
-        "attempts": [attempt.asdict()],
+        "attempts": [_json_data(attempt)],
     }
-    assert result.asdict() == expected
-    assert loads(result.json()) == expected
-    # json() is compact -- no space after "," or ":".
-    assert ", " not in result.json()
-    assert ": " not in result.json()
+    output = "".join(result.iter_json())
+    assert loads(output) == expected
+    assert ", " not in output
+    assert ": " not in output
+
+    stream = StringIO()
+    result.write_json(stream)
+    assert stream.getvalue() == output
 
 
 def test_notify_result_repr():
@@ -522,6 +567,7 @@ def test_apprise_result_defaults():
     assert result.timeout_count == 0
     assert result.elapsed == 0.0
     assert bool(result) is False
+    assert list(result.call_logs()) == []
 
 
 def test_apprise_result_elapsed_custom():
@@ -541,7 +587,7 @@ def test_apprise_result_start_end_time_match_elapsed():
     assert result.end_time.tzinfo is not None
     assert (result.end_time - result.start_time).total_seconds() == 4.0
     parsed = datetime.strptime(
-        result.asdict()["end_time"], AWARE_DATE_ISO_FORMAT
+        _json_data(result)["end_time"], AWARE_DATE_ISO_FORMAT
     )
     assert parsed == result.end_time
 
@@ -688,9 +734,71 @@ def test_apprise_result_logs_merges_and_sorts_across_services():
     assert messages == ["from slack", "from slack, later", "from discord"]
 
 
-def test_apprise_result_asdict_and_json():
-    """AppriseResult.asdict()/json() serialize status, counts, and every
-    NotifyResult entry."""
+def test_apprise_result_call_logs():
+    """Call logs expose a read-only snapshot of orchestration entries."""
+
+    t = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    entries = [
+        NotifyLogEntry(
+            level="WARNING", message="no services to notify", time=t
+        )
+    ]
+    result = AppriseResult(
+        status=AppriseResultStatus.NOMATCH, call_logs=entries
+    )
+
+    assert list(result.call_logs()) == entries
+    # Mutating the input list afterwards must not affect the snapshot.
+    entries.append(
+        NotifyLogEntry(level="WARNING", message="late addition", time=t)
+    )
+    assert len(list(result.call_logs())) == 1
+
+
+def test_result_logs_merge_call_logs():
+    """Combined logs merge call and service entries by time."""
+
+    early = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    middle = datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc)
+    late = datetime(2026, 1, 1, 12, 0, 2, tzinfo=timezone.utc)
+
+    slack = NotifyResult(
+        name="Slack",
+        url="slack://t/ch",
+        attempts=[
+            NotifyAttempt(
+                status=AppriseResultStatus.SUCCESS,
+                logs=[
+                    NotifyLogEntry(
+                        level="WARNING", message="from slack", time=middle
+                    )
+                ],
+            )
+        ],
+    )
+    call_logs = [
+        NotifyLogEntry(
+            level="TRACE", message="starting attempt 1/1", time=early
+        ),
+        NotifyLogEntry(level="TRACE", message="attempt finished", time=late),
+    ]
+
+    result = AppriseResult(
+        status=AppriseResultStatus.SUCCESS,
+        results=[slack],
+        call_logs=call_logs,
+    )
+
+    messages = [entry.message for entry in result.logs()]
+    assert messages == [
+        "starting attempt 1/1",
+        "from slack",
+        "attempt finished",
+    ]
+
+
+def test_apprise_result_iter_json_and_write_json():
+    """Overall JSON streams summary fields and every service result."""
 
     results = [
         _notify_result("Slack", "slack://t/ch", AppriseResultStatus.SUCCESS),
@@ -709,12 +817,29 @@ def test_apprise_result_asdict_and_json():
         "elapsed": 0.75,
         "start_time": result.start_time.strftime(AWARE_DATE_ISO_FORMAT),
         "end_time": result.end_time.strftime(AWARE_DATE_ISO_FORMAT),
-        "results": [r.asdict() for r in results],
+        "results": [_json_data(item) for item in results],
+        "call_logs": [],
     }
-    assert result.asdict() == expected
-    assert loads(result.json()) == expected
-    assert ", " not in result.json()
-    assert ": " not in result.json()
+    output = "".join(result.iter_json())
+    assert loads(output) == expected
+    assert ", " not in output
+    assert ": " not in output
+
+    stream = StringIO()
+    result.write_json(stream)
+    assert stream.getvalue() == output
+
+
+def test_result_json_includes_call_logs():
+    """Bounded result JSON includes call-level logs."""
+
+    t = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    entries = [NotifyLogEntry(level="WARNING", message="no services", time=t)]
+    result = AppriseResult(
+        status=AppriseResultStatus.NOMATCH, call_logs=entries
+    )
+
+    assert _json_data(result)["call_logs"] == [e.asdict() for e in entries]
 
 
 def test_apprise_result_repr():
@@ -749,3 +874,50 @@ def test_apprise_result_results_is_read_only_view():
 
     assert len(result) == 1
     assert len(result.results) == 1
+
+
+def test_apprise_result_closes_disk_backed_logs():
+    """Closing a result releases temporary files held by its log stores."""
+    from apprise.logger import _LogCaptureBudget, _NotifyLogStore
+
+    call_logs = _NotifyLogStore(
+        _LogCaptureBudget(memory_size=0, disk_size=4096)
+    )
+    attempt_logs = _NotifyLogStore(
+        _LogCaptureBudget(memory_size=0, disk_size=4096)
+    )
+    call_logs.append(NotifyLogEntry("WARNING", "call"))
+    attempt_logs.append(NotifyLogEntry("WARNING", "attempt"))
+    service = NotifyResult(
+        name="Slack",
+        url="slack://t/ch",
+        attempts=[
+            NotifyAttempt(
+                status=AppriseResultStatus.SUCCESS, logs=attempt_logs
+            )
+        ],
+    )
+
+    with AppriseResult(
+        status=AppriseResultStatus.SUCCESS,
+        results=[service],
+        call_logs=call_logs,
+    ) as result:
+        assert [entry.message for entry in result.logs()] == [
+            "call",
+            "attempt",
+        ]
+
+    assert call_logs._budget._disk is None
+    assert attempt_logs._budget._disk is None
+
+    # Closing ordinary list-backed results is also a safe no-op.
+    AppriseResult(
+        results=[
+            NotifyResult(
+                name="Slack",
+                url="slack://t/ch",
+                attempts=[NotifyAttempt(AppriseResultStatus.SUCCESS)],
+            )
+        ]
+    ).close()

--- a/tests/test_retry_wait.py
+++ b/tests/test_retry_wait.py
@@ -786,6 +786,30 @@ class TestStaticHelpers:
         service.retry = 2
         assert _resolve_retry_count(service, {"_retry_override": "x"}) == 2
 
+    def test_configured_max_attempts_preserves_override(self):
+        """Read timeout metadata without consuming the worker's override."""
+        from apprise.apprise import _configured_max_attempts
+
+        service = mock.Mock()
+        service.retry = 1
+
+        # The timeout result and worker must see the same retry limit.
+        kwargs = {"_retry_override": 3}
+        assert _configured_max_attempts(service, kwargs) == 4
+        assert kwargs == {"_retry_override": 3}
+
+    def test_configured_max_attempts_handles_bad_metadata(self):
+        """Leave invalid plugin metadata for the worker safety net."""
+        from apprise.apprise import _configured_max_attempts
+
+        class BrokenRetry:
+            @property
+            def retry(self):
+                # A plugin property may fail before its worker starts.
+                raise RuntimeError("bad retry metadata")
+
+        assert _configured_max_attempts(BrokenRetry(), {}) == 1
+
     def test_retry_override_end_to_end_is_bounded(self):
         """Prevent a huge tag retry suffix from creating an unbounded loop."""
         from apprise.common import APPRISE_MAX_SERVICE_RETRY
@@ -2710,6 +2734,7 @@ class TestServiceTimeout:
         # sequence when slower hosts change which one finishes first.
         assert len(slow_result.attempts) in (1, 2)
         assert slow_result.attempts[-1].status == AppriseResultStatus.TIMEOUT
+        assert slow_result.max_attempts == 4
         if len(slow_result.attempts) == 2:
             assert (
                 slow_result.attempts[0].status == AppriseResultStatus.FAILURE
@@ -2756,6 +2781,7 @@ class TestServiceTimeout:
         # As above, accept either attempt sequence at the shared deadline.
         assert len(slow_result.attempts) in (1, 2)
         assert slow_result.attempts[-1].status == AppriseResultStatus.TIMEOUT
+        assert slow_result.max_attempts == 4
         if len(slow_result.attempts) == 2:
             assert (
                 slow_result.attempts[0].status == AppriseResultStatus.FAILURE

--- a/tests/test_retry_wait.py
+++ b/tests/test_retry_wait.py
@@ -1276,14 +1276,16 @@ class TestExceptionHandling:
                     """Forward context cleanup to the wrapped executor."""
                     return self._real.__exit__(*exc)
 
-                def submit(self, fn, service, kwargs, call_deadline):
+                def submit(
+                    self, context_run, fn, service, kwargs, call_deadline
+                ):
                     """Return a failed future for ``s1`` and submit others."""
                     if service is s1:
                         fut = cf.Future()
                         fut.set_exception(RuntimeError("future boom"))
                         return fut
                     return self._real.submit(
-                        fn, service, kwargs, call_deadline
+                        context_run, fn, service, kwargs, call_deadline
                     )
 
                 def shutdown(self, *args, **kwargs):
@@ -1339,7 +1341,9 @@ class TestExceptionHandling:
                     """Forward context cleanup to the wrapped executor."""
                     return self._real.__exit__(*exc)
 
-                def submit(self, fn, service, kwargs, call_deadline):
+                def submit(
+                    self, context_run, fn, service, kwargs, call_deadline
+                ):
                     """Return a future that raises instead of running."""
                     fut = cf.Future()
                     fut.set_exception(RuntimeError("future boom"))
@@ -3270,6 +3274,88 @@ class TestServiceTimeout:
         messages = [e.message for e in service_result.logs()]
         assert messages == ["HTTP 429 Too Many Requests"]
 
+    def test_notify_callback_defaults_to_info(self):
+        """A callback raises the default capture level to INFO."""
+        N_MGR["slow"] = _SlowNotify
+        received = []
+
+        def _cb(entry, service):
+            """Collect every entry the callback actually receives."""
+            received.append(entry.message)
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            service = _SlowNotify(host="x", asset=asset, delay=0.0)
+
+            def _info_then_warn(**kw):
+                """Log at both INFO and WARNING, then report failure."""
+                service.logger.info("delivery attempt starting")
+                service.logger.warning("HTTP 429 Too Many Requests")
+                return False
+
+            service.send = _info_then_warn
+            a = Apprise(asset=asset, log_callback=_cb)
+            a.add(service)
+
+            apprise_logger = logging.getLogger("apprise")
+            restore_level = apprise_logger.level
+            apprise_logger.setLevel(logging.INFO)
+            logging.disable(logging.NOTSET)
+            try:
+                result = a.notify(body="test")
+            finally:
+                logging.disable(logging.CRITICAL)
+                apprise_logger.setLevel(restore_level)
+        finally:
+            N_MGR.unload_modules()
+
+        service_result = next(iter(result))
+        messages = [e.message for e in service_result.logs()]
+        assert messages == [
+            "delivery attempt starting",
+            "HTTP 429 Too Many Requests",
+        ]
+        assert received == [
+            "delivery attempt starting",
+            "HTTP 429 Too Many Requests",
+        ]
+
+    def test_notify_explicit_log_level_wins(self):
+        """An explicit log level overrides the callback default."""
+        N_MGR["slow"] = _SlowNotify
+        received = []
+
+        def _cb(entry, service):
+            """Collect every entry the callback actually receives."""
+            received.append(entry.message)
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            service = _SlowNotify(host="x", asset=asset, delay=0.0)
+
+            def _info_then_warn(**kw):
+                """Log at both INFO and WARNING, then report failure."""
+                service.logger.info("delivery attempt starting")
+                service.logger.warning("HTTP 429 Too Many Requests")
+                return False
+
+            service.send = _info_then_warn
+            a = Apprise(asset=asset, log_callback=_cb)
+            a.add(service)
+
+            logging.disable(logging.NOTSET)
+            try:
+                result = a.notify(body="test", log_level=logging.WARNING)
+            finally:
+                logging.disable(logging.CRITICAL)
+        finally:
+            N_MGR.unload_modules()
+
+        service_result = next(iter(result))
+        messages = [e.message for e in service_result.logs()]
+        assert messages == ["HTTP 429 Too Many Requests"]
+        assert received == ["HTTP 429 Too Many Requests"]
+
     def test_notify_log_level_call_override(self):
         """log_level passed directly to notify() captures finer entries
         for that one call, overriding the Apprise instance's default."""
@@ -3384,6 +3470,150 @@ class TestServiceTimeout:
         service_result = next(iter(result))
         messages = [e.message for e in service_result.logs()]
         assert messages == ["async attempt starting", "async 429"]
+
+    def test_async_notify_callback_defaults_to_info(self):
+        """Async callbacks also default to INFO capture."""
+        N_MGR["slow"] = _SlowNotify
+        received = []
+
+        def _cb(entry, service):
+            """Collect service entries and ignore orchestration logs."""
+            if service is not None:
+                received.append(entry.message)
+
+        try:
+            asset = AppriseAsset(async_mode=True)
+            service = _SlowNotify(host="x", asset=asset, delay=0.0)
+
+            async def _info_then_warn(**kw):
+                """Log at both INFO and WARNING, then report failure."""
+                service.logger.info("async attempt starting")
+                service.logger.warning("async 429")
+                return False
+
+            service.async_notify = _info_then_warn
+            a = Apprise(asset=asset, log_callback=_cb)
+            a.add(service)
+
+            apprise_logger = logging.getLogger("apprise")
+            restore_level = apprise_logger.level
+            apprise_logger.setLevel(logging.INFO)
+            logging.disable(logging.NOTSET)
+            try:
+                result = asyncio.run(a.async_notify(body="test"))
+            finally:
+                logging.disable(logging.CRITICAL)
+                apprise_logger.setLevel(restore_level)
+        finally:
+            N_MGR.unload_modules()
+
+        service_result = next(iter(result))
+        messages = [e.message for e in service_result.logs()]
+        assert messages == ["async attempt starting", "async 429"]
+        assert received == ["async attempt starting", "async 429"]
+
+    def test_notify_call_logs_no_services(self):
+        """Call logs include the warning when no services are loaded."""
+        a = Apprise()
+
+        logging.disable(logging.NOTSET)
+        try:
+            result = a.notify(body="test")
+        finally:
+            logging.disable(logging.CRITICAL)
+
+        assert result.status == AppriseResultStatus.NOMATCH
+        assert any(
+            "no service" in e.message.lower() for e in result.call_logs()
+        )
+        # Merged into the combined timeline too.
+        assert any("no service" in e.message.lower() for e in result.logs())
+
+    def test_notify_empty_content_returns_failure(self):
+        """Invalid empty content returns a failure result without dispatch."""
+        a = Apprise()
+        a.add(_TestNotify(host="localhost"))
+
+        result = a.notify(body="")
+
+        assert result.status == AppriseResultStatus.FAILURE
+        assert len(result) == 0
+
+    def test_async_notify_validation_results(self):
+        """Async validation distinguishes invalid content from no services."""
+        a = Apprise()
+        a.add(_TestNotify(host="localhost"))
+
+        invalid = asyncio.run(a.async_notify(body=""))
+        no_services = asyncio.run(Apprise().async_notify(body="test"))
+
+        assert invalid.status == AppriseResultStatus.FAILURE
+        assert no_services.status == AppriseResultStatus.NOMATCH
+
+    def test_notify_call_logs_retry_trace(self):
+        """Call logs include retry details at TRACE level."""
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            asset = AppriseAsset(async_mode=False)
+            service = _SlowNotify(host="x", asset=asset, delay=0.0, retry=1)
+
+            def _always_fail(**kw):
+                """Report failure on every attempt."""
+                return False
+
+            service.send = _always_fail
+            a = Apprise(asset=asset)
+            a.add(service)
+
+            apprise_logger = logging.getLogger("apprise")
+            restore_level = apprise_logger.level
+            apprise_logger.setLevel(logging.TRACE)
+            logging.disable(logging.NOTSET)
+            try:
+                result = a.notify(body="test", log_level=logging.TRACE)
+            finally:
+                logging.disable(logging.CRITICAL)
+                apprise_logger.setLevel(restore_level)
+        finally:
+            N_MGR.unload_modules()
+
+        call_messages = [e.message for e in result.call_logs()]
+        assert any("Starting attempt" in m for m in call_messages)
+        assert any("trying again" in m for m in call_messages)
+
+    def test_async_notify_call_logs(self):
+        """Async notifications also collect call-level logs."""
+        N_MGR["slow"] = _SlowNotify
+
+        try:
+            asset = AppriseAsset(async_mode=True)
+            service = _SlowNotify(host="x", asset=asset, delay=0.0)
+
+            async def _fail(**kw):
+                """Report failure without logging anything itself."""
+                return False
+
+            service.async_notify = _fail
+            a = Apprise(asset=asset)
+            a.add(service)
+
+            apprise_logger = logging.getLogger("apprise")
+            restore_level = apprise_logger.level
+            apprise_logger.setLevel(logging.TRACE)
+            logging.disable(logging.NOTSET)
+            try:
+                result = asyncio.run(
+                    a.async_notify(body="test", log_level=logging.TRACE)
+                )
+            finally:
+                logging.disable(logging.CRITICAL)
+                apprise_logger.setLevel(restore_level)
+        finally:
+            N_MGR.unload_modules()
+
+        call_messages = [e.message for e in result.call_logs()]
+        assert any("Starting attempt" in m for m in call_messages)
 
     def test_async_notify_log_callback(self):
         """log_callback works for a plugin's native async_notify()."""


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1683

- Adds structured notification results with service and attempt details.
- Captures service logs and messages related to the overall notification call.
- Adds `AppriseAsset.result_log_memory_size` to control how much result-log data remains in memory.
- Adds `AppriseAsset.result_log_disk_size` to limit temporary disk storage used after the memory allowance is reached.
- Keeps the existing memory-only behavior when disk storage is set to `0`.
- Streams large JSON results without rebuilding all logs in memory.
- Adds safe temporary-file cleanup and resilient storage-error handling.
- Improves retry, timeout, priority, and live log callback reporting.
- Expands coverage for concurrency, storage limits, cleanup, and failure handling.


<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): https://github.com/caronc/apprise-docs/commit/8f6f76d2f5ed806b58bb23c642bdae8d90469b3a
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@v2-further-log-refactoring

tox -e qa
```
