### PR TITLE
docs: fix typo recomended -> recommended

### DIFF
--- a/apprise/url.py
+++ b/apprise/url.py
@@ -1008,7 +1008,7 @@ class URLBase:
             verify_host (:obj:`bool`, optional): a flag kept with the parsed
                  URL which some child classes will later use to verify SSL
                  keys (if SSL transactions take place).  Unless under very
-                 specific circumstances, it is strongly recomended that
+                 specific circumstances, it is strongly recommended that
                  you leave this default value set to True.
 
         Returns:


### PR DESCRIPTION
Corrects the misspelling `recomended` -> `recommended` in `apprise/url.py`.

Documentation only, no behaviour change.