### PR TITLE
Fixes Gento Linux issue with memory based attachment handling

### DIFF
--- a/apprise/attachment/memory.py
+++ b/apprise/attachment/memory.py
@@ -111,10 +111,9 @@ class AttachMemory(AttachBase):
         )
 
     def open(self, *args, **kwargs):
-        """Return our memory object."""
-        # Return our object
+        """Return an independent handle to our memory object."""
         self._data.seek(0, 0)
-        return self._data
+        return io.BytesIO(self._data.getvalue())
 
     def __enter__(self):
         """Support with clause."""

--- a/tests/test_attach_memory.py
+++ b/tests/test_attach_memory.py
@@ -241,3 +241,17 @@ def test_attach_memory_open_reusable():
 
     # Each call to open() hands back an independent object
     assert mem.open() is not mem.open()
+
+
+def test_attach_memory_invalidate_closed_buffer():
+    """
+    API: AttachMemory().invalidate() on an already-closed buffer
+
+    """
+    mem = AttachMemory(content=b"content")
+
+    # Simulate our internal buffer already being closed
+    mem._data.close()
+
+    # invalidate() must not attempt to truncate a closed buffer
+    mem.invalidate()

--- a/tests/test_attach_memory.py
+++ b/tests/test_attach_memory.py
@@ -216,3 +216,28 @@ def test_attach_memory():
     response.invalidate()
     with pytest.raises(exception.AppriseFileNotFound):
         response.base64()
+
+
+def test_attach_memory_open_reusable():
+    """
+    API: AttachMemory().open() returns a reusable handle
+
+    """
+    mem = AttachMemory(content=b"content")
+
+    # Closing a handle returned by open() (as a `with` block does)
+    # must not affect the attachment itself
+    with mem.open() as fp:
+        assert fp.read() == b"content"
+
+    # The attachment is still usable afterwards
+    assert bool(mem) is True
+    assert len(mem) == len(b"content")
+    assert mem.exists() is True
+
+    # A second open() call still works and returns the full content
+    with mem.open() as fp:
+        assert fp.read() == b"content"
+
+    # Each call to open() hands back an independent object
+    assert mem.open() is not mem.open()


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1708

- Fixed a bug where sending the same in-memory attachment

## Checklist
* [ ] Documentation ticket created (if applicable): N/A 
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1708-gento-linux-attachment-issue

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    mailto://user:pass@gmail.com
