### PR TITLE
feat(matrix): add opt-in automatic SAS verification

### DIFF
--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -67,6 +67,7 @@ from .e2ee import (
     MATRIX_E2EE_SUPPORT,
     MatrixMegOlmSession,
     MatrixOlmAccount,
+    MatrixSASVerification,
     encrypt_attachment,
     verify_device_keys,
     verify_signed_otk,
@@ -256,6 +257,9 @@ class NotifyMatrix(NotifyBase):
     # key-shares skip devices that have no OTK available.
     default_e2ee_otk_replenish_threshold = 5
 
+    # Maximum time an opt-in verification bootstrap waits for SAS events.
+    default_autoverify_timeout_sec = 120
+
     # Used for server discovery
     discovery_base_key = "__discovery_base"
     discovery_identity_key = "__discovery_identity"
@@ -384,6 +388,11 @@ class NotifyMatrix(NotifyBase):
                 "type": "bool",
                 "default": True,
             },
+            "autoverify": {
+                "name": _("Automatic Device Verification"),
+                "type": "bool",
+                "default": False,
+            },
             "token": {
                 "alias_of": "token",
             },
@@ -404,6 +413,7 @@ class NotifyMatrix(NotifyBase):
         hsreq=None,
         webhook_path=None,
         e2ee=None,
+        autoverify=None,
         **kwargs,
     ):
         """Initialize Matrix Object."""
@@ -473,6 +483,11 @@ class NotifyMatrix(NotifyBase):
             self.template_args["e2ee"]["default"]
             if e2ee is None
             else parse_bool(e2ee)
+        )
+        self.autoverify = (
+            self.template_args["autoverify"]["default"]
+            if autoverify is None
+            else parse_bool(autoverify)
         )
 
         # Setup our mode
@@ -1027,6 +1042,12 @@ class NotifyMatrix(NotifyBase):
                     "Matrix E2EE setup failed; "
                     "messages will be sent unencrypted."
                 )
+
+        if e2ee_capable and self.autoverify and not self._e2ee_auto_verify():
+            self.logger.warning(
+                "Matrix E2EE automatic device verification did not complete."
+            )
+            return False
 
         # Plaintext attachment payloads for unencrypted rooms.
         # Lazy-initialized on the first unencrypted room so that purely
@@ -2131,6 +2152,266 @@ class NotifyMatrix(NotifyBase):
             expires=self.default_cache_expiry_sec,
         )
         return result
+
+    def _e2ee_send_verification_event(
+        self, event_type, user_id, device_id, content
+    ):
+        """Send one unencrypted SAS event to a specific Matrix device."""
+        path = "/sendToDevice/{}/{}".format(event_type, uuid.uuid4().hex)
+        ok, _, _ = self._fetch(
+            path,
+            payload={"messages": {user_id: {device_id: content}}},
+            method="PUT",
+        )
+        return ok
+
+    def _e2ee_verification_cancel(self, active, code, reason):
+        """Cancel an active SAS transaction on the peer device."""
+        if not active:
+            return False
+        return self._e2ee_send_verification_event(
+            "m.key.verification.cancel",
+            active["user_id"],
+            active["device_id"],
+            {
+                "transaction_id": active["transaction_id"],
+                "code": code,
+                "reason": reason,
+            },
+        )
+
+    def _e2ee_verification_peer_keys(self, user_id, device_id):
+        """Return verified device and advertised cross-signing keys."""
+        ok, response, _ = self._fetch(
+            "/keys/query",
+            payload={"device_keys": {user_id: [device_id]}},
+        )
+        if not ok or not isinstance(response, dict):
+            return None
+
+        device = (
+            response.get("device_keys", {}).get(user_id, {}).get(device_id)
+        )
+        if not device or not verify_device_keys(device, user_id, device_id):
+            return None
+
+        keys = dict(device.get("keys", {}))
+        master_key = response.get("master_keys", {}).get(user_id, {})
+        if isinstance(master_key, dict):
+            keys.update(master_key.get("keys", {}))
+        return keys
+
+    def _e2ee_store_verified_binding(self):
+        """Remember that the current custom E2EE identity completed SAS."""
+        binding = self.store.get("e2ee_device_binding")
+        if not binding:
+            return False
+        return self.store.set(
+            "e2ee_verified_binding",
+            binding,
+            expires=self.default_cache_expiry_sec,
+        )
+
+    def _e2ee_auto_verify(self):
+        """Automatically complete one same-user SAS verification.
+
+        This is an explicit bootstrap operation enabled by ``autoverify=yes``.
+        It consumes only unencrypted verification events from ``/sync`` and
+        does not introduce libolm or another Matrix device identity.
+        """
+        binding = self.store.get("e2ee_device_binding")
+        if binding and self.store.get("e2ee_verified_binding") == binding:
+            return True
+        if not self.user_id or not self.device_id or not self._e2ee_account:
+            return False
+
+        self.logger.info(
+            "Matrix E2EE: waiting up to %d seconds for a same-user "
+            "SAS verification request.",
+            self.default_autoverify_timeout_sec,
+        )
+        active = None
+        since = None
+        deadline = time() + self.default_autoverify_timeout_sec
+
+        while time() < deadline:
+            params = {"timeout": 3000}
+            if since:
+                params["since"] = since
+            ok, response, _ = self._fetch("/sync", params=params, method="GET")
+            if not ok or not isinstance(response, dict):
+                return False
+            since = response.get("next_batch") or since
+
+            events = response.get("to_device", {}).get("events", [])
+            for event in events if isinstance(events, list) else []:
+                if not isinstance(event, dict):
+                    continue
+                event_type = event.get("type")
+                sender = event.get("sender")
+                content = event.get("content", {})
+                if sender != self.user_id or not isinstance(content, dict):
+                    # Auto-verification is intentionally same-user only.
+                    continue
+
+                transaction_id = content.get("transaction_id")
+                from_device = content.get("from_device")
+
+                if event_type == "m.key.verification.request":
+                    timestamp = content.get("timestamp")
+                    now_ms = int(time() * 1000)
+                    if (
+                        not isinstance(timestamp, int)
+                        or timestamp < now_ms - 10 * 60 * 1000
+                        or timestamp > now_ms + 5 * 60 * 1000
+                        or not transaction_id
+                        or not from_device
+                        or "m.sas.v1" not in content.get("methods", [])
+                    ):
+                        continue
+                    if active:
+                        self._e2ee_verification_cancel(
+                            active,
+                            "m.unexpected_message",
+                            "Another verification is already active",
+                        )
+                        return False
+
+                    peer_keys = self._e2ee_verification_peer_keys(
+                        sender, from_device
+                    )
+                    if not peer_keys:
+                        return False
+                    active = {
+                        "transaction_id": transaction_id,
+                        "user_id": sender,
+                        "device_id": from_device,
+                        "peer_keys": peer_keys,
+                        "sas": None,
+                        "peer_done": False,
+                    }
+                    if not self._e2ee_send_verification_event(
+                        "m.key.verification.ready",
+                        sender,
+                        from_device,
+                        {
+                            "transaction_id": transaction_id,
+                            "from_device": self.device_id,
+                            "methods": ["m.sas.v1"],
+                        },
+                    ):
+                        return False
+                    continue
+
+                if not active or transaction_id != active["transaction_id"]:
+                    continue
+                if sender != active["user_id"]:
+                    continue
+
+                if event_type == "m.key.verification.cancel":
+                    self.logger.warning(
+                        "Matrix E2EE SAS verification was cancelled: %s",
+                        content.get("reason", "unspecified reason"),
+                    )
+                    return False
+
+                if event_type == "m.key.verification.start":
+                    try:
+                        sas = MatrixSASVerification(
+                            self.user_id,
+                            self.device_id,
+                            sender,
+                            active["device_id"],
+                            content,
+                        )
+                        accept = sas.accept_content()
+                    except (TypeError, ValueError):
+                        self._e2ee_verification_cancel(
+                            active,
+                            "m.unknown_method",
+                            "Unsupported SAS verification parameters",
+                        )
+                        return False
+                    active["sas"] = sas
+                    if not self._e2ee_send_verification_event(
+                        "m.key.verification.accept",
+                        sender,
+                        active["device_id"],
+                        accept,
+                    ):
+                        return False
+                    continue
+
+                sas = active.get("sas")
+                if sas is None:
+                    self._e2ee_verification_cancel(
+                        active,
+                        "m.unexpected_message",
+                        "SAS verification has not started",
+                    )
+                    return False
+
+                if event_type == "m.key.verification.key":
+                    try:
+                        sas.receive_key(content.get("key", ""))
+                        key_content = sas.key_content()
+                        mac_content = sas.mac_content(
+                            self._e2ee_account.signing_key
+                        )
+                    except (TypeError, ValueError):
+                        self._e2ee_verification_cancel(
+                            active,
+                            "m.invalid_message",
+                            "Invalid SAS public key",
+                        )
+                        return False
+                    if not self._e2ee_send_verification_event(
+                        "m.key.verification.key",
+                        sender,
+                        active["device_id"],
+                        key_content,
+                    ) or not self._e2ee_send_verification_event(
+                        "m.key.verification.mac",
+                        sender,
+                        active["device_id"],
+                        mac_content,
+                    ):
+                        return False
+                    continue
+
+                if event_type == "m.key.verification.mac":
+                    try:
+                        sas.verify_peer_mac(content, active["peer_keys"])
+                    except (TypeError, ValueError):
+                        self._e2ee_verification_cancel(
+                            active,
+                            "m.key_mismatch",
+                            "SAS device key MAC did not match",
+                        )
+                        return False
+                    if not self._e2ee_send_verification_event(
+                        "m.key.verification.done",
+                        sender,
+                        active["device_id"],
+                        {"transaction_id": transaction_id},
+                    ):
+                        return False
+                    if active["peer_done"]:
+                        self._e2ee_store_verified_binding()
+                        return True
+                    continue
+
+                if event_type == "m.key.verification.done":
+                    active["peer_done"] = True
+                    if sas.state == "verified":
+                        self._e2ee_store_verified_binding()
+                        return True
+
+        if active:
+            self._e2ee_verification_cancel(
+                active, "m.timeout", "SAS verification timed out"
+            )
+        return False
 
     def _e2ee_setup(self):
         """Ensure the E2EE device account exists and keys are uploaded.
@@ -3305,6 +3586,8 @@ class NotifyMatrix(NotifyBase):
 
         if not self.e2ee:
             params["e2ee"] = "no"
+        if self.autoverify:
+            params["autoverify"] = "yes"
 
         # Extend our parameters
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
@@ -3401,6 +3684,9 @@ class NotifyMatrix(NotifyBase):
         # E2EE flag
         if "e2ee" in results["qsd"]:
             results["e2ee"] = parse_bool(results["qsd"]["e2ee"])
+
+        if "autoverify" in results["qsd"]:
+            results["autoverify"] = parse_bool(results["qsd"]["autoverify"])
 
         # Get our mode
         results["mode"] = results["qsd"].get("mode")

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -2372,8 +2372,6 @@ class NotifyMatrix(NotifyBase):
 
                 if not active or transaction_id != active["transaction_id"]:
                     continue
-                if sender != active["user_id"]:
-                    continue
 
                 if event_type == "m.key.verification.cancel":
                     self.logger.warning(

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -1246,7 +1246,18 @@ class NotifyMatrix(NotifyBase):
                 has_error = True
                 continue
 
-        return not has_error
+        successful = not has_error
+        if (
+            successful
+            and e2ee_capable
+            and self.autoverify
+            and not self._e2ee_refresh_verified_state()
+        ):
+            self.logger.warning(
+                "Matrix E2EE verified device state could not be refreshed."
+            )
+
+        return successful
 
     def _send_attachments(self, attach):
         """Posts all of the provided attachments."""
@@ -2206,6 +2217,62 @@ class NotifyMatrix(NotifyBase):
         binding = self.store.get("e2ee_device_binding")
         if not binding:
             return False
+        return self.store.set(
+            "e2ee_verified_binding",
+            binding,
+            expires=self.default_cache_expiry_sec,
+        )
+
+    def _e2ee_refresh_verified_state(self):
+        """Extend only the state required to retain SAS verification.
+
+        The Matrix device ID and custom E2EE account are part of the verified
+        binding.  They must remain stable with the two binding records or a
+        future login would create a new identity that requires another SAS
+        verification.  Unrelated Matrix and E2EE cache entries are deliberately
+        left untouched.
+        """
+        binding = self.store.get("e2ee_device_binding")
+        if (
+            not binding
+            or self.store.get("e2ee_verified_binding") != binding
+            or not self.user_id
+            or not self.device_id
+            or not self._e2ee_account
+        ):
+            return False
+
+        current_binding = "{}|{}|{}|{}".format(
+            self.user_id,
+            self.device_id,
+            self._e2ee_account.identity_key,
+            self._e2ee_account.signing_key,
+        )
+        if binding != current_binding:
+            return False
+
+        refreshed = (
+            self.store.set(
+                "device_id",
+                self.device_id,
+                expires=self.default_cache_expiry_sec,
+            ),
+            self.store.set(
+                "e2ee_account",
+                self._e2ee_account.to_dict(),
+                expires=self.default_cache_expiry_sec,
+            ),
+            self.store.set(
+                "e2ee_device_binding",
+                binding,
+                expires=self.default_cache_expiry_sec,
+            ),
+        )
+        if not all(refreshed):
+            return False
+
+        # Write the trust marker last.  A partial refresh must fail closed
+        # instead of extending trust without its complete bound identity.
         return self.store.set(
             "e2ee_verified_binding",
             binding,

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -38,7 +38,8 @@
 import contextlib
 from json import dumps, loads
 import re
-from time import time
+import threading
+from time import monotonic, time
 import uuid
 
 from markdown import markdown
@@ -63,11 +64,11 @@ from ...utils.parse import (
     validate_regex,
 )
 from ..base import NotifyBase
+from . import sas
 from .e2ee import (
     MATRIX_E2EE_SUPPORT,
     MatrixMegOlmSession,
     MatrixOlmAccount,
-    MatrixSASVerification,
     encrypt_attachment,
     verify_device_keys,
     verify_signed_otk,
@@ -251,14 +252,18 @@ class NotifyMatrix(NotifyBase):
     # per batch (both on initial device registration and replenishment).
     default_e2ee_otk_count = 10
 
-    # Replenish the server-side OTK pool when the estimated remaining
-    # count drops below this value.  /keys/claim consumes one OTK per
-    # device; without replenishment the pool runs dry and subsequent
-    # key-shares skip devices that have no OTK available.
+    # Replenish one-time keys before too few remain for other devices.
     default_e2ee_otk_replenish_threshold = 5
 
     # Maximum time an opt-in verification bootstrap waits for SAS events.
     default_autoverify_timeout_sec = 120
+
+    # Delay retries so each send does not repeat the full verification timeout.
+    default_autoverify_retry_cooldown_sec = 60 * 15
+
+    # Refresh trust daily instead of rewriting private identity data after
+    # every successful notification.
+    default_autoverify_refresh_interval_sec = 60 * 60 * 24
 
     # Used for server discovery
     discovery_base_key = "__discovery_base"
@@ -489,6 +494,10 @@ class NotifyMatrix(NotifyBase):
             if autoverify is None
             else parse_bool(autoverify)
         )
+
+        # Let only one notification poll for a verification request at a time.
+        # This prevents concurrent calls from accepting the same request.
+        self._autoverify_lock = threading.Lock()
 
         # Setup our mode
         self.mode = (
@@ -984,16 +993,8 @@ class NotifyMatrix(NotifyBase):
             # We need to register
             return False
 
-        # Resolve user_id (and device_id / home_server as a side-effect) via
-        # /whoami whenever user_id is still absent after login/token setup.
-        # This covers all paths where the server does not return user_id:
-        #   - raw access-token auth (no /login flow at all)
-        #   - username + ?token= (password treated as token, not a login)
-        #   - servers that omit optional /login response fields
-        # Without user_id the m.direct lookup is skipped and
-        # each send creates a fresh orphan DM room instead of reusing the
-        # existing one.  home_server is recovered from user_id inside
-        # _whoami(); the fallback at handles any remaining gap.
+        # Resolve identity details omitted by token login or the server.
+        # Direct-message room reuse depends on knowing the user ID.
         if not self.user_id:
             self._whoami()
 
@@ -1043,11 +1044,13 @@ class NotifyMatrix(NotifyBase):
                     "messages will be sent unencrypted."
                 )
 
+        # Automatic verification is best-effort and does not decide delivery.
+        # Failed attempts remain unverified and retry on a later send.
         if e2ee_capable and self.autoverify and not self._e2ee_auto_verify():
             self.logger.warning(
-                "Matrix E2EE automatic device verification did not complete."
+                "Matrix E2EE automatic device verification did not "
+                "complete; continuing without confirming device trust."
             )
-            return False
 
         # Plaintext attachment payloads for unencrypted rooms.
         # Lazy-initialized on the first unencrypted room so that purely
@@ -1906,6 +1909,28 @@ class NotifyMatrix(NotifyBase):
 
         return None
 
+    @staticmethod
+    def _truncated_content(content):
+        """Return enough response content for a useful debug log entry."""
+        return (content or b"")[:2000]
+
+    @staticmethod
+    def _read_bounded(r, max_bytes):
+        """Read and close a response, returning ``None`` if it is too large."""
+        chunks = []
+        total = 0
+        try:
+            for chunk in r.iter_content(chunk_size=65536):
+                if not chunk:
+                    continue
+                total += len(chunk)
+                if total > max_bytes:
+                    return None
+                chunks.append(chunk)
+            return b"".join(chunks)
+        finally:
+            r.close()
+
     def _fetch(
         self,
         path,
@@ -1915,20 +1940,15 @@ class NotifyMatrix(NotifyBase):
         method="POST",
         url_override=None,
         ok_status=None,
+        timeout=None,
+        max_retry_wait=None,
+        max_response_bytes=None,
     ):
-        """Wrapper to request.post() to manage it's response better and
-        make the send() function cleaner and easier to maintain.
+        """Send a Matrix HTTP request and normalize its result.
 
-        This function always returns a 3-tuple:
-            (success, response, status_code)
-
-        The response is a dict when JSON is parseable, otherwise an empty
-        dict. The status_code defaults to 500 on local failures.
-
-        *ok_status* is an optional collection of additional HTTP status codes
-        to treat as success (no warning logged).  Use it for calls where a
-        non-200 response is expected and meaningful, e.g. 404 on a state-event
-        probe that returns "not found" = "feature not enabled".
+        Returns ``(success, response, status_code)``. Invalid JSON uses an
+        empty response. Optional arguments accept expected status codes and
+        limit request time, retry delays, or response size.
         """
 
         # Define our headers
@@ -1995,6 +2015,14 @@ class NotifyMatrix(NotifyBase):
         # Define how many attempts we'll make if we get caught in a
         # throttle event
         retries = self.default_retries if self.default_retries > 0 else 1
+
+        # Share one retry-wait budget across every 429 response in this call.
+        retry_deadline = (
+            monotonic() + max_retry_wait
+            if max_retry_wait is not None
+            else None
+        )
+
         while retries > 0:
             # Decrement our throttle retry count
             retries -= 1
@@ -2014,6 +2042,7 @@ class NotifyMatrix(NotifyBase):
 
             # Initialize our response object
             r = None
+            content = b""
 
             try:
                 r = fn(
@@ -2030,19 +2059,36 @@ class NotifyMatrix(NotifyBase):
                     params=params if params else None,
                     headers=headers,
                     verify=self.verify_certificate,
-                    timeout=self.request_timeout,
+                    timeout=(
+                        timeout
+                        if timeout is not None
+                        else self.request_timeout
+                    ),
                     allow_redirects=self.redirects,
+                    stream=max_response_bytes is not None,
                 )
 
                 # Store status code
                 status_code = r.status_code
 
+                if max_response_bytes is not None:
+                    content = self._read_bounded(r, max_response_bytes)
+                    if content is None:
+                        self.logger.warning(
+                            "Matrix response exceeded %d bytes; "
+                            "discarding it.",
+                            max_response_bytes,
+                        )
+                        return (False, {}, status_code)
+                else:
+                    content = r.content
+
                 self.logger.debug(
-                    "Matrix Response: code={}, {}".format(
-                        r.status_code, r.content
-                    )
+                    "Matrix Response: code=%s, %s",
+                    r.status_code,
+                    self._truncated_content(content),
                 )
-                response = loads(r.content)
+                response = loads(content)
 
                 if r.status_code == requests.codes.too_many_requests:
                     wait_ms = self.default_wait_ms
@@ -2056,14 +2102,37 @@ class NotifyMatrix(NotifyBase):
                         except KeyError:
                             pass
 
+                    if retry_deadline is not None:
+                        # Subtract earlier waits from the shared budget.
+                        remaining_wait = max(0.0, retry_deadline - monotonic())
+                        if remaining_wait <= 0:
+                            # Stop before another request when the budget ends.
+                            self.logger.warning(
+                                "Matrix server requested we throttle "
+                                "back, but our retry budget is "
+                                "exhausted; giving up."
+                            )
+                            return (False, response, status_code)
+                        wait_ms = min(wait_ms, remaining_wait * 1000)
+
                     self.logger.warning(
                         "Matrix server requested we throttle back "
                         "{}ms; retries left {}.".format(wait_ms, retries)
                     )
-                    self.logger.debug(f"Response Details:\r\n{r.content}")
+                    self.logger.debug(
+                        "Response Details:\r\n%r",
+                        (content or b"")[:2000],
+                    )
 
                     # Throttle for specified wait
                     self.throttle(wait=wait_ms / 1000)
+
+                    if (
+                        retry_deadline is not None
+                        and monotonic() >= retry_deadline
+                    ):
+                        # Do not retry when the wait consumed the budget.
+                        return (False, response, status_code)
 
                     # Try again
                     continue
@@ -2089,20 +2158,20 @@ class NotifyMatrix(NotifyBase):
                         )
                     )
 
-                    self.logger.debug(f"Response Details:\r\n{r.content}")
+                    self.logger.debug(
+                        "Response Details:\r\n%r",
+                        (content or b"")[:2000],
+                    )
 
                     # Return; we're done
                     return (False, response, status_code)
 
             except (AttributeError, TypeError, ValueError):
-                # This gets thrown if we can't parse our JSON Response
-                #  - ValueError = r.content is Unparsable
-                #  - TypeError = r.content is None
-                #  - AttributeError = r is None
+                # Reject missing or invalid JSON responses.
                 self.logger.warning("Invalid response from Matrix server.")
                 self.logger.debug(
                     "Response Details:\r\n%r",
-                    b"" if not r else (r.content or b""),
+                    content or b"",
                 )
                 return (False, {}, status_code)
 
@@ -2164,339 +2233,55 @@ class NotifyMatrix(NotifyBase):
         )
         return result
 
-    def _e2ee_send_verification_event(
-        self, event_type, user_id, device_id, content
-    ):
-        """Send one unencrypted SAS event to a specific Matrix device."""
-        path = "/sendToDevice/{}/{}".format(event_type, uuid.uuid4().hex)
-        ok, _, _ = self._fetch(
-            path,
-            payload={"messages": {user_id: {device_id: content}}},
-            method="PUT",
-        )
-        return ok
+    def _e2ee_binding_key(self):
+        """Return the identity shared by this device and E2EE account.
 
-    def _e2ee_verification_cancel(self, active, code, reason):
-        """Cancel an active SAS transaction on the peer device."""
-        if not active:
-            return False
-        return self._e2ee_send_verification_event(
-            "m.key.verification.cancel",
-            active["user_id"],
-            active["device_id"],
-            {
-                "transaction_id": active["transaction_id"],
-                "code": code,
-                "reason": reason,
-            },
-        )
-
-    def _e2ee_verification_peer_keys(self, user_id, device_id):
-        """Return verified device and advertised cross-signing keys."""
-        ok, response, _ = self._fetch(
-            "/keys/query",
-            payload={"device_keys": {user_id: [device_id]}},
-        )
-        if not ok or not isinstance(response, dict):
-            return None
-
-        device = (
-            response.get("device_keys", {}).get(user_id, {}).get(device_id)
-        )
-        if not device or not verify_device_keys(device, user_id, device_id):
-            return None
-
-        keys = dict(device.get("keys", {}))
-        master_key = response.get("master_keys", {}).get(user_id, {})
-        if isinstance(master_key, dict):
-            keys.update(master_key.get("keys", {}))
-        return keys
-
-    def _e2ee_store_verified_binding(self):
-        """Remember that the current custom E2EE identity completed SAS."""
-        binding = self.store.get("e2ee_device_binding")
-        if not binding:
-            return False
-        return self.store.set(
-            "e2ee_verified_binding",
-            binding,
-            expires=self.default_cache_expiry_sec,
-        )
-
-    def _e2ee_refresh_verified_state(self):
-        """Extend only the state required to retain SAS verification.
-
-        The Matrix device ID and custom E2EE account are part of the verified
-        binding.  They must remain stable with the two binding records or a
-        future login would create a new identity that requires another SAS
-        verification.  Unrelated Matrix and E2EE cache entries are deliberately
-        left untouched.
+        A changed user, device, or account key must not reuse cached trust.
         """
-        binding = self.store.get("e2ee_device_binding")
-        if (
-            not binding
-            or self.store.get("e2ee_verified_binding") != binding
-            or not self.user_id
-            or not self.device_id
-            or not self._e2ee_account
-        ):
-            return False
+        if self._e2ee_account is None:
+            # No account means there is no reusable encrypted identity.
+            return ""
 
-        current_binding = "{}|{}|{}|{}".format(
-            self.user_id,
-            self.device_id,
+        # Include every value that must stay stable for cached trust.
+        return "{}|{}|{}|{}".format(
+            self.user_id or "",
+            self.device_id or "",
             self._e2ee_account.identity_key,
             self._e2ee_account.signing_key,
-        )
-        if binding != current_binding:
-            return False
-
-        refreshed = (
-            self.store.set(
-                "device_id",
-                self.device_id,
-                expires=self.default_cache_expiry_sec,
-            ),
-            self.store.set(
-                "e2ee_account",
-                self._e2ee_account.to_dict(),
-                expires=self.default_cache_expiry_sec,
-            ),
-            self.store.set(
-                "e2ee_device_binding",
-                binding,
-                expires=self.default_cache_expiry_sec,
-            ),
-        )
-        if not all(refreshed):
-            return False
-
-        # Write the trust marker last.  A partial refresh must fail closed
-        # instead of extending trust without its complete bound identity.
-        return self.store.set(
-            "e2ee_verified_binding",
-            binding,
-            expires=self.default_cache_expiry_sec,
         )
 
     def _e2ee_auto_verify(self):
         """Automatically complete one same-user SAS verification.
 
-        This is an explicit bootstrap operation enabled by ``autoverify=yes``.
-        It consumes only unencrypted verification events from ``/sync`` and
-        does not introduce libolm or another Matrix device identity.
+        This delegates the opt-in bootstrap to the Matrix SAS helper.
         """
-        binding = self.store.get("e2ee_device_binding")
-        if binding and self.store.get("e2ee_verified_binding") == binding:
-            return True
-        if not self.user_id or not self.device_id or not self._e2ee_account:
-            return False
+        return sas.auto_verify(self)
 
-        self.logger.info(
-            "Matrix E2EE: waiting up to %d seconds for a same-user "
-            "SAS verification request.",
-            self.default_autoverify_timeout_sec,
-        )
-        active = None
-        since = None
-        deadline = time() + self.default_autoverify_timeout_sec
+    def _e2ee_refresh_verified_state(self):
+        """Extend SAS verification trust after a successful send.
 
-        while time() < deadline:
-            params = {"timeout": 3000}
-            if since:
-                params["since"] = since
-            ok, response, _ = self._fetch("/sync", params=params, method="GET")
-            if not ok or not isinstance(response, dict):
-                return False
-            since = response.get("next_batch") or since
-
-            events = response.get("to_device", {}).get("events", [])
-            for event in events if isinstance(events, list) else []:
-                if not isinstance(event, dict):
-                    continue
-                event_type = event.get("type")
-                sender = event.get("sender")
-                content = event.get("content", {})
-                if sender != self.user_id or not isinstance(content, dict):
-                    # Auto-verification is intentionally same-user only.
-                    continue
-
-                transaction_id = content.get("transaction_id")
-                from_device = content.get("from_device")
-
-                if event_type == "m.key.verification.request":
-                    timestamp = content.get("timestamp")
-                    now_ms = int(time() * 1000)
-                    if (
-                        not isinstance(timestamp, int)
-                        or timestamp < now_ms - 10 * 60 * 1000
-                        or timestamp > now_ms + 5 * 60 * 1000
-                        or not transaction_id
-                        or not from_device
-                        or "m.sas.v1" not in content.get("methods", [])
-                    ):
-                        continue
-                    if active:
-                        self._e2ee_verification_cancel(
-                            active,
-                            "m.unexpected_message",
-                            "Another verification is already active",
-                        )
-                        return False
-
-                    peer_keys = self._e2ee_verification_peer_keys(
-                        sender, from_device
-                    )
-                    if not peer_keys:
-                        return False
-                    active = {
-                        "transaction_id": transaction_id,
-                        "user_id": sender,
-                        "device_id": from_device,
-                        "peer_keys": peer_keys,
-                        "sas": None,
-                        "peer_done": False,
-                    }
-                    if not self._e2ee_send_verification_event(
-                        "m.key.verification.ready",
-                        sender,
-                        from_device,
-                        {
-                            "transaction_id": transaction_id,
-                            "from_device": self.device_id,
-                            "methods": ["m.sas.v1"],
-                        },
-                    ):
-                        return False
-                    continue
-
-                if not active or transaction_id != active["transaction_id"]:
-                    continue
-
-                if event_type == "m.key.verification.cancel":
-                    self.logger.warning(
-                        "Matrix E2EE SAS verification was cancelled: %s",
-                        content.get("reason", "unspecified reason"),
-                    )
-                    return False
-
-                if event_type == "m.key.verification.start":
-                    try:
-                        sas = MatrixSASVerification(
-                            self.user_id,
-                            self.device_id,
-                            sender,
-                            active["device_id"],
-                            content,
-                        )
-                        accept = sas.accept_content()
-                    except (TypeError, ValueError):
-                        self._e2ee_verification_cancel(
-                            active,
-                            "m.unknown_method",
-                            "Unsupported SAS verification parameters",
-                        )
-                        return False
-                    active["sas"] = sas
-                    if not self._e2ee_send_verification_event(
-                        "m.key.verification.accept",
-                        sender,
-                        active["device_id"],
-                        accept,
-                    ):
-                        return False
-                    continue
-
-                sas = active.get("sas")
-                if sas is None:
-                    self._e2ee_verification_cancel(
-                        active,
-                        "m.unexpected_message",
-                        "SAS verification has not started",
-                    )
-                    return False
-
-                if event_type == "m.key.verification.key":
-                    try:
-                        sas.receive_key(content.get("key", ""))
-                        key_content = sas.key_content()
-                        mac_content = sas.mac_content(
-                            self._e2ee_account.signing_key
-                        )
-                    except (TypeError, ValueError):
-                        self._e2ee_verification_cancel(
-                            active,
-                            "m.invalid_message",
-                            "Invalid SAS public key",
-                        )
-                        return False
-                    if not self._e2ee_send_verification_event(
-                        "m.key.verification.key",
-                        sender,
-                        active["device_id"],
-                        key_content,
-                    ) or not self._e2ee_send_verification_event(
-                        "m.key.verification.mac",
-                        sender,
-                        active["device_id"],
-                        mac_content,
-                    ):
-                        return False
-                    continue
-
-                if event_type == "m.key.verification.mac":
-                    try:
-                        sas.verify_peer_mac(content, active["peer_keys"])
-                    except (TypeError, ValueError):
-                        self._e2ee_verification_cancel(
-                            active,
-                            "m.key_mismatch",
-                            "SAS device key MAC did not match",
-                        )
-                        return False
-                    if not self._e2ee_send_verification_event(
-                        "m.key.verification.done",
-                        sender,
-                        active["device_id"],
-                        {"transaction_id": transaction_id},
-                    ):
-                        return False
-                    if active["peer_done"]:
-                        self._e2ee_store_verified_binding()
-                        return True
-                    continue
-
-                if event_type == "m.key.verification.done":
-                    active["peer_done"] = True
-                    if sas.state == "verified":
-                        self._e2ee_store_verified_binding()
-                        return True
-
-        if active:
-            self._e2ee_verification_cancel(
-                active, "m.timeout", "SAS verification timed out"
-            )
-        return False
+        The Matrix SAS helper refreshes only identity-related state.
+        """
+        return sas.refresh_verified_state(self)
 
     def _e2ee_setup(self):
         """Ensure the E2EE device account exists and keys are uploaded.
 
-        Creates a new :class:`MatrixOlmAccount` if one does not yet
-        exist in the persistent store, then calls
-        :meth:`_e2ee_upload_keys` if the server has not yet received
-        our device keys for the current access token.
-
-        Returns ``True`` on success, ``False`` on failure.
+        Restores or creates an account, then uploads any missing keys.
+        Returns ``True`` when the account is ready.
         """
         if self._e2ee_account is None:
+            # Prefer a saved identity so Matrix sees the same device again.
             acct_data = self.store.get("e2ee_account")
             if acct_data:
                 try:
                     self._e2ee_account = MatrixOlmAccount.from_dict(acct_data)
                 except Exception:
+                    # Invalid saved keys are replaced during normal setup.
                     self._e2ee_account = None
 
             if self._e2ee_account is None:
+                # First use or invalid storage requires a fresh local identity.
                 self._e2ee_account = MatrixOlmAccount()
                 self.store.set(
                     "e2ee_account",
@@ -2504,21 +2289,8 @@ class NotifyMatrix(NotifyBase):
                     expires=self.default_cache_expiry_sec,
                 )
 
-        # Keys uploaded status must match the current Matrix device identity
-        # and the account keys we are about to use. This lets us recover from
-        # cached state where the homeserver assigned a different device_id or
-        # where the local E2EE account changed.
-        current_binding = (
-            "{}|{}|{}|{}".format(
-                self.user_id or "",
-                self.device_id or "",
-                self._e2ee_account.identity_key,
-                self._e2ee_account.signing_key,
-            )
-            if self._e2ee_account is not None
-            else ""
-        )
-        if self.store.get("e2ee_device_binding") != current_binding:
+        # Discard upload state when the server device or local account changes.
+        if self.store.get("e2ee_device_binding") != self._e2ee_binding_key():
             self.store.clear("e2ee_keys_uploaded")
 
         if not self.store.get("e2ee_keys_uploaded"):
@@ -2570,12 +2342,7 @@ class NotifyMatrix(NotifyBase):
         )
         self.store.set(
             "e2ee_device_binding",
-            "{}|{}|{}|{}".format(
-                self.user_id,
-                self.device_id,
-                self._e2ee_account.identity_key,
-                self._e2ee_account.signing_key,
-            ),
+            self._e2ee_binding_key(),
             expires=self.default_cache_expiry_sec,
         )
 
@@ -2839,10 +2606,7 @@ class NotifyMatrix(NotifyBase):
             total_devices,
         )
 
-        # Build the claim request for all member devices.
-        # "signed_curve25519" is the algorithm Matrix clients publish and
-        # servers are required to support; "curve25519" (unsigned) is
-        # deprecated and usually yields no keys on current servers.
+        # Request the signed one-time keys supported by current Matrix clients.
         otk_request = {}
         for uid, devs in members.items():
             otk_request[uid] = dict.fromkeys(devs, "signed_curve25519")
@@ -2917,12 +2681,7 @@ class NotifyMatrix(NotifyBase):
                     )
                     continue
 
-                # Locate and verify the OTK for this device.
-                # Servers return signed_curve25519 keys (the algorithm we
-                # requested) as {"key": ..., "signatures": ...} dicts.
-                # signed_curve25519 OTKs are always KeyObjects
-                # {"key": ..., "signatures": ...}; plain-string values
-                # are not valid for this algorithm and are rejected.
+                # Accept only signed one-time-key objects for this device.
                 their_otk = None
                 otk_entry = otk_keys.get(uid, {}).get(dev_id, {})
                 self.logger.trace(
@@ -3013,19 +2772,9 @@ class NotifyMatrix(NotifyBase):
                     )
                     continue
 
-                # Build the m.room_key inner plaintext per Matrix spec:
-                #   https://spec.matrix.org/v1.11/client-server-api/#mroomkey
-                #
-                # Required fields only; non-standard extension fields
-                # (sender_device_keys, org.matrix.msc4147.device_keys) have
-                # been removed because they:
-                #   - Add ~930 bytes to an otherwise ~400-byte payload,
-                #     bloating the Olm ciphertext from ~400B to ~1640B.
-                #   - Are not part of the spec and may confuse strict
-                #     implementations (Element/matrix-sdk-crypto warns on
-                #     unknown fields in to-device events in some builds).
-                #   - Contain unsigned device-key material that recipients
-                #     should instead fetch via /keys/query for authenticity.
+                # Use only standard room-key fields. Device-key extensions
+                # add overhead, may confuse strict clients, and carry unsigned
+                # keys that recipients should query directly.
                 inner = dumps(
                     {
                         "type": "m.room_key",
@@ -3107,13 +2856,7 @@ class NotifyMatrix(NotifyBase):
             self.transaction_id,
         )
 
-        # Check whether the OTK pool needs topping up.  Pass the number of
-        # OTKs consumed (built_count) and any devices skipped because the
-        # server had no OTK for them so _e2ee_replenish_otks can log the
-        # right diagnostic and decide whether an upload is needed.
-        # We always reach here with built_count >= 1 (the any() guard above
-        # returns early when no messages were built), so the call is never
-        # redundant -- _e2ee_replenish_otks itself decides whether to upload.
+        # Refill one-time keys when this share consumed or could not find them.
         self._e2ee_replenish_otks(
             claimed_count=built_count,
             skipped_no_otk=skipped_no_otk,

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -486,16 +486,24 @@ class NotifyMatrix(NotifyBase):
             self.webhook_path = f"/{self.webhook_path}"
         self.webhook_path = self.webhook_path.rstrip("/") or "/"
 
-        # End-to-end encryption (server mode only; requires cryptography)
-        self.e2ee = (
-            self.template_args["e2ee"]["default"]
-            if e2ee is None
-            else parse_bool(e2ee)
-        )
+        # Resolve autoverify first: requesting it implies e2ee=yes unless
+        # e2ee was explicitly supplied, so turning on automatic device
+        # verification never also requires spelling out e2ee=yes.
         self.autoverify = (
             self.template_args["autoverify"]["default"]
             if autoverify is None
             else parse_bool(autoverify)
+        )
+
+        # End-to-end encryption (server mode only; requires cryptography)
+        self.e2ee = (
+            parse_bool(e2ee)
+            if e2ee is not None
+            else (
+                True
+                if self.autoverify
+                else self.template_args["e2ee"]["default"]
+            )
         )
 
         # Let only one notification poll for a verification request at a time.

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -252,7 +252,10 @@ class NotifyMatrix(NotifyBase):
     # per batch (both on initial device registration and replenishment).
     default_e2ee_otk_count = 10
 
-    # Replenish one-time keys before too few remain for other devices.
+    # Replenish the server-side OTK pool when the estimated remaining
+    # count drops below this value.  /keys/claim consumes one OTK per
+    # device; without replenishment the pool runs dry and subsequent
+    # key-shares skip devices that have no OTK available.
     default_e2ee_otk_replenish_threshold = 5
 
     # Maximum time an opt-in verification bootstrap waits for SAS events.
@@ -993,8 +996,16 @@ class NotifyMatrix(NotifyBase):
             # We need to register
             return False
 
-        # Resolve identity details omitted by token login or the server.
-        # Direct-message room reuse depends on knowing the user ID.
+        # Resolve user_id (and device_id / home_server as a side-effect) via
+        # /whoami whenever user_id is still absent after login/token setup.
+        # This covers all paths where the server does not return user_id:
+        #   - raw access-token auth (no /login flow at all)
+        #   - username + ?token= (password treated as token, not a login)
+        #   - servers that omit optional /login response fields
+        # Without user_id the m.direct lookup is skipped and
+        # each send creates a fresh orphan DM room instead of reusing the
+        # existing one.  home_server is recovered from user_id inside
+        # _whoami(); the fallback at handles any remaining gap.
         if not self.user_id:
             self._whoami()
 
@@ -2236,7 +2247,11 @@ class NotifyMatrix(NotifyBase):
     def _e2ee_binding_key(self):
         """Return the identity shared by this device and E2EE account.
 
-        A changed user, device, or account key must not reuse cached trust.
+        Keys uploaded status must match the current Matrix device identity
+        and the account keys we are about to use. This lets us recover from
+        cached state where the homeserver assigned a different device_id or
+        where the local E2EE account changed.  A changed user, device, or
+        account key must not reuse cached trust.
         """
         if self._e2ee_account is None:
             # No account means there is no reusable encrypted identity.
@@ -2606,7 +2621,10 @@ class NotifyMatrix(NotifyBase):
             total_devices,
         )
 
-        # Request the signed one-time keys supported by current Matrix clients.
+        # Build the claim request for all member devices.
+        # "signed_curve25519" is the algorithm Matrix clients publish and
+        # servers are required to support; "curve25519" (unsigned) is
+        # deprecated and usually yields no keys on current servers.
         otk_request = {}
         for uid, devs in members.items():
             otk_request[uid] = dict.fromkeys(devs, "signed_curve25519")
@@ -2681,7 +2699,12 @@ class NotifyMatrix(NotifyBase):
                     )
                     continue
 
-                # Accept only signed one-time-key objects for this device.
+                # Locate and verify the OTK for this device.
+                # Servers return signed_curve25519 keys (the algorithm we
+                # requested) as {"key": ..., "signatures": ...} dicts.
+                # signed_curve25519 OTKs are always KeyObjects
+                # {"key": ..., "signatures": ...}; plain-string values
+                # are not valid for this algorithm and are rejected.
                 their_otk = None
                 otk_entry = otk_keys.get(uid, {}).get(dev_id, {})
                 self.logger.trace(
@@ -2772,9 +2795,19 @@ class NotifyMatrix(NotifyBase):
                     )
                     continue
 
-                # Use only standard room-key fields. Device-key extensions
-                # add overhead, may confuse strict clients, and carry unsigned
-                # keys that recipients should query directly.
+                # Build the m.room_key inner plaintext per Matrix spec:
+                #   https://spec.matrix.org/v1.11/client-server-api/#mroomkey
+                #
+                # Required fields only; non-standard extension fields
+                # (sender_device_keys, org.matrix.msc4147.device_keys) have
+                # been removed because they:
+                #   - Add ~930 bytes to an otherwise ~400-byte payload,
+                #     bloating the Olm ciphertext from ~400B to ~1640B.
+                #   - Are not part of the spec and may confuse strict
+                #     implementations (Element/matrix-sdk-crypto warns on
+                #     unknown fields in to-device events in some builds).
+                #   - Contain unsigned device-key material that recipients
+                #     should instead fetch via /keys/query for authenticity.
                 inner = dumps(
                     {
                         "type": "m.room_key",
@@ -2856,7 +2889,13 @@ class NotifyMatrix(NotifyBase):
             self.transaction_id,
         )
 
-        # Refill one-time keys when this share consumed or could not find them.
+        # Check whether the OTK pool needs topping up.  Pass the number of
+        # OTKs consumed (built_count) and any devices skipped because the
+        # server had no OTK for them so _e2ee_replenish_otks can log the
+        # right diagnostic and decide whether an upload is needed.
+        # We always reach here with built_count >= 1 (the any() guard above
+        # returns early when no messages were built), so the call is never
+        # redundant -- _e2ee_replenish_otks itself decides whether to upload.
         self._e2ee_replenish_otks(
             claimed_count=built_count,
             skipped_no_otk=skipped_no_otk,

--- a/apprise/plugins/matrix/e2ee.py
+++ b/apprise/plugins/matrix/e2ee.py
@@ -43,6 +43,7 @@
 import base64
 from json import dumps
 import os
+import secrets
 import struct
 import time as _time
 import uuid
@@ -317,6 +318,209 @@ def encrypt_attachment(data):
     }
 
     return ciphertext, file_info
+
+
+class MatrixSASVerification:
+    """Minimal responder-side Matrix SAS verification state machine.
+
+    This uses the same ``cryptography`` primitives and device signing key as
+    Apprise's custom E2EE implementation. It only implements the responder
+    path needed for opt-in, automatic same-user verification; it creates no
+    second Olm account or device identity.
+    """
+
+    METHOD = "m.sas.v1"
+    KEY_AGREEMENT = "curve25519-hkdf-sha256"
+    HASH = "sha256"
+    MAC = "hkdf-hmac-sha256.v2"
+    SAS_METHODS = ("decimal", "emoji")
+
+    def __init__(
+        self,
+        own_user_id,
+        own_device_id,
+        peer_user_id,
+        peer_device_id,
+        start_content,
+    ):
+        """Create a responder for a validation start event."""
+        self.own_user_id = own_user_id
+        self.own_device_id = own_device_id
+        self.peer_user_id = peer_user_id
+        self.peer_device_id = peer_device_id
+        self.start_content = dict(start_content)
+        self.transaction_id = self.start_content.get("transaction_id")
+
+        if not self.transaction_id or not self.peer_device_id:
+            raise ValueError("Missing SAS transaction or peer device ID")
+        if self.start_content.get("from_device") != self.peer_device_id:
+            raise ValueError("SAS start device does not match request device")
+        if self.start_content.get("method") != self.METHOD:
+            raise ValueError("Unsupported SAS verification method")
+        if self.KEY_AGREEMENT not in self.start_content.get(
+            "key_agreement_protocols", []
+        ):
+            raise ValueError("Unsupported SAS key agreement")
+        if self.HASH not in self.start_content.get("hashes", []):
+            raise ValueError("Unsupported SAS hash")
+        if self.MAC not in self.start_content.get(
+            "message_authentication_codes", []
+        ):
+            raise ValueError("Unsupported SAS MAC")
+
+        offered_sas = self.start_content.get("short_authentication_string", [])
+        self.sas_methods = [
+            method for method in self.SAS_METHODS if method in offered_sas
+        ]
+        if "decimal" not in self.sas_methods:
+            raise ValueError("SAS start does not offer decimal verification")
+
+        self._private_key = X25519PrivateKey.generate()
+        self.public_key = _b64enc(
+            self._private_key.public_key().public_bytes(
+                Encoding.Raw, PublicFormat.Raw
+            )
+        )
+        self._shared_secret = None
+        self.state = "started"
+
+    def accept_content(self):
+        """Build ``m.key.verification.accept`` content."""
+        if self.state != "started":
+            raise ValueError("SAS verification start was already accepted")
+
+        digest = hashes.Hash(hashes.SHA256(), backend=default_backend())
+        digest.update(self.public_key.encode("ascii"))
+        digest.update(_canonical_json(self.start_content))
+        commitment = _b64enc(digest.finalize())
+        self.state = "accepted"
+        return {
+            "transaction_id": self.transaction_id,
+            "key_agreement_protocol": self.KEY_AGREEMENT,
+            "hash": self.HASH,
+            "message_authentication_code": self.MAC,
+            "short_authentication_string": self.sas_methods,
+            "commitment": commitment,
+        }
+
+    def receive_key(self, peer_public_key):
+        """Accept the initiator's ephemeral key and establish the SAS."""
+        if self.state != "accepted":
+            raise ValueError("Unexpected SAS key event")
+        peer_key = X25519PublicKey.from_public_bytes(_b64dec(peer_public_key))
+        self._shared_secret = self._private_key.exchange(peer_key)
+        self.state = "key_received"
+
+    def key_content(self):
+        """Build our ``m.key.verification.key`` content."""
+        if self.state != "key_received":
+            raise ValueError("SAS peer key has not been received")
+        return {
+            "transaction_id": self.transaction_id,
+            "key": self.public_key,
+        }
+
+    def _calculate_mac(
+        self,
+        value,
+        key_id,
+        sender_user_id,
+        sender_device_id,
+        receiver_user_id,
+        receiver_device_id,
+    ):
+        """Calculate an ``hkdf-hmac-sha256.v2`` SAS MAC."""
+        if self._shared_secret is None:
+            raise ValueError("SAS shared secret has not been established")
+
+        info = (
+            "MATRIX_KEY_VERIFICATION_MAC"
+            + sender_user_id
+            + sender_device_id
+            + receiver_user_id
+            + receiver_device_id
+            + self.transaction_id
+            + key_id
+        ).encode("utf-8")
+        mac_key = _hkdf_sha256(self._shared_secret, 32, salt=None, info=info)
+        return _b64enc(_hmac_sha256(mac_key, value.encode("utf-8")))
+
+    def mac_content(self, own_signing_key):
+        """Build the MAC proving possession of Apprise's device key."""
+        if self.state != "key_received":
+            raise ValueError("SAS peer key has not been received")
+
+        key_id = "ed25519:{}".format(self.own_device_id)
+        content = {
+            "transaction_id": self.transaction_id,
+            "mac": {
+                key_id: self._calculate_mac(
+                    own_signing_key,
+                    key_id,
+                    self.own_user_id,
+                    self.own_device_id,
+                    self.peer_user_id,
+                    self.peer_device_id,
+                )
+            },
+            "keys": self._calculate_mac(
+                key_id,
+                "KEY_IDS",
+                self.own_user_id,
+                self.own_device_id,
+                self.peer_user_id,
+                self.peer_device_id,
+            ),
+        }
+        self.state = "mac_sent"
+        return content
+
+    def verify_peer_mac(self, content, peer_keys):
+        """Validate the initiator's key MACs from a trusted keys query."""
+        if self.state != "mac_sent":
+            raise ValueError("Unexpected SAS MAC event")
+        if content.get("transaction_id") != self.transaction_id:
+            raise ValueError("SAS MAC transaction does not match")
+
+        macs = content.get("mac")
+        if not isinstance(macs, dict) or not macs:
+            raise ValueError("SAS MAC event contains no keys")
+        device_key_id = "ed25519:{}".format(self.peer_device_id)
+        if device_key_id not in macs:
+            raise ValueError("SAS MAC omits the peer device key")
+
+        key_ids = ",".join(sorted(macs))
+        expected_keys_mac = self._calculate_mac(
+            key_ids,
+            "KEY_IDS",
+            self.peer_user_id,
+            self.peer_device_id,
+            self.own_user_id,
+            self.own_device_id,
+        )
+        if not secrets.compare_digest(
+            content.get("keys", ""), expected_keys_mac
+        ):
+            raise ValueError("SAS key list MAC does not match")
+
+        for key_id, received_mac in macs.items():
+            try:
+                public_key = peer_keys[key_id]
+            except (KeyError, TypeError):
+                raise ValueError("SAS MAC references an unknown key") from None
+            expected_mac = self._calculate_mac(
+                public_key,
+                key_id,
+                self.peer_user_id,
+                self.peer_device_id,
+                self.own_user_id,
+                self.own_device_id,
+            )
+            if not secrets.compare_digest(received_mac, expected_mac):
+                raise ValueError("SAS device key MAC does not match")
+
+        self.state = "verified"
+        return True
 
 
 # -----------------------------------------------------------------------

--- a/apprise/plugins/matrix/e2ee.py
+++ b/apprise/plugins/matrix/e2ee.py
@@ -844,8 +844,14 @@ class MatrixOlmAccount:
             _b64dec(their_one_time_key_b64)
         )
 
-        # Olm uses the same temporary key as its base and first ratchet key.
-        # Using different keys would prevent the recipient from decrypting.
+        # E_A is Alice's ephemeral key.  It serves BOTH as the Base-Key
+        # (outer pre-key field 2) AND as the initial Ratchet-Key (inner
+        # field 1).  The Olm spec Section 5.1 is explicit:
+        #   "E_A^pub is also the ratchet key for the first message."
+        # libolm passes the same keypair to both the X3DH and the ratchet
+        # initialisation (ratchet.cpp: initialise_as_alice receives base_key
+        # and uses it as the initial sender ratchet key).  Using two
+        # different keys here breaks decryption.
         eph = X25519PrivateKey.generate()
         eph_pub = eph.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
 
@@ -857,8 +863,18 @@ class MatrixOlmAccount:
         dh2 = eph.exchange(their_ik)
         dh3 = eph.exchange(their_otk)
 
-        # Derive matching root and chain keys from the three shared secrets.
-        # Olm uses their 96 bytes directly, without an added prefix.
+        # Root-key derivation (libolm ratchet.cpp initialise_as_alice /
+        # vodozemac shared_secret.rs Shared3DHSecret::expand):
+        #   IKM  = DH1 || DH2 || DH3  (96 bytes -- no zero prefix)
+        #   salt = nullptr / 0x00*32   (RFC 5869: missing salt = HashLen zeros)
+        #   info = "OLM_ROOT"
+        #
+        # libolm passes the 96-byte secret directly
+        # (session.cpp: secret[3 * CURVE25519_SHARED_SECRET_LENGTH]).
+        # vodozemac does the same (Shared3DHSecret is Box<[u8; 96]>).
+        # Adding any prefix produces a different PRK and therefore
+        # different root/chain keys, causing the recipient to fail to
+        # decrypt the Olm pre-key message that carries the MegOLM room key.
         ikm = dh1 + dh2 + dh3
         keys = _hkdf_sha256(ikm, 64, salt=None, info=b"OLM_ROOT")
         root_key = keys[:32]
@@ -964,7 +980,12 @@ class MatrixOlmSession:
         #   0x1A = field 3 (bytes) -> Identity-Key (Alice's identity key)
         #   0x22 = field 4 (bytes) -> Message (inner message + inner MAC)
         #
-        # The outer message has no trailing MAC; adding one breaks decoding.
+        # The outer pre-key message has NO trailing MAC of its own.
+        # libolm session.cpp allocates exactly
+        # encode_one_time_key_message_length() bytes -- no extra space for an
+        # outer MAC.  vodozemac decodes the outer payload with prost (strict
+        # protobuf) so extra bytes after the last field cause a DecodeError
+        # and the session fails to establish.
         outer = (
             b"\x03"
             + _pb_bytes(1, self._their_otk_pub)

--- a/apprise/plugins/matrix/e2ee.py
+++ b/apprise/plugins/matrix/e2ee.py
@@ -212,6 +212,10 @@ def verify_device_keys(dev_info, user_id, device_id):
     - ``dev_info["device_id"] == device_id``
     - The Ed25519 self-signature over the canonical payload is valid.
     """
+    # Reject malformed server data before reading the device fields.
+    if not isinstance(dev_info, dict):
+        return False
+
     # Identity binding: payload fields must match who we think we're
     # verifying.  Without this a server could swap key objects across
     # users/devices and the signature would still verify.
@@ -221,11 +225,16 @@ def verify_device_keys(dev_info, user_id, device_id):
         return False
 
     sig_key = "ed25519:{}".format(device_id)
-    ed25519_pub = dev_info.get("keys", {}).get(sig_key, "")
+    keys = dev_info.get("keys")
+    ed25519_pub = keys.get(sig_key, "") if isinstance(keys, dict) else ""
     if not ed25519_pub:
         return False
 
-    sig = dev_info.get("signatures", {}).get(user_id, {}).get(sig_key, "")
+    signatures = dev_info.get("signatures")
+    user_sigs = (
+        signatures.get(user_id) if isinstance(signatures, dict) else None
+    )
+    sig = user_sigs.get(sig_key, "") if isinstance(user_sigs, dict) else ""
     if not sig:
         return False
 
@@ -321,19 +330,23 @@ def encrypt_attachment(data):
 
 
 class MatrixSASVerification:
-    """Minimal responder-side Matrix SAS verification state machine.
+    """Verify another session for the same user with Matrix SAS.
 
-    This uses the same ``cryptography`` primitives and device signing key as
-    Apprise's custom E2EE implementation. It only implements the responder
-    path needed for opt-in, automatic same-user verification; it creates no
-    second Olm account or device identity.
+    The exchange reuses Apprise's existing encrypted device identity.
     """
+
+    # Allow a generous margin beyond the device and master keys normally sent.
+    MAX_MAC_KEYS = 10
+
+    # Bound incoming key and MAC fields before processing them.
+    MAX_FIELD_LEN = 512
 
     METHOD = "m.sas.v1"
     KEY_AGREEMENT = "curve25519-hkdf-sha256"
     HASH = "sha256"
     MAC = "hkdf-hmac-sha256.v2"
-    SAS_METHODS = ("decimal", "emoji")
+    # Advertise only decimal because it is the format Apprise displays.
+    SAS_METHODS = ("decimal",)
 
     def __init__(
         self,
@@ -344,13 +357,17 @@ class MatrixSASVerification:
         start_content,
     ):
         """Create a responder for a validation start event."""
+        # Retain both identities because their order affects every SAS MAC.
         self.own_user_id = own_user_id
         self.own_device_id = own_device_id
         self.peer_user_id = peer_user_id
         self.peer_device_id = peer_device_id
+        # Copy the proposal so its commitment cannot change during
+        # verification.
         self.start_content = dict(start_content)
         self.transaction_id = self.start_content.get("transaction_id")
 
+        # Reject proposals that do not belong to the expected transaction.
         if not self.transaction_id or not self.peer_device_id:
             raise ValueError("Missing SAS transaction or peer device ID")
         if self.start_content.get("from_device") != self.peer_device_id:
@@ -368,6 +385,7 @@ class MatrixSASVerification:
         ):
             raise ValueError("Unsupported SAS MAC")
 
+        # Preserve only the display methods supported by both devices.
         offered_sas = self.start_content.get("short_authentication_string", [])
         self.sas_methods = [
             method for method in self.SAS_METHODS if method in offered_sas
@@ -375,13 +393,16 @@ class MatrixSASVerification:
         if "decimal" not in self.sas_methods:
             raise ValueError("SAS start does not offer decimal verification")
 
+        # Create a fresh temporary key for this verification attempt.
         self._private_key = X25519PrivateKey.generate()
         self.public_key = _b64enc(
             self._private_key.public_key().public_bytes(
                 Encoding.Raw, PublicFormat.Raw
             )
         )
+        # The shared secret is available only after the peer key arrives.
         self._shared_secret = None
+        self._peer_public_key = None
         self.state = "started"
 
     def accept_content(self):
@@ -389,10 +410,12 @@ class MatrixSASVerification:
         if self.state != "started":
             raise ValueError("SAS verification start was already accepted")
 
+        # Commit to our public key and the exact proposal being accepted.
         digest = hashes.Hash(hashes.SHA256(), backend=default_backend())
         digest.update(self.public_key.encode("ascii"))
         digest.update(_canonical_json(self.start_content))
         commitment = _b64enc(digest.finalize())
+        # The next valid event is the peer's temporary public key.
         self.state = "accepted"
         return {
             "transaction_id": self.transaction_id,
@@ -407,8 +430,17 @@ class MatrixSASVerification:
         """Accept the initiator's ephemeral key and establish the SAS."""
         if self.state != "accepted":
             raise ValueError("Unexpected SAS key event")
+        if (
+            not isinstance(peer_public_key, str)
+            or not 0 < len(peer_public_key) <= self.MAX_FIELD_LEN
+        ):
+            raise ValueError("SAS peer key is missing or malformed")
+
+        # Derive the secret shared only by the two temporary keys.
         peer_key = X25519PublicKey.from_public_bytes(_b64dec(peer_public_key))
         self._shared_secret = self._private_key.exchange(peer_key)
+        # The displayed SAS also binds both temporary public keys.
+        self._peer_public_key = peer_public_key
         self.state = "key_received"
 
     def key_content(self):
@@ -419,6 +451,44 @@ class MatrixSASVerification:
             "transaction_id": self.transaction_id,
             "key": self.public_key,
         }
+
+    def decimal_sas(self):
+        """Derive the decimal Short Authentication String.
+
+        Both devices derive three numbers from the shared secret. Comparing
+        those numbers outside Matrix detects an intercepted exchange.
+        """
+        if self._shared_secret is None or self._peer_public_key is None:
+            raise ValueError("SAS shared secret has not been established")
+
+        # The peer initiated this exchange, so its identity and key come first.
+        # This SAS context separates fields with "|"; the MAC context does not.
+        info = (
+            "MATRIX_KEY_VERIFICATION_SAS|"
+            + self.peer_user_id
+            + "|"
+            + self.peer_device_id
+            + "|"
+            + self._peer_public_key
+            + "|"
+            + self.own_user_id
+            + "|"
+            + self.own_device_id
+            + "|"
+            + self.public_key
+            + "|"
+            + self.transaction_id
+        ).encode("utf-8")
+        sas_bytes = _hkdf_sha256(self._shared_secret, 5, salt=None, info=info)
+
+        # The spec takes the top 39 of these 40 bits and splits them into
+        # three 13-bit groups, each shown as a number from 1000 to 9191.
+        value = int.from_bytes(sas_bytes, "big") >> 1
+        return (
+            ((value >> 26) & 0x1FFF) + 1000,
+            ((value >> 13) & 0x1FFF) + 1000,
+            (value & 0x1FFF) + 1000,
+        )
 
     def _calculate_mac(
         self,
@@ -433,6 +503,7 @@ class MatrixSASVerification:
         if self._shared_secret is None:
             raise ValueError("SAS shared secret has not been established")
 
+        # Bind the proof to both devices, this transaction, and this key.
         info = (
             "MATRIX_KEY_VERIFICATION_MAC"
             + sender_user_id
@@ -442,6 +513,7 @@ class MatrixSASVerification:
             + self.transaction_id
             + key_id
         ).encode("utf-8")
+        # Derive a separate MAC key for each value being proven.
         mac_key = _hkdf_sha256(self._shared_secret, 32, salt=None, info=info)
         return _b64enc(_hmac_sha256(mac_key, value.encode("utf-8")))
 
@@ -450,6 +522,7 @@ class MatrixSASVerification:
         if self.state != "key_received":
             raise ValueError("SAS peer key has not been received")
 
+        # Prove ownership of this device's long-term signing key.
         key_id = "ed25519:{}".format(self.own_device_id)
         content = {
             "transaction_id": self.transaction_id,
@@ -472,23 +545,47 @@ class MatrixSASVerification:
                 self.peer_device_id,
             ),
         }
+        # The responder now waits for the peer's matching proof.
         self.state = "mac_sent"
         return content
 
     def verify_peer_mac(self, content, peer_keys):
-        """Validate the initiator's key MACs from a trusted keys query."""
+        """Validate the initiator's MACs against the queried keys."""
         if self.state != "mac_sent":
             raise ValueError("Unexpected SAS MAC event")
         if content.get("transaction_id") != self.transaction_id:
             raise ValueError("SAS MAC transaction does not match")
 
+        # The peer must prove at least its own device signing key.
         macs = content.get("mac")
         if not isinstance(macs, dict) or not macs:
             raise ValueError("SAS MAC event contains no keys")
+        if len(macs) > self.MAX_MAC_KEYS:
+            # Reject oversized key lists before sorting or hashing them.
+            raise ValueError("SAS MAC event carries too many keys")
+
+        # Validate each bounded key ID and MAC before processing it.
+        for key_id, mac_value in macs.items():
+            if (
+                not isinstance(key_id, str)
+                or not 0 < len(key_id) <= self.MAX_FIELD_LEN
+                or not isinstance(mac_value, str)
+                or not 0 < len(mac_value) <= self.MAX_FIELD_LEN
+            ):
+                raise ValueError("SAS MAC event carries a malformed entry")
+
         device_key_id = "ed25519:{}".format(self.peer_device_id)
         if device_key_id not in macs:
             raise ValueError("SAS MAC omits the peer device key")
 
+        keys_mac = content.get("keys", "")
+        if (
+            not isinstance(keys_mac, str)
+            or not 0 < len(keys_mac) <= self.MAX_FIELD_LEN
+        ):
+            raise ValueError("SAS MAC event carries a malformed key list MAC")
+
+        # First verify that the advertised key list was not changed in transit.
         key_ids = ",".join(sorted(macs))
         expected_keys_mac = self._calculate_mac(
             key_ids,
@@ -498,16 +595,20 @@ class MatrixSASVerification:
             self.own_user_id,
             self.own_device_id,
         )
-        if not secrets.compare_digest(
-            content.get("keys", ""), expected_keys_mac
-        ):
+        if not secrets.compare_digest(keys_mac, expected_keys_mac):
             raise ValueError("SAS key list MAC does not match")
 
+        # Then validate the proof for every key named by the peer.
         for key_id, received_mac in macs.items():
             try:
                 public_key = peer_keys[key_id]
             except (KeyError, TypeError):
                 raise ValueError("SAS MAC references an unknown key") from None
+            if (
+                not isinstance(public_key, str)
+                or not 0 < len(public_key) <= self.MAX_FIELD_LEN
+            ):
+                raise ValueError("SAS MAC references a malformed key")
             expected_mac = self._calculate_mac(
                 public_key,
                 key_id,
@@ -519,6 +620,7 @@ class MatrixSASVerification:
             if not secrets.compare_digest(received_mac, expected_mac):
                 raise ValueError("SAS device key MAC does not match")
 
+        # Every advertised proof matched the queried keys.
         self.state = "verified"
         return True
 
@@ -742,14 +844,8 @@ class MatrixOlmAccount:
             _b64dec(their_one_time_key_b64)
         )
 
-        # E_A is Alice's ephemeral key.  It serves BOTH as the Base-Key
-        # (outer pre-key field 2) AND as the initial Ratchet-Key (inner
-        # field 1).  The Olm spec Section 5.1 is explicit:
-        #   "E_A^pub is also the ratchet key for the first message."
-        # libolm passes the same keypair to both the X3DH and the ratchet
-        # initialisation (ratchet.cpp: initialise_as_alice receives base_key
-        # and uses it as the initial sender ratchet key).  Using two
-        # different keys here breaks decryption.
+        # Olm uses the same temporary key as its base and first ratchet key.
+        # Using different keys would prevent the recipient from decrypting.
         eph = X25519PrivateKey.generate()
         eph_pub = eph.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
 
@@ -761,18 +857,8 @@ class MatrixOlmAccount:
         dh2 = eph.exchange(their_ik)
         dh3 = eph.exchange(their_otk)
 
-        # Root-key derivation (libolm ratchet.cpp initialise_as_alice /
-        # vodozemac shared_secret.rs Shared3DHSecret::expand):
-        #   IKM  = DH1 || DH2 || DH3  (96 bytes — no zero prefix)
-        #   salt = nullptr / 0x00*32   (RFC 5869: missing salt = HashLen zeros)
-        #   info = "OLM_ROOT"
-        #
-        # libolm passes the 96-byte secret directly
-        # (session.cpp: secret[3 * CURVE25519_SHARED_SECRET_LENGTH]).
-        # vodozemac does the same (Shared3DHSecret is Box<[u8; 96]>).
-        # Adding any prefix produces a different PRK and therefore
-        # different root/chain keys, causing the recipient to fail to
-        # decrypt the Olm pre-key message that carries the MegOLM room key.
+        # Derive matching root and chain keys from the three shared secrets.
+        # Olm uses their 96 bytes directly, without an added prefix.
         ikm = dh1 + dh2 + dh3
         keys = _hkdf_sha256(ikm, 64, salt=None, info=b"OLM_ROOT")
         root_key = keys[:32]
@@ -878,12 +964,7 @@ class MatrixOlmSession:
         #   0x1A = field 3 (bytes) -> Identity-Key (Alice's identity key)
         #   0x22 = field 4 (bytes) -> Message (inner message + inner MAC)
         #
-        # The outer pre-key message has NO trailing MAC of its own.
-        # libolm session.cpp allocates exactly
-        # encode_one_time_key_message_length() bytes — no extra space for an
-        # outer MAC.  vodozemac decodes the outer payload with prost (strict
-        # protobuf) so extra bytes after the last field cause a DecodeError
-        # and the session fails to establish.
+        # The outer message has no trailing MAC; adding one breaks decoding.
         outer = (
             b"\x03"
             + _pb_bytes(1, self._their_otk_pub)

--- a/apprise/plugins/matrix/sas.py
+++ b/apprise/plugins/matrix/sas.py
@@ -1,0 +1,691 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Handles opt-in SAS verification from another device for the same Matrix user.
+# A completed exchange is remembered for the current identity.
+# Cryptography lives in MatrixSASVerification; this module manages the events
+# and stored trust state.
+#
+# Protocol reference:
+# https://spec.matrix.org/v1.19/client-server-api/#key-verification-framework
+
+from json import dumps
+import math
+from time import monotonic, time
+import uuid
+
+from .e2ee import MatrixSASVerification, verify_device_keys
+
+# To-device event types exchanged during a SAS verification.
+EVENT_REQUEST = "m.key.verification.request"
+EVENT_READY = "m.key.verification.ready"
+EVENT_START = "m.key.verification.start"
+EVENT_ACCEPT = "m.key.verification.accept"
+EVENT_CANCEL = "m.key.verification.cancel"
+EVENT_KEY = "m.key.verification.key"
+EVENT_MAC = "m.key.verification.mac"
+EVENT_DONE = "m.key.verification.done"
+
+# Keep the supported method aligned with the SAS responder.
+SAS_METHOD = MatrixSASVerification.METHOD
+
+# Ignore requests outside these age limits as stale or replayed.
+REQUEST_MAX_PAST_MS = 10 * 60 * 1000
+REQUEST_MAX_FUTURE_MS = 5 * 60 * 1000
+
+# Bound identifiers before echoing, comparing, or hashing them.
+MAX_ID_LEN = 512
+
+# Bound the small key maps normally advertised by Matrix devices.
+MAX_DEVICE_KEYS = 8
+
+# SAS protocol responses should remain comfortably below this limit.
+MAX_RESPONSE_BYTES = 1024 * 1024
+
+
+def _valid_id(value):
+    """Return whether a Matrix ID is a non-empty string within our limit."""
+    return isinstance(value, str) and 0 < len(value) <= MAX_ID_LEN
+
+
+# Matrix always includes to-device events, so exclude everything else.
+# An empty room list avoids unnecessary nested filters and invalid limits.
+SYNC_FILTER = dumps(
+    {
+        "presence": {"types": []},
+        "account_data": {"types": []},
+        "room": {"rooms": []},
+    }
+)
+
+# Use this fallback when the configured read timeout is invalid.
+FALLBACK_SYNC_POLL_MS = 2000
+
+# Avoid near-instant polling when the configured timeout is very small.
+MIN_SYNC_POLL_MS = 250
+
+
+def _sync_poll_ms(plugin):
+    """Return a safe polling interval based on the configured read timeout."""
+    poll_ms = plugin.socket_read_timeout * 1000 / 2
+    if not math.isfinite(poll_ms) or poll_ms <= 0:
+        return FALLBACK_SYNC_POLL_MS
+
+    return max(MIN_SYNC_POLL_MS, int(poll_ms))
+
+
+def store_verified_binding(plugin):
+    """Remember that the current custom E2EE identity completed SAS."""
+    # Trust applies to the exact device and account recorded during setup.
+    binding = plugin.store.get("e2ee_device_binding")
+    if not binding:
+        # Never create a trust marker without an identity to bind it to.
+        return False
+
+    # Use the normal cache lifetime so related identity records expire
+    # together.
+    return plugin.store.set(
+        "e2ee_verified_binding",
+        binding,
+        expires=plugin.default_cache_expiry_sec,
+    )
+
+
+def refresh_verified_state(plugin):
+    """Refresh the identity state needed to retain SAS trust.
+
+    A changed device or E2EE account requires verification again. Other
+    cached Matrix state is left untouched.
+    """
+    # Do not delay delivery while another verification holds the lock.
+    if not plugin._autoverify_lock.acquire(blocking=False):
+        return False
+    try:
+        # Load the identity that was originally verified.
+        binding = plugin.store.get("e2ee_device_binding")
+        if (
+            not binding
+            or plugin.store.get("e2ee_verified_binding") != binding
+            or not plugin.user_id
+            or not plugin.device_id
+            or not plugin._e2ee_account
+        ):
+            # Missing or mismatched state requires verification again.
+            return False
+
+        # Confirm that the live account still matches the stored identity.
+        if binding != plugin._e2ee_binding_key():
+            return False
+
+        # Limit identity writes and treat an invalid timestamp as missing.
+        last_refreshed = plugin.store.get("e2ee_autoverify_refreshed_at", 0)
+        if not isinstance(last_refreshed, (int, float)) or not math.isfinite(
+            last_refreshed
+        ):
+            # Non-finite timestamps could suppress refreshes until expiration.
+            last_refreshed = 0
+        if (
+            time() - last_refreshed
+            < plugin.default_autoverify_refresh_interval_sec
+        ):
+            return True
+
+        # Refresh identity records in order and stop after the first failure.
+        if not plugin.store.set(
+            "device_id",
+            plugin.device_id,
+            expires=plugin.default_cache_expiry_sec,
+        ):
+            return False
+
+        if not plugin.store.set(
+            "e2ee_account",
+            plugin._e2ee_account.to_dict(),
+            expires=plugin.default_cache_expiry_sec,
+        ):
+            return False
+
+        if not plugin.store.set(
+            "e2ee_device_binding",
+            binding,
+            expires=plugin.default_cache_expiry_sec,
+        ):
+            return False
+
+        # Write the trust marker last. A partial refresh must fail closed
+        # instead of extending trust without its complete bound identity.
+        if not plugin.store.set(
+            "e2ee_verified_binding",
+            binding,
+            expires=plugin.default_cache_expiry_sec,
+        ):
+            return False
+
+        # A bookkeeping failure only causes another refresh sooner than
+        # planned.
+        plugin.store.set(
+            "e2ee_autoverify_refreshed_at",
+            time(),
+            expires=plugin.default_cache_expiry_sec,
+        )
+        return True
+    finally:
+        plugin._autoverify_lock.release()
+
+
+def auto_verify(plugin):
+    """Automatically complete one same-user SAS verification for *plugin*.
+
+    This is the entry point for the opt-in ``autoverify=yes`` bootstrap.
+    """
+    # Let one caller verify while concurrent callers continue delivery.
+    if not plugin._autoverify_lock.acquire(blocking=False):
+        return False
+
+    try:
+        # Reuse trust only when it belongs to the current stored identity.
+        binding = plugin.store.get("e2ee_device_binding")
+        if binding and plugin.store.get("e2ee_verified_binding") == binding:
+            # Already verified for the current identity; nothing to do.
+            return True
+
+        if (
+            not plugin.user_id
+            or not plugin.device_id
+            or not plugin._e2ee_account
+        ):
+            # Login and E2EE setup must finish before verification
+            # can begin.
+            return False
+
+        # Delay retries only for the identity that just failed.
+        if plugin.store.get("e2ee_autoverify_cooldown") == binding:
+            return False
+
+        # A fresh verifier owns all state for this single attempt.
+        result = MatrixSASAutoVerifier(plugin).run()
+        if not result:
+            plugin.store.set(
+                "e2ee_autoverify_cooldown",
+                binding,
+                expires=plugin.default_autoverify_retry_cooldown_sec,
+            )
+
+        return result
+    finally:
+        plugin._autoverify_lock.release()
+
+
+class MatrixSASAutoVerifier:
+    """Complete one same-user SAS verification.
+
+    Each instance handles one transaction and is discarded afterward.
+    """
+
+    def __init__(self, plugin):
+        """Bind this verifier to the owning NotifyMatrix instance."""
+        self.plugin = plugin
+
+        # No transaction exists until a valid request is accepted.
+        self.active = None
+
+        # Share one reliable deadline across every request in this attempt.
+        self.deadline = monotonic() + plugin.default_autoverify_timeout_sec
+
+    def _bounded_fetch(
+        self, path, bound_sec=None, best_effort=False, **kwargs
+    ):
+        """Fetch within this verification attempt's remaining time.
+
+        ``bound_sec`` can shorten a call. ``best_effort`` allows the final
+        cancellation request after the deadline.
+        """
+        remaining = max(0.0, self.deadline - monotonic())
+        if remaining <= 0 and not best_effort:
+            # Do not start another request after the deadline.
+            return (False, {}, None)
+        if bound_sec is None:
+            bound_sec = _sync_poll_ms(self.plugin) / 1000
+        # Allow two seconds for network activity around the server wait.
+        fetch_timeout = min(bound_sec, remaining) + 2
+        kwargs.setdefault("timeout", (fetch_timeout, fetch_timeout))
+        kwargs.setdefault("max_retry_wait", remaining)
+        kwargs.setdefault("max_response_bytes", MAX_RESPONSE_BYTES)
+        return self.plugin._fetch(path, **kwargs)
+
+    def run(self):
+        """Poll ``/sync`` until a SAS verification completes or expires."""
+        self.plugin.logger.info(
+            "Matrix E2EE: waiting up to %d seconds for a same-user "
+            "SAS verification request.",
+            self.plugin.default_autoverify_timeout_sec,
+        )
+
+        # Keep each poll below the configured socket read timeout.
+        max_poll_ms = _sync_poll_ms(self.plugin)
+
+        # The sync token prevents older events from being returned
+        # repeatedly.
+        since = None
+
+        while monotonic() < self.deadline:
+            # Cap the requested long poll by the time left in this attempt.
+            remaining_ms = max(0, int((self.deadline - monotonic()) * 1000))
+            poll_ms = min(max_poll_ms, remaining_ms)
+            params = {
+                "timeout": poll_ms,
+                # Only to-device events are needed for verification.
+                "filter": SYNC_FILTER,
+                # Verification polling should not make the account look online.
+                "set_presence": "offline",
+            }
+            if since:
+                params["since"] = since
+
+            # Verification events arrive through the normal Matrix sync feed.
+            ok, response, _ = self._bounded_fetch(
+                "/sync",
+                bound_sec=poll_ms / 1000,
+                params=params,
+                method="GET",
+            )
+            if not ok or not isinstance(response, dict):
+                # A failed sync ends this attempt without changing trust.
+                return False
+
+            # A missing sync token cannot be resumed safely and may cause a
+            # tight loop of immediate responses.
+            next_batch = response.get("next_batch")
+            if not isinstance(next_batch, str) or not next_batch:
+                return False
+            since = next_batch
+
+            # Treat malformed event containers as empty.
+            to_device = response.get("to_device")
+            events = (
+                to_device.get("events")
+                if isinstance(to_device, dict)
+                else None
+            )
+            for event in events if isinstance(events, list) else []:
+                try:
+                    # A handler returns None while the transaction is
+                    # still active.
+                    result = self._handle_event(event)
+                except (AttributeError, KeyError, TypeError, ValueError):
+                    # Skip malformed events without interrupting delivery.
+                    continue
+                if result is not None:
+                    return result
+                if monotonic() >= self.deadline:
+                    # Stop processing an oversized batch at the deadline.
+                    break
+
+        # Tell the peer when this verification attempt expires.
+        return self._fail("m.timeout", "SAS verification timed out")
+
+    def _handle_event(self, event):
+        """Dispatch one ``/sync`` to-device event.
+
+        Returns ``True``/``False`` when verification has reached a final
+        outcome, or ``None`` to keep polling.
+        """
+        if not isinstance(event, dict):
+            # Matrix events must be JSON objects.
+            return None
+
+        # Pull out the common fields before routing by event type.
+        event_type = event.get("type")
+        sender = event.get("sender")
+        content = event.get("content", {})
+        if sender != self.plugin.user_id or not isinstance(content, dict):
+            # Auto-verification is intentionally same-user only.
+            return None
+
+        if event_type == EVENT_REQUEST:
+            # A request may create the one active transaction.
+            return self._handle_request(sender, content)
+
+        # Remaining events must belong to the active transaction.
+        transaction_id = content.get("transaction_id")
+        if not self.active or transaction_id != self.active["transaction_id"]:
+            # Ignore late events and events for other verification attempts.
+            return None
+        if sender != self.active["user_id"]:
+            # Only the device owner that opened the transaction may
+            # continue it.
+            return None
+
+        if event_type == EVENT_CANCEL:
+            return self._handle_cancel(content)
+
+        if event_type == EVENT_START:
+            return self._handle_start(sender, content)
+
+        sas = self.active.get("sas")
+        if sas is None:
+            # Key, MAC, and done events are invalid until SAS has started.
+            return self._fail(
+                "m.unexpected_message", "SAS verification has not started"
+            )
+
+        if event_type == EVENT_KEY:
+            return self._handle_key(sas, sender, content)
+
+        if event_type == EVENT_MAC:
+            return self._handle_mac(sas, content)
+
+        if event_type == EVENT_DONE:
+            return self._handle_done(sas)
+
+        # Ignore unrelated event types.
+        return None
+
+    def _handle_request(self, sender, content):
+        """Handle ``m.key.verification.request``."""
+        # Read the fields required to identify a fresh request.
+        timestamp = content.get("timestamp")
+        now_ms = int(time() * 1000)
+        transaction_id = content.get("transaction_id")
+        from_device = content.get("from_device")
+        methods = content.get("methods")
+
+        if (
+            not isinstance(timestamp, int)
+            or timestamp < now_ms - REQUEST_MAX_PAST_MS
+            or timestamp > now_ms + REQUEST_MAX_FUTURE_MS
+            or not _valid_id(transaction_id)
+            or not _valid_id(from_device)
+            or not isinstance(methods, list)
+            or SAS_METHOD not in methods
+        ):
+            # Malformed or stale request; ignore and keep waiting.
+            return None
+
+        if self.active:
+            same_device = (
+                sender == self.active["user_id"]
+                and from_device == self.active["device_id"]
+            )
+            if same_device and transaction_id == self.active["transaction_id"]:
+                # Ignore an exact replay without cancelling our transaction.
+                return None
+
+            if same_device:
+                # Matrix requires both attempts from the device to be ended.
+                self._cancel(
+                    "m.unexpected_message",
+                    "A newer verification request superseded this one",
+                )
+                self.active = None
+
+            # Reject the new request without disturbing another device.
+            self._send_event(
+                EVENT_CANCEL,
+                sender,
+                from_device,
+                {
+                    "transaction_id": transaction_id,
+                    "code": "m.unexpected_message",
+                    "reason": "Another verification is already active",
+                },
+            )
+            return None
+
+        peer_keys = self._peer_keys(sender, from_device)
+        if not peer_keys:
+            # Verification cannot continue without a valid peer device key.
+            return False
+
+        # Keep all details needed by the remaining events in one record.
+        self.active = {
+            "transaction_id": transaction_id,
+            "user_id": sender,
+            "device_id": from_device,
+            "peer_keys": peer_keys,
+            "sas": None,
+            "peer_done": False,
+        }
+
+        # Tell the requesting device that this responder supports SAS.
+        if not self._send_event(
+            EVENT_READY,
+            sender,
+            from_device,
+            {
+                "transaction_id": transaction_id,
+                "from_device": self.plugin.device_id,
+                "methods": [SAS_METHOD],
+            },
+        ):
+            return False
+
+        return None
+
+    def _handle_cancel(self, content):
+        """Handle ``m.key.verification.cancel`` from the peer."""
+        # Preserve the peer's reason to make failed attempts diagnosable.
+        self.plugin.logger.warning(
+            "Matrix E2EE SAS verification was cancelled: %s",
+            content.get("reason") or "unspecified reason",
+        )
+        return False
+
+    def _handle_start(self, sender, content):
+        """Handle ``m.key.verification.start``."""
+        if self.active.get("sas") is not None:
+            # Reject a restart after committing to this transaction's key.
+            return self._fail(
+                "m.unexpected_message",
+                "SAS verification was already started",
+            )
+
+        try:
+            # Validate the proposal and prepare the matching acceptance event.
+            sas = MatrixSASVerification(
+                self.plugin.user_id,
+                self.plugin.device_id,
+                sender,
+                self.active["device_id"],
+                content,
+            )
+            accept = sas.accept_content()
+
+        except (TypeError, ValueError):
+            # Unsupported or malformed proposals end the transaction cleanly.
+            return self._fail(
+                "m.unknown_method", "Unsupported SAS verification parameters"
+            )
+
+        # Retain the state machine for the key and MAC events that follow.
+        self.active["sas"] = sas
+        if not self._send_event(
+            EVENT_ACCEPT,
+            sender,
+            self.active["device_id"],
+            accept,
+        ):
+            return False
+
+        return None
+
+    def _handle_key(self, sas, sender, content):
+        """Handle ``m.key.verification.key``."""
+        try:
+            # Establish the shared secret and build this device's proof.
+            sas.receive_key(content.get("key") or "")
+            sas_code = sas.decimal_sas()
+            key_content = sas.key_content()
+            mac_content = sas.mac_content(
+                self.plugin._e2ee_account.signing_key
+            )
+
+        except (TypeError, ValueError):
+            # Reject public keys that cannot form a valid exchange.
+            return self._fail("m.invalid_message", "Invalid SAS public key")
+
+        # Apprise responds automatically, so confirm its logged code on the
+        # other device before approving the verification there.
+        self.plugin.logger.info(
+            "Matrix E2EE SAS code (compare against your other device): "
+            "%d-%d-%d",
+            *sas_code,
+        )
+
+        # Both the public key and its MAC must reach the same peer device.
+        device_id = self.active["device_id"]
+        if not self._send_event(
+            EVENT_KEY, sender, device_id, key_content
+        ) or not self._send_event(EVENT_MAC, sender, device_id, mac_content):
+            return False
+
+        return None
+
+    def _handle_mac(self, sas, content):
+        """Handle ``m.key.verification.mac``."""
+        try:
+            # Confirm that the peer possesses the advertised device keys.
+            sas.verify_peer_mac(content, self.active["peer_keys"])
+
+        except (TypeError, ValueError):
+            # Treat malformed and mismatched proofs as verification failures.
+            return self._fail(
+                "m.key_mismatch", "SAS device key MAC did not match"
+            )
+
+        # Our side is complete once the peer's proof is valid.
+        if not self._send_event(
+            EVENT_DONE,
+            self.active["user_id"],
+            self.active["device_id"],
+            {"transaction_id": self.active["transaction_id"]},
+        ):
+            return False
+
+        if self.active["peer_done"]:
+            # Both devices are finished, so this identity may retain trust.
+            # Verification succeeds only if its trust marker is saved.
+            return store_verified_binding(self.plugin)
+
+        return None
+
+    def _handle_done(self, sas):
+        """Handle ``m.key.verification.done``."""
+        # The peer may finish before or after its MAC reaches us.
+        self.active["peer_done"] = True
+        if sas.state == "verified":
+            # Save trust only after verifying the peer's MAC.
+            return store_verified_binding(self.plugin)
+
+        return None
+
+    def _send_event(
+        self, event_type, user_id, device_id, content, best_effort=False
+    ):
+        """Send one unencrypted SAS event to a specific Matrix device."""
+        # A unique transaction path prevents repeated PUTs from colliding.
+        path = "/sendToDevice/{}/{}".format(event_type, uuid.uuid4().hex)
+        ok, _, _ = self._bounded_fetch(
+            path,
+            payload={"messages": {user_id: {device_id: content}}},
+            method="PUT",
+            best_effort=best_effort,
+        )
+        return ok
+
+    def _cancel(self, code, reason):
+        """Cancel the active SAS transaction on the peer device."""
+        if not self.active:
+            # There is no peer transaction to cancel yet.
+            return False
+
+        # Send the matching cancellation even when the deadline just passed.
+        return self._send_event(
+            EVENT_CANCEL,
+            self.active["user_id"],
+            self.active["device_id"],
+            {
+                "transaction_id": self.active["transaction_id"],
+                "code": code,
+                "reason": reason,
+            },
+            best_effort=True,
+        )
+
+    def _fail(self, code, reason):
+        """Cancel the active transaction (if any) and report failure."""
+        # Cancellation is best-effort; the local result remains a failure.
+        self._cancel(code, reason)
+        return False
+
+    def _peer_keys(self, user_id, device_id):
+        """Return validated device and advertised cross-signing keys."""
+        # Ask only for the device involved in this verification.
+        ok, response, _ = self._bounded_fetch(
+            "/keys/query",
+            payload={"device_keys": {user_id: [device_id]}},
+        )
+        if not ok or not isinstance(response, dict):
+            # Missing keys leave no identity for the SAS proof to confirm.
+            return None
+
+        # Validate each server field before using the self-signed device key.
+        device_keys = response.get("device_keys")
+        user_devices = (
+            device_keys.get(user_id) if isinstance(device_keys, dict) else None
+        )
+        device = (
+            user_devices.get(device_id)
+            if isinstance(user_devices, dict)
+            else None
+        )
+        if not isinstance(device, dict) or not verify_device_keys(
+            device, user_id, device_id
+        ):
+            return None
+
+        # Device keys are mandatory; advertised master keys are optional.
+        raw_keys = device.get("keys")
+        keys = (
+            dict(raw_keys)
+            if isinstance(raw_keys, dict) and len(raw_keys) <= MAX_DEVICE_KEYS
+            else {}
+        )
+
+        master_keys = response.get("master_keys")
+        master_key = (
+            master_keys.get(user_id) if isinstance(master_keys, dict) else None
+        )
+        if isinstance(master_key, dict):
+            raw_master_keys = master_key.get("keys")
+            if (
+                isinstance(raw_master_keys, dict)
+                and len(raw_master_keys) <= MAX_DEVICE_KEYS
+            ):
+                keys.update(raw_master_keys)
+
+        return keys

--- a/apprise/plugins/matrix/sas.py
+++ b/apprise/plugins/matrix/sas.py
@@ -264,7 +264,12 @@ class MatrixSASAutoVerifier:
         ``bound_sec`` can shorten a call. ``best_effort`` allows the final
         cancellation request after the deadline.
         """
-        remaining = max(0.0, self.deadline - monotonic())
+        # Clamp to the configured budget and the remaining time in this
+        # verification attempt.
+        remaining = min(
+            self.plugin.default_autoverify_timeout_sec,
+            max(0.0, self.deadline - monotonic()),
+        )
         if remaining <= 0 and not best_effort:
             # Do not start another request after the deadline.
             return (False, {}, None)

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -2455,6 +2455,269 @@ def test_plugin_matrix_e2ee_helpers():
     assert out.startswith(b'{"a"')
 
 
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_responder_roundtrip():
+    """The custom SAS responder interoperates without libolm."""
+    import hashlib
+
+    from cryptography.hazmat.primitives.asymmetric.x25519 import (
+        X25519PrivateKey,
+        X25519PublicKey,
+    )
+    from cryptography.hazmat.primitives.serialization import (
+        Encoding,
+        PublicFormat,
+    )
+
+    from apprise.plugins.matrix.e2ee import (
+        MatrixOlmAccount,
+        MatrixSASVerification,
+        _b64dec,
+        _b64enc,
+        _canonical_json,
+        _hkdf_sha256,
+        _hmac_sha256,
+    )
+
+    own_user = peer_user = "@u:h"
+    own_device = "APPRISE"
+    peer_device = "ELEMENT"
+    transaction_id = "sas-transaction"
+    start = {
+        "from_device": peer_device,
+        "transaction_id": transaction_id,
+        "method": "m.sas.v1",
+        "key_agreement_protocols": ["curve25519-hkdf-sha256"],
+        "hashes": ["sha256"],
+        "message_authentication_codes": ["hkdf-hmac-sha256.v2"],
+        "short_authentication_string": ["decimal", "emoji"],
+    }
+    sas = MatrixSASVerification(
+        own_user,
+        own_device,
+        peer_user,
+        peer_device,
+        start,
+    )
+    accept = sas.accept_content()
+    commitment = hashlib.sha256(
+        sas.public_key.encode("ascii") + _canonical_json(start)
+    ).digest()
+    assert accept["commitment"] == _b64enc(commitment)
+    assert accept["message_authentication_code"] == ("hkdf-hmac-sha256.v2")
+
+    peer_private = X25519PrivateKey.generate()
+    peer_public = _b64enc(
+        peer_private.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    )
+    sas.receive_key(peer_public)
+    assert sas.key_content()["key"] == sas.public_key
+    shared_secret = peer_private.exchange(
+        X25519PublicKey.from_public_bytes(_b64dec(sas.public_key))
+    )
+
+    def peer_mac(value, key_id):
+        info = (
+            "MATRIX_KEY_VERIFICATION_MAC"
+            + peer_user
+            + peer_device
+            + own_user
+            + own_device
+            + transaction_id
+            + key_id
+        ).encode("utf-8")
+        key = _hkdf_sha256(shared_secret, 32, salt=None, info=info)
+        return _b64enc(_hmac_sha256(key, value.encode("utf-8")))
+
+    own_account = MatrixOlmAccount()
+    own_mac = sas.mac_content(own_account.signing_key)
+    assert "ed25519:APPRISE" in own_mac["mac"]
+
+    peer_account = MatrixOlmAccount()
+    peer_key_id = "ed25519:{}".format(peer_device)
+    peer_content = {
+        "transaction_id": transaction_id,
+        "mac": {peer_key_id: peer_mac(peer_account.signing_key, peer_key_id)},
+        "keys": peer_mac(peer_key_id, "KEY_IDS"),
+    }
+    tampered = dict(peer_content)
+    tampered["keys"] = "invalid"
+    with pytest.raises(ValueError, match="key list MAC"):
+        sas.verify_peer_mac(tampered, {peer_key_id: peer_account.signing_key})
+    assert sas.verify_peer_mac(
+        peer_content, {peer_key_id: peer_account.signing_key}
+    )
+    assert sas.state == "verified"
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_auto_verify_flow():
+    """The Matrix plugin drives the same-user SAS to-device flow."""
+    from time import time
+
+    from cryptography.hazmat.primitives.asymmetric.x25519 import (
+        X25519PrivateKey,
+        X25519PublicKey,
+    )
+    from cryptography.hazmat.primitives.serialization import (
+        Encoding,
+        PublicFormat,
+    )
+
+    from apprise.plugins.matrix.e2ee import (
+        MatrixOlmAccount,
+        _b64dec,
+        _b64enc,
+        _hkdf_sha256,
+        _hmac_sha256,
+    )
+
+    user_id = "@u:h"
+    own_device = "APPRISE"
+    peer_device = "ELEMENT"
+    transaction_id = "sas-flow"
+    own_account = MatrixOlmAccount()
+    peer_account = MatrixOlmAccount()
+    peer_private = X25519PrivateKey.generate()
+    peer_public = _b64enc(
+        peer_private.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    )
+    peer_device_keys = peer_account.device_keys_payload(user_id, peer_device)
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+        autoverify=True,
+    )
+    obj.user_id = user_id
+    obj.device_id = own_device
+    obj._e2ee_account = own_account
+    binding = "{}|{}|{}|{}".format(
+        user_id,
+        own_device,
+        own_account.identity_key,
+        own_account.signing_key,
+    )
+    obj.store.set("e2ee_device_binding", binding, expires=60)
+
+    sent = []
+
+    def send_event(event_type, event_user, event_device, content):
+        sent.append((event_type, event_user, event_device, content))
+        return True
+
+    sync_index = 0
+
+    def fake_fetch(path, payload=None, params=None, method="POST", **kwargs):
+        nonlocal sync_index
+        if path == "/keys/query":
+            return (
+                True,
+                {"device_keys": {user_id: {peer_device: peer_device_keys}}},
+                requests.codes.ok,
+            )
+        assert path == "/sync"
+        if sync_index == 0:
+            event_type = "m.key.verification.request"
+            content = {
+                "from_device": peer_device,
+                "transaction_id": transaction_id,
+                "methods": ["m.sas.v1"],
+                "timestamp": int(time() * 1000),
+            }
+        elif sync_index == 1:
+            event_type = "m.key.verification.start"
+            content = {
+                "from_device": peer_device,
+                "transaction_id": transaction_id,
+                "method": "m.sas.v1",
+                "key_agreement_protocols": ["curve25519-hkdf-sha256"],
+                "hashes": ["sha256"],
+                "message_authentication_codes": ["hkdf-hmac-sha256.v2"],
+                "short_authentication_string": ["decimal", "emoji"],
+            }
+        elif sync_index == 2:
+            event_type = "m.key.verification.key"
+            content = {
+                "transaction_id": transaction_id,
+                "key": peer_public,
+            }
+        elif sync_index == 3:
+            event_type = "m.key.verification.mac"
+            own_key_event = next(
+                item for item in sent if item[0] == "m.key.verification.key"
+            )
+            own_public = own_key_event[3]["key"]
+            shared_secret = peer_private.exchange(
+                X25519PublicKey.from_public_bytes(_b64dec(own_public))
+            )
+            key_id = "ed25519:{}".format(peer_device)
+
+            def calculate_mac(value, info_key_id):
+                info = (
+                    "MATRIX_KEY_VERIFICATION_MAC"
+                    + user_id
+                    + peer_device
+                    + user_id
+                    + own_device
+                    + transaction_id
+                    + info_key_id
+                ).encode("utf-8")
+                key = _hkdf_sha256(shared_secret, 32, salt=None, info=info)
+                return _b64enc(_hmac_sha256(key, value.encode("utf-8")))
+
+            content = {
+                "transaction_id": transaction_id,
+                "mac": {
+                    key_id: calculate_mac(peer_account.signing_key, key_id)
+                },
+                "keys": calculate_mac(key_id, "KEY_IDS"),
+            }
+        else:
+            event_type = "m.key.verification.done"
+            content = {"transaction_id": transaction_id}
+
+        sync_index += 1
+        return (
+            True,
+            {
+                "next_batch": "sync-{}".format(sync_index),
+                "to_device": {
+                    "events": [
+                        {
+                            "type": event_type,
+                            "sender": user_id,
+                            "content": content,
+                        }
+                    ]
+                },
+            },
+            requests.codes.ok,
+        )
+
+    with (
+        mock.patch.object(obj, "_fetch", side_effect=fake_fetch),
+        mock.patch.object(
+            obj,
+            "_e2ee_send_verification_event",
+            side_effect=send_event,
+        ),
+    ):
+        assert obj._e2ee_auto_verify() is True
+
+    assert [item[0] for item in sent] == [
+        "m.key.verification.ready",
+        "m.key.verification.accept",
+        "m.key.verification.key",
+        "m.key.verification.mac",
+        "m.key.verification.done",
+    ]
+    assert obj.store.get("e2ee_verified_binding") == binding
+
+
 def test_plugin_matrix_e2ee_no_cryptography():
     """MATRIX_E2EE_SUPPORT is False when cryptography is unavailable."""
     import importlib
@@ -2967,6 +3230,21 @@ def test_plugin_matrix_e2ee_url_roundtrip():
         "no",
         "0",
     )
+
+    # Automatic verification is opt-in and survives URL round-trip.
+    obj3 = NotifyMatrix(
+        host="matrix.example.com",
+        user="user",
+        password="pass",
+        targets=["#room"],
+        autoverify=True,
+    )
+    assert obj3.autoverify is True
+    u3 = obj3.url()
+    assert "autoverify=yes" in u3
+    result = NotifyMatrix.parse_url(u3)
+    assert result is not None
+    assert result.get("autoverify") is True
 
 
 @mock.patch("requests.put")

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -2718,6 +2718,81 @@ def test_plugin_matrix_sas_auto_verify_flow():
     assert obj.store.get("e2ee_verified_binding") == binding
 
 
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_verified_state_refresh_is_minimal():
+    """Only identity state required to retain SAS trust is refreshed."""
+    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+        autoverify=True,
+        secure=True,
+    )
+    obj.user_id = "@u:h"
+    obj.device_id = "APPRISE"
+    obj._e2ee_account = MatrixOlmAccount()
+    binding = "{}|{}|{}|{}".format(
+        obj.user_id,
+        obj.device_id,
+        obj._e2ee_account.identity_key,
+        obj._e2ee_account.signing_key,
+    )
+    obj.store.set("e2ee_device_binding", binding, expires=60)
+    obj.store.set("e2ee_verified_binding", binding, expires=60)
+
+    with mock.patch.object(obj.store, "set", wraps=obj.store.set) as store_set:
+        assert obj._e2ee_refresh_verified_state() is True
+
+    assert [call.args[0] for call in store_set.call_args_list] == [
+        "device_id",
+        "e2ee_account",
+        "e2ee_device_binding",
+        "e2ee_verified_binding",
+    ]
+    assert all(
+        call.kwargs["expires"] == obj.default_cache_expiry_sec
+        for call in store_set.call_args_list
+    )
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+@pytest.mark.parametrize("delivery_ok", [True, False])
+def test_plugin_matrix_sas_refresh_only_after_success(delivery_ok):
+    """A failed Matrix delivery must not extend SAS trust."""
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+        autoverify=True,
+        secure=True,
+    )
+    obj.access_token = "token"
+    obj.user_id = "@u:h"
+    obj.device_id = "APPRISE"
+
+    with (
+        mock.patch.object(obj, "_e2ee_setup", return_value=True),
+        mock.patch.object(obj, "_e2ee_auto_verify", return_value=True),
+        mock.patch.object(obj, "_room_join", return_value="!r:h"),
+        mock.patch.object(obj, "_e2ee_room_encrypted", return_value=True),
+        mock.patch.object(
+            obj, "_e2ee_send_to_room", return_value=delivery_ok
+        ),
+        mock.patch.object(
+            obj, "_e2ee_refresh_verified_state", return_value=True
+        ) as refresh,
+    ):
+        assert obj._send_server_notification(body="test") is delivery_ok
+
+    assert refresh.call_count == (1 if delivery_ok else 0)
+
+
 def test_plugin_matrix_e2ee_no_cryptography():
     """MATRIX_E2EE_SUPPORT is False when cryptography is unavailable."""
     import importlib

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -2455,6 +2455,155 @@ def test_plugin_matrix_e2ee_helpers():
     assert out.startswith(b'{"a"')
 
 
+def _matrix_sas_start(peer_device="ELEMENT", transaction_id="sas-transaction"):
+    """Return a valid Matrix SAS start payload."""
+    return {
+        "from_device": peer_device,
+        "transaction_id": transaction_id,
+        "method": "m.sas.v1",
+        "key_agreement_protocols": ["curve25519-hkdf-sha256"],
+        "hashes": ["sha256"],
+        "message_authentication_codes": ["hkdf-hmac-sha256.v2"],
+        "short_authentication_string": ["decimal", "emoji"],
+    }
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+@pytest.mark.parametrize(
+    ("peer_device", "updates", "match"),
+    (
+        ("ELEMENT", {"transaction_id": None}, "Missing SAS transaction"),
+        (None, {}, "Missing SAS transaction"),
+        ("ELEMENT", {"from_device": "OTHER"}, "does not match"),
+        ("ELEMENT", {"method": "unsupported"}, "Unsupported SAS verification"),
+        ("ELEMENT", {"key_agreement_protocols": []}, "key agreement"),
+        ("ELEMENT", {"hashes": []}, "Unsupported SAS hash"),
+        (
+            "ELEMENT",
+            {"message_authentication_codes": []},
+            "Unsupported SAS MAC",
+        ),
+        ("ELEMENT", {"short_authentication_string": ["emoji"]}, "decimal"),
+    ),
+)
+def test_plugin_matrix_sas_rejects_invalid_start(peer_device, updates, match):
+    """SAS negotiation rejects incomplete or unsupported parameters."""
+    from apprise.plugins.matrix.e2ee import MatrixSASVerification
+
+    start = _matrix_sas_start(peer_device=peer_device)
+    start.update(updates)
+    with pytest.raises(ValueError, match=match):
+        MatrixSASVerification("@u:h", "APPRISE", "@u:h", peer_device, start)
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_rejects_invalid_state_transitions():
+    """SAS operations fail closed when received out of order."""
+    from apprise.plugins.matrix.e2ee import MatrixSASVerification
+
+    def sas():
+        return MatrixSASVerification(
+            "@u:h", "APPRISE", "@u:h", "ELEMENT", _matrix_sas_start()
+        )
+
+    obj = sas()
+    obj.accept_content()
+    with pytest.raises(ValueError, match="already accepted"):
+        obj.accept_content()
+    with pytest.raises(ValueError, match="peer key has not been received"):
+        obj.key_content()
+    with pytest.raises(ValueError, match="peer key has not been received"):
+        obj.mac_content("key")
+
+    obj = sas()
+    with pytest.raises(ValueError, match="Unexpected SAS key"):
+        obj.receive_key("invalid")
+    with pytest.raises(ValueError, match="shared secret"):
+        obj._calculate_mac("value", "id", "a", "b", "c", "d")
+    with pytest.raises(ValueError, match="Unexpected SAS MAC"):
+        obj.verify_peer_mac({}, {})
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_rejects_invalid_peer_mac():
+    """Every peer MAC and key-list validation failure is rejected."""
+    from cryptography.hazmat.primitives.asymmetric.x25519 import (
+        X25519PrivateKey,
+    )
+    from cryptography.hazmat.primitives.serialization import (
+        Encoding,
+        PublicFormat,
+    )
+
+    from apprise.plugins.matrix.e2ee import (
+        MatrixSASVerification,
+        _b64enc,
+    )
+
+    obj = MatrixSASVerification(
+        "@u:h", "APPRISE", "@u:h", "ELEMENT", _matrix_sas_start()
+    )
+    obj.accept_content()
+    peer_private = X25519PrivateKey.generate()
+    obj.receive_key(
+        _b64enc(
+            peer_private.public_key().public_bytes(
+                Encoding.Raw, PublicFormat.Raw
+            )
+        )
+    )
+    obj.mac_content("own-signing-key")
+
+    peer_key_id = "ed25519:ELEMENT"
+
+    def peer_mac(value, key_id):
+        return obj._calculate_mac(
+            value,
+            key_id,
+            "@u:h",
+            "ELEMENT",
+            "@u:h",
+            "APPRISE",
+        )
+
+    with pytest.raises(ValueError, match="transaction does not match"):
+        obj.verify_peer_mac({"transaction_id": "other"}, {})
+    with pytest.raises(ValueError, match="contains no keys"):
+        obj.verify_peer_mac({"transaction_id": "sas-transaction"}, {})
+    with pytest.raises(ValueError, match="omits the peer device"):
+        obj.verify_peer_mac(
+            {
+                "transaction_id": "sas-transaction",
+                "mac": {"ed25519:OTHER": "mac"},
+            },
+            {},
+        )
+
+    unknown_macs = {
+        "ed25519:UNKNOWN": "unknown",
+        peer_key_id: peer_mac("peer-signing-key", peer_key_id),
+    }
+    with pytest.raises(ValueError, match="unknown key"):
+        obj.verify_peer_mac(
+            {
+                "transaction_id": "sas-transaction",
+                "mac": unknown_macs,
+                "keys": peer_mac(",".join(sorted(unknown_macs)), "KEY_IDS"),
+            },
+            {peer_key_id: "peer-signing-key"},
+        )
+
+    with pytest.raises(ValueError, match="device key MAC"):
+        obj.verify_peer_mac(
+            {
+                "transaction_id": "sas-transaction",
+                "mac": {peer_key_id: "invalid"},
+                "keys": peer_mac(peer_key_id, "KEY_IDS"),
+            },
+            {peer_key_id: "peer-signing-key"},
+        )
+
+
 @pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_sas_responder_roundtrip():
     """The custom SAS responder interoperates without libolm."""
@@ -2483,15 +2632,7 @@ def test_plugin_matrix_sas_responder_roundtrip():
     own_device = "APPRISE"
     peer_device = "ELEMENT"
     transaction_id = "sas-transaction"
-    start = {
-        "from_device": peer_device,
-        "transaction_id": transaction_id,
-        "method": "m.sas.v1",
-        "key_agreement_protocols": ["curve25519-hkdf-sha256"],
-        "hashes": ["sha256"],
-        "message_authentication_codes": ["hkdf-hmac-sha256.v2"],
-        "short_authentication_string": ["decimal", "emoji"],
-    }
+    start = _matrix_sas_start(peer_device, transaction_id)
     sas = MatrixSASVerification(
         own_user,
         own_device,
@@ -2719,6 +2860,473 @@ def test_plugin_matrix_sas_auto_verify_flow():
 
 
 @pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_transport_and_persistence_guards():
+    """SAS transport and persistent binding helpers fail closed."""
+    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+        autoverify=True,
+        secure=True,
+    )
+    obj.user_id = "@u:h"
+    obj.device_id = "APPRISE"
+    obj._e2ee_account = MatrixOlmAccount()
+
+    with mock.patch.object(
+        obj, "_fetch", return_value=(True, {}, requests.codes.ok)
+    ) as fetch:
+        assert obj._e2ee_send_verification_event(
+            "m.key.verification.ready", "@u:h", "ELEMENT", {"x": 1}
+        )
+    assert fetch.call_args.args[0].startswith(
+        "/sendToDevice/m.key.verification.ready/"
+    )
+    assert fetch.call_args.kwargs["method"] == "PUT"
+
+    assert obj._e2ee_verification_cancel(None, "m.timeout", "timeout") is False
+    active = {
+        "user_id": "@u:h",
+        "device_id": "ELEMENT",
+        "transaction_id": "txn",
+    }
+    with mock.patch.object(
+        obj, "_e2ee_send_verification_event", return_value=True
+    ) as send:
+        assert obj._e2ee_verification_cancel(active, "m.timeout", "timeout")
+    assert send.call_args.args[0] == "m.key.verification.cancel"
+
+    with mock.patch.object(
+        obj, "_fetch", return_value=(False, None, requests.codes.bad_request)
+    ):
+        assert obj._e2ee_verification_peer_keys("@u:h", "ELEMENT") is None
+
+    with mock.patch.object(
+        obj,
+        "_fetch",
+        return_value=(
+            True,
+            {"device_keys": {"@u:h": {"ELEMENT": {}}}},
+            requests.codes.ok,
+        ),
+    ):
+        assert obj._e2ee_verification_peer_keys("@u:h", "ELEMENT") is None
+
+    peer = MatrixOlmAccount()
+    peer_device = peer.device_keys_payload("@u:h", "ELEMENT")
+    with mock.patch.object(
+        obj,
+        "_fetch",
+        return_value=(
+            True,
+            {
+                "device_keys": {"@u:h": {"ELEMENT": peer_device}},
+                "master_keys": {"@u:h": "invalid"},
+            },
+            requests.codes.ok,
+        ),
+    ):
+        assert obj._e2ee_verification_peer_keys("@u:h", "ELEMENT") == dict(
+            peer_device["keys"]
+        )
+
+    with mock.patch.object(obj.store, "get", return_value=None):
+        assert obj._e2ee_store_verified_binding() is False
+        assert obj._e2ee_refresh_verified_state() is False
+
+    current_binding = "{}|{}|{}|{}".format(
+        obj.user_id,
+        obj.device_id,
+        obj._e2ee_account.identity_key,
+        obj._e2ee_account.signing_key,
+    )
+    with mock.patch.object(
+        obj.store,
+        "get",
+        side_effect=lambda key: "wrong-binding",
+    ):
+        assert obj._e2ee_refresh_verified_state() is False
+
+    with (
+        mock.patch.object(
+            obj.store,
+            "get",
+            side_effect=lambda key: current_binding,
+        ),
+        mock.patch.object(obj.store, "set", return_value=False),
+    ):
+        assert obj._e2ee_refresh_verified_state() is False
+
+    with mock.patch.object(
+        obj.store,
+        "get",
+        side_effect=lambda key: current_binding,
+    ):
+        assert obj._e2ee_auto_verify() is True
+
+    obj.device_id = None
+    with mock.patch.object(obj.store, "get", return_value=None):
+        assert obj._e2ee_auto_verify() is False
+
+
+def _matrix_sas_event(event_type, content, sender="@u:h"):
+    """Build one to-device SAS event for state-machine tests."""
+    return {"type": event_type, "sender": sender, "content": content}
+
+
+def _matrix_sas_request(timestamp, transaction_id="txn"):
+    """Build one valid SAS request event."""
+    return _matrix_sas_event(
+        "m.key.verification.request",
+        {
+            "from_device": "ELEMENT",
+            "transaction_id": transaction_id,
+            "methods": ["m.sas.v1"],
+            "timestamp": timestamp,
+        },
+    )
+
+
+def _matrix_sas_start_event(transaction_id="txn", **updates):
+    """Build one SAS start event."""
+    content = _matrix_sas_start("ELEMENT", transaction_id)
+    content.update(updates)
+    return _matrix_sas_event("m.key.verification.start", content)
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_auto_verify_rejects_bad_events():
+    """Malformed, foreign, duplicate, and cancelled flows are rejected."""
+    from time import time
+
+    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
+
+    def run(events, peer_keys=True, send=True):
+        obj = NotifyMatrix(
+            host="h",
+            user="u",
+            password="pass",
+            targets=["#r"],
+            e2ee=True,
+            autoverify=True,
+            secure=True,
+        )
+        obj.user_id = "@u:h"
+        obj.device_id = "APPRISE"
+        obj._e2ee_account = MatrixOlmAccount()
+        sync_calls = 0
+
+        def fetch(path, **kwargs):
+            nonlocal sync_calls
+            assert path == "/sync"
+            sync_calls += 1
+            if sync_calls == 1:
+                return (
+                    True,
+                    {
+                        "next_batch": "next",
+                        "to_device": {"events": events},
+                    },
+                    requests.codes.ok,
+                )
+            return False, None, requests.codes.bad_request
+
+        with (
+            mock.patch.object(obj, "_fetch", side_effect=fetch),
+            mock.patch.object(
+                obj, "_e2ee_verification_peer_keys", return_value=peer_keys
+            ),
+            mock.patch.object(
+                obj, "_e2ee_send_verification_event", return_value=send
+            ) as sender,
+        ):
+            result = obj._e2ee_auto_verify()
+        return result, sender
+
+    now_ms = int(time() * 1000)
+    noise = [
+        "invalid",
+        _matrix_sas_event("unknown", {}, sender="@other:h"),
+        _matrix_sas_event("unknown", "invalid"),
+        _matrix_sas_request(None),
+        _matrix_sas_event(
+            "m.key.verification.key",
+            {"transaction_id": "unrelated", "key": "invalid"},
+        ),
+    ]
+    assert run(noise)[0] is False
+    assert run([_matrix_sas_request(now_ms)], peer_keys=None)[0] is False
+
+    result, sender = run(
+        [_matrix_sas_request(now_ms), _matrix_sas_request(now_ms)]
+    )
+    assert result is False
+    assert sender.call_args.args[0] == "m.key.verification.cancel"
+
+    assert run([_matrix_sas_request(now_ms)], send=False)[0] is False
+    result, _ = run(
+        [
+            _matrix_sas_request(now_ms),
+            _matrix_sas_event(
+                "m.key.verification.cancel",
+                {"transaction_id": "txn", "reason": "cancelled"},
+            ),
+        ]
+    )
+    assert result is False
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_auto_verify_rejects_protocol_failures():
+    """Protocol ordering, crypto, and send failures cancel verification."""
+    from time import time
+
+    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
+
+    now_ms = int(time() * 1000)
+
+    def run(events, send_results=True, sas=None):
+        obj = NotifyMatrix(
+            host="h",
+            user="u",
+            password="pass",
+            targets=["#r"],
+            e2ee=True,
+            autoverify=True,
+            secure=True,
+        )
+        obj.user_id = "@u:h"
+        obj.device_id = "APPRISE"
+        obj._e2ee_account = MatrixOlmAccount()
+        fetch = mock.Mock(
+            side_effect=[
+                (
+                    True,
+                    {"to_device": {"events": events}},
+                    requests.codes.ok,
+                ),
+                (False, None, requests.codes.bad_request),
+            ]
+        )
+        patches = [
+            mock.patch.object(obj, "_fetch", fetch),
+            mock.patch.object(
+                obj, "_e2ee_verification_peer_keys", return_value={"key": "x"}
+            ),
+            mock.patch.object(
+                obj,
+                "_e2ee_send_verification_event",
+                side_effect=(
+                    send_results if isinstance(send_results, list) else None
+                ),
+                return_value=(
+                    send_results if isinstance(send_results, bool) else True
+                ),
+            ),
+        ]
+        if sas is not None:
+            patches.append(
+                mock.patch(
+                    "apprise.plugins.matrix.base.MatrixSASVerification",
+                    return_value=sas,
+                )
+            )
+        with patches[0], patches[1], patches[2]:
+            if len(patches) == 4:
+                with patches[3]:
+                    return obj._e2ee_auto_verify()
+            return obj._e2ee_auto_verify()
+
+    request = _matrix_sas_request(now_ms)
+    assert run([request, _matrix_sas_start_event(method="invalid")]) is False
+    assert run([request, _matrix_sas_start_event()], [True, False]) is False
+    assert (
+        run(
+            [
+                request,
+                _matrix_sas_event(
+                    "m.key.verification.key",
+                    {"transaction_id": "txn", "key": "invalid"},
+                ),
+            ]
+        )
+        is False
+    )
+    assert (
+        run(
+            [
+                request,
+                _matrix_sas_start_event(),
+                _matrix_sas_event(
+                    "m.key.verification.key",
+                    {"transaction_id": "txn", "key": "invalid"},
+                ),
+            ]
+        )
+        is False
+    )
+
+    fake_sas = mock.Mock(state="mac_sent")
+    fake_sas.accept_content.return_value = {"transaction_id": "txn"}
+    fake_sas.key_content.return_value = {"transaction_id": "txn", "key": "k"}
+    fake_sas.mac_content.return_value = {"transaction_id": "txn", "mac": {}}
+    key_event = _matrix_sas_event(
+        "m.key.verification.key",
+        {"transaction_id": "txn", "key": "key"},
+    )
+    assert (
+        run(
+            [request, _matrix_sas_start_event(), key_event],
+            [True, True, False],
+            fake_sas,
+        )
+        is False
+    )
+    assert (
+        run(
+            [request, _matrix_sas_start_event(), key_event],
+            [True, True, True, False],
+            fake_sas,
+        )
+        is False
+    )
+
+    failing_mac_sas = mock.Mock(state="mac_sent")
+    failing_mac_sas.accept_content.return_value = {"transaction_id": "txn"}
+    failing_mac_sas.verify_peer_mac.side_effect = ValueError("bad MAC")
+    mac_event = _matrix_sas_event(
+        "m.key.verification.mac",
+        {"transaction_id": "txn", "mac": {}},
+    )
+    assert (
+        run(
+            [request, _matrix_sas_start_event(), mac_event],
+            True,
+            failing_mac_sas,
+        )
+        is False
+    )
+
+    valid_mac_sas = mock.Mock(state="mac_sent")
+    valid_mac_sas.accept_content.return_value = {"transaction_id": "txn"}
+    assert (
+        run(
+            [request, _matrix_sas_start_event(), mac_event],
+            [True, True, False],
+            valid_mac_sas,
+        )
+        is False
+    )
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_auto_verify_peer_done_and_timeout():
+    """Peer-first completion is accepted and active timeouts are cancelled."""
+    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+        autoverify=True,
+        secure=True,
+    )
+    obj.user_id = "@u:h"
+    obj.device_id = "APPRISE"
+    obj._e2ee_account = MatrixOlmAccount()
+    binding = "{}|{}|{}|{}".format(
+        obj.user_id,
+        obj.device_id,
+        obj._e2ee_account.identity_key,
+        obj._e2ee_account.signing_key,
+    )
+    obj.store.set("e2ee_device_binding", binding, expires=60)
+
+    fake_sas = mock.Mock(state="mac_sent")
+    fake_sas.accept_content.return_value = {"transaction_id": "txn"}
+    events = [
+        _matrix_sas_request(0),
+        _matrix_sas_start_event(),
+        _matrix_sas_event(
+            "m.key.verification.done", {"transaction_id": "txn"}
+        ),
+        _matrix_sas_event("unknown", {"transaction_id": "txn"}),
+        _matrix_sas_event("m.key.verification.mac", {"transaction_id": "txn"}),
+    ]
+    with (
+        mock.patch("apprise.plugins.matrix.base.time", return_value=0),
+        mock.patch.object(
+            obj,
+            "_fetch",
+            return_value=(
+                True,
+                {"to_device": {"events": events}},
+                requests.codes.ok,
+            ),
+        ),
+        mock.patch.object(
+            obj, "_e2ee_verification_peer_keys", return_value={"key": "x"}
+        ),
+        mock.patch.object(
+            obj, "_e2ee_send_verification_event", return_value=True
+        ),
+        mock.patch(
+            "apprise.plugins.matrix.base.MatrixSASVerification",
+            return_value=fake_sas,
+        ),
+    ):
+        assert obj._e2ee_auto_verify() is True
+
+    timeout_obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+        autoverify=True,
+        secure=True,
+    )
+    timeout_obj.user_id = "@u:h"
+    timeout_obj.device_id = "APPRISE"
+    timeout_obj._e2ee_account = MatrixOlmAccount()
+    timeout_obj.default_autoverify_timeout_sec = 1
+    with (
+        mock.patch(
+            "apprise.plugins.matrix.base.time", side_effect=[0, 0, 0, 2]
+        ),
+        mock.patch.object(
+            timeout_obj,
+            "_fetch",
+            return_value=(
+                True,
+                {"to_device": {"events": [_matrix_sas_request(0)]}},
+                requests.codes.ok,
+            ),
+        ),
+        mock.patch.object(
+            timeout_obj,
+            "_e2ee_verification_peer_keys",
+            return_value={"key": "x"},
+        ),
+        mock.patch.object(
+            timeout_obj, "_e2ee_send_verification_event", return_value=True
+        ) as send,
+    ):
+        assert timeout_obj._e2ee_auto_verify() is False
+    assert send.call_args.args[0] == "m.key.verification.cancel"
+
+    timeout_obj.default_autoverify_timeout_sec = 0
+    with mock.patch("apprise.plugins.matrix.base.time", return_value=0):
+        assert timeout_obj._e2ee_auto_verify() is False
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_sas_verified_state_refresh_is_minimal():
     """Only identity state required to retain SAS trust is refreshed."""
     from apprise.plugins.matrix.e2ee import MatrixOlmAccount
@@ -2789,6 +3397,41 @@ def test_plugin_matrix_sas_refresh_only_after_success(delivery_ok):
         assert obj._send_server_notification(body="test") is delivery_ok
 
     assert refresh.call_count == (1 if delivery_ok else 0)
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_send_handles_verify_and_refresh_failures():
+    """Verification blocks delivery, while a refresh failure does not."""
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+        autoverify=True,
+        secure=True,
+    )
+    obj.access_token = "token"
+    obj.user_id = "@u:h"
+    obj.device_id = "APPRISE"
+
+    with (
+        mock.patch.object(obj, "_e2ee_setup", return_value=True),
+        mock.patch.object(obj, "_e2ee_auto_verify", return_value=False),
+    ):
+        assert obj._send_server_notification(body="test") is False
+
+    with (
+        mock.patch.object(obj, "_e2ee_setup", return_value=True),
+        mock.patch.object(obj, "_e2ee_auto_verify", return_value=True),
+        mock.patch.object(obj, "_room_join", return_value="!r:h"),
+        mock.patch.object(obj, "_e2ee_room_encrypted", return_value=True),
+        mock.patch.object(obj, "_e2ee_send_to_room", return_value=True),
+        mock.patch.object(
+            obj, "_e2ee_refresh_verified_state", return_value=False
+        ),
+    ):
+        assert obj._send_server_notification(body="test") is True
 
 
 def test_plugin_matrix_e2ee_no_cryptography():

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -2781,9 +2781,7 @@ def test_plugin_matrix_sas_refresh_only_after_success(delivery_ok):
         mock.patch.object(obj, "_e2ee_auto_verify", return_value=True),
         mock.patch.object(obj, "_room_join", return_value="!r:h"),
         mock.patch.object(obj, "_e2ee_room_encrypted", return_value=True),
-        mock.patch.object(
-            obj, "_e2ee_send_to_room", return_value=delivery_ok
-        ),
+        mock.patch.object(obj, "_e2ee_send_to_room", return_value=delivery_ok),
         mock.patch.object(
             obj, "_e2ee_refresh_verified_state", return_value=True
         ) as refresh,

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -3217,6 +3217,75 @@ def test_plugin_matrix_e2ee_binding_key():
     )
 
 
+def test_plugin_matrix_autoverify_implies_e2ee():
+    """autoverify=yes implies e2ee=yes unless e2ee is set explicitly."""
+
+    # autoverify alone turns e2ee on without spelling it out.
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        secure=True,
+        autoverify=True,
+    )
+    assert obj.autoverify is True
+    assert obj.e2ee is True
+
+    # An explicit e2ee=no is still honored even with autoverify=yes.
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        secure=True,
+        autoverify=True,
+        e2ee=False,
+    )
+    assert obj.autoverify is True
+    assert obj.e2ee is False
+
+    # An explicit e2ee=yes alongside autoverify=yes is unaffected.
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        secure=True,
+        autoverify=True,
+        e2ee=True,
+    )
+    assert obj.autoverify is True
+    assert obj.e2ee is True
+
+    # Without autoverify, e2ee keeps its own (already-True) default.
+    obj = NotifyMatrix(
+        host="h", user="u", password="pass", targets=["#r"], secure=True
+    )
+    assert obj.autoverify is False
+    assert obj.e2ee is True
+
+    # The implied e2ee=yes survives a URL round trip: autoverify=yes is
+    # emitted, e2ee=no is not, and re-parsing yields the same identity.
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        secure=True,
+        autoverify=True,
+    )
+    url = obj.url()
+    assert "autoverify=yes" in url
+    assert "e2ee=no" not in url
+
+    results = NotifyMatrix.parse_url(url)
+    obj2 = NotifyMatrix(**results)
+    assert obj2.autoverify is True
+    assert obj2.e2ee is True
+    assert obj.url_identifier == obj2.url_identifier
+
+
 def _matrix_sas_plugin(user_id="@u:h", device_id="APPRISE"):
     """A NotifyMatrix instance with a ready-to-use E2EE identity."""
     from apprise.plugins.matrix.e2ee import MatrixOlmAccount

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -4414,7 +4414,7 @@ def test_plugin_matrix_sas_auto_verify_concurrency():
             calls += 1
         # Long enough that a blocking wait for this call would make the
         # elapsed-time assertion below fail.
-        _time.sleep(0.1)
+        _time.sleep(0.5)
         with state_lock:
             active -= 1
         return True
@@ -4436,7 +4436,7 @@ def test_plugin_matrix_sas_auto_verify_concurrency():
         elapsed = _time.monotonic() - start
 
     # The group finishes near the single verifier's running time.
-    assert elapsed < 0.3
+    assert elapsed < 1.0
     assert calls == 1
     assert max_concurrent == 1
     assert results.count(True) == 1

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -47,7 +47,11 @@ from apprise import (
     OverflowMode,
     PersistentStoreMode,
 )
-from apprise.plugins.matrix import MatrixDiscoveryException, NotifyMatrix
+from apprise.plugins.matrix import (
+    MatrixDiscoveryException,
+    NotifyMatrix,
+    sas as matrix_sas,
+)
 
 # Use Matrix's internal limit and mode names for exact boundary assertions.
 from apprise.plugins.matrix.base import (
@@ -656,6 +660,261 @@ def test_plugin_matrix_fetch(mock_post, mock_get, mock_put):
     request.content = dumps({"error": {}})
     postokay, _response, _ = obj._fetch("/retry/apprise/unit/test")
     assert postokay is False
+
+    # A caller with its own tight time budget can cap how long a 429's
+    # own server-requested wait is allowed to throttle for.
+    request.content = dumps({"retry_after_ms": 999999})
+    with mock.patch.object(obj, "throttle") as throttle:
+        postokay, _response, _ = obj._fetch(
+            "/retry/apprise/unit/test", max_retry_wait=1
+        )
+    assert postokay is False
+    # The second throttle uses the remaining shared 429 budget.
+    second_call_wait = throttle.call_args_list[1].kwargs["wait"]
+    assert second_call_wait == pytest.approx(1.0, abs=0.1)
+
+    # Restore success so object cleanup does not honor the mocked long retry.
+    request.status_code = requests.codes.ok
+    request.content = dumps(response_obj)
+    del obj
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_shared_retry_budget(mock_post, mock_get, mock_put):
+    """Every 429 response draws from one shared retry-wait budget."""
+    request = mock.Mock()
+    request.status_code = 429
+    request.content = dumps({"retry_after_ms": 999999})
+    mock_post.return_value = request
+
+    obj = NotifyMatrix(host="host", user="user", password="passwd")
+    obj.access_token = "token"
+
+    waits = []
+
+    def fake_throttle(wait=None):
+        if wait is not None:
+            waits.append(wait)
+
+    with (
+        mock.patch.object(obj, "throttle", side_effect=fake_throttle),
+        mock.patch(
+            "apprise.plugins.matrix.base.monotonic",
+            # retry_deadline anchor, then each 429 draws a remaining-wait
+            # check before sleeping and a deadline recheck right after.
+            side_effect=[0, 0.5, 0.6, 1.8, 1.9],
+        ),
+    ):
+        postokay, _response, _ = obj._fetch(
+            "/retry/apprise/unit/test", max_retry_wait=2
+        )
+    assert postokay is False
+    # The two waits use the remaining portions of the same two-second budget.
+    assert waits[0] == pytest.approx(1.5)
+    assert waits[1] == pytest.approx(0.2)
+
+    # Restore success so object cleanup does not honor the mocked long retry.
+    request.status_code = requests.codes.ok
+    request.content = dumps(
+        {
+            "access_token": "abcd1234",
+            "user_id": "@apprise:localhost",
+            "home_server": "localhost",
+        }
+    )
+    del obj
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_exhausted_retry_budget(mock_post, mock_get, mock_put):
+    """An exhausted retry-wait budget ends the attempt without a new request.
+
+    Once no time remains, a 429 must not be followed by another sleep and
+    another request; it must give up immediately instead.
+    """
+    request = mock.Mock()
+    request.status_code = 429
+    request.content = dumps({"retry_after_ms": 999999})
+    mock_post.return_value = request
+
+    obj = NotifyMatrix(host="host", user="user", password="passwd")
+    obj.access_token = "token"
+
+    with (
+        mock.patch.object(obj, "throttle") as throttle,
+        mock.patch(
+            "apprise.plugins.matrix.base.monotonic",
+            # retry_deadline anchor, then the very first remaining-wait
+            # check already finds the budget spent.
+            side_effect=[0, 2.0],
+        ),
+    ):
+        postokay, _response, _ = obj._fetch(
+            "/retry/apprise/unit/test", max_retry_wait=2
+        )
+
+    assert postokay is False
+    # throttle() is always called once before the initial request; giving
+    # up on the exhausted budget must not add a second, 429-driven wait.
+    throttle.assert_called_once_with()
+    assert mock_post.call_count == 1
+
+    # Restore success so object cleanup does not honor the mocked long retry.
+    request.status_code = requests.codes.ok
+    request.content = dumps(
+        {
+            "access_token": "abcd1234",
+            "user_id": "@apprise:localhost",
+            "home_server": "localhost",
+        }
+    )
+    del obj
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_retry_sleep_exhausts_budget(
+    mock_post, mock_get, mock_put
+):
+    """A budget consumed by the sleep itself also stops the retry loop.
+
+    The deadline is checked before sleeping and again right after -- a
+    wait that lands exactly on (or past) the deadline must not be
+    followed by one more request.
+    """
+    request = mock.Mock()
+    request.status_code = 429
+    request.content = dumps({"retry_after_ms": 999999})
+    mock_post.return_value = request
+
+    obj = NotifyMatrix(host="host", user="user", password="passwd")
+    obj.access_token = "token"
+
+    with (
+        mock.patch.object(obj, "throttle") as throttle,
+        mock.patch(
+            "apprise.plugins.matrix.base.monotonic",
+            # retry_deadline anchor, a remaining-wait check that is still
+            # positive (so the wait proceeds), then the post-sleep
+            # recheck lands exactly on the deadline.
+            side_effect=[0, 0.5, 1.0],
+        ),
+    ):
+        postokay, _response, _ = obj._fetch(
+            "/retry/apprise/unit/test", max_retry_wait=1
+        )
+
+    assert postokay is False
+    # The 429 wait happens once; no second request follows it.
+    assert throttle.call_args_list[-1] == mock.call(wait=0.5)
+    assert mock_post.call_count == 1
+
+    # Restore success so object cleanup does not honor the mocked long retry.
+    request.status_code = requests.codes.ok
+    request.content = dumps(
+        {
+            "access_token": "abcd1234",
+            "user_id": "@apprise:localhost",
+            "home_server": "localhost",
+        }
+    )
+    del obj
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_fetch_response_limit(mock_post, mock_get, mock_put):
+    """A response larger than max_response_bytes is discarded, not parsed.
+
+    The connection is closed instead of reading (and buffering) the rest
+    of a response that has already exceeded the caller's limit.
+    """
+    request = mock.Mock()
+    request.status_code = requests.codes.ok
+    request.iter_content.return_value = iter([b"x" * 1000, b"x" * 1001])
+    mock_post.return_value = request
+
+    obj = NotifyMatrix(host="host", user="user", password="passwd")
+    obj.access_token = "token"
+
+    postokay, response, status_code = obj._fetch(
+        "/some/path", max_response_bytes=2000
+    )
+
+    assert postokay is False
+    assert response == {}
+    assert status_code == requests.codes.ok
+    request.close.assert_called_once()
+
+    del obj
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_fetch_response_within_limit(
+    mock_post, mock_get, mock_put
+):
+    """A response at or under max_response_bytes is parsed normally.
+
+    An empty chunk (which a real stream can yield) is skipped rather
+    than counted or appended.
+    """
+    request = mock.Mock()
+    request.status_code = requests.codes.ok
+    request.iter_content.return_value = iter(
+        [b"", dumps({"ok": True}).encode()]
+    )
+    mock_post.return_value = request
+
+    obj = NotifyMatrix(host="host", user="user", password="passwd")
+    obj.access_token = "token"
+
+    postokay, response, _status_code = obj._fetch(
+        "/some/path", max_response_bytes=2000
+    )
+
+    assert postokay is True
+    assert response == {"ok": True}
+    # The stream is closed either way, not just on the oversized path.
+    request.close.assert_called_once()
+
+    del obj
+
+
+@mock.patch("requests.put")
+@mock.patch("requests.get")
+@mock.patch("requests.post")
+def test_plugin_matrix_fetch_stream_error(mock_post, mock_get, mock_put):
+    """Handle streamed download errors and close the response."""
+    request = mock.Mock()
+    request.status_code = requests.codes.ok
+
+    def broken_iter_content(chunk_size=None):
+        yield b"partial"
+        raise requests.exceptions.ChunkedEncodingError("broken transfer")
+
+    request.iter_content.side_effect = broken_iter_content
+    mock_post.return_value = request
+
+    obj = NotifyMatrix(host="host", user="user", password="passwd")
+    obj.access_token = "token"
+
+    postokay, response, status_code = obj._fetch(
+        "/some/path", max_response_bytes=2000
+    )
+
+    assert postokay is False
+    assert response == {}
+    assert status_code == requests.codes.ok
+    request.close.assert_called_once()
+
     del obj
 
 
@@ -2455,155 +2714,6 @@ def test_plugin_matrix_e2ee_helpers():
     assert out.startswith(b'{"a"')
 
 
-def _matrix_sas_start(peer_device="ELEMENT", transaction_id="sas-transaction"):
-    """Return a valid Matrix SAS start payload."""
-    return {
-        "from_device": peer_device,
-        "transaction_id": transaction_id,
-        "method": "m.sas.v1",
-        "key_agreement_protocols": ["curve25519-hkdf-sha256"],
-        "hashes": ["sha256"],
-        "message_authentication_codes": ["hkdf-hmac-sha256.v2"],
-        "short_authentication_string": ["decimal", "emoji"],
-    }
-
-
-@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
-@pytest.mark.parametrize(
-    ("peer_device", "updates", "match"),
-    (
-        ("ELEMENT", {"transaction_id": None}, "Missing SAS transaction"),
-        (None, {}, "Missing SAS transaction"),
-        ("ELEMENT", {"from_device": "OTHER"}, "does not match"),
-        ("ELEMENT", {"method": "unsupported"}, "Unsupported SAS verification"),
-        ("ELEMENT", {"key_agreement_protocols": []}, "key agreement"),
-        ("ELEMENT", {"hashes": []}, "Unsupported SAS hash"),
-        (
-            "ELEMENT",
-            {"message_authentication_codes": []},
-            "Unsupported SAS MAC",
-        ),
-        ("ELEMENT", {"short_authentication_string": ["emoji"]}, "decimal"),
-    ),
-)
-def test_plugin_matrix_sas_rejects_invalid_start(peer_device, updates, match):
-    """SAS negotiation rejects incomplete or unsupported parameters."""
-    from apprise.plugins.matrix.e2ee import MatrixSASVerification
-
-    start = _matrix_sas_start(peer_device=peer_device)
-    start.update(updates)
-    with pytest.raises(ValueError, match=match):
-        MatrixSASVerification("@u:h", "APPRISE", "@u:h", peer_device, start)
-
-
-@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
-def test_plugin_matrix_sas_rejects_invalid_state_transitions():
-    """SAS operations fail closed when received out of order."""
-    from apprise.plugins.matrix.e2ee import MatrixSASVerification
-
-    def sas():
-        return MatrixSASVerification(
-            "@u:h", "APPRISE", "@u:h", "ELEMENT", _matrix_sas_start()
-        )
-
-    obj = sas()
-    obj.accept_content()
-    with pytest.raises(ValueError, match="already accepted"):
-        obj.accept_content()
-    with pytest.raises(ValueError, match="peer key has not been received"):
-        obj.key_content()
-    with pytest.raises(ValueError, match="peer key has not been received"):
-        obj.mac_content("key")
-
-    obj = sas()
-    with pytest.raises(ValueError, match="Unexpected SAS key"):
-        obj.receive_key("invalid")
-    with pytest.raises(ValueError, match="shared secret"):
-        obj._calculate_mac("value", "id", "a", "b", "c", "d")
-    with pytest.raises(ValueError, match="Unexpected SAS MAC"):
-        obj.verify_peer_mac({}, {})
-
-
-@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
-def test_plugin_matrix_sas_rejects_invalid_peer_mac():
-    """Every peer MAC and key-list validation failure is rejected."""
-    from cryptography.hazmat.primitives.asymmetric.x25519 import (
-        X25519PrivateKey,
-    )
-    from cryptography.hazmat.primitives.serialization import (
-        Encoding,
-        PublicFormat,
-    )
-
-    from apprise.plugins.matrix.e2ee import (
-        MatrixSASVerification,
-        _b64enc,
-    )
-
-    obj = MatrixSASVerification(
-        "@u:h", "APPRISE", "@u:h", "ELEMENT", _matrix_sas_start()
-    )
-    obj.accept_content()
-    peer_private = X25519PrivateKey.generate()
-    obj.receive_key(
-        _b64enc(
-            peer_private.public_key().public_bytes(
-                Encoding.Raw, PublicFormat.Raw
-            )
-        )
-    )
-    obj.mac_content("own-signing-key")
-
-    peer_key_id = "ed25519:ELEMENT"
-
-    def peer_mac(value, key_id):
-        return obj._calculate_mac(
-            value,
-            key_id,
-            "@u:h",
-            "ELEMENT",
-            "@u:h",
-            "APPRISE",
-        )
-
-    with pytest.raises(ValueError, match="transaction does not match"):
-        obj.verify_peer_mac({"transaction_id": "other"}, {})
-    with pytest.raises(ValueError, match="contains no keys"):
-        obj.verify_peer_mac({"transaction_id": "sas-transaction"}, {})
-    with pytest.raises(ValueError, match="omits the peer device"):
-        obj.verify_peer_mac(
-            {
-                "transaction_id": "sas-transaction",
-                "mac": {"ed25519:OTHER": "mac"},
-            },
-            {},
-        )
-
-    unknown_macs = {
-        "ed25519:UNKNOWN": "unknown",
-        peer_key_id: peer_mac("peer-signing-key", peer_key_id),
-    }
-    with pytest.raises(ValueError, match="unknown key"):
-        obj.verify_peer_mac(
-            {
-                "transaction_id": "sas-transaction",
-                "mac": unknown_macs,
-                "keys": peer_mac(",".join(sorted(unknown_macs)), "KEY_IDS"),
-            },
-            {peer_key_id: "peer-signing-key"},
-        )
-
-    with pytest.raises(ValueError, match="device key MAC"):
-        obj.verify_peer_mac(
-            {
-                "transaction_id": "sas-transaction",
-                "mac": {peer_key_id: "invalid"},
-                "keys": peer_mac(peer_key_id, "KEY_IDS"),
-            },
-            {peer_key_id: "peer-signing-key"},
-        )
-
-
 @pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_sas_responder_roundtrip():
     """The custom SAS responder interoperates without libolm."""
@@ -2632,7 +2742,15 @@ def test_plugin_matrix_sas_responder_roundtrip():
     own_device = "APPRISE"
     peer_device = "ELEMENT"
     transaction_id = "sas-transaction"
-    start = _matrix_sas_start(peer_device, transaction_id)
+    start = {
+        "from_device": peer_device,
+        "transaction_id": transaction_id,
+        "method": "m.sas.v1",
+        "key_agreement_protocols": ["curve25519-hkdf-sha256"],
+        "hashes": ["sha256"],
+        "message_authentication_codes": ["hkdf-hmac-sha256.v2"],
+        "short_authentication_string": ["decimal", "emoji"],
+    }
     sas = MatrixSASVerification(
         own_user,
         own_device,
@@ -2692,8 +2810,1702 @@ def test_plugin_matrix_sas_responder_roundtrip():
 
 
 @pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_init_validation():
+    """MatrixSASVerification rejects malformed SAS start content."""
+    from apprise.plugins.matrix.e2ee import MatrixSASVerification
+
+    own_user = peer_user = "@u:h"
+    own_device, peer_device = "APPRISE", "ELEMENT"
+    base_start = {
+        "from_device": peer_device,
+        "transaction_id": "tx",
+        "method": "m.sas.v1",
+        "key_agreement_protocols": ["curve25519-hkdf-sha256"],
+        "hashes": ["sha256"],
+        "message_authentication_codes": ["hkdf-hmac-sha256.v2"],
+        "short_authentication_string": ["decimal", "emoji"],
+    }
+
+    def build(**overrides):
+        content = dict(base_start)
+        content.update(overrides)
+        return content
+
+    cases = (
+        ({"transaction_id": ""}, "Missing SAS transaction"),
+        ({"from_device": "OTHER"}, "does not match request device"),
+        ({"method": "m.other.v1"}, "Unsupported SAS verification method"),
+        (
+            {"key_agreement_protocols": ["other"]},
+            "Unsupported SAS key agreement",
+        ),
+        ({"hashes": ["sha1"]}, "Unsupported SAS hash"),
+        (
+            {"message_authentication_codes": ["other"]},
+            "Unsupported SAS MAC",
+        ),
+        (
+            {"short_authentication_string": ["emoji"]},
+            "does not offer decimal",
+        ),
+    )
+    for overrides, match in cases:
+        with pytest.raises(ValueError, match=match):
+            MatrixSASVerification(
+                own_user,
+                own_device,
+                peer_user,
+                peer_device,
+                build(**overrides),
+            )
+
+    # A peer device ID is required with the transaction ID.
+    with pytest.raises(ValueError, match="Missing SAS transaction"):
+        MatrixSASVerification(own_user, own_device, peer_user, "", base_start)
+
+
+def _make_sas(own_user, own_device, peer_user, peer_device, transaction_id):
+    """Build a fresh MatrixSASVerification responder for *transaction_id*."""
+    from apprise.plugins.matrix.e2ee import MatrixSASVerification
+
+    start = {
+        "from_device": peer_device,
+        "transaction_id": transaction_id,
+        "method": "m.sas.v1",
+        "key_agreement_protocols": ["curve25519-hkdf-sha256"],
+        "hashes": ["sha256"],
+        "message_authentication_codes": ["hkdf-hmac-sha256.v2"],
+        "short_authentication_string": ["decimal", "emoji"],
+    }
+    return MatrixSASVerification(
+        own_user, own_device, peer_user, peer_device, start
+    )
+
+
+def _completed_sas_pair(
+    own_user,
+    own_device,
+    peer_user,
+    peer_device,
+    transaction_id,
+    own_account,
+    peer_account,
+):
+    """Build a responder and matching peer at the MAC stage.
+
+    The returned helper creates additional valid MAC values for edge cases.
+    """
+    from cryptography.hazmat.primitives.asymmetric.x25519 import (
+        X25519PrivateKey,
+        X25519PublicKey,
+    )
+    from cryptography.hazmat.primitives.serialization import (
+        Encoding,
+        PublicFormat,
+    )
+
+    from apprise.plugins.matrix.e2ee import (
+        _b64dec,
+        _b64enc,
+        _hkdf_sha256,
+        _hmac_sha256,
+    )
+
+    sas = _make_sas(
+        own_user, own_device, peer_user, peer_device, transaction_id
+    )
+    sas.accept_content()
+
+    peer_private = X25519PrivateKey.generate()
+    peer_public = _b64enc(
+        peer_private.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    )
+    sas.receive_key(peer_public)
+    sas.mac_content(own_account.signing_key)
+
+    shared_secret = peer_private.exchange(
+        X25519PublicKey.from_public_bytes(_b64dec(sas.public_key))
+    )
+
+    def peer_mac(value, key_id):
+        info = (
+            "MATRIX_KEY_VERIFICATION_MAC"
+            + peer_user
+            + peer_device
+            + own_user
+            + own_device
+            + transaction_id
+            + key_id
+        ).encode("utf-8")
+        key = _hkdf_sha256(shared_secret, 32, salt=None, info=info)
+        return _b64enc(_hmac_sha256(key, value.encode("utf-8")))
+
+    key_id = "ed25519:{}".format(peer_device)
+    content = {
+        "transaction_id": transaction_id,
+        "mac": {key_id: peer_mac(peer_account.signing_key, key_id)},
+        "keys": peer_mac(key_id, "KEY_IDS"),
+    }
+    peer_keys = {key_id: peer_account.signing_key}
+    return sas, content, peer_keys, peer_mac
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_verification_state_guards():
+    """Out-of-order calls against MatrixSASVerification are rejected."""
+    own_user = peer_user = "@u:h"
+    own_device, peer_device = "APPRISE", "ELEMENT"
+
+    sas = _make_sas(own_user, own_device, peer_user, peer_device, "tx")
+    with pytest.raises(ValueError, match="peer key has not been received"):
+        sas.key_content()
+    with pytest.raises(ValueError, match="peer key has not been received"):
+        sas.mac_content("sig")
+    with pytest.raises(ValueError, match="Unexpected SAS key event"):
+        sas.receive_key("AAAA")
+
+    sas.accept_content()
+    with pytest.raises(ValueError, match="already accepted"):
+        sas.accept_content()
+    with pytest.raises(ValueError, match="Unexpected SAS MAC event"):
+        sas.verify_peer_mac({}, {})
+
+    with pytest.raises(
+        ValueError, match="shared secret has not been established"
+    ):
+        sas.decimal_sas()
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_invalid_peer_key():
+    """Reject malformed peer keys before decoding them."""
+    own_user = peer_user = "@u:h"
+    own_device, peer_device = "APPRISE", "ELEMENT"
+
+    for bad_key in ("", "A" * 513, None, 12345):
+        sas = _make_sas(own_user, own_device, peer_user, peer_device, "tx")
+        sas.accept_content()
+        with pytest.raises(ValueError, match="missing or malformed"):
+            sas.receive_key(bad_key)
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_mac_requires_secret():
+    """_calculate_mac refuses to run before the SAS key exchange."""
+    sas = _make_sas("@u:h", "APPRISE", "@u:h", "ELEMENT", "tx")
+    # Reach the MAC guard without creating a shared secret.
+    sas.state = "key_received"
+    with pytest.raises(
+        ValueError, match="shared secret has not been established"
+    ):
+        sas._calculate_mac("v", "kid", "@u:h", "APPRISE", "@u:h", "ELEMENT")
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_decimal_sas():
+    """decimal_sas derives the 3-number code the Matrix spec defines."""
+    from cryptography.hazmat.primitives.asymmetric.x25519 import (
+        X25519PrivateKey,
+    )
+    from cryptography.hazmat.primitives.serialization import (
+        Encoding,
+        PublicFormat,
+    )
+
+    from apprise.plugins.matrix.e2ee import _b64enc
+
+    sas = _make_sas("@u:h", "APPRISE", "@u:h", "ELEMENT", "tx")
+    sas.accept_content()
+    peer_private = X25519PrivateKey.generate()
+    peer_public = _b64enc(
+        peer_private.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    )
+    sas.receive_key(peer_public)
+
+    # Check the decimal bit splitting independently with five known bytes.
+    with mock.patch(
+        "apprise.plugins.matrix.e2ee._hkdf_sha256",
+        return_value=bytes([0xFF] * 5),
+    ) as hkdf:
+        # All 40 bits set -> each 13-bit group is 8191 -> +1000 = 9191.
+        assert sas.decimal_sas() == (9191, 9191, 9191)
+    assert hkdf.call_args.args[1] == 5
+
+    with mock.patch(
+        "apprise.plugins.matrix.e2ee._hkdf_sha256",
+        return_value=bytes(5),
+    ):
+        # All bits clear -> each 13-bit group is 0 -> +1000 = 1000.
+        assert sas.decimal_sas() == (1000, 1000, 1000)
+
+    with mock.patch(
+        "apprise.plugins.matrix.e2ee._hkdf_sha256",
+        return_value=b"\x00\x01\x00\x00\x00",
+    ) as hkdf:
+        # Cross-check against the spec's byte-by-byte formula.
+        b0, b1, b2, b3, b4 = b"\x00\x01\x00\x00\x00"
+        expected = (
+            ((b0 << 5) | (b1 >> 3)) + 1000,
+            (((b1 & 0x7) << 10) | (b2 << 2) | (b3 >> 6)) + 1000,
+            (((b3 & 0x3F) << 7) | (b4 >> 1)) + 1000,
+        )
+        assert sas.decimal_sas() == expected
+
+    # Require the spec's exact separators and initiator-first field order.
+    info = hkdf.call_args.kwargs["info"]
+    assert info == (
+        "MATRIX_KEY_VERIFICATION_SAS|"
+        "@u:h|ELEMENT|" + peer_public + "|"
+        "@u:h|APPRISE|" + sas.public_key + "|"
+        "tx"
+    ).encode("utf-8")
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_verify_peer_mac_errors():
+    """verify_peer_mac rejects tampered or incomplete MAC content."""
+    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
+
+    own_user = peer_user = "@u:h"
+    own_device, peer_device = "APPRISE", "ELEMENT"
+    own_account = MatrixOlmAccount()
+    peer_account = MatrixOlmAccount()
+
+    def build():
+        return _completed_sas_pair(
+            own_user,
+            own_device,
+            peer_user,
+            peer_device,
+            "tx",
+            own_account,
+            peer_account,
+        )
+
+    # Wrong transaction id
+    sas, content, peer_keys, _mac = build()
+    content["transaction_id"] = "other"
+    with pytest.raises(ValueError, match="transaction does not match"):
+        sas.verify_peer_mac(content, peer_keys)
+
+    # Missing/empty mac dict
+    sas, content, peer_keys, _mac = build()
+    content["mac"] = {}
+    with pytest.raises(ValueError, match="contains no keys"):
+        sas.verify_peer_mac(content, peer_keys)
+
+    # mac dict present but missing the peer's own device key id
+    sas, content, peer_keys, _mac = build()
+    content["mac"] = {"ed25519:someone-else": "AAAA"}
+    with pytest.raises(ValueError, match="omits the peer device key"):
+        sas.verify_peer_mac(content, peer_keys)
+
+    # An oversized key list is rejected before it is ever sorted/hashed.
+    sas, content, peer_keys, _mac = build()
+    device_key_id = next(iter(content["mac"]))
+    content["mac"] = {
+        device_key_id: content["mac"][device_key_id],
+        **{
+            f"ed25519:junk-{i}": "AAAA"
+            for i in range(matrix_sas.MatrixSASVerification.MAX_MAC_KEYS)
+        },
+    }
+    with pytest.raises(ValueError, match="too many keys"):
+        sas.verify_peer_mac(content, peer_keys)
+
+    # peer_keys is not a mapping at all (TypeError branch)
+    sas, content, peer_keys, _mac = build()
+    with pytest.raises(ValueError, match="unknown key"):
+        sas.verify_peer_mac(content, None)
+
+    # Reference an unknown key while keeping the key-list MAC valid.
+    sas, content, peer_keys, peer_mac = build()
+    device_key_id = next(iter(content["mac"]))
+    unknown_key_id = "ed25519:unknown-device"
+    macs = {
+        device_key_id: content["mac"][device_key_id],
+        unknown_key_id: peer_mac("garbage", unknown_key_id),
+    }
+    tampered = {
+        "transaction_id": "tx",
+        "mac": macs,
+        "keys": peer_mac(",".join(sorted(macs)), "KEY_IDS"),
+    }
+    with pytest.raises(ValueError, match="unknown key"):
+        sas.verify_peer_mac(tampered, peer_keys)
+
+    # Tampered per-device MAC value
+    sas, content, peer_keys, _mac = build()
+    content["mac"][device_key_id] = "tampered-value"
+    with pytest.raises(ValueError, match="device key MAC does not match"):
+        sas.verify_peer_mac(content, peer_keys)
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_mac_field_limits():
+    """Reject oversized MAC fields before processing them."""
+    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
+
+    own_user = peer_user = "@u:h"
+    own_device, peer_device = "APPRISE", "ELEMENT"
+    own_account = MatrixOlmAccount()
+    peer_account = MatrixOlmAccount()
+
+    def build():
+        return _completed_sas_pair(
+            own_user,
+            own_device,
+            peer_user,
+            peer_device,
+            "tx",
+            own_account,
+            peer_account,
+        )
+
+    # Oversized MAC value for an otherwise-valid key ID.
+    sas, content, peer_keys, _mac = build()
+    device_key_id = next(iter(content["mac"]))
+    content["mac"][device_key_id] = "A" * 513
+    with pytest.raises(ValueError, match="malformed entry"):
+        sas.verify_peer_mac(content, peer_keys)
+
+    # Oversized key ID replacing the real one.
+    sas, content, peer_keys, _mac = build()
+    device_key_id = next(iter(content["mac"]))
+    content["mac"] = {"ed25519:" + "A" * 513: content["mac"][device_key_id]}
+    with pytest.raises(ValueError, match="malformed entry"):
+        sas.verify_peer_mac(content, peer_keys)
+
+    # Oversized aggregate key-list MAC.
+    sas, content, peer_keys, _mac = build()
+    content["keys"] = "A" * 513
+    with pytest.raises(ValueError, match="malformed key list MAC"):
+        sas.verify_peer_mac(content, peer_keys)
+
+    # Missing key-list MAC.
+    sas, content, peer_keys, _mac = build()
+    del content["keys"]
+    with pytest.raises(ValueError, match="malformed key list MAC"):
+        sas.verify_peer_mac(content, peer_keys)
+
+    # An oversized public key returned for the peer's device.
+    sas, content, peer_keys, _mac = build()
+    device_key_id = next(iter(content["mac"]))
+    peer_keys = dict(peer_keys, **{device_key_id: "A" * 513})
+    with pytest.raises(ValueError, match="malformed key"):
+        sas.verify_peer_mac(content, peer_keys)
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_e2ee_binding_key():
+    """_e2ee_binding_key reflects the current device/account identity."""
+    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
+
+    obj = NotifyMatrix(
+        host="h", user="u", password="pass", targets=["#r"], secure=True
+    )
+    assert obj._e2ee_binding_key() == ""
+
+    obj._e2ee_account = MatrixOlmAccount()
+    obj.user_id = "@u:h"
+    obj.device_id = "APPRISE"
+    assert obj._e2ee_binding_key() == "{}|{}|{}|{}".format(
+        "@u:h",
+        "APPRISE",
+        obj._e2ee_account.identity_key,
+        obj._e2ee_account.signing_key,
+    )
+
+
+def _matrix_sas_plugin(user_id="@u:h", device_id="APPRISE"):
+    """A NotifyMatrix instance with a ready-to-use E2EE identity."""
+    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
+
+    obj = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+        autoverify=True,
+        secure=True,
+    )
+    obj.user_id = user_id
+    obj.device_id = device_id
+    obj._e2ee_account = MatrixOlmAccount()
+    return obj
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_send_event_and_cancel():
+    """_send_event builds the /sendToDevice request; _cancel/_fail no-op
+    without an active transaction."""
+    import re
+
+    obj = _matrix_sas_plugin()
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+
+    assert verifier._cancel("m.timeout", "x") is False
+    assert verifier._fail("m.timeout", "x") is False
+
+    with mock.patch.object(
+        obj, "_fetch", return_value=(True, {}, requests.codes.ok)
+    ) as fetch:
+        assert (
+            verifier._send_event(
+                "m.key.verification.ready", "@peer:h", "DEV", {"a": 1}
+            )
+            is True
+        )
+    args, kwargs = fetch.call_args
+    assert re.match(r"^/sendToDevice/[^/]+/[0-9a-f]{32}$", args[0])
+    assert kwargs["method"] == "PUT"
+    assert kwargs["payload"] == {"messages": {"@peer:h": {"DEV": {"a": 1}}}}
+    # To-device sends use the same bounded verification budget as sync.
+    assert kwargs["timeout"][0] > 0
+    assert kwargs["timeout"][1] > 0
+    assert 0 < kwargs["max_retry_wait"] <= obj.default_autoverify_timeout_sec
+
+    with mock.patch.object(obj, "_fetch", return_value=(False, {}, 500)):
+        assert (
+            verifier._send_event("m.key.verification.ready", "u", "d", {})
+            is False
+        )
+
+    verifier.active = {
+        "transaction_id": "tx",
+        "user_id": "@peer:h",
+        "device_id": "DEV",
+    }
+    with mock.patch.object(
+        obj, "_fetch", return_value=(True, {}, requests.codes.ok)
+    ) as fetch:
+        assert verifier._cancel("m.timeout", "reason") is True
+    _, kwargs = fetch.call_args
+    assert kwargs["payload"] == {
+        "messages": {
+            "@peer:h": {
+                "DEV": {
+                    "transaction_id": "tx",
+                    "code": "m.timeout",
+                    "reason": "reason",
+                }
+            }
+        }
+    }
+    assert verifier._fail("m.timeout", "reason") is False
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_peer_keys_branches():
+    """_peer_keys covers every failure and success path."""
+    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
+
+    obj = _matrix_sas_plugin()
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+
+    with mock.patch.object(
+        obj, "_fetch", return_value=(False, {}, 500)
+    ) as fetch:
+        assert verifier._peer_keys("@peer:h", "DEV") is None
+    # Key queries use the same bounded verification budget.
+    kwargs = fetch.call_args.kwargs
+    assert kwargs["timeout"][0] > 0
+    assert kwargs["timeout"][1] > 0
+    assert 0 < kwargs["max_retry_wait"] <= obj.default_autoverify_timeout_sec
+
+    with mock.patch.object(
+        obj, "_fetch", return_value=(True, [], requests.codes.ok)
+    ):
+        assert verifier._peer_keys("@peer:h", "DEV") is None
+
+    with mock.patch.object(
+        obj,
+        "_fetch",
+        return_value=(True, {"device_keys": {}}, requests.codes.ok),
+    ):
+        assert verifier._peer_keys("@peer:h", "DEV") is None
+
+    # Null server fields are malformed but must not crash verification.
+    for malformed_response in (
+        {"device_keys": None},
+        {"device_keys": {"@peer:h": None}},
+        {"device_keys": "not-a-dict"},
+    ):
+        with mock.patch.object(
+            obj,
+            "_fetch",
+            return_value=(True, malformed_response, requests.codes.ok),
+        ):
+            assert verifier._peer_keys("@peer:h", "DEV") is None
+
+    bad_device = {
+        "user_id": "@peer:h",
+        "device_id": "DEV",
+        "keys": {},
+        "signatures": {},
+    }
+    with mock.patch.object(
+        obj,
+        "_fetch",
+        return_value=(
+            True,
+            {"device_keys": {"@peer:h": {"DEV": bad_device}}},
+            requests.codes.ok,
+        ),
+    ):
+        assert verifier._peer_keys("@peer:h", "DEV") is None
+
+    peer_account = MatrixOlmAccount()
+    device = peer_account.device_keys_payload("@peer:h", "DEV")
+    response = {
+        "device_keys": {"@peer:h": {"DEV": device}},
+        "master_keys": {"@peer:h": {"keys": {"ed25519:master": "abc"}}},
+    }
+    with mock.patch.object(
+        obj, "_fetch", return_value=(True, response, requests.codes.ok)
+    ):
+        keys = verifier._peer_keys("@peer:h", "DEV")
+    assert keys["ed25519:master"] == "abc"
+    assert "ed25519:DEV" in keys
+
+    # An implausibly large keys map is rejected rather than copied; a real
+    # device or master-key object only ever advertises a couple of keys.
+    oversized_keys = {
+        f"curve25519:{i}": "k" for i in range(matrix_sas.MAX_DEVICE_KEYS + 1)
+    }
+    oversized_device = dict(device, keys=oversized_keys)
+    with (
+        mock.patch.object(matrix_sas, "verify_device_keys", return_value=True),
+        mock.patch.object(
+            obj,
+            "_fetch",
+            return_value=(
+                True,
+                {"device_keys": {"@peer:h": {"DEV": oversized_device}}},
+                requests.codes.ok,
+            ),
+        ),
+    ):
+        keys = verifier._peer_keys("@peer:h", "DEV")
+    assert keys == {}
+
+    oversized_master = dict(
+        response,
+        master_keys={"@peer:h": {"keys": oversized_keys}},
+    )
+    with mock.patch.object(
+        obj, "_fetch", return_value=(True, oversized_master, requests.codes.ok)
+    ):
+        keys = verifier._peer_keys("@peer:h", "DEV")
+    assert "curve25519:0" not in keys
+    assert "ed25519:DEV" in keys
+
+    malformed = dict(response, master_keys={"@peer:h": "not-a-dict"})
+    with mock.patch.object(
+        obj, "_fetch", return_value=(True, malformed, requests.codes.ok)
+    ):
+        keys = verifier._peer_keys("@peer:h", "DEV")
+    assert "ed25519:master" not in keys
+
+    # Treat null or malformed optional master keys as absent.
+    for master_keys_value in (None, {"@peer:h": {"keys": None}}):
+        with mock.patch.object(
+            obj,
+            "_fetch",
+            return_value=(
+                True,
+                dict(response, master_keys=master_keys_value),
+                requests.codes.ok,
+            ),
+        ):
+            keys = verifier._peer_keys("@peer:h", "DEV")
+        assert "ed25519:master" not in keys
+        assert "ed25519:DEV" in keys
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_handle_request_branches():
+    """_handle_request covers ignore/fail/success outcomes."""
+    from time import time
+
+    obj = _matrix_sas_plugin()
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+    now_ms = int(time() * 1000)
+
+    assert verifier._handle_request("@u:h", {"timestamp": "nope"}) is None
+
+    stale = {
+        "timestamp": now_ms - 20 * 60 * 1000,
+        "transaction_id": "tx",
+        "from_device": "DEV",
+        "methods": ["m.sas.v1"],
+    }
+    assert verifier._handle_request("@u:h", stale) is None
+
+    future = dict(stale, timestamp=now_ms + 20 * 60 * 1000)
+    assert verifier._handle_request("@u:h", future) is None
+
+    missing_tx = {
+        "timestamp": now_ms,
+        "from_device": "DEV",
+        "methods": ["m.sas.v1"],
+    }
+    assert verifier._handle_request("@u:h", missing_tx) is None
+
+    missing_device = {
+        "timestamp": now_ms,
+        "transaction_id": "tx",
+        "methods": ["m.sas.v1"],
+    }
+    assert verifier._handle_request("@u:h", missing_device) is None
+
+    wrong_method = {
+        "timestamp": now_ms,
+        "transaction_id": "tx",
+        "from_device": "DEV",
+        "methods": ["other"],
+    }
+    assert verifier._handle_request("@u:h", wrong_method) is None
+
+    # A present-but-null "methods" field must not crash the "in" check.
+    null_methods = {
+        "timestamp": now_ms,
+        "transaction_id": "tx",
+        "from_device": "DEV",
+        "methods": None,
+    }
+    assert verifier._handle_request("@u:h", null_methods) is None
+
+    # Identifiers are validated by type and length, not just truthiness.
+    for bad_transaction_id, bad_from_device in (
+        (["tx"], "DEV"),
+        ("x" * (matrix_sas.MAX_ID_LEN + 1), "DEV"),
+        ("tx", 12345),
+        ("tx", "x" * (matrix_sas.MAX_ID_LEN + 1)),
+    ):
+        bad_ids = {
+            "timestamp": now_ms,
+            "transaction_id": bad_transaction_id,
+            "from_device": bad_from_device,
+            "methods": ["m.sas.v1"],
+        }
+        assert verifier._handle_request("@u:h", bad_ids) is None
+    assert verifier.active is None
+
+    valid = {
+        "timestamp": now_ms,
+        "transaction_id": "tx",
+        "from_device": "DEV",
+        "methods": ["m.sas.v1"],
+    }
+
+    with mock.patch.object(verifier, "_peer_keys", return_value=None):
+        assert verifier._handle_request("@u:h", valid) is False
+    assert verifier.active is None
+
+    # Reject a new request without changing the active transaction.
+    active = {
+        "transaction_id": "other",
+        "user_id": "@u:h",
+        "device_id": "OLD",
+    }
+    verifier.active = active
+    with mock.patch.object(verifier, "_send_event", return_value=True) as se:
+        assert verifier._handle_request("@u:h", valid) is None
+    se.assert_called_once_with(
+        matrix_sas.EVENT_CANCEL,
+        "@u:h",
+        "DEV",
+        {
+            "transaction_id": "tx",
+            "code": "m.unexpected_message",
+            "reason": "Another verification is already active",
+        },
+    )
+    assert verifier.active is active
+    verifier.active = None
+
+    # An exact replay of the request that started the active transaction
+    # is ignored silently -- it must not cancel our own exchange.
+    active = {
+        "transaction_id": "tx",
+        "user_id": "@u:h",
+        "device_id": "DEV",
+    }
+    verifier.active = active
+    with mock.patch.object(verifier, "_send_event") as se:
+        assert verifier._handle_request("@u:h", valid) is None
+    se.assert_not_called()
+    assert verifier.active is active
+    verifier.active = None
+
+    # A second transaction from the same device cancels both attempts.
+    active = {
+        "transaction_id": "other",
+        "user_id": "@u:h",
+        "device_id": "DEV",
+    }
+    verifier.active = active
+    with (
+        mock.patch.object(verifier, "_cancel", return_value=True) as cancel,
+        mock.patch.object(verifier, "_send_event", return_value=True) as se,
+    ):
+        assert verifier._handle_request("@u:h", valid) is None
+    cancel.assert_called_once_with(
+        "m.unexpected_message",
+        "A newer verification request superseded this one",
+    )
+    se.assert_called_once_with(
+        matrix_sas.EVENT_CANCEL,
+        "@u:h",
+        "DEV",
+        {
+            "transaction_id": "tx",
+            "code": "m.unexpected_message",
+            "reason": "Another verification is already active",
+        },
+    )
+    assert verifier.active is None
+
+    with (
+        mock.patch.object(
+            verifier, "_peer_keys", return_value={"ed25519:DEV": "k"}
+        ),
+        mock.patch.object(verifier, "_send_event", return_value=False) as se,
+    ):
+        assert verifier._handle_request("@u:h", valid) is False
+    se.assert_called_once()
+    verifier.active = None
+
+    with (
+        mock.patch.object(
+            verifier, "_peer_keys", return_value={"ed25519:DEV": "k"}
+        ),
+        mock.patch.object(verifier, "_send_event", return_value=True),
+    ):
+        assert verifier._handle_request("@u:h", valid) is None
+    assert verifier.active["transaction_id"] == "tx"
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_handle_cancel():
+    """_handle_cancel always reports failure."""
+    obj = _matrix_sas_plugin()
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+    assert verifier._handle_cancel({"reason": "user declined"}) is False
+    assert verifier._handle_cancel({}) is False
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_handle_start_branches():
+    """_handle_start covers the invalid-params, send-failure, and success
+    outcomes."""
+    obj = _matrix_sas_plugin()
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+    verifier.active = {
+        "transaction_id": "tx",
+        "user_id": "@peer:h",
+        "device_id": "DEV",
+    }
+
+    with mock.patch.object(verifier, "_cancel", return_value=True) as cancel:
+        assert (
+            verifier._handle_start("@peer:h", {"transaction_id": "tx"})
+            is False
+        )
+    cancel.assert_called_once_with(
+        "m.unknown_method", "Unsupported SAS verification parameters"
+    )
+
+    valid_start = {
+        "from_device": "DEV",
+        "transaction_id": "tx",
+        "method": "m.sas.v1",
+        "key_agreement_protocols": ["curve25519-hkdf-sha256"],
+        "hashes": ["sha256"],
+        "message_authentication_codes": ["hkdf-hmac-sha256.v2"],
+        "short_authentication_string": ["decimal", "emoji"],
+    }
+
+    with mock.patch.object(verifier, "_send_event", return_value=False):
+        assert verifier._handle_start("@peer:h", valid_start) is False
+    assert verifier.active["sas"] is not None
+
+    verifier.active["sas"] = None
+    with mock.patch.object(verifier, "_send_event", return_value=True):
+        assert verifier._handle_start("@peer:h", valid_start) is None
+    assert verifier.active["sas"] is not None
+    first_sas = verifier.active["sas"]
+
+    # A second start must not replace an already committed temporary key.
+    with mock.patch.object(verifier, "_cancel", return_value=True) as cancel:
+        assert verifier._handle_start("@peer:h", valid_start) is False
+    cancel.assert_called_once_with(
+        "m.unexpected_message", "SAS verification was already started"
+    )
+    assert verifier.active["sas"] is first_sas
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_handle_key_branches():
+    """_handle_key covers the invalid-key and send-failure/success paths."""
+    from cryptography.hazmat.primitives.asymmetric.x25519 import (
+        X25519PrivateKey,
+    )
+    from cryptography.hazmat.primitives.serialization import (
+        Encoding,
+        PublicFormat,
+    )
+
+    from apprise.plugins.matrix.e2ee import _b64enc
+
+    obj = _matrix_sas_plugin()
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+    verifier.active = {
+        "transaction_id": "tx",
+        "user_id": "@peer:h",
+        "device_id": "DEV",
+    }
+
+    invalid_sas = _make_sas(obj.user_id, obj.device_id, "@peer:h", "DEV", "tx")
+    invalid_sas.accept_content()
+    with mock.patch.object(verifier, "_cancel", return_value=True) as cancel:
+        assert (
+            verifier._handle_key(
+                invalid_sas, "@peer:h", {"key": "not-valid-base64!!"}
+            )
+            is False
+        )
+    cancel.assert_called_once_with(
+        "m.invalid_message", "Invalid SAS public key"
+    )
+
+    # A present-but-null "key" field must not crash before it is rejected
+    # as an invalid public key.
+    null_key_sas = _make_sas(
+        obj.user_id, obj.device_id, "@peer:h", "DEV", "tx"
+    )
+    null_key_sas.accept_content()
+    with mock.patch.object(verifier, "_cancel", return_value=True):
+        assert (
+            verifier._handle_key(null_key_sas, "@peer:h", {"key": None})
+            is False
+        )
+
+    peer_private = X25519PrivateKey.generate()
+    peer_public = _b64enc(
+        peer_private.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    )
+
+    key_fail_sas = _make_sas(
+        obj.user_id, obj.device_id, "@peer:h", "DEV", "tx"
+    )
+    key_fail_sas.accept_content()
+    with mock.patch.object(verifier, "_send_event", return_value=False):
+        assert (
+            verifier._handle_key(key_fail_sas, "@peer:h", {"key": peer_public})
+            is False
+        )
+
+    mac_fail_sas = _make_sas(
+        obj.user_id, obj.device_id, "@peer:h", "DEV", "tx"
+    )
+    mac_fail_sas.accept_content()
+    with mock.patch.object(verifier, "_send_event", side_effect=[True, False]):
+        assert (
+            verifier._handle_key(mac_fail_sas, "@peer:h", {"key": peer_public})
+            is False
+        )
+
+    ok_sas = _make_sas(obj.user_id, obj.device_id, "@peer:h", "DEV", "tx")
+    ok_sas.accept_content()
+    with (
+        mock.patch.object(verifier, "_send_event", return_value=True),
+        mock.patch.object(obj.logger, "info") as log_info,
+    ):
+        assert (
+            verifier._handle_key(ok_sas, "@peer:h", {"key": peer_public})
+            is None
+        )
+    assert any(
+        "SAS code" in str(call.args[0]) for call in log_info.call_args_list
+    )
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_handle_mac_branches():
+    """_handle_mac covers the mismatch, send-failure, and completion
+    outcomes."""
+    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
+
+    obj = _matrix_sas_plugin()
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+    own_account = obj._e2ee_account
+    peer_account = MatrixOlmAccount()
+
+    def build_active(peer_done):
+        sas, content, peer_keys, _mac = _completed_sas_pair(
+            obj.user_id,
+            obj.device_id,
+            "@peer:h",
+            "DEV",
+            "tx",
+            own_account,
+            peer_account,
+        )
+        verifier.active = {
+            "transaction_id": "tx",
+            "user_id": "@peer:h",
+            "device_id": "DEV",
+            "peer_keys": peer_keys,
+            "peer_done": peer_done,
+        }
+        return sas, content
+
+    sas, _content = build_active(False)
+    with mock.patch.object(verifier, "_cancel", return_value=True) as cancel:
+        assert (
+            verifier._handle_mac(sas, {"transaction_id": "tx", "mac": {}})
+            is False
+        )
+    cancel.assert_called_once_with(
+        "m.key_mismatch", "SAS device key MAC did not match"
+    )
+
+    sas, content = build_active(False)
+    with mock.patch.object(verifier, "_send_event", return_value=False):
+        assert verifier._handle_mac(sas, content) is False
+
+    sas, content = build_active(True)
+    with (
+        mock.patch.object(verifier, "_send_event", return_value=True),
+        mock.patch.object(
+            matrix_sas, "store_verified_binding", return_value=True
+        ) as store,
+    ):
+        assert verifier._handle_mac(sas, content) is True
+    store.assert_called_once_with(obj)
+
+    # A failed persistence write must not be reported as success.
+    sas, content = build_active(True)
+    with (
+        mock.patch.object(verifier, "_send_event", return_value=True),
+        mock.patch.object(
+            matrix_sas, "store_verified_binding", return_value=False
+        ),
+    ):
+        assert verifier._handle_mac(sas, content) is False
+
+    sas, content = build_active(False)
+    with mock.patch.object(verifier, "_send_event", return_value=True):
+        assert verifier._handle_mac(sas, content) is None
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_handle_done_branches():
+    """_handle_done only reports success once the local SAS is verified."""
+    obj = _matrix_sas_plugin()
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+    verifier.active = {"peer_done": False}
+
+    class _FakeSAS:
+        state = "mac_sent"
+
+    fake = _FakeSAS()
+    assert verifier._handle_done(fake) is None
+    assert verifier.active["peer_done"] is True
+
+    fake.state = "verified"
+    verifier.active["peer_done"] = False
+    with mock.patch.object(
+        matrix_sas, "store_verified_binding", return_value=True
+    ) as store:
+        assert verifier._handle_done(fake) is True
+    store.assert_called_once_with(obj)
+
+    # A failed persistence write must not be reported as success.
+    verifier.active["peer_done"] = False
+    with mock.patch.object(
+        matrix_sas, "store_verified_binding", return_value=False
+    ):
+        assert verifier._handle_done(fake) is False
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_handle_event_dispatch():
+    """_handle_event routes every to-device event type correctly."""
+    obj = _matrix_sas_plugin()
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+
+    assert verifier._handle_event("not-a-dict") is None
+    assert verifier._handle_event({"type": "x", "sender": "@other:h"}) is None
+    assert (
+        verifier._handle_event(
+            {"type": "x", "sender": obj.user_id, "content": "nope"}
+        )
+        is None
+    )
+
+    with mock.patch.object(verifier, "_handle_request", return_value="R") as h:
+        result = verifier._handle_event(
+            {
+                "type": matrix_sas.EVENT_REQUEST,
+                "sender": obj.user_id,
+                "content": {"a": 1},
+            }
+        )
+    assert result == "R"
+    h.assert_called_once_with(obj.user_id, {"a": 1})
+
+    # No active transaction yet -- every non-request event is ignored.
+    assert (
+        verifier._handle_event(
+            {
+                "type": matrix_sas.EVENT_START,
+                "sender": obj.user_id,
+                "content": {"transaction_id": "tx"},
+            }
+        )
+        is None
+    )
+
+    verifier.active = {
+        "transaction_id": "tx",
+        "user_id": obj.user_id,
+        "sas": None,
+    }
+
+    assert (
+        verifier._handle_event(
+            {
+                "type": matrix_sas.EVENT_START,
+                "sender": obj.user_id,
+                "content": {"transaction_id": "other"},
+            }
+        )
+        is None
+    )
+
+    # Defensive same-transaction-owner check.
+    verifier.active["user_id"] = "@different:h"
+    assert (
+        verifier._handle_event(
+            {
+                "type": matrix_sas.EVENT_START,
+                "sender": obj.user_id,
+                "content": {"transaction_id": "tx"},
+            }
+        )
+        is None
+    )
+    verifier.active["user_id"] = obj.user_id
+
+    with mock.patch.object(
+        verifier, "_handle_cancel", return_value=False
+    ) as h:
+        result = verifier._handle_event(
+            {
+                "type": matrix_sas.EVENT_CANCEL,
+                "sender": obj.user_id,
+                "content": {"transaction_id": "tx"},
+            }
+        )
+    assert result is False
+    h.assert_called_once()
+
+    with mock.patch.object(verifier, "_handle_start", return_value=None) as h:
+        result = verifier._handle_event(
+            {
+                "type": matrix_sas.EVENT_START,
+                "sender": obj.user_id,
+                "content": {"transaction_id": "tx"},
+            }
+        )
+    assert result is None
+    h.assert_called_once()
+
+    with mock.patch.object(verifier, "_cancel", return_value=True) as cancel:
+        result = verifier._handle_event(
+            {
+                "type": matrix_sas.EVENT_KEY,
+                "sender": obj.user_id,
+                "content": {"transaction_id": "tx"},
+            }
+        )
+    assert result is False
+    cancel.assert_called_once_with(
+        "m.unexpected_message", "SAS verification has not started"
+    )
+
+    verifier.active["sas"] = mock.Mock()
+    for event_type, method in (
+        (matrix_sas.EVENT_KEY, "_handle_key"),
+        (matrix_sas.EVENT_MAC, "_handle_mac"),
+        (matrix_sas.EVENT_DONE, "_handle_done"),
+    ):
+        with mock.patch.object(verifier, method, return_value=None) as h:
+            result = verifier._handle_event(
+                {
+                    "type": event_type,
+                    "sender": obj.user_id,
+                    "content": {"transaction_id": "tx"},
+                }
+            )
+        assert result is None
+        h.assert_called_once()
+
+    assert (
+        verifier._handle_event(
+            {
+                "type": "m.some.other.event",
+                "sender": obj.user_id,
+                "content": {"transaction_id": "tx"},
+            }
+        )
+        is None
+    )
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_run_loop_mechanics():
+    """run() covers sync failure, malformed responses, the since token,
+    early termination, and timeout handling."""
+    obj = _matrix_sas_plugin()
+
+    # Sync itself fails outright.
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+    with mock.patch.object(obj, "_fetch", return_value=(False, {}, 500)):
+        assert verifier.run() is False
+
+    # Sync succeeds but returns a non-dict body.
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+    with mock.patch.object(
+        obj, "_fetch", return_value=(True, [], requests.codes.ok)
+    ):
+        assert verifier.run() is False
+
+    # Reject missing or invalid sync tokens instead of polling repeatedly.
+    for bad_batch_response in (
+        {"to_device": {"events": []}},
+        {"next_batch": None, "to_device": {"events": []}},
+        {"next_batch": "", "to_device": {"events": []}},
+        {"next_batch": 123, "to_device": {"events": []}},
+    ):
+        verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+        with mock.patch.object(
+            obj,
+            "_fetch",
+            return_value=(True, bad_batch_response, requests.codes.ok),
+        ):
+            assert verifier.run() is False
+
+    # A non-list "events" value is treated as empty rather than crashing.
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+    responses = iter(
+        [
+            (
+                True,
+                {
+                    "next_batch": "1",
+                    "to_device": {"events": "not-a-list"},
+                },
+                requests.codes.ok,
+            ),
+            (False, {}, 500),
+        ]
+    )
+    with mock.patch.object(
+        obj, "_fetch", side_effect=lambda *a, **k: next(responses)
+    ):
+        assert verifier.run() is False
+
+    # A present-but-null "to_device" field is treated the same way.
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+    responses = iter(
+        [
+            (True, {"next_batch": "1", "to_device": None}, requests.codes.ok),
+            (False, {}, 500),
+        ]
+    )
+    with mock.patch.object(
+        obj, "_fetch", side_effect=lambda *a, **k: next(responses)
+    ):
+        assert verifier.run() is False
+
+    # Skip malformed events and continue polling.
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+    responses = iter(
+        [
+            (
+                True,
+                {
+                    "next_batch": "1",
+                    "to_device": {"events": [{"type": "x"}]},
+                },
+                requests.codes.ok,
+            ),
+            (False, {}, 500),
+        ]
+    )
+    with (
+        mock.patch.object(
+            obj, "_fetch", side_effect=lambda *a, **k: next(responses)
+        ),
+        mock.patch.object(
+            verifier, "_handle_event", side_effect=AttributeError("boom")
+        ),
+    ):
+        assert verifier.run() is False
+
+    # Stop processing an oversized event batch at the deadline.
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+    # Set the construction-time deadline directly for this mocked clock.
+    verifier.deadline = 100
+    with (
+        mock.patch.object(
+            obj,
+            "_fetch",
+            return_value=(
+                True,
+                {
+                    "next_batch": "1",
+                    "to_device": {"events": [{"type": "a"}, {"type": "b"}]},
+                },
+                requests.codes.ok,
+            ),
+        ),
+        mock.patch.object(verifier, "_handle_event", return_value=None) as h,
+        mock.patch(
+            "apprise.plugins.matrix.sas.monotonic",
+            # while-check, remaining_ms, _bounded_fetch's own check,
+            # post-event-1 check, post-event-2 check (breaks), while
+            # re-check (exits).
+            side_effect=[1, 1, 1, 50, 150, 200],
+        ),
+    ):
+        assert verifier.run() is False
+    # The expired batch must not trigger another sync.
+    assert h.call_count == 2
+
+    # A terminal per-event result short-circuits the loop.
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+    with (
+        mock.patch.object(
+            obj,
+            "_fetch",
+            return_value=(
+                True,
+                {
+                    "next_batch": "1",
+                    "to_device": {"events": [{"type": "x"}]},
+                },
+                requests.codes.ok,
+            ),
+        ),
+        mock.patch.object(verifier, "_handle_event", return_value=True),
+    ):
+        assert verifier.run() is True
+
+    # The since token from one iteration is threaded into the next, and
+    # the reduced long-poll timeout is what actually gets sent.
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+    calls = []
+
+    def fake_fetch(path, params=None, method="GET", **kwargs):
+        calls.append(params)
+        if len(calls) == 1:
+            return (
+                True,
+                {"next_batch": "abc", "to_device": {"events": []}},
+                requests.codes.ok,
+            )
+        return (False, {}, 500)
+
+    with mock.patch.object(obj, "_fetch", side_effect=fake_fetch):
+        assert verifier.run() is False
+    assert "since" not in calls[0]
+    assert calls[0]["timeout"] == int(obj.socket_read_timeout * 1000 / 2)
+    assert calls[1]["since"] == "abc"
+
+    # Deadline reached with no active transaction -- fails closed with no
+    # network call for the no-op cancellation. Configure it before creation.
+    obj.default_autoverify_timeout_sec = 0
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+    with mock.patch.object(obj, "_fetch") as fetch:
+        assert verifier.run() is False
+    fetch.assert_not_called()
+
+    # Deadline reached with an active transaction -- the peer is told.
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+    verifier.active = {
+        "transaction_id": "tx",
+        "user_id": "@peer:h",
+        "device_id": "DEV",
+    }
+    with mock.patch.object(
+        obj, "_fetch", return_value=(True, {}, requests.codes.ok)
+    ) as fetch:
+        assert verifier.run() is False
+    assert fetch.call_args[0][0].startswith(
+        "/sendToDevice/m.key.verification.cancel/"
+    )
+    obj.default_autoverify_timeout_sec = (
+        NotifyMatrix.default_autoverify_timeout_sec
+    )
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_poll_timeout_margin():
+    """Sync uses bounded timeouts and does not mark the account online."""
+    import json
+
+    obj = _matrix_sas_plugin()
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+
+    with mock.patch.object(
+        obj, "_fetch", return_value=(False, {}, 500)
+    ) as fetch:
+        assert verifier.run() is False
+    sent_params = fetch.call_args.kwargs["params"]
+    assert sent_params["timeout"] == int(obj.socket_read_timeout * 1000 / 2)
+    assert sent_params["timeout"] < obj.socket_read_timeout * 1000
+    assert sent_params["set_presence"] == "offline"
+
+    # Both HTTP timeouts use the sanitized polling budget.
+    fetch_timeout = fetch.call_args.kwargs["timeout"]
+    expected = pytest.approx(sent_params["timeout"] / 1000 + 2)
+    assert fetch_timeout[0] == expected
+    assert fetch_timeout[1] == expected
+    assert fetch_timeout[1] < obj.socket_read_timeout * 10  # sane, not huge
+
+    # A 429 mid-poll must not be allowed to wait out the server's own
+    # arbitrary requested delay past what remains of this attempt.
+    assert fetch.call_args.kwargs["max_retry_wait"] == pytest.approx(
+        obj.default_autoverify_timeout_sec, abs=1
+    )
+
+    # Check filter behavior, including that any limits are positive.
+    parsed_filter = json.loads(sent_params["filter"])
+    assert parsed_filter["room"]["rooms"] == []
+    assert parsed_filter["presence"]["types"] == []
+    assert parsed_filter["account_data"]["types"] == []
+
+    def _walk_limits(node):
+        if isinstance(node, dict):
+            if "limit" in node:
+                yield node["limit"]
+            for value in node.values():
+                yield from _walk_limits(value)
+        elif isinstance(node, list):
+            for value in node:
+                yield from _walk_limits(value)
+
+    assert all(limit > 0 for limit in _walk_limits(parsed_filter))
+
+    # A custom ?rto= override scales the poll with it.
+    custom = NotifyMatrix(
+        host="h", user="u", password="pass", targets=["#r"], rto=10.0
+    )
+    custom.user_id = obj.user_id
+    custom.device_id = obj.device_id
+    custom._e2ee_account = obj._e2ee_account
+    custom_verifier = matrix_sas.MatrixSASAutoVerifier(custom)
+    with mock.patch.object(
+        custom, "_fetch", return_value=(False, {}, 500)
+    ) as fetch:
+        assert custom_verifier.run() is False
+    assert fetch.call_args.kwargs["params"]["timeout"] == 5000
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_expired_fetch():
+    """Do not start helper requests after the attempt deadline."""
+    obj = _matrix_sas_plugin()
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+    verifier.deadline = 0  # already expired relative to real monotonic time
+
+    with mock.patch.object(obj, "_fetch") as fetch:
+        result = verifier._bounded_fetch("/keys/query", payload={})
+
+    fetch.assert_not_called()
+    assert result == (False, {}, None)
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_expired_best_effort_fetch():
+    """A best-effort call still fires once the deadline has passed.
+
+    The terminal cancellation notice is deliberately sent past the
+    deadline -- that is exactly why the attempt is ending.
+    """
+    obj = _matrix_sas_plugin()
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+    verifier.deadline = 0  # already expired relative to real monotonic time
+
+    with mock.patch.object(
+        obj, "_fetch", return_value=(True, {}, requests.codes.ok)
+    ) as fetch:
+        result = verifier._bounded_fetch(
+            "/keys/query", payload={}, best_effort=True
+        )
+
+    fetch.assert_called_once()
+    assert result == (True, {}, requests.codes.ok)
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_fetch_response_limit():
+    """Every SAS request bounds how large a response it will accept."""
+    obj = _matrix_sas_plugin()
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+
+    with mock.patch.object(
+        obj, "_fetch", return_value=(True, {}, requests.codes.ok)
+    ) as fetch:
+        verifier._bounded_fetch("/keys/query", payload={})
+
+    assert (
+        fetch.call_args.kwargs["max_response_bytes"]
+        == matrix_sas.MAX_RESPONSE_BYTES
+    )
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_invalid_read_timeout():
+    """Invalid read timeouts use the safe polling fallback."""
+    obj = _matrix_sas_plugin()
+
+    for bad_value in (
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        0.0,
+        -5.0,
+        # Finite on its own, but 1e306 * 1000 overflows to inf -- this
+        # must be caught too, not just outright non-finite input.
+        1e306,
+    ):
+        obj.socket_read_timeout = bad_value
+        assert (
+            matrix_sas._sync_poll_ms(obj) == matrix_sas.FALLBACK_SYNC_POLL_MS
+        )
+
+    obj.socket_read_timeout = 8.0
+    assert matrix_sas._sync_poll_ms(obj) == 4000
+
+    # A tiny-but-valid timeout floors to a usable minimum poll rather
+    # than truncating toward a near-zero, busy-looping value.
+    obj.socket_read_timeout = 0.0001
+    assert matrix_sas._sync_poll_ms(obj) == matrix_sas.MIN_SYNC_POLL_MS
+
+    # The full run() loop must not raise either.
+    obj.socket_read_timeout = float("nan")
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+    with mock.patch.object(
+        obj, "_fetch", return_value=(False, {}, 500)
+    ) as fetch:
+        assert verifier.run() is False
+    assert (
+        fetch.call_args.kwargs["params"]["timeout"]
+        == matrix_sas.FALLBACK_SYNC_POLL_MS
+    )
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_poll_capped_by_deadline():
+    """The verification deadline also caps each poll request."""
+    obj = _matrix_sas_plugin()
+    obj.socket_read_timeout = 600.0  # would otherwise poll for 300s
+    obj.default_autoverify_timeout_sec = 5
+
+    verifier = matrix_sas.MatrixSASAutoVerifier(obj)
+    with mock.patch.object(
+        obj, "_fetch", return_value=(False, {}, 500)
+    ) as fetch:
+        assert verifier.run() is False
+    sent_timeout = fetch.call_args.kwargs["params"]["timeout"]
+    assert sent_timeout <= 5000
+    assert sent_timeout < int(obj.socket_read_timeout * 1000 / 2)
+    obj.default_autoverify_timeout_sec = (
+        NotifyMatrix.default_autoverify_timeout_sec
+    )
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_auto_verify_fast_paths():
+    """auto_verify() short-circuits when already verified or when the
+    plugin identity is not ready yet."""
+    obj = _matrix_sas_plugin()
+    binding = obj._e2ee_binding_key()
+    obj.store.set("e2ee_device_binding", binding, expires=60)
+    obj.store.set("e2ee_verified_binding", binding, expires=60)
+    with mock.patch.object(obj, "_fetch") as fetch:
+        assert matrix_sas.auto_verify(obj) is True
+    fetch.assert_not_called()
+
+    obj2 = NotifyMatrix(
+        host="h",
+        user="u",
+        password="pass",
+        targets=["#r"],
+        e2ee=True,
+        autoverify=True,
+    )
+    assert matrix_sas.auto_verify(obj2) is False
+
+    obj3 = _matrix_sas_plugin()
+    obj3.store.set("e2ee_device_binding", "unverified", expires=60)
+    with mock.patch.object(
+        matrix_sas.MatrixSASAutoVerifier, "run", return_value=True
+    ) as run:
+        assert matrix_sas.auto_verify(obj3) is True
+    run.assert_called_once()
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_auto_verify_cooldown():
+    """A failed attempt sets a cooldown so every later send is not
+    blocked for the full timeout until it expires."""
+    obj = _matrix_sas_plugin()
+    binding = obj._e2ee_binding_key()
+    obj.store.set("e2ee_device_binding", binding, expires=60)
+
+    with mock.patch.object(
+        matrix_sas.MatrixSASAutoVerifier, "run", return_value=False
+    ) as run:
+        assert matrix_sas.auto_verify(obj) is False
+    run.assert_called_once()
+
+    # The next call in the cooldown window returns immediately -- no new
+    # attempt, no network call.
+    with mock.patch.object(matrix_sas.MatrixSASAutoVerifier, "run") as run:
+        assert matrix_sas.auto_verify(obj) is False
+    run.assert_not_called()
+
+    # A changed identity is not blocked by another identity's cooldown.
+    obj.store.set("e2ee_device_binding", "a-different-binding", expires=60)
+    with mock.patch.object(
+        matrix_sas.MatrixSASAutoVerifier, "run", return_value=True
+    ) as run:
+        assert matrix_sas.auto_verify(obj) is True
+    run.assert_called_once()
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_auto_verify_concurrency():
+    """Let concurrent callers deliver while one caller verifies."""
+    import threading as _threading
+    import time as _time
+
+    obj = _matrix_sas_plugin()
+    obj.store.set("e2ee_device_binding", obj._e2ee_binding_key(), expires=60)
+
+    state_lock = _threading.Lock()
+    active = 0
+    max_concurrent = 0
+    calls = 0
+
+    def fake_run(_self):
+        nonlocal active, max_concurrent, calls
+        with state_lock:
+            active += 1
+            max_concurrent = max(max_concurrent, active)
+            calls += 1
+        # Long enough that a blocking wait for this call would make the
+        # elapsed-time assertion below fail.
+        _time.sleep(0.1)
+        with state_lock:
+            active -= 1
+        return True
+
+    results = []
+
+    def call_auto_verify():
+        results.append(matrix_sas.auto_verify(obj))
+
+    with mock.patch.object(matrix_sas.MatrixSASAutoVerifier, "run", fake_run):
+        threads = [
+            _threading.Thread(target=call_auto_verify) for _ in range(4)
+        ]
+        start = _time.monotonic()
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=5)
+        elapsed = _time.monotonic() - start
+
+    # The group finishes near the single verifier's running time.
+    assert elapsed < 0.3
+    assert calls == 1
+    assert max_concurrent == 1
+    assert results.count(True) == 1
+    assert results.count(False) == 3
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_refresh_concurrency():
+    """A concurrent refresh does not wait on an in-progress verification.
+
+    The verification lock can be held by a live SAS exchange for up to the
+    full attempt timeout; refreshing trust must not block behind it.
+    """
+    import time as _time
+
+    obj = _matrix_sas_plugin()
+
+    # Simulate a verification attempt already holding the lock.
+    obj._autoverify_lock.acquire()
+    try:
+        start = _time.monotonic()
+        result = matrix_sas.refresh_verified_state(obj)
+        elapsed = _time.monotonic() - start
+    finally:
+        obj._autoverify_lock.release()
+
+    assert result is False
+    assert elapsed < 0.1
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_store_verified_binding():
+    """store_verified_binding no-ops without a device binding to trust."""
+    obj = _matrix_sas_plugin()
+    assert matrix_sas.store_verified_binding(obj) is False
+
+    obj.store.set("e2ee_device_binding", "B", expires=60)
+    assert matrix_sas.store_verified_binding(obj) is True
+    assert obj.store.get("e2ee_verified_binding") == "B"
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_refresh_state():
+    """Trust refresh requires matching identities and successful writes."""
+    obj = _matrix_sas_plugin()
+    assert matrix_sas.refresh_verified_state(obj) is False
+
+    binding = obj._e2ee_binding_key()
+    obj.store.set("e2ee_device_binding", binding, expires=60)
+    assert matrix_sas.refresh_verified_state(obj) is False
+
+    obj.store.set("e2ee_verified_binding", binding, expires=60)
+
+    obj.device_id = "OTHERDEV"
+    assert matrix_sas.refresh_verified_state(obj) is False
+    obj.device_id = "APPRISE"
+
+    with mock.patch.object(
+        obj.store, "set", side_effect=[True, False, True, True]
+    ):
+        assert matrix_sas.refresh_verified_state(obj) is False
+
+    assert matrix_sas.refresh_verified_state(obj) is True
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_sas_auto_verify_flow():
-    """The Matrix plugin drives the same-user SAS to-device flow."""
+    """Exercise the full same-user SAS event flow."""
+    import re
     from time import time
 
     from cryptography.hazmat.primitives.asymmetric.x25519 import (
@@ -2736,20 +4548,10 @@ def test_plugin_matrix_sas_auto_verify_flow():
     obj.user_id = user_id
     obj.device_id = own_device
     obj._e2ee_account = own_account
-    binding = "{}|{}|{}|{}".format(
-        user_id,
-        own_device,
-        own_account.identity_key,
-        own_account.signing_key,
-    )
+    binding = obj._e2ee_binding_key()
     obj.store.set("e2ee_device_binding", binding, expires=60)
 
     sent = []
-
-    def send_event(event_type, event_user, event_device, content):
-        sent.append((event_type, event_user, event_device, content))
-        return True
-
     sync_index = 0
 
     def fake_fetch(path, payload=None, params=None, method="POST", **kwargs):
@@ -2760,6 +4562,14 @@ def test_plugin_matrix_sas_auto_verify_flow():
                 {"device_keys": {user_id: {peer_device: peer_device_keys}}},
                 requests.codes.ok,
             )
+        if path.startswith("/sendToDevice/"):
+            assert re.match(r"^/sendToDevice/[^/]+/[0-9a-f]{32}$", path)
+            event_type = path.split("/")[2]
+            target_user, devices = next(iter(payload["messages"].items()))
+            _target_device, content = next(iter(devices.items()))
+            sent.append((event_type, target_user, content))
+            return (True, {}, requests.codes.ok)
+
         assert path == "/sync"
         if sync_index == 0:
             event_type = "m.key.verification.request"
@@ -2791,7 +4601,7 @@ def test_plugin_matrix_sas_auto_verify_flow():
             own_key_event = next(
                 item for item in sent if item[0] == "m.key.verification.key"
             )
-            own_public = own_key_event[3]["key"]
+            own_public = own_key_event[2]["key"]
             shared_secret = peer_private.exchange(
                 X25519PublicKey.from_public_bytes(_b64dec(own_public))
             )
@@ -2839,14 +4649,7 @@ def test_plugin_matrix_sas_auto_verify_flow():
             requests.codes.ok,
         )
 
-    with (
-        mock.patch.object(obj, "_fetch", side_effect=fake_fetch),
-        mock.patch.object(
-            obj,
-            "_e2ee_send_verification_event",
-            side_effect=send_event,
-        ),
-    ):
+    with mock.patch.object(obj, "_fetch", side_effect=fake_fetch):
         assert obj._e2ee_auto_verify() is True
 
     assert [item[0] for item in sent] == [
@@ -2860,10 +4663,8 @@ def test_plugin_matrix_sas_auto_verify_flow():
 
 
 @pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
-def test_plugin_matrix_sas_transport_and_persistence_guards():
-    """SAS transport and persistent binding helpers fail closed."""
-    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
-
+def test_plugin_matrix_sas_failure_allows_send():
+    """A failed SAS bootstrap does not prevent message delivery."""
     obj = NotifyMatrix(
         host="h",
         user="u",
@@ -2873,461 +4674,33 @@ def test_plugin_matrix_sas_transport_and_persistence_guards():
         autoverify=True,
         secure=True,
     )
+    obj.access_token = "token"
     obj.user_id = "@u:h"
     obj.device_id = "APPRISE"
-    obj._e2ee_account = MatrixOlmAccount()
-
-    with mock.patch.object(
-        obj, "_fetch", return_value=(True, {}, requests.codes.ok)
-    ) as fetch:
-        assert obj._e2ee_send_verification_event(
-            "m.key.verification.ready", "@u:h", "ELEMENT", {"x": 1}
-        )
-    assert fetch.call_args.args[0].startswith(
-        "/sendToDevice/m.key.verification.ready/"
-    )
-    assert fetch.call_args.kwargs["method"] == "PUT"
-
-    assert obj._e2ee_verification_cancel(None, "m.timeout", "timeout") is False
-    active = {
-        "user_id": "@u:h",
-        "device_id": "ELEMENT",
-        "transaction_id": "txn",
-    }
-    with mock.patch.object(
-        obj, "_e2ee_send_verification_event", return_value=True
-    ) as send:
-        assert obj._e2ee_verification_cancel(active, "m.timeout", "timeout")
-    assert send.call_args.args[0] == "m.key.verification.cancel"
-
-    with mock.patch.object(
-        obj, "_fetch", return_value=(False, None, requests.codes.bad_request)
-    ):
-        assert obj._e2ee_verification_peer_keys("@u:h", "ELEMENT") is None
-
-    with mock.patch.object(
-        obj,
-        "_fetch",
-        return_value=(
-            True,
-            {"device_keys": {"@u:h": {"ELEMENT": {}}}},
-            requests.codes.ok,
-        ),
-    ):
-        assert obj._e2ee_verification_peer_keys("@u:h", "ELEMENT") is None
-
-    peer = MatrixOlmAccount()
-    peer_device = peer.device_keys_payload("@u:h", "ELEMENT")
-    with mock.patch.object(
-        obj,
-        "_fetch",
-        return_value=(
-            True,
-            {
-                "device_keys": {"@u:h": {"ELEMENT": peer_device}},
-                "master_keys": {"@u:h": "invalid"},
-            },
-            requests.codes.ok,
-        ),
-    ):
-        assert obj._e2ee_verification_peer_keys("@u:h", "ELEMENT") == dict(
-            peer_device["keys"]
-        )
-
-    with mock.patch.object(obj.store, "get", return_value=None):
-        assert obj._e2ee_store_verified_binding() is False
-        assert obj._e2ee_refresh_verified_state() is False
-
-    current_binding = "{}|{}|{}|{}".format(
-        obj.user_id,
-        obj.device_id,
-        obj._e2ee_account.identity_key,
-        obj._e2ee_account.signing_key,
-    )
-    with mock.patch.object(
-        obj.store,
-        "get",
-        side_effect=lambda key: "wrong-binding",
-    ):
-        assert obj._e2ee_refresh_verified_state() is False
 
     with (
+        mock.patch.object(obj, "_e2ee_setup", return_value=True),
         mock.patch.object(
-            obj.store,
-            "get",
-            side_effect=lambda key: current_binding,
-        ),
-        mock.patch.object(obj.store, "set", return_value=False),
-    ):
-        assert obj._e2ee_refresh_verified_state() is False
-
-    with mock.patch.object(
-        obj.store,
-        "get",
-        side_effect=lambda key: current_binding,
-    ):
-        assert obj._e2ee_auto_verify() is True
-
-    obj.device_id = None
-    with mock.patch.object(obj.store, "get", return_value=None):
-        assert obj._e2ee_auto_verify() is False
-
-
-def _matrix_sas_event(event_type, content, sender="@u:h"):
-    """Build one to-device SAS event for state-machine tests."""
-    return {"type": event_type, "sender": sender, "content": content}
-
-
-def _matrix_sas_request(timestamp, transaction_id="txn"):
-    """Build one valid SAS request event."""
-    return _matrix_sas_event(
-        "m.key.verification.request",
-        {
-            "from_device": "ELEMENT",
-            "transaction_id": transaction_id,
-            "methods": ["m.sas.v1"],
-            "timestamp": timestamp,
-        },
-    )
-
-
-def _matrix_sas_start_event(transaction_id="txn", **updates):
-    """Build one SAS start event."""
-    content = _matrix_sas_start("ELEMENT", transaction_id)
-    content.update(updates)
-    return _matrix_sas_event("m.key.verification.start", content)
-
-
-@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
-def test_plugin_matrix_sas_auto_verify_rejects_bad_events():
-    """Malformed, foreign, duplicate, and cancelled flows are rejected."""
-    from time import time
-
-    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
-
-    def run(events, peer_keys=True, send=True):
-        obj = NotifyMatrix(
-            host="h",
-            user="u",
-            password="pass",
-            targets=["#r"],
-            e2ee=True,
-            autoverify=True,
-            secure=True,
-        )
-        obj.user_id = "@u:h"
-        obj.device_id = "APPRISE"
-        obj._e2ee_account = MatrixOlmAccount()
-        sync_calls = 0
-
-        def fetch(path, **kwargs):
-            nonlocal sync_calls
-            assert path == "/sync"
-            sync_calls += 1
-            if sync_calls == 1:
-                return (
-                    True,
-                    {
-                        "next_batch": "next",
-                        "to_device": {"events": events},
-                    },
-                    requests.codes.ok,
-                )
-            return False, None, requests.codes.bad_request
-
-        with (
-            mock.patch.object(obj, "_fetch", side_effect=fetch),
-            mock.patch.object(
-                obj, "_e2ee_verification_peer_keys", return_value=peer_keys
-            ),
-            mock.patch.object(
-                obj, "_e2ee_send_verification_event", return_value=send
-            ) as sender,
-        ):
-            result = obj._e2ee_auto_verify()
-        return result, sender
-
-    now_ms = int(time() * 1000)
-    noise = [
-        "invalid",
-        _matrix_sas_event("unknown", {}, sender="@other:h"),
-        _matrix_sas_event("unknown", "invalid"),
-        _matrix_sas_request(None),
-        _matrix_sas_event(
-            "m.key.verification.key",
-            {"transaction_id": "unrelated", "key": "invalid"},
-        ),
-    ]
-    assert run(noise)[0] is False
-    assert run([_matrix_sas_request(now_ms)], peer_keys=None)[0] is False
-
-    result, sender = run(
-        [_matrix_sas_request(now_ms), _matrix_sas_request(now_ms)]
-    )
-    assert result is False
-    assert sender.call_args.args[0] == "m.key.verification.cancel"
-
-    assert run([_matrix_sas_request(now_ms)], send=False)[0] is False
-    result, _ = run(
-        [
-            _matrix_sas_request(now_ms),
-            _matrix_sas_event(
-                "m.key.verification.cancel",
-                {"transaction_id": "txn", "reason": "cancelled"},
-            ),
-        ]
-    )
-    assert result is False
-
-
-@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
-def test_plugin_matrix_sas_auto_verify_rejects_protocol_failures():
-    """Protocol ordering, crypto, and send failures cancel verification."""
-    from time import time
-
-    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
-
-    now_ms = int(time() * 1000)
-
-    def run(events, send_results=True, sas=None):
-        obj = NotifyMatrix(
-            host="h",
-            user="u",
-            password="pass",
-            targets=["#r"],
-            e2ee=True,
-            autoverify=True,
-            secure=True,
-        )
-        obj.user_id = "@u:h"
-        obj.device_id = "APPRISE"
-        obj._e2ee_account = MatrixOlmAccount()
-        fetch = mock.Mock(
-            side_effect=[
-                (
-                    True,
-                    {"to_device": {"events": events}},
-                    requests.codes.ok,
-                ),
-                (False, None, requests.codes.bad_request),
-            ]
-        )
-        patches = [
-            mock.patch.object(obj, "_fetch", fetch),
-            mock.patch.object(
-                obj, "_e2ee_verification_peer_keys", return_value={"key": "x"}
-            ),
-            mock.patch.object(
-                obj,
-                "_e2ee_send_verification_event",
-                side_effect=(
-                    send_results if isinstance(send_results, list) else None
-                ),
-                return_value=(
-                    send_results if isinstance(send_results, bool) else True
-                ),
-            ),
-        ]
-        if sas is not None:
-            patches.append(
-                mock.patch(
-                    "apprise.plugins.matrix.base.MatrixSASVerification",
-                    return_value=sas,
-                )
-            )
-        with patches[0], patches[1], patches[2]:
-            if len(patches) == 4:
-                with patches[3]:
-                    return obj._e2ee_auto_verify()
-            return obj._e2ee_auto_verify()
-
-    request = _matrix_sas_request(now_ms)
-    assert run([request, _matrix_sas_start_event(method="invalid")]) is False
-    assert run([request, _matrix_sas_start_event()], [True, False]) is False
-    assert (
-        run(
-            [
-                request,
-                _matrix_sas_event(
-                    "m.key.verification.key",
-                    {"transaction_id": "txn", "key": "invalid"},
-                ),
-            ]
-        )
-        is False
-    )
-    assert (
-        run(
-            [
-                request,
-                _matrix_sas_start_event(),
-                _matrix_sas_event(
-                    "m.key.verification.key",
-                    {"transaction_id": "txn", "key": "invalid"},
-                ),
-            ]
-        )
-        is False
-    )
-
-    fake_sas = mock.Mock(state="mac_sent")
-    fake_sas.accept_content.return_value = {"transaction_id": "txn"}
-    fake_sas.key_content.return_value = {"transaction_id": "txn", "key": "k"}
-    fake_sas.mac_content.return_value = {"transaction_id": "txn", "mac": {}}
-    key_event = _matrix_sas_event(
-        "m.key.verification.key",
-        {"transaction_id": "txn", "key": "key"},
-    )
-    assert (
-        run(
-            [request, _matrix_sas_start_event(), key_event],
-            [True, True, False],
-            fake_sas,
-        )
-        is False
-    )
-    assert (
-        run(
-            [request, _matrix_sas_start_event(), key_event],
-            [True, True, True, False],
-            fake_sas,
-        )
-        is False
-    )
-
-    failing_mac_sas = mock.Mock(state="mac_sent")
-    failing_mac_sas.accept_content.return_value = {"transaction_id": "txn"}
-    failing_mac_sas.verify_peer_mac.side_effect = ValueError("bad MAC")
-    mac_event = _matrix_sas_event(
-        "m.key.verification.mac",
-        {"transaction_id": "txn", "mac": {}},
-    )
-    assert (
-        run(
-            [request, _matrix_sas_start_event(), mac_event],
-            True,
-            failing_mac_sas,
-        )
-        is False
-    )
-
-    valid_mac_sas = mock.Mock(state="mac_sent")
-    valid_mac_sas.accept_content.return_value = {"transaction_id": "txn"}
-    assert (
-        run(
-            [request, _matrix_sas_start_event(), mac_event],
-            [True, True, False],
-            valid_mac_sas,
-        )
-        is False
-    )
-
-
-@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
-def test_plugin_matrix_sas_auto_verify_peer_done_and_timeout():
-    """Peer-first completion is accepted and active timeouts are cancelled."""
-    from apprise.plugins.matrix.e2ee import MatrixOlmAccount
-
-    obj = NotifyMatrix(
-        host="h",
-        user="u",
-        password="pass",
-        targets=["#r"],
-        e2ee=True,
-        autoverify=True,
-        secure=True,
-    )
-    obj.user_id = "@u:h"
-    obj.device_id = "APPRISE"
-    obj._e2ee_account = MatrixOlmAccount()
-    binding = "{}|{}|{}|{}".format(
-        obj.user_id,
-        obj.device_id,
-        obj._e2ee_account.identity_key,
-        obj._e2ee_account.signing_key,
-    )
-    obj.store.set("e2ee_device_binding", binding, expires=60)
-
-    fake_sas = mock.Mock(state="mac_sent")
-    fake_sas.accept_content.return_value = {"transaction_id": "txn"}
-    events = [
-        _matrix_sas_request(0),
-        _matrix_sas_start_event(),
-        _matrix_sas_event(
-            "m.key.verification.done", {"transaction_id": "txn"}
-        ),
-        _matrix_sas_event("unknown", {"transaction_id": "txn"}),
-        _matrix_sas_event("m.key.verification.mac", {"transaction_id": "txn"}),
-    ]
-    with (
-        mock.patch("apprise.plugins.matrix.base.time", return_value=0),
+            obj, "_e2ee_auto_verify", return_value=False
+        ) as verify,
+        mock.patch.object(obj, "_room_join", return_value="!r:h") as join,
+        mock.patch.object(obj, "_e2ee_room_encrypted", return_value=True),
         mock.patch.object(
-            obj,
-            "_fetch",
-            return_value=(
-                True,
-                {"to_device": {"events": events}},
-                requests.codes.ok,
-            ),
-        ),
-        mock.patch.object(
-            obj, "_e2ee_verification_peer_keys", return_value={"key": "x"}
-        ),
-        mock.patch.object(
-            obj, "_e2ee_send_verification_event", return_value=True
-        ),
-        mock.patch(
-            "apprise.plugins.matrix.base.MatrixSASVerification",
-            return_value=fake_sas,
-        ),
-    ):
-        assert obj._e2ee_auto_verify() is True
-
-    timeout_obj = NotifyMatrix(
-        host="h",
-        user="u",
-        password="pass",
-        targets=["#r"],
-        e2ee=True,
-        autoverify=True,
-        secure=True,
-    )
-    timeout_obj.user_id = "@u:h"
-    timeout_obj.device_id = "APPRISE"
-    timeout_obj._e2ee_account = MatrixOlmAccount()
-    timeout_obj.default_autoverify_timeout_sec = 1
-    with (
-        mock.patch(
-            "apprise.plugins.matrix.base.time", side_effect=[0, 0, 0, 2]
-        ),
-        mock.patch.object(
-            timeout_obj,
-            "_fetch",
-            return_value=(
-                True,
-                {"to_device": {"events": [_matrix_sas_request(0)]}},
-                requests.codes.ok,
-            ),
-        ),
-        mock.patch.object(
-            timeout_obj,
-            "_e2ee_verification_peer_keys",
-            return_value={"key": "x"},
-        ),
-        mock.patch.object(
-            timeout_obj, "_e2ee_send_verification_event", return_value=True
+            obj, "_e2ee_send_to_room", return_value=True
         ) as send,
+        mock.patch.object(
+            obj, "_e2ee_refresh_verified_state", return_value=False
+        ),
     ):
-        assert timeout_obj._e2ee_auto_verify() is False
-    assert send.call_args.args[0] == "m.key.verification.cancel"
+        assert obj._send_server_notification(body="test") is True
 
-    timeout_obj.default_autoverify_timeout_sec = 0
-    with mock.patch("apprise.plugins.matrix.base.time", return_value=0):
-        assert timeout_obj._e2ee_auto_verify() is False
+    verify.assert_called_once()
+    join.assert_called_once()
+    send.assert_called_once()
 
 
 @pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
-def test_plugin_matrix_sas_verified_state_refresh_is_minimal():
+def test_plugin_matrix_sas_refresh_is_minimal():
     """Only identity state required to retain SAS trust is refreshed."""
     from apprise.plugins.matrix.e2ee import MatrixOlmAccount
 
@@ -3360,6 +4733,7 @@ def test_plugin_matrix_sas_verified_state_refresh_is_minimal():
         "e2ee_account",
         "e2ee_device_binding",
         "e2ee_verified_binding",
+        "e2ee_autoverify_refreshed_at",
     ]
     assert all(
         call.kwargs["expires"] == obj.default_cache_expiry_sec
@@ -3368,8 +4742,107 @@ def test_plugin_matrix_sas_verified_state_refresh_is_minimal():
 
 
 @pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_refresh_throttled():
+    """A recent refresh is skipped entirely -- no rewrite of the
+    serialized E2EE account (or anything else) on every single send."""
+    from time import time as _time
+
+    obj = _matrix_sas_plugin()
+    binding = obj._e2ee_binding_key()
+    obj.store.set("e2ee_device_binding", binding, expires=60)
+    obj.store.set("e2ee_verified_binding", binding, expires=60)
+    obj.store.set("e2ee_autoverify_refreshed_at", _time(), expires=60)
+
+    with mock.patch.object(obj.store, "set") as store_set:
+        assert matrix_sas.refresh_verified_state(obj) is True
+    store_set.assert_not_called()
+
+    # Once the interval has genuinely elapsed, it refreshes normally.
+    obj.store.set(
+        "e2ee_autoverify_refreshed_at",
+        _time() - obj.default_autoverify_refresh_interval_sec - 1,
+        expires=60,
+    )
+    with mock.patch.object(obj.store, "set", wraps=obj.store.set) as store_set:
+        assert matrix_sas.refresh_verified_state(obj) is True
+    assert store_set.call_count == 5
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_refresh_trust_write_failure():
+    """A failed write of the trust marker itself must not be reported as
+    success, and must not go on to touch the refresh bookkeeping key."""
+    obj = _matrix_sas_plugin()
+    binding = obj._e2ee_binding_key()
+    obj.store.set("e2ee_device_binding", binding, expires=60)
+    obj.store.set("e2ee_verified_binding", binding, expires=60)
+
+    real_set = obj.store.set
+
+    def flaky_set(key, *args, **kwargs):
+        if key == "e2ee_verified_binding":
+            return False
+        return real_set(key, *args, **kwargs)
+
+    with mock.patch.object(
+        obj.store, "set", side_effect=flaky_set
+    ) as store_set:
+        assert matrix_sas.refresh_verified_state(obj) is False
+    assert "e2ee_autoverify_refreshed_at" not in [
+        call.args[0] for call in store_set.call_args_list
+    ]
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_refresh_invalid_timestamp():
+    """A malformed refresh timestamp is treated as missing."""
+    obj = _matrix_sas_plugin()
+    binding = obj._e2ee_binding_key()
+    obj.store.set("e2ee_device_binding", binding, expires=60)
+    obj.store.set("e2ee_verified_binding", binding, expires=60)
+    obj.store.set("e2ee_autoverify_refreshed_at", "not-a-number", expires=60)
+
+    assert matrix_sas.refresh_verified_state(obj) is True
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
+def test_plugin_matrix_sas_refresh_writes_short_circuit():
+    """A failure partway through the identity refresh stops immediately
+    instead of continuing to write (and serialize) the rest regardless."""
+    obj = _matrix_sas_plugin()
+    binding = obj._e2ee_binding_key()
+
+    write_order = [
+        "device_id",
+        "e2ee_account",
+        "e2ee_device_binding",
+        "e2ee_verified_binding",
+    ]
+    for fail_at in write_order:
+        obj.store.set("e2ee_device_binding", binding, expires=60)
+        obj.store.set("e2ee_verified_binding", binding, expires=60)
+
+        def flaky_set(
+            key, *args, _fail_at=fail_at, _real_set=obj.store.set, **kwargs
+        ):
+            if key == _fail_at:
+                return False
+            return _real_set(key, *args, **kwargs)
+
+        with mock.patch.object(
+            obj.store, "set", side_effect=flaky_set
+        ) as store_set:
+            assert matrix_sas.refresh_verified_state(obj) is False
+
+        called_keys = [call.args[0] for call in store_set.call_args_list]
+        # Every key up to and including the failed one was attempted, in
+        # order, and nothing after it was.
+        assert called_keys == write_order[: write_order.index(fail_at) + 1]
+
+
+@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 @pytest.mark.parametrize("delivery_ok", [True, False])
-def test_plugin_matrix_sas_refresh_only_after_success(delivery_ok):
+def test_plugin_matrix_sas_refresh_after_success(delivery_ok):
     """A failed Matrix delivery must not extend SAS trust."""
     obj = NotifyMatrix(
         host="h",
@@ -3397,41 +4870,6 @@ def test_plugin_matrix_sas_refresh_only_after_success(delivery_ok):
         assert obj._send_server_notification(body="test") is delivery_ok
 
     assert refresh.call_count == (1 if delivery_ok else 0)
-
-
-@pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
-def test_plugin_matrix_sas_send_handles_verify_and_refresh_failures():
-    """Verification blocks delivery, while a refresh failure does not."""
-    obj = NotifyMatrix(
-        host="h",
-        user="u",
-        password="pass",
-        targets=["#r"],
-        e2ee=True,
-        autoverify=True,
-        secure=True,
-    )
-    obj.access_token = "token"
-    obj.user_id = "@u:h"
-    obj.device_id = "APPRISE"
-
-    with (
-        mock.patch.object(obj, "_e2ee_setup", return_value=True),
-        mock.patch.object(obj, "_e2ee_auto_verify", return_value=False),
-    ):
-        assert obj._send_server_notification(body="test") is False
-
-    with (
-        mock.patch.object(obj, "_e2ee_setup", return_value=True),
-        mock.patch.object(obj, "_e2ee_auto_verify", return_value=True),
-        mock.patch.object(obj, "_room_join", return_value="!r:h"),
-        mock.patch.object(obj, "_e2ee_room_encrypted", return_value=True),
-        mock.patch.object(obj, "_e2ee_send_to_room", return_value=True),
-        mock.patch.object(
-            obj, "_e2ee_refresh_verified_state", return_value=False
-        ),
-    ):
-        assert obj._send_server_notification(body="test") is True
 
 
 def test_plugin_matrix_e2ee_no_cryptography():
@@ -3530,7 +4968,7 @@ def test_plugin_matrix_e2ee_olm_session():
 
     # Decode and check the outer pre-key wire format.
     # Outer: version(0x03) | field1(OTK) | field2(EK) | field3(IK) |
-    #        field4(inner+mac) | outer_mac(8)
+    #        field4(inner+mac)
     # Inner (in field 4): version(0x03) | field1(ratchet_key) |
     #        field2(chain_index) | field4(ciphertext,tag=0x22) | inner_mac(8)
     raw = _b64dec(result["body"])
@@ -3548,17 +4986,10 @@ def test_plugin_matrix_e2ee_olm_session():
 
 @pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")
 def test_plugin_matrix_e2ee_olm_roundtrip():
-    """Full Olm round-trip: Alice encrypts, Bob manually decrypts.
+    """Confirm that Bob can decrypt an Olm message from Alice.
 
-    This test implements the Bob (inbound) side of the Olm X3DH and
-    message-decryption protocol using the same cryptography primitives,
-    verifying that our Alice-side implementation produces wire bytes that
-    a conformant receiver can decrypt.
-
-    Critical invariant verified: the outer base-key (pre-key field 2)
-    equals the inner ratchet-key (normal-message field 1).  They MUST be
-    the same ephemeral key E_A or the receiver cannot reconstruct the
-    session and decryption fails.
+    The test also checks that the outer base key and inner ratchet key use
+    the same temporary key, as required for session setup.
     """
     import hmac as _hmac_stdlib
 
@@ -3669,15 +5100,8 @@ def test_plugin_matrix_e2ee_olm_roundtrip():
 
     raw = _b64dec(result["body"])
 
-    # Outer pre-key message format (Olm spec Section 5.2):
-    #   version(1) | protobuf(field1=OTK, field2=base_key,
-    #                          field3=IK, field4=inner_message)
-    #
-    # There is NO outer MAC on the pre-key message.  Only the inner
-    # normal-message (field 4) has its own 8-byte MAC appended.
-    # Reference: olm.md Section 5.2; libolm session.cpp
-    # encode_one_time_key_message_length() (no MAC bytes allocated);
-    # vodozemac src/olm/messages/pre_key.rs decode() (no MAC consumed).
+    # The outer message contains the one-time, base, identity, and inner
+    # message fields. Only the inner message has a MAC.
     assert raw[0:1] == b"\x03", "outer version must be 0x03"
 
     # Parse the full outer protobuf body (all bytes after the version byte)
@@ -3807,6 +5231,18 @@ def test_plugin_matrix_e2ee_verify_keys():
     # Missing ed25519 key entry -> False
     no_keys = {**dk, "keys": {f"curve25519:{dev}": acct.identity_key}}
     assert verify_device_keys(no_keys, uid, dev) is False
+
+    # Malformed homeserver keys must fail closed.
+    assert verify_device_keys(None, uid, dev) is False
+    assert verify_device_keys("not-a-dict", uid, dev) is False
+    assert verify_device_keys({**dk, "keys": None}, uid, dev) is False
+    assert verify_device_keys({**dk, "keys": "not-a-dict"}, uid, dev) is False
+    assert verify_device_keys({**dk, "signatures": None}, uid, dev) is False
+    assert verify_device_keys({**dk, "signatures": [1, 2]}, uid, dev) is False
+    assert (
+        verify_device_keys({**dk, "signatures": {uid: None}}, uid, dev)
+        is False
+    )
 
     # --- verify_signed_otk ---
 
@@ -6089,9 +7525,7 @@ def test_plugin_matrix_init_recovers_home_server_from_user_id(tmpdir):
     # Flush to disk before the second instance reads it.
     obj.store.flush()
 
-    # Second instance with the same credentials (same url_id) reads the store.
-    # The recovery branch (lines 506-509) should derive home_server from
-    # the stored user_id.
+    # The matching instance recovers its home server from the stored user ID.
     obj2 = NotifyMatrix(
         host="h", user="u", password="pass", targets=["#r"], asset=asset
     )

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -4414,7 +4414,7 @@ def test_plugin_matrix_sas_auto_verify_concurrency():
             calls += 1
         # Long enough that a blocking wait for this call would make the
         # elapsed-time assertion below fail.
-        _time.sleep(0.5)
+        _time.sleep(1.0)
         with state_lock:
             active -= 1
         return True
@@ -4432,11 +4432,11 @@ def test_plugin_matrix_sas_auto_verify_concurrency():
         for thread in threads:
             thread.start()
         for thread in threads:
-            thread.join(timeout=5)
+            thread.join(timeout=15)
         elapsed = _time.monotonic() - start
 
     # The group finishes near the single verifier's running time.
-    assert elapsed < 1.0
+    assert elapsed < 2.5
     assert calls == 1
     assert max_concurrent == 1
     assert results.count(True) == 1
@@ -4464,7 +4464,10 @@ def test_plugin_matrix_sas_refresh_concurrency():
         obj._autoverify_lock.release()
 
     assert result is False
-    assert elapsed < 0.1
+    # Non-blocking lock acquisition never waits on the held lock; this is
+    # only guarding against an accidental blocking wait being introduced,
+    # so leave generous headroom for slow/loaded CI machines.
+    assert elapsed < 2.0
 
 
 @pytest.mark.skipif(not CRYPTOGRAPHY_AVAILABLE, reason="Requires cryptography")


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1712

Closes #1712.

Doc Support: https://github.com/caronc/apprise-docs/pull/124

This adds opt-in automatic SAS device verification to the existing Matrix E2EE implementation through `autoverify=yes`. The option is disabled by default, so existing Matrix URLs and E2EE behavior remain unchanged.

The implementation is integrated directly with Apprise's current custom E2EE stack:

* It reuses the existing `cryptography`-based `MatrixOlmAccount`, device signing keys, persistent device identity, and storage.
* It does not add `libolm`, `python-olm`, or a parallel Matrix device identity.
* It implements only the responder-side `m.sas.v1` to-device flow needed by a headless notification sender: request, ready, start, accept, key, MAC, done, and cancel.
* Automatic acceptance is restricted to verification requests from another device belonging to the same Matrix user.
* Peer device signatures and SAS MACs are validated before the device binding is stored as verified.

The change was kept as narrowly scoped as possible: one optional Matrix URL parameter, a responder-only SAS state machine built on the existing E2EE primitives, and the minimum persistent state required to retain the verified identity.

The existing 20-day cache expiry is unchanged. After a completely successful notification, only the state required to retain SAS trust is renewed for another 20 days:

* Matrix device ID
* custom E2EE account keys
* E2EE device binding
* verified SAS binding

Access tokens, homeserver data, room state, Olm/MegOLM sessions, and unrelated cache entries are not renewed. Failed notification delivery does not extend the verification lifetime. If no notification succeeds for more than 20 days, SAS verification is required again.

## Checklist
* [ ] Documentation ticket created (if applicable): not yet; this can follow after the option and behavior are reviewed.
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (Ruff 0.15.8 check and format validation).
* [x] Test coverage added or updated.

## Testing

Automated validation:

```text
pytest -q tests/test_plugin_matrix.py
90 passed

ruff check apprise/plugins/matrix/base.py apprise/plugins/matrix/e2ee.py tests/test_plugin_matrix.py
All checks passed!

ruff format --check apprise/plugins/matrix/base.py apprise/plugins/matrix/e2ee.py tests/test_plugin_matrix.py
3 files already formatted
```

This was also tested in a live deployment using Apprise API, an encrypted Matrix direct-message room, and Element:

* Element initiated verification of the persistent Apprise device.
* Apprise automatically completed its side of the same-user SAS flow.
* The encrypted notification was delivered successfully.
* A second notification was delivered immediately without another verification request.
* The container was restarted with persistent storage mounted, and delivery continued without another verification request.
* The sliding refresh path was then deployed and a successful notification completed without a state-refresh warning.

Anyone can test the branch as follows:

```bash
python3 -m venv apprise
cd apprise
source bin/activate

pip install git+https://github.com/vampywiz17/apprise.git@codex/matrix-sas-autoverify

apprise -vv -t "SAS Test" -b "Encrypted Matrix notification" \
  "matrixs://USER:PASSWORD@HOMESERVER/@RECIPIENT:HOMESERVER?e2ee=yes&autoverify=yes"
```

During the first send, initiate SAS verification for the new Apprise device from another already trusted Element session belonging to the same Matrix account. Apprise waits for the verification request for up to 120 seconds. Subsequent successful sends reuse and renew the verified binding.
