### PR TITLE
Honor language= in onesignal:// and preserve it through url()

### DIFF
--- a/apprise/plugins/one_signal.py
+++ b/apprise/plugins/one_signal.py
@@ -160,6 +160,9 @@ class NotifyOneSignal(NotifyBase):
                 "type": "string",
                 "default": "en",
             },
+            "lang": {
+                "alias_of": "language",
+            },
             "image": {
                 "name": _("Include Image"),
                 "type": "bool",
@@ -564,6 +567,14 @@ class NotifyOneSignal(NotifyBase):
                 "yes" if (self.decode_tpl_args or needs_decoding) else "no"
             )
 
+        if self.subtitle:
+            # Our Subtitle if one was specified
+            params["subtitle"] = self.subtitle
+
+        if self.language != self.template_args["language"]["default"]:
+            # Only present our language if it differs from the default
+            params["language"] = self.language
+
         return "{schema}://{tp_id}{app}@{apikey}/{targets}?{params}".format(
             schema=self.secure_protocol,
             tp_id=(
@@ -697,7 +708,14 @@ class NotifyOneSignal(NotifyBase):
                 results["qsd"]["subtitle"]
             )
 
-        if "lang" in results["qsd"] and len(results["qsd"]["lang"]):
+        # language= is the argument declared in template_args (and the one
+        # documented); lang= is kept as an alias for backwards compatibility.
+        if "language" in results["qsd"] and len(results["qsd"]["language"]):
+            results["language"] = NotifyOneSignal.unquote(
+                results["qsd"]["language"]
+            )
+
+        elif "lang" in results["qsd"] and len(results["qsd"]["lang"]):
             results["language"] = NotifyOneSignal.unquote(
                 results["qsd"]["lang"]
             )

--- a/tests/test_plugin_onesignal.py
+++ b/tests/test_plugin_onesignal.py
@@ -148,8 +148,23 @@ apprise_url_tests = (
     (
         "onesignal://appid@apikey/playerid/?lang=es&subtitle=Sub",
         {
-            # Test Language and Subtitle Over-ride
+            # Test Language and Subtitle Over-ride (lang= alias)
             "instance": NotifyOneSignal,
+        },
+    ),
+    (
+        "onesignal://appid@apikey/playerid/?language=es&subtitle=Sub",
+        {
+            # Test Language and Subtitle Over-ride (language= as declared
+            # in template_args)
+            "instance": NotifyOneSignal,
+        },
+    ),
+    (
+        "onesignal://appid@apikey/playerid/?language=X",
+        {
+            # invalid language id (must be 2 characters)
+            "instance": TypeError,
         },
     ),
     (
@@ -366,6 +381,71 @@ def test_plugin_onesignal_url_round_trip():
     assert reloaded.targets["include_external_user_ids"] == ["@user"]
     assert reloaded.targets["included_segments"] == ["#segment"]
     assert reloaded.url() == url
+
+
+@mock.patch("requests.post")
+def test_plugin_onesignal_language_and_subtitle(mock_post):
+    """NotifyOneSignal() language= and subtitle= handling."""
+    mock_post.return_value = requests.Request()
+    mock_post.return_value.status_code = requests.codes.ok
+
+    # language= is the argument declared in template_args; it must be honored
+    obj = Apprise.instantiate("onesignal://appid@apikey/player/?language=fr")
+    assert isinstance(obj, NotifyOneSignal)
+    assert obj.language == "fr"
+
+    # lang= remains supported as an alias
+    obj = Apprise.instantiate("onesignal://appid@apikey/player/?lang=fr")
+    assert isinstance(obj, NotifyOneSignal)
+    assert obj.language == "fr"
+
+    # When both are provided, the declared language= entry wins
+    obj = Apprise.instantiate(
+        "onesignal://appid@apikey/player/?language=fr&lang=de"
+    )
+    assert isinstance(obj, NotifyOneSignal)
+    assert obj.language == "fr"
+
+    # An invalid language= is rejected the same way lang= is
+    with pytest.raises(TypeError):
+        Apprise.instantiate(
+            "onesignal://appid@apikey/player/?language=X",
+            suppress_exceptions=False,
+        )
+
+    # Both settings must survive a url() reload; previously neither was
+    # emitted, so a saved configuration silently reverted to the 'en'
+    # default and dropped the subtitle entirely.
+    obj = Apprise.instantiate(
+        "onesignal://appid@apikey/player/?language=fr&subtitle=Heads%20Up"
+    )
+    assert isinstance(obj, NotifyOneSignal)
+
+    url = obj.url()
+    assert "language=fr" in url
+    assert "subtitle=Heads%20Up" in url
+
+    reloaded = Apprise.instantiate(url)
+    assert isinstance(reloaded, NotifyOneSignal)
+    assert reloaded.language == "fr"
+    assert reloaded.subtitle == "Heads Up"
+    assert reloaded.url() == url
+
+    # The default language is not emitted, and no subtitle means no entry
+    obj = Apprise.instantiate("onesignal://appid@apikey/player")
+    assert isinstance(obj, NotifyOneSignal)
+    assert obj.language == "en"
+    assert "language=" not in obj.url()
+    assert "subtitle=" not in obj.url()
+
+    # The language keys the payload OneSignal is sent, so losing it changed
+    # what was actually delivered
+    assert reloaded.notify(title="Title", body="Body") is True
+    assert mock_post.call_count == 1
+    payload = loads(mock_post.call_args_list[0][1]["data"])
+    assert payload["headings"] == {"fr": "Title"}
+    assert payload["contents"] == {"fr": "Body"}
+    assert payload["subtitle"] == {"fr": "Heads Up"}
 
 
 @mock.patch("requests.post")


### PR DESCRIPTION
## Description

`NotifyOneSignal` declares `language` in `template_args` (`apprise/plugins/one_signal.py:158`) with a default of `en`, and the OneSignal service documentation lists `language` as "The 2 character language code to push your message as". `parse_url()` never read that argument. It looked up `results["qsd"]["lang"]` instead (`apprise/plugins/one_signal.py:700`), a key that appears nowhere in `template_args`, so the declared and documented `language=` was accepted silently and did nothing, and the undeclared `lang=` was the only spelling that worked.

```python
>>> import apprise
>>> apprise.Apprise.instantiate("onesignal://appid@apikey/player/?language=fr").language
'en'
>>> apprise.Apprise.instantiate("onesignal://appid@apikey/player/?lang=fr").language
'fr'
```

`url()` compounded this by emitting neither `language` nor `subtitle`, so both settings were discarded whenever a configuration was rebuilt from `url()`. This is not cosmetic: `self.language` keys the `headings`, `contents` and `subtitle` dictionaries in the payload sent to OneSignal, so a reloaded object delivered the message under `en` and dropped the subtitle entirely.

```python
>>> obj = apprise.Apprise.instantiate("onesignal://appid@apikey/player/?lang=fr&subtitle=Heads%20Up")
>>> apprise.Apprise.instantiate(obj.url()).language
'en'
>>> apprise.Apprise.instantiate(obj.url()).subtitle is None
True
```

**Fix:** `parse_url()` now reads the declared `language=` first and falls back to `lang=`, following the same first/fallback shape `smsmanager.py` uses for its `from=` and `sender=` pair. `lang` is registered as an `alias_of` entry so it remains supported and is visible in the plugin schema rather than being an undocumented accident. `url()` emits `subtitle` when one is set and `language` when it differs from the default, matching how `contents` and `decode` are already conditionally emitted a few lines above.

No documentation change is needed: the service documentation already describes `language`, and this makes the code match it.

## Checklist
* [ ] Documentation ticket created (if applicable): not applicable, the documented `language=` argument is what this makes work
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing

Added `test_plugin_onesignal_language_and_subtitle` to `tests/test_plugin_onesignal.py` covering `language=`, the `lang=` alias, `language=` winning when both are supplied, `language=X` being rejected for not being 2 characters, the `url()` round trip preserving both values, the default `en` not being emitted, and the resulting payload keying `headings`, `contents` and `subtitle` under `fr`. Two entries were also added to `apprise_url_tests` so `AppriseURLTester` exercises `language=` alongside the existing `lang=` entry.

Confirmed the tests actually cover the bug. Reverting only `apprise/plugins/one_signal.py` to master while keeping the new tests fails:

```
FAILED tests/test_plugin_onesignal.py::test_plugin_onesignal_urls - AssertionError
FAILED tests/test_plugin_onesignal.py::test_plugin_onesignal_language_and_subtitle
E       AssertionError: assert 'en' == 'fr'
2 failed, 3 passed
```

With the fix, `python -m pytest tests/test_plugin_onesignal.py -q` gives `5 passed`, and `coverage run --source=apprise -m pytest tests/test_plugin_onesignal.py` followed by `coverage report -m --include="*one_signal*"` reports `191 statements, 0 missed, 80 branches, 0 partial, 100.0%` for the changed file.

`ruff check .` reports `All checks passed!` and `ruff format --check .` reports `427 files already formatted`, both on the pinned `ruff==0.15.8` from `tox -e lint`. The full suite (`coverage run --source=apprise -m pytest tests`) was run on Python 3.11 with all plugin extras installed.

Anyone can reproduce the parsing half without a OneSignal account:

```bash
python -c "import apprise; print(apprise.Apprise.instantiate('onesignal://appid@apikey/player/?language=fr').language)"
```

On master this prints `en`. With this branch it prints `fr`.
