### PR TITLE
fix: replace bare except with except Exception in region validation

### DIFF
--- a/apprise/plugins/jira.py
+++ b/apprise/plugins/jira.py
@@ -377,7 +377,7 @@ class NotifyJira(NotifyBase):
             if self.region_name not in JIRA_REGIONS:
                 # allow the outer except to handle this common response
                 raise
-        except:
+        except Exception:
             # Invalid region specified
             msg = "The Jira region specified ({}) is invalid.".format(
                 region_name

--- a/apprise/plugins/mailgun.py
+++ b/apprise/plugins/mailgun.py
@@ -275,7 +275,7 @@ class NotifyMailgun(NotifyBase):
             if self.region_name not in MAILGUN_REGIONS:
                 # allow the outer except to handle this common response
                 raise
-        except:
+        except Exception:
             # Invalid region specified
             msg = f"The Mailgun region specified ({region_name}) is invalid."
             self.logger.warning(msg)

--- a/apprise/plugins/opsgenie.py
+++ b/apprise/plugins/opsgenie.py
@@ -379,7 +379,7 @@ class NotifyOpsgenie(NotifyBase):
             if self.region_name not in OPSGENIE_REGIONS:
                 # allow the outer except to handle this common response
                 raise
-        except:
+        except Exception:
             # Invalid region specified
             msg = f"The Opsgenie region specified ({region_name}) is invalid."
             self.logger.warning(msg)


### PR DESCRIPTION

### Summary

Three bare `except:` clauses in the region-validation blocks of the Jira,
Mailgun and Opsgenie notification plugins catch everything, including
`KeyboardInterrupt`/`SystemExit`, and hide programming errors as if they were
invalid-region responses.

Replace with `except Exception:` — same intended behavior (report an invalid
region, re-raise `TypeError`), but unexpected exceptions now propagate.

### Verification

- `python -m py_compile` on the three plugin files → OK

### Files changed

- `apprise/plugins/jira.py` (1 line)
- `apprise/plugins/mailgun.py` (1 line)
- `apprise/plugins/opsgenie.py` (1 line)