### PR TITLE
Allow periods in Pingram API keys (JWT format)

### DIFF
--- a/apprise/plugins/pingram.py
+++ b/apprise/plugins/pingram.py
@@ -30,6 +30,8 @@
 #  2. Open your Environment settings and visit the "API Keys" section.
 #  3. Create a new Secret Key (server-to-server) or Public Key. It will
 #     look like: pingram_sk_AbCdEf012345 or pingram_pk_AbCdEf012345
+#     Newer keys carry a JWT after the prefix, so they additionally
+#     contain periods, e.g. pingram_sk_aaaa.bbbb.cccc
 #
 #  Your Apprise URL should be assembled as:
 #     pingram://{apikey}/{target}
@@ -176,7 +178,7 @@ class NotifyPingram(NotifyBase):
                 "type": "string",
                 "required": True,
                 "private": True,
-                "regex": (r"^pingram_(sk|pk)_[\w-]+$", "i"),
+                "regex": (r"^pingram_(sk|pk)_[\w.-]+$", "i"),
             },
             "target_email": {
                 "name": _("Target Email"),

--- a/tests/test_plugin_pingram.py
+++ b/tests/test_plugin_pingram.py
@@ -138,6 +138,24 @@ apprise_url_tests = (
         },
     ),
     (
+        "pingram://pingram_sk_aaaa.bbbb.cccc/+15551235553",
+        {
+            # Newer keys embed a JWT after the prefix, so the key itself
+            # contains periods
+            "instance": NotifyPingram,
+            "requests_response_text": PINGRAM_GOOD_RESPONSE,
+        },
+    ),
+    (
+        "pingram://pingram_pk_aaaa.bbbb.cccc-dd_ee/user@example.ca",
+        {
+            # JWTs are base64url encoded, so - and _ show up alongside the
+            # period delimiters
+            "instance": NotifyPingram,
+            "requests_response_text": PINGRAM_GOOD_RESPONSE,
+        },
+    ),
+    (
         "pingram://pingram_sk_abc123/+15551235553/+15551235554",
         {
             # Multiple id-less phone numbers become separate targets


### PR DESCRIPTION
## Problem

Pingram now issues API keys that carry a JWT after the `pingram_sk_` / `pingram_pk_` prefix:

```
pingram_sk_eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.<payload>.<signature>
```

The `apikey` template regex only permits `[\w-]`, which excludes the `.` delimiters. `validate_regex()` therefore rejects the key and `__init__()` raises `TypeError`. To the user this surfaces only as a generic load failure, with no hint that the key format is the problem:

```
[WARNING] apprise: An invalid Pingram API Key (pingram_sk_...) was specified.
[ERROR]   apprise: Could not load URL pingram://pingram_sk_.../+1555... on line 3.
```

The header comment in `pingram.py` documents the older `pingram_sk_AbCdEf012345` shape, which is what the regex was written against.

## Fix

Widen the character class from `[\w-]` to `[\w.-]`. The rest of the JWT alphabet is base64url, whose `-` and `_` are already covered by the existing `-` and `\w`, so adding `.` is sufficient. The header comment is updated to mention the JWT-style keys.

## Testing

Two cases added to `apprise_url_tests` in `tests/test_plugin_pingram.py` covering a JWT-shaped secret key and a public key exercising the full base64url alphabet.

Verified the tests actually cover the bug — reverting just the regex while keeping the new tests fails with exactly the reported error:

```
TypeError: An invalid Pingram API Key (pingram_sk_aaaa.bbbb.cccc) was specified.
1 failed, 5 passed
```

With the fix: `6 passed`, and `ruff format --check` / `ruff check` are clean.

Also confirmed end-to-end against a live Pingram account (self-hosted `apprise-api`): the URL now loads, the `sms` channel is auto-detected from the phone-number target, and the message is delivered:

```
[DEBUG] apprise: Pingram POST URL: https://api.pingram.io/send (cert_verify=True)
[INFO]  apprise: Sent Pingram notification to +1555...
```

Follow-up to #1665.