### PR TITLE
Add Signalgrid notification service plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ The table below identifies the services this tool supports and some example serv
 | [ServerChan](https://appriseit.com/services/serverchan/) | schan://   | (TCP) 443    | schan://sendkey/
 | [Session Open Group Server](https://appriseit.com/services/sogs/) | session:// or sessions:// | (TCP) 80 or 443 | sessions://public_key:seed@hostname/room<br />sessions://public_key:seed@hostname/room1/room2<br />sessions://public_key:seed@hostname:port/room<br />session://public_key:seed@hostname/room
 | [Signal API](https://appriseit.com/services/signal/) | signal://  or signals:// | (TCP) 80 or 443  | signal://hostname:port/FromPhoneNo<br/>signal://hostname:port/FromPhoneNo/ToPhoneNo<br/>signal://hostname:port/FromPhoneNo/ToPhoneNo1/ToPhoneNo2/ToPhoneNoN/
+| [Signalgrid](https://appriseit.com/services/signalgrid/) | signalgrid://  | (TCP) 443   | signalgrid://CLIENT_KEY/CHANNEL<br />signalgrid://CLIENT_KEY/CHANNEL?critical=true
 | [SIGNL4](https://appriseit.com/services/signl4/) | signl4://  | (TCP) 80 or 443  | signl4://hostname
 | [SimplePush](https://appriseit.com/services/simplepush/) | spush://   | (TCP) 443    | spush://apikey<br />spush://salt:password@apikey<br />spush://apikey?event=Apprise
 | [Slack](https://appriseit.com/services/slack/) | slack://  | (TCP) 443   | slack://TokenA/TokenB/TokenC/<br />slack://TokenA/TokenB/TokenC/Channel<br />slack://botname@TokenA/TokenB/TokenC/Channel<br />slack://user@TokenA/TokenB/TokenC/Channel1/Channel2/ChannelN

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The table below identifies the services this tool supports and some example serv
 | [ServerChan](https://appriseit.com/services/serverchan/) | schan://   | (TCP) 443    | schan://sendkey/
 | [Session Open Group Server](https://appriseit.com/services/sogs/) | session:// or sessions:// | (TCP) 80 or 443 | sessions://public_key:seed@hostname/room<br />sessions://public_key:seed@hostname/room1/room2<br />sessions://public_key:seed@hostname:port/room<br />session://public_key:seed@hostname/room
 | [Signal API](https://appriseit.com/services/signal/) | signal://  or signals:// | (TCP) 80 or 443  | signal://hostname:port/FromPhoneNo<br/>signal://hostname:port/FromPhoneNo/ToPhoneNo<br/>signal://hostname:port/FromPhoneNo/ToPhoneNo1/ToPhoneNo2/ToPhoneNoN/
-| [Signalgrid](https://appriseit.com/services/signalgrid/) | signalgrid://  | (TCP) 443   | signalgrid://CLIENT_KEY/CHANNEL<br />signalgrid://CLIENT_KEY/CHANNEL?critical=true
+| [Signalgrid](https://appriseit.com/services/signalgrid/) | signalgrid://  | (TCP) 443   | signalgrid://CLIENT_KEY/CHANNEL<br />signalgrid://CLIENT_KEY/CHANNEL1/CHANNEL2<br />signalgrid://CLIENT_KEY/CHANNEL?critical=true
 | [SIGNL4](https://appriseit.com/services/signl4/) | signl4://  | (TCP) 80 or 443  | signl4://hostname
 | [SimplePush](https://appriseit.com/services/simplepush/) | spush://   | (TCP) 443    | spush://apikey<br />spush://salt:password@apikey<br />spush://apikey?event=Apprise
 | [Slack](https://appriseit.com/services/slack/) | slack://  | (TCP) 443   | slack://TokenA/TokenB/TokenC/<br />slack://TokenA/TokenB/TokenC/Channel<br />slack://botname@TokenA/TokenB/TokenC/Channel<br />slack://user@TokenA/TokenB/TokenC/Channel1/Channel2/ChannelN

--- a/apprise/plugins/signalgrid.py
+++ b/apprise/plugins/signalgrid.py
@@ -1,0 +1,254 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import requests
+
+from ..common import NotifyType
+from ..locale import gettext_lazy as _
+from ..utils.parse import parse_bool, validate_regex
+from .base import NotifyBase
+
+
+class NotifySignalgrid(NotifyBase):
+    """A wrapper for Signalgrid Notifications."""
+
+    service_name = "Signalgrid"
+
+    service_url = "https://signalgrid.co/"
+
+    protocol = "signalgrid"
+
+    setup_url = "https://docs.signalgrid.co/integrations/apprise/"
+
+    notify_url = "https://api.signalgrid.co/v1/push"
+
+    templates = ("{schema}://{client_key}/{channel}",)
+
+    template_tokens = dict(
+        NotifyBase.template_tokens,
+        **{
+            "client_key": {
+                "name": _("Client Key"),
+                "type": "string",
+                "private": True,
+                "required": True,
+            },
+            "channel": {
+                "name": _("Channel Token"),
+                "type": "string",
+                "required": True,
+            },
+        },
+    )
+
+    template_args = dict(
+        NotifyBase.template_args,
+        **{
+            "client_key": {
+                "alias_of": "client_key",
+            },
+            "channel": {
+                "alias_of": "channel",
+            },
+            "critical": {
+                "name": _("Critical Notification"),
+                "type": "bool",
+                "default": False,
+            },
+        },
+    )
+
+    notify_type_map = {
+        NotifyType.INFO: "INFO",
+        NotifyType.SUCCESS: "SUCCESS",
+        NotifyType.WARNING: "WARN",
+        NotifyType.FAILURE: "CRIT",
+    }
+
+    def __init__(self, client_key, channel, critical=False, **kwargs):
+        """Initialize Signalgrid Object."""
+        super().__init__(**kwargs)
+
+        self.client_key = validate_regex(client_key)
+        if not self.client_key:
+            msg = "An invalid Signalgrid Client Key was specified."
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        self.channel = validate_regex(channel)
+        if not self.channel:
+            msg = "An invalid Signalgrid Channel Token was specified."
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        self.critical = parse_bool(critical, False)
+
+    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+        """Perform Signalgrid Notification."""
+
+        headers = {
+            "User-Agent": self.app_id,
+        }
+
+        payload = {
+            "client_key": self.client_key,
+            "channel": self.channel,
+            "title": title,
+            "body": body,
+            "type": self.notify_type_map.get(notify_type, "INFO"),
+            "critical": "true" if self.critical else "false",
+        }
+
+        self.logger.debug(
+            "Signalgrid POST URL:"
+            f" {self.notify_url} (cert_verify={self.verify_certificate!r})"
+        )
+
+        # Do not log client_key or channel.
+        self.logger.debug(
+            "Signalgrid Payload: title=%r, type=%r, critical=%r",
+            title,
+            payload["type"],
+            payload["critical"],
+        )
+
+        self.throttle()
+
+        try:
+            response = requests.post(
+                self.notify_url,
+                data=payload,
+                headers=headers,
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+                allow_redirects=self.redirects,
+            )
+
+            if response.status_code != requests.codes.ok:
+                status_str = NotifySignalgrid.http_response_code_lookup(
+                    response.status_code
+                )
+
+                self.logger.warning(
+                    (
+                        "Failed to send Signalgrid notification:{}{}error={}."
+                    ).format(
+                        status_str,
+                        ", " if status_str else "",
+                        response.status_code,
+                    )
+                )
+                self.logger.debug(
+                    "Response Details:\r\n%r",
+                    (response.content or b"")[:2000],
+                )
+
+                return False
+
+            self.logger.info("Sent Signalgrid notification.")
+
+        except requests.RequestException as e:
+            self.logger.warning(
+                "A Connection error occurred sending Signalgrid notification."
+            )
+            self.logger.debug(f"Socket Exception: {e!s}")
+            return False
+
+        return True
+
+    @property
+    def url_identifier(self):
+        """Return identifiers unique to this Signalgrid configuration."""
+        return (
+            self.protocol,
+            self.client_key,
+            self.channel,
+        )
+
+    def url(self, privacy=False, *args, **kwargs):
+        """Return the Signalgrid Apprise URL."""
+
+        params = {
+            "critical": "true" if self.critical else "false",
+        }
+
+        params.update(
+            self.url_parameters(
+                privacy=privacy,
+                *args,
+                **kwargs,
+            )
+        )
+
+        return "{schema}://{client_key}/{channel}/?{params}".format(
+            schema=self.protocol,
+            client_key=self.pprint(
+                self.client_key,
+                privacy,
+                safe="",
+            ),
+            channel=NotifySignalgrid.quote(
+                self.channel,
+                safe="",
+            ),
+            params=NotifySignalgrid.urlencode(params),
+        )
+
+    @staticmethod
+    def parse_url(url):
+        """Parse Signalgrid URL."""
+
+        results = NotifyBase.parse_url(url, verify_host=False)
+        if not results:
+            return results
+
+        # client_key occupies the URL hostname:
+        # signalgrid://CLIENT_KEY/CHANNEL
+        results["client_key"] = NotifySignalgrid.unquote(
+            results.get("host") or ""
+        )
+
+        # channel occupies the URL path.
+        fullpath = results.get("fullpath") or ""
+        results["channel"] = NotifySignalgrid.unquote(fullpath.strip("/"))
+
+        # Query-string variants are supported as well.
+        if "client_key" in results["qsd"] and len(
+            results["qsd"]["client_key"]
+        ):
+            results["client_key"] = NotifySignalgrid.unquote(
+                results["qsd"]["client_key"]
+            )
+
+        if "channel" in results["qsd"] and len(results["qsd"]["channel"]):
+            results["channel"] = NotifySignalgrid.unquote(
+                results["qsd"]["channel"]
+            )
+
+        results["critical"] = parse_bool(results["qsd"].get("critical", False))
+
+        return results

--- a/apprise/plugins/signalgrid.py
+++ b/apprise/plugins/signalgrid.py
@@ -25,29 +25,69 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+# Steps to get your Signalgrid Client Key and Channel Token:
+#  1. Visit https://signalgrid.co/ and sign in (or create an account).
+#  2. Open your account settings and copy your Client Key.
+#  3. Create (or select) a channel and copy its Channel Token.
+#
+#  Your Apprise URL should be assembled as:
+#     signalgrid://{client_key}/{channel}
+#
+#  You can notify more than one channel in a single call by adding extra
+#  channel tokens to the path:
+#     signalgrid://{client_key}/{channel1}/{channel2}
+#
+# Resources:
+# - https://docs.signalgrid.co/integrations/apprise/
+# - https://docs.signalgrid.co/api/push-api/
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
 import requests
 
 from ..common import NotifyType
 from ..locale import gettext_lazy as _
-from ..utils.parse import parse_bool, validate_regex
+from ..utils.parse import parse_bool, parse_list, validate_regex
 from .base import NotifyBase
+
+# Signalgrid's push API maps each Apprise notification type to one of its
+# own notification type strings.
+SIGNALGRID_TYPE_MAP = {
+    NotifyType.INFO: "INFO",
+    NotifyType.SUCCESS: "SUCCESS",
+    NotifyType.WARNING: "WARN",
+    NotifyType.FAILURE: "CRIT",
+}
 
 
 class NotifySignalgrid(NotifyBase):
     """A wrapper for Signalgrid Notifications."""
 
+    # The default descriptive name associated with the Notification
     service_name = "Signalgrid"
 
+    # The services URL
     service_url = "https://signalgrid.co/"
 
-    protocol = "signalgrid"
+    # The default secure protocol
+    secure_protocol = "signalgrid"
 
+    # A URL that takes you to the setup/help of the specific protocol
     setup_url = "https://docs.signalgrid.co/integrations/apprise/"
 
+    # Signalgrid Push API URL
     notify_url = "https://api.signalgrid.co/v1/push"
 
-    templates = ("{schema}://{client_key}/{channel}",)
+    # Signalgrid's push API has no documented support for file/image
+    # attachments, so we don't advertise it here.
+    attachment_support = False
 
+    # Define object URL templates
+    templates = ("{schema}://{client_key}/{targets}",)
+
+    # Define our template tokens
     template_tokens = dict(
         NotifyBase.template_tokens,
         **{
@@ -57,22 +97,22 @@ class NotifySignalgrid(NotifyBase):
                 "private": True,
                 "required": True,
             },
-            "channel": {
-                "name": _("Channel Token"),
-                "type": "string",
-                "required": True,
+            "targets": {
+                "name": _("Channels"),
+                "type": "list:string",
             },
         },
     )
 
+    # Define our template arguments
     template_args = dict(
         NotifyBase.template_args,
         **{
             "client_key": {
                 "alias_of": "client_key",
             },
-            "channel": {
-                "alias_of": "channel",
+            "to": {
+                "alias_of": "targets",
             },
             "critical": {
                 "name": _("Critical Notification"),
@@ -82,44 +122,90 @@ class NotifySignalgrid(NotifyBase):
         },
     )
 
-    notify_type_map = {
-        NotifyType.INFO: "INFO",
-        NotifyType.SUCCESS: "SUCCESS",
-        NotifyType.WARNING: "WARN",
-        NotifyType.FAILURE: "CRIT",
-    }
-
-    def __init__(self, client_key, channel, critical=False, **kwargs):
+    def __init__(
+        self,
+        client_key: Optional[str] = None,
+        targets: Optional[list[str]] = None,
+        critical: bool = False,
+        **kwargs: Any,
+    ) -> None:
         """Initialize Signalgrid Object."""
         super().__init__(**kwargs)
 
+        # Our Client Key authenticates us with Signalgrid
         self.client_key = validate_regex(client_key)
         if not self.client_key:
             msg = "An invalid Signalgrid Client Key was specified."
             self.logger.warning(msg)
             raise TypeError(msg)
 
-        self.channel = validate_regex(channel)
-        if not self.channel:
-            msg = "An invalid Signalgrid Channel Token was specified."
-            self.logger.warning(msg)
-            raise TypeError(msg)
+        # Store the channel(s) we're notifying. No channels is valid at
+        # load time; send() will simply have nothing to notify.
+        self.targets = parse_list(targets)
 
+        # Whether this notification should be flagged as critical
         self.critical = parse_bool(critical, False)
 
-    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+    def __len__(self) -> int:
+        """Returns the number of channels associated with this
+        notification."""
+        # Always return at least 1 so the framework counts this instance
+        return len(self.targets) if self.targets else 1
+
+    def send(
+        self,
+        body: str,
+        title: str = "",
+        notify_type: str = NotifyType.INFO,
+        attach: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> bool:
         """Perform Signalgrid Notification."""
 
+        # Let the user know attachments are silently dropped since
+        # Signalgrid's push API has no documented way to accept them
+        if attach:
+            self.logger.warning(
+                "Signalgrid does not support attachments; they will"
+                " be ignored."
+            )
+
+        # We need at least one channel to notify
+        if not self.targets:
+            self.logger.warning(
+                "There are no Signalgrid channels to notify, aborting."
+            )
+            return False
+
+        # Track whether any channel notification failed
+        has_error = False
+        for channel in self.targets:
+            if not self._send_to_channel(body, title, notify_type, channel):
+                has_error = True
+
+        return not has_error
+
+    def _send_to_channel(
+        self,
+        body: str,
+        title: str,
+        notify_type: str,
+        channel: str,
+    ) -> bool:
+        """Post a single notification to one Signalgrid channel."""
+
+        # Prepare our headers
         headers = {
             "User-Agent": self.app_id,
         }
 
+        # Prepare our payload
         payload = {
             "client_key": self.client_key,
-            "channel": self.channel,
+            "channel": channel,
             "title": title,
             "body": body,
-            "type": self.notify_type_map.get(notify_type, "INFO"),
+            "type": SIGNALGRID_TYPE_MAP.get(notify_type, "INFO"),
             "critical": "true" if self.critical else "false",
         }
 
@@ -128,7 +214,7 @@ class NotifySignalgrid(NotifyBase):
             f" {self.notify_url} (cert_verify={self.verify_certificate!r})"
         )
 
-        # Do not log client_key or channel.
+        # Never log the client key or channel token
         self.logger.debug(
             "Signalgrid Payload: title=%r, type=%r, critical=%r",
             title,
@@ -136,6 +222,7 @@ class NotifySignalgrid(NotifyBase):
             payload["critical"],
         )
 
+        # Always call throttle before any remote server i/o is made
         self.throttle()
 
         try:
@@ -154,9 +241,8 @@ class NotifySignalgrid(NotifyBase):
                 )
 
                 self.logger.warning(
-                    (
-                        "Failed to send Signalgrid notification:{}{}error={}."
-                    ).format(
+                    "Failed to send Signalgrid notification: "
+                    "{}{}error={}.".format(
                         status_str,
                         ", " if status_str else "",
                         response.status_code,
@@ -181,21 +267,23 @@ class NotifySignalgrid(NotifyBase):
         return True
 
     @property
-    def url_identifier(self):
-        """Return identifiers unique to this Signalgrid configuration."""
-        return (
-            self.protocol,
-            self.client_key,
-            self.channel,
-        )
+    def url_identifier(self) -> tuple[Any, ...]:
+        """Return identifiers unique to this Signalgrid configuration.
 
-    def url(self, privacy=False, *args, **kwargs):
+        Channels are delivery destinations, not connection identity, so
+        they're intentionally left out here.
+        """
+        return (self.secure_protocol, self.client_key)
+
+    def url(self, privacy: bool = False, *args: Any, **kwargs: Any) -> str:
         """Return the Signalgrid Apprise URL."""
 
+        # Prepare our parameters
         params = {
             "critical": "true" if self.critical else "false",
         }
 
+        # Extend our parameters with the ones inherited from our parent
         params.update(
             self.url_parameters(
                 privacy=privacy,
@@ -204,51 +292,52 @@ class NotifySignalgrid(NotifyBase):
             )
         )
 
-        return "{schema}://{client_key}/{channel}/?{params}".format(
-            schema=self.protocol,
+        return "{schema}://{client_key}/{targets}/?{params}".format(
+            schema=self.secure_protocol,
             client_key=self.pprint(
                 self.client_key,
                 privacy,
                 safe="",
             ),
-            channel=NotifySignalgrid.quote(
-                self.channel,
-                safe="",
+            targets="/".join(
+                NotifySignalgrid.quote(channel, safe="")
+                for channel in self.targets
             ),
             params=NotifySignalgrid.urlencode(params),
         )
 
     @staticmethod
-    def parse_url(url):
+    def parse_url(url: str) -> Optional[dict[str, Any]]:
         """Parse Signalgrid URL."""
 
         results = NotifyBase.parse_url(url, verify_host=False)
         if not results:
             return results
 
-        # client_key occupies the URL hostname:
-        # signalgrid://CLIENT_KEY/CHANNEL
+        # The client key occupies the URL hostname:
+        # signalgrid://CLIENT_KEY/CHANNEL1/CHANNEL2
         results["client_key"] = NotifySignalgrid.unquote(
             results.get("host") or ""
         )
 
-        # channel occupies the URL path.
-        fullpath = results.get("fullpath") or ""
-        results["channel"] = NotifySignalgrid.unquote(fullpath.strip("/"))
+        # Every remaining path entry is a channel we deliver to
+        results["targets"] = NotifySignalgrid.split_path(
+            results.get("fullpath") or ""
+        )
 
-        # Query-string variants are supported as well.
-        if "client_key" in results["qsd"] and len(
-            results["qsd"]["client_key"]
-        ):
+        # Support ?to= as a comma-separated alias for additional channels
+        if "to" in results["qsd"] and results["qsd"]["to"]:
+            results["targets"] += NotifySignalgrid.parse_list(
+                results["qsd"]["to"]
+            )
+
+        # Support ?client_key= to override the hostname-derived value
+        if "client_key" in results["qsd"] and results["qsd"]["client_key"]:
             results["client_key"] = NotifySignalgrid.unquote(
                 results["qsd"]["client_key"]
             )
 
-        if "channel" in results["qsd"] and len(results["qsd"]["channel"]):
-            results["channel"] = NotifySignalgrid.unquote(
-                results["qsd"]["channel"]
-            )
-
+        # Support ?critical= to flag the notification as critical
         results["critical"] = parse_bool(results["qsd"].get("critical", False))
 
         return results

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -84,7 +84,7 @@ notification services. It supports sending alerts to platforms such as: \
 `RSyslog`, `SendGrid`, \
 `SendPulse`, `ServerChan`, `SerwerSMS`, `Session Open Group Server`, \
 `Seven`, `SFR`, \
-`Signal`, `SIGNL4`, `SimplePush`, \
+`Signal`, `Signalgrid`, `SIGNL4`, `SimplePush`, \
 `Sinch`, `Slack`, `SMPP`, `SMSC`, `SMSEagle`, `SMS Manager`, `SMTP2Go`, \
 `SparkPost`, `Splunk`, `Spike`, `Spug Push`, `Stackfield`, `Super Toasty`, \
 `Streamlabs`, `Stride`, \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,7 @@ keywords = [
     "Seven",
     "SFR",
     "Signal",
+    "Signalgrid",
     "SIGNL4",
     "SimplePush",
     "Sinch",

--- a/tests/test_plugin_signalgrid.py
+++ b/tests/test_plugin_signalgrid.py
@@ -1,0 +1,176 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import logging
+from unittest import mock
+
+from helpers import AppriseURLTester
+import requests
+
+import apprise
+from apprise.plugins.signalgrid import NotifySignalgrid
+
+logging.disable(logging.CRITICAL)
+
+
+apprise_url_tests = (
+    (
+        "signalgrid://",
+        {
+            "instance": TypeError,
+        },
+    ),
+    (
+        "signalgrid://CLIENTKEY/CHANNEL",
+        {
+            "instance": NotifySignalgrid,
+        },
+    ),
+    (
+        "signalgrid://CLIENTKEY/CHANNEL?critical=yes",
+        {
+            "instance": NotifySignalgrid,
+        },
+    ),
+    (
+        "signalgrid://CLIENTKEY/CHANNEL",
+        {
+            "instance": NotifySignalgrid,
+            "response": False,
+            "requests_response_code": requests.codes.internal_server_error,
+        },
+    ),
+    (
+        "signalgrid://CLIENTKEY/CHANNEL",
+        {
+            "instance": NotifySignalgrid,
+            "test_requests_exceptions": True,
+        },
+    ),
+)
+
+
+def test_plugin_signalgrid_urls():
+    """NotifySignalgrid() Apprise URLs."""
+    AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+@mock.patch("requests.post")
+def test_plugin_signalgrid_payload(mock_post):
+    """Test Signalgrid request payload."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = b"OK"
+    mock_post.return_value = response
+
+    obj = NotifySignalgrid(
+        client_key="CLIENTKEY",
+        channel="CHANNEL",
+        critical=True,
+    )
+
+    assert (
+        obj.notify(
+            title="Server Down",
+            body="api01 is unreachable",
+            notify_type=apprise.NotifyType.FAILURE,
+        )
+        is True
+    )
+
+    assert mock_post.call_count == 1
+
+    args, kwargs = mock_post.call_args
+
+    assert args[0] == "https://api.signalgrid.co/v1/push"
+    assert kwargs["data"]["client_key"] == "CLIENTKEY"
+    assert kwargs["data"]["channel"] == "CHANNEL"
+    assert kwargs["data"]["title"] == "Server Down"
+    assert kwargs["data"]["body"] == "api01 is unreachable"
+    assert kwargs["data"]["type"] == "CRIT"
+    assert kwargs["data"]["critical"] == "true"
+
+
+@mock.patch("requests.post")
+def test_plugin_signalgrid_type_mapping(mock_post):
+    """Test Apprise to Signalgrid type mapping."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    obj = NotifySignalgrid(
+        client_key="CLIENTKEY",
+        channel="CHANNEL",
+    )
+
+    mappings = (
+        (apprise.NotifyType.INFO, "INFO"),
+        (apprise.NotifyType.SUCCESS, "SUCCESS"),
+        (apprise.NotifyType.WARNING, "WARN"),
+        (apprise.NotifyType.FAILURE, "CRIT"),
+    )
+
+    for notify_type, expected in mappings:
+        mock_post.reset_mock()
+
+        assert (
+            obj.notify(
+                title="Test",
+                body="Test",
+                notify_type=notify_type,
+            )
+            is True
+        )
+
+        assert mock_post.call_args.kwargs["data"]["type"] == expected
+        assert mock_post.call_args.kwargs["data"]["critical"] == "false"
+
+
+def test_plugin_signalgrid_url_roundtrip():
+    """Test Signalgrid URL parsing and reconstruction."""
+
+    obj = NotifySignalgrid(
+        client_key="CLIENTKEY",
+        channel="CHANNEL",
+        critical=True,
+    )
+
+    generated = obj.url()
+    parsed = NotifySignalgrid.parse_url(generated)
+
+    assert parsed is not None
+    assert parsed["client_key"] == "CLIENTKEY"
+    assert parsed["channel"] == "CHANNEL"
+    assert parsed["critical"] is True
+
+    obj2 = NotifySignalgrid(**parsed)
+
+    assert obj2.client_key == "CLIENTKEY"
+    assert obj2.channel == "CHANNEL"
+    assert obj2.critical is True

--- a/tests/test_plugin_signalgrid.py
+++ b/tests/test_plugin_signalgrid.py
@@ -26,6 +26,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import logging
+import os
 from unittest import mock
 
 from helpers import AppriseURLTester
@@ -35,6 +36,9 @@ import apprise
 from apprise.plugins.signalgrid import NotifySignalgrid
 
 logging.disable(logging.CRITICAL)
+
+# Attachment Directory
+TEST_VAR_DIR = os.path.join(os.path.dirname(__file__), "var")
 
 
 apprise_url_tests = (
@@ -48,12 +52,34 @@ apprise_url_tests = (
         "signalgrid://CLIENTKEY/CHANNEL",
         {
             "instance": NotifySignalgrid,
+            "privacy_url": "signalgrid://C...Y/CHANNEL/",
+        },
+    ),
+    (
+        "signalgrid://CLIENTKEY/CHANNEL1/CHANNEL2",
+        {
+            "instance": NotifySignalgrid,
         },
     ),
     (
         "signalgrid://CLIENTKEY/CHANNEL?critical=yes",
         {
             "instance": NotifySignalgrid,
+        },
+    ),
+    (
+        "signalgrid://CLIENTKEY/CHANNEL?to=CHANNEL2,CHANNEL3",
+        {
+            "instance": NotifySignalgrid,
+        },
+    ),
+    (
+        # No channels specified at all; the plugin still loads, but has
+        # nothing to notify
+        "signalgrid://CLIENTKEY",
+        {
+            "instance": NotifySignalgrid,
+            "notify_response": False,
         },
     ),
     (
@@ -90,7 +116,7 @@ def test_plugin_signalgrid_payload(mock_post):
 
     obj = NotifySignalgrid(
         client_key="CLIENTKEY",
-        channel="CHANNEL",
+        targets=["CHANNEL"],
         critical=True,
     )
 
@@ -126,7 +152,7 @@ def test_plugin_signalgrid_type_mapping(mock_post):
 
     obj = NotifySignalgrid(
         client_key="CLIENTKEY",
-        channel="CHANNEL",
+        targets=["CHANNEL"],
     )
 
     mappings = (
@@ -152,12 +178,68 @@ def test_plugin_signalgrid_type_mapping(mock_post):
         assert mock_post.call_args.kwargs["data"]["critical"] == "false"
 
 
+@mock.patch("requests.post")
+def test_plugin_signalgrid_multi_channel(mock_post):
+    """Test Signalgrid sends one request per channel."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    obj = NotifySignalgrid(
+        client_key="CLIENTKEY",
+        targets=["CHANNEL1", "CHANNEL2"],
+    )
+
+    assert len(obj) == 2
+
+    assert obj.notify(title="Test", body="Test") is True
+    assert mock_post.call_count == 2
+
+    sent_channels = {
+        call.kwargs["data"]["channel"] for call in mock_post.call_args_list
+    }
+    assert sent_channels == {"CHANNEL1", "CHANNEL2"}
+
+
+@mock.patch("requests.post")
+def test_plugin_signalgrid_multi_channel_partial_failure(mock_post):
+    """Test one failed channel still notifies the rest and reports False."""
+
+    ok_response = mock.Mock()
+    ok_response.status_code = requests.codes.ok
+
+    error_response = mock.Mock()
+    error_response.status_code = requests.codes.internal_server_error
+    error_response.content = b"error"
+
+    mock_post.side_effect = [error_response, ok_response]
+
+    obj = NotifySignalgrid(
+        client_key="CLIENTKEY",
+        targets=["CHANNEL1", "CHANNEL2"],
+    )
+
+    assert obj.notify(title="Test", body="Test") is False
+    assert mock_post.call_count == 2
+
+
+def test_plugin_signalgrid_no_targets():
+    """Test that a Signalgrid object with no channels loads but has
+    nothing to notify."""
+
+    obj = NotifySignalgrid(client_key="CLIENTKEY")
+
+    assert len(obj) == 1
+    assert obj.notify(title="Test", body="Test") is False
+
+
 def test_plugin_signalgrid_url_roundtrip():
     """Test Signalgrid URL parsing and reconstruction."""
 
     obj = NotifySignalgrid(
         client_key="CLIENTKEY",
-        channel="CHANNEL",
+        targets=["CHANNEL1", "CHANNEL2"],
         critical=True,
     )
 
@@ -166,11 +248,45 @@ def test_plugin_signalgrid_url_roundtrip():
 
     assert parsed is not None
     assert parsed["client_key"] == "CLIENTKEY"
-    assert parsed["channel"] == "CHANNEL"
+    assert parsed["targets"] == ["CHANNEL1", "CHANNEL2"]
     assert parsed["critical"] is True
 
     obj2 = NotifySignalgrid(**parsed)
 
     assert obj2.client_key == "CLIENTKEY"
-    assert obj2.channel == "CHANNEL"
+    assert obj2.targets == ["CHANNEL1", "CHANNEL2"]
     assert obj2.critical is True
+
+    # Two connections that share a client key differ only in the channels
+    # they notify, so they still identify as the same connection.
+    assert obj.url_identifier == obj2.url_identifier
+
+
+def test_plugin_signalgrid_client_key_override():
+    """Test that ?client_key= overrides the hostname-derived value."""
+
+    parsed = NotifySignalgrid.parse_url(
+        "signalgrid://IGNOREME/CHANNEL?client_key=REALKEY"
+    )
+
+    assert parsed is not None
+    assert parsed["client_key"] == "REALKEY"
+
+
+@mock.patch("requests.post")
+def test_plugin_signalgrid_attach_warning(mock_post):
+    """Test that attachments are ignored with a warning."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    obj = NotifySignalgrid(client_key="CLIENTKEY", targets=["CHANNEL"])
+
+    attach = apprise.AppriseAttachment(
+        os.path.join(TEST_VAR_DIR, "apprise-test.gif")
+    )
+
+    with mock.patch.object(obj, "logger") as mock_logger:
+        assert obj.notify(title="Test", body="Test", attach=attach) is True
+        assert mock_logger.warning.called


### PR DESCRIPTION
## Description

Adds native Signalgrid notification support to Apprise.

Signalgrid is a push notification service for delivering notifications to iOS and Android devices. The integration supports Apprise notification types as well as independent Signalgrid critical notifications.

## Signalgrid Notifications

* **Source**: https://signalgrid.co/
* **Image Support**: No
* **Message Format**: Plain Text
* **Message Limit**: No plugin-specific limit

Signalgrid provides push notifications for iOS and Android devices.

Apprise notification types are mapped as follows:

| Apprise | Signalgrid |
|---------|------------|
| `info` | `INFO` |
| `success` | `SUCCESS` |
| `warning` | `WARN` |
| `failure` | `CRIT` |

Critical notifications are controlled independently using the `critical` parameter.

## Account Setup

1. Sign in to your Signalgrid account.
2. Obtain your Signalgrid client key.
3. Create or select a channel and copy its channel token.
4. Use the client key and channel token in the Apprise URL.

Additional setup documentation:
https://docs.signalgrid.co/integrations/apprise/

## Syntax

Valid syntax is as follows:

- `signalgrid://{client_key}/{channel}`
- `signalgrid://{client_key}/{channel}?critical=true`

## Parameter Breakdown

| Variable | Required | Description |
|----------|----------|-------------|
| `client_key` | Yes | Your Signalgrid client key |
| `channel` | Yes | The Signalgrid channel token receiving the notification |
| `critical` | No | Send as a critical notification (`true` or `false`). Defaults to `false` |

## Examples

Send a normal notification:

```bash
apprise -vv \
    -t "Server Status" \
    -b "Server is online" \
    "signalgrid://CLIENT_KEY/CHANNEL?critical=false"
```

Send a critical failure notification:

```bash
apprise -vv \
    -t "Server Down" \
    -b "The server is unreachable" \
    -n failure \
    "signalgrid://CLIENT_KEY/CHANNEL?critical=true"
```

## New Service Completion Status

* [x] apprise/plugins/signalgrid.py
* [x] pyproject.toml
    - Updated keywords section with Signalgrid alphabetically.
* [x] README.md
    - Added Signalgrid quick-reference entry.
* [x] packaging/redhat/python-apprise.spec
    - Verify Signalgrid is present in the `%global common_description` service list before checking this box.

## Checklist

* [x] Documentation ticket created: [apprise-docs/121](https://github.com/caronc/apprise-docs/pull/121)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (`tox -e lint`).
* [x] Test coverage added or updated (`tox -e qa`).

## Testing

```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the Signalgrid branch
pip install git+https://github.com/signalgridco/apprise.git@signalgrid

# Send a normal notification
apprise -vv \
    -t "Apprise Test" \
    -b "Hello from Apprise via Signalgrid" \
    "signalgrid://CLIENT_KEY/CHANNEL?critical=false"

# Send a critical notification
apprise -vv \
    -t "Critical Test" \
    -b "Critical notification from Apprise via Signalgrid" \
    -n failure \
    "signalgrid://CLIENT_KEY/CHANNEL?critical=true"
```

The implementation has also been validated against the Signalgrid API with successful real notification delivery.
