### PR TITLE
Removed ambiguity surrounding 'server' variable references

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,11 +264,10 @@ You can also check out the [Graphical version of Apprise](https://github.com/car
 
 # Command Line Usage
 
-A small command line interface (CLI) tool is also provided with this package called *apprise*. If you know the server urls you wish to notify, you can simply provide them all on the command line and send your notifications that way:
+A command line tool named *apprise* is included. Provide one or more service URLs to send a notification:
+
 ```bash
-# Send a notification to as many servers as you want
-# as you can easily chain one after another (the -vv provides some
-# additional verbosity to help let you know what is going on):
+# Send to several services. The -vv option shows additional details.
 apprise -vv -t 'my title' -b 'my notification body' \
    'mailto://myemail:mypass@gmail.com' \
    'pbul://o.gn5kj6nfhv736I7jC3cj3QLRiyhgl98b'
@@ -463,7 +462,7 @@ import apprise
 # Create an Apprise instance
 apobj = apprise.Apprise()
 
-# Add all of the notification services by their server url.
+# Add notification services by URL.
 # A sample email notification:
 apobj.add('mailto://myuserid:mypass@gmail.com')
 

--- a/apprise/apprise.py
+++ b/apprise/apprise.py
@@ -72,9 +72,9 @@ from .utils.parse import parse_list, parse_urls
 # Grant access to our Notification Manager Singleton
 N_MGR = NotificationManager()
 
-# One (server, notify()-kwargs) pair as produced by _create_notify_gen()
+# One (service, notify()-kwargs) pair as produced by _create_notify_gen()
 # and threaded through every dispatch primitive below.
-ServerCall = tuple[NotifyBase, dict[str, Any]]
+ServiceCall = tuple[NotifyBase, dict[str, Any]]
 
 # Extra seconds of patience for notify() calls.
 _ABANDON_GRACE_SECONDS = 0.1
@@ -154,29 +154,29 @@ def _abandoned_call_descriptions() -> list[str]:
 
 
 def _service_metadata(
-    server: NotifyBase,
+    service: NotifyBase,
 ) -> tuple[str, str, Optional[str], tuple[str, ...], int]:
     """Safely gather one service's identifying metadata.
 
     Plugin metadata helpers can raise. This helper keeps result-building
     defensive and returns (name, url, url_id, tag, weight).
     """
-    name = getattr(server, "service_name", "Unknown")
+    name = getattr(service, "service_name", "Unknown")
 
     try:
-        url = server.url(privacy=True)
+        url = service.url(privacy=True)
 
     except Exception:
         url = "unknown://"
 
     try:
-        url_id = server.url_id()
+        url_id = service.url_id()
 
     except Exception:
         url_id = None
 
     try:
-        weight = len(server)
+        weight = len(service)
 
     except Exception:
         weight = 1
@@ -184,7 +184,7 @@ def _service_metadata(
     try:
         # Sort tags for stable output. Custom tag objects may fail during
         # conversion, so use the same fallback as the metadata above.
-        tag = tuple(sorted(str(t) for t in getattr(server, "tags", ())))
+        tag = tuple(sorted(str(t) for t in getattr(service, "tags", ())))
 
     except Exception:
         tag = ()
@@ -192,16 +192,16 @@ def _service_metadata(
     return name, url, url_id, tag, weight
 
 
-def _safe_error_result(server: NotifyBase) -> NotifyResult:
+def _safe_error_result(service: NotifyBase) -> NotifyResult:
     """Build a best-effort result when a plugin fails outside dispatch."""
-    name, url, url_id, tag, weight = _service_metadata(server)
+    name, url, url_id, tag, weight = _service_metadata(service)
 
     return NotifyResult(
         name=name,
         url=url,
         url_id=url_id,
         tag=tag,
-        optional=getattr(server, "optional", False),
+        optional=getattr(service, "optional", False),
         weight=weight,
         max_attempts=1,
         # No real attempt data exists here, so keep one synthetic failure.
@@ -211,7 +211,7 @@ def _safe_error_result(server: NotifyBase) -> NotifyResult:
 
 
 def _compute_deadline(
-    server: NotifyBase, call_deadline: Optional[float]
+    service: NotifyBase, call_deadline: Optional[float]
 ) -> Optional[float]:
     """Return the monotonic deadline for one service dispatch.
 
@@ -224,7 +224,7 @@ def _compute_deadline(
     change the time limit. ``None`` means neither limit is enabled.
     """
     service_timeout = getattr(
-        server.asset,
+        service.asset,
         "_service_timeout",
         AppriseAsset._service_timeout,
     )
@@ -237,7 +237,7 @@ def _compute_deadline(
     # TRACE keeps large batches from spamming normal DEBUG output.
     logger.trace(
         "Deadline for '%s': %s",
-        getattr(server, "service_name", "Unknown"),
+        getattr(service, "service_name", "Unknown"),
         "none"
         if deadline is None
         else "{:.3f}s from now".format(deadline - time.monotonic()),
@@ -246,7 +246,7 @@ def _compute_deadline(
 
 
 def _timeout_result(
-    server: NotifyBase,
+    service: NotifyBase,
     elapsed: float,
     max_attempts: int,
 ) -> NotifyResult:
@@ -255,14 +255,14 @@ def _timeout_result(
     The worker may still be running. Record only what Apprise knows here:
     it stopped waiting, and optional handling still belongs to NotifyResult.
     """
-    name, url, url_id, tag, weight = _service_metadata(server)
+    name, url, url_id, tag, weight = _service_metadata(service)
 
     return NotifyResult(
         name=name,
         url=url,
         url_id=url_id,
         tag=tag,
-        optional=getattr(server, "optional", False),
+        optional=getattr(service, "optional", False),
         weight=weight,
         # Preserve the configured retry count even when the outer wait wins.
         max_attempts=max_attempts,
@@ -499,7 +499,7 @@ class Apprise:
 
     def __init__(
         self,
-        servers: Optional[
+        services: Optional[
             Union[
                 str,
                 dict,
@@ -517,24 +517,16 @@ class Apprise:
         ] = None,
         log_level: Optional[int] = None,
     ) -> None:
-        """Loads a set of server urls while applying the Asset() module to each
-        if specified.
+        """Load notification services with shared defaults.
 
-        If no asset is provided, then the default asset is used.
-
-        Optionally specify a global ContentLocation for a more strict means of
-        handling Attachments.
-
-        log_callback receives captured entries as ``callback(entry, service)``.
-        ``service`` is ``None`` for orchestration entries returned by
-        ``AppriseResult.call_logs()``. The callback must be synchronous.
-
-        log_level controls captured service and call-level entries. It defaults
-        to WARNING, or INFO when a log_callback is configured.
+        ``asset`` and ``location`` control service and attachment handling.
+        ``log_callback(entry, service)`` receives captured logs synchronously;
+        orchestration logs use ``None`` as the service. ``log_level`` defaults
+        to WARNING, or INFO when a callback is configured.
         """
 
-        # Initialize a server list of URLs
-        self.servers = []
+        # Store notification services and configuration sources.
+        self.services = []
 
         # Assigns an central asset object that will be later passed into each
         # notification plugin.  Assets contain information such as the local
@@ -545,8 +537,8 @@ class Apprise:
             asset if isinstance(asset, AppriseAsset) else AppriseAsset()
         )
 
-        if servers:
-            self.add(servers)
+        if services:
+            self.add(services)
 
         # Initialize our locale object
         self.locale = AppriseLocale()
@@ -575,13 +567,10 @@ class Apprise:
         tag: Optional[Union[str, list[str]]] = None,
         suppress_exceptions: bool = True,
     ) -> Optional[NotifyBase]:
-        """Returns the instance of a instantiated plugin based on the provided
-        Server URL.  If the url fails to be parsed, then None is returned.
+        """Create a notification service from a URL or dictionary.
 
-        The specified url can be either a string (the URL itself) or a
-        dictionary containing all of the components needed to istantiate
-        the notification service.  If identifying a dictionary, at the bare
-        minimum, one must specify the schema.
+        Dictionaries must include at least a ``schema``. Invalid input returns
+        ``None``.
 
         An example of a url dictionary object might look like:
           {
@@ -594,8 +583,7 @@ class Apprise:
         Alternatively the string is much easier to specify:
           mailto://user:mypassword@google.com
 
-        The dictionary works well for people who are calling details() to
-        extract the components they need to build the URL manually.
+        Dictionaries are useful with components returned by ``details()``.
         """
 
         # Initialize our result set
@@ -611,7 +599,7 @@ class Apprise:
             )
 
             if results is None:
-                # Failed to parse the server URL; detailed logging handled
+                # Failed to parse the service URL; detailed logging handled
                 # inside url_to_dict - nothing to report here.
                 return None
 
@@ -723,7 +711,7 @@ class Apprise:
 
     def add(
         self,
-        servers: Union[
+        services: Union[
             str,
             dict,
             NotifyBase,
@@ -734,14 +722,10 @@ class Apprise:
         asset: Optional[AppriseAsset] = None,
         tag: Optional[Union[str, list[str]]] = None,
     ) -> bool:
-        """Adds one or more server URLs into our list.
+        """Add one or more notification services.
 
-        You can override the global asset if you wish by including it with the
-        server(s) that you add.
-
-        The tag allows you to associate 1 or more tag values to the server(s)
-        being added. tagging a service allows you to exclusively access them
-        when calling the notify() function.
+        ``asset`` overrides the shared asset for these services. Use ``tag``
+        to group services and select them in ``notify()`` calls.
         """
 
         # Initialize our return status
@@ -751,37 +735,37 @@ class Apprise:
             # prepare default asset
             asset = self.asset
 
-        if isinstance(servers, str):
-            # build our server list
-            servers = parse_urls(servers)
-            if len(servers) == 0:
+        if isinstance(services, str):
+            # build our service list
+            services = parse_urls(services)
+            if len(services) == 0:
                 return False
 
-        elif isinstance(servers, dict):
+        elif isinstance(services, dict):
             # no problem, we support kwargs, convert it to a list
-            servers = [servers]
+            services = [services]
 
-        elif isinstance(servers, (ConfigBase, NotifyBase, AppriseConfig)):
+        elif isinstance(services, (ConfigBase, NotifyBase, AppriseConfig)):
             # Go ahead and just add our plugin into our list
-            self.servers.append(servers)
+            self.services.append(services)
             return True
 
-        elif not isinstance(servers, (tuple, set, list)):
+        elif not isinstance(services, (tuple, set, list)):
             logger.error(
-                f"An invalid notification (type={type(servers)}) was"
+                f"An invalid notification (type={type(services)}) was"
                 " specified."
             )
             return False
 
-        for server in servers:
-            if isinstance(server, (ConfigBase, NotifyBase, AppriseConfig)):
+        for service in services:
+            if isinstance(service, (ConfigBase, NotifyBase, AppriseConfig)):
                 # Go ahead and just add our plugin into our list
-                self.servers.append(server)
+                self.services.append(service)
                 continue
 
-            elif not isinstance(server, (str, dict)):
+            elif not isinstance(service, (str, dict)):
                 logger.error(
-                    f"An invalid notification (type={type(server)}) was"
+                    f"An invalid notification (type={type(service)}) was"
                     " specified."
                 )
                 return_status = False
@@ -789,29 +773,29 @@ class Apprise:
 
             # Instantiate ourselves an object, this function throws or
             # returns None if it fails
-            instance = Apprise.instantiate(server, asset=asset, tag=tag)
+            instance = Apprise.instantiate(service, asset=asset, tag=tag)
             if not isinstance(instance, NotifyBase):
                 # No logging is required as instantiate() handles failure
                 # and/or success reasons for us
                 return_status = False
                 continue
 
-            # Add our initialized plugin to our server listings
-            self.servers.append(instance)
+            # Add our initialized plugin to our service listings
+            self.services.append(instance)
 
         # Return our status
         return return_status
 
     def clear(self) -> None:
-        """Empties our server list."""
-        self.servers[:] = []
+        """Empties our service list."""
+        self.services[:] = []
 
     def find(
         self,
         tag: Any = common.MATCH_ALL_TAG,
         match_always: bool = True,
     ) -> Iterator[NotifyBase]:
-        """Returns a list of all servers matching against the tag specified."""
+        """Yield services that match the requested tag filter."""
 
         # Build our tag setup
         #   - top level entries are treated as an 'or'
@@ -828,25 +812,25 @@ class Apprise:
         match_always = common.MATCH_ALWAYS_TAG if match_always else None
 
         # Iterate over our loaded plugins
-        for entry in self.servers:
+        for entry in self.services:
             if isinstance(entry, (ConfigBase, AppriseConfig)):
-                # load our servers
-                servers = entry.servers()
+                # load our services
+                services = entry.services()
 
             else:
-                servers = [
+                services = [
                     entry,
                 ]
 
-            for server in servers:
+            for service in services:
                 # Apply our tag matching based on our defined logic
                 if is_exclusive_match(
                     logic=tag,
-                    data=server.tags,
+                    data=service.tags,
                     match_all=common.MATCH_ALL_TAG,
                     match_always=match_always,
                 ):
-                    yield server
+                    yield service
         return
 
     @staticmethod
@@ -855,7 +839,7 @@ class Apprise:
 
         A filter like "3:endpoint:2" or "endpoint:2" carries ":2" as the
         call-level retry count.  When present it overrides each matched
-        server's configured retry for this single notify() call.
+        service's configured retry for this single notify() call.
         """
         if tag is None or tag == common.MATCH_ALL_TAG:
             return None
@@ -897,12 +881,12 @@ class Apprise:
         return False
 
     @staticmethod
-    def _server_priority_for_tag_name(server, tag_name):
-        """Return the dispatch priority stored on *server* for *tag_name*.
+    def _service_priority_for_tag_name(service, tag_name):
+        """Return the dispatch priority stored on *service* for *tag_name*.
 
         Missing tags and plain strings use priority zero.
         """
-        for stag in server.tags:
+        for stag in service.tags:
             if str(stag) == tag_name:
                 return stag.priority if isinstance(stag, AppriseTag) else 0
         return 0
@@ -931,19 +915,19 @@ class Apprise:
         return retry_tokens
 
     @staticmethod
-    def _match_service_retry(server, retry_tokens):
-        """Return the first retry override matching ``server``.
+    def _match_service_retry(service, retry_tokens):
+        """Return the first retry override matching ``service``.
 
         Plain tokens match names; priority tokens also require that priority.
         """
         for ft in retry_tokens:
             tag_name = str(ft)
             if not ft.has_priority:
-                if tag_name in server.tags:
+                if tag_name in service.tags:
                     return ft.retry
 
             else:
-                for stag in server.tags:
+                for stag in service.tags:
                     if isinstance(stag, AppriseTag):
                         if (
                             str(stag) == tag_name
@@ -964,11 +948,11 @@ class Apprise:
             return all_calls
 
         result = []
-        for server, kwargs in all_calls:
-            retry = Apprise._match_service_retry(server, retry_tokens)
+        for service, kwargs in all_calls:
+            retry = Apprise._match_service_retry(service, retry_tokens)
             if retry is not None:
                 kwargs = dict(kwargs, _retry_override=retry)
-            result.append((server, kwargs))
+            result.append((service, kwargs))
         return result
 
     @staticmethod
@@ -1011,15 +995,15 @@ class Apprise:
     def _build_tag_chains(all_calls, tag):
         """Group *all_calls* into per-OR-token escalation chains.
 
-        Returns {chain_key: {priority: [(server, kwargs)]}}.
+        Returns {chain_key: {priority: [(service, kwargs)]}}.
         Each service joins its first matching OR chain; unmatched services
         use ``""``. Match-all filters create one ``""`` chain.
         """
         if tag is None or tag == common.MATCH_ALL_TAG:
             chain: dict[int, list] = {}
-            for server, kwargs in all_calls:
-                p = Apprise._server_priority_for_filter(server, tag)
-                chain.setdefault(p, []).append((server, kwargs))
+            for service, kwargs in all_calls:
+                p = Apprise._service_priority_for_filter(service, tag)
+                chain.setdefault(p, []).append((service, kwargs))
             return {"": chain}
 
         # Flatten OR tokens while keeping true AND groups in the catch-all
@@ -1043,33 +1027,31 @@ class Apprise:
                     or_tag_names.append(str(AppriseTag.parse(tok)))
 
         chains: dict[str, dict[int, list]] = {}
-        for server, kwargs in all_calls:
+        for service, kwargs in all_calls:
             for chain_key in or_tag_names:
-                if chain_key and chain_key in server.tags:
-                    p = Apprise._server_priority_for_tag_name(
-                        server, chain_key
+                if chain_key and chain_key in service.tags:
+                    p = Apprise._service_priority_for_tag_name(
+                        service, chain_key
                     )
                     chains.setdefault(chain_key, {}).setdefault(p, []).append(
-                        (server, kwargs)
+                        (service, kwargs)
                     )
                     break
             else:
                 # fallback: use global priority
-                p = Apprise._server_priority_for_filter(server, tag)
+                p = Apprise._service_priority_for_filter(service, tag)
                 chains.setdefault("", {}).setdefault(p, []).append(
-                    (server, kwargs)
+                    (service, kwargs)
                 )
 
         return chains
 
     @staticmethod
-    def _server_priority_for_filter(server, tag):
-        """Return the effective dispatch priority for *server* given *tag*.
+    def _service_priority_for_filter(service, tag):
+        """Return the effective dispatch priority for *service* given *tag*.
 
-        The priority comes from the AppriseTag stored on the server whose
-        name matches one of the tag-filter names.  When multiple server tags
-        match, the minimum (highest-precedence) priority is returned.
-        Returns 0 when no matching priority tag is found.
+        Return the highest-precedence matching tag priority, or zero when no
+        priority tag matches.
         """
         if tag is None or tag == common.MATCH_ALL_TAG:
             return 0
@@ -1088,14 +1070,14 @@ class Apprise:
 
         priorities = [
             stag.priority if isinstance(stag, AppriseTag) else 0
-            for stag in server.tags
+            for stag in service.tags
             if str(stag) in filter_names
         ]
         return min(priorities) if priorities else 0
 
     @staticmethod
     def _split_and_dispatch(
-        batch: list[ServerCall], call_deadline: Optional[float] = None
+        batch: list[ServiceCall], call_deadline: Optional[float] = None
     ) -> tuple[bool, list[NotifyResult]]:
         """Dispatch sequential and parallel subsets of ``batch``.
 
@@ -1137,7 +1119,7 @@ class Apprise:
 
     @staticmethod
     async def _split_and_dispatch_async(
-        batch: list[ServerCall], call_deadline: Optional[float] = None
+        batch: list[ServiceCall], call_deadline: Optional[float] = None
     ) -> tuple[bool, list[NotifyResult]]:
         """Dispatch sequential and asynchronous subsets of ``batch``.
 
@@ -1318,7 +1300,7 @@ class Apprise:
                 )
 
             if not all_calls:
-                # Tag filter matched nothing, or no servers are loaded at all.
+                # Tag filter matched nothing, or no services are loaded at all.
                 return AppriseResult(
                     status=AppriseResultStatus.NOMATCH,
                     results=[],
@@ -1529,7 +1511,7 @@ class Apprise:
                 )
 
             if not all_calls:
-                # Tag filter matched nothing, or no servers are loaded at all.
+                # Tag filter matched nothing, or no services are loaded at all.
                 return AppriseResult(
                     status=AppriseResultStatus.NOMATCH,
                     results=[],
@@ -1651,7 +1633,7 @@ class Apprise:
     def _create_notify_calls(self, *args, **kwargs):
         """Creates notifications for all the plugins loaded.
 
-        Returns a list of (server, notify() kwargs) tuples for plugins with
+        Returns a list of (service, notify() kwargs) tuples for plugins with
         parallelism disabled and another list for plugins with parallelism
         enabled.
         """
@@ -1660,11 +1642,11 @@ class Apprise:
 
         # Split into sequential and parallel notify() calls.
         sequential, parallel = [], []
-        for server, notify_kwargs in all_calls:
-            if server.asset.async_mode:
-                parallel.append((server, notify_kwargs))
+        for service, notify_kwargs in all_calls:
+            if service.asset.async_mode:
+                parallel.append((service, notify_kwargs))
             else:
-                sequential.append((server, notify_kwargs))
+                sequential.append((service, notify_kwargs))
 
         return sequential, parallel
 
@@ -1748,48 +1730,45 @@ class Apprise:
         )
 
         # Iterate over our loaded plugins
-        for server in self.find(tag, match_always=match_always):
+        for service in self.find(tag, match_always=match_always):
             # If our code reaches here, we either did not define a tag (it
             # was set to None), or we did define a tag and the logic above
             # determined we need to notify the service it's associated with
 
-            # Resolve this server's actual per-call rendering target.
-            # Single-format servers always resolve to their one declared
-            # format. Multi-format servers may resolve differently per
-            # call depending on ?format= or this notify() call's
-            # body_format.
-            target_format = server.resolve_format(body_format)
+            # Resolve the output format for this call. Multi-format services
+            # may use the URL's format or the format passed to notify().
+            target_format = service.resolve_format(body_format)
 
             # Apply the service's own cap before conversion. Its asset may
             # differ from the top-level asset and have a smaller limit.
-            capped_title, capped_body = server.asset.enforce_payload_max_size(
+            capped_title, capped_body = service.asset.enforce_payload_max_size(
                 title, body
             )
             if len(capped_title) + len(capped_body) < len(title) + len(body):
                 logger.warning(
                     "%s payload trimmed to stay within the configured "
                     "payload_max_size of %d characters.",
-                    server.service_name,
-                    server.asset._payload_max_size,
+                    service.service_name,
+                    service.asset._payload_max_size,
                 )
 
             # Cache by the resolved format, title handling, and payload cap.
             # Services with the same output needs can share converted content.
             key = (
                 target_format
-                if server.title_maxlen > 0
+                if service.title_maxlen > 0
                 else f"_{target_format}"
             )
-            if server.asset._payload_max_size:
+            if service.asset._payload_max_size:
                 # Allocation settings can produce different capped content,
                 # so each combination needs its own conversion.
                 key += (
-                    f"-cap{server.asset._payload_max_size}"
-                    f"-buf{server.asset._payload_buffer_threshold}"
-                    f"-min{server.asset._payload_min_buffer}"
+                    f"-cap{service.asset._payload_max_size}"
+                    f"-buf{service.asset._payload_buffer_threshold}"
+                    f"-min{service.asset._payload_min_buffer}"
                 )
 
-            if server.interpret_emojis:
+            if service.interpret_emojis:
                 # alter our key slightly to handle emojis since their value is
                 # pulled out of the notification
                 key += "-emojis"
@@ -1802,7 +1781,7 @@ class Apprise:
 
                 # Conversion of title only occurs for services where the title
                 # is blended with the body (title_maxlen <= 0)
-                if conversion_title_map[key] and server.title_maxlen <= 0:
+                if conversion_title_map[key] and service.title_maxlen <= 0:
                     conversion_title_map[key] = convert_between(
                         body_format,
                         target_format,
@@ -1840,7 +1819,7 @@ class Apprise:
                         logger.error(msg)
                         raise TypeError(msg) from None
 
-                if server.interpret_emojis:
+                if service.interpret_emojis:
                     #
                     # Convert our :emoji: definitions
                     #
@@ -1867,11 +1846,11 @@ class Apprise:
                 # token prevents direct callers from skipping their own cap.
                 "_payload_precapped": _PAYLOAD_PRECAPPED,
             }
-            yield (server, kwargs)
+            yield (service, kwargs)
 
     @staticmethod
     def _notify_sequential(
-        *services_kwargs: ServerCall, call_deadline: Optional[float] = None
+        *services_kwargs: ServiceCall, call_deadline: Optional[float] = None
     ) -> tuple[bool, list[NotifyResult]]:
         """Process a list of notify() calls one at a time, in order.
 
@@ -1963,7 +1942,7 @@ class Apprise:
 
     @staticmethod
     def _notify_parallel_threadpool(
-        *services_kwargs: ServerCall, call_deadline: Optional[float] = None
+        *services_kwargs: ServiceCall, call_deadline: Optional[float] = None
     ) -> tuple[bool, list[NotifyResult]]:
         """Process a list of notify() calls in parallel via a thread pool.
 
@@ -2093,7 +2072,7 @@ class Apprise:
 
     @staticmethod
     async def _notify_parallel_asyncio(
-        *services_kwargs: ServerCall, call_deadline: Optional[float] = None
+        *services_kwargs: ServiceCall, call_deadline: Optional[float] = None
     ) -> tuple[bool, list[NotifyResult]]:
         """Process a list of async_notify() calls concurrently via asyncio.
 
@@ -2462,40 +2441,38 @@ class Apprise:
     def urls(self, privacy: bool = False) -> list[str]:
         """Returns all of the loaded URLs defined in this apprise object."""
         urls = []
-        for s in self.servers:
+        for s in self.services:
             if isinstance(s, (ConfigBase, AppriseConfig)):
-                for s_ in s.servers():
+                for s_ in s.services():
                     urls.append(s_.url(privacy=privacy))
             else:
                 urls.append(s.url(privacy=privacy))
         return urls
 
     def pop(self, index: int) -> NotifyBase:
-        """Removes an indexed Notification Service from the stack and returns
-        it.
+        """Remove and return the notification service at ``index``.
 
-        The thing is we can never pop AppriseConfig() entries, only what was
-        loaded within them. So pop needs to carefully iterate over our list and
-        only track actual entries.
+        Configuration containers remain loaded; only their services can be
+        removed.
         """
 
         # Tracking variables
         prev_offset = -1
         offset = prev_offset
 
-        for idx, s in enumerate(self.servers):
+        for idx, s in enumerate(self.services):
             if isinstance(s, (ConfigBase, AppriseConfig)):
-                servers = s.servers()
-                if len(servers) > 0:
+                services = s.services()
+                if len(services) > 0:
                     # Acquire a new maximum offset to work with
-                    offset = prev_offset + len(servers)
+                    offset = prev_offset + len(services)
 
                     if offset >= index:
                         # we can pop an element from our config stack
                         fn = (
                             s.pop
                             if isinstance(s, ConfigBase)
-                            else s.server_pop
+                            else s.service_pop
                         )
 
                         return fn(
@@ -2507,7 +2484,7 @@ class Apprise:
             else:
                 offset = prev_offset + 1
                 if offset == index:
-                    return self.servers.pop(idx)
+                    return self.services.pop(idx)
 
             # Update our old offset
             prev_offset = offset
@@ -2516,21 +2493,21 @@ class Apprise:
         raise IndexError("list index out of range")
 
     def __getitem__(self, index: int) -> NotifyBase:
-        """Returns the indexed server entry of a loaded notification server."""
+        """Return the loaded notification service at ``index``."""
         # Tracking variables
         prev_offset = -1
         offset = prev_offset
 
-        for idx, s in enumerate(self.servers):
+        for idx, s in enumerate(self.services):
             if isinstance(s, (ConfigBase, AppriseConfig)):
-                # Get our list of servers associate with our config object
-                servers = s.servers()
-                if len(servers) > 0:
+                # Get our list of services associate with our config object
+                services = s.services()
+                if len(services) > 0:
                     # Acquire a new maximum offset to work with
-                    offset = prev_offset + len(servers)
+                    offset = prev_offset + len(services)
 
                     if offset >= index:
-                        return servers[
+                        return services[
                             (
                                 index
                                 if prev_offset == -1
@@ -2541,7 +2518,7 @@ class Apprise:
             else:
                 offset = prev_offset + 1
                 if offset == index:
-                    return self.servers[idx]
+                    return self.services[idx]
 
             # Update our old offset
             prev_offset = offset
@@ -2557,11 +2534,11 @@ class Apprise:
             # and asset details associated with it
             "urls": [
                 {
-                    "url": server.url(privacy=False),
-                    "tag": server.tags if server.tags else None,
-                    "asset": server.asset,
+                    "url": service.url(privacy=False),
+                    "tag": service.tags if service.tags else None,
+                    "asset": service.asset,
                 }
-                for server in self.servers
+                for service in self.services
             ],
             "locale": self.locale,
             "debug": self.debug,
@@ -2572,7 +2549,7 @@ class Apprise:
 
     def __setstate__(self, state: dict[str, object]) -> None:
         """Pickle Support loads()"""
-        self.servers = []
+        self.services = []
         self.asset = state["asset"]
         self.locale = state["locale"]
 
@@ -2596,7 +2573,7 @@ class Apprise:
         return len(self) > 0
 
     def __iter__(self) -> Iterator[NotifyBase]:
-        """Returns an iterator to each of our servers loaded.
+        """Returns an iterator to each of our services loaded.
 
         This includes those found inside configuration.
         """
@@ -2605,24 +2582,22 @@ class Apprise:
                 (
                     [s]
                     if not isinstance(s, (ConfigBase, AppriseConfig))
-                    else iter(s.servers())
+                    else iter(s.services())
                 )
-                for s in self.servers
+                for s in self.services
             ]
         )
 
     def __len__(self) -> int:
-        """Returns the number of servers loaded; this includes those found
-        within loaded configuration.
+        """Return the number of loaded notification services.
 
-        This funtion nnever actually counts the Config entry themselves (if
-        they exist), only what they contain.
+        Configuration containers are not counted, but their services are.
         """
         return sum(
             (
                 1
                 if not isinstance(s, (ConfigBase, AppriseConfig))
-                else len(s.servers())
+                else len(s.services())
             )
-            for s in self.servers
+            for s in self.services
         )

--- a/apprise/apprise.py
+++ b/apprise/apprise.py
@@ -495,7 +495,12 @@ def _call_with_retry(
 
 
 class Apprise:
-    """Our Notification Manager."""
+    """Manage and dispatch messages to Apprise services.
+
+    A service is any loaded notification plugin. It is not necessarily a push
+    notification server: email, IRC, XMPP, desktop integrations, webhooks, and
+    other custom protocols all use the same service interface.
+    """
 
     def __init__(
         self,
@@ -517,12 +522,26 @@ class Apprise:
         ] = None,
         log_level: Optional[int] = None,
     ) -> None:
-        """Load notification services with shared defaults.
+        """Initialize the manager and optionally load one or more services.
 
-        ``asset`` and ``location`` control service and attachment handling.
-        ``log_callback(entry, service)`` receives captured logs synchronously;
-        orchestration logs use ``None`` as the service. ``log_level`` defaults
-        to WARNING, or INFO when a callback is configured.
+        ``services`` may be a URL, a URL dictionary, an instantiated
+        notification or configuration plugin, an :class:`AppriseConfig`
+        object, or a list containing any mixture of these. URL-based services
+        are instantiated with ``asset``; when no asset is supplied, a default
+        :class:`AppriseAsset` is created and shared with them.
+
+        ``location`` applies an optional :class:`ContentLocation` restriction
+        when attachments are prepared. For example, callers can prevent a
+        remotely sourced request from attaching local content. A value of
+        ``None`` leaves attachment locations unrestricted.
+
+        ``log_callback`` receives captured entries synchronously as
+        ``callback(entry, service)``. ``service`` is the plugin associated with
+        the entry, or ``None`` for orchestration messages exposed through
+        :meth:`AppriseResult.call_logs`. ``log_level`` controls the minimum
+        captured level and defaults to ``WARNING``, or ``INFO`` when a callback
+        is configured. Both settings may be overridden by an individual call
+        to :meth:`notify` or :meth:`async_notify`.
         """
 
         # Store notification services and configuration sources.
@@ -567,10 +586,17 @@ class Apprise:
         tag: Optional[Union[str, list[str]]] = None,
         suppress_exceptions: bool = True,
     ) -> Optional[NotifyBase]:
-        """Create a notification service from a URL or dictionary.
+        """Create a notification service from a URL or URL dictionary.
 
-        Dictionaries must include at least a ``schema``. Invalid input returns
-        ``None``.
+        A string is parsed as an Apprise URL. A dictionary supplies the parsed
+        constructor components directly and must contain at least ``schema``
+        so the matching plugin can be selected. ``tag`` replaces the tags in
+        the parsed data, and ``asset`` is passed to the plugin instance.
+
+        Invalid, unsupported, or disabled services return ``None``. Plugin
+        constructor errors are also converted to ``None`` when
+        ``suppress_exceptions`` is true; setting it to false lets those errors
+        reach the caller.
 
         An example of a url dictionary object might look like:
           {
@@ -583,7 +609,9 @@ class Apprise:
         Alternatively the string is much easier to specify:
           mailto://user:mypassword@google.com
 
-        Dictionaries are useful with components returned by ``details()``.
+        The dictionary form is particularly useful to callers that use
+        :meth:`details` to discover the fields supported by a plugin and then
+        build those fields programmatically.
         """
 
         # Initialize our result set
@@ -722,10 +750,21 @@ class Apprise:
         asset: Optional[AppriseAsset] = None,
         tag: Optional[Union[str, list[str]]] = None,
     ) -> bool:
-        """Add one or more notification services.
+        """Add one or more notification services or configuration sources.
 
-        ``asset`` overrides the shared asset for these services. Use ``tag``
-        to group services and select them in ``notify()`` calls.
+        A string may contain one or more URLs and is split with
+        :func:`parse_urls`. Dictionaries are treated as parsed URL components.
+        Existing :class:`NotifyBase`, :class:`ConfigBase`, and
+        :class:`AppriseConfig` objects are stored directly.
+
+        ``asset`` overrides the manager's shared asset for services created
+        from URLs or dictionaries. ``tag`` associates one or more tags with
+        those newly created services so they can be selected by
+        :meth:`notify`, :meth:`async_notify`, or :meth:`find`.
+
+        The return value is true only when every supplied item was accepted.
+        Valid items are retained even if another item in the same collection
+        is invalid.
         """
 
         # Initialize our return status
@@ -787,7 +826,7 @@ class Apprise:
         return return_status
 
     def clear(self) -> None:
-        """Empties our service list."""
+        """Remove all directly loaded services and configuration sources."""
         self.services[:] = []
 
     def find(
@@ -795,7 +834,18 @@ class Apprise:
         tag: Any = common.MATCH_ALL_TAG,
         match_always: bool = True,
     ) -> Iterator[NotifyBase]:
-        """Yield services that match the requested tag filter."""
+        """Yield loaded services that match ``tag``.
+
+        Services inside configuration sources are resolved before matching,
+        so callers see the same flattened sequence used for delivery. At the
+        top level, tag entries are alternatives (OR); nested collections are
+        intersections (AND). For example, ``[('a', 'b'), 'c']`` means
+        ``(a AND b) OR c``.
+
+        When ``match_always`` is true, services carrying the reserved
+        ``always`` tag are yielded even when the requested filter would not
+        otherwise select them.
+        """
 
         # Build our tag setup
         #   - top level entries are treated as an 'or'
@@ -1735,8 +1785,11 @@ class Apprise:
             # was set to None), or we did define a tag and the logic above
             # determined we need to notify the service it's associated with
 
-            # Resolve the output format for this call. Multi-format services
-            # may use the URL's format or the format passed to notify().
+            # Resolve this service's actual output format for this call.
+            # A single-format service always uses its declared format. A
+            # multi-format service may resolve differently for each call,
+            # based on its URL's ``format`` option or the ``body_format``
+            # supplied to notify().
             target_format = service.resolve_format(body_format)
 
             # Apply the service's own cap before conversion. Its asset may
@@ -2452,8 +2505,12 @@ class Apprise:
     def pop(self, index: int) -> NotifyBase:
         """Remove and return the notification service at ``index``.
 
-        Configuration containers remain loaded; only their services can be
-        removed.
+        Indexing uses the flattened service view: directly added plugins and
+        plugins discovered inside configuration sources share one continuous
+        sequence. Configuration containers are never popped by this method.
+        When ``index`` identifies one of their services, that service is
+        removed from the container while the configuration source remains
+        loaded. An out-of-range index raises :class:`IndexError`.
         """
 
         # Tracking variables
@@ -2493,7 +2550,12 @@ class Apprise:
         raise IndexError("list index out of range")
 
     def __getitem__(self, index: int) -> NotifyBase:
-        """Return the loaded notification service at ``index``."""
+        """Return a service by its index in the flattened service view.
+
+        Configuration sources themselves are not addressable here. Their
+        discovered services occupy positions in the same sequence as services
+        added directly. An out-of-range index raises :class:`IndexError`.
+        """
         # Tracking variables
         prev_offset = -1
         offset = prev_offset
@@ -2573,9 +2635,10 @@ class Apprise:
         return len(self) > 0
 
     def __iter__(self) -> Iterator[NotifyBase]:
-        """Returns an iterator to each of our services loaded.
+        """Iterate over the flattened collection of loaded services.
 
-        This includes those found inside configuration.
+        Configuration containers are not yielded. Instead, each service
+        discovered inside them is yielded alongside directly added services.
         """
         return chain(
             *[
@@ -2589,9 +2652,13 @@ class Apprise:
         )
 
     def __len__(self) -> int:
-        """Return the number of loaded notification services.
+        """Return the size of the flattened collection of loaded services.
 
-        Configuration containers are not counted, but their services are.
+        Directly added notification plugins each count as one. Configuration
+        containers do not count as entries themselves; every service currently
+        discovered inside them does. Calling ``len()`` may therefore cause a
+        configuration source to be read or refreshed according to its cache
+        policy.
         """
         return sum(
             (

--- a/apprise/apprise_attachment.py
+++ b/apprise/apprise_attachment.py
@@ -228,7 +228,7 @@ class AppriseAttachment:
                 return_status = False
                 continue
 
-            # Add our initialized plugin to our server listings
+            # Add the initialized plugin to our attachment list.
             if isinstance(instance, list):
                 self.attachments.extend(instance)
 
@@ -268,12 +268,11 @@ class AppriseAttachment:
                 logger.warning(f"Unsupported schema {schema}.")
                 return None
 
-        # Parse our url details of the server object as dictionary containing
-        # all of the information parsed from our URL
+        # Parse the attachment URL into constructor arguments.
         results = A_MGR[schema].parse_url(url)
 
         if not results:
-            # Failed to parse the server URL
+            # The attachment URL could not be parsed.
             logger.warning(f"Unparseable URL {url}.")
             return None
 

--- a/apprise/apprise_config.py
+++ b/apprise/apprise_config.py
@@ -62,53 +62,15 @@ class AppriseConfig:
         insecure_includes: bool = False,
         **kwargs: Any,
     ) -> None:
-        """Loads all of the paths specified (if any).
+        """Load one or more configuration sources.
 
-        The path can either be a single string identifying one explicit
-        location, otherwise you can pass in a series of locations to scan
-        via a list.
-
-        If no path is specified then a default list is used.
-
-        By default we cache our responses so that subsiquent calls does not
-        cause the content to be retrieved again. Setting this to False does
-        mean more then one call can be made to retrieve the (same) data.  This
-        method can be somewhat inefficient if disabled and you're set up to
-        make remote calls.  Only disable caching if you understand the
-        consequences.
-
-        You can alternatively set the cache value to an int identifying the
-        number of seconds the previously retrieved can exist for before it
-        should be considered expired.
-
-        It's also worth nothing that the cache value is only set to elements
-        that are not already of subclass ConfigBase()
-
-        recursion defines how deep we recursively handle entries that use the
-        `import` keyword. This keyword requires us to fetch more configuration
-        from another source and add it to our existing compilation. If the
-        file we remotely retrieve also has an `import` reference, we will only
-        advance through it if recursion is set to 2 deep.  If set to zero
-        it is off.  There is no limit to how high you set this value. It would
-        be recommended to keep it low if you do intend to use it.
-
-        insecure includes by default are disabled. When set to True, all
-        Apprise Config files marked to be in STRICT mode are treated as being
-        in ALWAYS mode.
-
-        Take a file:// based configuration for example, only a file:// based
-        configuration can import another file:// based one. because it is set
-        to STRICT mode. If an http:// based configuration file attempted to
-        import a file:// one it woul fail. However this import would be
-        possible if insecure_includes is set to True.
-
-        There are cases where a self hosting apprise developer may wish to load
-        configuration from memory (in a string format) that contains import
-        entries (even file:// based ones).  In these circumstances if you want
-        these includes to be honored, this value must be set to True.
+        ``cache`` may be a boolean or a lifetime in seconds. ``recursion``
+        limits nested ``include`` entries; zero disables them. Enabling
+        ``insecure_includes`` permits includes that normal source security
+        rules would reject.
         """
 
-        # Initialize a server list of URLs
+        # Store the configuration sources used to discover services.
         self.configs = []
 
         # Prepare our Asset Object
@@ -140,30 +102,11 @@ class AppriseConfig:
         recursion: int | None = None,
         insecure_includes: bool | None = None,
     ) -> bool:
-        """Adds one or more config URLs into our list.
+        """Add one or more configuration URLs or sources.
 
-        You can override the global asset if you wish by including it with the
-        config(s) that you add.
-
-        By default we cache our responses so that subsiquent calls does not
-        cause the content to be retrieved again. Setting this to False does
-        mean more then one call can be made to retrieve the (same) data.  This
-        method can be somewhat inefficient if disabled and you're set up to
-        make remote calls.  Only disable caching if you understand the
-        consequences.
-
-        You can alternatively set the cache value to an int identifying the
-        number of seconds the previously retrieved can exist for before it
-        should be considered expired.
-
-        It's also worth nothing that the cache value is only set to elements
-        that are not already of subclass ConfigBase()
-
-        Optionally override the default recursion value.
-
-        Optionally override the insecure_includes flag. if insecure_includes is
-        set to True then all plugins that are set to a STRICT mode will be a
-        treated as ALWAYS.
+        ``asset``, ``cache``, ``recursion``, and ``insecure_includes`` override
+        this object's defaults for newly created sources. Existing
+        ``ConfigBase`` objects keep their own settings.
         """
 
         # Initialize our return status
@@ -233,7 +176,7 @@ class AppriseConfig:
                 return_status = False
                 continue
 
-            # Add our initialized plugin to our server listings
+            # Keep the initialized configuration source.
             self.configs.append(instance)
 
         # Return our status
@@ -248,19 +191,11 @@ class AppriseConfig:
         recursion: int | None = None,
         insecure_includes: bool | None = None,
     ) -> bool:
-        """Adds one configuration file in it's raw format. Content gets loaded
-        as a memory based object and only exists for the life of this
-        AppriseConfig object it was loaded into.
+        """Add raw configuration content as an in-memory source.
 
-        If you know the format ('yaml' or 'text') you can specify it for
-        slightly less overhead during this call.  Otherwise the configuration
-        is auto-detected.
-
-        Optionally override the default recursion value.
-
-        Optionally override the insecure_includes flag. if insecure_includes is
-        set to True then all plugins that are set to a STRICT mode will be a
-        treated as ALWAYS.
+        Set ``format`` to ``yaml`` or ``text`` to skip automatic detection.
+        ``recursion`` and ``insecure_includes`` override this object's defaults
+        for the new source.
         """
 
         # Initialize our default recursion value
@@ -305,29 +240,24 @@ class AppriseConfig:
             )
             return False
 
-        # Add our initialized plugin to our server listings
+        # Keep the initialized in-memory configuration source.
         self.configs.append(instance)
 
         # Return our status
         return True
 
-    def servers(
+    def services(
         self,
         tag: str | list[str] = common.MATCH_ALL_TAG,
         match_always: bool = True,
         *args: Any,
         **kwargs: Any,
     ) -> list[NotifyBase]:
-        """Returns all of our servers dynamically build based on parsed
-        configuration.
+        """Build services from matching configuration sources.
 
-        If a tag is specified, it applies to the configuration sources
-        themselves and not the notification services inside them.
-
-        This is for filtering the configuration files polled for results.
-
-        If the anytag is set, then any notification that is found set with that
-        tag are included in the response.
+        ``tag`` filters the configuration sources, not the services they
+        contain. Services tagged ``always`` are included when ``match_always``
+        is enabled.
         """
 
         # A match_always flag allows us to pick up on our 'any' keyword
@@ -354,9 +284,8 @@ class AppriseConfig:
                 match_all=common.MATCH_ALL_TAG,
                 match_always=match_always,
             ):
-                # Build ourselves a list of services dynamically and return the
-                # as a list
-                response.extend(entry.servers())
+                # Add services discovered in this configuration source.
+                response.extend(entry.services())
 
         return response
 
@@ -392,12 +321,11 @@ class AppriseConfig:
                 logger.error(f"Unsupported schema {schema}.")
                 return None
 
-        # Parse our url details of the server object as dictionary containing
-        # all of the information parsed from our URL
+        # Parse the configuration URL into constructor arguments.
         results = C_MGR[schema].parse_url(url)
 
         if not results:
-            # Failed to parse the server URL
+            # The configuration URL could not be parsed.
             # CWE-312 (Secure Logging) Handling
             secure_logging = (
                 asset.secure_logging
@@ -454,18 +382,18 @@ class AppriseConfig:
         """Empties our configuration list."""
         self.configs[:] = []
 
-    def server_pop(self, index: int) -> NotifyBase:
-        """Removes an indexed Apprise Notification from the servers."""
+    def service_pop(self, index: int) -> NotifyBase:
+        """Remove and return the notification service at ``index``."""
 
         # Tracking variables
         prev_offset = -1
         offset = prev_offset
 
         for entry in self.configs:
-            servers = entry.servers(cache=True)
-            if len(servers) > 0:
+            services = entry.services(cache=True)
+            if len(services) > 0:
                 # Acquire a new maximum offset to work with
-                offset = prev_offset + len(servers)
+                offset = prev_offset + len(services)
 
                 if offset >= index:
                     # we can pop an notification from our config stack

--- a/apprise/apprise_config.py
+++ b/apprise/apprise_config.py
@@ -47,10 +47,14 @@ C_MGR = ConfigurationManager()
 
 
 class AppriseConfig:
-    """Our Apprise Configuration File Manager.
+    """Manage the configuration sources from which services are discovered.
 
-    - Supports a list of URLs defined one after another (text format)
-    - Supports a destinct YAML configuration format
+    Apprise supports a simple text format containing service URLs and a richer
+    YAML format. Sources may be local files, remote URLs, in-memory content, or
+    any other registered configuration plugin.
+
+    See https://appriseit.com/getting-started/configuration/ for the supported
+    file formats and examples.
     """
 
     def __init__(
@@ -62,12 +66,36 @@ class AppriseConfig:
         insecure_includes: bool = False,
         **kwargs: Any,
     ) -> None:
-        """Load one or more configuration sources.
+        """Initialize the manager and optionally add configuration sources.
 
-        ``cache`` may be a boolean or a lifetime in seconds. ``recursion``
-        limits nested ``include`` entries; zero disables them. Enabling
-        ``insecure_includes`` permits includes that normal source security
-        rules would reject.
+        ``paths`` may be one source string or a list of source strings. A
+        source can be an explicit configuration URL such as ``file://`` or
+        ``https://``; a path without a scheme is treated as a local file. If
+        ``paths`` is omitted, the manager starts empty. Default configuration
+        locations are selected by higher-level callers such as the CLI, not by
+        this class.
+
+        ``asset`` is shared with configuration plugins and with the services
+        they create. ``cache`` controls whether a source is read again: true
+        retains parsed results, false reloads on each request, and an integer
+        gives the cache lifetime in seconds. Caching matters most for remote
+        sources, where reloading requires another network request.
+
+        ``recursion`` is the number of nested ``include`` levels to follow.
+        Zero disables includes, one loads sources named by the top-level
+        configuration, and larger values allow the included sources to include
+        others. Keep this value low when loading content you do not control.
+
+        Configuration plugins declare whether they may be included from other
+        source types. In strict mode, a local ``file://`` source may include
+        another local file, but a remote ``http://`` or ``https://`` source may
+        not reach into the local filesystem. ``insecure_includes=True`` relaxes
+        this strict same-type boundary; it does not override sources that
+        prohibit inclusion entirely. This option is also required when trusted
+        in-memory configuration must include local files.
+
+        See https://appriseit.com/getting-started/configuration/ for the
+        configuration syntax and include examples.
         """
 
         # Store the configuration sources used to discover services.
@@ -102,11 +130,29 @@ class AppriseConfig:
         recursion: int | None = None,
         insecure_includes: bool | None = None,
     ) -> bool:
-        """Add one or more configuration URLs or sources.
+        """Add one or more configuration sources to the manager.
 
-        ``asset``, ``cache``, ``recursion``, and ``insecure_includes`` override
-        this object's defaults for newly created sources. Existing
-        ``ConfigBase`` objects keep their own settings.
+        ``configs`` accepts a source string, an instantiated
+        :class:`ConfigBase`, or a collection containing either. Strings without
+        a URL scheme are treated as local file paths. ``tag`` is attached to
+        newly created configuration sources and can later select which sources
+        :meth:`services` reads; it does not tag each service found inside.
+
+        ``asset``, ``cache``, ``recursion``, and ``insecure_includes`` are
+        passed to sources created from strings. ``asset``, ``recursion``, and
+        ``insecure_includes`` fall back to this manager's values when omitted.
+        An already instantiated :class:`ConfigBase` retains all of its own
+        settings because it is stored directly.
+
+        The cache setting may be true to retain parsed results, false to reload
+        whenever services are requested, or a non-negative integer cache
+        lifetime in seconds. ``recursion`` limits nested ``include`` entries.
+        ``insecure_includes`` relaxes strict cross-source inclusion rules; use
+        it only for trusted configuration.
+
+        The return value is true only when every supplied item was accepted.
+        Valid sources remain loaded when another item in the same collection
+        is invalid.
         """
 
         # Initialize our return status
@@ -191,11 +237,19 @@ class AppriseConfig:
         recursion: int | None = None,
         insecure_includes: bool | None = None,
     ) -> bool:
-        """Add raw configuration content as an in-memory source.
+        """Add raw configuration text as an in-memory source.
 
-        Set ``format`` to ``yaml`` or ``text`` to skip automatic detection.
-        ``recursion`` and ``insecure_includes`` override this object's defaults
-        for the new source.
+        The content exists only for the lifetime of the resulting in-memory
+        configuration object. Set ``format`` to ``yaml`` or ``text`` when it is
+        known; otherwise Apprise detects the format. The method returns false
+        when ``content`` is not a string or its format cannot be determined.
+
+        ``asset`` is passed to services created from the content, while ``tag``
+        labels the in-memory configuration source for filtering by
+        :meth:`services`. ``recursion`` and ``insecure_includes`` fall back to
+        this manager's defaults when omitted. Enable insecure includes only
+        when trusted in-memory content must include a source, such as a local
+        ``file://`` configuration, that the normal security boundary rejects.
         """
 
         # Initialize our default recursion value
@@ -253,11 +307,18 @@ class AppriseConfig:
         *args: Any,
         **kwargs: Any,
     ) -> list[NotifyBase]:
-        """Build services from matching configuration sources.
+        """Read matching configuration sources and return their services.
 
-        ``tag`` filters the configuration sources, not the services they
-        contain. Services tagged ``always`` are included when ``match_always``
-        is enabled.
+        ``tag`` is matched against tags on the configuration sources
+        themselves, not tags on the services defined inside those sources.
+        This lets a caller choose which files or remote locations to poll.
+        Top-level tag entries are alternatives (OR), while nested collections
+        are intersections (AND).
+
+        When ``match_always`` is true, configuration sources carrying the
+        reserved ``always`` tag are read even if the requested filter would not
+        otherwise select them. Each matching source applies its own cache,
+        recursion, and include-security policy as it builds the returned list.
         """
 
         # A match_always flag allows us to pick up on our 'any' keyword
@@ -383,7 +444,12 @@ class AppriseConfig:
         self.configs[:] = []
 
     def service_pop(self, index: int) -> NotifyBase:
-        """Remove and return the notification service at ``index``."""
+        """Remove and return a service from the flattened configuration view.
+
+        The configuration sources remain loaded. ``index`` addresses the
+        services discovered across them as one continuous sequence, and an
+        out-of-range index raises :class:`IndexError`.
+        """
 
         # Tracking variables
         prev_offset = -1

--- a/apprise/cli.py
+++ b/apprise/cli.py
@@ -363,8 +363,7 @@ class CustomHelpCommand(click.Command):
         formatter.write_text("")
         content = (
             (
-                "Send a notification to all of the specified servers "
-                "identified by their URLs"
+                "Send a notification to the services identified by their URLs"
             ),
             (
                 "the content provided within the title, body and "
@@ -790,7 +789,7 @@ def _force_exit(apobj: Apprise, status: AppriseResultStatus) -> None:
 @click.argument(
     "urls",
     nargs=-1,
-    metavar="SERVER_URL [SERVER_URL2 [SERVER_URL3]]",
+    metavar="SERVICE_URL [SERVICE_URL2 [SERVICE_URL3]]",
 )
 @click.pass_context
 def main(
@@ -821,8 +820,7 @@ def main(
     debug,
     version,
 ):
-    """Send a notification to all of the specified servers identified by their
-    URLs the content provided within the title, body and notification-type.
+    """Send a notification to the services identified by the given URLs.
 
     For a list of all of the supported services and information on how to use
     them, check out https://github.com/caronc/apprise
@@ -1190,7 +1188,7 @@ def main(
 
     if not dry_run and not (a or storage_action):
         click.echo(
-            "You must specify at least one server URL or populated "
+            "You must specify at least one service URL or populated "
             "configuration file."
         )
         click.echo("Try 'apprise --help' for more information.")
@@ -1454,8 +1452,8 @@ def main(
         # we iterated at least once in the loop.
         url = None
 
-        for idx, server in enumerate(a.find(tag=tags)):
-            url = server.url(privacy=True)
+        for idx, service in enumerate(a.find(tag=tags)):
+            url = service.url(privacy=True)
             click.echo(
                 "{: 4d}. {}".format(
                     idx + 1,
@@ -1471,15 +1469,15 @@ def main(
             click.echo(
                 "{:>10}: {}".format(
                     "uid",
-                    "- n/a -" if not server.url_id() else server.url_id(),
+                    "- n/a -" if not service.url_id() else service.url_id(),
                 )
             )
 
-            if server.tags:
+            if service.tags:
                 click.echo(
                     "{:>10}: {}".format(
                         "tags",
-                        ", ".join(sorted(str(t) for t in server.tags)),
+                        ", ".join(sorted(str(t) for t in service.tags)),
                     )
                 )
 

--- a/apprise/cli.py
+++ b/apprise/cli.py
@@ -362,9 +362,7 @@ class CustomHelpCommand(click.Command):
         # Custom help message
         formatter.write_text("")
         content = (
-            (
-                "Send a notification to the services identified by their URLs"
-            ),
+            ("Send a notification to the services identified by their URLs"),
             (
                 "the content provided within the title, body and "
                 "notification-type."

--- a/apprise/cli.py
+++ b/apprise/cli.py
@@ -818,7 +818,8 @@ def main(
     debug,
     version,
 ):
-    """Send a notification to the services identified by the given URLs.
+    """Send the supplied title, body, and notification type to the services
+    identified by the given URLs or configuration sources.
 
     For a list of all of the supported services and information on how to use
     them, check out https://github.com/caronc/apprise

--- a/apprise/config/base.py
+++ b/apprise/config/base.py
@@ -106,43 +106,12 @@ class ConfigBase(URLBase):
         insecure_includes: bool = False,
         **kwargs: object,
     ) -> None:
-        """Initialize some general logging and common server arguments that
-        will keep things consistent when working with the configurations that
-        inherit this class.
+        """Initialize settings shared by all configuration sources.
 
-        By default we cache our responses so that subsiquent calls does not
-        cause the content to be retrieved again.  For local file references
-        this makes no difference at all.  But for remote content, this does
-        mean more then one call can be made to retrieve the (same) data.  This
-        method can be somewhat inefficient if disabled.  Only disable caching
-        if you understand the consequences.
-
-        You can alternatively set the cache value to an int identifying the
-        number of seconds the previously retrieved can exist for before it
-        should be considered expired.
-
-        recursion defines how deep we recursively handle entries that use the
-        `include` keyword. This keyword requires us to fetch more configuration
-        from another source and add it to our existing compilation. If the
-        file we remotely retrieve also has an `include` reference, we will only
-        advance through it if recursion is set to 2 deep.  If set to zero
-        it is off.  There is no limit to how high you set this value. It would
-        be recommended to keep it low if you do intend to use it.
-
-        insecure_include by default are disabled. When set to True, all
-        Apprise Config files marked to be in STRICT mode are treated as being
-        in ALWAYS mode.
-
-        Take a file:// based configuration for example, only a file:// based
-        configuration can include another file:// based one. because it is set
-        to STRICT mode. If an http:// based configuration file attempted to
-        include a file:// one it woul fail. However this include would be
-        possible if insecure_includes is set to True.
-
-        There are cases where a self hosting apprise developer may wish to load
-        configuration from memory (in a string format) that contains 'include'
-        entries (even file:// based ones).  In these circumstances if you want
-        these 'include' entries to be honored, this value must be set to True.
+        ``cache`` may be a boolean or a lifetime in seconds. ``recursion``
+        limits nested ``include`` entries; zero disables them. Enabling
+        ``insecure_includes`` allows includes that a source's normal security
+        policy would reject, including file URLs from remote configurations.
         """
 
         super().__init__(**kwargs)
@@ -153,7 +122,7 @@ class ConfigBase(URLBase):
         self._cached_time = None
 
         # Tracks previously loaded content for speed
-        self._cached_servers = None
+        self._cached_services = None
 
         # Initialize our recursion value
         self.recursion = recursion
@@ -194,20 +163,19 @@ class ConfigBase(URLBase):
 
         return
 
-    def servers(
+    def services(
         self,
         asset: AppriseAsset | None = None,
         **kwargs: object,
     ) -> list[plugins.NotifyBase]:
-        """Performs reads loaded configuration and returns all of the services
-        that could be parsed and loaded."""
+        """Read the configuration and return the services it defines."""
 
         if not self.expired():
             # We already have cached results to return; use them
-            return self._cached_servers
+            return self._cached_services
 
         # Our cached response object
-        self._cached_servers = []
+        self._cached_services = []
 
         # read() causes the child class to do whatever it takes for the
         # config plugin to load the data source and return unparsed content
@@ -218,7 +186,7 @@ class ConfigBase(URLBase):
             self._cached_time = time.time()
 
             # Nothing more to do; return our empty cache list
-            return self._cached_servers
+            return self._cached_services
 
         # Our Configuration format uses a default if one wasn't one detected
         # or enfored.
@@ -235,14 +203,14 @@ class ConfigBase(URLBase):
         asset = asset if isinstance(asset, AppriseAsset) else self.asset
 
         # Execute our config parse function which always returns a tuple
-        # of our servers and our configuration
-        servers, configs = fn(content=content, asset=asset)
+        # of our services and our configuration
+        services, configs = fn(content=content, asset=asset)
 
         # Free memory
         del content
 
-        # Add entry to our server list
-        self._cached_servers.extend(servers)
+        # Add entry to our service list
+        self._cached_services.extend(services)
 
         # Configuration files were detected; recursively populate them
         # If we have been configured to do so
@@ -277,11 +245,10 @@ class ConfigBase(URLBase):
                     url if not asset.secure_logging else cwe312_url(url)
                 )
 
-                # Parse our url details of the server object as dictionary
-                # containing all of the information parsed from our URL
+                # Parse the included configuration URL into constructor args.
                 results = C_MGR[schema].parse_url(url)
                 if not results:
-                    # Failed to parse the server URL
+                    # The included configuration URL could not be parsed.
                     self.logger.error(
                         f"Unparseable include URL {loggable_url}"
                     )
@@ -331,9 +298,8 @@ class ConfigBase(URLBase):
                     self.logger.debug(f"Loading Exception: {e!s}")
                     continue
 
-                # if we reach here, we can now add this servers found
-                # in this configuration file to our list
-                self._cached_servers.extend(cfg_plugin.servers(asset=asset))
+                # Add services found in the included configuration.
+                self._cached_services.extend(cfg_plugin.services(asset=asset))
 
             else:
                 # CWE-312 (Secure Logging) Handling
@@ -346,9 +312,9 @@ class ConfigBase(URLBase):
                     loggable_url,
                 )
 
-        if self._cached_servers:
+        if self._cached_services:
             self.logger.debug(
-                f"Loaded {len(self._cached_servers)} entries from"
+                f"Loaded {len(self._cached_services)} entries from"
                 f" {self.url(privacy=asset.secure_logging)}"
             )
         else:
@@ -360,7 +326,7 @@ class ConfigBase(URLBase):
         # Set the time our content was cached at
         self._cached_time = time.time()
 
-        return self._cached_servers
+        return self._cached_services
 
     def read(self) -> str | None:
         """This object should be implimented by the child classes."""
@@ -369,7 +335,7 @@ class ConfigBase(URLBase):
     def expired(self) -> bool:
         """Simply returns True if the configuration should be considered as
         expired or False if content should be retrieved."""
-        if isinstance(self._cached_servers, list) and self.cache:
+        if isinstance(self._cached_services, list) and self.cache:
             # We have enough reason to look further into our cached content
             # and verify it has not expired.
             if self.cache is True:
@@ -645,8 +611,8 @@ class ConfigBase(URLBase):
         """Parse the specified content as though it were a simple text file
         only containing a list of URLs.
 
-        Return a tuple that looks like (servers, configs) where:
-          - servers contains a list of loaded notification plugins
+        Return a tuple that looks like (services, configs) where:
+          - services contains a list of loaded notification plugins
           - configs contains a list of additional configuration files
             referenced.
 
@@ -673,7 +639,7 @@ class ConfigBase(URLBase):
             <Group(s)>=<Tag(s)>
         """
         # A list of loaded Notification Services
-        servers = []
+        services = []
 
         # A list of additional configuration files referenced using
         # the include keyword
@@ -865,10 +831,10 @@ class ConfigBase(URLBase):
                 continue
 
             # if we reach here, we successfully loaded our data
-            servers.append(plugin)
+            services.append(plugin)
 
         # Return what was loaded
-        return (servers, configs)
+        return (services, configs)
 
     @staticmethod
     def config_parse_yaml(
@@ -878,8 +844,8 @@ class ConfigBase(URLBase):
         """Parse the specified content as though it were a yaml file
         specifically formatted for Apprise.
 
-        Return a tuple that looks like (servers, configs) where:
-          - servers contains a list of loaded notification plugins
+        Return a tuple that looks like (services, configs) where:
+          - services contains a list of loaded notification plugins
           - configs contains a list of additional configuration files
             referenced.
 
@@ -887,7 +853,7 @@ class ConfigBase(URLBase):
         """
 
         # A list of loaded Notification Services
-        servers = []
+        services = []
 
         # A list of additional configuration files referenced using
         # the include keyword
@@ -1556,10 +1522,10 @@ class ConfigBase(URLBase):
                 continue
 
             # if we reach here, we successfully loaded our data
-            servers.append(plugin)
+            services.append(plugin)
 
         preloaded.clear()
-        return (servers, configs)
+        return (services, configs)
 
     def pop(self, index: int = -1) -> object:
         """Removes an indexed Notification Service from the stack and returns
@@ -1568,16 +1534,16 @@ class ConfigBase(URLBase):
         By default, the last element of the list is removed.
         """
 
-        if not isinstance(self._cached_servers, list):
+        if not isinstance(self._cached_services, list):
             # Generate ourselves a list of content we can pull from
-            self.servers()
+            self.services()
 
         # Pop the element off of the stack
-        return self._cached_servers.pop(index)
+        return self._cached_services.pop(index)
 
     def clear_cache(self) -> None:
         """Cleans cache"""
-        self._cached_servers = None
+        self._cached_services = None
         self._cached_time = None
 
     @staticmethod
@@ -1726,37 +1692,36 @@ class ConfigBase(URLBase):
         return tokens
 
     def __getitem__(self, index: int) -> object:
-        """Returns the indexed server entry associated with the loaded
-        notification servers."""
-        if not isinstance(self._cached_servers, list):
+        """Return the loaded notification service at ``index``."""
+        if not isinstance(self._cached_services, list):
             # Generate ourselves a list of content we can pull from
-            self.servers()
+            self.services()
 
-        return self._cached_servers[index]
+        return self._cached_services[index]
 
     def __iter__(self) -> object:
-        """Returns an iterator to our server list."""
-        if not isinstance(self._cached_servers, list):
+        """Returns an iterator to our service list."""
+        if not isinstance(self._cached_services, list):
             # Generate ourselves a list of content we can pull from
-            self.servers()
+            self.services()
 
-        return iter(self._cached_servers)
+        return iter(self._cached_services)
 
     def __len__(self) -> int:
-        """Returns the total number of servers loaded."""
-        if not isinstance(self._cached_servers, list):
+        """Returns the total number of services loaded."""
+        if not isinstance(self._cached_services, list):
             # Generate ourselves a list of content we can pull from
-            self.servers()
+            self.services()
 
-        return len(self._cached_servers)
+        return len(self._cached_services)
 
     def __bool__(self) -> bool:
         """Allows the Apprise object to be wrapped in an 'if statement'.
 
         True is returned if our content was downloaded correctly.
         """
-        if not isinstance(self._cached_servers, list):
+        if not isinstance(self._cached_services, list):
             # Generate ourselves a list of content we can pull from
-            self.servers()
+            self.services()
 
-        return bool(self._cached_servers)
+        return bool(self._cached_services)

--- a/apprise/config/base.py
+++ b/apprise/config/base.py
@@ -106,12 +106,43 @@ class ConfigBase(URLBase):
         insecure_includes: bool = False,
         **kwargs: object,
     ) -> None:
-        """Initialize settings shared by all configuration sources.
+        """Initialize some general logging and common service arguments that
+        will keep things consistent when working with the configurations that
+        inherit this class.
 
-        ``cache`` may be a boolean or a lifetime in seconds. ``recursion``
-        limits nested ``include`` entries; zero disables them. Enabling
-        ``insecure_includes`` allows includes that a source's normal security
-        policy would reject, including file URLs from remote configurations.
+        By default we cache our responses so that subsiquent calls does not
+        cause the content to be retrieved again.  For local file references
+        this makes no difference at all.  But for remote content, this does
+        mean more then one call can be made to retrieve the (same) data.  This
+        method can be somewhat inefficient if disabled.  Only disable caching
+        if you understand the consequences.
+
+        You can alternatively set the cache value to an int identifying the
+        number of seconds the previously retrieved can exist for before it
+        should be considered expired.
+
+        recursion defines how deep we recursively handle entries that use the
+        `include` keyword. This keyword requires us to fetch more configuration
+        from another source and add it to our existing compilation. If the
+        file we remotely retrieve also has an `include` reference, we will only
+        advance through it if recursion is set to 2 deep.  If set to zero
+        it is off.  There is no limit to how high you set this value. It would
+        be recommended to keep it low if you do intend to use it.
+
+        insecure_include by default are disabled. When set to True, all
+        Apprise Config files marked to be in STRICT mode are treated as being
+        in ALWAYS mode.
+
+        Take a file:// based configuration for example, only a file:// based
+        configuration can include another file:// based one. because it is set
+        to STRICT mode. If an http:// based configuration file attempted to
+        include a file:// one it woul fail. However this include would be
+        possible if insecure_includes is set to True.
+
+        There are cases where a self hosting apprise developer may wish to load
+        configuration from memory (in a string format) that contains 'include'
+        entries (even file:// based ones).  In these circumstances if you want
+        these 'include' entries to be honored, this value must be set to True.
         """
 
         super().__init__(**kwargs)

--- a/apprise/config/base.py
+++ b/apprise/config/base.py
@@ -106,43 +106,33 @@ class ConfigBase(URLBase):
         insecure_includes: bool = False,
         **kwargs: object,
     ) -> None:
-        """Initialize some general logging and common service arguments that
-        will keep things consistent when working with the configurations that
-        inherit this class.
+        """Initialize behavior shared by all configuration plugins.
 
-        By default we cache our responses so that subsiquent calls does not
-        cause the content to be retrieved again.  For local file references
-        this makes no difference at all.  But for remote content, this does
-        mean more then one call can be made to retrieve the (same) data.  This
-        method can be somewhat inefficient if disabled.  Only disable caching
-        if you understand the consequences.
+        ``cache=True`` retains parsed services after the first read.
+        ``cache=False`` reads and parses the source whenever :meth:`services`
+        is called, and a non-negative integer retains results for that many
+        seconds. Reloading is especially significant for an ``http://`` or
+        ``https://`` source because it performs another network request.
 
-        You can alternatively set the cache value to an int identifying the
-        number of seconds the previously retrieved can exist for before it
-        should be considered expired.
+        ``recursion`` controls how many levels of ``include`` entries are
+        followed. Zero ignores all includes; one reads sources included by this
+        source; two also follows includes found in those child sources, and so
+        on. A low limit protects against unexpectedly large or circular trees.
 
-        recursion defines how deep we recursively handle entries that use the
-        `include` keyword. This keyword requires us to fetch more configuration
-        from another source and add it to our existing compilation. If the
-        file we remotely retrieve also has an `include` reference, we will only
-        advance through it if recursion is set to 2 deep.  If set to zero
-        it is off.  There is no limit to how high you set this value. It would
-        be recommended to keep it low if you do intend to use it.
+        Each configuration plugin declares an
+        :class:`~apprise.common.ContentIncludeMode`. ``ALWAYS`` sources may be
+        included normally, ``NEVER`` sources cannot be included, and ``STRICT``
+        sources may only be included by a compatible source type. For example,
+        a local ``file://`` configuration can include another local file, but
+        an ``http://`` configuration cannot include a local file.
+        ``insecure_includes=True`` relaxes the ``STRICT`` compatibility check,
+        effectively treating strict sources as always includable; it never
+        overrides ``NEVER``. This is useful when trusted in-memory content must
+        include a local file, but it should not be enabled for untrusted input.
 
-        insecure_include by default are disabled. When set to True, all
-        Apprise Config files marked to be in STRICT mode are treated as being
-        in ALWAYS mode.
-
-        Take a file:// based configuration for example, only a file:// based
-        configuration can include another file:// based one. because it is set
-        to STRICT mode. If an http:// based configuration file attempted to
-        include a file:// one it woul fail. However this include would be
-        possible if insecure_includes is set to True.
-
-        There are cases where a self hosting apprise developer may wish to load
-        configuration from memory (in a string format) that contains 'include'
-        entries (even file:// based ones).  In these circumstances if you want
-        these 'include' entries to be honored, this value must be set to True.
+        Additional keyword arguments are handled by :class:`URLBase`. The
+        optional ``encoding`` and ``format`` values select the source encoding
+        and force ``text`` or ``yaml`` parsing respectively.
         """
 
         super().__init__(**kwargs)
@@ -199,7 +189,19 @@ class ConfigBase(URLBase):
         asset: AppriseAsset | None = None,
         **kwargs: object,
     ) -> list[plugins.NotifyBase]:
-        """Read the configuration and return the services it defines."""
+        """Read, parse, and return all services defined by this source.
+
+        A valid cache is returned immediately. Otherwise :meth:`read` obtains
+        the raw text, the selected text or YAML parser creates service plugins,
+        and any permitted ``include`` entries are loaded recursively. Included
+        services are appended to the direct services in the returned list.
+
+        ``asset`` overrides the source's asset for newly parsed services and is
+        propagated to included sources. A read failure or source with no
+        usable content returns an empty list. The result becomes this object's
+        mutable cache; methods such as ``len()``, iteration, indexing, and
+        :meth:`pop` all operate on that same list.
+        """
 
         if not self.expired():
             # We already have cached results to return; use them
@@ -1723,7 +1725,7 @@ class ConfigBase(URLBase):
         return tokens
 
     def __getitem__(self, index: int) -> object:
-        """Return the loaded notification service at ``index``."""
+        """Return the cached service at ``index``, loading it if necessary."""
         if not isinstance(self._cached_services, list):
             # Generate ourselves a list of content we can pull from
             self.services()
@@ -1731,7 +1733,7 @@ class ConfigBase(URLBase):
         return self._cached_services[index]
 
     def __iter__(self) -> object:
-        """Returns an iterator to our service list."""
+        """Iterate over cached services, loading the source if necessary."""
         if not isinstance(self._cached_services, list):
             # Generate ourselves a list of content we can pull from
             self.services()
@@ -1739,7 +1741,11 @@ class ConfigBase(URLBase):
         return iter(self._cached_services)
 
     def __len__(self) -> int:
-        """Returns the total number of services loaded."""
+        """Return the number of parsed services, loading when necessary.
+
+        The configuration source itself is not counted. Services obtained from
+        permitted nested includes are included in the total.
+        """
         if not isinstance(self._cached_services, list):
             # Generate ourselves a list of content we can pull from
             self.services()

--- a/apprise/plugins/__init__.py
+++ b/apprise/plugins/__init__.py
@@ -486,8 +486,7 @@ def url_to_dict(url, secure_logging=True):
         )
 
     else:
-        # Parse our url details of the server object as dictionary
-        # containing all of the information parsed from our URL
+        # Parse the service URL into constructor arguments.
         results = N_MGR[schema].parse_url(url_)
         if not results:
             logger.error(

--- a/apprise/plugins/vapid/subscription.py
+++ b/apprise/plugins/vapid/subscription.py
@@ -278,12 +278,7 @@ class WebPushSubscriptionManager:
         return bool(self.__subscriptions)
 
     def __len__(self) -> int:
-        """Returns the number of servers loaded; this includes those found
-        within loaded configuration.
-
-        This funtion nnever actually counts the Config entry themselves (if
-        they exist), only what they contain.
-        """
+        """Return the number of loaded Web Push subscriptions."""
         return len(self.__subscriptions)
 
     def __iadd__(
@@ -300,7 +295,7 @@ class WebPushSubscriptionManager:
         return key.lower() in self.__subscriptions
 
     def clear(self) -> None:
-        """Empties our server list."""
+        """Remove all Web Push subscriptions."""
         self.__subscriptions.clear()
 
     @property

--- a/apprise/plugins/vapid/subscription.py
+++ b/apprise/plugins/vapid/subscription.py
@@ -278,7 +278,11 @@ class WebPushSubscriptionManager:
         return bool(self.__subscriptions)
 
     def __len__(self) -> int:
-        """Return the number of loaded Web Push subscriptions."""
+        """Return the number of subscription records held by this manager.
+
+        Each record represents one endpoint and counts once, regardless of the
+        endpoint's host or push-service implementation.
+        """
         return len(self.__subscriptions)
 
     def __iadd__(
@@ -295,7 +299,7 @@ class WebPushSubscriptionManager:
         return key.lower() in self.__subscriptions
 
     def clear(self) -> None:
-        """Remove all Web Push subscriptions."""
+        """Remove every subscription record from this manager."""
         self.__subscriptions.clear()
 
     @property

--- a/apprise/result.py
+++ b/apprise/result.py
@@ -75,7 +75,7 @@ class AppriseResultStatus(IntEnum):
     # NOTE: 2 is intentionally unused because Click reserves it for invalid
     # command-line arguments.
 
-    # No service was attempted: no loaded servers or no tag match.
+    # No service was attempted: no loaded services or no tag match.
     # Only AppriseResult.status uses NOMATCH.
     NOMATCH = 3
 

--- a/packaging/man/apprise.1
+++ b/packaging/man/apprise.1
@@ -135,7 +135,7 @@ There are too many service URL and combinations to list here\. It's best to visi
 .P
 The \fBenvironment variable\fR of \fBAPPRISE_URLS\fR (comma/space delimited) can be specified to provide the default set of URLs you wish to notify if none are otherwise specified\.
 .SH "EXAMPLES"
-Send a notification to as many servers as you want to specify as you can easily chain them together:
+Send a notification to multiple services by chaining their URLs:
 .IP "" 4
 .nf
 $ apprise \-vv \-t "my title" \-b "my notification body" \e

--- a/packaging/man/apprise.1.html
+++ b/packaging/man/apprise.1.html
@@ -295,8 +295,7 @@ provide the default set of URLs you wish to notify if none are otherwise specifi
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
-<p>Send a notification to as many servers as you want to specify as you can
-easily chain them together:</p>
+<p>Send a notification to multiple services by chaining their URLs:</p>
 
 <pre><code>$ apprise -vv -t "my title" -b "my notification body" \
    "mailto://myemail:mypass@gmail.com" \

--- a/packaging/man/apprise.md
+++ b/packaging/man/apprise.md
@@ -195,8 +195,7 @@ provide the default set of URLs you wish to notify if none are otherwise specifi
 
 ## EXAMPLES
 
-Send a notification to as many servers as you want to specify as you can
-easily chain them together:
+Send a notification to multiple services by chaining their URLs:
 
     $ apprise -vv -t "my title" -b "my notification body" \
        "mailto://myemail:mypass@gmail.com" \

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -78,8 +78,8 @@ def test_apprise_object():
 
     """
 
-    def do_notify(server, *args, **kwargs):
-        return server.notify(*args, **kwargs)
+    def do_notify(service, *args, **kwargs):
+        return service.notify(*args, **kwargs)
 
     apprise_test(do_notify)
 
@@ -91,9 +91,9 @@ def test_apprise_async():
     """
     with OuterEventLoop() as loop:
 
-        def do_notify(server, *args, **kwargs):
+        def do_notify(service, *args, **kwargs):
             return loop.run_until_complete(
-                server.async_notify(*args, **kwargs)
+                service.async_notify(*args, **kwargs)
             )
 
         apprise_test(do_notify)
@@ -116,15 +116,15 @@ def apprise_test(do_notify):
     # We can load the device using our asset
     a = Apprise(asset=asset)
 
-    # We can load our servers up front as well
-    servers = [
+    # We can load our services up front as well
+    services = [
         "json://myhost",
         "kodi://kodi.server.local",
     ]
 
-    a = Apprise(servers=servers)
+    a = Apprise(services=services)
 
-    # 2 servers loaded
+    # 2 services loaded
     assert len(a) == 2
 
     # Apprise object can also be directly tested with 'if' keyword
@@ -134,7 +134,7 @@ def apprise_test(do_notify):
     # We can retrieve our URLs this way:
     assert len(a.urls()) == 2
 
-    # We can add another server
+    # We can add another service
     assert (
         a.add(
             "mmosts://mattermost.server.local/3ccdd113474722377935511fc85d3dd4"
@@ -146,7 +146,7 @@ def apprise_test(do_notify):
     # Try adding nothing but delimiters
     assert a.add(",, ,, , , , ,") is False
 
-    # The number of servers added doesn't change
+    # The number of services added doesn't change
     assert len(a) == 3
 
     # We can pop an object off of our stack by it's indexed value:
@@ -181,7 +181,7 @@ def apprise_test(do_notify):
     assert a.add("json://user:@@@:bad?no.good") is False
     assert len(a) == 0
 
-    # Add a server with our asset we created earlier
+    # Add a service with our asset we created earlier
     assert (
         a.add(
             "mmosts://mattermost.server.local/"
@@ -191,16 +191,16 @@ def apprise_test(do_notify):
         is True
     )
 
-    # Clear our server listings again
+    # Clear our service listings again
     a.clear()
     assert len(a) == 0
 
-    # No servers to notify
+    # No services to notify
     assert bool(do_notify(a, title="my title", body="my body")) is False
 
     # More Variations of Multiple Adding of URLs
     a = Apprise()
-    assert a.add(servers)
+    assert a.add(services)
     assert len(a) == 2
     a.clear()
 
@@ -285,7 +285,7 @@ def apprise_test(do_notify):
     # We'll fail because we've got nothing to notify
     assert bool(do_notify(a, title="my title", body="my body")) is False
 
-    # Clear our server listings again
+    # Clear our service listings again
     a.clear()
 
     assert a.add("good://localhost") is True
@@ -703,8 +703,8 @@ def test_apprise_tagging(mock_request):
 
     """
 
-    def do_notify(server, *args, **kwargs):
-        return server.notify(*args, **kwargs)
+    def do_notify(service, *args, **kwargs):
+        return service.notify(*args, **kwargs)
 
     apprise_tagging_test(mock_request, do_notify)
 
@@ -717,9 +717,9 @@ def test_apprise_tagging_async(mock_request):
     """
     with OuterEventLoop() as loop:
 
-        def do_notify(server, *args, **kwargs):
+        def do_notify(service, *args, **kwargs):
             return loop.run_until_complete(
-                server.async_notify(*args, **kwargs)
+                service.async_notify(*args, **kwargs)
             )
 
         apprise_tagging_test(mock_request, do_notify)
@@ -1345,13 +1345,14 @@ def test_apprise_multi_format_resolution(caplog):
     API: multi-format notify_format resolution
 
     """
-    # Older pytest releases (e.g. the one shipped with EL9) do not
-    # un-disable logging on our behalf when caplog.set_level() is
-    # called, so a prior module-level logging.disable(logging.CRITICAL)
-    # call would otherwise silently swallow this debug message. Clear
-    # it explicitly and restore it once we're done.
-    logging.disable(logging.NOTSET)
+    # Older pytest versions may leave logging disabled after set_level().
+    # Override that state only when needed, then restore it below.
     caplog.set_level(logging.DEBUG, logger=LOGGER_NAME)
+    manual_override = not logging.getLogger(LOGGER_NAME).isEnabledFor(
+        logging.DEBUG
+    )
+    if manual_override:
+        logging.disable(logging.NOTSET)
 
     try:
 
@@ -1456,7 +1457,8 @@ def test_apprise_multi_format_resolution(caplog):
         assert multi.notify(body="hi", body_format=NotifyFormat.HTML) is True
         assert multi.received == [("send", "hi")]
     finally:
-        logging.disable(logging.CRITICAL)
+        if manual_override:
+            logging.disable(logging.CRITICAL)
 
 
 def test_apprise_multi_format_conversion_cache():
@@ -1501,7 +1503,7 @@ def test_apprise_multi_format_conversion_cache():
         assert (
             bool(a.notify(body="hello", body_format=NotifyFormat.TEXT)) is True
         )
-        # Both servers resolve to HTML; the body should only be converted
+        # Both services resolve to HTML; the body should only be converted
         # once and reused, exactly like the single-format cache today.
         assert mock_convert.call_count == 1
 
@@ -1701,15 +1703,16 @@ def test_apprise_payload_max_size_cache_key_includes_buffer_settings():
     assert delivered1 != delivered2
 
 
-def test_apprise_payload_max_size_warns_when_trimming(caplog):
+def test_apprise_payload_trim_warning(caplog):
     """API: Log a warning only when a service cap trims the input."""
-    # Older pytest releases (e.g. the one shipped with EL9) do not
-    # un-disable logging on our behalf when caplog.set_level() is
-    # called, so a prior module-level logging.disable(logging.CRITICAL)
-    # call would otherwise silently swallow this warning. Clear it
-    # explicitly and restore it once we're done.
-    logging.disable(logging.NOTSET)
+    # Older pytest versions may leave logging disabled after set_level().
+    # Override that state only when needed, then restore it below.
     caplog.set_level(logging.WARNING, logger=LOGGER_NAME)
+    manual_override = not logging.getLogger(LOGGER_NAME).isEnabledFor(
+        logging.WARNING
+    )
+    if manual_override:
+        logging.disable(logging.NOTSET)
 
     try:
 
@@ -1735,7 +1738,8 @@ def test_apprise_payload_max_size_warns_when_trimming(caplog):
         assert bool(a.notify(title="", body="x")) is True
         assert "payload_max_size" not in caplog.text
     finally:
-        logging.disable(logging.CRITICAL)
+        if manual_override:
+            logging.disable(logging.CRITICAL)
 
 
 def test_apprise_multi_format_details():
@@ -2956,7 +2960,7 @@ def test_apprise_async_mode(mock_threadpool, mock_gather, mock_request):
     a = Apprise(asset=asset)
 
     # add our services
-    a.add(servers=services)
+    a.add(services=services)
 
     # 2 services loaded
     assert len(a) == 2
@@ -2992,7 +2996,7 @@ def test_apprise_async_mode(mock_threadpool, mock_gather, mock_request):
         assert a.asset.async_mode is False
 
         # add our services
-        a.add(servers=services)
+        a.add(services=services)
 
         # 2 services loaded
         assert len(a) == 2

--- a/tests/test_apprise_cli.py
+++ b/tests/test_apprise_cli.py
@@ -101,7 +101,7 @@ def test_apprise_cli_nux_env(tmpdir):
 
     runner = CliRunner()
     result = runner.invoke(cli.main)
-    # no servers specified; we return 1 (non-zero)
+    # no services specified; we return 1 (non-zero)
     assert result.exit_code == 1
 
     result = runner.invoke(cli.main, ["-v"])

--- a/tests/test_apprise_config.py
+++ b/tests/test_apprise_config.py
@@ -66,7 +66,7 @@ def test_apprise_config(tmpdir):
     # Create ourselves a config object
     ac = AppriseConfig()
 
-    # There are no servers loaded
+    # There are no services loaded
     assert len(ac) == 0
 
     # Object can be directly checked as a boolean; response is False
@@ -74,7 +74,7 @@ def test_apprise_config(tmpdir):
     assert not ac
 
     # lets try anyway
-    assert len(ac.servers()) == 0
+    assert len(ac.services()) == 0
 
     t = tmpdir.mkdir("simple-formatting").join("apprise")
     t.write("""
@@ -108,8 +108,8 @@ def test_apprise_config(tmpdir):
     # when there is at least one entry
     assert ac
 
-    # We should be able to read our 4 servers from that
-    assert len(ac.servers()) == 4
+    # We should be able to read our 4 services from that
+    assert len(ac.services()) == 4
 
     # Get our URL back
     assert isinstance(ac[0].url(), str)
@@ -128,7 +128,7 @@ def test_apprise_config(tmpdir):
     assert len(ac) == 1
 
     # No urls were set
-    assert len(ac.servers()) == 0
+    assert len(ac.services()) == 0
 
     # Create a ConfigBase object
     cb = ConfigBase()
@@ -158,7 +158,7 @@ def test_apprise_config(tmpdir):
     assert len(ac) == 1
 
     # No urls were set
-    assert len(ac.servers()) == 0
+    assert len(ac.services()) == 0
 
     #
     # Test Internatialization and the handling of unicode characters
@@ -180,7 +180,7 @@ def test_apprise_config(tmpdir):
 
     # This will fail because our default encoding is utf-8; however the file
     # we opened was not; it was latin-1 and could not be parsed.
-    assert len(ac.servers()) == 0
+    assert len(ac.services()) == 0
 
     # Test iterator
     count = 0
@@ -195,7 +195,7 @@ def test_apprise_config(tmpdir):
     assert len(ac) == 1
 
     # Our URL should be found
-    assert len(ac.servers()) == 1
+    assert len(ac.services()) == 1
 
     # Get our URL back
     assert isinstance(ac[0].url(), str)
@@ -224,14 +224,14 @@ def test_apprise_config(tmpdir):
     # One configuration file should have been found
     assert len(ac) == 1
 
-    assert len(ac.servers()) == 1
+    assert len(ac.services()) == 1
 
     # update our buffer size to be slightly smaller then what we allow
     ac[0].max_buffer_size = len(buf) - 1
 
     # Content is automatically cached; so even though we adjusted the buffer
     # above, our results have been cached so we get a 1 response.
-    assert len(ac.servers()) == 1
+    assert len(ac.services()) == 1
 
 
 def test_apprise_multi_config_entries(tmpdir):
@@ -269,7 +269,7 @@ def test_apprise_multi_config_entries(tmpdir):
     # Create ourselves a config object
     ac = AppriseConfig()
 
-    # There are no servers loaded
+    # There are no services loaded
     assert len(ac) == 0
 
     # Support adding of muilt strings and objects:
@@ -285,11 +285,11 @@ def test_apprise_multi_config_entries(tmpdir):
 
     # Try to pop an element out of range
     with pytest.raises(IndexError):
-        ac.server_pop(len(ac.servers()))
+        ac.service_pop(len(ac.services()))
 
     # Pop our elements
-    while len(ac.servers()) > 0:
-        assert isinstance(ac.server_pop(len(ac.servers()) - 1), NotifyBase)
+    while len(ac.services()) > 0:
+        assert isinstance(ac.service_pop(len(ac.services()) - 1), NotifyBase)
 
 
 def test_apprise_add_config():
@@ -323,8 +323,8 @@ def test_apprise_add_config():
     # when there is at least one entry
     assert ac
 
-    # We should be able to read our 3 servers from that
-    assert len(ac.servers()) == 3
+    # We should be able to read our 3 services from that
+    assert len(ac.services()) == 3
 
     # Get our URL back
     assert isinstance(ac[0].url(), str)
@@ -334,7 +334,7 @@ def test_apprise_add_config():
     assert ac.add_config(content=42) is False
     assert ac.add_config(content=None) is False
 
-    # Still only one server loaded
+    # Still only one service loaded
     assert len(ac) == 1
 
     # Test having a pre-defined asset object and tag created
@@ -342,11 +342,11 @@ def test_apprise_add_config():
         ac.add_config(content=content, asset=AppriseAsset(), tag="a") is True
     )
 
-    # Now there are 2 servers loaded
+    # Now there are 2 services loaded
     assert len(ac) == 2
 
     # and 6 urls.. (as we've doubled up)
-    assert len(ac.servers()) == 6
+    assert len(ac.services()) == 6
 
     content = """
     # A YAML File
@@ -378,8 +378,8 @@ def test_apprise_add_config():
     # when there is at least one entry
     assert ac
 
-    # We should be able to read our 4 servers from that
-    assert len(ac.servers()) == 4
+    # We should be able to read our 4 services from that
+    assert len(ac.services()) == 4
 
     # Now an invalid configuration file
     content = "invalid"
@@ -389,7 +389,7 @@ def test_apprise_add_config():
     assert ac.add_config(content=content) is False
 
     # Nothing is loaded
-    assert len(ac.servers()) == 0
+    assert len(ac.services()) == 0
 
 
 def test_apprise_config_tagging(tmpdir):
@@ -414,13 +414,13 @@ def test_apprise_config_tagging(tmpdir):
     assert ac.add(configs=str(t), asset=AppriseAsset(), tag="a,b") is True
 
     # Now filter: a:
-    assert len(ac.servers(tag="a")) == 2
+    assert len(ac.services(tag="a")) == 2
     # Now filter: a or b:
-    assert len(ac.servers(tag="a,b")) == 3
+    assert len(ac.services(tag="a,b")) == 3
     # Now filter: a and b
-    assert len(ac.servers(tag=[("a", "b")])) == 1
+    assert len(ac.services(tag=[("a", "b")])) == 1
     # all matches everything
-    assert len(ac.servers(tag="all")) == 3
+    assert len(ac.services(tag="all")) == 3
 
     # Test cases using the `always` keyword
     # Create ourselves a config object
@@ -434,20 +434,20 @@ def test_apprise_config_tagging(tmpdir):
     assert ac.add(configs=str(t), asset=AppriseAsset(), tag="c,d") is True
 
     # Now filter: a:
-    assert len(ac.servers(tag="a")) == 1
+    assert len(ac.services(tag="a")) == 1
     # Now filter: a or b:
-    assert len(ac.servers(tag="a,b")) == 2
+    assert len(ac.services(tag="a,b")) == 2
     # Now filter: e
     # we'll match the `always'
-    assert len(ac.servers(tag="e")) == 1
-    assert len(ac.servers(tag="e", match_always=False)) == 0
+    assert len(ac.services(tag="e")) == 1
+    assert len(ac.services(tag="e", match_always=False)) == 0
     # all matches everything
-    assert len(ac.servers(tag="all")) == 3
+    assert len(ac.services(tag="all")) == 3
 
     # Now filter: d
     # we'll match the `always' tag
-    assert len(ac.servers(tag="d")) == 2
-    assert len(ac.servers(tag="d", match_always=False)) == 1
+    assert len(ac.services(tag="d")) == 2
+    assert len(ac.services(tag="d", match_always=False)) == 1
 
 
 def test_apprise_config_instantiate():
@@ -543,8 +543,8 @@ def test_invalid_apprise_config(tmpdir):
     # One configuration file
     assert len(ac) == 1
 
-    # All of the servers were invalid and would not load
-    assert len(ac.servers()) == 0
+    # All of the services were invalid and would not load
+    assert len(ac.services()) == 0
 
 
 def test_apprise_config_with_apprise_obj(tmpdir):
@@ -590,19 +590,19 @@ def test_apprise_config_with_apprise_obj(tmpdir):
     assert len(ac) == 1
 
     # 2 services found in it
-    assert len(ac.servers()) == 2
+    assert len(ac.services()) == 2
 
     # Pop one of them (at index 0)
-    ac.server_pop(0)
+    ac.service_pop(0)
 
     # Verify that it no longer listed
-    assert len(ac.servers()) == 1
+    assert len(ac.services()) == 1
 
     # Test our ability to add Config objects to our apprise object
     a = Apprise()
 
     # Add our configuration object
-    assert a.add(servers=ac) is True
+    assert a.add(services=ac) is True
 
     # Detect our 1 entry (originally there were 2 but we deleted one)
     assert len(a) == 1
@@ -612,7 +612,7 @@ def test_apprise_config_with_apprise_obj(tmpdir):
 
     # Add our configuration object
     assert (
-        a.add(servers=[AppriseConfig(str(t)), AppriseConfig(str(t))]) is True
+        a.add(services=[AppriseConfig(str(t)), AppriseConfig(str(t))]) is True
     )
 
     # Detect our 5 loaded entries now; 1 from first config, and another
@@ -620,8 +620,8 @@ def test_apprise_config_with_apprise_obj(tmpdir):
     assert len(a) == 5
 
     # We can't add garbage
-    assert a.add(servers=object()) is False
-    assert a.add(servers=[object(), object()]) is False
+    assert a.add(services=object()) is False
+    assert a.add(services=[object(), object()]) is False
 
     # Our length is unchanged
     assert len(a) == 5
@@ -684,7 +684,7 @@ def test_apprise_config_with_apprise_obj(tmpdir):
     # Below we add 3 different types, a ConfigBase, NotifyBase, and URL
     assert (
         a.add(
-            servers=[
+            services=[
                 ConfigFile(path=(str(t))),
                 "good://another.host",
                 GoodNotification(**{"host": "nuxref.com"}),
@@ -817,7 +817,7 @@ include strict://{cfg04!s}""")
     # Create ourselves a config object
     ac = AppriseConfig()
 
-    # There are no servers loaded
+    # There are no services loaded
     assert len(ac) == 0
 
     # load our configuration
@@ -827,7 +827,7 @@ include strict://{cfg04!s}""")
     assert len(ac) == 1
 
     # 1 service will be loaded as there is no recursion at this point
-    assert len(ac.servers()) == 1
+    assert len(ac.services()) == 1
 
     # Create ourselves a config object
     ac = AppriseConfig(recursion=1)
@@ -840,7 +840,7 @@ include strict://{cfg04!s}""")
     assert len(ac) == 1
 
     # 2 services loaded now that we loaded the same file twice
-    assert len(ac.servers()) == 2
+    assert len(ac.services()) == 2
 
     #
     # Now we test relative file inclusion
@@ -849,7 +849,7 @@ include strict://{cfg04!s}""")
     # Create ourselves a config object
     ac = AppriseConfig(recursion=10)
 
-    # There are no servers loaded
+    # There are no services loaded
     assert len(ac) == 0
 
     # load our configuration
@@ -860,14 +860,14 @@ include strict://{cfg04!s}""")
 
     # 11 services loaded because we reloaded ourselves 10 times
     # after loading the first entry
-    assert len(ac.servers()) == 11
+    assert len(ac.services()) == 11
 
     # Test our include modes (strict, always, and never)
 
     # Create ourselves a config object
     ac = AppriseConfig(recursion=1)
 
-    # There are no servers loaded
+    # There are no services loaded
     assert len(ac) == 0
 
     # load our configuration
@@ -876,7 +876,7 @@ include strict://{cfg04!s}""")
     # verify it loaded
     assert len(ac) == 1
 
-    # 2 servers loaded
+    # 2 services loaded
     # 1 - from the file read (which is set at mode STRICT
     # 1 - from the always://
     #
@@ -884,12 +884,12 @@ include strict://{cfg04!s}""")
     #  file:// (the one doing the include) so it is also ignored.
     #
     # By turning on the insecure_includes, we can include the strict files too
-    assert len(ac.servers()) == 2
+    assert len(ac.services()) == 2
 
     # Create ourselves a config object
     ac = AppriseConfig(recursion=1, insecure_includes=True)
 
-    # There are no servers loaded
+    # There are no services loaded
     assert len(ac) == 0
 
     # load our configuration
@@ -898,11 +898,11 @@ include strict://{cfg04!s}""")
     # verify it loaded
     assert len(ac) == 1
 
-    # 3 servers loaded
+    # 3 services loaded
     # 1 - from the file read (which is set at mode STRICT
     # 1 - from the always://
     # 1 - from the strict:// (due to insecure_includes set)
-    assert len(ac.servers()) == 3
+    assert len(ac.services()) == 3
 
 
 def test_apprise_config_file_loading(tmpdir):
@@ -1056,7 +1056,7 @@ class ConfigBugger(ConfigBase):
 
 
 @mock.patch("os.path.getsize")
-def test_config_base_parse_inaccessible_text_file(mock_getsize, tmpdir):
+def test_config_base_inaccessible_text_file(mock_getsize, tmpdir):
     """
     API: ConfigBase.parse_inaccessible_text_file
 
@@ -1079,7 +1079,7 @@ def test_config_base_parse_inaccessible_text_file(mock_getsize, tmpdir):
     assert len(ac) == 1
 
     # Thus no notifications are loaded
-    assert len(ac.servers()) == 0
+    assert len(ac.services()) == 0
 
 
 def test_config_base_parse_yaml_file01(tmpdir):
@@ -1097,7 +1097,7 @@ def test_config_base_parse_yaml_file01(tmpdir):
     assert len(ac) == 1
 
     # no notifications are loaded
-    assert len(ac.servers()) == 0
+    assert len(ac.services()) == 0
 
 
 def test_config_base_parse_yaml_file02(tmpdir):
@@ -1121,13 +1121,13 @@ def test_config_base_parse_yaml_file02(tmpdir):
     assert len(ac) == 1
 
     # no notifications are loaded
-    assert len(ac.servers()) == 3
+    assert len(ac.services()) == 3
 
     # Test our ability to add Config objects to our apprise object
     a = Apprise()
 
     # Add our configuration object
-    assert a.add(servers=ac) is True
+    assert a.add(services=ac) is True
 
     # Detect our 3 entry as they should have loaded successfully
     assert len(a) == 3
@@ -1172,13 +1172,13 @@ def test_config_base_parse_yaml_file03(tmpdir):
     assert len(ac) == 1
 
     # no notifications lines processed is 3
-    assert len(ac.servers()) == 3
+    assert len(ac.services()) == 3
 
     # Test our ability to add Config objects to our apprise object
     a = Apprise()
 
     # Add our configuration object
-    assert a.add(servers=ac) is True
+    assert a.add(services=ac) is True
 
     # Detect our 3 entry as they should have loaded successfully
     assert len(a) == 3
@@ -1220,13 +1220,13 @@ def test_config_base_parse_yaml_file04(tmpdir):
     assert len(ac) == 1
 
     # no notifications are loaded
-    assert len(ac.servers()) == 3
+    assert len(ac.services()) == 3
 
     # Test our ability to add Config objects to our apprise object
     a = Apprise()
 
     # Add our configuration object
-    assert a.add(servers=ac) is True
+    assert a.add(services=ac) is True
 
     # Detect our 3 entry as they should have loaded successfully
     assert len(a) == 3
@@ -1279,7 +1279,7 @@ def test_apprise_config_template_parse(tmpdir):
     ac = AppriseConfig(paths=str(t))
 
     # 2 emails to be sent
-    assert len(ac.servers()) == 2
+    assert len(ac.services()) == 2
 
     # The below checks are very customized for NotifyMail but just
     # test that the content got passed correctly
@@ -1419,7 +1419,7 @@ def test_apprise_config_template_parse(tmpdir):
     ac = AppriseConfig(paths=str(t))
 
     # 2 emails to be sent and 1 Sinch service call
-    assert len(ac.servers()) == 4
+    assert len(ac.services()) == 4
 
     # Verify our users got placed into the to
     assert len(ac[0][0].targets) == 3
@@ -1472,7 +1472,7 @@ def test_config_base_yaml_trace_logging(tmpdir):
     ):
         ac = AppriseConfig(paths=str(t))
         assert len(ac) == 1
-        assert len(ac.servers()) == 1
+        assert len(ac.services()) == 1
 
         # We expect our TRACE log call to have happened at least once
         assert m_trace.called is True
@@ -1490,17 +1490,17 @@ def test_config_base_clear_cache(tmpdir):
     ac = AppriseConfig(paths=str(t))
 
     # Trigger a load to populate cache inside the config instance
-    assert len(ac.servers()) == 1
+    assert len(ac.services()) == 1
 
     # The underlying config object should have cached state
     cfg = ac[0]
     assert isinstance(cfg, ConfigBase)
-    assert isinstance(getattr(cfg, "_cached_servers", None), list)
+    assert isinstance(getattr(cfg, "_cached_services", None), list)
     assert getattr(cfg, "_cached_time", None) is not None
 
     # Now clear it and confirm it resets as expected
     cfg.clear_cache()
-    assert getattr(cfg, "_cached_servers", None) is None
+    assert getattr(cfg, "_cached_services", None) is None
     assert getattr(cfg, "_cached_time", None) is None
 
 
@@ -1545,7 +1545,7 @@ def test_config_base_expired_with_int_cache(monkeypatch):
     cb = ConfigBase(cache=30)
 
     # Seed cache
-    cb._cached_servers = []
+    cb._cached_services = []
     cb._cached_time = 1000.0
 
     # Within cache window

--- a/tests/test_config_base.py
+++ b/tests/test_config_base.py
@@ -107,8 +107,8 @@ def test_config_base():
     # read is not supported in the base object; only the children
     assert cb.read() is None
 
-    # There are no servers loaded on a freshly created object
-    assert len(cb.servers()) == 0
+    # There are no services loaded on a freshly created object
+    assert len(cb.services()) == 0
 
     # Unsupported URLs are not parsed
     assert ConfigBase.parse_url(url="invalid://") is None
@@ -1296,7 +1296,7 @@ include:
     assert "http://localhost/apprise/cfg03" in config
 
 
-def test_config_base_config_parse_yaml_includes(
+def test_config_base_yaml_includes(
     requests_remote_config: Mock,
 ) -> None:
     """
@@ -1325,13 +1325,13 @@ def test_config_base_config_parse_yaml_includes(
     )
 
     # Force a fresh parse and get the loaded plugin
-    servers = ac.servers()
+    services = ac.services()
 
     # the following will return
-    assert len(servers) == 3
+    assert len(services) == 3
 
     # representation for NotifyBase subclasses.
-    urls = {n.url() for n in servers}
+    urls = {n.url() for n in services}
 
     # The *exact* URL string may include extra params depending on defaults,
     # so we check using containment instead of strict equality.
@@ -1709,10 +1709,10 @@ urls:
 
     ac = AppriseConfig(paths=str(cfg))
     # Force a fresh parse and get the loaded plugin
-    servers = ac.servers()
-    assert len(servers) == 1
+    services = ac.services()
+    assert len(services) == 1
 
-    plugin = servers[0]
+    plugin = services[0]
     asset = plugin.asset
 
     # tz was accepted and normalised
@@ -1747,10 +1747,10 @@ urls:
 
     base_asset = AppriseAsset(timezone="UTC")
     ac = AppriseConfig(paths=str(cfg))
-    servers = ac.servers(asset=base_asset)
-    assert len(servers) == 1
+    services = ac.services(asset=base_asset)
+    assert len(services) == 1
 
-    tzinfo = servers[0].asset.tzinfo
+    tzinfo = services[0].asset.tzinfo
 
     # The key assertion: 'tz' MUST NOT have been applied
     assert getattr(tzinfo, "key", "").lower() != "europe/london"
@@ -1790,10 +1790,10 @@ urls:
 
     base_asset = AppriseAsset(timezone="UTC")
     ac = AppriseConfig(paths=str(cfg))
-    servers = ac.servers(asset=base_asset)
-    assert len(servers) == 1
+    services = ac.services(asset=base_asset)
+    assert len(services) == 1
 
-    tzinfo = servers[0].asset.tzinfo
+    tzinfo = services[0].asset.tzinfo
 
     # 1) Did not “accidentally” become a valid IANA from elsewhere.
     assert getattr(tzinfo, "key", "").lower() != "europe/london"
@@ -1805,7 +1805,7 @@ urls:
     assert isinstance(tzinfo.tzname(dt), str)
 
 
-def test_config_base_parse_yaml_file05_tags_alias_dict_form(tmpdir):
+def test_config_base_yaml_tag_alias_dict(tmpdir):
     """
     API: ConfigBase.parse_yaml_file (#5)
 
@@ -1832,10 +1832,10 @@ def test_config_base_parse_yaml_file05_tags_alias_dict_form(tmpdir):
     assert len(ac) == 1
 
     # All entries should load
-    assert len(ac.servers()) == 3
+    assert len(ac.services()) == 3
 
     a = Apprise()
-    assert a.add(servers=ac) is True
+    assert a.add(services=ac) is True
     assert len(a) == 3
 
     # Verify tag matching works
@@ -1847,7 +1847,7 @@ def test_config_base_parse_yaml_file05_tags_alias_dict_form(tmpdir):
     assert sum(1 for _ in a.find("test1, test3")) == 2
 
 
-def test_config_base_parse_yaml_file06_tags_alias_list_form(tmpdir):
+def test_config_base_yaml_tag_alias_list(tmpdir):
     """
     API: ConfigBase.parse_yaml_file (#6)
 
@@ -1874,10 +1874,10 @@ def test_config_base_parse_yaml_file06_tags_alias_list_form(tmpdir):
     assert len(ac) == 1
 
     # First URL expands to 2, second expands to 1
-    assert len(ac.servers()) == 3
+    assert len(ac.services()) == 3
 
     a = Apprise()
-    assert a.add(servers=ac) is True
+    assert a.add(services=ac) is True
     assert len(a) == 3
 
     # Verify tag matching works across expanded entries
@@ -1887,7 +1887,7 @@ def test_config_base_parse_yaml_file06_tags_alias_list_form(tmpdir):
     assert sum(1 for _ in a.find("test1, test2")) == 2
 
 
-def test_config_base_parse_yaml_file07_tag_priority_over_tags(tmpdir):
+def test_config_base_yaml_tag_priority(tmpdir):
     """
     API: ConfigBase.parse_yaml_file (#7)
 
@@ -1908,10 +1908,10 @@ def test_config_base_parse_yaml_file07_tag_priority_over_tags(tmpdir):
     assert len(ac) == 1
 
     # Entry should load successfully
-    assert len(ac.servers()) == 1
+    assert len(ac.services()) == 1
 
     a = Apprise()
-    assert a.add(servers=ac) is True
+    assert a.add(services=ac) is True
     assert len(a) == 1
 
     # Tag priority check

--- a/tests/test_config_http.py
+++ b/tests/test_config_http.py
@@ -179,7 +179,7 @@ def test_config_http(mock_post):
     # make another remote request
     mock_post.reset_mock()
     assert ch
-    assert len(ch.servers()) == 1
+    assert len(ch.services()) == 1
     assert len(ch) == 1
 
     # No remote post has been made
@@ -189,7 +189,7 @@ def test_config_http(mock_post):
         # even with 10 seconds elapsed, no fetch will be made
         assert ch.expired() is False
         assert ch
-        assert len(ch.servers()) == 1
+        assert len(ch.services()) == 1
         assert len(ch) == 1
 
     # No remote post has been made
@@ -199,7 +199,7 @@ def test_config_http(mock_post):
         # but 30+ seconds from now is considered expired
         assert ch.expired() is True
         assert ch
-        assert len(ch.servers()) == 1
+        assert len(ch.services()) == 1
         assert len(ch) == 1
 
     # Our content would have been renewed with a single new fetch

--- a/tests/test_decorator_notify.py
+++ b/tests/test_decorator_notify.py
@@ -691,7 +691,7 @@ def test_notify_multi_instance_decoration(tmpdir):
     assert len(ac) == 1
 
     # 2 notification endpoints are loaded
-    assert len(ac.servers()) == 2
+    assert len(ac.services()) == 2
 
     # Nothing stored yet in our object
     assert len(verify_obj) == 0

--- a/tests/test_escapes.py
+++ b/tests/test_escapes.py
@@ -52,10 +52,10 @@ def test_apprise_interpret_escapes(mock_request):
     # Load our asset
     a = apprise.Apprise(asset=asset)
 
-    # add a test server
+    # add a test service
     assert a.add("json://localhost") is True
 
-    # Our servers should carry this flag
+    # Our services should carry this flag
     assert a[0].asset.interpret_escapes is False
 
     # Send notification
@@ -98,10 +98,10 @@ def test_apprise_interpret_escapes(mock_request):
     # Load our asset
     a = apprise.Apprise(asset=asset)
 
-    # add a test server
+    # add a test service
     assert a.add("json://localhost") is True
 
-    # Our servers should carry this flag
+    # Our services should carry this flag
     assert a[0].asset.interpret_escapes is True
 
     # Send notification

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -401,10 +401,10 @@ def test_apprise_secure_logging(mock_request):
     a = Apprise(asset=asset)
 
     with LogCapture(level=logging.DEBUG) as stream:
-        # add a test server
+        # add a test service
         assert a.add("json://user:pass1$-3!@localhost") is True
 
-        # Our servers should carry this flag
+        # Our services should carry this flag
         assert a[0].asset.secure_logging is True
 
         logs = re.split(r"\r*\n", stream.getvalue().rstrip())
@@ -436,10 +436,10 @@ def test_apprise_secure_logging(mock_request):
     a = Apprise(asset=asset)
 
     with LogCapture(level=logging.DEBUG) as stream:
-        # add a test server
+        # add a test service
         assert a.add("json://user:pass1$-3!@localhost") is True
 
-        # Our servers should carry this flag
+        # Our services should carry this flag
         assert a[0].asset.secure_logging is False
 
         logs = re.split(r"\r*\n", stream.getvalue().rstrip())

--- a/tests/test_plugin_aprs.py
+++ b/tests/test_plugin_aprs.py
@@ -390,5 +390,5 @@ def test_plugin_aprs_config_files():
     # Add our configuration
     aobj.add(ac)
 
-    assert len(ac.servers()) == 6
+    assert len(ac.services()) == 6
     assert len(aobj) == 6

--- a/tests/test_plugin_dapnet.py
+++ b/tests/test_plugin_dapnet.py
@@ -256,10 +256,10 @@ def test_plugin_dapnet_config_files(mock_post):
     # Add our configuration
     aobj.add(ac)
 
-    # We should be able to read our 7 servers from that
+    # We should be able to read our 7 services from that
     # 4x normal (invalid + 3 exclusivly specified to be so)
     # 3x emerg
-    assert len(ac.servers()) == 7
+    assert len(ac.services()) == 7
     assert len(aobj) == 7
     assert len(list(aobj.find(tag="normal"))) == 3
     for s in aobj.find(tag="normal"):

--- a/tests/test_plugin_gnome.py
+++ b/tests/test_plugin_gnome.py
@@ -325,11 +325,11 @@ def test_plugin_gnome_parse_configuration(obj):
     # Add our configuration
     aobj.add(ac)
 
-    # We should be able to read our 14 servers from that
+    # We should be able to read our 14 services from that
     # 6x low
     # 6x high
     # 2x invalid (so takes on normal urgency)
-    assert len(ac.servers()) == 14
+    assert len(ac.services()) == 14
     assert len(aobj) == 14
     assert len(list(aobj.find(tag="low"))) == 6
     for s in aobj.find(tag="low"):

--- a/tests/test_plugin_gotify.py
+++ b/tests/test_plugin_gotify.py
@@ -201,11 +201,11 @@ def test_plugin_gotify_config_files(mock_post):
     # Add our configuration
     aobj.add(ac)
 
-    # We should be able to read our 8 servers from that
+    # We should be able to read our 8 services from that
     # 4x low
     # 3x emerg
     # 1x invalid (so takes on normal priority)
-    assert len(ac.servers()) == 8
+    assert len(ac.services()) == 8
     assert len(aobj) == 8
     assert len(list(aobj.find(tag="low"))) == 4
     for s in aobj.find(tag="low"):

--- a/tests/test_plugin_growl.py
+++ b/tests/test_plugin_growl.py
@@ -303,8 +303,8 @@ def test_plugin_growl_general(mock_gntp):
         # Our expected Query response (True, False, or exception type)
         response = meta.get("response", True)
 
-        # Allow us to force the server response code to be something other then
-        # the defaults
+        # Allow us to force the server response code to be something other
+        # then the defaults
         growl_response = meta.get("growl_response", bool(response))
 
         mock_notifier = mock.Mock()
@@ -423,11 +423,11 @@ def test_plugin_growl_config_files(mock_gntp):
     # Add our configuration
     aobj.add(ac)
 
-    # We should be able to read our 7 servers from that
+    # We should be able to read our 7 services from that
     # 3x low
     # 3x emerg
     # 1x invalid (so takes on normal priority)
-    assert len(ac.servers()) == 7
+    assert len(ac.services()) == 7
     assert len(aobj) == 7
     assert len(list(aobj.find(tag="low"))) == 3
     for s in aobj.find(tag="low"):

--- a/tests/test_plugin_jira.py
+++ b/tests/test_plugin_jira.py
@@ -427,11 +427,11 @@ def test_plugin_jira_config_files(mock_post):
     # Add our configuration
     aobj.add(ac)
 
-    # We should be able to read our 9 servers from that
+    # We should be able to read our 9 services from that
     # 4x low
     # 4x emerg
     # 1x invalid (so takes on normal priority)
-    assert len(ac.servers()) == 9
+    assert len(ac.services()) == 9
     assert len(aobj) == 9
     assert len(list(aobj.find(tag="low"))) == 4
     for s in aobj.find(tag="low"):

--- a/tests/test_plugin_join.py
+++ b/tests/test_plugin_join.py
@@ -255,11 +255,11 @@ def test_plugin_join_config_files(mock_post):
     # Add our configuration
     aobj.add(ac)
 
-    # We should be able to read our 7 servers from that
+    # We should be able to read our 7 services from that
     # 3x low
     # 3x emerg
     # 1x invalid (so takes on normal priority)
-    assert len(ac.servers()) == 7
+    assert len(ac.services()) == 7
     assert len(aobj) == 7
     assert len(list(aobj.find(tag="low"))) == 3
     for s in aobj.find(tag="low"):

--- a/tests/test_plugin_ntfy.py
+++ b/tests/test_plugin_ntfy.py
@@ -695,11 +695,11 @@ def test_plugin_ntfy_config_files(mock_post, mock_get):
     # Add our configuration
     aobj.add(ac)
 
-    # We should be able to read our 8 servers from that
+    # We should be able to read our 8 services from that
     # 3x min
     # 4x max
     # 1x invalid (so takes on normal priority)
-    assert len(ac.servers()) == 8
+    assert len(ac.services()) == 8
     assert len(aobj) == 8
     assert len(list(aobj.find(tag="min"))) == 3
     for s in aobj.find(tag="min"):
@@ -850,9 +850,9 @@ def test_plugin_ntfy_xtags_no_apprise_tag_collision():
     )
     a = apprise.Apprise()
     a.add(cfg)
-    servers = list(cfg.servers())
-    assert len(servers) == 1
-    s = servers[0]
+    services = list(cfg.services())
+    assert len(services) == 1
+    s = services[0]
     # X-Tags must be preserved
     assert s._NotifyNtfy__tags == ["warning"]
     # No Apprise routing tag should have been created

--- a/tests/test_plugin_opsgenie.py
+++ b/tests/test_plugin_opsgenie.py
@@ -426,11 +426,11 @@ def test_plugin_opsgenie_config_files(mock_post):
     # Add our configuration
     aobj.add(ac)
 
-    # We should be able to read our 9 servers from that
+    # We should be able to read our 9 services from that
     # 4x low
     # 4x emerg
     # 1x invalid (so takes on normal priority)
-    assert len(ac.servers()) == 9
+    assert len(ac.services()) == 9
     assert len(aobj) == 9
     assert len(list(aobj.find(tag="low"))) == 4
     for s in aobj.find(tag="low"):

--- a/tests/test_plugin_prowl.py
+++ b/tests/test_plugin_prowl.py
@@ -228,11 +228,11 @@ def test_plugin_prowl_config_files(mock_post):
     # Add our configuration
     aobj.add(ac)
 
-    # We should be able to read our 7 servers from that
+    # We should be able to read our 7 services from that
     # 3x low
     # 3x emerg
     # 1x invalid (so takes on normal priority)
-    assert len(ac.servers()) == 7
+    assert len(ac.services()) == 7
     assert len(aobj) == 7
     assert len(list(aobj.find(tag="low"))) == 3
     for s in aobj.find(tag="low"):

--- a/tests/test_plugin_pushover.py
+++ b/tests/test_plugin_pushover.py
@@ -693,11 +693,11 @@ def test_plugin_pushover_config_files(mock_post):
     # Add our configuration
     aobj.add(ac)
 
-    # We should be able to read our 7 servers from that
+    # We should be able to read our 7 services from that
     # 3x low
     # 3x emerg
     # 1x invalid (so takes on normal priority)
-    assert len(ac.servers()) == 7
+    assert len(ac.services()) == 7
     assert len(aobj) == 7
     assert len(list(aobj.find(tag="low"))) == 3
     for s in aobj.find(tag="low"):

--- a/tests/test_retry_wait.py
+++ b/tests/test_retry_wait.py
@@ -708,7 +708,7 @@ class TestStaticHelpers:
         """Returns 0 when no tag in service.tags matches tag_name."""
         service = mock.Mock()
         service.tags = {AppriseTag("alerts", priority=3, has_priority=True)}
-        assert Apprise._server_priority_for_tag_name(service, "backup") == 0
+        assert Apprise._service_priority_for_tag_name(service, "backup") == 0
 
     def test_match_service_retry_plain_string_tag(self):
         """Plain string in service.tags matched by a priority-prefixed token.


### PR DESCRIPTION
## Description
This is a breaking change that renames all reference from `server` to `service` that resided in the Apprise core.  8 years ago when I started the project, it made sense.  But seeing how we're introducing breaking changes in this new major release (Apprise v2), I want to address the OCD in me and fix this variable naming and references to 'servers'.

I personally found this confusing and 'services' makes more sense going forward.  The key things that may break public references will be:
- `servers` → `services`
- `servers()` → `services()`
- `server_pop()` → `service_pop()`

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/115](https://github.com/caronc/apprise-docs/pull/115)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
<!-- If your change is testable by others, define how to validate it here -->
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@<this.branch-name>

# Test coverage still 100% - no breaking changes from an Apprise perspective in this code base
tox -e qa
```
