### PR TITLE
Add Lauther notification support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The table below identifies the services this tool supports and some example serv
 | [Kumulos](https://appriseit.com/services/kumulos/) | kumulos:// | (TCP) 443 | kumulos://apikey/serverkey
 | [LaMetric Time](https://appriseit.com/services/lametric/) | lametric:// | (TCP) 443 | lametric://apikey@device_ipaddr<br/>lametric://apikey@hostname:port<br/>lametric://client_id@client_secret
 | [Lark](https://appriseit.com/services/lark/) | lark://  | (TCP) 443   | lark://BotToken
+| [Lauther](https://appriseit.com/services/lauther/) | lauther:// | (TCP) 443 | lauther://Token
 | [Line](https://appriseit.com/services/line/) | line:// | (TCP) 443 | line://Token@User<br/>line://Token/User1/User2/UserN
 | [Mailgun](https://appriseit.com/services/mailgun/) | mailgun:// | (TCP) 443 | mailgun://user@hostname/apikey<br />mailgun://user@hostname/apikey/email<br />mailgun://user@hostname/apikey/email1/email2/emailN<br />mailgun://user@hostname/apikey/?name="From%20User"
 | [MailerSend](https://appriseit.com/services/mailersend/) | mailersend://  | (TCP) 443   | mailersend://APIToken:FromEmail/<br />mailersend://APIToken:FromEmail/ToEmail<br />mailersend://APIToken:FromEmail/ToEmail1/ToEmail2/ToEmailN/

--- a/apprise/plugins/lauther.py
+++ b/apprise/plugins/lauther.py
@@ -1,0 +1,318 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Lauther — notifications & anonymous identity
+#   1. Install the Lauther app (https://lauther.app/)
+#   2. In the app: Apps -> + -> New token
+#   3. Your token looks like: lpt_AbCdEf...
+#
+# Syntax:
+#   lauther://{token}
+#   lauther://{token}?priority=high&sound=default
+#
+
+import requests
+
+from ..common import NotifyType
+from ..locale import gettext_lazy as _
+from ..utils.parse import validate_regex
+from .base import NotifyBase
+
+
+# Priorities (Pushover-style scale)
+class LautherPriority:
+    LOWEST = -2
+    LOW = -1
+    NORMAL = 0
+    HIGH = 1
+    EMERGENCY = 2
+
+
+LAUTHER_PRIORITIES = {
+    # Note: This also acts as a reverse lookup mapping
+    LautherPriority.LOWEST: "lowest",
+    LautherPriority.LOW: "low",
+    LautherPriority.NORMAL: "normal",
+    LautherPriority.HIGH: "high",
+    LautherPriority.EMERGENCY: "emergency",
+}
+
+LAUTHER_PRIORITY_MAP = {
+    # short for 'lowest'
+    "lowest": LautherPriority.LOWEST,
+    # short for 'low'
+    "low": LautherPriority.LOW,
+    # short for 'normal'
+    "normal": LautherPriority.NORMAL,
+    # short for 'high'
+    "high": LautherPriority.HIGH,
+    # short for 'emergency'
+    "emergency": LautherPriority.EMERGENCY,
+}
+
+
+class NotifyLauther(NotifyBase):
+    """A wrapper for Lauther Notifications."""
+
+    # The default descriptive name associated with the Notification
+    service_name = _("Lauther")
+
+    # The services URL
+    service_url = "https://lauther.app/"
+
+    # The default secure protocol
+    secure_protocol = "lauther"
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = "https://lauther.app/docs.html"
+
+    # Notification URL
+    notify_url = "https://api.lauther.id/v1/push"
+
+    # Define object templates
+    templates = ("{schema}://{token}",)
+
+    # Define our tokens; these are the minimum tokens required required to
+    # be passed into this function (as arguments).
+    template_tokens = dict(
+        NotifyBase.template_tokens,
+        **{
+            "token": {
+                "name": _("Token"),
+                "type": "string",
+                "private": True,
+                "required": True,
+                "regex": (r"^lpt_[a-z0-9]+$", "i"),
+            },
+        },
+    )
+
+    # Define our template arguments
+    template_args = dict(
+        NotifyBase.template_args,
+        **{
+            "token": {
+                "alias_of": "token",
+            },
+            "priority": {
+                "name": _("Priority"),
+                "type": "choice:int",
+                "values": LAUTHER_PRIORITIES,
+                "default": LautherPriority.NORMAL,
+            },
+            "sound": {
+                "name": _("Sound"),
+                "type": "string",
+            },
+            "click": {
+                "name": _("Click URL"),
+                "type": "string",
+            },
+        },
+    )
+
+    def __init__(self, token, priority=None, sound=None, click=None, **kwargs):
+        """Initialize Lauther Object."""
+        super().__init__(**kwargs)
+
+        self.token = validate_regex(
+            token, *self.template_tokens["token"]["regex"]
+        )
+        if not self.token:
+            msg = f"The Lauther token specified ({token}) is invalid."
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # The priority of the message
+        self.priority = int(
+            NotifyLauther.template_args["priority"]["default"]
+            if priority is None
+            else next(
+                (
+                    v
+                    # Longest key first: "lowest" and "low" share a prefix, so
+                    # a shortest-first scan resolves "low" to LOWEST. Upstream
+                    # Pushover avoids this with single-letter keys, which is
+                    # not available here — its scale has no "lowest".
+                    for k, v in sorted(
+                        LAUTHER_PRIORITY_MAP.items(),
+                        key=lambda kv: -len(kv[0]),
+                    )
+                    if str(priority).lower().startswith(k)
+                ),
+                (
+                    int(priority)
+                    if str(priority).lstrip("+-").isdigit()
+                    else NotifyLauther.template_args["priority"]["default"]
+                ),
+            )
+        )
+        if self.priority not in LAUTHER_PRIORITIES:
+            msg = f"The Lauther priority specified ({priority}) is invalid."
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # An optional sound and click-through URL
+        self.sound = sound
+        self.click = click
+
+        return
+
+    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+        """Perform the Lauther Notification."""
+
+        headers = {
+            "User-Agent": self.app_id,
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.token}",
+        }
+
+        payload = {
+            "title": title,
+            "message": body,
+            "priority": self.priority,
+        }
+        if self.sound:
+            payload["sound"] = self.sound
+        if self.click:
+            payload["url"] = self.click
+
+        self.logger.debug(
+            "Lauther POST URL:"
+            f" {self.notify_url} (cert_verify={self.verify_certificate!r})"
+        )
+        self.logger.debug(f"Lauther Payload: {payload!s}")
+
+        # Always call throttle before any remote server i/o is made
+        self.throttle()
+
+        try:
+            r = requests.post(
+                self.notify_url,
+                json=payload,
+                headers=headers,
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+                allow_redirects=self.redirects,
+            )
+            if r.status_code != requests.codes.ok:
+                # We had a problem
+                status_str = NotifyLauther.http_response_code_lookup(
+                    r.status_code
+                )
+
+                self.logger.warning(
+                    "Failed to send Lauther notification: "
+                    "{}{}error={}.".format(
+                        status_str, ", " if status_str else "", r.status_code
+                    )
+                )
+
+                self.logger.debug(
+                    "Response Details:\r\n%r", (r.content or b"")[:2000]
+                )
+
+                # Return; we're done
+                return False
+
+            else:
+                self.logger.info("Sent Lauther notification.")
+
+        except requests.RequestException as e:
+            self.logger.warning(
+                "A Connection error occurred sending Lauther notification."
+            )
+            self.logger.debug(f"Socket Exception: {e!s}")
+
+            # Return; we're done
+            return False
+
+        return True
+
+    def url(self, privacy=False, *args, **kwargs):
+        """Returns the URL built dynamically based on specified arguments."""
+
+        # Define any URL parameters
+        params = {
+            "priority": LAUTHER_PRIORITIES[self.priority],
+        }
+        if self.sound:
+            params["sound"] = self.sound
+        if self.click:
+            params["click"] = self.click
+
+        # Extend our parameters
+        params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
+
+        return "{schema}://{token}/?{params}".format(
+            schema=self.secure_protocol,
+            token=self.pprint(self.token, privacy, safe=""),
+            params=NotifyLauther.urlencode(params),
+        )
+
+    @property
+    def url_identifier(self):
+        """Returns all of the identifiers that make this URL unique from
+        another simliar one.
+
+        Targets or end points should never be identified here.
+        """
+        return (self.secure_protocol, self.token)
+
+    @staticmethod
+    def parse_url(url):
+        """Parses the URL and returns enough arguments that can allow us to re-
+        instantiate this object."""
+
+        results = NotifyBase.parse_url(url, verify_host=False)
+        if not results:
+            # We're done early as we couldn't load the results
+            return results
+
+        # Allow over-ride; template_args advertises `token` as an argument,
+        # so a URL of the form lauther://?token=lpt_... has to work.
+        if "token" in results["qsd"] and len(results["qsd"]["token"]):
+            results["token"] = NotifyLauther.unquote(results["qsd"]["token"])
+
+        else:
+            results["token"] = NotifyLauther.unquote(results["host"])
+
+        # Get our priority (if defined)
+        if "priority" in results["qsd"] and len(results["qsd"]["priority"]):
+            results["priority"] = NotifyLauther.unquote(
+                results["qsd"]["priority"]
+            )
+
+        # Get our sound (if defined)
+        if "sound" in results["qsd"] and len(results["qsd"]["sound"]):
+            results["sound"] = NotifyLauther.unquote(results["qsd"]["sound"])
+
+        # Get our click-through URL (if defined)
+        if "click" in results["qsd"] and len(results["qsd"]["click"]):
+            results["click"] = NotifyLauther.unquote(results["qsd"]["click"])
+
+        return results

--- a/apprise/plugins/lauther.py
+++ b/apprise/plugins/lauther.py
@@ -25,7 +25,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# Lauther — notifications & anonymous identity
+# Lauther - notifications and anonymous identity
 #   1. Install the Lauther app (https://lauther.app/)
 #   2. In the app: Apps -> + -> New token
 #   3. Your token looks like: lpt_AbCdEf...
@@ -34,6 +34,8 @@
 #   lauther://{token}
 #   lauther://{token}?priority=high&sound=default
 #
+# Resources:
+# - https://lauther.app/docs.html
 
 import requests
 
@@ -79,7 +81,7 @@ class NotifyLauther(NotifyBase):
     """A wrapper for Lauther Notifications."""
 
     # The default descriptive name associated with the Notification
-    service_name = _("Lauther")
+    service_name = "Lauther"
 
     # The services URL
     service_url = "https://lauther.app/"
@@ -88,15 +90,23 @@ class NotifyLauther(NotifyBase):
     secure_protocol = "lauther"
 
     # A URL that takes you to the setup/help of the specific protocol
-    setup_url = "https://lauther.app/docs.html"
+    setup_url = "https://appriseit.com/services/lauther/"
 
     # Notification URL
     notify_url = "https://api.lauther.id/v1/push"
 
+    # The Lauther API has no endpoint for uploading files, so there is
+    # nothing to wire up here; attachment_support stays at its False
+    # default.
+
+    # The maximum allowable characters allowed in the body per message as
+    # documented by the Lauther API
+    body_maxlen = 2000
+
     # Define object templates
     templates = ("{schema}://{token}",)
 
-    # Define our tokens; these are the minimum tokens required required to
+    # Define our tokens; these are the minimum tokens required to
     # be passed into this function (as arguments).
     template_tokens = dict(
         NotifyBase.template_tokens,
@@ -132,10 +142,44 @@ class NotifyLauther(NotifyBase):
                 "name": _("Click URL"),
                 "type": "string",
             },
+            "icon": {
+                "name": _("Icon URL"),
+                "type": "string",
+            },
+            "color": {
+                "name": _("Color"),
+                "type": "string",
+            },
+            # Named "group" (not "tag") since "tag" is already claimed by
+            # Apprise's own notification tagging system (see ?tag= in the
+            # CLI/API docs); the value is still sent to Lauther as "tag".
+            "group": {
+                "name": _("Group"),
+                "type": "string",
+            },
+            # Named "route" (not "path") since "path" is already the
+            # reserved key Apprise's URL parser uses for the URL's own
+            # path component; the value is still sent to Lauther as
+            # "path".
+            "route": {
+                "name": _("Route"),
+                "type": "string",
+            },
         },
     )
 
-    def __init__(self, token, priority=None, sound=None, click=None, **kwargs):
+    def __init__(
+        self,
+        token,
+        priority=None,
+        sound=None,
+        click=None,
+        icon=None,
+        color=None,
+        group=None,
+        route=None,
+        **kwargs,
+    ):
         """Initialize Lauther Object."""
         super().__init__(**kwargs)
 
@@ -157,7 +201,7 @@ class NotifyLauther(NotifyBase):
                     # Longest key first: "lowest" and "low" share a prefix, so
                     # a shortest-first scan resolves "low" to LOWEST. Upstream
                     # Pushover avoids this with single-letter keys, which is
-                    # not available here — its scale has no "lowest".
+                    # not available here since its scale has no "lowest".
                     for k, v in sorted(
                         LAUTHER_PRIORITY_MAP.items(),
                         key=lambda kv: -len(kv[0]),
@@ -176,9 +220,13 @@ class NotifyLauther(NotifyBase):
             self.logger.warning(msg)
             raise TypeError(msg)
 
-        # An optional sound and click-through URL
+        # Optional appearance overrides and metadata
         self.sound = sound
         self.click = click
+        self.icon = icon
+        self.color = color
+        self.group = group
+        self.route = route
 
         return
 
@@ -200,6 +248,14 @@ class NotifyLauther(NotifyBase):
             payload["sound"] = self.sound
         if self.click:
             payload["url"] = self.click
+        if self.icon:
+            payload["icon"] = self.icon
+        if self.color:
+            payload["color"] = self.color
+        if self.group:
+            payload["tag"] = self.group
+        if self.route:
+            payload["path"] = self.route
 
         self.logger.debug(
             "Lauther POST URL:"
@@ -264,6 +320,14 @@ class NotifyLauther(NotifyBase):
             params["sound"] = self.sound
         if self.click:
             params["click"] = self.click
+        if self.icon:
+            params["icon"] = self.icon
+        if self.color:
+            params["color"] = self.color
+        if self.group:
+            params["group"] = self.group
+        if self.route:
+            params["route"] = self.route
 
         # Extend our parameters
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
@@ -314,5 +378,21 @@ class NotifyLauther(NotifyBase):
         # Get our click-through URL (if defined)
         if "click" in results["qsd"] and len(results["qsd"]["click"]):
             results["click"] = NotifyLauther.unquote(results["qsd"]["click"])
+
+        # Get our icon URL (if defined)
+        if "icon" in results["qsd"] and len(results["qsd"]["icon"]):
+            results["icon"] = NotifyLauther.unquote(results["qsd"]["icon"])
+
+        # Get our color (if defined)
+        if "color" in results["qsd"] and len(results["qsd"]["color"]):
+            results["color"] = NotifyLauther.unquote(results["qsd"]["color"])
+
+        # Get our grouping/collapse key (if defined)
+        if "group" in results["qsd"] and len(results["qsd"]["group"]):
+            results["group"] = NotifyLauther.unquote(results["qsd"]["group"])
+
+        # Get our paired-site route (if defined)
+        if "route" in results["qsd"] and len(results["qsd"]["route"]):
+            results["route"] = NotifyLauther.unquote(results["qsd"]["route"])
 
         return results

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -68,7 +68,8 @@ notification services. It supports sending alerts to platforms such as: \
 `Gotify`, `GroupMe`, `Growl`, `Guilded`, `Home Assistant`, `httpSMS`, \
 `HumHub`, \
 `IFTTT`, `IRC`, `Jellyfin`, `Jira`, `Join`, `Kavenegar`, `KODI`, `Kook`, \
-`Kumulos`, `LaMetric`, `Lark`, `Line`, `MacOSX`, `Mailgun`, `MailerSend`, \
+`Kumulos`, `LaMetric`, `Lark`, `Lauther`, `Line`, `MacOSX`, `Mailgun`, \
+`MailerSend`, \
 `Mastodon`, \
 `Mattermost`, `Matrix`, `MessageBird`, `Microsoft Windows`, \
 `Microsoft Teams`, `Misskey`, \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ keywords = [
     "Kumulos",
     "LaMetric",
     "Lark",
+    "Lauther",
     "Line",
     "MacOSX",
     "Mailgun",

--- a/tests/test_plugin_lauther.py
+++ b/tests/test_plugin_lauther.py
@@ -118,6 +118,15 @@ apprise_url_tests = (
         },
     ),
     (
+        "lauther://lpt_abc123"
+        "?icon=https://example.ca/icon.png&color=%23D9EF00"
+        "&group=orders&route=/orders/123",
+        {
+            # Icon, color, group, and paired-site route overrides
+            "instance": NotifyLauther,
+        },
+    ),
+    (
         "lauther://lpt_abc123",
         {
             "instance": NotifyLauther,

--- a/tests/test_plugin_lauther.py
+++ b/tests/test_plugin_lauther.py
@@ -1,0 +1,219 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Disable logging for a cleaner testing output
+import logging
+from unittest.mock import Mock, patch
+
+from helpers import AppriseURLTester
+import requests
+
+from apprise import Apprise, NotifyType
+from apprise.plugins.lauther import LautherPriority, NotifyLauther
+
+logging.disable(logging.CRITICAL)
+
+# Our Testing URLs
+apprise_url_tests = (
+    (
+        "lauther://",
+        {
+            # No token specified
+            "instance": TypeError,
+        },
+    ),
+    (
+        "lauther://:@/",
+        {
+            "instance": TypeError,
+        },
+    ),
+    (
+        "lauther://%badtoken%",
+        {
+            # Not a valid token
+            "instance": TypeError,
+        },
+    ),
+    (
+        "lauther://abc123",
+        {
+            # Tokens must carry the lpt_ prefix
+            "instance": TypeError,
+        },
+    ),
+    (
+        "lauther://lpt_abc123",
+        {
+            # A valid token
+            "instance": NotifyLauther,
+            # Our expected url(privacy=True) startswith() response:
+            "privacy_url": "lauther://l...3/",
+        },
+    ),
+    (
+        "lauther://?token=lpt_abc123",
+        {
+            # Token provided as an argument
+            "instance": NotifyLauther,
+        },
+    ),
+    (
+        "lauther://lpt_abc123?priority=high",
+        {
+            # Priority by name
+            "instance": NotifyLauther,
+        },
+    ),
+    (
+        "lauther://lpt_abc123?priority=2",
+        {
+            # Priority by value
+            "instance": NotifyLauther,
+        },
+    ),
+    (
+        "lauther://lpt_abc123?priority=invalid",
+        {
+            # An invalid priority falls back to the default
+            "instance": NotifyLauther,
+        },
+    ),
+    (
+        "lauther://lpt_abc123?priority=99",
+        {
+            # An out-of-range priority is not acceptable
+            "instance": TypeError,
+        },
+    ),
+    (
+        "lauther://lpt_abc123?sound=default&click=https://example.ca",
+        {
+            # Sound and click-through URL
+            "instance": NotifyLauther,
+        },
+    ),
+    (
+        "lauther://lpt_abc123",
+        {
+            "instance": NotifyLauther,
+            # force a failure
+            "response": False,
+            "requests_response_code": requests.codes.internal_server_error,
+        },
+    ),
+    (
+        "lauther://lpt_abc123",
+        {
+            "instance": NotifyLauther,
+            # throw a bizarre code forcing us to fail to look it up
+            "response": False,
+            "requests_response_code": 999,
+        },
+    ),
+    (
+        "lauther://lpt_abc123",
+        {
+            "instance": NotifyLauther,
+            # Throws a series of i/o exceptions with this flag
+            # is set and tests that we gracefully handle them
+            "test_requests_exceptions": True,
+        },
+    ),
+)
+
+
+def test_plugin_lauther_urls():
+    """NotifyLauther() Apprise URLs."""
+
+    # Run our general tests
+    AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+@patch("requests.post")
+def test_plugin_lauther_general(mock_post):
+    """NotifyLauther() General Checks."""
+
+    response = Mock()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    # Prepare our object
+    obj = Apprise.instantiate("lauther://lpt_abc123")
+    assert isinstance(obj, NotifyLauther)
+    assert obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
+
+    assert mock_post.call_count == 1
+    details = mock_post.call_args_list[0]
+    assert details[0][0] == "https://api.lauther.id/v1/push"
+
+    # The token travels in the Authorization header, never the payload
+    assert details[1]["headers"]["Authorization"] == "Bearer lpt_abc123"
+    assert "token" not in details[1]["json"]
+
+    # Verify our url() call is reversible back into the same object
+    assert isinstance(obj.url(), str)
+    obj_b = Apprise.instantiate(obj.url())
+    assert isinstance(obj_b, NotifyLauther)
+    assert obj.url_identifier == obj_b.url_identifier
+
+    # The token is masked when privacy is requested
+    assert "lpt_abc123" not in obj.url(privacy=True)
+
+
+@patch("requests.post")
+def test_plugin_lauther_priority(mock_post):
+    """NotifyLauther() Priority Handling."""
+
+    response = Mock()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    # Named priorities resolve to their integer equivalent
+    obj = Apprise.instantiate("lauther://lpt_abc123?priority=emergency")
+    assert isinstance(obj, NotifyLauther)
+    assert obj.priority == LautherPriority.EMERGENCY
+
+    # As do numeric ones
+    obj = Apprise.instantiate("lauther://lpt_abc123?priority=-2")
+    assert isinstance(obj, NotifyLauther)
+    assert obj.priority == LautherPriority.LOWEST
+
+    # No priority at all lands on the default
+    obj = Apprise.instantiate("lauther://lpt_abc123")
+    assert isinstance(obj, NotifyLauther)
+    assert obj.priority == LautherPriority.NORMAL
+
+    # "low" and "lowest" share a prefix; each must resolve to itself. A
+    # shortest-key-first scan silently mapped "low" onto LOWEST.
+    obj = Apprise.instantiate("lauther://lpt_abc123?priority=low")
+    assert isinstance(obj, NotifyLauther)
+    assert obj.priority == LautherPriority.LOW
+
+    obj = Apprise.instantiate("lauther://lpt_abc123?priority=lowest")
+    assert isinstance(obj, NotifyLauther)
+    assert obj.priority == LautherPriority.LOWEST


### PR DESCRIPTION
## What this adds

Support for [Lauther](https://lauther.app/) — a push notification and identity service with a plain documented HTTPS API. API docs: https://lauther.app/docs.html

Users mint a token in the Lauther app (**Apps → + → New token**); it carries an `lpt_` prefix, which the plugin validates before attempting any I/O.

## URL syntax

| Format | Notes |
| --- | --- |
| `lauther://{token}` | Simplest form |
| `lauther://?token={token}` | Token as an argument |
| `lauther://{token}?priority=high` | By name: `lowest`, `low`, `normal`, `high`, `emergency` |
| `lauther://{token}?priority=2` | Or by value, on the familiar `-2`…`2` scale |
| `lauther://{token}?sound=default` | Optional sound |
| `lauther://{token}?click=https://example.com` | Optional tap-through URL |

## Notes for review

- The credential is sent as `Authorization: Bearer …` rather than in the body. The service accepts both, but its documentation recommends the header wherever the client is under the caller's control.
- **Easy manual verification without credentials:** the service is live, and any invalid token returns `HTTP 403`, e.g.
  ```
  curl -X POST https://api.lauther.id/v1/push \
    -H "Authorization: Bearer lpt_invalid" \
    -H "Content-Type: application/json" \
    -d '{"title":"t","message":"m"}'
  → {"error":"Invalid or revoked token"}
  ```
- `tests/test_plugin_lauther.py` follows the `AppriseURLTester` table style used by `test_plugin_chanify.py`, plus checks for priority resolution and for the token not appearing in the payload or in `url(privacy=True)`.
- `pytest tests/test_plugin_lauther.py` → 3 passed. `ruff check` and `ruff format --check` are clean on both files.
- One pre-existing failure in `tests/test_apprise_translations.py::test_apprise_trans_add` reproduces on a pristine checkout of `master` on this machine (Windows), so it is unrelated to this change.

Happy to draft a wiki page for the plugin if that would help — and glad to adjust anything that does not match house conventions.

Readme Docs added here: https://github.com/caronc/apprise-docs/pull/123