### PR TITLE
feat: add WPUSH (wpush://) notification plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ The table below identifies the services this tool supports and some example serv
 | [WeChat (WeCom)](https://appriseit.com/services/wechat/) | wechat://  | (TCP) 443   | wechat://CorpID:AppSecret@AgentID/@all<br/>wechat://CorpID:AppSecret@AgentID/UserID
 | [WeCom Bot](https://appriseit.com/services/wecombot/) | wecombot://  | (TCP) 443   | wecombot://BotKey
 | [WhatsApp](https://appriseit.com/services/whatsapp/) | whatsapp://  | (TCP) 443   | whatsapp://AccessToken@FromPhoneID/ToPhoneNo<br/>whatsapp://Template:AccessToken@FromPhoneID/ToPhoneNo
+| [WPUSH](https://appriseit.com/services/wpush/) | wpush://  | (TCP) 443   | wpush://APIKey<br/>wpush://APIKey/Topic1/Topic2/TopicN
 | [WxPusher](https://appriseit.com/services/wxpusher/) | wxpusher://  | (TCP) 443   | wxpusher://AppToken@UserID1/UserID2/UserIDN<br/>wxpusher://AppToken@Topic1/Topic2/Topic3<br/>wxpusher://AppToken@UserID1/Topic1/
 | [XBMC](https://appriseit.com/services/xbmc/) | xbmc:// or xbmcs://    | (TCP) 8080 or 443   | xbmc://hostname<br />xbmc://user@hostname<br />xbmc://user:password@hostname:port
 | [XMPP](https://appriseit.com/services/xmpp/) | xmpp:// or xmpps://    | (TCP) 5222 or 5223   | xmpp://user:pass@hostname<br />xmpps://user:pass@hostname/jid<br />xmpps://user:pass@hostname/jid1/jid2@example.ca

--- a/apprise/plugins/wpush.py
+++ b/apprise/plugins/wpush.py
@@ -1,0 +1,339 @@
+#
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# WPUSH is a Chinese multi-channel push platform (WeChat, App, SMS, email,
+# DingTalk, Feishu, WeCom, webhook, and more). Docs: https://wpush.cn/docs
+#
+# Obtain your API Key from https://wpush.cn/settings (starts with WPUSH).
+# Bind at least one channel at https://wpush.cn/channels before sending.
+#
+# Apprise URL forms:
+#   wpush://{apikey}
+#   wpush://{apikey}?channel=wechat
+#   wpush://{apikey}?channel=feishu&topic_code={code}
+#   wpush://?apikey={apikey}
+#
+# Native API URL (also accepted):
+#   https://api.wpush.cn/api/v1/send?apikey={apikey}
+#
+# Success is JSON code === 0 (unlike PushPlus which uses code 200).
+
+import json
+import re
+
+import requests
+
+from ..common import NotifyType
+from ..locale import gettext_lazy as _
+from ..url import PrivacyMode
+from ..utils.parse import validate_regex
+from .base import NotifyBase
+
+
+class WPushChannel:
+    """WPUSH delivery channels."""
+
+    WECHAT = "wechat"
+    APP = "app"
+    SMS = "sms"
+    MAIL = "mail"
+    WEBHOOK = "webhook"
+    DINGTALK = "dingtalk"
+    FEISHU = "feishu"
+    WECHAT_WORK = "wechat_work"
+    CLAWBOT = "clawbot"
+    QQBOT = "qqbot"
+
+
+WPUSH_CHANNELS = (
+    WPushChannel.WECHAT,
+    WPushChannel.APP,
+    WPushChannel.SMS,
+    WPushChannel.MAIL,
+    WPushChannel.WEBHOOK,
+    WPushChannel.DINGTALK,
+    WPushChannel.FEISHU,
+    WPushChannel.WECHAT_WORK,
+    WPushChannel.CLAWBOT,
+    WPushChannel.QQBOT,
+)
+
+WPUSH_CHANNEL_DEFAULT = WPushChannel.WECHAT
+
+
+class NotifyWPush(NotifyBase):
+    """A wrapper for WPUSH Notifications."""
+
+    service_name = "WPUSH"
+
+    service_url = "https://wpush.cn/"
+
+    secure_protocol = "wpush"
+
+    setup_url = "https://wpush.cn/docs"
+
+    notify_url = "https://api.wpush.cn/api/v1/send"
+
+    # Practical caps aligned with WPUSH open API docs
+    body_maxlen = 10000
+    title_maxlen = 255
+
+    templates = ("{schema}://{apikey}",)
+
+    template_tokens = dict(
+        NotifyBase.template_tokens,
+        **{
+            "apikey": {
+                "name": _("API Key"),
+                "type": "string",
+                "private": True,
+                "required": True,
+                # Keys start with WPUSH followed by alphanumeric characters
+                "regex": (r"^WPUSH[a-z0-9]+$", "i"),
+            },
+        },
+    )
+
+    template_args = dict(
+        NotifyBase.template_args,
+        **{
+            "apikey": {
+                "alias_of": "apikey",
+            },
+            "channel": {
+                "name": _("Channel"),
+                "type": "choice:string",
+                "values": WPUSH_CHANNELS,
+                "default": WPUSH_CHANNEL_DEFAULT,
+            },
+            "topic_code": {
+                "name": _("Topic Code"),
+                "type": "string",
+            },
+            # Convenience alias used elsewhere in Apprise
+            "to": {
+                "alias_of": "topic_code",
+            },
+        },
+    )
+
+    def __init__(self, apikey, channel=None, topic_code=None, **kwargs):
+        """Initialize WPUSH Object."""
+        super().__init__(**kwargs)
+
+        self.apikey = validate_regex(
+            apikey, *self.template_tokens["apikey"]["regex"]
+        )
+        if not self.apikey:
+            msg = "The WPUSH API Key ({}) is invalid.".format(apikey)
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        if channel:
+            self.channel = next(
+                (c for c in WPUSH_CHANNELS if c == channel.lower()),
+                None,
+            )
+            if not self.channel:
+                msg = "The WPUSH channel ({}) is not valid.".format(channel)
+                self.logger.warning(msg)
+                raise TypeError(msg)
+        else:
+            self.channel = WPUSH_CHANNEL_DEFAULT
+
+        self.topic_code = (
+            topic_code
+            if isinstance(topic_code, str) and topic_code.strip()
+            else None
+        )
+
+    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+        """Perform WPUSH Notification."""
+
+        headers = {
+            "User-Agent": self.app_id,
+            "Content-Type": "application/json",
+        }
+
+        payload = {
+            "apikey": self.apikey,
+            # title is required by WPUSH; fall back to body when empty
+            "title": title if title else body,
+            "content": body,
+            "channel": self.channel,
+        }
+        if self.topic_code:
+            payload["topic_code"] = self.topic_code
+
+        self.logger.debug(
+            "WPUSH POST URL: %s (cert_verify=%r)",
+            self.notify_url,
+            self.verify_certificate,
+        )
+        self.logger.debug("WPUSH Payload: %r", payload)
+
+        self.throttle()
+
+        try:
+            r = requests.post(
+                self.notify_url,
+                headers=headers,
+                data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+                allow_redirects=self.redirects,
+            )
+
+            if r.status_code != requests.codes.ok:
+                status_str = NotifyWPush.http_response_code_lookup(
+                    r.status_code
+                )
+                self.logger.warning(
+                    "Failed to send WPUSH notification: "
+                    "{}{}error={}.".format(
+                        status_str,
+                        ", " if status_str else "",
+                        r.status_code,
+                    )
+                )
+                self.logger.debug(
+                    "Response Details:\r\n%r",
+                    (r.content or b"")[:2000],
+                )
+                return False
+
+            try:
+                content = json.loads(r.content)
+            except (AttributeError, TypeError, ValueError):
+                content = {}
+                self.logger.debug(
+                    "Failed to parse WPUSH JSON response; body: %r",
+                    (r.content or b"")[:2000],
+                )
+
+            # WPUSH success is code === 0 (not PushPlus's 200)
+            api_code = content.get("code") if content else None
+            if api_code != 0:
+                error_str = (
+                    content.get("message", "Unknown error")
+                    if content
+                    else "Unknown error"
+                )
+                self.logger.warning(
+                    "Failed to send WPUSH notification: "
+                    "code={}: {}.".format(api_code, error_str)
+                )
+                self.logger.debug(
+                    "Response Details:\r\n%r",
+                    content if content else (r.content or b"")[:2000],
+                )
+                return False
+
+        except requests.RequestException as e:
+            self.logger.warning(
+                "A Connection error occurred sending WPUSH notification."
+            )
+            self.logger.debug("Socket Exception: %s", str(e))
+            return False
+
+        self.logger.info("Sent WPUSH notification.")
+        return True
+
+    @property
+    def url_identifier(self):
+        """Returns identifiers that make this URL unique."""
+        return (self.secure_protocol, self.apikey)
+
+    def url(self, privacy=False, *args, **kwargs):
+        """Returns the URL built dynamically based on specified arguments."""
+        params = {}
+        if self.channel != WPUSH_CHANNEL_DEFAULT:
+            params["channel"] = self.channel
+        if self.topic_code:
+            params["topic_code"] = self.topic_code
+        params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
+
+        return "{schema}://{apikey}/?{params}".format(
+            schema=self.secure_protocol,
+            apikey=self.pprint(
+                self.apikey, privacy, mode=PrivacyMode.Secret, safe=""
+            ),
+            params=NotifyWPush.urlencode(params),
+        )
+
+    @staticmethod
+    def parse_url(url):
+        """Parses the URL and returns enough arguments to re-instantiate."""
+        results = NotifyBase.parse_url(url, verify_host=False)
+        if not results:
+            return results
+
+        if "apikey" in results["qsd"] and results["qsd"]["apikey"]:
+            results["apikey"] = NotifyWPush.unquote(results["qsd"]["apikey"])
+        else:
+            results["apikey"] = NotifyWPush.unquote(results["host"])
+
+        if "channel" in results["qsd"] and results["qsd"]["channel"]:
+            results["channel"] = NotifyWPush.unquote(results["qsd"]["channel"])
+
+        if "topic_code" in results["qsd"] and results["qsd"]["topic_code"]:
+            results["topic_code"] = NotifyWPush.unquote(
+                results["qsd"]["topic_code"]
+            )
+        elif "to" in results["qsd"] and results["qsd"]["to"]:
+            results["topic_code"] = NotifyWPush.unquote(results["qsd"]["to"])
+
+        return results
+
+    @staticmethod
+    def parse_native_url(url):
+        """Support native WPUSH API URLs:
+        https://api.wpush.cn/api/v1/send?apikey=KEY[&channel=…]
+        """
+        result = re.match(
+            r"^https?://api\.wpush\.cn/api/v1/send"
+            r"(?:\?(?P<params>[^#]+))?$",
+            url,
+            re.I,
+        )
+        if result:
+            params = result.group("params") or ""
+            key = re.search(
+                r"(?:(?:^|&))apikey=(?P<apikey>[^&]+)",
+                params,
+                re.I,
+            )
+            if key:
+                return NotifyWPush.parse_url(
+                    "{schema}://{apikey}/?{params}".format(
+                        schema=NotifyWPush.secure_protocol,
+                        apikey=NotifyWPush.unquote(key.group("apikey")),
+                        params=params,
+                    )
+                )
+        return None

--- a/apprise/plugins/wpush.py
+++ b/apprise/plugins/wpush.py
@@ -45,6 +45,7 @@
 #     wpush://{apikey}/{topic}?channel=feishu,dingtalk
 #     wpush://{apikey}?url=https://example.com/
 #     wpush://{apikey}?channel=qqbot&group={qq_group_code}
+#     wpush://{apikey}?channel=feishu&option=ops
 #
 # Native API URL (also accepted):
 #     https://api.wpush.cn/api/v1/send?apikey={apikey}
@@ -193,9 +194,9 @@ class NotifyWPush(NotifyBase):
             "topic": {
                 "alias_of": "targets",
             },
-            # QQ group code used with channel=qqbot
+            # QQ group code or multi-instance option code (API `option`)
             "group": {
-                "name": _("QQ Group Code"),
+                "name": _("Group / Option Code"),
                 "type": "string",
                 "map_to": "group",
             },
@@ -254,15 +255,15 @@ class NotifyWPush(NotifyBase):
         # Send one request for each resolved topic code
         self.topics = parse_list(targets)
 
-        # QQ group code; ignored unless the qqbot channel is also selected
+        # Sub-target passed as API `option` (QQ group code or instance code)
         self.group = (
             group if isinstance(group, str) and group.strip() else None
         )
 
-        # WPUSH rejects requests that combine group and topic targets
+        # WPUSH rejects requests that combine option and topic targets
         if self.group and self.topics:
             msg = (
-                "The WPUSH group option cannot be combined with topic targets."
+                "The WPUSH option/group cannot be combined with topic targets."
             )
             self.logger.warning(msg)
             raise TypeError(msg)
@@ -316,8 +317,9 @@ class NotifyWPush(NotifyBase):
                 # Add the topic code when broadcasting to a specific topic
                 payload["topic_code"] = topic
 
-            elif self.group and WPushChannel.QQBOT in self.channels:
-                # Send the group code only when QQ Robot is selected
+            elif self.group:
+                # API `option`: qqbot group code, or multi-instance code for
+                # webhook / dingtalk / feishu / wechat_work
                 payload["option"] = self.group
 
             self.logger.debug(
@@ -378,9 +380,9 @@ class NotifyWPush(NotifyBase):
                         (r.content or b"")[:2000],
                     )
 
-                # Check WPUSH's result code
+                # Check WPUSH's result code (reject bool; False == 0 in Python)
                 api_code = content.get("code") if content else None
-                if api_code != 0:
+                if isinstance(api_code, bool) or api_code != 0:
                     # WPUSH rejected the request
                     error_str = (
                         content.get("message", "Unknown error")

--- a/apprise/plugins/wpush.py
+++ b/apprise/plugins/wpush.py
@@ -8,11 +8,11 @@
 # modification, are permitted provided that the following conditions are met:
 #
 # 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
+#    this list of conditions and the following disclaimer.
 #
 # 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
 #
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -26,50 +26,81 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# WPUSH is a Chinese multi-channel push platform (WeChat, App, SMS, email,
-# DingTalk, Feishu, WeCom, webhook, and more). Docs: https://wpush.cn/docs
+# WPUSH sends messages through WeChat, its App, SMS, Email, DingTalk, Feishu,
+# WeCom, Webhooks, WeChat ClawBot, and QQ Robot. One request can use several
+# channels.
 #
-# Obtain your API Key from https://wpush.cn/settings (starts with WPUSH).
-# Bind at least one channel at https://wpush.cn/channels before sending.
+# Steps to get your API Key:
+#  1. Visit https://wpush.cn/ and sign in (or register).
+#  2. Visit https://wpush.cn/apikey and copy your API Key. It always
+#     starts with "WPUSH" followed by 27 more characters (32 total).
+#  3. Visit https://wpush.cn/channels and bind at least one delivery
+#     channel (WeChat, Email, etc.) before sending your first message.
 #
-# Apprise URL forms:
-#   wpush://{apikey}
-#   wpush://{apikey}?channel=wechat
-#   wpush://{apikey}?channel=feishu&topic_code={code}
-#   wpush://?apikey={apikey}
+# Basic Apprise URL:
+#     wpush://{apikey}
+#
+# To notify a topic's subscribers, add extra channels, attach a
+# click-through link, or target a specific QQ group:
+#     wpush://{apikey}/{topic}?channel=feishu,dingtalk
+#     wpush://{apikey}?url=https://example.com/
+#     wpush://{apikey}?channel=qqbot&group={qq_group_code}
 #
 # Native API URL (also accepted):
-#   https://api.wpush.cn/api/v1/send?apikey={apikey}
+#     https://api.wpush.cn/api/v1/send?apikey={apikey}
 #
-# Success is JSON code === 0 (unlike PushPlus which uses code 200).
+# Resources:
+# - https://wpush.cn/docs
+# - https://github.com/WPUSH/skills (current parameters)
 
 import json
 import re
+from uuid import uuid4
 
 import requests
 
 from ..common import NotifyType
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
-from ..utils.parse import validate_regex
+from ..utils.parse import parse_list, validate_regex
 from .base import NotifyBase
 
 
 class WPushChannel:
     """WPUSH delivery channels."""
 
+    # WeChat (WPUSH default)
     WECHAT = "wechat"
+
+    # WPUSH mobile App
     APP = "app"
+
+    # SMS
     SMS = "sms"
+
+    # Email
     MAIL = "mail"
+
+    # Configured Webhook
     WEBHOOK = "webhook"
+
+    # DingTalk
     DINGTALK = "dingtalk"
+
+    # Feishu
     FEISHU = "feishu"
+
+    # WeCom (WeChat Work / Enterprise WeChat)
     WECHAT_WORK = "wechat_work"
+
+    # WeChat ClawBot
     CLAWBOT = "clawbot"
+
+    # QQ Robot with optional group targeting
     QQBOT = "qqbot"
 
 
+# WPUSH accepts one or more of these channel values per request
 WPUSH_CHANNELS = (
     WPushChannel.WECHAT,
     WPushChannel.APP,
@@ -83,28 +114,41 @@ WPUSH_CHANNELS = (
     WPushChannel.QQBOT,
 )
 
+# Default delivery channel
 WPUSH_CHANNEL_DEFAULT = WPushChannel.WECHAT
 
 
 class NotifyWPush(NotifyBase):
     """A wrapper for WPUSH Notifications."""
 
+    # Service name shown to users
     service_name = "WPUSH"
 
+    # WPUSH website
     service_url = "https://wpush.cn/"
 
+    # Apprise URL scheme
     secure_protocol = "wpush"
 
-    setup_url = "https://wpush.cn/docs"
+    # Plugin setup guide
+    setup_url = "https://appriseit.com/services/wpush/"
 
+    # Notification endpoint
     notify_url = "https://api.wpush.cn/api/v1/send"
 
-    # Practical caps aligned with WPUSH open API docs
+    # WPUSH limits messages to 10,000 characters and titles to 255
     body_maxlen = 10000
     title_maxlen = 255
 
-    templates = ("{schema}://{apikey}",)
+    # Define object URL templates
+    templates = (
+        # No topic: broadcast a personal notification
+        "{schema}://{apikey}",
+        # Topics in path: one API call per topic
+        "{schema}://{apikey}/{targets}",
+    )
 
+    # Define our template tokens
     template_tokens = dict(
         NotifyBase.template_tokens,
         **{
@@ -113,39 +157,74 @@ class NotifyWPush(NotifyBase):
                 "type": "string",
                 "private": True,
                 "required": True,
-                # Keys start with WPUSH followed by alphanumeric characters
-                "regex": (r"^WPUSH[a-z0-9]+$", "i"),
+                # WPUSH followed by exactly 27 more characters (32 total)
+                "regex": (r"^WPUSH[a-z0-9]{27}$", "i"),
+            },
+            # Topic codes go directly in the URL path with no prefix
+            "targets": {
+                "name": _("Topics"),
+                "type": "list:string",
             },
         },
     )
 
+    # Define our template arguments
     template_args = dict(
         NotifyBase.template_args,
         **{
+            # Allow the API Key to be supplied as a query parameter
             "apikey": {
                 "alias_of": "apikey",
             },
+            # One or more comma-separated channels; WeChat is the default
             "channel": {
                 "name": _("Channel"),
-                "type": "choice:string",
-                "values": WPUSH_CHANNELS,
-                "default": WPUSH_CHANNEL_DEFAULT,
+                "type": "list:string",
             },
-            "topic_code": {
-                "name": _("Topic Code"),
-                "type": "string",
-            },
-            # Convenience alias used elsewhere in Apprise
+            # ?to= is the standard Apprise alias for targets (topics)
             "to": {
-                "alias_of": "topic_code",
+                "alias_of": "targets",
+            },
+            # Keep WPUSH's ?topic_code= name as another target alias.
+            "topic_code": {
+                "alias_of": "targets",
+            },
+            # ?topic= is another alias for topic targets
+            "topic": {
+                "alias_of": "targets",
+            },
+            # QQ group code used with channel=qqbot
+            "group": {
+                "name": _("QQ Group Code"),
+                "type": "string",
+                "map_to": "group",
+            },
+            # ?option= mirrors WPUSH's own API field name for the above
+            "option": {
+                "alias_of": "group",
+            },
+            # Optional click-through link included with the notification
+            "url": {
+                "name": _("Click URL"),
+                "type": "string",
+                "map_to": "click_url",
             },
         },
     )
 
-    def __init__(self, apikey, channel=None, topic_code=None, **kwargs):
+    def __init__(
+        self,
+        apikey,
+        targets=None,
+        channel=None,
+        group=None,
+        click_url=None,
+        **kwargs,
+    ):
         """Initialize WPUSH Object."""
         super().__init__(**kwargs)
 
+        # Validate the required API Key
         self.apikey = validate_regex(
             apikey, *self.template_tokens["apikey"]["regex"]
         )
@@ -154,166 +233,295 @@ class NotifyWPush(NotifyBase):
             self.logger.warning(msg)
             raise TypeError(msg)
 
+        # Resolve one or more delivery channels (comma-separated)
         if channel:
-            self.channel = next(
-                (c for c in WPUSH_CHANNELS if c == channel.lower()),
-                None,
-            )
-            if not self.channel:
-                msg = "The WPUSH channel ({}) is not valid.".format(channel)
-                self.logger.warning(msg)
-                raise TypeError(msg)
-        else:
-            self.channel = WPUSH_CHANNEL_DEFAULT
+            self.channels = []
+            for entry in parse_list(channel):
+                resolved = next(
+                    (c for c in WPUSH_CHANNELS if c == entry.lower()),
+                    None,
+                )
+                if not resolved:
+                    msg = "The WPUSH channel ({}) is not valid.".format(entry)
+                    self.logger.warning(msg)
+                    raise TypeError(msg)
+                self.channels.append(resolved)
 
-        self.topic_code = (
-            topic_code
-            if isinstance(topic_code, str) and topic_code.strip()
+        else:
+            # Default to WeChat
+            self.channels = [WPUSH_CHANNEL_DEFAULT]
+
+        # Send one request for each resolved topic code
+        self.topics = parse_list(targets)
+
+        # QQ group code; ignored unless the qqbot channel is also selected
+        self.group = (
+            group if isinstance(group, str) and group.strip() else None
+        )
+
+        # WPUSH rejects requests that combine group and topic targets
+        if self.group and self.topics:
+            msg = (
+                "The WPUSH group option cannot be combined with topic targets."
+            )
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # Optional click-through link delivered alongside the notification
+        self.click_url = (
+            click_url
+            if isinstance(click_url, str) and click_url.strip()
             else None
         )
+
+    def __len__(self):
+        """Return the topic count, or one for a direct send."""
+        # Keep direct sends countable by the framework
+        return len(self.topics) if self.topics else 1
 
     def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
         """Perform WPUSH Notification."""
 
+        # Authenticate in both supported locations; WPUSH prefers the header
         headers = {
             "User-Agent": self.app_id,
             "Content-Type": "application/json",
+            "X-API-Key": self.apikey,
         }
 
-        payload = {
-            "apikey": self.apikey,
-            # title is required by WPUSH; fall back to body when empty
-            "title": title if title else body,
-            "content": body,
-            "channel": self.channel,
-        }
-        if self.topic_code:
-            payload["topic_code"] = self.topic_code
+        # A single call can target more than one channel at once
+        channel_str = ",".join(self.channels)
 
-        self.logger.debug(
-            "WPUSH POST URL: %s (cert_verify=%r)",
-            self.notify_url,
-            self.verify_certificate,
-        )
-        self.logger.debug("WPUSH Payload: %r", payload)
+        # Use None to send once without a topic.
+        topics_to_notify = self.topics if self.topics else [None]
 
-        self.throttle()
+        # Track whether any individual send failed
+        has_error = False
 
-        try:
-            r = requests.post(
+        for topic in topics_to_notify:
+            # Build this topic's payload
+            payload = {
+                "apikey": self.apikey,
+                # title is required by WPUSH; fall back to body when empty
+                "title": title if title else body,
+                "content": body,
+                "channel": channel_str,
+            }
+
+            # Add an optional click-through link
+            if self.click_url:
+                payload["url"] = self.click_url
+
+            if topic:
+                # Add the topic code when broadcasting to a specific topic
+                payload["topic_code"] = topic
+
+            elif self.group and WPushChannel.QQBOT in self.channels:
+                # Send the group code only when QQ Robot is selected
+                payload["option"] = self.group
+
+            self.logger.debug(
+                "WPUSH POST URL: %s (cert_verify=%r)",
                 self.notify_url,
-                headers=headers,
-                data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
-                verify=self.verify_certificate,
-                timeout=self.request_timeout,
-                allow_redirects=self.redirects,
+                self.verify_certificate,
             )
+            self.logger.debug("WPUSH Payload: %r", payload)
 
-            if r.status_code != requests.codes.ok:
-                status_str = NotifyWPush.http_response_code_lookup(
-                    r.status_code
-                )
-                self.logger.warning(
-                    "Failed to send WPUSH notification: "
-                    "{}{}error={}.".format(
-                        status_str,
-                        ", " if status_str else "",
-                        r.status_code,
-                    )
-                )
-                self.logger.debug(
-                    "Response Details:\r\n%r",
-                    (r.content or b"")[:2000],
-                )
-                return False
+            # Give each request a unique key to prevent duplicate delivery
+            headers["X-Idempotency-Key"] = str(uuid4())
+
+            # Throttle each request
+            self.throttle()
 
             try:
-                content = json.loads(r.content)
-            except (AttributeError, TypeError, ValueError):
-                content = {}
-                self.logger.debug(
-                    "Failed to parse WPUSH JSON response; body: %r",
-                    (r.content or b"")[:2000],
+                r = requests.post(
+                    self.notify_url,
+                    headers=headers,
+                    # Preserve non-ASCII text, including Chinese characters
+                    data=json.dumps(payload, ensure_ascii=False).encode(
+                        "utf-8"
+                    ),
+                    verify=self.verify_certificate,
+                    timeout=self.request_timeout,
+                    allow_redirects=self.redirects,
                 )
 
-            # WPUSH success is code === 0 (not PushPlus's 200)
-            api_code = content.get("code") if content else None
-            if api_code != 0:
-                error_str = (
-                    content.get("message", "Unknown error")
-                    if content
-                    else "Unknown error"
-                )
+                if r.status_code != requests.codes.ok:
+                    # Log the HTTP failure, then try the next topic
+                    status_str = NotifyWPush.http_response_code_lookup(
+                        r.status_code
+                    )
+                    self.logger.warning(
+                        "Failed to send WPUSH notification: "
+                        "{}{}error={}.".format(
+                            status_str,
+                            ", " if status_str else "",
+                            r.status_code,
+                        )
+                    )
+                    self.logger.debug(
+                        "Response Details:\r\n%r",
+                        (r.content or b"")[:2000],
+                    )
+                    # Mark our failure and continue with the next topic
+                    has_error = True
+                    continue
+
+                # WPUSH reports success as code 0 in its JSON response
+                try:
+                    content = json.loads(r.content)
+                except (AttributeError, TypeError, ValueError):
+                    # Handle malformed, missing, or unavailable response data
+                    content = {}
+                    self.logger.debug(
+                        "Failed to parse WPUSH JSON response; body: %r",
+                        (r.content or b"")[:2000],
+                    )
+
+                # Check WPUSH's result code
+                api_code = content.get("code") if content else None
+                if api_code != 0:
+                    # WPUSH rejected the request
+                    error_str = (
+                        content.get("message", "Unknown error")
+                        if content
+                        else "Unknown error"
+                    )
+                    self.logger.warning(
+                        "Failed to send WPUSH notification: "
+                        "code={}: {}.".format(api_code, error_str)
+                    )
+                    self.logger.debug(
+                        "Response Details:\r\n%r",
+                        content if content else (r.content or b"")[:2000],
+                    )
+                    # Mark our failure and continue with the next topic
+                    has_error = True
+                    continue
+
+            except requests.RequestException as e:
                 self.logger.warning(
-                    "Failed to send WPUSH notification: "
-                    "code={}: {}.".format(api_code, error_str)
+                    "A Connection error occurred sending WPUSH notification."
                 )
-                self.logger.debug(
-                    "Response Details:\r\n%r",
-                    content if content else (r.content or b"")[:2000],
-                )
-                return False
+                self.logger.debug("Socket Exception: %s", str(e))
+                # Mark our failure and continue with the next topic
+                has_error = True
+                continue
 
-        except requests.RequestException as e:
-            self.logger.warning(
-                "A Connection error occurred sending WPUSH notification."
+            # Notification delivered for this topic
+            self.logger.info(
+                "Sent WPUSH notification%s.",
+                " to topic {}".format(topic) if topic else "",
             )
-            self.logger.debug("Socket Exception: %s", str(e))
-            return False
 
-        self.logger.info("Sent WPUSH notification.")
-        return True
+        return not has_error
 
     @property
     def url_identifier(self):
-        """Returns identifiers that make this URL unique."""
+        """Return the fields that uniquely identify this WPUSH account.
+
+        Topics are targets, so they are excluded.
+        """
+        # The API Key alone identifies the WPUSH account
         return (self.secure_protocol, self.apikey)
 
     def url(self, privacy=False, *args, **kwargs):
-        """Returns the URL built dynamically based on specified arguments."""
+        """Build a WPUSH URL from this configuration."""
+
+        # Collect optional URL parameters
         params = {}
-        if self.channel != WPUSH_CHANNEL_DEFAULT:
-            params["channel"] = self.channel
-        if self.topic_code:
-            params["topic_code"] = self.topic_code
+
+        # Include ?channel= when it differs from the default
+        if self.channels != [WPUSH_CHANNEL_DEFAULT]:
+            params["channel"] = ",".join(self.channels)
+
+        # Include the QQ group code when set
+        if self.group:
+            params["group"] = self.group
+
+        # Include the click-through link when set
+        if self.click_url:
+            params["url"] = self.click_url
+
+        # Add standard Apprise options such as verify and format
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
 
+        # Mask the API Key when privacy mode is active
+        apikey_str = self.pprint(
+            self.apikey, privacy, mode=PrivacyMode.Secret, safe=""
+        )
+
+        if self.topics:
+            # One or more topics: include them in the URL path
+            return "{schema}://{apikey}/{targets}/?{params}".format(
+                schema=self.secure_protocol,
+                apikey=apikey_str,
+                targets="/".join(
+                    NotifyWPush.quote(t, safe="") for t in self.topics
+                ),
+                params=NotifyWPush.urlencode(params),
+            )
+
+        # No topics produce a simple personal notification URL
         return "{schema}://{apikey}/?{params}".format(
             schema=self.secure_protocol,
-            apikey=self.pprint(
-                self.apikey, privacy, mode=PrivacyMode.Secret, safe=""
-            ),
+            apikey=apikey_str,
             params=NotifyWPush.urlencode(params),
         )
 
     @staticmethod
     def parse_url(url):
-        """Parses the URL and returns enough arguments to re-instantiate."""
+        """Parse a WPUSH URL into constructor arguments."""
         results = NotifyBase.parse_url(url, verify_host=False)
         if not results:
+            # Stop when the base URL could not be parsed
             return results
 
+        # Prefer ?apikey= query parameter over the URL host field
         if "apikey" in results["qsd"] and results["qsd"]["apikey"]:
             results["apikey"] = NotifyWPush.unquote(results["qsd"]["apikey"])
         else:
             results["apikey"] = NotifyWPush.unquote(results["host"])
 
+        # Collect topic codes from the URL path
+        results["targets"] = NotifyWPush.split_path(results["fullpath"])
+
+        # ?to= adds comma- or space-separated topics
+        if "to" in results["qsd"] and results["qsd"]["to"]:
+            results["targets"] += NotifyWPush.parse_list(results["qsd"]["to"])
+
+        # ?topic_code= mirrors WPUSH's own API field name
+        if "topic_code" in results["qsd"] and results["qsd"]["topic_code"]:
+            results["targets"] += NotifyWPush.parse_list(
+                results["qsd"]["topic_code"]
+            )
+
+        # ?topic= is another alias for topic targets
+        if "topic" in results["qsd"] and results["qsd"]["topic"]:
+            results["targets"] += NotifyWPush.parse_list(
+                results["qsd"]["topic"]
+            )
+
+        # Pass channels to __init__ for splitting and validation
         if "channel" in results["qsd"] and results["qsd"]["channel"]:
             results["channel"] = NotifyWPush.unquote(results["qsd"]["channel"])
 
-        if "topic_code" in results["qsd"] and results["qsd"]["topic_code"]:
-            results["topic_code"] = NotifyWPush.unquote(
-                results["qsd"]["topic_code"]
-            )
-        elif "to" in results["qsd"] and results["qsd"]["to"]:
-            results["topic_code"] = NotifyWPush.unquote(results["qsd"]["to"])
+        # Accept ?option=, but prefer ?group= when both are set
+        if "option" in results["qsd"] and results["qsd"]["option"]:
+            results["group"] = NotifyWPush.unquote(results["qsd"]["option"])
+        if "group" in results["qsd"] and results["qsd"]["group"]:
+            results["group"] = NotifyWPush.unquote(results["qsd"]["group"])
+
+        # Extract the optional click-through link from ?url=
+        if "url" in results["qsd"] and results["qsd"]["url"]:
+            results["click_url"] = NotifyWPush.unquote(results["qsd"]["url"])
 
         return results
 
     @staticmethod
     def parse_native_url(url):
-        """Support native WPUSH API URLs:
-        https://api.wpush.cn/api/v1/send?apikey=KEY[&channel=…]
+        """Parse a native WPUSH API URL such as:
+        https://api.wpush.cn/api/v1/send?apikey=KEY[&channel=...]
         """
         result = re.match(
             r"^https?://api\.wpush\.cn/api/v1/send"

--- a/apprise/plugins/wpush.py
+++ b/apprise/plugins/wpush.py
@@ -181,6 +181,7 @@ class NotifyWPush(NotifyBase):
             "channel": {
                 "name": _("Channel"),
                 "type": "list:string",
+                "values": WPUSH_CHANNELS,
             },
             # ?to= is the standard Apprise alias for targets (topics)
             "to": {
@@ -246,7 +247,11 @@ class NotifyWPush(NotifyBase):
                     msg = "The WPUSH channel ({}) is not valid.".format(entry)
                     self.logger.warning(msg)
                     raise TypeError(msg)
-                self.channels.append(resolved)
+                # Remove duplicate channels before sorting them
+                if resolved not in self.channels:
+                    self.channels.append(resolved)
+
+            self.channels.sort()
 
         else:
             # Default to WeChat
@@ -299,6 +304,12 @@ class NotifyWPush(NotifyBase):
         # Track whether any individual send failed
         has_error = False
 
+        self.logger.debug(
+            "WPUSH POST URL: %s (cert_verify=%r)",
+            self.notify_url,
+            self.verify_certificate,
+        )
+
         for topic in topics_to_notify:
             # Build this topic's payload
             payload = {
@@ -318,15 +329,9 @@ class NotifyWPush(NotifyBase):
                 payload["topic_code"] = topic
 
             elif self.group:
-                # API `option`: qqbot group code, or multi-instance code for
-                # webhook / dingtalk / feishu / wechat_work
+                # The option selects a QQ group or a bound channel instance
                 payload["option"] = self.group
 
-            self.logger.debug(
-                "WPUSH POST URL: %s (cert_verify=%r)",
-                self.notify_url,
-                self.verify_certificate,
-            )
             self.logger.debug("WPUSH Payload: %r", payload)
 
             # Give each request a unique key to prevent duplicate delivery
@@ -380,7 +385,7 @@ class NotifyWPush(NotifyBase):
                         (r.content or b"")[:2000],
                     )
 
-                # Check WPUSH's result code (reject bool; False == 0 in Python)
+                # Accept only integer zero because Booleans compare as numbers
                 api_code = content.get("code") if content else None
                 if isinstance(api_code, bool) or api_code != 0:
                     # WPUSH rejected the request

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -92,7 +92,8 @@ notification services. It supports sending alerts to platforms such as: \
 `Synology Chat`, `Syslog`, `Techulus Push`, `Telegram`, `Threema Gateway`, \
 `Trigv`, `Twilio`, `Twitter`, `Twist`, `Vapid`, `Viber`, `VictorOps`, \
 `Voipms`, `Vonage`, `WebPush`, `WeChat (WeCom)`, `WeCom Bot`, `WhatsApp`, \
-`Webex Teams`, `Workflows`, `WxPusher`, `XBMC`, `XMPP`, `Zoom`, and `Zulip`.}
+`Webex Teams`, `Workflows`, `WPUSH`, `WxPusher`, `XBMC`, `XMPP`, `Zoom`, \
+and `Zulip`.}
 
 Name:           python-%{pypi_name}
 Version:        1.13.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,7 @@ keywords = [
     "WhatsApp",
     "Windows",
     "Workflows",
+    "WPUSH",
     "WxPusher",
     "XBMC",
     "XML",

--- a/tests/test_plugin_wpush.py
+++ b/tests/test_plugin_wpush.py
@@ -199,7 +199,7 @@ def test_plugin_wpush_init():
     obj = NotifyWPush(apikey=GOOD_KEY, channel="mail")
     assert obj.channels == [WPushChannel.MAIL]
 
-    # parse_list() sorts and dedupes, so the stored order is alphabetical
+    # Channels are stored once in alphabetical order
     obj = NotifyWPush(apikey=GOOD_KEY, channel="feishu,dingtalk,qqbot")
     assert obj.channels == [
         WPushChannel.DINGTALK,
@@ -213,6 +213,10 @@ def test_plugin_wpush_init():
 
     obj = NotifyWPush(apikey=GOOD_KEY, channel="qqbot", group="123456")
     assert obj.group == "123456"
+
+    # Channel matching ignores case and duplicates
+    obj = NotifyWPush(apikey=GOOD_KEY, channel="Feishu,dingtalk,feishu")
+    assert obj.channels == [WPushChannel.DINGTALK, WPushChannel.FEISHU]
 
     obj = NotifyWPush(apikey=GOOD_KEY, click_url="https://example.com/")
     assert obj.click_url == "https://example.com/"
@@ -244,7 +248,7 @@ def test_plugin_wpush_url_round_trip():
 
     assert obj.url_identifier == obj2.url_identifier
     assert obj.topics == obj2.topics
-    # parse_list() sorts and dedupes, so the stored order is alphabetical
+    # Channels are stored once in alphabetical order
     assert obj2.channels == [WPushChannel.DINGTALK, WPushChannel.FEISHU]
     assert obj2.click_url == "https://example.com/"
 
@@ -293,7 +297,7 @@ def test_plugin_wpush_send_multi_channel(mock_post):
     response.content = GOOD_RESPONSE.encode("utf-8")
     mock_post.return_value = response
 
-    # parse_list() sorts and dedupes, so the joined string is alphabetical
+    # The payload keeps the stored alphabetical order
     obj = NotifyWPush(apikey=GOOD_KEY, channel="feishu,dingtalk,qqbot")
     assert obj.send(body="msg", title="t") is True
     assert mock_post.call_count == 1
@@ -324,14 +328,13 @@ def test_plugin_wpush_send_qqbot_group(mock_post):
     response.content = GOOD_RESPONSE.encode("utf-8")
     mock_post.return_value = response
 
-    # qqbot selected + group set -> option is sent
+    # Send the group code for QQ Robot
     obj = NotifyWPush(apikey=GOOD_KEY, channel="qqbot", group="123456")
     assert obj.send(body="msg") is True
     payload = loads(mock_post.call_args[1]["data"])
     assert payload["option"] == "123456"
 
-    # group/option is channel-agnostic (feishu/dingtalk/webhook/wechat_work
-    # multi-instance codes, or qqbot group codes)
+    # Other supported channels use option to select a bound instance
     mock_post.reset_mock()
     obj = NotifyWPush(apikey=GOOD_KEY, channel="mail", group="123456")
     assert obj.send(body="msg") is True
@@ -419,8 +422,8 @@ def test_plugin_wpush_apprise_integration(mock_post):
     assert mock_post.call_count == 1
 
 
-def test_plugin_wpush_option_for_non_qqbot_channels():
-    """option/group must be sent for feishu/dingtalk/webhook instance codes."""
+def test_plugin_wpush_instance_options():
+    """Send instance codes through the option field."""
     from json import loads
 
     for channel in ("feishu", "dingtalk", "webhook", "wechat_work"):
@@ -442,8 +445,52 @@ def test_plugin_wpush_option_for_non_qqbot_channels():
             assert payload.get("channel") == channel
 
 
+def test_plugin_wpush_parse_native_url():
+    """Parse supported and invalid native URLs."""
+
+    # Parse the API Key
+    result = NotifyWPush.parse_native_url(
+        "https://api.wpush.cn/api/v1/send?apikey={}".format(GOOD_KEY)
+    )
+    assert result is not None
+    obj = NotifyWPush(**result)
+    assert obj.apikey == GOOD_KEY
+
+    # Preserve the channel parameter
+    result = NotifyWPush.parse_native_url(
+        "https://api.wpush.cn/api/v1/send?apikey={}&channel=mail".format(
+            GOOD_KEY
+        )
+    )
+    assert result is not None
+    obj = NotifyWPush(**result)
+    assert obj.channels == [WPushChannel.MAIL]
+
+    # Reject a URL without an API Key
+    assert (
+        NotifyWPush.parse_native_url(
+            "https://api.wpush.cn/api/v1/send?channel=mail"
+        )
+        is None
+    )
+
+    # Reject other domains
+    assert (
+        NotifyWPush.parse_native_url(
+            "https://other.example.com/api/v1/send?apikey={}".format(GOOD_KEY)
+        )
+        is None
+    )
+
+    # Reject a URL without query parameters
+    assert (
+        NotifyWPush.parse_native_url("https://api.wpush.cn/api/v1/send")
+        is None
+    )
+
+
 def test_plugin_wpush_rejects_boolean_code():
-    """JSON code:false must not be treated as success (False == 0 in Python)."""
+    """Reject Boolean codes even though False equals zero in Python."""
     obj = Apprise.instantiate("wpush://{}".format(GOOD_KEY))
     with mock.patch("requests.post") as mock_post:
         mock_post.return_value = mock.Mock(

--- a/tests/test_plugin_wpush.py
+++ b/tests/test_plugin_wpush.py
@@ -4,7 +4,29 @@
 # Apprise - Push Notification Library.
 # Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
 #
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 
+# Disable logging for a cleaner testing output
 from json import dumps, loads
 import logging
 from unittest import mock
@@ -16,15 +38,14 @@ import requests
 from apprise import Apprise
 from apprise.plugins.wpush import (
     WPUSH_CHANNEL_DEFAULT,
-    WPUSH_CHANNELS,
     NotifyWPush,
     WPushChannel,
 )
 
 logging.disable(logging.CRITICAL)
 
-# WPUSH + 32 alphanumeric characters
-GOOD_KEY = "WPUSH" + ("a" * 32)
+# WPUSH + exactly 27 more alphanumeric characters (32 total)
+GOOD_KEY = "WPUSH" + ("a" * 27)
 
 GOOD_RESPONSE = dumps(
     {"code": 0, "message": "success", "data": "1126950958891274240"}
@@ -64,11 +85,68 @@ apprise_url_tests = (
         },
     ),
     (
+        "wpush://{}?channel=feishu,dingtalk,qqbot".format(GOOD_KEY),
+        {
+            "instance": NotifyWPush,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    (
+        "wpush://{}/topic1/topic2".format(GOOD_KEY),
+        {
+            "instance": NotifyWPush,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    (
+        "wpush://{}?to=topic1,topic2".format(GOOD_KEY),
+        {
+            "instance": NotifyWPush,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    (
         "wpush://{}?topic_code=mytopic".format(GOOD_KEY),
         {
             "instance": NotifyWPush,
             "requests_response_text": GOOD_RESPONSE,
         },
+    ),
+    (
+        "wpush://{}?topic=mytopic".format(GOOD_KEY),
+        {
+            "instance": NotifyWPush,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    (
+        "wpush://{}?channel=qqbot&group=123456".format(GOOD_KEY),
+        {
+            "instance": NotifyWPush,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    (
+        "wpush://{}?channel=qqbot&option=123456".format(GOOD_KEY),
+        {
+            "instance": NotifyWPush,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    (
+        "wpush://{}?url=https://example.com/".format(GOOD_KEY),
+        {
+            "instance": NotifyWPush,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    (
+        "wpush://{}?channel=nope".format(GOOD_KEY),
+        {"instance": TypeError},
+    ),
+    (
+        "wpush://{}?group=123456&topic_code=mytopic".format(GOOD_KEY),
+        {"instance": TypeError},
     ),
     (
         "https://api.wpush.cn/api/v1/send?apikey={}".format(GOOD_KEY),
@@ -109,23 +187,78 @@ def test_plugin_wpush_urls():
 
 
 def test_plugin_wpush_init():
+    """NotifyWPush() object initialization."""
     obj = NotifyWPush(apikey=GOOD_KEY)
     assert obj.apikey == GOOD_KEY
-    assert obj.channel == WPUSH_CHANNEL_DEFAULT
-    assert obj.topic_code is None
+    assert obj.channels == [WPUSH_CHANNEL_DEFAULT]
+    assert obj.topics == []
+    assert obj.group is None
+    assert obj.click_url is None
+    assert len(obj) == 1
 
     obj = NotifyWPush(apikey=GOOD_KEY, channel="mail")
-    assert obj.channel == WPushChannel.MAIL
+    assert obj.channels == [WPushChannel.MAIL]
+
+    # parse_list() sorts and dedupes, so the stored order is alphabetical
+    obj = NotifyWPush(apikey=GOOD_KEY, channel="feishu,dingtalk,qqbot")
+    assert obj.channels == [
+        WPushChannel.DINGTALK,
+        WPushChannel.FEISHU,
+        WPushChannel.QQBOT,
+    ]
+
+    obj = NotifyWPush(apikey=GOOD_KEY, targets=["topic1", "topic2"])
+    assert obj.topics == ["topic1", "topic2"]
+    assert len(obj) == 2
+
+    obj = NotifyWPush(apikey=GOOD_KEY, channel="qqbot", group="123456")
+    assert obj.group == "123456"
+
+    obj = NotifyWPush(apikey=GOOD_KEY, click_url="https://example.com/")
+    assert obj.click_url == "https://example.com/"
 
     with pytest.raises(TypeError):
         NotifyWPush(apikey=GOOD_KEY, channel="nope")
 
     with pytest.raises(TypeError):
+        NotifyWPush(apikey=GOOD_KEY, channel="feishu,nope")
+
+    with pytest.raises(TypeError):
         NotifyWPush(apikey="bad")
+
+    with pytest.raises(TypeError):
+        # Group and topic targets cannot be combined
+        NotifyWPush(apikey=GOOD_KEY, group="123456", targets=["topic1"])
+
+
+def test_plugin_wpush_url_round_trip():
+    """NotifyWPush() url() round trip through parse_url()."""
+    obj = NotifyWPush(
+        apikey=GOOD_KEY,
+        channel="feishu,dingtalk",
+        targets=["topic1", "topic2"],
+        click_url="https://example.com/",
+    )
+    results = NotifyWPush.parse_url(obj.url())
+    obj2 = NotifyWPush(**results)
+
+    assert obj.url_identifier == obj2.url_identifier
+    assert obj.topics == obj2.topics
+    # parse_list() sorts and dedupes, so the stored order is alphabetical
+    assert obj2.channels == [WPushChannel.DINGTALK, WPushChannel.FEISHU]
+    assert obj2.click_url == "https://example.com/"
+
+    # Round trip a QQ Robot group without a topic
+    obj3 = NotifyWPush(apikey=GOOD_KEY, channel="qqbot", group="123456")
+    results3 = NotifyWPush.parse_url(obj3.url())
+    obj4 = NotifyWPush(**results3)
+    assert obj4.group == "123456"
+    assert obj4.channels == [WPushChannel.QQBOT]
 
 
 @mock.patch("requests.post")
 def test_plugin_wpush_send_ok(mock_post):
+    """Send once when no topic is set."""
     response = mock.Mock()
     response.status_code = requests.codes.ok
     response.content = GOOD_RESPONSE.encode("utf-8")
@@ -135,12 +268,16 @@ def test_plugin_wpush_send_ok(mock_post):
     assert obj.send(body="hello", title="title") is True
     assert mock_post.call_count == 1
     assert mock_post.call_args[0][0] == "https://api.wpush.cn/api/v1/send"
+    assert mock_post.call_args[1]["headers"]["X-API-Key"] == GOOD_KEY
+    assert "X-Idempotency-Key" in mock_post.call_args[1]["headers"]
     payload = loads(mock_post.call_args[1]["data"])
     assert payload["apikey"] == GOOD_KEY
     assert payload["title"] == "title"
     assert payload["content"] == "hello"
     assert payload["channel"] == WPUSH_CHANNEL_DEFAULT
     assert "topic_code" not in payload
+    assert "option" not in payload
+    assert "url" not in payload
 
     mock_post.reset_mock()
     assert obj.send(body="only body") is True
@@ -149,15 +286,30 @@ def test_plugin_wpush_send_ok(mock_post):
 
 
 @mock.patch("requests.post")
-def test_plugin_wpush_send_topic_and_channel(mock_post):
+def test_plugin_wpush_send_multi_channel(mock_post):
+    """Send to several channels in one request."""
     response = mock.Mock()
     response.status_code = requests.codes.ok
     response.content = GOOD_RESPONSE.encode("utf-8")
     mock_post.return_value = response
 
-    obj = NotifyWPush(
-        apikey=GOOD_KEY, channel="feishu", topic_code="abc123"
-    )
+    # parse_list() sorts and dedupes, so the joined string is alphabetical
+    obj = NotifyWPush(apikey=GOOD_KEY, channel="feishu,dingtalk,qqbot")
+    assert obj.send(body="msg", title="t") is True
+    assert mock_post.call_count == 1
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["channel"] == "dingtalk,feishu,qqbot"
+
+
+@mock.patch("requests.post")
+def test_plugin_wpush_send_topic_and_channel(mock_post):
+    """Send to one topic through a selected channel."""
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = GOOD_RESPONSE.encode("utf-8")
+    mock_post.return_value = response
+
+    obj = NotifyWPush(apikey=GOOD_KEY, channel="feishu", targets="abc123")
     assert obj.send(body="msg", title="t") is True
     payload = loads(mock_post.call_args[1]["data"])
     assert payload["channel"] == "feishu"
@@ -165,7 +317,73 @@ def test_plugin_wpush_send_topic_and_channel(mock_post):
 
 
 @mock.patch("requests.post")
+def test_plugin_wpush_send_qqbot_group(mock_post):
+    """NotifyWPush() includes "option" only for the qqbot channel."""
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = GOOD_RESPONSE.encode("utf-8")
+    mock_post.return_value = response
+
+    # qqbot selected + group set -> option is sent
+    obj = NotifyWPush(apikey=GOOD_KEY, channel="qqbot", group="123456")
+    assert obj.send(body="msg") is True
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["option"] == "123456"
+
+    # group set but qqbot not selected -> option is omitted entirely
+    mock_post.reset_mock()
+    obj = NotifyWPush(apikey=GOOD_KEY, channel="mail", group="123456")
+    assert obj.send(body="msg") is True
+    payload = loads(mock_post.call_args[1]["data"])
+    assert "option" not in payload
+
+
+@mock.patch("requests.post")
+def test_plugin_wpush_send_click_url(mock_post):
+    """Include an optional click-through URL."""
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = GOOD_RESPONSE.encode("utf-8")
+    mock_post.return_value = response
+
+    obj = NotifyWPush(apikey=GOOD_KEY, click_url="https://example.com/")
+    assert obj.send(body="msg") is True
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["url"] == "https://example.com/"
+
+
+@mock.patch("requests.post")
+def test_plugin_wpush_send_multiple_topics(mock_post):
+    """NotifyWPush() sends once per topic and reports partial failure."""
+    ok_response = mock.Mock()
+    ok_response.status_code = requests.codes.ok
+    ok_response.content = GOOD_RESPONSE.encode("utf-8")
+
+    bad_response = mock.Mock()
+    bad_response.status_code = requests.codes.ok
+    bad_response.content = BAD_RESPONSE.encode("utf-8")
+
+    # Capture each key while the shared headers dictionary changes
+    seen_keys = []
+    responses = [ok_response, bad_response]
+
+    def _side_effect(*args, **kwargs):
+        seen_keys.append(kwargs["headers"]["X-Idempotency-Key"])
+        return responses[len(seen_keys) - 1]
+
+    mock_post.side_effect = _side_effect
+
+    obj = NotifyWPush(apikey=GOOD_KEY, targets=["topic1", "topic2"])
+    assert obj.send(body="msg") is False
+    assert mock_post.call_count == 2
+
+    # Each request must use a different key
+    assert seen_keys[0] != seen_keys[1]
+
+
+@mock.patch("requests.post")
 def test_plugin_wpush_send_api_error(mock_post):
+    """Handle a WPUSH error returned with HTTP 200."""
     response = mock.Mock()
     response.status_code = requests.codes.ok
     response.content = BAD_RESPONSE.encode("utf-8")
@@ -175,7 +393,20 @@ def test_plugin_wpush_send_api_error(mock_post):
 
 
 @mock.patch("requests.post")
+def test_plugin_wpush_bad_json(mock_post):
+    """Handle a response that is not JSON."""
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = b"not-json"
+    mock_post.return_value = response
+
+    obj = NotifyWPush(apikey=GOOD_KEY)
+    assert obj.send(body="msg") is False
+
+
+@mock.patch("requests.post")
 def test_plugin_wpush_apprise_integration(mock_post):
+    """Send through Apprise."""
     response = mock.Mock()
     response.status_code = requests.codes.ok
     response.content = GOOD_RESPONSE.encode("utf-8")

--- a/tests/test_plugin_wpush.py
+++ b/tests/test_plugin_wpush.py
@@ -318,7 +318,7 @@ def test_plugin_wpush_send_topic_and_channel(mock_post):
 
 @mock.patch("requests.post")
 def test_plugin_wpush_send_qqbot_group(mock_post):
-    """NotifyWPush() includes "option" only for the qqbot channel."""
+    """NotifyWPush() includes API option whenever group/option is set."""
     response = mock.Mock()
     response.status_code = requests.codes.ok
     response.content = GOOD_RESPONSE.encode("utf-8")
@@ -330,12 +330,13 @@ def test_plugin_wpush_send_qqbot_group(mock_post):
     payload = loads(mock_post.call_args[1]["data"])
     assert payload["option"] == "123456"
 
-    # group set but qqbot not selected -> option is omitted entirely
+    # group/option is channel-agnostic (feishu/dingtalk/webhook/wechat_work
+    # multi-instance codes, or qqbot group codes)
     mock_post.reset_mock()
     obj = NotifyWPush(apikey=GOOD_KEY, channel="mail", group="123456")
     assert obj.send(body="msg") is True
     payload = loads(mock_post.call_args[1]["data"])
-    assert "option" not in payload
+    assert payload["option"] == "123456"
 
 
 @mock.patch("requests.post")
@@ -416,3 +417,37 @@ def test_plugin_wpush_apprise_integration(mock_post):
     assert aobj.add("wpush://{}".format(GOOD_KEY))
     assert aobj.notify(title="T", body="B") is True
     assert mock_post.call_count == 1
+
+
+def test_plugin_wpush_option_for_non_qqbot_channels():
+    """option/group must be sent for feishu/dingtalk/webhook instance codes."""
+    from json import loads
+
+    for channel in ("feishu", "dingtalk", "webhook", "wechat_work"):
+        obj = Apprise.instantiate(
+            "wpush://{}?channel={}&option=ops".format(GOOD_KEY, channel)
+        )
+        assert isinstance(obj, NotifyWPush)
+        assert obj.group == "ops"
+
+        with mock.patch("requests.post") as mock_post:
+            mock_post.return_value = mock.Mock(
+                status_code=200,
+                content=GOOD_RESPONSE.encode("utf-8"),
+            )
+            assert obj.notify(title="t", body="b") is True
+            assert mock_post.called
+            payload = loads(mock_post.call_args[1]["data"].decode("utf-8"))
+            assert payload.get("option") == "ops"
+            assert payload.get("channel") == channel
+
+
+def test_plugin_wpush_rejects_boolean_code():
+    """JSON code:false must not be treated as success (False == 0 in Python)."""
+    obj = Apprise.instantiate("wpush://{}".format(GOOD_KEY))
+    with mock.patch("requests.post") as mock_post:
+        mock_post.return_value = mock.Mock(
+            status_code=200,
+            content=dumps({"code": False, "message": "nope"}).encode("utf-8"),
+        )
+        assert obj.notify(title="t", body="b") is False

--- a/tests/test_plugin_wpush.py
+++ b/tests/test_plugin_wpush.py
@@ -1,0 +1,187 @@
+#
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+
+from json import dumps, loads
+import logging
+from unittest import mock
+
+from helpers import AppriseURLTester
+import pytest
+import requests
+
+from apprise import Apprise
+from apprise.plugins.wpush import (
+    WPUSH_CHANNEL_DEFAULT,
+    WPUSH_CHANNELS,
+    NotifyWPush,
+    WPushChannel,
+)
+
+logging.disable(logging.CRITICAL)
+
+# WPUSH + 32 alphanumeric characters
+GOOD_KEY = "WPUSH" + ("a" * 32)
+
+GOOD_RESPONSE = dumps(
+    {"code": 0, "message": "success", "data": "1126950958891274240"}
+)
+BAD_RESPONSE = dumps({"code": 401, "message": "API Key error"})
+
+apprise_url_tests = (
+    (
+        "wpush://",
+        {"instance": TypeError},
+    ),
+    (
+        "wpush://short",
+        {"instance": TypeError},
+    ),
+    (
+        "wpush://{}".format(GOOD_KEY),
+        {
+            "instance": NotifyWPush,
+            "privacy_url": "wpush://****/",
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    (
+        "wpush://?apikey={}".format(GOOD_KEY),
+        {
+            "instance": NotifyWPush,
+            "privacy_url": "wpush://****/",
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    (
+        "wpush://{}?channel=feishu".format(GOOD_KEY),
+        {
+            "instance": NotifyWPush,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    (
+        "wpush://{}?topic_code=mytopic".format(GOOD_KEY),
+        {
+            "instance": NotifyWPush,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    (
+        "https://api.wpush.cn/api/v1/send?apikey={}".format(GOOD_KEY),
+        {
+            "instance": NotifyWPush,
+            "requests_response_text": GOOD_RESPONSE,
+        },
+    ),
+    (
+        "wpush://{}".format(GOOD_KEY),
+        {
+            "instance": NotifyWPush,
+            "response": False,
+            "requests_response_text": BAD_RESPONSE,
+        },
+    ),
+    (
+        "wpush://{}".format(GOOD_KEY),
+        {
+            "instance": NotifyWPush,
+            "response": False,
+            "requests_response_code": requests.codes.internal_server_error,
+        },
+    ),
+    (
+        "wpush://{}".format(GOOD_KEY),
+        {
+            "instance": NotifyWPush,
+            "test_requests_exceptions": True,
+        },
+    ),
+)
+
+
+def test_plugin_wpush_urls():
+    """NotifyWPush() Apprise URL test suite."""
+    AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+def test_plugin_wpush_init():
+    obj = NotifyWPush(apikey=GOOD_KEY)
+    assert obj.apikey == GOOD_KEY
+    assert obj.channel == WPUSH_CHANNEL_DEFAULT
+    assert obj.topic_code is None
+
+    obj = NotifyWPush(apikey=GOOD_KEY, channel="mail")
+    assert obj.channel == WPushChannel.MAIL
+
+    with pytest.raises(TypeError):
+        NotifyWPush(apikey=GOOD_KEY, channel="nope")
+
+    with pytest.raises(TypeError):
+        NotifyWPush(apikey="bad")
+
+
+@mock.patch("requests.post")
+def test_plugin_wpush_send_ok(mock_post):
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = GOOD_RESPONSE.encode("utf-8")
+    mock_post.return_value = response
+
+    obj = NotifyWPush(apikey=GOOD_KEY)
+    assert obj.send(body="hello", title="title") is True
+    assert mock_post.call_count == 1
+    assert mock_post.call_args[0][0] == "https://api.wpush.cn/api/v1/send"
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["apikey"] == GOOD_KEY
+    assert payload["title"] == "title"
+    assert payload["content"] == "hello"
+    assert payload["channel"] == WPUSH_CHANNEL_DEFAULT
+    assert "topic_code" not in payload
+
+    mock_post.reset_mock()
+    assert obj.send(body="only body") is True
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["title"] == "only body"
+
+
+@mock.patch("requests.post")
+def test_plugin_wpush_send_topic_and_channel(mock_post):
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = GOOD_RESPONSE.encode("utf-8")
+    mock_post.return_value = response
+
+    obj = NotifyWPush(
+        apikey=GOOD_KEY, channel="feishu", topic_code="abc123"
+    )
+    assert obj.send(body="msg", title="t") is True
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["channel"] == "feishu"
+    assert payload["topic_code"] == "abc123"
+
+
+@mock.patch("requests.post")
+def test_plugin_wpush_send_api_error(mock_post):
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = BAD_RESPONSE.encode("utf-8")
+    mock_post.return_value = response
+    obj = NotifyWPush(apikey=GOOD_KEY)
+    assert obj.send(body="msg") is False
+
+
+@mock.patch("requests.post")
+def test_plugin_wpush_apprise_integration(mock_post):
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    response.content = GOOD_RESPONSE.encode("utf-8")
+    mock_post.return_value = response
+
+    aobj = Apprise()
+    assert aobj.add("wpush://{}".format(GOOD_KEY))
+    assert aobj.notify(title="T", body="B") is True
+    assert mock_post.call_count == 1


### PR DESCRIPTION
## Summary
- Add `apprise/plugins/wpush.py` with `wpush://{apikey}` URL scheme
- Optional `?channel=` and `?topic_code=`
- Native URL: `https://api.wpush.cn/api/v1/send?apikey=…`
- Tests in `tests/test_plugin_wpush.py`

## WPUSH API notes
- Endpoint: `POST https://api.wpush.cn/api/v1/send`
- Fields: `apikey`, `title`, `content`, `channel` (default `wechat`)
- Success: HTTP 200 **and** JSON `code === 0` (PushPlus uses `200`; do not confuse)
- Error field: `message`
- Site/docs: https://wpush.cn / https://wpush.cn/docs
- Same contract as Uptime Kuma's built-in WPUSH provider

Docs added here: https://github.com/caronc/apprise-docs/pull/126

## Test plan
- [ ] `pytest tests/test_plugin_wpush.py`
- [ ] Manual: `apprise -vv -t 't' -b 'b' 'wpush://WPUSH…'`