### PR TITLE
fixes intermittent test failures for matrix

### DIFF
--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -25,6 +25,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import gc
 from json import dumps, loads
 
 # Disable logging for a cleaner testing output
@@ -75,6 +76,16 @@ MATRIX_GOOD_RESPONSE = dumps(
 
 # Attachment Directory
 TEST_VAR_DIR = os.path.join(os.path.dirname(__file__), "var")
+
+
+def _force_del_cleanup():
+    """Run a garbage collection pass right after `del obj`.
+
+    This is required otherwise the timing of the systems garbage collection
+    can cause issues with the testing
+    """
+    gc.collect()
+
 
 # Our Testing URLs
 apprise_url_tests = (
@@ -1075,6 +1086,7 @@ def test_plugin_matrix_rooms(mock_post, mock_get, mock_put):
 
     # Force a object removal (thus a logout call)
     del obj
+    _force_del_cleanup()
 
 
 def test_plugin_matrix_url_parsing():
@@ -1167,6 +1179,7 @@ def test_plugin_matrix_image_errors(mock_post, mock_get, mock_put):
 
     # Force a object removal (thus a logout call)
     del obj
+    _force_del_cleanup()
 
     def mock_function_handing(url, data, **kwargs):
         """Dummy function for handling image posts (successfully)"""
@@ -1203,6 +1216,7 @@ def test_plugin_matrix_image_errors(mock_post, mock_get, mock_put):
 
     # Force a object removal (thus a logout call)
     del obj
+    _force_del_cleanup()
 
 
 @mock.patch("requests.put")
@@ -1331,6 +1345,7 @@ def test_plugin_matrix_attachments_api_v3(mock_post, mock_put):
 
     # Force a object removal (thus a logout call)
     del obj
+    _force_del_cleanup()
 
 
 @mock.patch("requests.put")
@@ -1583,6 +1598,7 @@ def test_plugin_matrix_attachments_api_v2(mock_post, mock_get, mock_put):
 
     # Force a object removal (thus a logout call)
     del obj
+    _force_del_cleanup()
 
     # Instantiate our object
     obj = Apprise.instantiate("matrixs://user:pass@localhost/#general?v=2")
@@ -1696,6 +1712,7 @@ def test_plugin_matrix_attachments_api_v2(mock_post, mock_get, mock_put):
 
     # Force a object removal (thus a logout call)
     del obj
+    _force_del_cleanup()
 
     # Instantiate our object (no discovery required)
     obj = Apprise.instantiate(
@@ -1964,6 +1981,7 @@ def test_plugin_matrix_transaction_ids_api_v3_no_cache(
 
         # Force a object removal (thus a logout call)
         del obj
+        _force_del_cleanup()
 
         assert mock_get.call_count == 0
         assert mock_post.call_count == 1


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1715 and #1710 

garbage collection issue with the handling of Python v3.9 (EPEL9) and the way the Matrix Objects are deconstructed can cause random issues during desting not enforced.

Fixes error:
```text
____________________ test_plugin_matrix_attachments_api_v2 _____________________

mock_post = <MagicMock name='post' id='140587612706416'>
mock_get = <MagicMock name='get' id='140587612491104'>
mock_put = <MagicMock name='put' id='140587612149120'>

    @mock.patch("requests.put")
    @mock.patch("requests.get")
    @mock.patch("requests.post")
    def test_plugin_matrix_attachments_api_v2(mock_post, mock_get, mock_put):
        """NotifyMatrix() Attachment Checks (v2)"""
    
        # Prepare a good response
        response = mock.Mock()
        response.status_code = requests.codes.ok
        response.content = MATRIX_GOOD_RESPONSE.encode("utf-8")
    
        # Prepare a bad response
        bad_response = mock.Mock()
        bad_response.status_code = requests.codes.internal_server_error
    
        # Prepare Mock return object
        mock_post.return_value = response
        mock_get.return_value = response
        mock_put.return_value = response
    
        # Instantiate our object
        obj = Apprise.instantiate("***localhost/#general?v=2")
    
        # attach our content
        attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
    
        assert (
            obj.notify(
                body="body",
                title="title",
                notify_type=NotifyType.INFO,
                attach=attach,
            )
            is True
        )
    
        attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
    
        # Attach an unsupported file
        mock_post.return_value = response
        mock_get.return_value = response
        mock_post.side_effect = None
        mock_get.side_effect = None
    
        # Force a object removal (thus a logout call)
        del obj
    
        # Instantiate our object
        obj = Apprise.instantiate("***localhost/#general?v=2")
    
        # Reset our object
        mock_post.reset_mock()
        mock_get.reset_mock()
        mock_put.reset_mock()
    
        assert (
            obj.notify(
                body="body",
                title="title",
                notify_type=NotifyType.INFO,
                attach=attach,
            )
            is True
        )
    
        # Test our call count -- login, join, upload use POST; sends use PUT
        assert mock_post.call_count == 3
        assert (
            mock_post.call_args_list[0][0][0]
            == "https://matrix.example.com/_matrix/client/r0/login"
        )
        assert (
            mock_post.call_args_list[1][0][0]
            == "https://matrix.example.com/_matrix/client/r0/"
            "join/%23general%3Alocalhost"
        )
        assert (
            mock_post.call_args_list[2][0][0]
            == "https://matrix.example.com/_matrix/media/r0/upload"
        )
        assert mock_put.call_count == 2
        assert (
            mock_put.call_args_list[0][0][0]
            == "https://matrix.example.com/_matrix/client/r0"
            "/rooms/%21abc123%3Alocalhost/send/m.room.message/0"
        )
        assert (
            mock_put.call_args_list[1][0][0]
            == "https://matrix.example.com/_matrix/client/r0/"
            "rooms/%21abc123%3Alocalhost/send/m.room.message/1"
        )
    
        # Attach an unsupported file type; these are skipped
        attach = AppriseAttachment(
            os.path.join(TEST_VAR_DIR, "apprise-archive.zip")
        )
        assert (
            obj.notify(
                body="body",
                title="title",
                notify_type=NotifyType.INFO,
                attach=attach,
            )
            is True
        )
    
        # An invalid attachment will cause a failure
        path = os.path.join(TEST_VAR_DIR, "/invalid/path/to/an/invalid/file.jpg")
        attach = AppriseAttachment(path)
        assert (
            obj.notify(
                body="body",
                title="title",
                notify_type=NotifyType.INFO,
                attach=path,
            )
            is False
        )
    
        # update our attachment to be valid
        attach = AppriseAttachment(os.path.join(TEST_VAR_DIR, "apprise-test.gif"))
    
        mock_post.return_value = None
        mock_get.return_value = None
    
        # Throw an exception on the first call to requests.post()
        for side_effect in (requests.RequestException(), OSError(), bad_response):
            # Reset our value
            mock_post.reset_mock()
            mock_get.reset_mock()
    
            mock_post.side_effect = [side_effect, response]
            mock_get.side_effect = [side_effect, response]
    
            assert obj.send(body="test", attach=attach) is False
    
        # Throw an exception on the attachment send (now uses PUT)
        for side_effect in (requests.RequestException(), OSError(), bad_response):
            # Reset our value
            mock_post.reset_mock()
            mock_get.reset_mock()
            mock_put.reset_mock()
    
            mock_post.side_effect = [response]  # upload ok
            mock_put.side_effect = [side_effect, side_effect]  # sends fail
    
            # We'll fail now because of our error handling
            assert obj.send(body="test", attach=attach) is False
    
        # handle a bad response on the attachment send (now PUT)
        mock_post.side_effect = [response]  # upload ok
        mock_put.side_effect = [bad_response, response]  # attachment fails
        mock_get.side_effect = None
    
        # We'll fail now because of an internal exception
        assert obj.send(body="test", attach=attach) is False
    
        # Force a object removal (thus a logout call)
        del obj
    
        # Instantiate our object (no discovery required)
        obj = Apprise.instantiate(
            "***localhost/#general?v=2&discovery=no&image=y"
        )
    
        # Reset our object
        mock_post.reset_mock()
        mock_get.reset_mock()
        mock_put.reset_mock()
    
        # login + join succeed; image inline send (now PUT) fails
        mock_post.side_effect = [response, response]
        mock_get.side_effect = None
        mock_put.side_effect = [bad_response]
    
        # image attachment didn't succeed
>       assert (
            obj.notify(body="body", title="title", notify_type=NotifyType.INFO)
            is False
        )

tests/test_plugin_matrix.py:1716: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../BUILDROOT/python-apprise-1.13.0-1.el9.x86_64/usr/lib/python3.9/site-packages/apprise/plugins/base.py:713: in notify
    the_calls = [self.send(**kwargs2) for kwargs2 in send_calls]
../../BUILDROOT/python-apprise-1.13.0-1.el9.x86_64/usr/lib/python3.9/site-packages/apprise/plugins/base.py:713: in <listcomp>
    the_calls = [self.send(**kwargs2) for kwargs2 in send_calls]
../../BUILDROOT/python-apprise-1.13.0-1.el9.x86_64/usr/lib/python3.9/site-packages/apprise/plugins/matrix/base.py:595: in send
    return getattr(
../../BUILDROOT/python-apprise-1.13.0-1.el9.x86_64/usr/lib/python3.9/site-packages/apprise/plugins/matrix/base.py:1042: in _send_server_notification
    room_id = self._room_join(room)
../../BUILDROOT/python-apprise-1.13.0-1.el9.x86_64/usr/lib/python3.9/site-packages/apprise/plugins/matrix/base.py:1685: in _room_join
    postokay, response, status_code = self._fetch(path, payload=payload)
../../BUILDROOT/python-apprise-1.13.0-1.el9.x86_64/usr/lib/python3.9/site-packages/apprise/plugins/matrix/base.py:1987: in _fetch
    r = fn(
/usr/lib64/python3.9/unittest/mock.py:1092: in __call__
    return self._mock_call(*args, **kwargs)
/usr/lib64/python3.9/unittest/mock.py:1096: in _mock_call
    return self._execute_mock_call(*args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <MagicMock name='post' id='140587612706416'>
args = ('https://localhost/_matrix/client/r0/join/%23general%3Alocalhost',)
kwargs = {'allow_redirects': True, 'data': '{}', 'headers': {'Accept': 'application/json', 'Authorization': '***', 'Content-Type': 'application/json', 'User-Agent': 'Apprise'}, 'params': None, ...}
effect = <list_iterator object at 0x7fdd1ab84700>

    def _execute_mock_call(self, /, *args, **kwargs):
        # separate from _increment_mock_call so that awaited functions are
        # executed separately from their call, also AsyncMock overrides this method
    
        effect = self.side_effect
        if effect is not None:
            if _is_exception(effect):
                raise effect
            elif not _callable(effect):
>               result = next(effect)
E               StopIteration

/usr/lib64/python3.9/unittest/mock.py:1153: StopIteration
```

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [ ] Documentation ticket created (if applicable): n/a
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@el9-matrix-build-failure-fix

tox -e qa
```
