### PR TITLE
Apprise Exception Handling (v2 prep)

### DIFF
--- a/apprise/apprise.py
+++ b/apprise/apprise.py
@@ -53,6 +53,7 @@ from .common import (
 from .config.base import ConfigBase
 from .conversion import convert_between
 from .emojis import apply_emojis
+from .exception import AppriseImproperlyConfigured
 from .locale import AppriseLocale
 from .logger import NotifyLogEntry, _ServiceLogCapture, logger
 from .manager_plugins import NotificationManager
@@ -290,11 +291,11 @@ def _timeout_log_entry(name: str, elapsed: float) -> NotifyLogEntry:
 def _validate_timeout(value: Union[int, float]) -> float:
     """Validate a timeout value shared by notify()/async_notify()."""
     if not isinstance(value, (int, float)) or isinstance(value, bool):
-        raise TypeError("timeout must be an int or float.")
+        raise AppriseImproperlyConfigured("timeout must be an int or float.")
 
     # inf/nan rejected: use 0 to mean "unbounded" instead.
     if not math.isfinite(value) or value < 0:
-        raise ValueError("timeout must be >= 0 and finite.")
+        raise AppriseImproperlyConfigured("timeout must be >= 0 and finite.")
 
     return float(value)
 
@@ -1254,7 +1255,8 @@ class Apprise:
         ``timeout`` limits the entire call in seconds; unfinished services
         report TIMEOUT. The earlier call or service limit applies. A value of
         0 leaves only the service limit active. Values must be finite,
-        non-negative numbers; invalid values raise TypeError or ValueError.
+        non-negative numbers; invalid values raise
+        ``AppriseImproperlyConfigured``.
 
         log_callback overrides the instance default for this call. It must be
         synchronous; schedule any async work from inside the callback.
@@ -1690,7 +1692,7 @@ class Apprise:
         if not (title or body or attach):
             msg = "No message content specified to deliver"
             logger.error(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         try:
             notify_type = (
@@ -1703,7 +1705,7 @@ class Apprise:
             err = (
                 f"An invalid notification type ({notify_type}) was specified."
             )
-            raise TypeError(err) from None
+            raise AppriseImproperlyConfigured(err) from None
 
         try:
             if title and isinstance(title, bytes):
@@ -1718,7 +1720,7 @@ class Apprise:
                 f"type: {self.asset.encoding}"
             )
             logger.error(msg)
-            raise TypeError(msg) from None
+            raise AppriseImproperlyConfigured(msg) from None
 
         # Normalize falsy values. Each service applies the cap from its own
         # asset below, which may differ from ``self.asset``.
@@ -1838,7 +1840,7 @@ class Apprise:
                         # Must be of string type
                         msg = "Failed to escape message body"
                         logger.error(msg)
-                        raise TypeError(msg) from None
+                        raise AppriseImproperlyConfigured(msg) from None
 
                 if server.interpret_emojis:
                     #

--- a/apprise/apprise_attachment.py
+++ b/apprise/apprise_attachment.py
@@ -31,6 +31,7 @@ from typing import Any, Optional, Union
 from .asset import AppriseAsset
 from .attachment.base import AttachBase
 from .common import ContentLocation
+from .exception import AppriseImproperlyConfigured
 from .logger import logger
 from .manager_attachment import AttachmentManager
 from .url import URLBase
@@ -117,14 +118,16 @@ class AppriseAttachment:
                     "specified.",
                 )
                 logger.warning(err)
-                raise TypeError(err) from None
+                raise AppriseImproperlyConfigured(err) from None
         else:
             # do not set location if no initialization was made for it
             self.location = None
 
         # Now parse any paths specified
         if paths is not None and not self.add(paths):
-            raise TypeError("One or more attachments could not be added.")
+            raise AppriseImproperlyConfigured(
+                "One or more attachments could not be added."
+            )
 
     def add(
         self,

--- a/apprise/asset.py
+++ b/apprise/asset.py
@@ -38,6 +38,7 @@ from .common import (
     NotifyType,
     PersistentStoreMode,
 )
+from .exception import AppriseImproperlyConfigured
 from .manager_plugins import NotificationManager
 from .utils.time import zoneinfo
 
@@ -293,14 +294,14 @@ class AppriseAsset:
         # Assign default arguments if specified
         for key, value in kwargs.items():
             if not hasattr(AppriseAsset, key):
-                raise AttributeError(
+                raise AppriseImproperlyConfigured(
                     f"AppriseAsset init(): An invalid key {key} was specified."
                 )
 
             if key.startswith("_") and (
                 key not in self._KWARGS_INTERNAL_ALLOWLIST
             ):
-                raise AttributeError(
+                raise AppriseImproperlyConfigured(
                     f"AppriseAsset init(): {key} can not be set directly; "
                     "use its dedicated keyword argument instead."
                 )
@@ -330,13 +331,13 @@ class AppriseAsset:
                     f"An invalid persistent store mode ({storage_mode}) was "
                     "specified."
                 )
-                raise AttributeError(err) from None
+                raise AppriseImproperlyConfigured(err) from None
 
         if isinstance(storage_idlen, int):
             # Define the number of characters utilized from our namespace lengh
             if storage_idlen < 0:
                 # Unsupported type
-                raise ValueError(
+                raise AppriseImproperlyConfigured(
                     "AppriseAsset storage_idlen(): Value must "
                     "be an integer and > 0"
                 )
@@ -350,7 +351,7 @@ class AppriseAsset:
         elif timezone is not None:
             self._tzinfo = zoneinfo(timezone)
             if not self._tzinfo:
-                raise AttributeError(
+                raise AppriseImproperlyConfigured(
                     "AppriseAsset timezone provided is invalid"
                 ) from None
         else:
@@ -362,13 +363,13 @@ class AppriseAsset:
             if not isinstance(service_timeout, (int, float)) or isinstance(
                 service_timeout, bool
             ):
-                raise TypeError(
+                raise AppriseImproperlyConfigured(
                     "AppriseAsset service_timeout must be an int or float."
                 )
 
             if not math.isfinite(service_timeout) or service_timeout < 0:
                 # Use 0 for no timeout; infinity is unsafe on some platforms.
-                raise ValueError(
+                raise AppriseImproperlyConfigured(
                     "AppriseAsset service_timeout must be >= 0 and "
                     "finite (0 disables the timeout entirely)."
                 )
@@ -380,12 +381,12 @@ class AppriseAsset:
             if not isinstance(payload_max_size, int) or isinstance(
                 payload_max_size, bool
             ):
-                raise TypeError(
+                raise AppriseImproperlyConfigured(
                     "AppriseAsset payload_max_size must be an int."
                 )
 
             if payload_max_size < 0:
-                raise ValueError(
+                raise AppriseImproperlyConfigured(
                     "AppriseAsset payload_max_size must be >= 0 "
                     "(0 disables the cap entirely)."
                 )
@@ -397,12 +398,12 @@ class AppriseAsset:
             if not isinstance(payload_buffer_threshold, int) or isinstance(
                 payload_buffer_threshold, bool
             ):
-                raise TypeError(
+                raise AppriseImproperlyConfigured(
                     "AppriseAsset payload_buffer_threshold must be an int."
                 )
 
             if payload_buffer_threshold < 0:
-                raise ValueError(
+                raise AppriseImproperlyConfigured(
                     "AppriseAsset payload_buffer_threshold must be >= 0."
                 )
 
@@ -413,12 +414,12 @@ class AppriseAsset:
             if not isinstance(payload_min_buffer, int) or isinstance(
                 payload_min_buffer, bool
             ):
-                raise TypeError(
+                raise AppriseImproperlyConfigured(
                     "AppriseAsset payload_min_buffer must be an int."
                 )
 
             if payload_min_buffer < 0:
-                raise ValueError(
+                raise AppriseImproperlyConfigured(
                     "AppriseAsset payload_min_buffer must be >= 0."
                 )
 
@@ -429,12 +430,12 @@ class AppriseAsset:
             if not isinstance(result_log_memory_size, int) or isinstance(
                 result_log_memory_size, bool
             ):
-                raise TypeError(
+                raise AppriseImproperlyConfigured(
                     "AppriseAsset result_log_memory_size must be an int."
                 )
 
             if result_log_memory_size < 0:
-                raise ValueError(
+                raise AppriseImproperlyConfigured(
                     "AppriseAsset result_log_memory_size must be >= 0."
                 )
 
@@ -445,12 +446,12 @@ class AppriseAsset:
             if not isinstance(result_log_disk_size, int) or isinstance(
                 result_log_disk_size, bool
             ):
-                raise TypeError(
+                raise AppriseImproperlyConfigured(
                     "AppriseAsset result_log_disk_size must be an int."
                 )
 
             if result_log_disk_size < 0:
-                raise ValueError(
+                raise AppriseImproperlyConfigured(
                     "AppriseAsset result_log_disk_size must be >= 0."
                 )
 
@@ -468,13 +469,13 @@ class AppriseAsset:
 
                 except UnicodeEncodeError:
                     # Bad data; don't pass it along
-                    raise ValueError(
+                    raise AppriseImproperlyConfigured(
                         "AppriseAsset namespace_salt(): "
                         "Value provided could not be encoded"
                     ) from None
 
             else:  # Unsupported
-                raise ValueError(
+                raise AppriseImproperlyConfigured(
                     "AppriseAsset namespace_salt(): Value provided must be "
                     "string or bytes object"
                 )
@@ -573,7 +574,7 @@ class AppriseAsset:
             return AppriseAsset.hex_to_rgb(color)
 
         # Unsupported type
-        raise ValueError(
+        raise AppriseImproperlyConfigured(
             "AppriseAsset html_color(): An invalid color_type was specified."
         )
 

--- a/apprise/attachment/base.py
+++ b/apprise/attachment/base.py
@@ -33,6 +33,7 @@ import time
 
 from .. import exception
 from ..common import ContentLocation
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import URLBase
 from ..utils.parse import parse_bool
@@ -160,13 +161,13 @@ class AttachBase(URLBase):
             except (TypeError, ValueError):
                 err = f"An invalid cache value ({cache}) was specified."
                 self.logger.warning(err)
-                raise TypeError(err) from None
+                raise AppriseImproperlyConfigured(err) from None
 
             # Some simple error checking
             if self.cache < 0:
                 err = f"A negative cache value ({cache}) was specified."
                 self.logger.warning(err)
-                raise TypeError(err)
+                raise AppriseImproperlyConfigured(err)
 
         else:
             self.cache = None
@@ -185,7 +186,7 @@ class AttachBase(URLBase):
         ):
             err = f"An invalid mime-type ({mimetype}) was specified."
             self.logger.warning(err)
-            raise TypeError(err)
+            raise AppriseImproperlyConfigured(err)
 
         return
 

--- a/apprise/attachment/memory.py
+++ b/apprise/attachment/memory.py
@@ -34,6 +34,7 @@ import uuid
 
 from .. import exception
 from ..common import ContentLocation
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from .base import AttachBase
 
@@ -77,7 +78,7 @@ class AttachMemory(AttachBase):
                 name = str(uuid.uuid4()) + ".txt"
 
         elif not isinstance(content, bytes):
-            raise TypeError(
+            raise AppriseImproperlyConfigured(
                 "Provided content for memory attachment is invalid"
             )
 

--- a/apprise/config/base.py
+++ b/apprise/config/base.py
@@ -35,6 +35,7 @@ import yaml
 
 from .. import common, plugins
 from ..asset import AppriseAsset
+from ..exception import AppriseImproperlyConfigured
 from ..logger import logging
 from ..manager_config import ConfigurationManager
 from ..manager_plugins import NotificationManager
@@ -177,7 +178,7 @@ class ConfigBase(URLBase):
             except (AttributeError, ValueError):
                 err = f"An invalid config format ({fmt}) was specified."
                 self.logger.warning(err)
-                raise TypeError(err) from None
+                raise AppriseImproperlyConfigured(err) from None
 
         # Set our cache flag; it can be True or a (positive) integer
         try:
@@ -185,12 +186,12 @@ class ConfigBase(URLBase):
             if self.cache < 0:
                 err = f"A negative cache value ({cache}) was specified."
                 self.logger.warning(err)
-                raise TypeError(err)
+                raise AppriseImproperlyConfigured(err)
 
         except (ValueError, TypeError):
             err = f"An invalid cache value ({cache}) was specified."
             self.logger.warning(err)
-            raise TypeError(err) from None
+            raise AppriseImproperlyConfigured(err) from None
 
         return
 

--- a/apprise/exception.py
+++ b/apprise/exception.py
@@ -28,7 +28,7 @@ import errno
 
 
 class AppriseException(Exception):
-    """Base Apprise Exception Class."""
+    """Base class for exceptions raised by Apprise."""
 
     def __init__(self, message, error_code=0):
         super().__init__(message)
@@ -36,28 +36,50 @@ class AppriseException(Exception):
 
 
 class ApprisePluginException(AppriseException):
-    """Class object for handling exceptions raised from within a plugin."""
+    """Raised when a notification plugin cannot complete an operation."""
 
     def __init__(self, message, error_code=600):
         super().__init__(message, error_code=error_code)
 
 
-class AppriseDiskIOError(AppriseException):
-    """Thrown when an disk i/o error occurs."""
+class AppriseImproperlyConfigured(
+    AppriseException, TypeError, ValueError, AttributeError
+):
+    """Raised when Apprise receives missing, invalid, or conflicting settings.
 
-    def __init__(self, message, error_code=errno.EIO):
+    It remains compatible with code that catches the built-in exceptions
+    historically raised for these errors: ``TypeError``, ``ValueError``, and
+    ``AttributeError``.
+    """
+
+    def __init__(self, message, error_code=errno.EINVAL):
         super().__init__(message, error_code=error_code)
 
 
+class AppriseDiskIOError(AppriseException, OSError):
+    """Raised when a disk I/O operation fails."""
+
+    def __init__(self, message, error_code=errno.EIO):
+        super().__init__(message, error_code=error_code)
+        # Expose the standard I/O error code and message for compatibility
+        # with code that catches the built-in OSError.
+        self.errno = error_code
+        self.strerror = message
+
+    def __str__(self):
+        """Return the original message while exposing standard I/O details."""
+        return str(self.args[0])
+
+
 class AppriseInvalidData(AppriseException):
-    """Thrown when bad data was passed into an internal function."""
+    """Raised when Apprise cannot safely use supplied or stored data."""
 
     def __init__(self, message, error_code=errno.EINVAL):
         super().__init__(message, error_code=error_code)
 
 
 class AppriseFileNotFound(AppriseDiskIOError, FileNotFoundError):
-    """Thrown when a persistent write occured in MEMORY mode."""
+    """Raised when an attachment or stored file cannot be found."""
 
     def __init__(self, message):
         super().__init__(message, error_code=errno.ENOENT)

--- a/apprise/logger.py
+++ b/apprise/logger.py
@@ -42,6 +42,7 @@ import threading
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 from .common import AWARE_DATE_ISO_FORMAT, JSON_COMPACT_SEPARATORS
+from .exception import AppriseDiskIOError
 
 if TYPE_CHECKING:
     # Import NotifyBase only for static analysis. Importing it at runtime
@@ -311,11 +312,11 @@ class _LogCaptureBudget:
 
                 # A short write means the record cannot be trusted later.
                 if self._disk.write(header) != len(header):
-                    raise OSError("short result log header write")
+                    raise AppriseDiskIOError("short result log header write")
 
                 # Write the complete log entry immediately after its header.
                 if self._disk.write(payload) != len(payload):
-                    raise OSError("short result log entry write")
+                    raise AppriseDiskIOError("short result log entry write")
 
                 if previous is not None:
                     # Link this capture's entries across the shared file.
@@ -325,7 +326,7 @@ class _LogCaptureBudget:
                     link = self._LINK.pack(offset)
 
                     if self._disk.write(link) != len(link):
-                        raise OSError("short result log link write")
+                        raise AppriseDiskIOError("short result log link write")
 
                 # Make completed writes available to result readers.
                 self._disk.flush()
@@ -355,7 +356,7 @@ class _LogCaptureBudget:
         with self._lock:
             # A closed result no longer has disk content to replay.
             if self._disk is None:
-                raise OSError("result log storage is closed")
+                raise AppriseDiskIOError("result log storage is closed")
 
             # Move directly to the record owned by this capture.
             self._disk.seek(offset)
@@ -365,21 +366,21 @@ class _LogCaptureBudget:
 
             # Reject partial records before decoding their content.
             if len(header) != self._HEADER.size:
-                raise OSError("truncated result log header")
+                raise AppriseDiskIOError("truncated result log header")
 
             # Recover the content length and the next record location.
             size, next_offset = self._HEADER.unpack(header)
 
             # A record cannot be larger than the complete disk allowance.
             if size > self.disk_size:
-                raise OSError("invalid result log entry size")
+                raise AppriseDiskIOError("invalid result log entry size")
 
             # Read only the number of bytes declared by this record.
             payload = self._disk.read(size)
 
             # Do not pass incomplete content to the JSON decoder.
             if len(payload) != size:
-                raise OSError("truncated result log entry")
+                raise AppriseDiskIOError("truncated result log entry")
 
             return payload, next_offset
 
@@ -552,7 +553,9 @@ class _NotifyLogStore:
                             and index + 1 < self._disk_count
                         ):
                             # The entry chain ended sooner than expected.
-                            raise OSError("truncated result log chain")
+                            raise AppriseDiskIOError(
+                                "truncated result log chain"
+                            )
 
                         # Continue from the location saved in this record.
                         offset = next_offset

--- a/apprise/persistent_store.py
+++ b/apprise/persistent_store.py
@@ -49,6 +49,7 @@ from .common import (
     NAIVE_DATE_ISO_FORMAT,
     PersistentStoreMode,
 )
+from .exception import AppriseImproperlyConfigured
 from .logger import logger
 from .utils.disk import path_decode
 
@@ -146,7 +147,7 @@ class CacheObject:
             )
 
         else:  # Unsupported
-            raise AttributeError(
+            raise AppriseImproperlyConfigured(
                 f"An invalid expiry time ({expires} was specified"
             )
 
@@ -199,11 +200,15 @@ class CacheObject:
             # Acquire some useful integrity objects
             class_name = content.get("c", "")
             if not isinstance(class_name, str):
-                raise TypeError("Class name not expected string")
+                raise AppriseImproperlyConfigured(
+                    "Class name not expected string"
+                )
 
             hashsum = content.get("!", "")
             if not isinstance(hashsum, str):
-                raise TypeError("SHA1SUM not expected string")
+                raise AppriseImproperlyConfigured(
+                    "SHA1SUM not expected string"
+                )
 
         except (TypeError, KeyError) as e:
             logger.trace(f"CacheObject could not be parsed from {content}")
@@ -396,7 +401,7 @@ class PersistentStore:
         if not isinstance(namespace, str) or not self.__valid_key.match(
             namespace
         ):
-            raise AttributeError(
+            raise AppriseImproperlyConfigured(
                 f"Persistent Storage namespace ({namespace}) provided is"
                 " invalid"
             )
@@ -437,11 +442,9 @@ class PersistentStore:
             )
 
         except (AttributeError, ValueError):
-            err = (
-                f"An invalid persistent storage mode ({mode}) was specified.",
-            )
+            err = f"An invalid persistent storage mode ({mode}) was specified."
             logger.warning(err)
-            raise AttributeError(err) from None
+            raise AppriseImproperlyConfigured(err) from None
 
         # Prepare our environment
         self.__prepare()
@@ -505,7 +508,7 @@ class PersistentStore:
             key = self.base_key
 
         elif not isinstance(key, str) or not self.__valid_key.match(key):
-            raise AttributeError(
+            raise AppriseImproperlyConfigured(
                 f"Persistent Storage key ({key} provided is invalid"
             )
 
@@ -513,7 +516,7 @@ class PersistentStore:
             # One last check, we will accept read() objets with the expectation
             # it will return a binary dataset
             if not (hasattr(data, "read") and callable(data.read)):
-                raise AttributeError(
+                raise AppriseImproperlyConfigured(
                     f"Invalid data type {type(data)} provided to Persistent"
                     " Storage"
                 )
@@ -522,7 +525,7 @@ class PersistentStore:
                 # Read in our data
                 data = data.read()
                 if not isinstance(data, (bytes, str)):
-                    raise AttributeError(
+                    raise AppriseImproperlyConfigured(
                         f"Invalid data type {type(data)} provided to"
                         " Persistent Storage"
                     )
@@ -769,7 +772,7 @@ class PersistentStore:
             key = self.base_key
 
         elif not isinstance(key, str) or not self.__valid_key.match(key):
-            raise AttributeError(
+            raise AppriseImproperlyConfigured(
                 f"Persistent Storage key ({key} provided is invalid"
             )
 
@@ -1368,7 +1371,7 @@ class PersistentStore:
                 namespace = [namespace]
 
             elif not isinstance(namespace, (tuple, set, list)):
-                raise AttributeError(
+                raise AppriseImproperlyConfigured(
                     "namespace must be None, a string, or a tuple/set/list "
                     "of strings"
                 )

--- a/apprise/plugins/africas_talking.py
+++ b/apprise/plugins/africas_talking.py
@@ -33,6 +33,7 @@
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import (
     is_phone_no,
@@ -207,7 +208,7 @@ class NotifyAfricasTalking(NotifyBase):
                 " invalid."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.apikey = validate_regex(
             apikey, *self.template_tokens["apikey"]["regex"]
@@ -217,7 +218,7 @@ class NotifyAfricasTalking(NotifyBase):
                 f"The Africas Talking apikey specified ({apikey}) is invalid."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Prepare Sender
         self.sender = (
@@ -250,7 +251,7 @@ class NotifyAfricasTalking(NotifyBase):
                     f"The Africas Talking mode specified ({mode}) is invalid."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
         else:
             self.mode = self.template_args["mode"]["default"]
 

--- a/apprise/plugins/apprise_api.py
+++ b/apprise/plugins/apprise_api.py
@@ -33,6 +33,7 @@ import requests
 
 from .. import exception
 from ..common import NotifyFormat, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import URL_PATH_SAFE_CHARS, parse_list, validate_regex
@@ -207,7 +208,7 @@ class NotifyAppriseAPI(NotifyBase):
         if not self.token:
             msg = f"The Apprise API token specified ({token}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.method = (
             self.template_args["method"]["default"]
@@ -218,7 +219,7 @@ class NotifyAppriseAPI(NotifyBase):
         if self.method not in APPRISE_API_METHODS:
             msg = f"The method specified ({method}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Version 2 keeps the configuration ID out of the HTTP URL. Version 1
         # remains available for older Apprise API servers.
@@ -230,7 +231,7 @@ class NotifyAppriseAPI(NotifyBase):
         if self.version not in APPRISE_API_VERSIONS:
             msg = f"The Apprise API version specified ({version}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Build list of tags
         self.__tags = parse_list(tags)

--- a/apprise/plugins/aprs.py
+++ b/apprise/plugins/aprs.py
@@ -74,6 +74,7 @@ import sys
 
 from .. import __version__
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import is_call_sign, parse_call_sign
@@ -231,7 +232,7 @@ class NotifyAprs(NotifyBase):
         if not (self.user and self.password):
             msg = "An APRS user/pass was not provided."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         """
         Check if the user tries to use a read-only access
@@ -241,7 +242,7 @@ class NotifyAprs(NotifyBase):
         if self.password == "-1":
             msg = "APRS read-only passwords are not supported."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         """
         Check if the password is numeric
@@ -249,7 +250,7 @@ class NotifyAprs(NotifyBase):
         if not self.password.isnumeric():
             msg = "Invalid APRS-IS password"
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         """
         Convert given user name (FROM callsign) and
@@ -269,7 +270,7 @@ class NotifyAprs(NotifyBase):
                 )
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Update our delay
         if delay is None:
@@ -287,7 +288,7 @@ class NotifyAprs(NotifyBase):
             except (TypeError, ValueError):
                 msg = f"Unsupported APRS-IS delay ({delay}) specified. "
                 self.logger.warning(msg)
-                raise TypeError(msg) from None
+                raise AppriseImproperlyConfigured(msg) from None
 
         # Bump up our request_rate
         self.request_rate_per_sec += self.delay

--- a/apprise/plugins/bark.py
+++ b/apprise/plugins/bark.py
@@ -43,6 +43,7 @@ except ImportError:
     BARK_AESGCM_SUPPORT = False
 
 from ..common import NotifyFormat, NotifyImageSize, NotifyType
+from ..exception import AppriseImproperlyConfigured, ApprisePluginException
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import parse_bool, parse_list
@@ -357,7 +358,7 @@ class NotifyBark(NotifyBase):
                     "characters."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg) from None
+                raise AppriseImproperlyConfigured(msg) from None
 
             # AES-GCM only accepts 128/192/256-bit (16/24/32 byte) keys
             if len(encryption_key_bytes) not in BARK_AES_KEY_LENGTHS:
@@ -366,7 +367,7 @@ class NotifyBark(NotifyBase):
                     "32 ASCII characters."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             # Fail closed; never fall back to sending plaintext when the
             # caller asked for encryption but the library isn't available
@@ -376,7 +377,7 @@ class NotifyBark(NotifyBase):
                     "Install Apprise with the 'all-plugins' extra."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             # We're ready to encrypt every outbound payload with this key
             self.encryption_key = encryption_key
@@ -597,7 +598,9 @@ class NotifyBark(NotifyBase):
         # characters (a 96-bit GCM nonce)
         iv = secrets.token_urlsafe(BARK_GCM_IV_RANDOM_BYTES)
         if len(iv) != BARK_GCM_IV_LENGTH or not iv.isascii():
-            raise ValueError("Bark generated an incompatible AES-GCM IV")
+            raise ApprisePluginException(
+                "Bark generated an incompatible AES-GCM IV"
+            )
 
         # Bark decrypts a compact JSON object back into its parameters
         plaintext = json.dumps(

--- a/apprise/plugins/base.py
+++ b/apprise/plugins/base.py
@@ -54,6 +54,7 @@ from ..conversion import (
     split_dialect_chunk,
     truncate_dialect_chunk,
 )
+from ..exception import AppriseImproperlyConfigured
 from ..locale import Translatable, gettext_lazy as _
 from ..persistent_store import PersistentStore
 from ..url import URLBase
@@ -495,7 +496,7 @@ class NotifyBase(URLBase):
                 if _retry_val < 0:
                     msg = f"Service retry count must be >= 0; got {_retry_raw}"
                     self.logger.warning(msg)
-                    raise TypeError(msg)
+                    raise AppriseImproperlyConfigured(msg)
                 self.retry = min(_retry_val, APPRISE_MAX_SERVICE_RETRY)
             except (TypeError, ValueError):
                 self.logger.warning(
@@ -517,7 +518,7 @@ class NotifyBase(URLBase):
         #   2. asset.default_service_wait
         # Only valid non-negative finite floats are accepted; integers are
         # promoted to float.  Invalid values fall back to the asset default.
-        # Negative values raise TypeError.
+        # Negative values are invalid and use the same fallback.
         _wait_raw = kwargs.get("wait")
         if _wait_raw is not None:
             try:
@@ -525,7 +526,7 @@ class NotifyBase(URLBase):
                 if not math.isfinite(_wait_val) or _wait_val < 0.0:
                     msg = f"Service retry wait must be >= 0; got {_wait_raw}"
                     self.logger.warning(msg)
-                    raise TypeError(msg)
+                    raise AppriseImproperlyConfigured(msg)
                 self.wait = min(_wait_val, APPRISE_MAX_SERVICE_WAIT)
             except (TypeError, ValueError):
                 self.logger.warning(
@@ -620,7 +621,7 @@ class NotifyBase(URLBase):
                     f"An invalid notification format ({value}) was specified."
                 )
                 self.logger.warning(err)
-                raise TypeError(err) from None
+                raise AppriseImproperlyConfigured(err) from None
 
             if len(self._formats()) == 1:
                 # Single-format plugin: force the requested destination
@@ -641,7 +642,7 @@ class NotifyBase(URLBase):
                     f"({value}) was specified."
                 )
                 self.logger.warning(err)
-                raise TypeError(err) from None
+                raise AppriseImproperlyConfigured(err) from None
 
         if "overflow" in kwargs:
             value = kwargs["overflow"]
@@ -655,7 +656,7 @@ class NotifyBase(URLBase):
             except (AttributeError, ValueError):
                 err = f"An invalid overflow method ({value}) was specified."
                 self.logger.warning(err)
-                raise TypeError(err) from None
+                raise AppriseImproperlyConfigured(err) from None
 
         # Prepare our Persistent Storage switch
         self.persistent_storage = parse_bool(
@@ -930,7 +931,7 @@ class NotifyBase(URLBase):
             # Deny notifications issued to services that are disabled
             msg = f"{self.service_name} is currently disabled on this system."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Prepare attachments if required
         if attach is not None and not isinstance(attach, AppriseAttachment):
@@ -949,7 +950,7 @@ class NotifyBase(URLBase):
             # present
             msg = "No message body or attachment was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         if not body and not self.attachment_support:
             # If no body was specified, then we know that an attachment
@@ -963,7 +964,7 @@ class NotifyBase(URLBase):
                 "attachments; service skipped"
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Handle situations where the title is None
         title = title if title else ""

--- a/apprise/plugins/blink1.py
+++ b/apprise/plugins/blink1.py
@@ -33,6 +33,7 @@
 import time
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from .base import NotifyBase
 
@@ -234,7 +235,7 @@ class NotifyBlink1(NotifyBase):
                 <= self.duration
                 <= BLINK1_MAX_DURATION_MS
             ):
-                raise ValueError("out of range")
+                raise AppriseImproperlyConfigured("out of range")
 
         except (TypeError, ValueError):
             msg = (
@@ -243,13 +244,13 @@ class NotifyBlink1(NotifyBase):
                 f" {BLINK1_MAX_DURATION_MS} ms."
             )
             self.logger.warning(msg)
-            raise TypeError(msg) from None
+            raise AppriseImproperlyConfigured(msg) from None
 
         # Fade transition time (ms)
         try:
             self.fade = int(BLINK1_DEFAULT_FADE_MS if fade is None else fade)
             if not (BLINK1_MIN_FADE_MS <= self.fade <= BLINK1_MAX_FADE_MS):
-                raise ValueError("out of range")
+                raise AppriseImproperlyConfigured("out of range")
 
         except (TypeError, ValueError):
             msg = (
@@ -257,7 +258,7 @@ class NotifyBlink1(NotifyBase):
                 f" {BLINK1_MIN_FADE_MS} and {BLINK1_MAX_FADE_MS} ms."
             )
             self.logger.warning(msg)
-            raise TypeError(msg) from None
+            raise AppriseImproperlyConfigured(msg) from None
 
         # LED selector; unrecognised values silently fall back to ALL
         self.ledn = (

--- a/apprise/plugins/bluesky.py
+++ b/apprise/plugins/bluesky.py
@@ -40,6 +40,7 @@ import requests
 
 from ..attachment.base import AttachBase
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from .base import NotifyBase
@@ -142,7 +143,7 @@ class NotifyBlueSky(NotifyBase):
         if not self.user:
             msg = "A BlueSky UserID/Handle must be specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Set our default host
         self.host = self.bluesky_default_host

--- a/apprise/plugins/brevo.py
+++ b/apprise/plugins/brevo.py
@@ -36,6 +36,7 @@ import requests
 from .. import exception
 from ..common import NotifyFormat, NotifyType
 from ..conversion import convert_between
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_email, parse_list, validate_regex
 from ..utils.sanitize import sanitize_payload
@@ -221,13 +222,13 @@ class NotifyBrevo(NotifyBase):
         if not self.apikey:
             msg = f"An invalid Brevo API Key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         result = is_email(from_email)
         if not result:
             msg = f"Invalid ~From~ email specified: {from_email}"
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store email address
         self.from_email = result["full_email"]
@@ -241,7 +242,7 @@ class NotifyBrevo(NotifyBase):
                     f"{reply_to}"
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             self.reply_to = (
                 result["name"] if result["name"] else False,

--- a/apprise/plugins/bulksms.py
+++ b/apprise/plugins/bulksms.py
@@ -38,6 +38,7 @@ import re
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import is_phone_no, parse_bool, parse_phone_no
@@ -195,7 +196,7 @@ class NotifyBulkSMS(NotifyBase):
                     f"({source}) is invalid."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             # Tidy source
             self.source = "+{}".format(result["full"])
@@ -209,7 +210,7 @@ class NotifyBulkSMS(NotifyBase):
         if self.route not in BULKSMS_ROUTING_GROUPS:
             msg = f"The route specified ({route}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Define whether or not we should set the unicode flag
         self.unicode = (

--- a/apprise/plugins/bulkvs.py
+++ b/apprise/plugins/bulkvs.py
@@ -37,6 +37,7 @@ import json
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import is_phone_no, parse_bool, parse_phone_no
@@ -142,7 +143,7 @@ class NotifyBulkVS(NotifyBase):
         if not (self.user and self.password):
             msg = "A BulkVS user/pass was not provided."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         result = is_phone_no(source)
         if not result:
@@ -150,7 +151,7 @@ class NotifyBulkVS(NotifyBase):
                 f"The Account (From) Phone # specified ({source}) is invalid."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Tidy source
         self.source = result["full"]

--- a/apprise/plugins/burstsms.py
+++ b/apprise/plugins/burstsms.py
@@ -33,6 +33,7 @@
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import (
@@ -191,7 +192,7 @@ class NotifyBurstSMS(NotifyBase):
         if not self.apikey:
             msg = f"An invalid Burst SMS API Key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # API Secret (associated with project)
         self.secret = validate_regex(
@@ -200,7 +201,7 @@ class NotifyBurstSMS(NotifyBase):
         if not self.secret:
             msg = f"An invalid Burst SMS API Secret ({secret}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         if not country:
             self.country = self.template_args["country"]["default"]
@@ -212,7 +213,7 @@ class NotifyBurstSMS(NotifyBase):
                     f"An invalid Burst SMS country ({country}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         # Set our Validity
         self.validity = self.template_args["validity"]["default"]
@@ -226,7 +227,7 @@ class NotifyBurstSMS(NotifyBase):
                     " invalid."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg) from None
+                raise AppriseImproperlyConfigured(msg) from None
 
         # Prepare Batch Mode Flag
         self.batch = (
@@ -238,7 +239,7 @@ class NotifyBurstSMS(NotifyBase):
         if not self.source:
             msg = f"The Account Sender ID specified ({source}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Parse our targets
         self.targets = []

--- a/apprise/plugins/chanify.py
+++ b/apprise/plugins/chanify.py
@@ -35,6 +35,7 @@
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import validate_regex
 from .base import NotifyBase
@@ -100,7 +101,7 @@ class NotifyChanify(NotifyBase):
         if not self.token:
             msg = f"The Chanify token specified ({token}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         return
 

--- a/apprise/plugins/chime.py
+++ b/apprise/plugins/chime.py
@@ -65,6 +65,7 @@ import re
 import requests
 
 from ..common import NotifyFormat, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import validate_regex
 from .base import NotifyBase
@@ -166,7 +167,7 @@ class NotifyChime(NotifyBase):
                 "({}) was specified.".format(webhook_id)
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Validate the Webhook Token
         self.token = validate_regex(token)
@@ -176,7 +177,7 @@ class NotifyChime(NotifyBase):
                 "({}) was specified.".format(token)
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         return
 

--- a/apprise/plugins/clickatell.py
+++ b/apprise/plugins/clickatell.py
@@ -33,6 +33,7 @@ from itertools import chain
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_phone_no, parse_phone_no, validate_regex
 from .base import NotifyBase
@@ -116,7 +117,7 @@ class NotifyClickatell(NotifyBase):
         if not self.apikey:
             msg = f"An invalid Clickatell API Token ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.source = None
         if source:
@@ -128,7 +129,7 @@ class NotifyClickatell(NotifyBase):
                 )
                 self.logger.warning(msg)
 
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             # Tidy source
             self.source = result["full"]

--- a/apprise/plugins/clicksend.py
+++ b/apprise/plugins/clicksend.py
@@ -43,6 +43,7 @@ from json import dumps
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import is_phone_no, parse_bool, parse_phone_no
@@ -147,7 +148,7 @@ class NotifyClickSend(NotifyBase):
         if not (self.user and self.password):
             msg = "A ClickSend user/pass was not provided."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         for target in parse_phone_no(targets):
             # Validate targets and drop bad ones:

--- a/apprise/plugins/custom_form.py
+++ b/apprise/plugins/custom_form.py
@@ -30,6 +30,7 @@ import re
 import requests
 
 from ..common import NotifyFormat, NotifyImageSize, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import URL_PATH_SAFE_CHARS
@@ -222,7 +223,7 @@ class NotifyForm(NotifyBase):
         if self.method not in METHODS:
             msg = f"The method specified ({method}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Custom File Attachment Over-Ride Support
         if not isinstance(attach_as, str):
@@ -235,7 +236,7 @@ class NotifyForm(NotifyBase):
             if not result:
                 msg = f"The attach-as specified ({attach_as}) is invalid."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             self.attach_as = ""
             self.attach_multi_support = False

--- a/apprise/plugins/custom_json.py
+++ b/apprise/plugins/custom_json.py
@@ -32,6 +32,7 @@ import requests
 
 from .. import exception
 from ..common import NotifyFormat, NotifyImageSize, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import URL_PATH_SAFE_CHARS
@@ -192,7 +193,7 @@ class NotifyJSON(NotifyBase):
         if self.method not in METHODS:
             msg = f"The method specified ({method}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.params = {}
         if params:

--- a/apprise/plugins/custom_xml.py
+++ b/apprise/plugins/custom_xml.py
@@ -32,6 +32,7 @@ import requests
 
 from .. import exception
 from ..common import NotifyFormat, NotifyImageSize, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import URL_PATH_SAFE_CHARS
@@ -205,7 +206,7 @@ class NotifyXML(NotifyBase):
         if self.method not in METHODS:
             msg = f"The method specified ({method}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # A payload map allows users to over-ride the default mapping if
         # they're detected with the :overide=value.  Normally this would

--- a/apprise/plugins/d7networks.py
+++ b/apprise/plugins/d7networks.py
@@ -39,6 +39,7 @@ from json import dumps, loads
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import (
     is_phone_no,
@@ -178,7 +179,7 @@ class NotifyD7Networks(NotifyBase):
         if not self.token:
             msg = f"The D7 Networks token specified ({token}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Parse our targets
         self.targets = []

--- a/apprise/plugins/dapnet.py
+++ b/apprise/plugins/dapnet.py
@@ -51,6 +51,7 @@ import requests
 from requests.auth import HTTPBasicAuth
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import is_call_sign, parse_bool, parse_call_sign, parse_list
@@ -197,7 +198,7 @@ class NotifyDapnet(NotifyBase):
         if not (self.user and self.password):
             msg = "A Dapnet user/pass was not provided."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Get the transmitter group
         self.txgroups = parse_list(

--- a/apprise/plugins/dbus.py
+++ b/apprise/plugins/dbus.py
@@ -28,6 +28,7 @@
 import sys
 
 from ..common import NotifyImageSize, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_bool
 from .base import NotifyBase
@@ -254,7 +255,7 @@ class NotifyDBus(NotifyBase):
         if self.schema not in MAINLOOP_MAP:
             msg = f"The schema specified ({self.schema}) is not supported."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # The urgency of the message
         self.urgency = int(
@@ -283,7 +284,7 @@ class NotifyDBus(NotifyBase):
                     " invalid."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg) from None
+                raise AppriseImproperlyConfigured(msg) from None
         else:
             self.x_axis = None
             self.y_axis = None

--- a/apprise/plugins/dingtalk.py
+++ b/apprise/plugins/dingtalk.py
@@ -35,6 +35,7 @@ import time
 import requests
 
 from ..common import NotifyFormat, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import parse_list, validate_regex
@@ -141,7 +142,7 @@ class NotifyDingTalk(NotifyBase):
         if not self.token:
             msg = f"An invalid DingTalk API Token ({token}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.secret = None
         if secret:
@@ -151,7 +152,7 @@ class NotifyDingTalk(NotifyBase):
             if not self.secret:
                 msg = f"An invalid DingTalk Secret ({token}) was specified."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         # Parse our targets
         self.targets = []

--- a/apprise/plugins/discord.py
+++ b/apprise/plugins/discord.py
@@ -56,6 +56,7 @@ import requests
 from ..apprise_attachment import AppriseAttachment
 from ..attachment.base import AttachBase
 from ..common import NotifyFormat, NotifyImageSize, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_bool, parse_list, validate_regex
 from ..utils.templates import TemplateType, apply_template
@@ -277,7 +278,7 @@ class NotifyDiscord(NotifyBase):
                 f"An invalid Discord Webhook ID ({webhook_id}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Webhook Token (associated with project)
         self.webhook_token = validate_regex(webhook_token)
@@ -287,7 +288,7 @@ class NotifyDiscord(NotifyBase):
                 f"({webhook_token}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Text To Speech
         self.tts = tts
@@ -331,7 +332,7 @@ class NotifyDiscord(NotifyBase):
                     "specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg) from None
+                raise AppriseImproperlyConfigured(msg) from None
         else:
             self.flags = None
 
@@ -364,7 +365,7 @@ class NotifyDiscord(NotifyBase):
                 # add() failed (unsupported schema, unparseable URL, etc.)
                 msg = "The Discord template specified could not be loaded."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             # Enforce maximum file size
             self.template[0].max_file_size = self.max_discord_template_size
@@ -380,7 +381,7 @@ class NotifyDiscord(NotifyBase):
                 f"({tokens}) are not identified as a dictionary."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # else: NoneType - this is okay
 

--- a/apprise/plugins/eight00com.py
+++ b/apprise/plugins/eight00com.py
@@ -53,6 +53,7 @@ from json import dumps
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_phone_no, parse_phone_no, validate_regex
 from .base import NotifyBase
@@ -158,14 +159,14 @@ class NotifyEight00com(NotifyBase):
         if not self.token:
             msg = "An 800.com Personal Access Token must be specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Validate the from (source) phone number
         result = is_phone_no(source)
         if not result:
             msg = "The 800.com from phone # ({}) is invalid.".format(source)
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store our source number as digits only
         self.source = result["full"]

--- a/apprise/plugins/email/base.py
+++ b/apprise/plugins/email/base.py
@@ -40,6 +40,7 @@ from typing import Optional
 
 from ...common import NotifyFormat, NotifyType, PersistentStoreMode
 from ...conversion import convert_between
+from ...exception import AppriseImproperlyConfigured
 from ...locale import gettext_lazy as _
 from ...logger import logger
 from ...url import PrivacyMode
@@ -335,7 +336,7 @@ class NotifyEmail(NotifyBase):
                 secure_mode
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Validate recipients (cc:) and drop bad ones:
         for recipient in parse_emails(cc):
@@ -431,7 +432,7 @@ class NotifyEmail(NotifyBase):
                 else "{}".format(self.from_addr[1])
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store our lookup
         self.names[self.from_addr[1]] = self.from_addr[0]

--- a/apprise/plugins/emby.py
+++ b/apprise/plugins/emby.py
@@ -35,6 +35,7 @@ import requests
 
 from .. import __version__ as VERSION
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import parse_bool
@@ -144,7 +145,7 @@ class NotifyEmby(NotifyBase):
             # User was not specified
             msg = "No Emby username was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         return
 

--- a/apprise/plugins/evolution.py
+++ b/apprise/plugins/evolution.py
@@ -66,6 +66,7 @@ from ..conversion import (
     commonmark_scan_autolink_dest,
     commonmark_scan_paren_dest,
 )
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import (
     is_phone_no,
@@ -170,7 +171,7 @@ class NotifyEvolution(NotifyBase):
         if not self.apikey:
             msg = f"An invalid Evolution API key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Instance name
         self.instance = validate_regex(instance)
@@ -180,7 +181,7 @@ class NotifyEvolution(NotifyBase):
                 f"({instance}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Parse and validate recipient phone numbers
         self.phone = []
@@ -201,7 +202,7 @@ class NotifyEvolution(NotifyBase):
         if not self.phone:
             msg = "No valid Evolution API phone numbers were specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         return
 

--- a/apprise/plugins/exotel.py
+++ b/apprise/plugins/exotel.py
@@ -31,6 +31,7 @@ import re
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import (
@@ -268,7 +269,7 @@ class NotifyExotel(NotifyBase):
         if not self.sid:
             msg = "An invalid Exotel SID ({}) was specified.".format(sid)
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # API Token (associated with account)
         self.token = validate_regex(token)
@@ -277,7 +278,7 @@ class NotifyExotel(NotifyBase):
                 token
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # API Key used as the HTTP Basic Auth username. Older URLs did not
         # carry this separately, so default it to the account SID.
@@ -287,7 +288,7 @@ class NotifyExotel(NotifyBase):
                 apikey
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Used for URL generation afterwards only
         self.invalid_targets = []
@@ -309,7 +310,7 @@ class NotifyExotel(NotifyBase):
                 region_name
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Define whether or not we should set the unicode flag
         self.unicode = (
@@ -359,7 +360,7 @@ class NotifyExotel(NotifyBase):
                     priority
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             # store our successfully looked up priority
             self.priority = EXOTEL_PRIORITY_MAP[result]
@@ -374,7 +375,7 @@ class NotifyExotel(NotifyBase):
                 "({}) is invalid.".format(source)
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store our parsed value
         self.source = result

--- a/apprise/plugins/fcm/__init__.py
+++ b/apprise/plugins/fcm/__init__.py
@@ -53,6 +53,7 @@ import requests
 
 from ...apprise_attachment import AppriseAttachment
 from ...common import NotifyImageSize, NotifyType
+from ...exception import AppriseImproperlyConfigured
 from ...locale import gettext_lazy as _
 from ...utils.logic import dict_full_update
 from ...utils.parse import parse_bool, parse_list, validate_regex
@@ -248,7 +249,7 @@ class NotifyFCM(NotifyBase):
             if self.mode and self.mode not in FCM_MODES:
                 msg = f"The FCM mode specified ({mode}) is invalid."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         # Used for Legacy Mode; this is the Web API Key retrieved from the
         # User Panel
@@ -275,12 +276,12 @@ class NotifyFCM(NotifyBase):
             if not self.project:
                 msg = f"An invalid FCM Project ID ({project}) was specified."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             if not keyfile:
                 msg = "No FCM JSON KeyFile was specified."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             # Our keyfile object is just an AppriseAttachment object
             self.keyfile = AppriseAttachment(asset=self.asset)
@@ -295,7 +296,7 @@ class NotifyFCM(NotifyBase):
             if not self.apikey:
                 msg = f"An invalid FCM API key ({apikey}) was specified."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         # Acquire Device IDs to notify
         self.targets = parse_list(targets)

--- a/apprise/plugins/fcm/priority.py
+++ b/apprise/plugins/fcm/priority.py
@@ -31,6 +31,7 @@
 
 # Legacy priorities are defined here:
 # - https://firebase.google.com/docs/cloud-messaging/http-server-ref
+from ...exception import AppriseImproperlyConfigured
 from ...logger import logger
 from .common import FCM_MODES, FCMMode
 
@@ -171,7 +172,7 @@ class FCMPriorityManager:
         if self.mode not in FCM_MODES:
             msg = f"The FCM mode specified ({mode}) is invalid."
             logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.priority = None
         if priority:
@@ -186,7 +187,7 @@ class FCMPriorityManager:
             if not self.priority:
                 msg = f"An invalid FCM Priority ({priority}) was specified."
                 logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
     def payload(self):
         """Returns our payload depending on our mode."""

--- a/apprise/plugins/feishu.py
+++ b/apprise/plugins/feishu.py
@@ -37,6 +37,7 @@ from json import dumps
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import validate_regex
 from .base import NotifyBase
@@ -106,7 +107,7 @@ class NotifyFeishu(NotifyBase):
         if not self.token:
             msg = f"The Feishu token specified ({token}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         return
 

--- a/apprise/plugins/flock.py
+++ b/apprise/plugins/flock.py
@@ -45,6 +45,7 @@ import re
 import requests
 
 from ..common import NotifyFormat, NotifyImageSize, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_bool, parse_list, validate_regex
 from .base import NotifyBase
@@ -157,7 +158,7 @@ class NotifyFlock(NotifyBase):
         if not self.token:
             msg = f"An invalid Flock Access Key ({token}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Track whether or not we want to send an image with our notification
         # or not.
@@ -189,7 +190,7 @@ class NotifyFlock(NotifyBase):
             # We have a bot token and no target(s) to message
             msg = "No Flock targets to notify."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         return
 

--- a/apprise/plugins/flowtriq.py
+++ b/apprise/plugins/flowtriq.py
@@ -61,6 +61,7 @@ from json import dumps
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import URL_PATH_SAFE_CHARS, validate_regex
 from .base import NotifyBase
@@ -145,25 +146,25 @@ class NotifyFlowtriq(NotifyBase):
                 apikey
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Webhook Path (the full path portion of the webhook URL provided
         # by the Flowtriq dashboard)
         if not webhook_path:
             msg = "A Flowtriq Webhook Path must be specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.webhook_path = webhook_path.strip("/")
         if not self.webhook_path:
             msg = "A Flowtriq Webhook Path must be specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         if not self.host:
             msg = "A Flowtriq hostname must be specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
     def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
         """Perform Flowtriq Notification."""

--- a/apprise/plugins/fluxer.py
+++ b/apprise/plugins/fluxer.py
@@ -54,6 +54,7 @@ import requests
 
 from ..attachment.base import AttachBase
 from ..common import NotifyFormat, NotifyImageSize, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import (
     is_hostname,
@@ -292,7 +293,7 @@ class NotifyFluxer(NotifyBase):
         if not self.webhook_id:
             msg = f"An invalid Fluxer Webhook ID ({webhook_id}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Webhook Token (associated with project)
         self.webhook_token = validate_regex(
@@ -304,7 +305,7 @@ class NotifyFluxer(NotifyBase):
                 f"({webhook_token}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Prepare our mode
         self.mode = (
@@ -316,13 +317,13 @@ class NotifyFluxer(NotifyBase):
         if self.mode not in FLUXER_MODES:
             msg = f"An invalid Fluxer Mode ({mode}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         if not self.host and self.mode == FluxerMode.PRIVATE:
             # No host provided
             msg = f"An invalid Fluxer Hostname ({self.host}) was provided."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         if self.mode == FluxerMode.PRIVATE and self.__auto_cloud_host.search(
             self.host
@@ -399,7 +400,7 @@ class NotifyFluxer(NotifyBase):
                     f"An invalid Fluxer flags setting ({flags}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg) from None
+                raise AppriseImproperlyConfigured(msg) from None
         else:
             self.flags = None
 

--- a/apprise/plugins/fortysixelks.py
+++ b/apprise/plugins/fortysixelks.py
@@ -42,6 +42,7 @@ from typing import Any, Optional
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import (
@@ -147,12 +148,12 @@ class Notify46Elks(NotifyBase):
         if not self.password:
             msg = "No 46elks password was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         elif not self.user:
             msg = "No 46elks user was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Parse our targets
         self.targets = []

--- a/apprise/plugins/freemobile.py
+++ b/apprise/plugins/freemobile.py
@@ -37,6 +37,7 @@ from json import dumps
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from .base import NotifyBase
 
@@ -97,7 +98,7 @@ class NotifyFreeMobile(NotifyBase):
                 "A FreeMobile user and password combination was not provided."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         return
 

--- a/apprise/plugins/glib.py
+++ b/apprise/plugins/glib.py
@@ -28,6 +28,7 @@
 import sys
 
 from ..common import NotifyImageSize, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_bool
 from .base import NotifyBase
@@ -237,7 +238,7 @@ class NotifyGLib(NotifyBase):
                     f" ({x_axis},{y_axis}) are invalid."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg) from None
+                raise AppriseImproperlyConfigured(msg) from None
         else:
             self.x_axis = None
             self.y_axis = None

--- a/apprise/plugins/google_chat.py
+++ b/apprise/plugins/google_chat.py
@@ -72,6 +72,7 @@ from ..conversion import (
     commonmark_scan_autolink_dest,
     commonmark_scan_paren_dest,
 )
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import validate_regex
 from .base import NotifyBase
@@ -174,7 +175,7 @@ class NotifyGoogleChat(NotifyBase):
                 f"({workspace}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Webhook Key (associated with project)
         self.webhook_key = validate_regex(webhook_key)
@@ -184,7 +185,7 @@ class NotifyGoogleChat(NotifyBase):
                 f"({webhook_key}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Webhook Token (associated with project)
         self.webhook_token = validate_regex(webhook_token)
@@ -194,7 +195,7 @@ class NotifyGoogleChat(NotifyBase):
                 f"({webhook_token}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         if thread_key:
             self.thread_key = validate_regex(thread_key)
@@ -204,7 +205,7 @@ class NotifyGoogleChat(NotifyBase):
                     f"({thread_key}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
         else:
             self.thread_key = None
 

--- a/apprise/plugins/gotify.py
+++ b/apprise/plugins/gotify.py
@@ -35,6 +35,7 @@ from json import dumps
 import requests
 
 from ..common import NotifyFormat, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import URL_PATH_SAFE_CHARS, validate_regex
 from .base import NotifyBase
@@ -167,7 +168,7 @@ class NotifyGotify(NotifyBase):
         if not self.token:
             msg = f"An invalid Gotify Token ({token}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # prepare our fullpath
         self.fullpath = kwargs.get("fullpath", "/")

--- a/apprise/plugins/groupme.py
+++ b/apprise/plugins/groupme.py
@@ -56,6 +56,7 @@ from json import dumps, loads
 import requests
 
 from ..common import NotifyFormat, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import validate_regex
 from .base import NotifyBase
@@ -159,7 +160,7 @@ class NotifyGroupMe(NotifyBase):
         if not self.bot_id:
             msg = "A GroupMe bot_id must be specified ({}).".format(bot_id)
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store the optional access token (needed for image uploads)
         self.token = validate_regex(token) if token else None

--- a/apprise/plugins/home_assistant.py
+++ b/apprise/plugins/home_assistant.py
@@ -36,6 +36,7 @@ from uuid import uuid4
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import (
@@ -213,7 +214,7 @@ class NotifyHomeAssistant(NotifyBase):
                 f"({accesstoken}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # An Optional Notification Identifier
         self.nid = None
@@ -225,7 +226,7 @@ class NotifyHomeAssistant(NotifyBase):
                     f"({nid}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         # Prepare Batch Mode Flag
         self.batch = (

--- a/apprise/plugins/httpsms.py
+++ b/apprise/plugins/httpsms.py
@@ -33,6 +33,7 @@ import json
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_phone_no, parse_phone_no, validate_regex
 from .base import NotifyBase
@@ -128,7 +129,7 @@ class NotifyHttpSMS(NotifyBase):
         if not self.apikey:
             msg = f"An invalid API Key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         result = is_phone_no(source)
         if not result:
@@ -136,7 +137,7 @@ class NotifyHttpSMS(NotifyBase):
                 f"The Account (From) Phone # specified ({source}) is invalid."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Tidy source
         self.source = result["full"]

--- a/apprise/plugins/humhub.py
+++ b/apprise/plugins/humhub.py
@@ -70,6 +70,7 @@ from json import dumps, loads
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import parse_list
@@ -173,7 +174,7 @@ class NotifyHumHub(NotifyBase):
         if not self.user:
             msg = "A HumHub bearer token or username must be specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Accumulate invalid targets for lossless URL round-tripping
         self._invalid_targets = []
@@ -200,7 +201,7 @@ class NotifyHumHub(NotifyBase):
         if not self.targets:
             msg = "No valid HumHub container ID(s) were specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         return
 

--- a/apprise/plugins/ifttt.py
+++ b/apprise/plugins/ifttt.py
@@ -45,6 +45,7 @@ import re
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_list, validate_regex
 from .base import NotifyBase
@@ -155,14 +156,14 @@ class NotifyIFTTT(NotifyBase):
         if not self.webhook_id:
             msg = f"An invalid IFTTT Webhook ID ({webhook_id}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store our Events we wish to trigger
         self.events = parse_list(events)
         if not self.events:
             msg = "You must specify at least one event you wish to trigger on."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Tokens to include in post
         self.add_tokens = {}
@@ -185,7 +186,7 @@ class NotifyIFTTT(NotifyBase):
                     " provided"
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
     def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
         """Perform IFTTT Notification."""

--- a/apprise/plugins/irc/base.py
+++ b/apprise/plugins/irc/base.py
@@ -48,6 +48,7 @@ import re
 from typing import Any, Optional
 
 from ...common import NotifyType
+from ...exception import AppriseImproperlyConfigured
 from ...locale import gettext_lazy as _
 from ...url import PrivacyMode
 from ...utils.parse import parse_bool, parse_list
@@ -209,7 +210,7 @@ class NotifyIRC(NotifyBase):
             if self.auth_mode not in IRC_AUTH_MODES:
                 msg = f"The IRC auth mode specified ({mode}) is invalid."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         self.fullname = (name or "").strip()
 

--- a/apprise/plugins/jira.py
+++ b/apprise/plugins/jira.py
@@ -47,6 +47,7 @@ from json import dumps, loads
 import requests
 
 from ..common import NotifyType, PersistentStoreMode
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_uuid, parse_bool, parse_list, validate_regex
 from .base import NotifyBase
@@ -350,7 +351,7 @@ class NotifyJira(NotifyBase):
         if not self.apikey:
             msg = "An invalid Jira API Key ({}) was specified.".format(apikey)
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # The Priority of the message
         self.priority = (
@@ -383,7 +384,7 @@ class NotifyJira(NotifyBase):
                 region_name
             )
             self.logger.warning(msg)
-            raise TypeError(msg) from None
+            raise AppriseImproperlyConfigured(msg) from None
 
         if action and isinstance(action, str):
             self.action = next(
@@ -394,7 +395,7 @@ class NotifyJira(NotifyBase):
                     action
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
         else:
             self.action = self.template_args["action"]["default"]
 
@@ -410,7 +411,7 @@ class NotifyJira(NotifyBase):
                         "is invalid.".format(_k)
                     )
                     self.logger.warning(msg)
-                    raise TypeError(msg)
+                    raise AppriseImproperlyConfigured(msg)
 
                 _v_lower = _v.lower()
                 v = next(
@@ -423,7 +424,7 @@ class NotifyJira(NotifyBase):
                         "specified ({}) is invalid.".format(k, _v)
                     )
                     self.logger.warning(msg)
-                    raise TypeError(msg)
+                    raise AppriseImproperlyConfigured(msg)
 
                 # Update our mapping
                 self.mapping[k] = v

--- a/apprise/plugins/join.py
+++ b/apprise/plugins/join.py
@@ -40,6 +40,7 @@ import re
 import requests
 
 from ..common import NotifyImageSize, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_bool, parse_list, validate_regex
 from .base import NotifyBase
@@ -214,7 +215,7 @@ class NotifyJoin(NotifyBase):
         if not self.apikey:
             msg = f"An invalid Join API Key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # The Priority of the message
         self.priority = int(

--- a/apprise/plugins/kavenegar.py
+++ b/apprise/plugins/kavenegar.py
@@ -39,6 +39,7 @@ from json import loads
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_phone_no, parse_phone_no, validate_regex
 from .base import NotifyBase
@@ -163,7 +164,7 @@ class NotifyKavenegar(NotifyBase):
         if not self.apikey:
             msg = f"An invalid Kavenegar API Key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.source = None
         if source is not None:
@@ -171,7 +172,7 @@ class NotifyKavenegar(NotifyBase):
             if not result:
                 msg = f"The Kavenegar source specified ({source}) is invalid."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             # Store our source
             self.source = result["full"]

--- a/apprise/plugins/kook.py
+++ b/apprise/plugins/kook.py
@@ -67,6 +67,7 @@ import re
 import requests
 
 from ..common import NotifyFormat, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_list
 from .base import NotifyBase
@@ -216,7 +217,7 @@ class NotifyKook(NotifyBase):
         if not self.token:
             msg = "A Kook token must be specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Resolve operating mode
         if mode and isinstance(mode, str):
@@ -228,7 +229,7 @@ class NotifyKook(NotifyBase):
             if self.mode not in KOOK_MODES:
                 msg = f"The Kook mode specified ({mode}) is not valid."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         else:
             # Default to bot mode

--- a/apprise/plugins/kumulos.py
+++ b/apprise/plugins/kumulos.py
@@ -40,6 +40,7 @@ from json import dumps
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import validate_regex
 from .base import NotifyBase
@@ -116,7 +117,7 @@ class NotifyKumulos(NotifyBase):
         if not self.apikey:
             msg = f"An invalid Kumulos API Key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Server Key (associated with project)
         self.serverkey = validate_regex(
@@ -125,7 +126,7 @@ class NotifyKumulos(NotifyBase):
         if not self.serverkey:
             msg = f"An invalid Kumulos Server Key ({serverkey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
     def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
         """Perform Kumulos Notification."""

--- a/apprise/plugins/lametric.py
+++ b/apprise/plugins/lametric.py
@@ -93,6 +93,7 @@ import re
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_hostname, is_ipaddr, validate_regex
 from .base import NotifyBase
@@ -560,7 +561,7 @@ class NotifyLametric(NotifyBase):
         if self.mode not in LAMETRIC_MODES:
             msg = f"An invalid LaMetric Mode ({mode}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         if self.mode == LametricMode.CLOUD:
             try:
@@ -571,7 +572,7 @@ class NotifyLametric(NotifyBase):
                     f"({app_id}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg) from None
+                raise AppriseImproperlyConfigured(msg) from None
 
             # Detect our Access Token
             self.lametric_app_access_token = validate_regex(
@@ -583,7 +584,7 @@ class NotifyLametric(NotifyBase):
                     f"({app_token}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             # If app_ver is specified, it over-rides all
             if app_ver:
@@ -596,7 +597,7 @@ class NotifyLametric(NotifyBase):
                         f"({app_ver}) was specified."
                     )
                     self.logger.warning(msg)
-                    raise TypeError(msg)
+                    raise AppriseImproperlyConfigured(msg)
 
             else:
                 # If app_ver wasn't specified, we parse it from the
@@ -618,7 +619,7 @@ class NotifyLametric(NotifyBase):
                     f"({apikey}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         if priority not in LAMETRIC_PRIORITIES:
             self.priority = self.template_args["priority"]["default"]

--- a/apprise/plugins/lark.py
+++ b/apprise/plugins/lark.py
@@ -34,6 +34,7 @@ import re
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import validate_regex
@@ -88,7 +89,7 @@ class NotifyLark(NotifyBase):
         if not self.token:
             msg = f"The Lark Bot Token token specified ({token}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.webhook_url = f"{self.notify_url}{self.token}"
 

--- a/apprise/plugins/lauther.py
+++ b/apprise/plugins/lauther.py
@@ -40,6 +40,7 @@
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import validate_regex
 from .base import NotifyBase
@@ -189,7 +190,7 @@ class NotifyLauther(NotifyBase):
         if not self.token:
             msg = f"The Lauther token specified ({token}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # The priority of the message
         self.priority = int(
@@ -218,7 +219,7 @@ class NotifyLauther(NotifyBase):
         if self.priority not in LAUTHER_PRIORITIES:
             msg = f"The Lauther priority specified ({priority}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Optional appearance overrides and metadata
         self.sound = sound

--- a/apprise/plugins/line.py
+++ b/apprise/plugins/line.py
@@ -34,6 +34,7 @@ import re
 import requests
 
 from ..common import NotifyImageSize, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import parse_bool, parse_list, validate_regex
@@ -122,7 +123,7 @@ class NotifyLine(NotifyBase):
         if not self.token:
             msg = f"An invalid Access Token ({token}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Display our Apprise Image
         self.include_image = include_image

--- a/apprise/plugins/mailersend.py
+++ b/apprise/plugins/mailersend.py
@@ -67,6 +67,7 @@ import requests
 from .. import exception
 from ..common import NotifyFormat, NotifyType
 from ..conversion import convert_between
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_email, parse_list, validate_regex
 from ..utils.sanitize import sanitize_payload
@@ -190,14 +191,14 @@ class NotifyMailerSend(NotifyBase):
         if not self.apikey:
             msg = f"An invalid MailerSend API Key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Validate and store the From Email
         result = is_email(from_email)
         if not result:
             msg = f"Invalid MailerSend From email specified: {from_email}"
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store the verified from address
         self.from_email = result["full_email"]
@@ -212,7 +213,7 @@ class NotifyMailerSend(NotifyBase):
                     f" ({reply_to}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             self.reply_to = result["full_email"]
 

--- a/apprise/plugins/mailgun.py
+++ b/apprise/plugins/mailgun.py
@@ -58,6 +58,7 @@ from email.utils import formataddr
 import requests
 
 from ..common import NotifyFormat, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..logger import logger
 from ..utils.parse import is_email, parse_bool, parse_emails, validate_regex
@@ -231,13 +232,13 @@ class NotifyMailgun(NotifyBase):
         if not self.apikey:
             msg = f"An invalid Mailgun API Key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Validate our username
         if not self.user:
             msg = "No Mailgun username was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Acquire Email 'To'
         self.targets = []
@@ -279,7 +280,7 @@ class NotifyMailgun(NotifyBase):
             # Invalid region specified
             msg = f"The Mailgun region specified ({region_name}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg) from None
+            raise AppriseImproperlyConfigured(msg) from None
 
         # Get our From username (if specified)
         self.from_addr = [self.app_id, f"{self.user}@{self.host}"]
@@ -298,7 +299,7 @@ class NotifyMailgun(NotifyBase):
             # Parse Source domain based on from_addr
             msg = f"Invalid ~From~ email format: {self.from_addr}"
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         if targets:
             # Validate recipients (to:) and drop bad ones:

--- a/apprise/plugins/mastodon.py
+++ b/apprise/plugins/mastodon.py
@@ -35,6 +35,7 @@ import requests
 
 from ..attachment.base import AttachBase
 from ..common import NotifyFormat, NotifyImageSize, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import parse_bool, parse_list, validate_regex
@@ -285,7 +286,7 @@ class NotifyMastodon(NotifyBase):
         if not self.token:
             msg = "An invalid Mastodon Access Token was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         if visibility:
             # Input is a string; attempt to get the lookup from our
@@ -314,7 +315,7 @@ class NotifyMastodon(NotifyBase):
                     " invalid."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         else:
             self.visibility = self.template_args["visibility"]["default"]
@@ -384,7 +385,7 @@ class NotifyMastodon(NotifyBase):
             # important we don't switch from the users original intentions
             msg = "No Mastodon targets to notify."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Ping targets (tokens from URL, already split by parse_list)
         self.ping = []

--- a/apprise/plugins/matrix/base.py
+++ b/apprise/plugins/matrix/base.py
@@ -51,7 +51,7 @@ from ...common import (
     PersistentStoreMode,
 )
 from ...conversion import html_to_text
-from ...exception import AppriseException
+from ...exception import AppriseImproperlyConfigured, ApprisePluginException
 from ...locale import gettext_lazy as _
 from ...url import PrivacyMode
 from ...utils.parse import (
@@ -86,7 +86,7 @@ MATRIX_V3_MEDIA_PATH = "/_matrix/media/v3"
 MATRIX_V2_MEDIA_PATH = "/_matrix/media/r0"
 
 
-class MatrixDiscoveryException(AppriseException):
+class MatrixDiscoveryException(ApprisePluginException):
     """Apprise Matrix Exception Class."""
 
 
@@ -485,7 +485,7 @@ class NotifyMatrix(NotifyBase):
         if self.mode and self.mode not in MATRIX_WEBHOOK_MODES:
             msg = f"The mode specified ({mode}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Setup our version
         self.version = (
@@ -496,7 +496,7 @@ class NotifyMatrix(NotifyBase):
         if self.version not in MATRIX_VERSIONS:
             msg = f"The version specified ({version}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Setup our message type
         self.msgtype = (
@@ -507,7 +507,7 @@ class NotifyMatrix(NotifyBase):
         if self.msgtype and self.msgtype not in MATRIX_MESSAGE_TYPES:
             msg = f"The msgtype specified ({msgtype}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         if self.mode == MatrixWebhookMode.T2BOT:
             # t2bot configuration requires that a webhook id is specified
@@ -520,12 +520,12 @@ class NotifyMatrix(NotifyBase):
                     f"({self.password}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         elif not is_hostname(self.host):
             msg = f"An invalid Matrix Hostname ({self.host}) was specified"
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         else:
             # Verify port if specified
@@ -536,7 +536,7 @@ class NotifyMatrix(NotifyBase):
             ):
                 msg = f"An invalid Matrix Port ({self.port}) was specified"
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         if self.mode != MatrixWebhookMode.DISABLED:
             # Discovery only works when we're not using webhooks

--- a/apprise/plugins/matrix/e2ee.py
+++ b/apprise/plugins/matrix/e2ee.py
@@ -83,6 +83,7 @@ except ImportError:
     MATRIX_E2EE_SUPPORT = False
 
 from ...common import JSON_COMPACT_SEPARATORS
+from ...exception import AppriseInvalidData
 
 # Rotate the MegOLM session after this many messages
 MEGOLM_ROTATION_MSGS = 100
@@ -943,7 +944,9 @@ class MatrixMegOlmSession:
     def from_dict(data):
         """Restore from a ``to_dict()`` snapshot."""
         if data.get("version") != MATRIX_MEGOLM_STORE_VERSION:
-            raise ValueError("Incompatible MegOLM session cache format")
+            raise AppriseInvalidData(
+                "Incompatible MegOLM session cache format"
+            )
         return MatrixMegOlmSession(
             ratchet=[_b64dec(r) for r in data["ratchet"]],
             counter=data["counter"],

--- a/apprise/plugins/mattermost.py
+++ b/apprise/plugins/mattermost.py
@@ -63,6 +63,7 @@ from typing import Any
 import requests
 
 from ..common import NotifyImageSize, NotifyType, PersistentStoreMode
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import (
     URL_PATH_SAFE_CHARS,
@@ -264,7 +265,7 @@ class NotifyMattermost(NotifyBase):
             if self.mode not in MATTERMOST_MODES:
                 msg = f"The Mattermost mode specified ({mode}) is invalid."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
         else:
             self.mode = self.template_args["mode"]["default"]
 
@@ -276,7 +277,7 @@ class NotifyMattermost(NotifyBase):
         if not self.token:
             msg = f"An invalid Mattermost Token ({token}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Used for URL generation afterwards only
         self._invalid_targets = []

--- a/apprise/plugins/messagebird.py
+++ b/apprise/plugins/messagebird.py
@@ -34,6 +34,7 @@
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_phone_no, parse_phone_no, validate_regex
 from .base import NotifyBase
@@ -126,13 +127,13 @@ class NotifyMessageBird(NotifyBase):
         if not self.apikey:
             msg = f"An invalid MessageBird API Key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         result = is_phone_no(source)
         if not result:
             msg = f"The MessageBird source specified ({source}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store our source
         self.source = result["full"]

--- a/apprise/plugins/misskey.py
+++ b/apprise/plugins/misskey.py
@@ -48,6 +48,7 @@ from json import dumps
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import validate_regex
 from .base import NotifyBase
@@ -156,7 +157,7 @@ class NotifyMisskey(NotifyBase):
         if not self.token:
             msg = "An invalid Misskey Access Token was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         if visibility:
             # Input is a string; attempt to get the lookup from our
@@ -179,7 +180,7 @@ class NotifyMisskey(NotifyBase):
                     " invalid."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
         else:
             self.visibility = self.template_args["visibility"]["default"]
 

--- a/apprise/plugins/mqtt.py
+++ b/apprise/plugins/mqtt.py
@@ -39,6 +39,7 @@ import ssl
 from time import sleep
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import parse_bool, parse_list
@@ -269,12 +270,12 @@ class NotifyMQTT(NotifyBase):
                 or self.qos > self.template_args["qos"]["max"]
             ):
                 # Let error get handle on exceptio higher up
-                raise ValueError("")
+                raise AppriseImproperlyConfigured("")
 
         except (ValueError, TypeError):
             msg = f"An invalid MQTT QOS ({qos}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg) from None
+            raise AppriseImproperlyConfigured(msg) from None
 
         if not self.port:
             # Assign port (if not otherwise set)
@@ -311,7 +312,7 @@ class NotifyMQTT(NotifyBase):
                 f"An invalid MQTT Protocol version ({version}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg) from None
+            raise AppriseImproperlyConfigured(msg) from None
 
         # Our MQTT Client Object
         self.client = mqtt.Client(

--- a/apprise/plugins/msg91.py
+++ b/apprise/plugins/msg91.py
@@ -40,6 +40,7 @@ import re
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import (
     is_phone_no,
@@ -172,7 +173,7 @@ class NotifyMSG91(NotifyBase):
                 f"({authkey}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Template ID
         self.template = validate_regex(
@@ -181,7 +182,7 @@ class NotifyMSG91(NotifyBase):
         if not self.template:
             msg = f"An invalid MSG91 Template ID ({template}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         if short_url is None:
             self.short_url = self.template_args["short_url"]["default"]

--- a/apprise/plugins/nextcloud.py
+++ b/apprise/plugins/nextcloud.py
@@ -32,7 +32,7 @@ import re
 import requests
 
 from ..common import NotifyType, PersistentStoreMode
-from ..exception import AppriseException
+from ..exception import AppriseImproperlyConfigured, ApprisePluginException
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import parse_list
@@ -52,7 +52,7 @@ IS_USER = re.compile(
 )
 
 
-class NextcloudGroupDiscoveryException(AppriseException):
+class NextcloudGroupDiscoveryException(ApprisePluginException):
     """Apprise Nextcloud Group Discovery Exception Class."""
 
 
@@ -237,7 +237,7 @@ class NotifyNextcloud(NotifyBase):
                     f"At invalid Nextcloud version ({version}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg) from None
+                raise AppriseImproperlyConfigured(msg) from None
 
         # Support URL Prefix
         self.url_prefix = (

--- a/apprise/plugins/nextcloudtalk.py
+++ b/apprise/plugins/nextcloudtalk.py
@@ -30,6 +30,7 @@ from json import dumps
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import parse_list
@@ -131,7 +132,7 @@ class NotifyNextcloudTalk(NotifyBase):
         if self.user is None or self.password is None:
             msg = "A NextCloudTalk User and Password must be specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store our targets
         self.targets = parse_list(targets)

--- a/apprise/plugins/notica.py
+++ b/apprise/plugins/notica.py
@@ -44,6 +44,7 @@ import re
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import URL_PATH_SAFE_CHARS, validate_regex
@@ -167,7 +168,7 @@ class NotifyNotica(NotifyBase):
         if not self.token:
             msg = f"An invalid Notica Token ({token}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Setup our mode
         self.mode = NoticaMode.SELFHOSTED if self.host else NoticaMode.OFFICIAL

--- a/apprise/plugins/notifiarr.py
+++ b/apprise/plugins/notifiarr.py
@@ -32,6 +32,7 @@ import re
 import requests
 
 from ..common import NotifyImageSize, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_bool, parse_list, validate_regex
 from .base import NotifyBase
@@ -158,7 +159,7 @@ class NotifyNotifiarr(NotifyBase):
         if not self.apikey:
             msg = f"An invalid Notifiarr APIKey ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Place a thumbnail image inline with the message body
         self.include_image = (
@@ -181,7 +182,7 @@ class NotifyNotifiarr(NotifyBase):
                     f"({event}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg) from None
+                raise AppriseImproperlyConfigured(msg) from None
 
         # Prepare our targets
         self.targets = {

--- a/apprise/plugins/notifico.py
+++ b/apprise/plugins/notifico.py
@@ -59,6 +59,7 @@ import re
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import parse_bool, validate_regex
@@ -249,7 +250,7 @@ class NotifyNotifico(NotifyBase):
                 f"An invalid Notifico Project ID ({project_id}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Assign our message hook
         self.msghook = validate_regex(
@@ -261,7 +262,7 @@ class NotifyNotifico(NotifyBase):
                 f"An invalid Notifico Message Token ({msghook}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Detect operating mode: self-hosted when a hostname is present
         self.mode = (

--- a/apprise/plugins/notifyre.py
+++ b/apprise/plugins/notifyre.py
@@ -62,6 +62,7 @@ from json import dumps, loads
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_phone_no, parse_bool, parse_phone_no
 from .base import NotifyBase
@@ -213,7 +214,7 @@ class NotifyNotifyre(NotifyBase):
         if not apikey:
             msg = "A Notifyre API key must be specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store our API key
         self.apikey = apikey
@@ -230,7 +231,7 @@ class NotifyNotifyre(NotifyBase):
                     mode
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         else:
             # Default to SMS
@@ -246,7 +247,7 @@ class NotifyNotifyre(NotifyBase):
                     "({}) is invalid.".format(source)
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             # Store normalised number with country code prefix
             self.source = "+{}".format(result["full"])

--- a/apprise/plugins/ntfy.py
+++ b/apprise/plugins/ntfy.py
@@ -44,6 +44,7 @@ import requests
 from ..attachment.base import AttachBase
 from ..attachment.memory import AttachMemory
 from ..common import NotifyFormat, NotifyImageSize, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import (
@@ -345,7 +346,7 @@ class NotifyNtfy(NotifyBase):
         if self.mode not in NTFY_MODES:
             msg = f"An invalid ntfy Mode ({mode}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Show image associated with notification
         self.include_image = include_image
@@ -362,7 +363,7 @@ class NotifyNtfy(NotifyBase):
                 f"An invalid ntfy Authentication type ({auth}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Attach a file (URL supported)
         self.attach = attach

--- a/apprise/plugins/octopush.py
+++ b/apprise/plugins/octopush.py
@@ -36,6 +36,7 @@ from json import dumps
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import (
@@ -197,8 +198,8 @@ class NotifyOctopush(NotifyBase):
 
     def __init__(
         self,
-        api_login,
-        api_key,
+        api_login=None,
+        api_key=None,
         targets=None,
         batch=False,
         sender=None,
@@ -217,7 +218,7 @@ class NotifyOctopush(NotifyBase):
                 api_login
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store our API Key
         self.api_key = validate_regex(api_key)
@@ -226,7 +227,7 @@ class NotifyOctopush(NotifyBase):
                 api_key
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Prepare Batch Mode Flag
         self.batch = batch
@@ -255,7 +256,7 @@ class NotifyOctopush(NotifyBase):
         if self.mtype is None:
             msg = "The Octopush type specified ({}) is invalid.".format(mtype)
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.purpose = (
             self.template_args["purpose"]["default"]
@@ -267,7 +268,7 @@ class NotifyOctopush(NotifyBase):
                 purpose
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.purpose = self.purpose.lower()
         if self.purpose not in OCTOPUSH_PURPOSES:
@@ -275,7 +276,7 @@ class NotifyOctopush(NotifyBase):
                 purpose
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.sender = None
         if sender:
@@ -285,7 +286,7 @@ class NotifyOctopush(NotifyBase):
                     sender
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         # Initialize numbers list
         self.targets = []

--- a/apprise/plugins/office365.py
+++ b/apprise/plugins/office365.py
@@ -53,6 +53,7 @@ import requests
 
 from .. import exception
 from ..common import NotifyFormat, NotifyType, PersistentStoreMode
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import is_email, parse_bool, parse_emails, validate_regex
@@ -352,7 +353,7 @@ class NotifyOffice365(NotifyBase):
             if _mode not in OFFICE365_MODES:
                 msg = f"The Office 365 mode specified ({mode}) is invalid."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
             self.mode = _mode
         else:
             _src = is_email(source) if source else None
@@ -376,7 +377,7 @@ class NotifyOffice365(NotifyBase):
                 f"({client_id}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Client Secret (org) or seed Refresh Token (personal)
         self.secret = validate_regex(secret)
@@ -386,7 +387,7 @@ class NotifyOffice365(NotifyBase):
                 f"({secret}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         if self.mode == Office365Mode.ORG:
             # Tenant identifier — required for org mode
@@ -396,7 +397,7 @@ class NotifyOffice365(NotifyBase):
             if not self.tenant:
                 msg = f"An invalid Office 365 Tenant ({tenant}) was specified."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         else:
             # Personal mode requires no tenant
@@ -518,7 +519,7 @@ class NotifyOffice365(NotifyBase):
                     f"mode; got ({self.source})."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             self.from_email = result["full_email"]
             self.from_name = result["name"] or None

--- a/apprise/plugins/one_signal.py
+++ b/apprise/plugins/one_signal.py
@@ -38,6 +38,7 @@ from json import dumps
 import requests
 
 from ..common import NotifyImageSize, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.base64 import decode_b64_dict, encode_b64_dict
 from ..utils.parse import is_email, parse_bool, parse_list, validate_regex
@@ -225,14 +226,14 @@ class NotifyOneSignal(NotifyBase):
         if not self.apikey:
             msg = f"An invalid OneSignal API key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # The App ID associated with the account
         self.app = validate_regex(app)
         if not self.app:
             msg = f"An invalid OneSignal Application ID ({app}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Prepare Batch Mode Flag
         self.batch_size = (
@@ -286,7 +287,7 @@ class NotifyOneSignal(NotifyBase):
         if not self.language or len(self.language) != 2:
             msg = f"An invalid OneSignal Language ({language}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Sort our targets
         for target_ in parse_list(targets):
@@ -347,7 +348,7 @@ class NotifyOneSignal(NotifyBase):
                 f"({custom}) are not identified as a dictionary."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Postback Data
         self.postback_data = {}
@@ -360,7 +361,7 @@ class NotifyOneSignal(NotifyBase):
                 f"({postback}) are not identified as a dictionary."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
         return
 
     def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):

--- a/apprise/plugins/opsgenie.py
+++ b/apprise/plugins/opsgenie.py
@@ -51,6 +51,7 @@ from json import dumps, loads
 import requests
 
 from ..common import NotifyType, PersistentStoreMode
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_uuid, parse_bool, parse_list, validate_regex
 from .base import NotifyBase
@@ -352,7 +353,7 @@ class NotifyOpsgenie(NotifyBase):
         if not self.apikey:
             msg = f"An invalid Opsgenie API Key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # The Priority of the message
         self.priority = (
@@ -383,7 +384,7 @@ class NotifyOpsgenie(NotifyBase):
             # Invalid region specified
             msg = f"The Opsgenie region specified ({region_name}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg) from None
+            raise AppriseImproperlyConfigured(msg) from None
 
         if action and isinstance(action, str):
             self.action = next(
@@ -392,7 +393,7 @@ class NotifyOpsgenie(NotifyBase):
             if self.action not in OPSGENIE_ACTIONS:
                 msg = f"The Opsgenie action specified ({action}) is invalid."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
         else:
             self.action = self.template_args["action"]["default"]
 
@@ -408,7 +409,7 @@ class NotifyOpsgenie(NotifyBase):
                         "is invalid."
                     )
                     self.logger.warning(msg)
-                    raise TypeError(msg)
+                    raise AppriseImproperlyConfigured(msg)
 
                 v_lower = v_.lower()
                 v = next(
@@ -421,7 +422,7 @@ class NotifyOpsgenie(NotifyBase):
                         f"specified ({v_}) is invalid."
                     )
                     self.logger.warning(msg)
-                    raise TypeError(msg)
+                    raise AppriseImproperlyConfigured(msg)
 
                 # Update our mapping
                 self.mapping[k] = v

--- a/apprise/plugins/pagerduty.py
+++ b/apprise/plugins/pagerduty.py
@@ -35,6 +35,7 @@ from json import dumps
 import requests
 
 from ..common import NotifyImageSize, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import parse_bool, validate_regex
@@ -227,7 +228,7 @@ class NotifyPagerDuty(NotifyBase):
         if not self.apikey:
             msg = f"An invalid Pager Duty API Key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.integration_key = validate_regex(integrationkey)
         if not self.integration_key:
@@ -236,7 +237,7 @@ class NotifyPagerDuty(NotifyBase):
                 f"({integrationkey}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # An Optional Source
         self.source = self.template_tokens["source"]["default"]
@@ -248,7 +249,7 @@ class NotifyPagerDuty(NotifyBase):
                     f"({source}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
         else:
             self.component = self.template_tokens["source"]["default"]
 
@@ -262,7 +263,7 @@ class NotifyPagerDuty(NotifyBase):
                     f"({component}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
         else:
             self.component = self.template_tokens["component"]["default"]
 
@@ -282,7 +283,7 @@ class NotifyPagerDuty(NotifyBase):
             # Invalid region specified
             msg = f"The PagerDuty region specified ({region_name}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg) from None
+            raise AppriseImproperlyConfigured(msg) from None
 
         # The severity (if specified)
         self.severity = (
@@ -302,7 +303,7 @@ class NotifyPagerDuty(NotifyBase):
             # Invalid severity specified
             msg = f"The PagerDuty severity specified ({severity}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # A clickthrough option for notifications
         self.click = click

--- a/apprise/plugins/pagertree.py
+++ b/apprise/plugins/pagertree.py
@@ -31,6 +31,7 @@ from uuid import uuid4
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_list, validate_regex
 from .base import NotifyBase
@@ -177,7 +178,7 @@ class NotifyPagerTree(NotifyBase):
                 f"({integration}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # thirdparty (optional, in case they want to pass the
         # acknowledge or resolve action)
@@ -191,7 +192,7 @@ class NotifyPagerTree(NotifyBase):
                     f"({thirdparty}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         self.headers = {}
         if headers:

--- a/apprise/plugins/parseplatform.py
+++ b/apprise/plugins/parseplatform.py
@@ -31,6 +31,7 @@ import re
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import URL_PATH_SAFE_CHARS, validate_regex
 from .base import NotifyBase
@@ -147,7 +148,7 @@ class NotifyParsePlatform(NotifyBase):
                 f"({app_id}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Master Key
         self.master_key = validate_regex(master_key)
@@ -157,7 +158,7 @@ class NotifyParsePlatform(NotifyBase):
                 f"({master_key}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Initialize Devices Array
         self.devices = []
@@ -170,7 +171,7 @@ class NotifyParsePlatform(NotifyBase):
                     f"({device}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
         else:
             self.device = self.template_args["device"]["default"]
 

--- a/apprise/plugins/pinglet.py
+++ b/apprise/plugins/pinglet.py
@@ -47,6 +47,7 @@ from typing import Any, Optional
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import validate_regex
@@ -215,21 +216,21 @@ class NotifyPinglet(NotifyBase):
         if not self.token:
             msg = f"An invalid Pinglet API Key ({token}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # The Namespace the topic resides in
         self.namespace = validate_regex(namespace)
         if not self.namespace:
             msg = f"An invalid Pinglet Namespace ({namespace}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # The Topic to publish to (auto-created on first publish)
         self.topic = validate_regex(topic)
         if not self.topic:
             msg = f"An invalid Pinglet Topic ({topic}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # prepare our fullpath
         self.fullpath = kwargs.get("fullpath")

--- a/apprise/plugins/pingram.py
+++ b/apprise/plugins/pingram.py
@@ -51,6 +51,7 @@ import requests
 
 from ..common import NotifyFormat, NotifyImageSize, NotifyType
 from ..conversion import convert_between
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import (
     is_email,
@@ -293,7 +294,7 @@ class NotifyPingram(NotifyBase):
                 apikey
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # For tracking our email -> name lookups
         self.names = {}
@@ -336,7 +337,7 @@ class NotifyPingram(NotifyBase):
             if self.mode not in PINGRAM_MODES:
                 msg = f"The Pingram mode specified ({mode}) is invalid."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         else:
             # Detect mode based on whether or not a message_type was
@@ -361,7 +362,7 @@ class NotifyPingram(NotifyBase):
                     "({}) was specified.".format(message_type)
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         # Acquire Carbon Copies
         self.cc = set()
@@ -385,7 +386,7 @@ class NotifyPingram(NotifyBase):
             # Invalid region specified
             msg = f"The Pingram region specified ({region}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg) from None
+            raise AppriseImproperlyConfigured(msg) from None
 
         # Initialize an empty set of channels
         self.channels = set()
@@ -398,7 +399,7 @@ class NotifyPingram(NotifyBase):
                     f"({channel}) is invalid."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg) from None
+                raise AppriseImproperlyConfigured(msg) from None
             self.channels.add(channel)
 
         # Used for URL generation afterwards only

--- a/apprise/plugins/plivo.py
+++ b/apprise/plugins/plivo.py
@@ -36,6 +36,7 @@ from json import dumps
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import (
     is_phone_no,
@@ -156,7 +157,7 @@ class NotifyPlivo(NotifyBase):
                 "invalid."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.token = validate_regex(
             token, *self.template_tokens["token"]["regex"]
@@ -167,13 +168,13 @@ class NotifyPlivo(NotifyBase):
                 "invalid."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         result = is_phone_no(source)
         if not result:
             msg = f"The Plivo source specified ({source}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store our source; enforce E.164 format
         self.source = f"+{result['full']}"

--- a/apprise/plugins/postmark.py
+++ b/apprise/plugins/postmark.py
@@ -57,6 +57,7 @@ import requests
 
 from .. import exception
 from ..common import NotifyFormat, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_email, parse_emails, validate_regex
 from ..utils.sanitize import sanitize_payload
@@ -183,7 +184,7 @@ class NotifyPostmark(NotifyBase):
         if not self.apikey:
             msg = f"An invalid Postmark API Key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Validate our from email address
         result = is_email(from_email)
@@ -192,7 +193,7 @@ class NotifyPostmark(NotifyBase):
                 f"An invalid Postmark From email ({from_email}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store our from address as a (name, email) tuple
         self.from_addr = (

--- a/apprise/plugins/prowl.py
+++ b/apprise/plugins/prowl.py
@@ -30,6 +30,7 @@ import contextlib
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import validate_regex
 from .base import NotifyBase
@@ -171,7 +172,7 @@ class NotifyProwl(NotifyBase):
         if not self.apikey:
             msg = f"An invalid Prowl API Key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store the provider key (if specified)
         if providerkey:
@@ -184,7 +185,7 @@ class NotifyProwl(NotifyBase):
                     f"({providerkey}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         else:
             # No provider key was set

--- a/apprise/plugins/pushbullet.py
+++ b/apprise/plugins/pushbullet.py
@@ -31,6 +31,7 @@ import requests
 
 from ..attachment.base import AttachBase
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_email, parse_list, validate_regex
 from .base import NotifyBase
@@ -130,7 +131,7 @@ class NotifyPushBullet(NotifyBase):
                 f"({accesstoken}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.targets = parse_list(targets)
         if len(self.targets) == 0:

--- a/apprise/plugins/pushdeer.py
+++ b/apprise/plugins/pushdeer.py
@@ -28,6 +28,7 @@
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import validate_regex
 from .base import NotifyBase
@@ -102,7 +103,7 @@ class NotifyPushDeer(NotifyBase):
         if not self.push_key:
             msg = f"An invalid PushDeer API Pushkey ({pushkey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
     def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
         """Perform PushDeer Notification."""

--- a/apprise/plugins/pushed.py
+++ b/apprise/plugins/pushed.py
@@ -32,6 +32,7 @@ import re
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import parse_list, validate_regex
@@ -131,7 +132,7 @@ class NotifyPushed(NotifyBase):
                 f"An invalid Pushed Application Key ({app_key}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Access Secret (associated with project)
         self.app_secret = validate_regex(app_secret)
@@ -141,7 +142,7 @@ class NotifyPushed(NotifyBase):
                 f"({app_secret}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Initialize channel list
         self.channels = []
@@ -175,7 +176,7 @@ class NotifyPushed(NotifyBase):
                 # explicitly identifying at least one.
                 msg = "No Pushed targets to notify."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         return
 

--- a/apprise/plugins/pushjet.py
+++ b/apprise/plugins/pushjet.py
@@ -30,6 +30,7 @@ from json import dumps
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import validate_regex
@@ -116,7 +117,7 @@ class NotifyPushjet(NotifyBase):
                 f"An invalid Pushjet Secret Key ({secret_key}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         return
 

--- a/apprise/plugins/pushme.py
+++ b/apprise/plugins/pushme.py
@@ -28,6 +28,7 @@
 import requests
 
 from ..common import NotifyFormat, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_bool, validate_regex
 from .base import NotifyBase
@@ -94,7 +95,7 @@ class NotifyPushMe(NotifyBase):
         if not self.token:
             msg = f"An invalid PushMe Token ({token}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Set Status type
         self.status = status

--- a/apprise/plugins/pushover.py
+++ b/apprise/plugins/pushover.py
@@ -58,6 +58,7 @@ except ImportError:
 from ..attachment.base import AttachBase
 from ..common import NotifyFormat, NotifyType
 from ..conversion import convert_between
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_bool, parse_list, validate_regex
 from .base import NotifyBase
@@ -324,8 +325,8 @@ class NotifyPushover(NotifyBase):
 
     def __init__(
         self,
-        user_key,
-        token,
+        user_key=None,
+        token=None,
         targets=None,
         priority=None,
         sound=None,
@@ -345,14 +346,14 @@ class NotifyPushover(NotifyBase):
         if not self.token:
             msg = f"An invalid Pushover Access Token ({token}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # User Key (associated with project)
         self.user_key = validate_regex(user_key)
         if not self.user_key:
             msg = f"An invalid Pushover User Key ({user_key}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Track our valid devices and groups separately
         targets = parse_list(targets)
@@ -429,7 +430,7 @@ class NotifyPushover(NotifyBase):
                     "Pushover emergency interval must be at least 30 seconds."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             if self.expire < 0 or self.expire > 10800:
                 msg = (
@@ -437,7 +438,7 @@ class NotifyPushover(NotifyBase):
                     "0 to 10800 seconds."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         # End-to-end encryption: validate and store the encryption key.
         # The key must be exactly 64 hex characters (256-bit AES key).
@@ -451,7 +452,7 @@ class NotifyPushover(NotifyBase):
                     "got {} chars".format(len(_key))
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             self.encryption_key = _key
         else:

--- a/apprise/plugins/pushplus.py
+++ b/apprise/plugins/pushplus.py
@@ -80,6 +80,7 @@ import re
 import requests
 
 from ..common import NotifyFormat, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import parse_list, validate_regex
@@ -275,7 +276,7 @@ class NotifyPushplus(NotifyBase):
         if not self.token:
             msg = "The Pushplus token ({}) is invalid.".format(token)
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Resolve the delivery channel from the schema alias when the URL
         # was entered as wechat:// or wecom:// instead of pushplus://.
@@ -298,7 +299,7 @@ class NotifyPushplus(NotifyBase):
             if not self.channel:
                 msg = "The Pushplus channel ({}) is not valid.".format(channel)
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         elif schema_channel:
             # Schema-implied channel (wechat:// or wecom://)

--- a/apprise/plugins/pushsafer.py
+++ b/apprise/plugins/pushsafer.py
@@ -32,6 +32,7 @@ import requests
 
 from .. import exception
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_list, validate_regex
 from ..utils.sanitize import sanitize_payload
@@ -458,7 +459,7 @@ class NotifyPushSafer(NotifyBase):
                     f"({priority}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg) from None
+                raise AppriseImproperlyConfigured(msg) from None
 
             # store our successfully looked up priority
             self.priority = PUSHSAFER_PRIORITY_MAP[match]
@@ -469,7 +470,7 @@ class NotifyPushSafer(NotifyBase):
         ):
             msg = f"An invalid PushSafer priority ({priority}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg) from None
+            raise AppriseImproperlyConfigured(msg) from None
 
         #
         # Sound
@@ -509,7 +510,7 @@ class NotifyPushSafer(NotifyBase):
             if not match:
                 msg = f"An invalid PushSafer sound ({sound}) was specified."
                 self.logger.warning(msg)
-                raise TypeError(msg) from None
+                raise AppriseImproperlyConfigured(msg) from None
 
             # store our successfully looked up sound
             self.sound = PUSHSAFER_SOUND_MAP[match]
@@ -520,7 +521,7 @@ class NotifyPushSafer(NotifyBase):
         ):
             msg = f"An invalid PushSafer sound ({sound}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg) from None
+            raise AppriseImproperlyConfigured(msg) from None
 
         #
         # Vibration
@@ -539,14 +540,14 @@ class NotifyPushSafer(NotifyBase):
                 f"An invalid PushSafer vibration ({vibration}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg) from None
+            raise AppriseImproperlyConfigured(msg) from None
 
         if self.vibration and self.vibration not in PUSHSAFER_VIBRATIONS:
             msg = (
                 f"An invalid PushSafer vibration ({vibration}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg) from None
+            raise AppriseImproperlyConfigured(msg) from None
 
         #
         # Private Key (associated with project)
@@ -558,7 +559,7 @@ class NotifyPushSafer(NotifyBase):
                 f"({privatekey}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.targets = parse_list(targets)
         if len(self.targets) == 0:

--- a/apprise/plugins/pushward.py
+++ b/apprise/plugins/pushward.py
@@ -48,6 +48,7 @@ from json import dumps
 import requests
 
 from ..common import NotifyImageSize, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import validate_regex
 from .base import NotifyBase
@@ -211,7 +212,7 @@ class NotifyPushWard(NotifyBase):
                 f"({apikey}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # An explicit level forces every notification to that level
         self.level = None
@@ -220,7 +221,7 @@ class NotifyPushWard(NotifyBase):
             if self.level is None:
                 msg = f"An invalid PushWard level ({level}) was specified."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         # Per-notification-type level mapping; each type may be overridden from
         # the URL, otherwise it falls back to the default
@@ -239,7 +240,7 @@ class NotifyPushWard(NotifyBase):
             if resolved is None:
                 msg = f"An invalid PushWard level ({value}) was specified."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
             self.level_map[ntype] = resolved
 
         # Acquire our volume (only applied to critical notifications)
@@ -250,12 +251,12 @@ class NotifyPushWard(NotifyBase):
             except (ValueError, TypeError):
                 msg = f"An invalid PushWard volume ({volume}) was specified."
                 self.logger.warning(msg)
-                raise TypeError(msg) from None
+                raise AppriseImproperlyConfigured(msg) from None
 
             if self.volume < 0.0 or self.volume > 1.0:
                 msg = f"An invalid PushWard volume ({volume}) was specified."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
         else:
             self.volume = None
 

--- a/apprise/plugins/pushy.py
+++ b/apprise/plugins/pushy.py
@@ -33,6 +33,7 @@ import re
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_list, validate_regex
 from .base import NotifyBase
@@ -133,7 +134,7 @@ class NotifyPushy(NotifyBase):
         if not self.apikey:
             msg = f"An invalid Pushy Secret API Key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Get our targets
         self.devices = []

--- a/apprise/plugins/qq.py
+++ b/apprise/plugins/qq.py
@@ -33,6 +33,7 @@ import re
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import validate_regex
@@ -86,7 +87,7 @@ class NotifyQQ(NotifyBase):
         if not self.token:
             msg = f"The QQ Push token ({token}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.webhook_url = f"{self.notify_url}{self.token}"
 

--- a/apprise/plugins/reddit.py
+++ b/apprise/plugins/reddit.py
@@ -53,6 +53,7 @@ import requests
 
 from .. import __title__, __version__
 from ..common import NotifyFormat, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import parse_bool, parse_list, validate_regex
@@ -284,19 +285,19 @@ class NotifyReddit(NotifyBase):
         if self.kind not in REDDIT_MESSAGE_KINDS:
             msg = f"An invalid Reddit message kind ({kind}) was specified"
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.user = validate_regex(self.user)
         if not self.user:
             msg = f"An invalid Reddit User ID ({self.user}) was specified"
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.password = validate_regex(self.password)
         if not self.password:
             msg = f"An invalid Reddit Password ({self.password}) was specified"
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.client_id = validate_regex(
             app_id, *self.template_tokens["app_id"]["regex"]
@@ -304,7 +305,7 @@ class NotifyReddit(NotifyBase):
         if not self.client_id:
             msg = f"An invalid Reddit App ID ({app_id}) was specified"
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.client_secret = validate_regex(
             app_secret, *self.template_tokens["app_secret"]["regex"]
@@ -312,7 +313,7 @@ class NotifyReddit(NotifyBase):
         if not self.client_secret:
             msg = f"An invalid Reddit App Secret ({app_secret}) was specified"
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Build list of subreddits
         self.subreddits = [

--- a/apprise/plugins/resend.py
+++ b/apprise/plugins/resend.py
@@ -47,6 +47,7 @@ import requests
 
 from .. import exception
 from ..common import NotifyFormat, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_email, parse_emails, validate_regex
 from ..utils.sanitize import sanitize_payload
@@ -185,7 +186,7 @@ class NotifyResend(NotifyBase):
         if not self.apikey:
             msg = f"An invalid Resend API Key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Acquire Targets (To Emails)
         self.targets = []
@@ -207,7 +208,7 @@ class NotifyResend(NotifyBase):
             # Invalid from
             msg = "Invalid ~From~ email specified: {}".format(from_addr)
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # initialize our from address
         self.from_addr = (

--- a/apprise/plugins/revolt.py
+++ b/apprise/plugins/revolt.py
@@ -41,6 +41,7 @@ from json import dumps, loads
 import requests
 
 from ..common import NotifyFormat, NotifyImageSize, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_list, validate_regex
 from .base import NotifyBase
@@ -146,7 +147,7 @@ class NotifyRevolt(NotifyBase):
         if not self.bot_token:
             msg = f"An invalid Revolt Bot Token ({bot_token}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Parse our Channel IDs
         self.targets = []

--- a/apprise/plugins/ringcentral.py
+++ b/apprise/plugins/ringcentral.py
@@ -68,6 +68,7 @@ from time import time
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import is_phone_no, parse_phone_no, validate_regex
@@ -296,7 +297,7 @@ class NotifyRingCentral(NotifyBase):
                     "({}) was specified.".format(mode)
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             # Store resolved mode
             self.mode = match
@@ -316,7 +317,7 @@ class NotifyRingCentral(NotifyBase):
                 )
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Validate Client Secret
         self.client_secret = validate_regex(
@@ -328,7 +329,7 @@ class NotifyRingCentral(NotifyBase):
                 "({}) was specified.".format(client_secret)
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Validate JWT token (only strict regex check in JWT mode)
         if self.mode == RingCentralAuthMode.JWT:
@@ -339,7 +340,7 @@ class NotifyRingCentral(NotifyBase):
                     "({}) was specified.".format(token)
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
         else:
             # BASIC mode -- token holds the user password (not validated)
             self.token = token
@@ -352,7 +353,7 @@ class NotifyRingCentral(NotifyBase):
                 "({}) is invalid.".format(source)
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store normalised source digits only
         self.source = result["full"]
@@ -381,7 +382,7 @@ class NotifyRingCentral(NotifyBase):
                 "({}) was specified.".format(environment)
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store resolved environment
         self.environment = match

--- a/apprise/plugins/rocketchat.py
+++ b/apprise/plugins/rocketchat.py
@@ -32,6 +32,7 @@ import re
 import requests
 
 from ..common import NotifyFormat, NotifyImageSize, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import parse_bool, parse_list
@@ -230,7 +231,7 @@ class NotifyRocketChat(NotifyBase):
         if self.mode and self.mode not in ROCKETCHAT_AUTH_MODES:
             msg = f"The authentication mode specified ({mode}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Detect our mode if it wasn't specified
         if not self.mode:
@@ -257,12 +258,12 @@ class NotifyRocketChat(NotifyBase):
                 else "user/apikey"
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         elif self.mode == RocketChatAuthMode.WEBHOOK and not self.webhook:
             msg = "No Rocket.Chat Incoming Webhook was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         if self.mode == RocketChatAuthMode.TOKEN:
             # Set our headers for further communication
@@ -304,7 +305,7 @@ class NotifyRocketChat(NotifyBase):
         ):
             msg = "No Rocket.Chat room and/or channels specified to notify."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Prepare our avatar setting
         # - if specified; that trumps all

--- a/apprise/plugins/rsyslog.py
+++ b/apprise/plugins/rsyslog.py
@@ -29,6 +29,7 @@ import os
 import socket
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_bool
 from .base import NotifyBase
@@ -219,7 +220,7 @@ class NotifyRSyslog(NotifyBase):
             except KeyError:
                 msg = f"An invalid syslog facility ({facility}) was specified."
                 self.logger.warning(msg)
-                raise TypeError(msg) from None
+                raise AppriseImproperlyConfigured(msg) from None
 
         else:
             self.facility = SYSLOG_FACILITY_MAP[

--- a/apprise/plugins/ryver.py
+++ b/apprise/plugins/ryver.py
@@ -39,6 +39,7 @@ import re
 import requests
 
 from ..common import NotifyImageSize, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_bool, validate_regex
 from .base import NotifyBase
@@ -147,7 +148,7 @@ class NotifyRyver(NotifyBase):
         if not self.token:
             msg = f"An invalid Ryver API Token ({token}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Organization (associated with project)
         self.organization = validate_regex(
@@ -159,7 +160,7 @@ class NotifyRyver(NotifyBase):
                 f"({organization}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store our webhook mode
         self.mode = None if not isinstance(mode, str) else mode.lower()
@@ -167,7 +168,7 @@ class NotifyRyver(NotifyBase):
         if self.mode not in RYVER_WEBHOOK_MODES:
             msg = f"The Ryver webhook mode specified ({mode}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Place an image inline with the message body
         self.include_image = include_image

--- a/apprise/plugins/sendgrid.py
+++ b/apprise/plugins/sendgrid.py
@@ -52,6 +52,7 @@ import requests
 
 from .. import exception
 from ..common import NotifyFormat, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_email, parse_list, validate_regex
 from ..utils.sanitize import sanitize_payload
@@ -189,13 +190,13 @@ class NotifySendGrid(NotifyBase):
         if not self.apikey:
             msg = f"An invalid SendGrid API Key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         result = is_email(from_email)
         if not result:
             msg = f"Invalid ~From~ email specified: {from_email}"
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store email address
         self.from_email = result["full_email"]

--- a/apprise/plugins/sendpulse.py
+++ b/apprise/plugins/sendpulse.py
@@ -39,6 +39,7 @@ import requests
 from .. import exception
 from ..common import NotifyFormat, NotifyType, PersistentStoreMode
 from ..conversion import convert_between
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_email, parse_emails, validate_regex
 from ..utils.sanitize import sanitize_payload
@@ -249,7 +250,7 @@ class NotifySendPulse(NotifyBase):
                 else "{}".format(from_addr_[1])
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store our lookup
         self.from_addr = from_addr_[1]
@@ -264,7 +265,7 @@ class NotifySendPulse(NotifyBase):
                 client_id
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Client Secret
         self.client_secret = validate_regex(
@@ -276,7 +277,7 @@ class NotifySendPulse(NotifyBase):
                 "({}) was specified.".format(client_secret)
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Acquire Targets (To Emails)
         self.targets = []
@@ -301,7 +302,7 @@ class NotifySendPulse(NotifyBase):
                     f" ({template}) is invalid."
                 )
                 self.logger.warning(err)
-                raise TypeError(err) from None
+                raise AppriseImproperlyConfigured(err) from None
 
         # Now our dynamic template data (if defined)
         self.template_data = (

--- a/apprise/plugins/serverchan.py
+++ b/apprise/plugins/serverchan.py
@@ -30,6 +30,7 @@ import re
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import validate_regex
 from .base import NotifyBase
@@ -87,7 +88,7 @@ class NotifyServerChan(NotifyBase):
         if not self.token:
             msg = f"An invalid ServerChan API Token ({token}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
     def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
         """Perform ServerChan Notification."""

--- a/apprise/plugins/serwersms.py
+++ b/apprise/plugins/serwersms.py
@@ -56,6 +56,7 @@ import re
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import (
@@ -188,13 +189,13 @@ class NotifySerwerSMS(NotifyBase):
         if not self.user:
             msg = "A SerwerSMS username must be specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Validate password
         if not self.password:
             msg = "A SerwerSMS password must be specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Validate sender name
         self.sender = validate_regex(
@@ -204,7 +205,7 @@ class NotifySerwerSMS(NotifyBase):
         if not self.sender:
             msg = "A SerwerSMS sender name ({}) is invalid.".format(sender)
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Parse our targets into phones and groups
         self.target_phones = []

--- a/apprise/plugins/ses.py
+++ b/apprise/plugins/ses.py
@@ -95,6 +95,7 @@ from xml.etree import ElementTree
 import requests
 
 from ..common import NotifyFormat, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import is_email, parse_emails, validate_regex
@@ -264,7 +265,7 @@ class NotifySES(NotifyBase):
         if not self.aws_access_key_id:
             msg = "An invalid AWS Access Key ID was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store our AWS API Secret Access key
         self.aws_secret_access_key = validate_regex(secret_access_key)
@@ -274,7 +275,7 @@ class NotifySES(NotifyBase):
                 f"({secret_access_key}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Acquire our AWS Region Name:
         # eg. us-east-1, cn-north-1, us-west-2, ...
@@ -284,7 +285,7 @@ class NotifySES(NotifyBase):
         if not self.aws_region_name:
             msg = f"An invalid AWS Region ({region_name}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Acquire Email 'To'
         self.targets = []
@@ -325,7 +326,7 @@ class NotifySES(NotifyBase):
                 f"{self.user}@{self.host}"
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.reply_to = None
         if reply_to:
@@ -335,7 +336,7 @@ class NotifySES(NotifyBase):
                     f"{reply_to}"
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             self.reply_to = (
                 result["name"] if result["name"] else False,

--- a/apprise/plugins/seven.py
+++ b/apprise/plugins/seven.py
@@ -34,6 +34,7 @@ import json
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_phone_no, parse_bool, parse_phone_no
 from .base import NotifyBase
@@ -137,7 +138,7 @@ class NotifySeven(NotifyBase):
         if not self.apikey:
             msg = f"An invalid seven API Key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.source = None if not isinstance(source, str) else source.strip()
         self.flash = (

--- a/apprise/plugins/sfr.py
+++ b/apprise/plugins/sfr.py
@@ -45,6 +45,7 @@ import json
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import is_phone_no, parse_phone_no
@@ -180,13 +181,13 @@ class NotifySFR(NotifyBase):
                 "combination was not provided."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.space_id = space_id
         if not self.space_id:
             msg = "A SFR Space ID is required."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.voice = voice if voice else self.template_args["voice"]["default"]
         self.lang = lang if lang else self.template_args["lang"]["default"]
@@ -226,7 +227,7 @@ class NotifySFR(NotifyBase):
                 "provide as least one valid phone number."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         return
 

--- a/apprise/plugins/signal_api.py
+++ b/apprise/plugins/signal_api.py
@@ -35,6 +35,7 @@ import requests
 
 from .. import exception
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import is_phone_no, parse_bool, parse_phone_no
@@ -190,7 +191,7 @@ class NotifySignalAPI(NotifyBase):
                 f"({source}) was provided."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.source = "+{}".format(result["full"])
 

--- a/apprise/plugins/signalgrid.py
+++ b/apprise/plugins/signalgrid.py
@@ -48,6 +48,7 @@ from typing import Any, Optional
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_bool, parse_list, validate_regex
 from .base import NotifyBase
@@ -137,7 +138,7 @@ class NotifySignalgrid(NotifyBase):
         if not self.client_key:
             msg = "An invalid Signalgrid Client Key was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store the channel(s) we're notifying. No channels is valid at
         # load time; send() will simply have nothing to notify.

--- a/apprise/plugins/signl4.py
+++ b/apprise/plugins/signl4.py
@@ -35,6 +35,7 @@ from typing import Any, Optional
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import parse_bool, validate_regex
@@ -137,7 +138,7 @@ class NotifySIGNL4(NotifyBase):
                 "({}) was specified.".format(secret)
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # A service option for notifications
         self.service = service

--- a/apprise/plugins/simplepush.py
+++ b/apprise/plugins/simplepush.py
@@ -33,6 +33,7 @@ from os import urandom
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import validate_regex
@@ -138,7 +139,7 @@ class NotifySimplePush(NotifyBase):
         if not self.apikey:
             msg = f"An invalid SimplePush API Key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         if event:
             # Event Name (associated with project)
@@ -149,7 +150,7 @@ class NotifySimplePush(NotifyBase):
                     f"({event}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         else:
             # Default Event Name

--- a/apprise/plugins/sinch.py
+++ b/apprise/plugins/sinch.py
@@ -40,6 +40,7 @@ import json
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import is_phone_no, parse_phone_no, validate_regex
@@ -190,7 +191,7 @@ class NotifySinch(NotifyBase):
                 f"({service_plan_id}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # The Authentication Token associated with the account
         self.api_token = validate_regex(
@@ -202,7 +203,7 @@ class NotifySinch(NotifyBase):
                 f"({api_token}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Setup our region
         self.region = (
@@ -213,7 +214,7 @@ class NotifySinch(NotifyBase):
         if self.region and self.region not in SINCH_REGIONS:
             msg = f"The region specified ({region}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # The Source Phone # and/or short-code
         result = is_phone_no(source, min_len=5)
@@ -223,7 +224,7 @@ class NotifySinch(NotifyBase):
                 f"({source}) is invalid."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Tidy source
         self.source = result["full"]
@@ -237,7 +238,7 @@ class NotifySinch(NotifyBase):
                     f"({source}) is invalid."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             # else... it as a short code so we're okay
 

--- a/apprise/plugins/slack.py
+++ b/apprise/plugins/slack.py
@@ -94,6 +94,7 @@ from ..conversion import (
     commonmark_scan_autolink_dest,
     commonmark_scan_paren_dest,
 )
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_email, parse_bool, parse_list, validate_regex
 from ..utils.templates import TemplateType, apply_template
@@ -618,7 +619,7 @@ class NotifySlack(NotifyBase):
             if self.mode not in SLACK_MODES:
                 msg = f"The Slack mode specified ({mode}) is invalid."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         elif workflow_path:
             # Mode will be determined by segment count below;
@@ -658,7 +659,7 @@ class NotifySlack(NotifyBase):
                         f" ({workflow_path!r} has {seg_count})."
                     )
                     self.logger.warning(msg)
-                    raise TypeError(msg)
+                    raise AppriseImproperlyConfigured(msg)
             else:
                 # Auto-detect sub-mode from segment count
                 if seg_count == 4:
@@ -672,7 +673,7 @@ class NotifySlack(NotifyBase):
                         f" {seg_count})."
                     )
                     self.logger.warning(msg)
-                    raise TypeError(msg)
+                    raise AppriseImproperlyConfigured(msg)
 
         elif self.mode in (SlackMode.WEBHOOK, SlackMode.WEBHOOK_GOV):
             self.workflow_path = []
@@ -686,7 +687,7 @@ class NotifySlack(NotifyBase):
                     f"({token_a}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             self.token_b = validate_regex(
                 token_b, *self.template_tokens["token_b"]["regex"]
@@ -697,7 +698,7 @@ class NotifySlack(NotifyBase):
                     f"({token_b}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             self.token_c = validate_regex(
                 token_c, *self.template_tokens["token_c"]["regex"]
@@ -708,7 +709,7 @@ class NotifySlack(NotifyBase):
                     f"({token_c}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
         else:
             self.workflow_path = []
             self.token_a = None
@@ -723,7 +724,7 @@ class NotifySlack(NotifyBase):
                     f"({access_token}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         # Look the users up by their email address and map them back to their
         # id here for future queries (if needed). This allows people to
@@ -790,7 +791,7 @@ class NotifySlack(NotifyBase):
                 # add() failed (unsupported schema, unparseable URL, etc.)
                 msg = f"The Slack template ({template!r}) could not be loaded."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
             # Enforce maximum file size
             self.template[0].max_file_size = self.max_slack_template_size
 
@@ -805,7 +806,7 @@ class NotifySlack(NotifyBase):
                 f"({tokens}) are not identified as a dictionary."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # A template always implies Block Kit mode; there is no meaningful
         # use for templates outside of blocks mode.

--- a/apprise/plugins/smpp.py
+++ b/apprise/plugins/smpp.py
@@ -41,6 +41,7 @@ except ImportError:
 
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_phone_no, parse_phone_no
 from .base import NotifyBase
@@ -142,7 +143,7 @@ class NotifySMPP(NotifyBase):
         if not (self.user and self.password):
             msg = "No SMPP user/pass combination was provided"
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         result = is_phone_no(source)
         if not result:
@@ -150,7 +151,7 @@ class NotifySMPP(NotifyBase):
                 f"The Account (From) Phone # specified ({source}) is invalid."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Tidy source
         self.source = result["full"]

--- a/apprise/plugins/smsc.py
+++ b/apprise/plugins/smsc.py
@@ -54,6 +54,7 @@ from json import loads
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import (
@@ -193,13 +194,13 @@ class NotifySMSC(NotifyBase):
         if not self.user:
             msg = "An SMSC login must be specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Validate password
         if not self.password:
             msg = "An SMSC password must be specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Optional sender ID
         self.sender = None
@@ -208,7 +209,7 @@ class NotifySMSC(NotifyBase):
             if not self.sender:
                 msg = f"The SMSC sender ID specified ({sender}) is invalid."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         # Transliteration flag
         self.translit = (

--- a/apprise/plugins/smseagle.py
+++ b/apprise/plugins/smseagle.py
@@ -34,6 +34,7 @@ import requests
 
 from .. import exception
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import (
@@ -257,7 +258,7 @@ class NotifySMSEagle(NotifyBase):
                 f" ({token if token else self.user}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         #
         # Priority
@@ -300,7 +301,7 @@ class NotifySMSEagle(NotifyBase):
                     f"An invalid SMSEagle priority ({priority}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg) from None
+                raise AppriseImproperlyConfigured(msg) from None
 
             # store our successfully looked up priority
             self.priority = SMSEAGLE_PRIORITY_MAP[result]
@@ -311,7 +312,7 @@ class NotifySMSEagle(NotifyBase):
         ):
             msg = f"An invalid SMSEagle priority ({priority}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Validate our targerts
         for target in parse_phone_no(targets):

--- a/apprise/plugins/smsmanager.py
+++ b/apprise/plugins/smsmanager.py
@@ -36,6 +36,7 @@
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import (
     is_phone_no,
@@ -172,7 +173,7 @@ class NotifySMSManager(NotifyBase):
         if not self.apikey:
             msg = f"An invalid API Key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Setup our gateway
         self.gateway = (
@@ -183,7 +184,7 @@ class NotifySMSManager(NotifyBase):
         if self.gateway not in SMS_MANAGER_GATEWAYS:
             msg = f"The Gateway specified ({gateway}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Define whether or not we should operate in a batch mode
         self.batch = (

--- a/apprise/plugins/smtp2go.py
+++ b/apprise/plugins/smtp2go.py
@@ -52,6 +52,7 @@ import requests
 
 from .. import exception
 from ..common import NotifyFormat, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_email, parse_bool, parse_emails, validate_regex
 from ..utils.sanitize import sanitize_payload
@@ -182,13 +183,13 @@ class NotifySMTP2Go(NotifyBase):
         if not self.apikey:
             msg = f"An invalid SMTP2Go API Key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Validate our username
         if not self.user:
             msg = "No SMTP2Go username was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Acquire Email 'To'
         self.targets = []
@@ -220,7 +221,7 @@ class NotifySMTP2Go(NotifyBase):
             # Parse Source domain based on from_addr
             msg = f"Invalid ~From~ email format: {self.from_addr}"
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         if targets:
             # Validate recipients (to:) and drop bad ones:

--- a/apprise/plugins/sns.py
+++ b/apprise/plugins/sns.py
@@ -36,6 +36,7 @@ from xml.etree import ElementTree
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import is_phone_no, parse_list, validate_regex
@@ -228,7 +229,7 @@ class NotifySNS(NotifyBase):
         if not self.aws_access_key_id:
             msg = "An invalid AWS Access Key ID was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store our AWS API Secret Access key
         self.aws_secret_access_key = validate_regex(secret_access_key)
@@ -238,7 +239,7 @@ class NotifySNS(NotifyBase):
                 f"({secret_access_key}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Acquire our AWS Region Name:
         # eg. us-east-1, cn-north-1, us-west-2, ...
@@ -248,7 +249,7 @@ class NotifySNS(NotifyBase):
         if not self.aws_region_name:
             msg = f"An invalid AWS Region ({region_name}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Initialize topic list
         self.topics = []
@@ -297,7 +298,7 @@ class NotifySNS(NotifyBase):
             if self.mode not in SNS_MODES:
                 msg = f"The AWS SNS mode specified ({mode}) is invalid."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         else:
             # Auto-detect: topic mode when all targets are SNS topics

--- a/apprise/plugins/sogs.py
+++ b/apprise/plugins/sogs.py
@@ -95,6 +95,7 @@ except ImportError:
     NOTIFY_SESSIONOGS_ENABLED = False
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_list
 from .base import NotifyBase
@@ -285,7 +286,7 @@ class NotifySessionOGS(NotifyBase):
                 f"characters ({_pk!r} is invalid)."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store the validated public key.
         self.public_key = _pk
@@ -298,7 +299,7 @@ class NotifySessionOGS(NotifyBase):
                 f"characters ({_seed!r} is invalid)."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store the validated seed hex string.
         self.seed = _seed
@@ -330,7 +331,7 @@ class NotifySessionOGS(NotifyBase):
         if not self.rooms:
             msg = "At least one valid SOGS room token must be specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
     def _sogs_auth_headers(self, method, path, body_bytes=None):
         """

--- a/apprise/plugins/sparkpost.py
+++ b/apprise/plugins/sparkpost.py
@@ -62,6 +62,7 @@ import requests
 
 from .. import exception
 from ..common import NotifyFormat, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_email, parse_bool, parse_emails, validate_regex
 from ..utils.sanitize import sanitize_payload
@@ -246,13 +247,13 @@ class NotifySparkPost(NotifyBase):
         if not self.apikey:
             msg = f"An invalid SparkPost API Key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Validate our username
         if not self.user:
             msg = "No SparkPost username was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Acquire Email 'To'
         self.targets = []
@@ -282,7 +283,7 @@ class NotifySparkPost(NotifyBase):
             # Invalid region specified
             msg = f"The SparkPost region specified ({region_name}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg) from None
+            raise AppriseImproperlyConfigured(msg) from None
 
         # Get our From username (if specified)
         self.from_name = from_name
@@ -294,7 +295,7 @@ class NotifySparkPost(NotifyBase):
             # Parse Source domain based on from_addr
             msg = f"Invalid ~From~ email format: {self.from_addr}"
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.headers = {}
         if headers:

--- a/apprise/plugins/spike.py
+++ b/apprise/plugins/spike.py
@@ -35,6 +35,7 @@ import re
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import validate_regex
@@ -84,7 +85,7 @@ class NotifySpike(NotifyBase):
         if not self.token:
             msg = f"The Spike.sh integration key ({token}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.webhook_url = f"{self.notify_url}{self.token}"
 

--- a/apprise/plugins/splunk.py
+++ b/apprise/plugins/splunk.py
@@ -39,6 +39,7 @@ import re
 import requests
 
 from ..common import NOTIFY_TYPES, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import validate_regex
 from .base import NotifyBase
@@ -233,7 +234,7 @@ class NotifySplunk(NotifyBase):
         if not self.apikey:
             msg = f"The Splunk API Key specified ({apikey}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.routing_key = validate_regex(
             routing_key, *self.template_tokens["routing_key"]["regex"]
@@ -243,7 +244,7 @@ class NotifySplunk(NotifyBase):
                 f"The Splunk Routing Key specified ({routing_key}) is invalid."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         if not (
             isinstance(entity_id, str) and len(entity_id.strip(" \r\n\t\v/"))
@@ -262,7 +263,7 @@ class NotifySplunk(NotifyBase):
             if self.action not in SPLUNK_ACTIONS:
                 msg = f"The Splunk action specified ({action}) is invalid."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
         else:
             self.action = self.template_args["action"]["default"]
 
@@ -277,7 +278,7 @@ class NotifySplunk(NotifyBase):
                         f"The Splunk mapping key specified ({k_}) is invalid."
                     )
                     self.logger.warning(msg)
-                    raise TypeError(msg)
+                    raise AppriseImproperlyConfigured(msg)
 
                 v_upper = v_.upper()
                 v = next(
@@ -290,7 +291,7 @@ class NotifySplunk(NotifyBase):
                         f"specified ({v_}) is invalid."
                     )
                     self.logger.warning(msg)
-                    raise TypeError(msg)
+                    raise AppriseImproperlyConfigured(msg)
 
                 # Update our mapping
                 self.mapping[k] = v

--- a/apprise/plugins/spugpush.py
+++ b/apprise/plugins/spugpush.py
@@ -35,6 +35,7 @@ import re
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import validate_regex
@@ -84,7 +85,7 @@ class NotifySpugpush(NotifyBase):
         if not self.token:
             msg = f"The SpugPush token ({token}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.webhook_url = f"{self.notify_url}{self.token}"
 

--- a/apprise/plugins/stackfield.py
+++ b/apprise/plugins/stackfield.py
@@ -48,6 +48,7 @@ import re
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import validate_regex
@@ -128,7 +129,7 @@ class NotifyStackfield(NotifyBase):
                 f"An invalid Stackfield webhook token ({token}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
     def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
         """Perform Stackfield Notification."""

--- a/apprise/plugins/streamlabs.py
+++ b/apprise/plugins/streamlabs.py
@@ -38,6 +38,7 @@
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import validate_regex
 from .base import NotifyBase
@@ -202,7 +203,7 @@ class NotifyStreamlabs(NotifyBase):
         if not self.access_token:
             msg = "An invalid Streamslabs access token was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store the call
         try:
@@ -216,7 +217,7 @@ class NotifyStreamlabs(NotifyBase):
             msg = f"The streamlabs call specified ({call}) is invalid."
             self.logger.warning(msg)
             self.logger.debug(f"Socket Exception: {e!s}")
-            raise TypeError(msg) from None
+            raise AppriseImproperlyConfigured(msg) from None
 
         # Store the alert_type
         # only applicable when calling /alerts
@@ -231,7 +232,7 @@ class NotifyStreamlabs(NotifyBase):
             msg = f"The streamlabs alert type specified ({call}) is invalid."
             self.logger.warning(msg)
             self.logger.debug(f"Socket Exception: {e!s}")
-            raise TypeError(msg) from None
+            raise AppriseImproperlyConfigured(msg) from None
 
         # params only applicable when calling /alerts
         self.image_href = image_href
@@ -254,7 +255,7 @@ class NotifyStreamlabs(NotifyBase):
         if not self.currency:
             msg = "An invalid Streamslabs currency was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # only applicable when calling /donations
         # The name of the donor
@@ -262,7 +263,7 @@ class NotifyStreamlabs(NotifyBase):
         if not self.name:
             msg = "An invalid Streamslabs donor was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # An identifier for this donor,
         # which is used to group donations with the same donor.

--- a/apprise/plugins/synology.py
+++ b/apprise/plugins/synology.py
@@ -30,6 +30,7 @@ from json import dumps
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import URL_PATH_SAFE_CHARS
@@ -143,7 +144,7 @@ class NotifySynology(NotifyBase):
         if not self.token:
             msg = f"An invalid Synology Token ({token}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.fullpath = kwargs.get("fullpath")
 

--- a/apprise/plugins/syslog.py
+++ b/apprise/plugins/syslog.py
@@ -28,6 +28,7 @@
 import syslog
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_bool
 from .base import NotifyBase
@@ -185,7 +186,7 @@ class NotifySyslog(NotifyBase):
             except KeyError:
                 msg = f"An invalid syslog facility ({facility}) was specified."
                 self.logger.warning(msg)
-                raise TypeError(msg) from None
+                raise AppriseImproperlyConfigured(msg) from None
         else:
             self.facility = SYSLOG_FACILITY_MAP[
                 self.template_tokens["facility"]["default"]

--- a/apprise/plugins/techuluspush.py
+++ b/apprise/plugins/techuluspush.py
@@ -54,6 +54,7 @@ from json import dumps
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import validate_regex
 from .base import NotifyBase
@@ -114,7 +115,7 @@ class NotifyTechulusPush(NotifyBase):
         if not self.apikey:
             msg = f"An invalid Techulus Push API key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
     def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
         """Perform Techulus Push Notification."""

--- a/apprise/plugins/telegram.py
+++ b/apprise/plugins/telegram.py
@@ -78,6 +78,7 @@ from ..conversion import (
     commonmark_scan_autolink_dest,
     commonmark_scan_paren_dest,
 )
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_bool, parse_list, validate_regex
 from ..utils.templates import TemplateType, apply_template
@@ -469,7 +470,7 @@ class NotifyTelegram(NotifyBase):
         if not self.bot_token:
             err = f"The Telegram Bot Token specified ({bot_token}) is invalid."
             self.logger.warning(err)
-            raise TypeError(err)
+            raise AppriseImproperlyConfigured(err)
 
         # Get our Markdown Version
         self.markdown_ver = (
@@ -512,7 +513,7 @@ class NotifyTelegram(NotifyBase):
         if self.content and self.content not in TELEGRAM_CONTENT_PLACEMENT:
             msg = f"The content placement specified ({content}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         if topic:
             try:
@@ -522,7 +523,7 @@ class NotifyTelegram(NotifyBase):
                 # Not a valid integer; ignore entry
                 err = f"The Telegram Topic ID specified ({topic}) is invalid."
                 self.logger.warning(err)
-                raise TypeError(err) from exc
+                raise AppriseImproperlyConfigured(err) from exc
         else:
             # No Topic Thread
             self.topic = None
@@ -587,7 +588,7 @@ class NotifyTelegram(NotifyBase):
                     " could not be loaded."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             # Enforce a maximum file size on our template
             self.template[0].max_file_size = self.max_telegram_template_size
@@ -603,7 +604,7 @@ class NotifyTelegram(NotifyBase):
                 f" ({tokens}) are not identified as a dictionary."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
     def send_media(self, target, notify_type, payload=None, attach=None):
         """Sends a sticker based on the specified notify type."""

--- a/apprise/plugins/threema.py
+++ b/apprise/plugins/threema.py
@@ -36,6 +36,7 @@ from itertools import chain
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import is_email, is_phone_no, parse_list, validate_regex
@@ -147,20 +148,20 @@ class NotifyThreema(NotifyBase):
         if not self.user:
             msg = "Threema Gateway ID must be specified"
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Verify our Gateway ID
         if len(self.user) != 8:
             msg = "Threema Gateway ID must be 8 characters in length"
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Verify our secret
         self.secret = validate_regex(secret)
         if not self.secret:
             msg = f"An invalid Threema API Secret ({secret}) was specified"
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Parse our targets
         self.targets = []

--- a/apprise/plugins/trigv.py
+++ b/apprise/plugins/trigv.py
@@ -47,6 +47,7 @@ from json import dumps
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_list, validate_regex
 from .base import NotifyBase
@@ -221,7 +222,7 @@ class NotifyTrigv(NotifyBase):
         if not self.api_key:
             msg = f"An invalid Trigv API Key ({api_key}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Build our list of channels to notify; validate each one as
         # we go so a single bad entry fails loudly instead of silently
@@ -233,7 +234,7 @@ class NotifyTrigv(NotifyBase):
                     f"An invalid Trigv channel slug ({target}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             self.targets.append(channel)
 
@@ -265,7 +266,7 @@ class NotifyTrigv(NotifyBase):
         if self.urgency not in TRIGV_URGENCIES:
             msg = f"An invalid Trigv urgency ({urgency}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # A custom hostname (e.g. a local/self-hosted ingest gateway)
         # overrides our default api.trigv.com endpoint; a port can be

--- a/apprise/plugins/twilio.py
+++ b/apprise/plugins/twilio.py
@@ -49,6 +49,7 @@ import re
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import is_phone_no, parse_phone_no, validate_regex
@@ -230,7 +231,7 @@ class NotifyTwilio(NotifyBase):
                 f"An invalid Twilio Account SID ({account_sid}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # The Authentication Token associated with the account
         self.auth_token = validate_regex(
@@ -242,7 +243,7 @@ class NotifyTwilio(NotifyBase):
                 f"({auth_token}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # The API Key associated with the account (optional)
         self.apikey = validate_regex(
@@ -266,7 +267,7 @@ class NotifyTwilio(NotifyBase):
                     "is invalid."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
         else:
             self.method = self.template_args["method"]["default"]
 
@@ -278,7 +279,7 @@ class NotifyTwilio(NotifyBase):
                 f"({source}) is invalid."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # prepare our default mode to use for all numbers that follow in
         # target definitions
@@ -298,7 +299,7 @@ class NotifyTwilio(NotifyBase):
                 "message mode Whatsapp."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         result = is_phone_no(result.group("phoneno"), min_len=5)
         if not result:
@@ -307,7 +308,7 @@ class NotifyTwilio(NotifyBase):
                 f"({source}) is invalid."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store The Source Phone # and/or short-code
         self.source = result["full"]
@@ -322,7 +323,7 @@ class NotifyTwilio(NotifyBase):
                     f"({source}) is invalid."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             # else... it as a short code so we're okay
 

--- a/apprise/plugins/twist.py
+++ b/apprise/plugins/twist.py
@@ -36,6 +36,7 @@ import re
 import requests
 
 from ..common import NotifyFormat, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import is_email, parse_list
@@ -181,7 +182,7 @@ class NotifyTwist(NotifyBase):
             # let outer exception handle this
             msg = f"The Twist Auth email specified ({self.email}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Re-assign email based on what was parsed
         self.email = result["full_email"]
@@ -196,7 +197,7 @@ class NotifyTwist(NotifyBase):
         if not self.password:
             msg = f"No Twist password was specified with account: {self.email}"
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Validate recipients and drop bad ones:
         for recipient in parse_list(targets):

--- a/apprise/plugins/twitter.py
+++ b/apprise/plugins/twitter.py
@@ -58,6 +58,7 @@ from requests_oauthlib import OAuth1
 
 from ..attachment.base import AttachBase
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import parse_bool, parse_list, validate_regex
@@ -241,25 +242,25 @@ class NotifyTwitter(NotifyBase):
         if not self.ckey:
             msg = "An invalid Twitter Consumer Key was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.csecret = validate_regex(csecret)
         if not self.csecret:
             msg = "An invalid Twitter Consumer Secret was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.akey = validate_regex(akey)
         if not self.akey:
             msg = "An invalid Twitter Access Key was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.asecret = validate_regex(asecret)
         if not self.asecret:
             msg = "An invalid Access Secret was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store our webhook mode
         self.mode = (
@@ -277,7 +278,7 @@ class NotifyTwitter(NotifyBase):
                     f"The Twitter message mode specified ({mode}) is invalid."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
         else:
             self.mode = self.template_args["mode"]["default"]
 

--- a/apprise/plugins/vapid/__init__.py
+++ b/apprise/plugins/vapid/__init__.py
@@ -39,6 +39,7 @@ from ...common import (
     NotifyType,
     PersistentStoreMode,
 )
+from ...exception import AppriseImproperlyConfigured
 from ...locale import gettext_lazy as _
 from ...utils import pem as _pem
 from ...utils.base64 import base64_urlencode
@@ -258,7 +259,7 @@ class NotifyVapid(NotifyBase):
             ):
                 msg = f"The Vapid TTL specified ({self.ttl}) is out of range."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         # Place a thumbnail image inline with the message body
         self.include_image = (
@@ -271,7 +272,7 @@ class NotifyVapid(NotifyBase):
         if not result:
             msg = f"An invalid Vapid Subscriber({subscriber}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
         self.subscriber = result["full_email"]
 
         # Store our Mode/service
@@ -290,7 +291,7 @@ class NotifyVapid(NotifyBase):
             # Invalid region specified
             msg = f"The Vapid mode specified ({mode}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg) from None
+            raise AppriseImproperlyConfigured(msg) from None
 
         # Our Private keyfile
         self.keyfile = keyfile

--- a/apprise/plugins/viber.py
+++ b/apprise/plugins/viber.py
@@ -36,6 +36,7 @@ from typing import Any, Optional
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import parse_list, validate_regex
@@ -127,7 +128,7 @@ class NotifyViber(NotifyBase):
         if not self.token:
             msg = "An invalid Viber authentication token was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Sender name is required by the API; provide a safe default
         sourcev = (source or "").strip()

--- a/apprise/plugins/voipms.py
+++ b/apprise/plugins/voipms.py
@@ -39,6 +39,7 @@ from json import loads
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_email, is_phone_no, parse_phone_no
 from .base import NotifyBase
@@ -133,14 +134,14 @@ class NotifyVoipms(NotifyBase):
         if self.password is None:
             msg = "Password has to be specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # User is the email associated with the account
         result = is_email(email)
         if not result:
             msg = f"An invalid VoIPms user email: ({email}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
         self.email = result["full_email"]
 
         # Validate our source Phone #
@@ -148,7 +149,7 @@ class NotifyVoipms(NotifyBase):
         if not result:
             msg = f"An invalid VoIPms source phone # ({source}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Source Phone # only supports +1 country code
         # Allow 7 digit phones (presume they're local with +1 country code)
@@ -161,7 +162,7 @@ class NotifyVoipms(NotifyBase):
                 f"({source}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store our source phone number (without country code)
         self.source = result["area"] + result["line"]

--- a/apprise/plugins/vonage.py
+++ b/apprise/plugins/vonage.py
@@ -35,6 +35,7 @@ import contextlib
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import is_phone_no, parse_phone_no, validate_regex
@@ -155,7 +156,7 @@ class NotifyVonage(NotifyBase):
         if not self.apikey:
             msg = f"An invalid Vonage API Key ({apikey}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # API Secret (associated with project)
         self.secret = validate_regex(
@@ -164,7 +165,7 @@ class NotifyVonage(NotifyBase):
         if not self.secret:
             msg = f"An invalid Vonage API Secret ({secret}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Set our Time to Live Flag
         self.ttl = self.template_args["ttl"]["default"]
@@ -178,7 +179,7 @@ class NotifyVonage(NotifyBase):
         ):
             msg = f"The Vonage TTL specified ({self.ttl}) is out of range."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # The Source Phone #
         self.source = source
@@ -189,7 +190,7 @@ class NotifyVonage(NotifyBase):
                 f"The Account (From) Phone # specified ({source}) is invalid."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Store our parsed value
         self.source = result["full"]

--- a/apprise/plugins/webexteams.py
+++ b/apprise/plugins/webexteams.py
@@ -87,6 +87,7 @@ import re
 import requests
 
 from ..common import NotifyFormat, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_list, validate_regex
 from .base import NotifyBase
@@ -224,7 +225,7 @@ class NotifyWebexTeams(NotifyBase):
             if self.mode not in WEBEX_TEAMS_MODES:
                 msg = f"The Webex Teams mode specified ({mode}) is invalid."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         else:
             # Auto-detect: webhook tokens are 80-160 lowercase alphanumeric
@@ -257,7 +258,7 @@ class NotifyWebexTeams(NotifyBase):
                     f" specified ({_tok}) is invalid."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         else:  # WebexTeamsMode.BOT
             self.token = None
@@ -267,7 +268,7 @@ class NotifyWebexTeams(NotifyBase):
             if not _at:
                 msg = "A Webex Teams bot access token must be specified."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             self.access_token = _at
 

--- a/apprise/plugins/wechat.py
+++ b/apprise/plugins/wechat.py
@@ -82,6 +82,7 @@ import re
 import requests
 
 from ..common import NotifyFormat, NotifyType, PersistentStoreMode
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_list, validate_regex
 from .base import NotifyBase
@@ -241,14 +242,14 @@ class NotifyWeChat(NotifyBase):
         if not self.corpid:
             msg = "A WeChat (WeCom) Corp ID must be specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Validate the App Secret
         self.corpsecret = validate_regex(corpsecret)
         if not self.corpsecret:
             msg = "A WeChat (WeCom) App Secret must be specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Validate the Agent ID (must be a non-negative integer string)
         self.agentid = validate_regex(
@@ -261,7 +262,7 @@ class NotifyWeChat(NotifyBase):
                 " it must be a non-negative integer.".format(agentid)
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Parsed and validated recipient lists
         self.users = []

--- a/apprise/plugins/wecombot.py
+++ b/apprise/plugins/wecombot.py
@@ -60,6 +60,7 @@ import re
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import validate_regex
 from .base import NotifyBase
@@ -125,7 +126,7 @@ class NotifyWeComBot(NotifyBase):
         if not self.key:
             msg = f"An invalid WeCom Bot Webhook Key ({key}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Prepare our notification URL now:
         self.api_url = self.notify_url.format(

--- a/apprise/plugins/whatsapp.py
+++ b/apprise/plugins/whatsapp.py
@@ -57,6 +57,7 @@ import re
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import (
     is_phone_no,
@@ -225,7 +226,7 @@ class NotifyWhatsApp(NotifyBase):
         if not self.token:
             msg = f"An invalid WhatsApp Access Token ({token}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # The From Phone ID associated with the account
         self.from_phone_id = validate_regex(
@@ -237,7 +238,7 @@ class NotifyWhatsApp(NotifyBase):
                 f"({from_phone_id}) was specified."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # The template to associate with the message
         if template:
@@ -250,7 +251,7 @@ class NotifyWhatsApp(NotifyBase):
                     f"({template}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             # The Template language Code to use
             if language:
@@ -263,7 +264,7 @@ class NotifyWhatsApp(NotifyBase):
                         f"({language}) was specified."
                     )
                     self.logger.warning(msg)
-                    raise TypeError(msg)
+                    raise AppriseImproperlyConfigured(msg)
             else:
                 self.language = self.template_tokens["language"]["default"]
         else:
@@ -329,7 +330,7 @@ class NotifyWhatsApp(NotifyBase):
                     f"An invalid Template Component ID ({key}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             if matched.group("id"):
                 #
@@ -350,7 +351,7 @@ class NotifyWhatsApp(NotifyBase):
                         f"(:{key}={val}) was specified."
                     )
                     self.logger.warning(msg)
-                    raise TypeError(msg)
+                    raise AppriseImproperlyConfigured(msg)
                 index = matched.group("id")
 
             if index in self.components:
@@ -359,7 +360,7 @@ class NotifyWhatsApp(NotifyBase):
                     f"({key}) was already assigned."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
             self.components[index] = map_to
             self.component_keys = self.components.keys()

--- a/apprise/plugins/workflows.py
+++ b/apprise/plugins/workflows.py
@@ -64,6 +64,7 @@ import requests
 
 from ..apprise_attachment import AppriseAttachment
 from ..common import NotifyFormat, NotifyImageSize, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import parse_bool, validate_regex
 from ..utils.templates import TemplateType, apply_template
@@ -245,7 +246,7 @@ class NotifyWorkflows(NotifyBase):
         if not self.workflow:
             msg = f"An invalid Workflows ID ({workflow}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.signature = validate_regex(
             signature, *self.template_tokens["signature"]["regex"]
@@ -253,7 +254,7 @@ class NotifyWorkflows(NotifyBase):
         if not self.signature:
             msg = f"An invalid Signature ({signature}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Place a thumbnail image inline with the message body
         self.include_image = bool(
@@ -281,7 +282,7 @@ class NotifyWorkflows(NotifyBase):
                     f" ({routing_id}) was specified."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         # Wrap Text
         self.wrap = bool(
@@ -297,7 +298,7 @@ class NotifyWorkflows(NotifyBase):
                 # add() failed (unsupported schema, unparseable URL, etc.)
                 msg = "The Workflows template specified could not be loaded."
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
             # Enforce maximum file size
             self.template[0].max_file_size = self.max_workflows_template_size
 
@@ -325,7 +326,7 @@ class NotifyWorkflows(NotifyBase):
                 f"({tokens}) are not identified as a dictionary."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # else:  NoneType - this is okay
         return

--- a/apprise/plugins/wxpusher.py
+++ b/apprise/plugins/wxpusher.py
@@ -40,6 +40,7 @@ import re
 import requests
 
 from ..common import NotifyFormat, NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..url import PrivacyMode
 from ..utils.parse import parse_list, validate_regex
@@ -175,7 +176,7 @@ class NotifyWxPusher(NotifyBase):
         if not self.token:
             msg = f"An invalid WxPusher App Token ({token}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Used for URL generation afterwards only
         self._invalid_targets = []

--- a/apprise/plugins/xmpp/adapter.py
+++ b/apprise/plugins/xmpp/adapter.py
@@ -43,6 +43,7 @@ from typing import Any, Callable, Optional
 import certifi
 
 from ...compat import dataclass_compat as dataclass
+from ...exception import AppriseException, AppriseImproperlyConfigured
 from .common import SECURE_MODES, SecureXMPPMode
 
 # Default our global support flag
@@ -63,13 +64,19 @@ except ImportError:
     FuturesTimeoutError = Exception  # type: ignore[misc]
 
 
-class XMPPChannelBindingError(Exception):
+class XMPPChannelBindingError(AppriseException):
     """SASL SCRAM-PLUS channel-binding authentication failure.
 
     Raised when the server rejects authentication because TLS
     channel-binding data (tls-unique or tls-exporter) was unavailable
     or mismatched.  Callers may retry with SCRAM-PLUS disabled.
     """
+
+    def __init__(
+        self,
+        message="SASL SCRAM-PLUS channel-binding authentication failed.",
+    ):
+        super().__init__(message)
 
 
 @dataclass(frozen=True, slots=True)
@@ -619,7 +626,7 @@ class SlixmppAdapter:
                 # Resolve connection behaviour from secure mode
                 mode_cfg = SECURE_MODES.get(self.config.secure)
                 if not mode_cfg:
-                    raise ValueError(
+                    raise AppriseImproperlyConfigured(
                         f"Unsupported XMPP secure mode: {self.config.secure}"
                     )
 
@@ -809,7 +816,7 @@ class SlixmppAdapter:
 
             mode_cfg = SECURE_MODES.get(self.config.secure)
             if not mode_cfg:
-                raise ValueError(
+                raise AppriseImproperlyConfigured(
                     f"Unsupported XMPP secure mode: {self.config.secure}"
                 )
 

--- a/apprise/plugins/xmpp/base.py
+++ b/apprise/plugins/xmpp/base.py
@@ -33,6 +33,7 @@ import re
 from typing import Any, Optional
 
 from ...common import NotifyType
+from ...exception import AppriseImproperlyConfigured
 from ...locale import gettext_lazy as _
 from ...url import PrivacyMode
 from ...utils.parse import parse_bool, parse_list, validate_regex
@@ -208,7 +209,7 @@ class NotifyXMPP(NotifyBase):
         except ValueError:
             msg = f"An invalid XMPP JID ({self.user}) was specified."
             self.logger.warning(msg)
-            raise TypeError(msg) from None
+            raise AppriseImproperlyConfigured(msg) from None
 
         self.targets: list[(str, str)] = []
         # Flag for tracking if we want Multi-User Chat function enabled
@@ -240,7 +241,7 @@ class NotifyXMPP(NotifyBase):
                     f"({secure_mode}) is invalid."
                 )
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         else:
             self.secure_mode = (
@@ -497,7 +498,7 @@ class NotifyXMPP(NotifyBase):
         raw = (value or "").strip()
         results = IS_JID.match(raw)
         if not results:
-            raise ValueError("Invalid JID")
+            raise AppriseImproperlyConfigured("Invalid JID")
 
         is_muc = bool(results.group("is_room"))
         host = results.group("domain") or default_host

--- a/apprise/plugins/zoom.py
+++ b/apprise/plugins/zoom.py
@@ -62,6 +62,7 @@ import re
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import validate_regex
 from .base import NotifyBase
@@ -169,7 +170,7 @@ class NotifyZoom(NotifyBase):
         },
     )
 
-    def __init__(self, webhook_id, token, mode=None, **kwargs):
+    def __init__(self, webhook_id=None, token=None, mode=None, **kwargs):
         """Initialize Zoom Object."""
         super().__init__(**kwargs)
 
@@ -182,14 +183,14 @@ class NotifyZoom(NotifyBase):
                 " characters."
             )
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Validate our verification token
         self.token = validate_regex(token)
         if not self.token:
             msg = "A Zoom verification token must be specified."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         # Validate notification mode
         if mode is None:
@@ -213,7 +214,7 @@ class NotifyZoom(NotifyBase):
             if not self.mode:
                 msg = "The Zoom mode ({}) is invalid.".format(mode)
                 self.logger.warning(msg)
-                raise TypeError(msg)
+                raise AppriseImproperlyConfigured(msg)
 
     def send(
         self,

--- a/apprise/plugins/zulip.py
+++ b/apprise/plugins/zulip.py
@@ -62,6 +62,7 @@ import re
 import requests
 
 from ..common import NotifyType
+from ..exception import AppriseImproperlyConfigured
 from ..locale import gettext_lazy as _
 from ..utils.parse import is_email, parse_list, validate_regex
 from .base import NotifyBase
@@ -203,7 +204,7 @@ class NotifyZulip(NotifyBase):
         except (TypeError, AttributeError) as err:
             msg = f"The Zulip botname specified ({botname}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg) from err
+            raise AppriseImproperlyConfigured(msg) from err
 
         try:
             match = VALIDATE_ORG.match(organization.strip())
@@ -222,7 +223,7 @@ class NotifyZulip(NotifyBase):
                 f"({organization}) is invalid."
             )
             self.logger.warning(msg)
-            raise TypeError(msg) from err
+            raise AppriseImproperlyConfigured(msg) from err
 
         self.token = validate_regex(
             token, *self.template_tokens["token"]["regex"]
@@ -230,7 +231,7 @@ class NotifyZulip(NotifyBase):
         if not self.token:
             msg = f"The Zulip token specified ({token}) is invalid."
             self.logger.warning(msg)
-            raise TypeError(msg)
+            raise AppriseImproperlyConfigured(msg)
 
         self.targets = parse_list(targets)
         if len(self.targets) == 0:

--- a/tests/test_apprise_asset.py
+++ b/tests/test_apprise_asset.py
@@ -34,6 +34,7 @@ from zoneinfo import ZoneInfo
 import pytest
 
 from apprise.asset import AppriseAsset
+from apprise.exception import AppriseImproperlyConfigured
 
 logging.disable(logging.CRITICAL)
 
@@ -56,14 +57,14 @@ def test_timezone():
     asset = AppriseAsset(timezone=ZoneInfo("America/Toronto"))
     assert isinstance(asset.tzinfo, tzinfo)
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAsset(timezone=object)
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAsset(timezone="invalid")
 
     # The private field cannot bypass the validated timezone argument.
-    with pytest.raises(AttributeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAsset(_tzinfo=timezone.utc)
 
 
@@ -88,15 +89,15 @@ def test_service_timeout():
     assert asset._service_timeout == 0.0
 
     # Negative values are rejected
-    with pytest.raises(ValueError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAsset(service_timeout=-1)
 
     # Non-numeric types are rejected
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAsset(service_timeout="invalid")
 
     # Booleans are rejected even though bool is technically an int subclass
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAsset(service_timeout=True)
 
     # inf might look like a second way to spell "unbounded" (0 is the
@@ -104,20 +105,20 @@ def test_service_timeout():
     # float("inf")) raises OverflowError on some platforms, silently
     # turning a successful notification into a reported FAILURE -- so
     # it's rejected outright, same as any other non-finite value.
-    with pytest.raises(ValueError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAsset(service_timeout=float("inf"))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAsset(service_timeout=float("-inf"))
 
     # NaN fails every ordering comparison, so it would otherwise slip
     # past a plain "< 0" check and silently disable the timeout as an
     # accidental side effect of its comparison semantics.
-    with pytest.raises(ValueError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAsset(service_timeout=float("nan"))
 
     # The private field cannot bypass the validated public argument.
-    with pytest.raises(AttributeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAsset(_service_timeout=99.0)
 
 
@@ -137,22 +138,22 @@ def test_payload_max_size():
     assert asset._payload_max_size == 0
 
     # Negative values are rejected
-    with pytest.raises(ValueError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAsset(payload_max_size=-1)
 
     # Non-int types are rejected -- a float character count makes no sense
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAsset(payload_max_size=12.5)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAsset(payload_max_size="invalid")
 
     # Booleans are rejected even though bool is technically an int subclass
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAsset(payload_max_size=True)
 
     # The private field cannot bypass the validated public argument.
-    with pytest.raises(AttributeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAsset(_payload_max_size=250)
 
 
@@ -175,31 +176,31 @@ def test_payload_buffer_threshold_and_min_buffer():
     assert asset._payload_min_buffer == 0
 
     # Negative values are rejected.
-    with pytest.raises(ValueError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAsset(payload_buffer_threshold=-1)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAsset(payload_min_buffer=-1)
 
     # Non-int types are rejected.
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAsset(payload_buffer_threshold=12.5)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAsset(payload_min_buffer="invalid")
 
     # Booleans are rejected even though bool is technically an int subclass.
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAsset(payload_buffer_threshold=True)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAsset(payload_min_buffer=True)
 
     # Private fields cannot bypass the validated public arguments.
-    with pytest.raises(AttributeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAsset(_payload_buffer_threshold=2)
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAsset(_payload_min_buffer=7)
 
 
@@ -216,12 +217,12 @@ def test_result_log_storage_sizes():
     assert asset.result_log_disk_size == 4096
 
     for name in ("result_log_memory_size", "result_log_disk_size"):
-        with pytest.raises(ValueError):
+        with pytest.raises(AppriseImproperlyConfigured):
             AppriseAsset(**{name: -1})
         for value in (True, 1.5, "1024"):
-            with pytest.raises(TypeError):
+            with pytest.raises(AppriseImproperlyConfigured):
                 AppriseAsset(**{name: value})
-        with pytest.raises(AttributeError):
+        with pytest.raises(AppriseImproperlyConfigured):
             AppriseAsset(**{"_{}".format(name): 1})
 
 

--- a/tests/test_apprise_attachments.py
+++ b/tests/test_apprise_attachments.py
@@ -40,6 +40,7 @@ from apprise import Apprise, AppriseAsset, AttachmentManager
 from apprise.apprise_attachment import AppriseAttachment
 from apprise.attachment import AttachBase
 from apprise.common import ContentLocation
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.logger import LogCapture
 
 logging.disable(logging.CRITICAL)
@@ -231,9 +232,8 @@ def test_apprise_attachment():
     # length remains unchanged
     assert len(aa) == 0
 
-    # if instantiating attachments from the class, it will throw a TypeError
-    # if attachments couldn't be loaded
-    with pytest.raises(TypeError):
+    # Direct construction reports attachments that could not be loaded.
+    with pytest.raises(AppriseImproperlyConfigured):
         AppriseAttachment("garbage://")
 
     # Load our other attachment types
@@ -260,7 +260,7 @@ def test_apprise_attachment():
     # Our length is still zero
     assert len(aa) == 0
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         # Invalid location specified
         AppriseAttachment(location="invalid")
 

--- a/tests/test_attach_base.py
+++ b/tests/test_attach_base.py
@@ -32,6 +32,7 @@ from unittest import mock
 import pytest
 
 from apprise.attachment.base import AttachBase
+from apprise.exception import AppriseImproperlyConfigured
 
 logging.disable(logging.CRITICAL)
 
@@ -62,7 +63,7 @@ def test_attach_base():
 
     """
     # an invalid mime-type
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         AttachBase(**{"mimetype": "invalid"})
 
     # a valid mime-type does not cause an exception to throw

--- a/tests/test_attach_memory.py
+++ b/tests/test_attach_memory.py
@@ -36,6 +36,7 @@ from apprise import AppriseAttachment, exception
 from apprise.attachment.base import AttachBase
 from apprise.attachment.memory import AttachMemory
 from apprise.common import ContentLocation
+from apprise.exception import AppriseImproperlyConfigured
 
 logging.disable(logging.CRITICAL)
 
@@ -74,7 +75,7 @@ def test_attach_memory_parse_url():
     # Stub function
     assert mem.download()
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         # garbage in, garbage out
         AttachMemory(content=3)
 

--- a/tests/test_config_base.py
+++ b/tests/test_config_base.py
@@ -40,6 +40,7 @@ import yaml
 
 from apprise import Apprise, AppriseAsset, AppriseConfig, ConfigFormat
 from apprise.config import ConfigBase
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.email import NotifyEmail
 from apprise.utils.time import zoneinfo
 
@@ -87,11 +88,11 @@ def test_config_base():
     """
 
     # invalid types throw exceptions
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         ConfigBase(**{"format": "invalid"})
 
     # Config format types are not the same as ConfigBase ones
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         ConfigBase(**{"format": "markdown"})
 
     cb = ConfigBase(**{"format": "yaml"})

--- a/tests/test_config_http.py
+++ b/tests/test_config_http.py
@@ -37,6 +37,7 @@ import requests
 from apprise import NotificationManager
 from apprise.common import ConfigFormat
 from apprise.config.http import ConfigHTTP
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins import NotifyBase
 
 logging.disable(logging.CRITICAL)
@@ -215,7 +216,7 @@ def test_config_http(mock_post):
 
     results = ConfigHTTP.parse_url("http://localhost:8080/path/?cache=-10")
     assert isinstance(results, dict)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         ch = ConfigHTTP(**results)
 
     results = ConfigHTTP.parse_url("http://user@localhost?format=text")

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -1,0 +1,123 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import errno
+import logging
+
+import pytest
+
+from apprise.exception import (
+    AppriseDiskIOError,
+    AppriseException,
+    AppriseFileNotFound,
+    AppriseImproperlyConfigured,
+    AppriseInvalidData,
+    ApprisePluginException,
+)
+
+# Disable logging for a cleaner testing output
+logging.disable(logging.CRITICAL)
+
+
+def test_appriseexception_base_behavior():
+    """AppriseException stores the message and defaults error_code to 0."""
+    exc = AppriseException("something went wrong")
+    assert str(exc) == "something went wrong"
+    assert exc.error_code == 0
+
+    exc = AppriseException("with a code", error_code=42)
+    assert exc.error_code == 42
+
+
+def test_appriseplugin_exception_defaults():
+    """ApprisePluginException defaults its error_code to 600."""
+    exc = ApprisePluginException("plugin failure")
+    assert isinstance(exc, AppriseException)
+    assert exc.error_code == 600
+
+    exc = ApprisePluginException("plugin failure", error_code=503)
+    assert exc.error_code == 503
+
+
+def test_appriseimproperlyconfigured_is_apprise_exception():
+    """AppriseImproperlyConfigured is a first-class AppriseException."""
+    exc = AppriseImproperlyConfigured("bad config")
+    assert isinstance(exc, AppriseException)
+    assert exc.error_code == errno.EINVAL
+
+
+def test_appriseimproperlyconfigured_builtin_compatibility():
+    """The new exception remains compatible with historical built-ins."""
+    exc = AppriseImproperlyConfigured("bad config")
+    assert isinstance(exc, TypeError)
+    assert isinstance(exc, ValueError)
+    assert isinstance(exc, AttributeError)
+
+    for builtin in (TypeError, ValueError, AttributeError):
+        with pytest.raises(builtin):
+            raise AppriseImproperlyConfigured("bad config")
+
+    with pytest.raises(AppriseException):
+        raise AppriseImproperlyConfigured("bad config")
+
+
+def test_appriseinvaliddata_defaults():
+    """AppriseInvalidData defaults its error_code to EINVAL."""
+    exc = AppriseInvalidData("bad data")
+    assert isinstance(exc, AppriseException)
+    assert exc.error_code == errno.EINVAL
+
+
+def test_apprisediskioerror_is_oserror():
+    """AppriseDiskIOError supplies standard and Apprise error details."""
+    exc = AppriseDiskIOError("disk failure")
+    assert isinstance(exc, AppriseException)
+    assert isinstance(exc, OSError)
+    assert exc.error_code == errno.EIO
+    assert exc.errno == errno.EIO
+    assert exc.strerror == "disk failure"
+    assert str(exc) == "disk failure"
+
+    with pytest.raises(OSError):
+        raise AppriseDiskIOError("disk failure")
+
+    custom = AppriseDiskIOError("disk full", error_code=errno.ENOSPC)
+    assert custom.error_code == errno.ENOSPC
+    assert custom.errno == errno.ENOSPC
+    assert custom.strerror == "disk full"
+
+
+def test_apprisefilenotfound_is_filenotfounderror():
+    """AppriseFileNotFound remains catchable as FileNotFoundError/OSError."""
+    exc = AppriseFileNotFound("missing attachment")
+    assert isinstance(exc, AppriseDiskIOError)
+    assert isinstance(exc, FileNotFoundError)
+    assert isinstance(exc, OSError)
+    assert exc.error_code == errno.ENOENT
+    assert exc.errno == errno.ENOENT
+    assert exc.strerror == "missing attachment"
+    assert str(exc) == "missing attachment"

--- a/tests/test_notify_base.py
+++ b/tests/test_notify_base.py
@@ -38,6 +38,7 @@ import pytest
 
 from apprise import AppriseAsset, NotifyFormat, NotifyImageSize, NotifyType
 from apprise.common import OverflowMode
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins import NotifyBase
 
 logging.disable(logging.CRITICAL)
@@ -50,11 +51,11 @@ def test_notify_base():
     """
 
     # invalid types throw exceptions
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyBase(**{"format": "invalid"})
 
     # invalid types throw exceptions
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyBase(**{"overflow": "invalid"})
 
     # Bad port information

--- a/tests/test_persistent_store.py
+++ b/tests/test_persistent_store.py
@@ -95,10 +95,10 @@ def test_persistent_storage_asset(tmpdir):
 def test_persistent_storage_bad_mode(tmpdir):
     """Persistent Storage Bad Mode Testing."""
     # Create ourselves an attachment object set in Memory Mode only
-    with pytest.raises(AttributeError):
+    with pytest.raises(exception.AppriseImproperlyConfigured):
         PersistentStore(namespace="abc", path=str(tmpdir), mode="invalid")
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(exception.AppriseImproperlyConfigured):
         AppriseAsset(storage_mode="invalid")
 
 
@@ -110,7 +110,7 @@ def test_disabled_persistent_storage(tmpdir):
     )
     assert pc.read() is None
     assert pc.read("mykey") is None
-    with pytest.raises(AttributeError):
+    with pytest.raises(exception.AppriseImproperlyConfigured):
         # Invalid key specified
         pc.read("!invalid")
     assert pc.write("data") is False
@@ -147,33 +147,33 @@ def test_disabled_persistent_storage(tmpdir):
     # After all of the above, nothing was done to the directory
     assert len(os.listdir(str(tmpdir))) == 0
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(exception.AppriseImproperlyConfigured):
         # invalid persistent store specified
         PersistentStore(namespace="abc", path=str(tmpdir), mode="garbage")
 
 
 def test_persistent_storage_init(tmpdir):
     """Test storage initialization."""
-    with pytest.raises(AttributeError):
+    with pytest.raises(exception.AppriseImproperlyConfigured):
         PersistentStore(namespace="", path=str(tmpdir))
-    with pytest.raises(AttributeError):
+    with pytest.raises(exception.AppriseImproperlyConfigured):
         PersistentStore(namespace=None, path=str(tmpdir))
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(exception.AppriseImproperlyConfigured):
         PersistentStore(namespace="_", path=str(tmpdir))
-    with pytest.raises(AttributeError):
+    with pytest.raises(exception.AppriseImproperlyConfigured):
         PersistentStore(namespace=".", path=str(tmpdir))
-    with pytest.raises(AttributeError):
+    with pytest.raises(exception.AppriseImproperlyConfigured):
         PersistentStore(namespace="-", path=str(tmpdir))
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(exception.AppriseImproperlyConfigured):
         PersistentStore(namespace="_abc", path=str(tmpdir))
-    with pytest.raises(AttributeError):
+    with pytest.raises(exception.AppriseImproperlyConfigured):
         PersistentStore(namespace=".abc", path=str(tmpdir))
-    with pytest.raises(AttributeError):
+    with pytest.raises(exception.AppriseImproperlyConfigured):
         PersistentStore(namespace="-abc", path=str(tmpdir))
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(exception.AppriseImproperlyConfigured):
         PersistentStore(namespace="%", path=str(tmpdir))
 
 
@@ -210,7 +210,7 @@ def test_persistent_storage_general(tmpdir):
     # i min in the future
     assert pc.set("key", "value", 60)
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(exception.AppriseImproperlyConfigured):
         assert pc.set("key", "value", "invalid")
 
     pc = PersistentStore(namespace=namespace, path=str(tmpdir))
@@ -1010,14 +1010,14 @@ def test_persistent_custom_io(tmpdir):
     # Initialize it for memory only
     pc = PersistentStore(path=str(tmpdir))
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(exception.AppriseImproperlyConfigured):
         pc.open("!invalid#-Key")
 
     # We can't open the file as it does not exist
     with pytest.raises(FileNotFoundError):
         pc.open("valid-key")
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(exception.AppriseImproperlyConfigured):
         # Bad data
         pc.open(1234)
 
@@ -1071,13 +1071,13 @@ def test_persistent_custom_io(tmpdir):
             pass
 
     # Writing
-    with pytest.raises(AttributeError):
+    with pytest.raises(exception.AppriseImproperlyConfigured):
         pc.write(1234)
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(exception.AppriseImproperlyConfigured):
         pc.write(None)
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(exception.AppriseImproperlyConfigured):
         pc.write(True)
 
     pc = PersistentStore(str(tmpdir))
@@ -1100,7 +1100,7 @@ def test_persistent_custom_io(tmpdir):
         mock_file.side_effect = OSError
         assert pc.write(b"test") is False
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(exception.AppriseImproperlyConfigured):
         pc.write(b"data", key="!invalid#-Key")
 
     pc.delete()
@@ -1531,7 +1531,7 @@ def test_persistent_storage_disk_prune(tmpdir):
     assert pc.get("key-t01") is None
     assert pc.read() is None
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(exception.AppriseImproperlyConfigured):
         # provide garbage in namespace field and we're going to have a problem
         PersistentStore.disk_prune(
             namespace=object, path=str(tmpdir), expires=0, action=True

--- a/tests/test_plugin_africas_talking.py
+++ b/tests/test_plugin_africas_talking.py
@@ -33,6 +33,7 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import Apprise, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.africas_talking import NotifyAfricasTalking
 
 logging.disable(logging.CRITICAL)
@@ -43,21 +44,21 @@ apprise_url_tests = (
         "atalk://",
         {
             # Instantiated but no auth, so no notification can happen
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "atalk://:@/",
         {
             # invalid auth
-            "instance": TypeError
+            "instance": AppriseImproperlyConfigured
         },
     ),
     (
         "atalk://user@^/",
         {
             # invalid apikey
-            "instance": TypeError
+            "instance": AppriseImproperlyConfigured
         },
     ),
     (
@@ -87,7 +88,7 @@ apprise_url_tests = (
     ),
     (
         "atalk://user@apikey/+{}?mode=invalid".format("4" * 11),
-        {"instance": TypeError},
+        {"instance": AppriseImproperlyConfigured},
     ),
     (
         "atalk://user@apikey/+{}?mode=s".format("4" * 11),

--- a/tests/test_plugin_apprise_api.py
+++ b/tests/test_plugin_apprise_api.py
@@ -35,6 +35,7 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyFormat, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.apprise_api import AppriseAPIVersion, NotifyAppriseAPI
 
 logging.disable(logging.CRITICAL)
@@ -62,21 +63,21 @@ apprise_url_tests = (
     (
         "apprise://localhost",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # invalid token
     (
         "apprise://localhost/!",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # No token specified (whitespace is trimmed)
     (
         "apprise://localhost/%%20",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # A valid URL with Token
@@ -184,7 +185,7 @@ apprise_url_tests = (
     (
         "apprise://localhost/mytoken1/?version=3",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -242,7 +243,7 @@ apprise_url_tests = (
     (
         "apprises://localhost:8080/abc123/?method=invalid",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_bark.py
+++ b/tests/test_plugin_bark.py
@@ -37,6 +37,10 @@ import pytest
 import requests
 
 from apprise import Apprise, NotifyFormat
+from apprise.exception import (
+    AppriseImproperlyConfigured,
+    ApprisePluginException,
+)
 import apprise.plugins.bark as bark_module
 from apprise.plugins.bark import NotifyBark
 
@@ -385,7 +389,9 @@ def test_plugin_bark_aesgcm_wire_format(
 )
 def test_plugin_bark_rejects_invalid_encryption_keys(key):
     """NotifyBark() rejects keys Bark cannot use as raw AES keys."""
-    with pytest.raises(TypeError, match="Bark encryption key"):
+    with pytest.raises(
+        AppriseImproperlyConfigured, match="Bark encryption key"
+    ):
         NotifyBark(
             host="localhost",
             targets=("device-key",),
@@ -398,7 +404,10 @@ def test_plugin_bark_encryption_fails_closed_without_cryptography(monkeypatch):
     """NotifyBark() never downgrades requested encryption to plaintext."""
     monkeypatch.setattr(bark_module, "BARK_AESGCM_SUPPORT", False)
 
-    with pytest.raises(TypeError, match="requires the 'cryptography' package"):
+    with pytest.raises(
+        AppriseImproperlyConfigured,
+        match="requires the 'cryptography' package",
+    ):
         NotifyBark(
             host="localhost",
             targets=("device-key",),
@@ -642,8 +651,11 @@ def test_plugin_bark_rejects_incompatible_generated_iv(monkeypatch):
         encryption_key="k" * 32,
     )
 
-    with pytest.raises(ValueError, match="incompatible AES-GCM IV"):
+    with pytest.raises(
+        ApprisePluginException, match="incompatible AES-GCM IV"
+    ) as exc_info:
         instance._encrypt_payload({"body": "private body"})
+    assert exc_info.value.error_code == 600
 
 
 @mock.patch("requests.post")

--- a/tests/test_plugin_base_formatting.py
+++ b/tests/test_plugin_base_formatting.py
@@ -44,6 +44,7 @@ from apprise import (
     NotifyFormat,
     OverflowMode,
 )
+from apprise.exception import AppriseImproperlyConfigured
 
 logging.disable(logging.CRITICAL)
 
@@ -116,7 +117,7 @@ def test_notify_overflow_truncate_with_amalgamation():
             return True
 
     # We should throw an exception because our specified overflow is wrong.
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         # Load our object
         obj = TestNotification(overflow="invalid")
 
@@ -347,7 +348,7 @@ def test_notify_overflow_truncate_no_amalgamation():
             return True
 
     # We should throw an exception because our specified overflow is wrong.
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         # Load our object
         obj = TestNotification(overflow="invalid")
 

--- a/tests/test_plugin_blink1.py
+++ b/tests/test_plugin_blink1.py
@@ -33,6 +33,7 @@ from helpers import AppriseURLTester
 import pytest
 
 from apprise import Apprise, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.blink1 import (
     BLINK1_DEFAULT_DURATION_MS,
     BLINK1_DEFAULT_FADE_MS,
@@ -121,46 +122,46 @@ apprise_url_tests = (
             "instance": NotifyBlink1,
         },
     ),
-    # Non-numeric duration -> TypeError
+    # Non-numeric duration
     (
         "blink1://?duration=abc",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
-    # Negative duration -> TypeError
+    # Negative duration
     (
         "blink1://?duration=-1",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
-    # Duration exceeds maximum -> TypeError
+    # Duration above the maximum
     (
         f"blink1://?duration={BLINK1_MAX_DURATION_MS + 1}",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
-    # Non-numeric fade -> TypeError
+    # Non-numeric fade
     (
         "blink1://?fade=abc",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
-    # Negative fade -> TypeError
+    # Negative fade
     (
         "blink1://?fade=-1",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
-    # Fade exceeds maximum -> TypeError
+    # Fade above the maximum
     (
         f"blink1://?fade={BLINK1_MAX_FADE_MS + 1}",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
 )

--- a/tests/test_plugin_bluesky.py
+++ b/tests/test_plugin_bluesky.py
@@ -36,6 +36,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.bluesky import NotifyBlueSky
 
 # Disable logging for a cleaner testing output
@@ -56,20 +57,20 @@ apprise_url_tests = (
         "bluesky://",
         {
             # Missing user and app_pass
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "bluesky://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "bluesky://app-pw",
         {
             # Missing User
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -473,7 +474,7 @@ def test_plugin_bluesky_general(mocker):
 def test_plugin_bluesky_edge_cases():
     """NotifyBlueSky() Edge Cases."""
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyBlueSky()
 
 

--- a/tests/test_plugin_brevo.py
+++ b/tests/test_plugin_brevo.py
@@ -35,6 +35,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.brevo import NotifyBrevo
 
 logging.disable(logging.CRITICAL)
@@ -77,14 +78,14 @@ apprise_url_tests = (
         "brevo://invalid-api-key+*-d:user@example.com",
         {
             # An invalid API Key
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         ("brevo://abcd:user@example.com/newuser@example.com?reply=%20!"),
         {
             # An invalid Reply-To address
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -187,15 +188,15 @@ def test_plugin_brevo_edge_cases(mock_post, mock_get):
     """NotifyBrevo() Edge Cases."""
 
     # no apikey
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyBrevo(apikey=None, from_email="user@example.com")
 
     # invalid from email
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyBrevo(apikey="abcd", from_email="!invalid")
 
     # no email
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyBrevo(apikey="abcd", from_email=None)
 
     # Invalid To email address

--- a/tests/test_plugin_bulksms.py
+++ b/tests/test_plugin_bulksms.py
@@ -35,6 +35,7 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import Apprise, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.bulksms import NotifyBulkSMS
 
 logging.disable(logging.CRITICAL)
@@ -121,7 +122,7 @@ apprise_url_tests = (
         "bulksms://{}:{}@admin?route=invalid".format("a" * 10, "b" * 10),
         {
             # invalid route
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -139,7 +140,7 @@ apprise_url_tests = (
         ),
         {
             # use get args to acomplish the same thing
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_bulkvs.py
+++ b/tests/test_plugin_bulkvs.py
@@ -35,6 +35,7 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import Apprise, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.bulkvs import NotifyBulkVS
 
 logging.disable(logging.CRITICAL)
@@ -45,28 +46,28 @@ apprise_url_tests = (
         "bulkvs://",
         {
             # Instantiated but no auth, so no otification can happen
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "bulkvs://:@/",
         {
             # invalid auth
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "bulkvs://{}@9876543210/".format("a" * 10),
         {
             # Just user provided (no password)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "bulkvs://{}:{}@{}".format("u" * 10, "p" * 10, "3" * 5),
         {
             # invalid source number provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_burstsms.py
+++ b/tests/test_plugin_burstsms.py
@@ -35,6 +35,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.burstsms import NotifyBurstSMS
 
 logging.disable(logging.CRITICAL)
@@ -45,28 +46,28 @@ apprise_url_tests = (
         "burstsms://",
         {
             # No API Key specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "burstsms://:@/",
         {
             # invalid Auth key
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "burstsms://{}@12345678".format("a" * 8),
         {
             # Just a key provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "burstsms://{}:{}@%20".format("d" * 8, "e" * 16),
         {
             # Invalid source number
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -123,7 +124,7 @@ apprise_url_tests = (
             "a" * 8, "b" * 16, "5" * 11, "6" * 11
         ),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Test our validity
@@ -141,7 +142,7 @@ apprise_url_tests = (
             "a" * 8, "b" * 16, "5" * 11, "6" * 11
         ),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -198,17 +199,17 @@ def test_plugin_burstsms_edge_cases(mock_post):
     source = "+1 (555) 123-3456"
 
     # No apikey specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyBurstSMS(apikey=None, secret=secret, source=source)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyBurstSMS(apikey="  ", secret=secret, source=source)
 
     # No secret specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyBurstSMS(apikey=apikey, secret=None, source=source)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyBurstSMS(apikey=apikey, secret="  ", source=source)
 
     # a error response

--- a/tests/test_plugin_chanify.py
+++ b/tests/test_plugin_chanify.py
@@ -31,6 +31,7 @@ import logging
 from helpers import AppriseURLTester
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.chanify import NotifyChanify
 
 logging.disable(logging.CRITICAL)
@@ -40,19 +41,19 @@ apprise_url_tests = (
     (
         "chanify://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "chanify://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "chanify://%badtoken%",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_chime.py
+++ b/tests/test_plugin_chime.py
@@ -35,6 +35,7 @@ import pytest
 import requests
 
 from apprise import Apprise, NotifyFormat
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.chime import NotifyChime
 
 logging.disable(logging.CRITICAL)
@@ -50,21 +51,21 @@ apprise_url_tests = (
         # No webhook_id or token
         "chime://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         # Empty URL
         "chime://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         # Webhook ID supplied but no token
         "chime://aabbccdd-1234-5678-abcd-ef1234567890",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -149,20 +150,20 @@ def test_plugin_chime_init(mock_post):
     mock_post.return_value = requests.Request()
     mock_post.return_value.status_code = requests.codes.ok
 
-    # Missing webhook_id raises TypeError
-    with pytest.raises(TypeError):
+    # A webhook ID is required.
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyChime(webhook_id=None, token=TEST_TOKEN)
 
-    # Blank webhook_id raises TypeError
-    with pytest.raises(TypeError):
+    # A blank webhook ID is invalid.
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyChime(webhook_id="  ", token=TEST_TOKEN)
 
-    # Missing token raises TypeError
-    with pytest.raises(TypeError):
+    # A token is required.
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyChime(webhook_id=TEST_WEBHOOK_ID, token=None)
 
-    # Blank token raises TypeError
-    with pytest.raises(TypeError):
+    # A blank token is invalid.
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyChime(webhook_id=TEST_WEBHOOK_ID, token="  ")
 
     # Valid object instantiates without error

--- a/tests/test_plugin_clickatell.py
+++ b/tests/test_plugin_clickatell.py
@@ -33,6 +33,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.clickatell import NotifyClickatell
 
 logging.disable(logging.CRITICAL)
@@ -43,35 +44,35 @@ apprise_url_tests = (
         "clickatell://",
         {
             # only schema provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "clickatell:///",
         {
             # invalid apikey
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "clickatell://@/",
         {
             # invalid apikey
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "clickatell://{}@/".format("1" * 10),
         {
             # no api key provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "clickatell://{}@{}/".format("1" * 3, "a" * 32),
         {
             # invalid From/Source
-            "instance": TypeError
+            "instance": AppriseImproperlyConfigured
         },
     ),
     (
@@ -193,7 +194,7 @@ def test_plugin_clickatell_edge_cases(mock_post):
     from_phone = "+1 (555) 123-3456"
 
     # No apikey specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyClickatell(apikey=None, from_phone=from_phone)
 
     # a error response

--- a/tests/test_plugin_clicksend.py
+++ b/tests/test_plugin_clicksend.py
@@ -30,6 +30,7 @@ import logging
 
 from helpers import AppriseURLTester
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.clicksend import NotifyClickSend
 
 logging.disable(logging.CRITICAL)
@@ -40,14 +41,14 @@ apprise_url_tests = (
         "clicksend://",
         {
             # We failed to identify any valid authentication
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "clicksend://:@/",
         {
             # We failed to identify any valid authentication
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_custom_form.py
+++ b/tests/test_plugin_custom_form.py
@@ -34,6 +34,7 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyFormat, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.custom_form import NotifyForm
 
 logging.disable(logging.CRITICAL)
@@ -70,7 +71,7 @@ apprise_url_tests = (
     (
         "form://user@localhost?method=invalid",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_custom_json.py
+++ b/tests/test_plugin_custom_json.py
@@ -36,6 +36,7 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyFormat, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.custom_json import NotifyJSON
 
 logging.disable(logging.CRITICAL)
@@ -72,7 +73,7 @@ apprise_url_tests = (
     (
         "json://user@localhost?method=invalid",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_custom_xml.py
+++ b/tests/test_plugin_custom_xml.py
@@ -35,6 +35,7 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyFormat, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.custom_xml import NotifyXML
 
 logging.disable(logging.CRITICAL)
@@ -78,7 +79,7 @@ apprise_url_tests = (
     (
         "xml://user@localhost?method=invalid",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_d7networks.py
+++ b/tests/test_plugin_d7networks.py
@@ -35,6 +35,7 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import Apprise, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.d7networks import NotifyD7Networks
 
 logging.disable(logging.CRITICAL)
@@ -45,14 +46,14 @@ apprise_url_tests = (
         "d7sms://",
         {
             # We failed to identify any valid authentication
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "d7sms://:@/",
         {
             # We failed to identify any valid authentication
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_dapnet.py
+++ b/tests/test_plugin_dapnet.py
@@ -34,6 +34,7 @@ import requests
 
 import apprise
 from apprise import NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.dapnet import DapnetPriority, NotifyDapnet
 
 logging.disable(logging.CRITICAL)
@@ -44,28 +45,28 @@ apprise_url_tests = (
         "dapnet://",
         {
             # We failed to identify any valid authentication
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "dapnet://:@/",
         {
             # We failed to identify any valid authentication
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "dapnet://user:pass",
         {
             # No call-sign specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "dapnet://user@host",
         {
             # No password specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_dbus.py
+++ b/tests/test_plugin_dbus.py
@@ -34,6 +34,7 @@ from helpers import reload_plugin
 import pytest
 
 import apprise
+from apprise.exception import AppriseImproperlyConfigured
 
 # Disable logging for a cleaner testing output
 logging.disable(logging.CRITICAL)
@@ -309,7 +310,7 @@ def test_plugin_dbus_url_parsing(mock_dbus_module):
     assert "y=200" in obj.url()
 
     # Test Invalid X/Y
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyDBus(x_axis="invalid")
 
 
@@ -359,11 +360,11 @@ def test_plugin_dbus_schema_not_supported(mock_dbus_module, mocker):
     reload_plugin("dbus")
     from apprise.plugins.dbus import NotifyDBus
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyDBus(schema="not-a-real-schema")
 
     # Assert warning emitted (message content is stable)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyDBus(schema="still-not-real")
 
 

--- a/tests/test_plugin_dingtalk.py
+++ b/tests/test_plugin_dingtalk.py
@@ -34,6 +34,7 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import Apprise, NotifyFormat
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.dingtalk import NotifyDingTalk
 
 logging.disable(logging.CRITICAL)
@@ -44,14 +45,14 @@ apprise_url_tests = (
         "dingtalk://",
         {
             # No Access Token specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "dingtalk://a_bd_/",
         {
             # invalid Access Token
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -109,7 +110,7 @@ apprise_url_tests = (
     (
         "dingtalk://{}/?to={}&secret=_".format("a" * 8, "1" * 14),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_discord.py
+++ b/tests/test_plugin_discord.py
@@ -41,6 +41,7 @@ import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyFormat, NotifyType
 from apprise.common import OverflowMode
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.discord import NotifyDiscord
 
 logging.disable(logging.CRITICAL)
@@ -53,21 +54,21 @@ apprise_url_tests = (
     (
         "discord://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # An invalid url
     (
         "discord://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # No webhook_token specified
     (
         "discord://%s" % ("i" * 24),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Provide both an webhook id and a webhook token
@@ -177,14 +178,14 @@ apprise_url_tests = (
         "discord://{}/{}?flags=-1".format("i" * 24, "t" * 64),
         {
             # invalid flags specified (variation 1)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "discord://{}/{}?flags=invalid".format("i" * 24, "t" * 64),
         {
             # invalid flags specified (variation 2)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # different format support
@@ -543,17 +544,17 @@ def test_plugin_discord_general(mock_sleep, mock_post):
     }
 
     # Invalid webhook id
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyDiscord(webhook_id=None, webhook_token=webhook_token)
     # Invalid webhook id (whitespace)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyDiscord(webhook_id="  ", webhook_token=webhook_token)
 
     # Invalid webhook token
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyDiscord(webhook_id=webhook_id, webhook_token=None)
     # Invalid webhook token (whitespace)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyDiscord(webhook_id=webhook_id, webhook_token="   ")
 
     obj = NotifyDiscord(
@@ -1431,12 +1432,12 @@ def test_plugin_discord_template_tokens(tmpdir):
 
 
 def test_plugin_discord_template_token_invalid():
-    """NotifyDiscord() non-dict tokens raises TypeError."""
+    """NotifyDiscord() rejects template tokens that are not a dictionary."""
 
     webhook_id = "A" * 24
     webhook_token = "B" * 64
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyDiscord(
             webhook_id=webhook_id,
             webhook_token=webhook_token,
@@ -1445,7 +1446,7 @@ def test_plugin_discord_template_token_invalid():
 
 
 def test_plugin_discord_template_add_failure():
-    """NotifyDiscord() template add() failure raises TypeError."""
+    """NotifyDiscord() rejects a template attachment it cannot add."""
 
     webhook_id = "A" * 24
     webhook_token = "B" * 64
@@ -1456,7 +1457,7 @@ def test_plugin_discord_template_add_failure():
             "apprise.plugins.discord.AppriseAttachment.add",
             return_value=False,
         ),
-        pytest.raises(TypeError),
+        pytest.raises(AppriseImproperlyConfigured),
     ):
         NotifyDiscord(
             webhook_id=webhook_id,

--- a/tests/test_plugin_eight00com.py
+++ b/tests/test_plugin_eight00com.py
@@ -37,6 +37,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.eight00com import NotifyEight00com
 
 logging.disable(logging.CRITICAL)
@@ -49,22 +50,22 @@ apprise_url_tests = (
     (
         "eight00com://",
         {
-            # No token -> TypeError
-            "instance": TypeError,
+            # Missing token
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "eight00com://:@/",
         {
-            # Empty token -> TypeError
-            "instance": TypeError,
+            # Empty token
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "eight00com://GOODTOKEN@badphone",
         {
-            # Non-numeric from-phone -> TypeError
-            "instance": TypeError,
+            # Non-numeric source phone number
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -161,16 +162,16 @@ def test_plugin_eight00com_init(mock_post):
     response.status_code = requests.codes.ok
     mock_post.return_value = response
 
-    # Missing token -> TypeError
-    with pytest.raises(TypeError):
+    # A token is required.
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyEight00com(token=None, source="8005551234")
 
-    # Empty token -> TypeError
-    with pytest.raises(TypeError):
+    # An empty token is invalid.
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyEight00com(token="", source="8005551234")
 
-    # Invalid source phone -> TypeError
-    with pytest.raises(TypeError):
+    # The source must be a valid phone number.
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyEight00com(token="mytoken", source="notaphone")
 
     # Valid with source only: defaults to texting ourselves

--- a/tests/test_plugin_email.py
+++ b/tests/test_plugin_email.py
@@ -52,7 +52,7 @@ from apprise import (
 )
 from apprise.attachment.memory import AttachMemory
 from apprise.config import ConfigBase
-from apprise.exception import AppriseException
+from apprise.exception import AppriseException, AppriseImproperlyConfigured
 from apprise.plugins import email
 
 try:
@@ -73,19 +73,19 @@ TEST_URLS = (
     (
         "mailto://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "mailtos://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "mailto://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # No Username
@@ -93,7 +93,7 @@ TEST_URLS = (
         "mailtos://:pass@nuxref.com:567",
         {
             # Can't prepare a To address using this expression
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -101,7 +101,7 @@ TEST_URLS = (
         "mailto://user:pass@fastmail.com?tz=invalid",
         {
             # An error is thrown for this
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Pre-Configured Email Services
@@ -431,7 +431,7 @@ TEST_URLS = (
     (
         "mailtos://nuxref.com?user=&pass=.",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Invalid To Address is accepted, but we won't be able to properly email
@@ -447,21 +447,21 @@ TEST_URLS = (
     (
         'mailtos://nuxref.com?user=%20"&pass=.',
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Invalid From (and To) Address
     (
         "mailtos://nuxref.com?to=test",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Invalid Secure Mode
     (
         "mailtos://user:pass@example.com?mode=notamode",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # STARTTLS flag checking
@@ -2577,7 +2577,7 @@ def test_plugin_host_detection_from_source_email(mock_smtp, mock_smtp_ssl):
     assert results["smtp_host"] == "mobile.charter.net"
     assert results["password"] == "password"
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         # We will fail
         Apprise.instantiate(results, suppress_exceptions=False)
 

--- a/tests/test_plugin_emby.py
+++ b/tests/test_plugin_emby.py
@@ -35,6 +35,7 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import Apprise
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.emby import NotifyEmby
 
 logging.disable(logging.CRITICAL)
@@ -60,7 +61,7 @@ apprise_url_tests = (
         "emby://localhost",
         {
             # Missing a username
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_evolution.py
+++ b/tests/test_plugin_evolution.py
@@ -34,6 +34,7 @@ import pytest
 import requests
 
 from apprise import Apprise, NotifyFormat
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.evolution import NotifyEvolution
 
 logging.disable(logging.CRITICAL)
@@ -61,28 +62,28 @@ apprise_url_tests = (
     (
         "evolution://hostname/myinstance/5511999999999",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Missing instance (single path entry treated as instance; no phone left)
     (
         "evolution://myapikey@hostname/5511999999999",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Missing phone number
     (
         "evolution://myapikey@hostname/myinstance",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Invalid phone number
     (
         "evolution://myapikey@hostname/myinstance/notaphone",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Valid HTTP — minimal
@@ -180,27 +181,27 @@ def test_plugin_evolution_edge_cases():
     """NotifyEvolution() direct instantiation edge cases."""
 
     # No apikey
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyEvolution(
             apikey=None, instance="inst", targets=["5511999999999"]
         )
 
     # Blank apikey
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyEvolution(
             apikey="   ", instance="inst", targets=["5511999999999"]
         )
 
     # No instance
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyEvolution(apikey="key", instance=None, targets=["5511999999999"])
 
     # No targets
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyEvolution(apikey="key", instance="inst", targets=[])
 
     # All targets invalid
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyEvolution(
             apikey="key", instance="inst", targets=["notaphone", "xx"]
         )

--- a/tests/test_plugin_exotel.py
+++ b/tests/test_plugin_exotel.py
@@ -34,6 +34,7 @@ import pytest
 import requests
 
 from apprise import Apprise, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.exotel import NotifyExotel
 
 logging.disable(logging.CRITICAL)
@@ -44,42 +45,42 @@ apprise_url_tests = (
         "exotel://",
         {
             # No Account SID specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "exotel://:@/",
         {
             # invalid Auth token
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "exotel://{}@12345678".format("a" * 32),
         {
             # Just sid provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "exotel://{}:{}@_".format("a" * 32, "b" * 32),
         {
             # sid and token provided but invalid from
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "exotel://{}:{}@/%20".format("a" * 32, "b" * 32),
         {
             # sid and token provided but no from
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "exotel://{}:{}@{}".format("a" * 32, "b" * 32, "3" * 8),
         {
             # sid and token provided and from but invalid from no
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -118,7 +119,7 @@ apprise_url_tests = (
         "exotel://{}:{}@12345/{}".format("a" * 32, "b" * 32, "4" * 11),
         {
             # using short-code (5 characters) is not supported
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -196,7 +197,7 @@ apprise_url_tests = (
         ),
         {
             # Test region flag Invalid
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -223,7 +224,7 @@ apprise_url_tests = (
         ),
         {
             # Test region flag Invalid
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -290,16 +291,16 @@ def test_plugin_exotel_edge_cases(mock_post):
 
     mock_post.return_value = response
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyExotel(sid=sid, token=token, source=" ")
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyExotel(sid=sid, token=token, source=source, apikey=" ")
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyExotel(sid=sid, token=token, source=source, region_name=" ")
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyExotel(sid=sid, token=token, source=source, priority=" ")
 
     # Programmatic priority shorthand is supported as an Apprise convenience.

--- a/tests/test_plugin_fcm.py
+++ b/tests/test_plugin_fcm.py
@@ -59,6 +59,8 @@ except ImportError:
 # Disable logging for a cleaner testing output
 import logging
 
+from apprise.exception import AppriseImproperlyConfigured
+
 logging.disable(logging.CRITICAL)
 
 # Test files for KeyFile Directory
@@ -72,21 +74,21 @@ apprise_url_tests = (
         "fcm://",
         {
             # We failed to identify any valid authentication
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "fcm://:@/",
         {
             # We failed to identify any valid authentication
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "fcm://project@%20%20/",
         {
             # invalid apikey
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -118,7 +120,7 @@ apprise_url_tests = (
         "fcm://apikey/device?mode=invalid",
         {
             # Valid device, invalid mode
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -194,7 +196,7 @@ apprise_url_tests = (
         "fcm://%20?to=device&keyfile=/invalid/path",
         {
             # invalid Project ID
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -219,7 +221,7 @@ apprise_url_tests = (
         "fcm://project_id?to=device&mode=oauth2",
         {
             # no keyfile was specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -960,10 +962,10 @@ def test_plugin_fcm_priority_manager():
     assert not instance.payload()
     assert str(instance) == ""
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         instance = FCMPriorityManager(mode, "invalid")
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         instance = FCMPriorityManager("invald", "high")
 
     # mode validation is done at the higher NotifyFCM() level so

--- a/tests/test_plugin_feishu.py
+++ b/tests/test_plugin_feishu.py
@@ -31,6 +31,7 @@ import logging
 from helpers import AppriseURLTester
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.feishu import NotifyFeishu
 
 logging.disable(logging.CRITICAL)
@@ -40,19 +41,19 @@ apprise_url_tests = (
     (
         "feishu://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "feishu://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "feishu://%badtoken%",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_flock.py
+++ b/tests/test_plugin_flock.py
@@ -33,6 +33,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.flock import NotifyFlock
 
 logging.disable(logging.CRITICAL)
@@ -42,14 +43,14 @@ apprise_url_tests = (
     (
         "flock://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # An invalid url
     (
         "flock://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Provide a token
@@ -176,7 +177,7 @@ apprise_url_tests = (
     (
         "flock://%s/g:/u:?format=text" % ("i" * 24),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # we don't focus on the invalid length of the user/group fields.
@@ -245,8 +246,8 @@ def test_plugin_flock_edge_cases(mock_post, mock_get):
     """NotifyFlock() Edge Cases."""
 
     # Initializes the plugin with an invalid token
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyFlock(token=None)
     # Whitespace also acts as an invalid token value
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyFlock(token="   ")

--- a/tests/test_plugin_flowtriq.py
+++ b/tests/test_plugin_flowtriq.py
@@ -36,6 +36,7 @@ import pytest
 import requests
 
 from apprise import Apprise, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.flowtriq import NotifyFlowtriq
 
 logging.disable(logging.CRITICAL)
@@ -52,14 +53,14 @@ apprise_url_tests = (
     (
         "flowtriq://apikey@hostname",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # No API key specified
     (
         "flowtriq://hostname/hooks/abc123",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Provide a hostname, apikey, and webhook path (insecure)
@@ -150,24 +151,24 @@ def test_plugin_flowtriq_urls():
 def test_plugin_flowtriq_edge_cases():
     """NotifyFlowtriq() Edge Cases."""
     # Initializes the plugin with an invalid API key
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyFlowtriq(apikey=None, webhook_path="hooks/abc123")
     # Whitespace also acts as an invalid API key
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyFlowtriq(apikey="   ", webhook_path="hooks/abc123")
 
     # Missing webhook path
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyFlowtriq(apikey="validkey", webhook_path=None)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyFlowtriq(apikey="validkey", webhook_path="   ")
 
     # A webhook path consisting only of slashes strips to empty
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyFlowtriq(apikey="validkey", webhook_path="///")
 
     # Missing host is caught after super().__init__()
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyFlowtriq(
             apikey="validkey", webhook_path="hooks/abc123", host=None
         )

--- a/tests/test_plugin_fluxer.py
+++ b/tests/test_plugin_fluxer.py
@@ -42,6 +42,7 @@ import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyFormat, NotifyType
 from apprise.common import OverflowMode
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.fluxer import NotifyFluxer
 
 logging.disable(logging.CRITICAL)
@@ -63,21 +64,21 @@ apprise_url_tests = (
     (
         "fluxer://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # An invalid url
     (
         "fluxer://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # No webhook_token specified
     (
         "fluxer://%s" % ("0" * 10),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Provide both a webhook id and a webhook token
@@ -161,7 +162,7 @@ apprise_url_tests = (
         # Invalid Mode
         "fluxer://jack@{}/{}?mode=invalid".format(*_tokens()),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -214,14 +215,14 @@ apprise_url_tests = (
         "fluxer://{}/{}?flags=-1".format(*_tokens()),
         {
             # invalid flags specified (variation 1)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "fluxer://{}/{}?flags=invalid".format(*_tokens()),
         {
             # invalid flags specified (variation 2)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # different format support
@@ -456,14 +457,14 @@ def test_plugin_fluxer_429(
     webhook_id, webhook_token = _tokens()
 
     # Basic construction checks (keep these, they match plugin validation)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyFluxer(webhook_id=None, webhook_token=webhook_token)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyFluxer(webhook_id="  ", webhook_token=webhook_token)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyFluxer(webhook_id=webhook_id, webhook_token=None)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyFluxer(webhook_id=webhook_id, webhook_token="   ")
 
     obj = NotifyFluxer(
@@ -638,18 +639,18 @@ def test_plugin_fluxer_general(
     mock_post.return_value.content = ""
 
     # Invalid webhook id
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyFluxer(webhook_id=None, webhook_token=webhook_token)
     # Invalid webhook id (whitespace)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyFluxer(webhook_id="  ", webhook_token=webhook_token)
 
     # Invalid webhook token
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyFluxer(webhook_id=webhook_id, webhook_token=None)
 
     # Private mode but no hostname provided
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyFluxer(
             webhook_id=webhook_id,
             webhook_token=webhook_token,

--- a/tests/test_plugin_freemobile.py
+++ b/tests/test_plugin_freemobile.py
@@ -31,6 +31,7 @@ import logging
 from helpers import AppriseURLTester
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.freemobile import NotifyFreeMobile
 
 logging.disable(logging.CRITICAL)
@@ -40,13 +41,13 @@ apprise_url_tests = (
     (
         "freemobile://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "freemobile://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_glib.py
+++ b/tests/test_plugin_glib.py
@@ -34,6 +34,7 @@ from helpers import reload_plugin
 import pytest
 
 import apprise
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.glib import GLibUrgency, NotifyGLib
 
 # Disable logging output during testing
@@ -248,10 +249,10 @@ def test_plugin_glib_disabled(mocker, enabled_glib_environment):
 
 
 def test_plugin_glib_invalid_coords():
-    """Invalid x/y coordinates cause TypeError"""
-    with pytest.raises(TypeError):
+    """Invalid x/y coordinates are rejected."""
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyGLib(x_axis="bad", y_axis="1")
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyGLib(x_axis="1", y_axis="bad")
 
 

--- a/tests/test_plugin_google_chat.py
+++ b/tests/test_plugin_google_chat.py
@@ -36,6 +36,7 @@ import pytest
 import requests
 
 from apprise import Apprise, NotifyFormat, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.google_chat import NotifyGoogleChat
 
 logging.disable(logging.CRITICAL)
@@ -45,27 +46,27 @@ apprise_url_tests = (
     (
         "gchat://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "gchat://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Workspace, but not Key or Token
     (
         "gchat://workspace",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Workspace and key, but no Token
     (
         "gchat://workspace/key/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Credentials are good
@@ -233,7 +234,7 @@ def test_plugin_google_chat_general(mock_post):
 
 def test_plugin_google_chat_edge_case():
     """NotifyGoogleChat() Edge Cases."""
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyGoogleChat("workspace", "webhook", "token", thread_key=object())
 
 

--- a/tests/test_plugin_gotify.py
+++ b/tests/test_plugin_gotify.py
@@ -36,6 +36,7 @@ import requests
 
 import apprise
 from apprise import NotifyFormat
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.gotify import GotifyPriority, NotifyGotify
 
 logging.disable(logging.CRITICAL)
@@ -52,7 +53,7 @@ apprise_url_tests = (
     (
         "gotify://hostname",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Provide a hostname and token
@@ -152,10 +153,10 @@ def test_plugin_gotify_urls():
 def test_plugin_gotify_edge_cases():
     """NotifyGotify() Edge Cases."""
     # Initializes the plugin with an invalid token
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyGotify(token=None)
     # Whitespace also acts as an invalid token value
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyGotify(token="   ")
 
 

--- a/tests/test_plugin_groupme.py
+++ b/tests/test_plugin_groupme.py
@@ -36,6 +36,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.groupme import NotifyGroupMe
 
 logging.disable(logging.CRITICAL)
@@ -60,21 +61,21 @@ apprise_url_tests = (
         # No bot_id
         "groupme://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         # Empty URL
         "groupme://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         # Invalid bot_id containing non-hex characters
         "groupme://not-a-valid-bot-id!",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -154,16 +155,16 @@ def test_plugin_groupme_init(mock_post):
     mock_post.return_value = requests.Request()
     mock_post.return_value.status_code = requests.codes.accepted
 
-    # Missing bot_id raises TypeError
-    with pytest.raises(TypeError):
+    # A bot ID is required.
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyGroupMe(bot_id=None)
 
-    # Blank bot_id raises TypeError
-    with pytest.raises(TypeError):
+    # A blank bot ID is invalid.
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyGroupMe(bot_id="")
 
-    # bot_id with invalid characters raises TypeError
-    with pytest.raises(TypeError):
+    # A bot ID cannot contain unsupported characters.
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyGroupMe(bot_id="not-valid!")
 
     # Valid bot_id instantiates without error

--- a/tests/test_plugin_guilded.py
+++ b/tests/test_plugin_guilded.py
@@ -34,6 +34,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.guilded import NotifyGuilded
 
 logging.disable(logging.CRITICAL)
@@ -46,21 +47,21 @@ apprise_url_tests = (
     (
         "guilded://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # An invalid url
     (
         "guilded://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # No webhook_token specified
     (
         "guilded://%s" % ("i" * 24),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Provide both an webhook id and a webhook token
@@ -212,17 +213,17 @@ def test_plugin_guilded_general(mock_post):
     mock_post.return_value.status_code = requests.codes.ok
 
     # Invalid webhook id
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyGuilded(webhook_id=None, webhook_token=webhook_token)
     # Invalid webhook id (whitespace)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyGuilded(webhook_id="  ", webhook_token=webhook_token)
 
     # Invalid webhook token
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyGuilded(webhook_id=webhook_id, webhook_token=None)
     # Invalid webhook token (whitespace)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyGuilded(webhook_id=webhook_id, webhook_token="   ")
 
     obj = NotifyGuilded(

--- a/tests/test_plugin_homeassistant.py
+++ b/tests/test_plugin_homeassistant.py
@@ -35,6 +35,7 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import Apprise
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.home_assistant import NotifyHomeAssistant
 
 logging.disable(logging.CRITICAL)
@@ -44,26 +45,26 @@ apprise_url_tests = (
     (
         "hassio://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "hassio://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "hassios://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # No Long Lived Access Token specified
     (
         "hassio://user@localhost",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -144,7 +145,7 @@ apprise_url_tests = (
         "hassios://localhost/long.lived.token?nid=!%",
         {
             # Invalid notification_id
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_httpsms.py
+++ b/tests/test_plugin_httpsms.py
@@ -35,6 +35,7 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import Apprise, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.httpsms import NotifyHttpSMS
 
 logging.disable(logging.CRITICAL)
@@ -45,21 +46,21 @@ apprise_url_tests = (
         "httpsms://",
         {
             # Instantiated but no auth, so no notification can happen
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "httpsms://:@/",
         {
             # invalid token
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "httpsms://{}:{}@{}".format("u" * 10, "p" * 10, "3" * 5),
         {
             # invalid source number provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_humhub.py
+++ b/tests/test_plugin_humhub.py
@@ -34,6 +34,7 @@ import pytest
 import requests
 
 from apprise import Apprise
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.humhub import NotifyHumHub
 
 logging.disable(logging.CRITICAL)
@@ -51,35 +52,35 @@ apprise_url_tests = (
     (
         "humhub://hostname",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Token present but no container ID
     (
         "humhub://token@hostname",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Invalid container ID (not numeric)
     (
         "humhubs://token@hostname/invalid",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Negative container ID (not a positive integer)
     (
         "humhubs://token@hostname/-1",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Zero container ID (not a positive integer)
     (
         "humhubs://token@hostname/0",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Valid bearer token + container ID over HTTP (insecure)
@@ -197,23 +198,23 @@ def test_plugin_humhub_init():
     """NotifyHumHub() initialization edge cases."""
 
     # No user/token at all
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyHumHub(user=None, host="hostname", targets=["1"])
 
     # Empty string user
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyHumHub(user="", host="hostname", targets=["1"])
 
     # No containers specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyHumHub(user="token", host="hostname", targets=[])
 
     # None targets
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyHumHub(user="token", host="hostname", targets=None)
 
     # Only invalid targets
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyHumHub(user="token", host="hostname", targets=["bad", "0", "-5"])
 
     # Mixed valid and invalid -- should succeed, dropping the bad ones
@@ -414,7 +415,7 @@ def test_plugin_humhub_url_parsing():
 
     # Empty / invalid URL returns None (no host)
     assert NotifyHumHub.parse_url("humhubs://") is None
-    # Only host, no user -- parse_url succeeds; TypeError raised at init
+    # Parsing accepts a host alone; initialization later requires a user.
     result = NotifyHumHub.parse_url("humhubs://hostname/1")
     assert result is not None
 

--- a/tests/test_plugin_ifttt.py
+++ b/tests/test_plugin_ifttt.py
@@ -34,6 +34,7 @@ import pytest
 import requests
 
 from apprise import NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.ifttt import NotifyIFTTT
 
 logging.disable(logging.CRITICAL)
@@ -43,20 +44,20 @@ apprise_url_tests = (
     (
         "ifttt://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "ifttt://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # No User
     (
         "ifttt://EventID/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # A nicely formed ifttt url with 1 event and a new key/value store
@@ -94,7 +95,7 @@ apprise_url_tests = (
         "https://maker.ifttt.com/use/WebHookID/",
         {
             # No EventID specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -166,19 +167,19 @@ def test_plugin_ifttt_edge_cases(mock_post, mock_get):
     mock_post.return_value.content = "{}"
 
     # No webhook_id specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyIFTTT(webhook_id=None, events=None)
 
     # Initializes the plugin with an invalid webhook id
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyIFTTT(webhook_id=None, events=events)
 
     # Whitespace also acts as an invalid webhook id
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyIFTTT(webhook_id="   ", events=events)
 
     # No events specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyIFTTT(webhook_id=webhook_id, events=None)
 
     obj = NotifyIFTTT(webhook_id=webhook_id, events=events)
@@ -219,7 +220,7 @@ def test_plugin_ifttt_edge_cases(mock_post, mock_get):
     )
 
     # Invalid del_tokens entry
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyIFTTT(
             webhook_id=webhook_id,
             events=events,

--- a/tests/test_plugin_irc.py
+++ b/tests/test_plugin_irc.py
@@ -36,6 +36,7 @@ from unittest import mock
 
 import pytest
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.irc import NotifyIRC
 from apprise.plugins.irc.client import IRCClient
 from apprise.plugins.irc.protocol import (
@@ -110,7 +111,7 @@ def test_plugin_irc_modes() -> None:
     """NotifyIRC auth mode tests."""
     with (
         mock.patch.object(NotifyIRC, "apply_irc_defaults"),
-        pytest.raises(TypeError),
+        pytest.raises(AppriseImproperlyConfigured),
     ):
         NotifyIRC(host="irc.example.com", targets=["#c"], mode="invalid")
 

--- a/tests/test_plugin_jellyfin.py
+++ b/tests/test_plugin_jellyfin.py
@@ -31,6 +31,7 @@ import logging
 from helpers import AppriseURLTester
 
 from apprise import Apprise
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins import jellyfin
 
 logging.disable(logging.CRITICAL)
@@ -58,7 +59,7 @@ apprise_url_tests = (
         "jellyfin://localhost",
         {
             # Missing a username
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_jira.py
+++ b/tests/test_plugin_jira.py
@@ -35,6 +35,7 @@ from helpers import AppriseURLTester
 import requests
 
 import apprise
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.jira import JiraPriority, NotifyJira, NotifyType
 
 logging.disable(logging.CRITICAL)
@@ -56,28 +57,28 @@ apprise_url_tests = (
         "jira://",
         {
             # We failed to identify any valid authentication
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "jira://:@/",
         {
             # We failed to identify any valid authentication
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "jira://%20%20/",
         {
             # invalid apikey specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "jira://apikey/user/?region=xx",
         {
             # invalid region id
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -148,21 +149,21 @@ apprise_url_tests = (
         "jira://apikey/@user?action=invalid",
         {
             # Assign an entity
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "jira://from@apikey/@user?:invalid=note",
         {
             # Assign an entity
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "jira://apikey/@user?:warning=invalid",
         {
             # Assign an entity
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Creates an index entry

--- a/tests/test_plugin_join.py
+++ b/tests/test_plugin_join.py
@@ -35,6 +35,7 @@ import requests
 
 import apprise
 from apprise import NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.join import JoinPriority, NotifyJoin
 
 logging.disable(logging.CRITICAL)
@@ -44,14 +45,14 @@ apprise_url_tests = (
     (
         "join://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # API Key + bad url
     (
         "join://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # APIkey; no device
@@ -191,11 +192,11 @@ def test_plugin_join_edge_cases(mock_post, mock_get):
     NotifyJoin(apikey=apikey, targets=None)
 
     # Initializes the plugin with an invalid apikey
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyJoin(apikey=None)
 
     # Whitespace also acts as an invalid apikey
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyJoin(apikey="   ")
 
     # Initializes the plugin with devices set to a set

--- a/tests/test_plugin_kavenegar.py
+++ b/tests/test_plugin_kavenegar.py
@@ -30,6 +30,7 @@ import logging
 
 from helpers import AppriseURLTester
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.kavenegar import NotifyKavenegar
 
 logging.disable(logging.CRITICAL)
@@ -40,14 +41,14 @@ apprise_url_tests = (
         "kavenegar://",
         {
             # We failed to identify any valid authentication
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "kavenegar://:@/",
         {
             # We failed to identify any valid authentication
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -91,14 +92,14 @@ apprise_url_tests = (
         "kavenegar://{}@{}/{}".format("a" * 14, "b" * 24, "3" * 14),
         {
             # invalid from number
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "kavenegar://{}@{}/{}".format("3" * 4, "b" * 24, "3" * 14),
         {
             # invalid from number
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_kook.py
+++ b/tests/test_plugin_kook.py
@@ -37,6 +37,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyFormat
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.kook import (
     KookMode,
     NotifyKook,
@@ -67,14 +68,14 @@ TEST_URLS = (
     (
         "kook://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Invalid mode
     (
         f"kook://{BOT_TOKEN}/?mode=invalid",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     ##
@@ -352,16 +353,16 @@ def test_plugin_kook_webhook_mode():
     assert obj2.mode == KookMode.WEBHOOK
 
     # Missing token
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyKook(token=None)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyKook(token="")
 
 
 def test_plugin_kook_mode_invalid():
-    """Invalid mode raises TypeError."""
-    with pytest.raises(TypeError):
+    """An invalid mode is rejected."""
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyKook(token=BOT_TOKEN, mode="invalid_mode")
 
 

--- a/tests/test_plugin_kumulos.py
+++ b/tests/test_plugin_kumulos.py
@@ -32,6 +32,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.kumulos import NotifyKumulos
 
 logging.disable(logging.CRITICAL)
@@ -45,7 +46,7 @@ apprise_url_tests = (
         "kumulos://",
         {
             # No API or Server Key specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -55,14 +56,14 @@ apprise_url_tests = (
             # We don't have strict host checking on for kumulos, so this URL
             # actually becomes parseable and :@ becomes a hostname.
             # The below errors because a second token wasn't found
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         f"kumulos://{UUID4}/",
         {
             # No server key was specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -119,13 +120,13 @@ def test_plugin_kumulos_edge_cases():
     """NotifyKumulos() Edge Cases."""
 
     # Invalid API Key
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyKumulos(None, None)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyKumulos("     ", None)
 
     # Invalid Server Key
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyKumulos("abcd", None)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyKumulos("abcd", "       ")

--- a/tests/test_plugin_lametric.py
+++ b/tests/test_plugin_lametric.py
@@ -32,6 +32,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.lametric import NotifyLametric
 
 logging.disable(logging.CRITICAL)
@@ -45,14 +46,14 @@ apprise_url_tests = (
         "lametric://",
         {
             # No APIKey or App ID specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "lametric://:@/",
         {
             # No APIKey or App ID specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -61,7 +62,7 @@ apprise_url_tests = (
         ),
         {
             # No APIKey specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -139,7 +140,7 @@ apprise_url_tests = (
         "?app_ver=invalid".format("A" * 88),
         {
             # We set invalid app version
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # our lametric object initialized via argument
@@ -168,7 +169,7 @@ apprise_url_tests = (
         f"lametrics://{UUID4}@192.168.0.7/?mode=invalid",
         {
             # Invalid Mode
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -324,9 +325,9 @@ def test_plugin_lametric_urls():
 def test_plugin_lametric_edge_cases():
     """NotifyLametric() Edge Cases."""
     # Initializes the plugin with an invalid API Key
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyLametric(apikey=None, mode="device")
 
     # Initializes the plugin with an invalid Client Secret
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyLametric(client_id="valid", secret=None, mode="cloud")

--- a/tests/test_plugin_lark.py
+++ b/tests/test_plugin_lark.py
@@ -4,6 +4,7 @@ import logging
 from helpers import AppriseURLTester
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.lark import NotifyLark
 
 logging.disable(logging.CRITICAL)
@@ -14,7 +15,7 @@ apprise_url_tests = (
         "lark://",
         {
             # Teams Token missing
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -23,7 +24,7 @@ apprise_url_tests = (
             # We don't have strict host checking on for lark, so this URL
             # actually becomes parseable and :@ becomes a hostname.
             # The below errors because a second token wasn't found
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_lauther.py
+++ b/tests/test_plugin_lauther.py
@@ -33,6 +33,7 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import Apprise, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.lauther import LautherPriority, NotifyLauther
 
 logging.disable(logging.CRITICAL)
@@ -43,27 +44,27 @@ apprise_url_tests = (
         "lauther://",
         {
             # No token specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "lauther://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "lauther://%badtoken%",
         {
             # Not a valid token
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "lauther://abc123",
         {
             # Tokens must carry the lpt_ prefix
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -107,7 +108,7 @@ apprise_url_tests = (
         "lauther://lpt_abc123?priority=99",
         {
             # An out-of-range priority is not acceptable
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_line.py
+++ b/tests/test_plugin_line.py
@@ -30,6 +30,7 @@ import logging
 
 from helpers import AppriseURLTester
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.line import NotifyLine
 
 logging.disable(logging.CRITICAL)
@@ -40,14 +41,14 @@ apprise_url_tests = (
         "line://",
         {
             # No Access Token
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "line://%20/",
         {
             # invalid Access Token; no Integration/Routing Key
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_mailersend.py
+++ b/tests/test_plugin_mailersend.py
@@ -35,6 +35,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.mailersend import NotifyMailerSend
 
 logging.disable(logging.CRITICAL)
@@ -77,7 +78,7 @@ apprise_url_tests = (
         # invalid API key (contains disallowed characters)
         "mailersend://bad+key*!:user@example.com",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -146,7 +147,7 @@ apprise_url_tests = (
         # Invalid Reply-To address
         ("mailersend://abcd:user@example.com/newuser@example.com?reply=%20!"),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -226,23 +227,23 @@ def test_plugin_mailersend_edge_cases(mock_post, mock_get):
     """NotifyMailerSend() Edge Cases."""
 
     # No API key
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyMailerSend(apikey=None, from_email="user@example.com")
 
     # Invalid API key
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyMailerSend(apikey="bad+key*!", from_email="user@example.com")
 
     # Invalid From email
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyMailerSend(apikey="abcd", from_email="!invalid")
 
     # No From email
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyMailerSend(apikey="abcd", from_email=None)
 
-    # Invalid Reply-To email raises TypeError
-    with pytest.raises(TypeError):
+    # An invalid Reply-To address is rejected.
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyMailerSend(
             apikey="abcd",
             from_email="user@example.com",

--- a/tests/test_plugin_mailgun.py
+++ b/tests/test_plugin_mailgun.py
@@ -34,6 +34,7 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.mailgun import NotifyMailgun
 
 logging.disable(logging.CRITICAL)
@@ -46,20 +47,20 @@ apprise_url_tests = (
     (
         "mailgun://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "mailgun://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # No Token specified
     (
         "mailgun://user@localhost.localdomain",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Token is valid, but no user name specified
@@ -68,7 +69,7 @@ apprise_url_tests = (
             "a" * 32, "b" * 8, "c" * 8
         ),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Invalid from email address
@@ -77,7 +78,7 @@ apprise_url_tests = (
             "a" * 32, "b" * 8, "c" * 8
         ),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # No To email address, but everything else is valid
@@ -137,7 +138,7 @@ apprise_url_tests = (
             "a" * 32, "b" * 8, "c" * 8
         ),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Use of both 'name' and 'from' together; these are synonymous

--- a/tests/test_plugin_mastodon.py
+++ b/tests/test_plugin_mastodon.py
@@ -37,6 +37,7 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyFormat, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.mastodon import NotifyMastodon
 
 logging.disable(logging.CRITICAL)
@@ -66,7 +67,7 @@ apprise_url_tests = (
         "mastodon://hostname",
         {
             # Missing Access Token
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -153,14 +154,14 @@ apprise_url_tests = (
         "mastodon://access_token@hostname/-/%/",
         {
             # Invalid users specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "mastodon://access_token@hostname?visibility=invalid",
         {
             # An invalid visibility
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_matrix.py
+++ b/tests/test_plugin_matrix.py
@@ -25,6 +25,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import errno
 import gc
 from json import dumps, loads
 
@@ -44,6 +45,11 @@ from apprise import (
     AppriseAttachment,
     NotifyType,
     PersistentStoreMode,
+)
+from apprise.exception import (
+    AppriseImproperlyConfigured,
+    AppriseInvalidData,
+    ApprisePluginException,
 )
 from apprise.plugins.matrix import MatrixDiscoveryException, NotifyMatrix
 
@@ -65,6 +71,14 @@ MATRIX_GOOD_RESPONSE = dumps(
         "m.identity_server": {"base_url": "https://vector.im"},
     }
 )
+
+
+def test_plugin_matrix_discovery_exception():
+    """Matrix discovery failures use the common plugin exception."""
+    exc = MatrixDiscoveryException("discovery failed")
+    assert isinstance(exc, ApprisePluginException)
+    assert exc.error_code == 600
+
 
 # Attachment Directory
 TEST_VAR_DIR = os.path.join(os.path.dirname(__file__), "var")
@@ -108,9 +122,9 @@ apprise_url_tests = (
     (
         "matrix://localhost",
         {
-            # response is TypeError because we'll try to initialize as
-            # a t2bot and fail (localhost is too short of a api key)
-            "instance": TypeError
+            # Initialization as t2bot fails because localhost is too short
+            # to be an API key.
+            "instance": AppriseImproperlyConfigured
         },
     ),
     (
@@ -181,7 +195,7 @@ apprise_url_tests = (
         "matrix://user:token@localhost:123/#general/?v=invalid",
         {
             # Invalid version specified
-            "instance": TypeError
+            "instance": AppriseImproperlyConfigured
         },
     ),
     (
@@ -262,21 +276,21 @@ apprise_url_tests = (
         "matrixs://user:pass@hostname:port/#room_alias",
         {
             # Invalid Port specified (was a string)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "matrixs://user:pass@hostname:0/#room_alias",
         {
             # Invalid Port specified (was a string)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "matrixs://user:pass@hostname:65536/#room_alias",
         {
             # Invalid Port specified (was a string)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # More general testing...
@@ -319,7 +333,7 @@ apprise_url_tests = (
         "matrix://user:token@localhost?mode=On",
         {
             # invalid webhook specified (unexpected boolean)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -461,7 +475,7 @@ def test_plugin_matrix_general(mock_post, mock_get, mock_put):
     assert obj.send(body="test") is True
     assert obj.send(title="title", body="test") is True
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         # invalid message type specified
         kwargs = NotifyMatrix.parse_url(
             "matrix://user:passwd@hostname/#abcd?msgtype=invalid"
@@ -2945,6 +2959,13 @@ def test_plugin_matrix_e2ee_megolm_session():
     s2 = MatrixMegOlmSession.from_dict(d)
     assert s2.session_id == s.session_id
     assert s2._counter == s._counter
+
+    # Cache data from an unsupported version is invalid, not a setting error.
+    with pytest.raises(
+        AppriseInvalidData, match="Incompatible MegOLM session cache format"
+    ) as exc_info:
+        MatrixMegOlmSession.from_dict({"version": -1})
+    assert exc_info.value.error_code == errno.EINVAL
 
     # should_rotate: explicit count threshold
     assert not s.should_rotate(msg_count=MEGOLM_ROTATION_MSGS - 1)

--- a/tests/test_plugin_mattermost.py
+++ b/tests/test_plugin_mattermost.py
@@ -37,6 +37,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.mattermost import MattermostMode, NotifyMattermost
 
 # Attachment test fixtures
@@ -53,7 +54,7 @@ apprise_url_tests = (
         "mmosts://localhost",
         {
             # Thrown because there was no webhook id specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -210,7 +211,7 @@ apprise_url_tests = (
         "mmost://localhost/token?mode=invalid",
         {
             # invalid mode is detected in __init__
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -286,9 +287,9 @@ def test_plugin_mattermost_edge_cases():
     """NotifyMattermost() Edge Cases."""
 
     # Invalid Authorization Token
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyMattermost(None)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyMattermost("     ")
 
 

--- a/tests/test_plugin_messagebird.py
+++ b/tests/test_plugin_messagebird.py
@@ -33,6 +33,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.messagebird import NotifyMessageBird
 
 logging.disable(logging.CRITICAL)
@@ -43,21 +44,21 @@ apprise_url_tests = (
         "msgbird://",
         {
             # No hostname/apikey specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "msgbird://{}/abcd".format("a" * 25),
         {
             # invalid characters in source phone number
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "msgbird://{}/123".format("a" * 25),
         {
             # invalid source phone number
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -149,7 +150,7 @@ def test_plugin_messagebird_edge_cases(mock_post):
     source = "+1 (555) 123-3456"
 
     # No apikey specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyMessageBird(apikey=None, source=source)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyMessageBird(apikey="     ", source=source)

--- a/tests/test_plugin_misskey.py
+++ b/tests/test_plugin_misskey.py
@@ -31,6 +31,7 @@ import os
 
 from helpers import AppriseURLTester
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.misskey import NotifyMisskey
 
 logging.disable(logging.CRITICAL)
@@ -60,7 +61,7 @@ apprise_url_tests = (
         "misskey://hostname",
         {
             # Missing Access Token
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -99,7 +100,7 @@ apprise_url_tests = (
         "misskey://access_token@hostname?visibility=invalid",
         {
             # An invalid visibility
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_mqtt.py
+++ b/tests/test_plugin_mqtt.py
@@ -34,6 +34,7 @@ from unittest.mock import ANY, Mock, call
 import pytest
 
 import apprise
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.mqtt import NotifyMQTT
 
 # Disable logging for a cleaner testing output
@@ -193,18 +194,18 @@ def test_plugin_mqtt_invalid_settings_failure(mqtt_client_mock):
     """Verify notifier instantiation croaks on invalid settings."""
 
     # Test case for invalid/unsupported MQTT version.
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         apprise.Apprise.instantiate(
             "mqtt://localhost?version=v1.0.0.0", suppress_exceptions=False
         )
 
     # Test case for invalid/unsupported `qos`.
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         apprise.Apprise.instantiate(
             "mqtt://localhost?qos=123", suppress_exceptions=False
         )
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         apprise.Apprise.instantiate(
             "mqtt://localhost?qos=invalid", suppress_exceptions=False
         )

--- a/tests/test_plugin_msg91.py
+++ b/tests/test_plugin_msg91.py
@@ -36,6 +36,7 @@ import pytest
 import requests
 
 from apprise import Apprise, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.msg91 import NotifyMSG91
 
 logging.disable(logging.CRITICAL)
@@ -46,21 +47,21 @@ apprise_url_tests = (
         "msg91://",
         {
             # No hostname/authkey specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "msg91://-",
         {
             # Invalid AuthKey
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "msg91://{}".format("a" * 23),
         {
             # valid AuthKey but no Template ID
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -158,13 +159,13 @@ def test_plugin_msg91_edge_cases(mock_post):
     target = "+1 (555) 123-3456"
 
     # No authkey specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyMSG91(template="1234", authkey=None, targets=target)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyMSG91(template="1234", authkey="    ", targets=target)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyMSG91(template="     ", authkey="a" * 23, targets=target)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyMSG91(template=None, authkey="a" * 23, targets=target)
 
 

--- a/tests/test_plugin_nextcloud.py
+++ b/tests/test_plugin_nextcloud.py
@@ -34,7 +34,14 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import Apprise, AppriseAsset, NotifyType, PersistentStoreMode
-from apprise.plugins.nextcloud import NotifyNextcloud
+from apprise.exception import (
+    AppriseImproperlyConfigured,
+    ApprisePluginException,
+)
+from apprise.plugins.nextcloud import (
+    NextcloudGroupDiscoveryException,
+    NotifyNextcloud,
+)
 
 NEXTCLOUD_GOOD_RESPONSE = dumps(
     {
@@ -44,6 +51,14 @@ NEXTCLOUD_GOOD_RESPONSE = dumps(
         }
     }
 )
+
+
+def test_plugin_nextcloud_discovery_exception():
+    """Nextcloud discovery failures use the common plugin exception."""
+    exc = NextcloudGroupDiscoveryException("discovery failed")
+    assert isinstance(exc, ApprisePluginException)
+    assert exc.error_code == 600
+
 
 logging.disable(logging.CRITICAL)
 
@@ -89,7 +104,7 @@ apprise_url_tests = (
         "ncloud://user@localhost?to=user1,user2&version=invalid",
         {
             # An invalid version was specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
             "requests_response_text": NEXTCLOUD_GOOD_RESPONSE,
         },
     ),
@@ -97,7 +112,7 @@ apprise_url_tests = (
         "ncloud://user@localhost?to=user1,user2&version=0",
         {
             # An invalid version was specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
             "requests_response_text": NEXTCLOUD_GOOD_RESPONSE,
         },
     ),
@@ -105,7 +120,7 @@ apprise_url_tests = (
         "ncloud://user@localhost?to=user1,user2&version=-23",
         {
             # An invalid version was specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
             "requests_response_text": NEXTCLOUD_GOOD_RESPONSE,
         },
     ),

--- a/tests/test_plugin_nextcloudtalk.py
+++ b/tests/test_plugin_nextcloudtalk.py
@@ -33,6 +33,7 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import Apprise, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.nextcloudtalk import NotifyNextcloudTalk
 
 logging.disable(logging.CRITICAL)
@@ -64,21 +65,21 @@ apprise_url_tests = (
         "nctalk://localhost",
         {
             # No user and password and roomid specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "nctalk://localhost/roomid",
         {
             # No user and password specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "nctalk://user@localhost/roomid",
         {
             # No password specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_notica.py
+++ b/tests/test_plugin_notica.py
@@ -31,6 +31,7 @@ import logging
 from helpers import AppriseURLTester
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.notica import NotifyNotica
 
 logging.disable(logging.CRITICAL)
@@ -40,13 +41,13 @@ apprise_url_tests = (
     (
         "notica://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "notica://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Native URL

--- a/tests/test_plugin_notifiarr.py
+++ b/tests/test_plugin_notifiarr.py
@@ -36,6 +36,7 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.notifiarr import NotifyNotifiarr
 
 logging.disable(logging.CRITICAL)
@@ -45,13 +46,13 @@ apprise_url_tests = (
     (
         "notifiarr://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "notifiarr://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -67,7 +68,7 @@ apprise_url_tests = (
     (
         "notifiarr://apikey/1234/?event=invalid",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_notifico.py
+++ b/tests/test_plugin_notifico.py
@@ -35,6 +35,7 @@ import pytest
 import requests
 
 from apprise.common import NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.notifico import NotificoMode, NotifyNotifico
 
 logging.disable(logging.CRITICAL)
@@ -44,27 +45,27 @@ apprise_url_tests = (
     (
         "notifico://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "notifico://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "notifico://1234",
         {
             # Just a project id provided (no message token)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "notifico://abcd/ckhrjW8w672m6HG",
         {
             # an invalid project id provided (not all digits)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -178,7 +179,7 @@ apprise_url_tests = (
     (
         "notifico://example.com/abcd/ckhrjW8w672m6HG",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -368,22 +369,22 @@ def test_plugin_notifico_selfhosted_https(mock_get):
 
 @mock.patch("requests.get")
 def test_plugin_notifico_invalid_params(mock_get):
-    """NotifyNotifico() invalid init parameters raise TypeError."""
+    """NotifyNotifico() rejects invalid initialization parameters."""
 
     # Invalid project_id (not all digits)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyNotifico(project_id="abc", msghook="validhook")
 
     # Invalid msghook (contains special characters)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyNotifico(project_id="1234", msghook="bad hook!")
 
     # None project_id
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyNotifico(project_id=None, msghook="validhook")
 
     # None msghook
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyNotifico(project_id="1234", msghook=None)
 
     # No HTTP calls should have been made

--- a/tests/test_plugin_notifyre.py
+++ b/tests/test_plugin_notifyre.py
@@ -37,6 +37,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.notifyre import NotifyNotifyre, NotifyreMode
 
 logging.disable(logging.CRITICAL)
@@ -71,14 +72,14 @@ apprise_url_tests = (
         "notifyre://",
         {
             # No API key
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "notifyre://:@/",
         {
             # Empty credentials
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -135,7 +136,7 @@ apprise_url_tests = (
         "notifyre://{}/+15551234567?mode=invalid".format(API_KEY),
         {
             # Invalid mode
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -230,21 +231,21 @@ def test_plugin_notifyre_init():
     """Initialization and validation coverage."""
 
     # Missing API key
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyNotifyre(apikey=None, targets=["+15551234567"])
 
     # Empty API key
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyNotifyre(apikey="", targets=["+15551234567"])
 
     # Invalid mode
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyNotifyre(
             apikey=API_KEY, targets=["+15551234567"], mode="invalid"
         )
 
     # Invalid source phone number
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyNotifyre(
             apikey=API_KEY, targets=["+15551234567"], source="not-a-phone"
         )

--- a/tests/test_plugin_ntfy.py
+++ b/tests/test_plugin_ntfy.py
@@ -38,6 +38,7 @@ import requests
 
 import apprise
 from apprise import NotifyFormat
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.ntfy import NotifyNtfy, NtfyPriority
 
 logging.disable(logging.CRITICAL)
@@ -373,14 +374,14 @@ apprise_url_tests = (
         "ntfys://user:web/token@localhost/topic/?mode=invalid",
         {
             # Invalid mode
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "ntfys://token@localhost/topic/?auth=invalid",
         {
             # Invalid Authentication type
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Invalid hostname on localhost/private mode

--- a/tests/test_plugin_octopush.py
+++ b/tests/test_plugin_octopush.py
@@ -34,6 +34,7 @@ import pytest
 import requests
 
 from apprise import Apprise, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.octopush import NotifyOctopush
 
 logging.disable(logging.CRITICAL)
@@ -44,42 +45,42 @@ apprise_url_tests = (
         "octopush://",
         {
             # No API Login or API Key specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "octopush://:@/",
         {
             # Invalid API Login
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "octopush://user@myaccount.com",
         {
             # Valid API Login, but no API Key provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "octopush://_/apikey?login=invalid",
         {
             # Invalid login
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "octopush://user@myaccount.com/%20",
         {
             # Valid API Login, but invalid API Key provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "octopush://%20:user@myaccount.com/apikey",
         {
             # All valid entries, but invalid sender
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -124,7 +125,7 @@ apprise_url_tests = (
         "&purpose=invalid",
         {
             # Testing invalid purpose change
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -141,7 +142,7 @@ apprise_url_tests = (
         "&type=invalid",
         {
             # Testing invalid type change
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -210,7 +211,7 @@ def test_plugin_octopush_parse_url_and_validation():
 
     assert NotifyOctopush.parse_url(None) is None
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyOctopush(
             api_login="user@myaccount.com",
             api_key="apikey",

--- a/tests/test_plugin_office365.py
+++ b/tests/test_plugin_office365.py
@@ -38,6 +38,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.office365 import NotifyOffice365
 
 logging.disable(logging.CRITICAL)
@@ -54,14 +55,14 @@ apprise_url_tests = (
         "o365://",
         {
             # Missing tenant, client_id, secret, and targets!
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "o365://:@/",
         {
             # invalid url
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -75,7 +76,7 @@ apprise_url_tests = (
         ),
         {
             # Expected failure
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -89,7 +90,7 @@ apprise_url_tests = (
         ),
         {
             # Expected failure
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -437,7 +438,7 @@ def test_plugin_office365_general(mock_get, mock_post):
     # Test our notification
     assert bool(obj.notify(title="title", body="test")) is True
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         # No secret
         NotifyOffice365(
             email=email,
@@ -1295,7 +1296,7 @@ def test_plugin_office365_personal_mode(mock_post, mock_get):
     # Explicit mode=org on a personal domain — still requires valid email
     # source (no tenant needed for the personal flow, but org requires tenant)
     #
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         # tenant is None but mode=org demands a valid tenant
         NotifyOffice365(
             source="user@live.com",
@@ -1307,7 +1308,7 @@ def test_plugin_office365_personal_mode(mock_post, mock_get):
     #
     # Personal mode requires source to be a valid email
     #
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyOffice365(
             source="not-an-email",
             client_id=client_id,
@@ -1316,9 +1317,9 @@ def test_plugin_office365_personal_mode(mock_post, mock_get):
         )
 
     #
-    # Invalid mode string raises TypeError
+    # An invalid mode is rejected.
     #
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyOffice365(
             source="user@live.com",
             client_id=client_id,

--- a/tests/test_plugin_onesignal.py
+++ b/tests/test_plugin_onesignal.py
@@ -36,6 +36,7 @@ import pytest
 import requests
 
 from apprise import Apprise
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.one_signal import NotifyOneSignal
 
 logging.disable(logging.CRITICAL)
@@ -46,35 +47,35 @@ apprise_url_tests = (
         "onesignal://",
         {
             # We failed to identify any valid authentication
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "onesignal://:@/",
         {
             # We failed to identify any valid authentication
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "onesignal://apikey/",
         {
             # no app id specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "onesignal://appid@%20%20/",
         {
             # invalid apikey
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "onesignal://appid@apikey/playerid/?lang=X",
         {
             # invalid language id (must be 2 characters)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -330,13 +331,13 @@ def test_plugin_onesignal_edge_cases():
     assert len(obj) == 16
 
     # custom must be a dictionary
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyOneSignal(
             app="appid", apikey="key", targets=["@user"], custom="not-a-dict"
         )
 
     # postback must be a dictionary
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyOneSignal(
             app="appid",
             apikey="key",

--- a/tests/test_plugin_opsgenie.py
+++ b/tests/test_plugin_opsgenie.py
@@ -35,6 +35,7 @@ from helpers import AppriseURLTester
 import requests
 
 import apprise
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.opsgenie import (
     NotifyOpsgenie,
     NotifyType,
@@ -60,28 +61,28 @@ apprise_url_tests = (
         "opsgenie://",
         {
             # We failed to identify any valid authentication
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "opsgenie://:@/",
         {
             # We failed to identify any valid authentication
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "opsgenie://%20%20/",
         {
             # invalid apikey specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "opsgenie://apikey/user/?region=xx",
         {
             # invalid region id
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -152,21 +153,21 @@ apprise_url_tests = (
         "opsgenie://apikey/@user?action=invalid",
         {
             # Assign an entity
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "opsgenie://from@apikey/@user?:invalid=note",
         {
             # Assign an entity
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "opsgenie://apikey/@user?:warning=invalid",
         {
             # Assign an entity
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Creates an index entry

--- a/tests/test_plugin_pagerduty.py
+++ b/tests/test_plugin_pagerduty.py
@@ -33,6 +33,7 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import Apprise, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.pagerduty import NotifyPagerDuty
 
 logging.disable(logging.CRITICAL)
@@ -43,56 +44,56 @@ apprise_url_tests = (
         "pagerduty://",
         {
             # No Access Token or Integration/Routing Key specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pagerduty://%20@%20/",
         {
             # invalid Access Token and Integration/Routing Key
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pagerduty://%20/",
         {
             # invalid Access Token; no Integration/Routing Key
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pagerduty://%20@abcd/",
         {
             # Invalid Integration/Routing Key (but valid Access Token)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pagerduty://myroutekey@myapikey/%20",
         {
             # bad source
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pagerduty://myroutekey@myapikey/mysource/%20",
         {
             # bad component
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pagerduty://myroutekey@myapikey?region=invalid",
         {
             # invalid region
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pagerduty://myroutekey@myapikey?severity=invalid",
         {
             # invalid severity
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_pagertree.py
+++ b/tests/test_plugin_pagertree.py
@@ -33,6 +33,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.pagertree import NotifyPagerTree
 
 logging.disable(logging.CRITICAL)
@@ -46,14 +47,14 @@ apprise_url_tests = (
         "pagertree://",
         {
             # Missing Integration ID
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Invalid Integration ID
     (
         "pagertree://%s" % ("+" * 24),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Minimum requirements met
@@ -87,7 +88,7 @@ apprise_url_tests = (
     (
         "pagertree://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -172,5 +173,5 @@ def test_plugin_pagertree_general(mock_post):
     mock_post.return_value.status_code = requests.codes.ok
 
     # Invalid thirdparty id
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPagerTree(integration=INTEGRATION_ID, thirdparty="   ")

--- a/tests/test_plugin_parse_platform.py
+++ b/tests/test_plugin_parse_platform.py
@@ -31,6 +31,7 @@ import logging
 from helpers import AppriseURLTester
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.parseplatform import NotifyParsePlatform
 
 logging.disable(logging.CRITICAL)
@@ -54,21 +55,21 @@ apprise_url_tests = (
     (
         "parsep://%s" % ("a" * 32),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # APIkey; no master_key
     (
         "parsep://app_id@%s" % ("a" * 32),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # APIkey; no app_id
     (
         "parseps://:master_key@%s" % ("a" * 32),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # app_id + master_key (using arguments=)
@@ -93,7 +94,7 @@ apprise_url_tests = (
     (
         "parsep://app_id:master_key@localhost?device=invalid",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Normal Query

--- a/tests/test_plugin_pinglet.py
+++ b/tests/test_plugin_pinglet.py
@@ -36,6 +36,7 @@ import requests
 
 import apprise
 from apprise import NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.pinglet import NotifyPinglet, PingletPriority
 
 logging.disable(logging.CRITICAL)
@@ -59,20 +60,20 @@ apprise_url_tests = (
     (
         "pinglet://hostname/acme/deploys",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # No namespace and/or topic specified
     (
         "pinglet://token@hostname",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pinglet://token@hostname/deploys",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Provide an API Key, namespace, and topic
@@ -184,16 +185,16 @@ def test_plugin_pinglet_urls():
 def test_plugin_pinglet_edge_cases():
     """NotifyPinglet() Edge Cases."""
     # Initializes the plugin with an invalid token
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPinglet(token=None, namespace="acme", topic="deploys")
     # Whitespace also acts as an invalid token value
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPinglet(token="   ", namespace="acme", topic="deploys")
 
     # Missing namespace and/or topic
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPinglet(token="abc123", namespace=None, topic="deploys")
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPinglet(token="abc123", namespace="acme", topic=None)
 
     # Direct instantiation without a fullpath defaults to "/"

--- a/tests/test_plugin_pingram.py
+++ b/tests/test_plugin_pingram.py
@@ -36,6 +36,7 @@ import pytest
 import requests
 
 from apprise import Apprise, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.pingram import NotifyPingram
 
 logging.disable(logging.CRITICAL)
@@ -50,48 +51,48 @@ apprise_url_tests = (
         "pingram://",
         {
             # No API Key at all
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pingram://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pingram://abcd",
         {
             # Doesn't match the pingram_(sk|pk)_ prefix
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pingram://pingram_sk_key/+15551235553/?mode=invalid",
         {
             # Invalid mode
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pingram://pingram_sk_key/+15551235553/?region=invalid",
         {
             # Invalid region
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pingram://pingram_sk_key/+15551235553/?type=*(",
         {
             # Invalid type
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pingram://pingram_sk_key/+15551235553/?channels=bad",
         {
             # Invalid channel
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -796,12 +797,12 @@ def test_plugin_pingram_targets(mock_post):
 def test_plugin_pingram_edge_cases():
     """NotifyPingram() Edge Cases."""
 
-    # No API Key raises TypeError
-    with pytest.raises(TypeError):
+    # An API key is required.
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPingram(apikey=None, targets=["+15551239876"])
 
-    # An invalid API Key (wrong prefix) raises TypeError
-    with pytest.raises(TypeError):
+    # An API key with the wrong prefix is invalid.
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPingram(apikey="not-a-pingram-key", targets=["+15551239876"])
 
     # Tests case where tokens is == None

--- a/tests/test_plugin_plivo.py
+++ b/tests/test_plugin_plivo.py
@@ -30,6 +30,7 @@ import logging
 
 from helpers import AppriseURLTester
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.plivo import NotifyPlivo
 
 logging.disable(logging.CRITICAL)
@@ -40,35 +41,35 @@ apprise_url_tests = (
         "plivo://",
         {
             # No hostname/apikey specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "plivo://{}@{}/15551232000".format("a" * 10, "a" * 25),
         {
             # invalid auth id
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "plivo://{}@{}/15551232000".format("a" * 25, "a" * 10),
         {
             # invalid token
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "plivo://{}@{}/123".format("a" * 25, "a" * 40),
         {
             # invalid phone number
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "plivo://{}@{}/abc".format("a" * 25, "a" * 40),
         {
             # invalid phone number
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_postmark.py
+++ b/tests/test_plugin_postmark.py
@@ -35,6 +35,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.postmark import NotifyPostmark
 
 logging.disable(logging.CRITICAL)
@@ -48,28 +49,28 @@ apprise_url_tests = (
         "postmark://",
         {
             # No credentials
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "postmark://:@/",
         {
             # Empty credentials
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "postmark://abcd",
         {
             # API key only, no from email
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "postmark://abcd@host",
         {
             # API key only, no from email
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -206,15 +207,15 @@ def test_plugin_postmark_edge_cases(mock_post, mock_get):
     """NotifyPostmark() Edge Cases."""
 
     # No API key
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPostmark(apikey=None, from_email="user@example.com")
 
     # Invalid from email
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPostmark(apikey="abcd", from_email="!invalid")
 
     # No from email (None)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPostmark(apikey="abcd", from_email=None)
 
     # Invalid target email -- plugin loads but target is dropped

--- a/tests/test_plugin_prowl.py
+++ b/tests/test_plugin_prowl.py
@@ -34,6 +34,7 @@ import pytest
 import requests
 
 import apprise
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.prowl import NotifyProwl, ProwlPriority
 
 logging.disable(logging.CRITICAL)
@@ -43,21 +44,21 @@ apprise_url_tests = (
     (
         "prowl://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # bad url
     (
         "prowl://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Invalid API Key
     (
         "prowl://%s" % ("a" * 20),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Provider Key
@@ -71,7 +72,7 @@ apprise_url_tests = (
     (
         "prowl://{}/{}".format("a" * 40, "b" * 20),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # APIkey; no device
@@ -176,16 +177,16 @@ def test_plugin_prowl():
 def test_plugin_prowl_edge_cases():
     """NotifyProwl() Edge Cases."""
     # Initializes the plugin with an invalid apikey
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyProwl(apikey=None)
     # Whitespace also acts as an invalid apikey value
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyProwl(apikey="  ")
 
     # Whitespace also acts as an invalid provider key
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyProwl(apikey="abcd", providerkey=object())
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyProwl(apikey="abcd", providerkey="  ")
 
 

--- a/tests/test_plugin_pushbullet.py
+++ b/tests/test_plugin_pushbullet.py
@@ -37,6 +37,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.pushbullet import NotifyPushBullet
 
 logging.disable(logging.CRITICAL)
@@ -49,13 +50,13 @@ apprise_url_tests = (
     (
         "pbul://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pbul://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # APIkey
@@ -439,9 +440,9 @@ def test_plugin_pushbullet_edge_cases(mock_post, mock_get):
     mock_get.content = b""
 
     # Invalid Access Token
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushBullet(accesstoken=None)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushBullet(accesstoken="     ")
 
     obj = NotifyPushBullet(accesstoken=accesstoken, targets=recipients)

--- a/tests/test_plugin_pushdeer.py
+++ b/tests/test_plugin_pushdeer.py
@@ -33,6 +33,7 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import Apprise
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.pushdeer import NotifyPushDeer
 
 logging.disable(logging.CRITICAL)
@@ -42,13 +43,13 @@ apprise_url_tests = (
     (
         "pushdeer://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pushdeers://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_pushed.py
+++ b/tests/test_plugin_pushed.py
@@ -33,6 +33,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.pushed import NotifyPushed
 
 logging.disable(logging.CRITICAL)
@@ -42,21 +43,21 @@ apprise_url_tests = (
     (
         "pushed://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Application Key Only
     (
         "pushed://%s" % ("a" * 32),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Invalid URL
     (
         "pushed://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Application Key+Secret
@@ -87,7 +88,7 @@ apprise_url_tests = (
         "pushed://{}/{}/dropped_value/".format("a" * 32, "a" * 64),
         {
             # No entries validated is a fail
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Application Key+Secret + 2 channels
@@ -220,28 +221,28 @@ def test_plugin_pushed_edge_cases(mock_post, mock_get):
     mock_get.return_value.status_code = requests.codes.ok
 
     # No application Key specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushed(
             app_key=None,
             app_secret=app_secret,
             recipients=None,
         )
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushed(
             app_key="  ",
             app_secret=app_secret,
             recipients=None,
         )
     # No application Secret specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushed(
             app_key=app_key,
             app_secret=None,
             recipients=None,
         )
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushed(
             app_key=app_key,
             app_secret="   ",

--- a/tests/test_plugin_pushjet.py
+++ b/tests/test_plugin_pushjet.py
@@ -32,6 +32,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.pushjet import NotifyPushjet
 
 logging.disable(logging.CRITICAL)
@@ -60,7 +61,7 @@ apprise_url_tests = (
     (
         "pjet://%s" % ("a" * 32),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # The proper way to log in
@@ -134,8 +135,8 @@ def test_plugin_pushjet_edge_cases():
     """NotifyPushjet() Edge Cases."""
 
     # No application Key specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushjet(secret_key=None)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushjet(secret_key="  ")

--- a/tests/test_plugin_pushme.py
+++ b/tests/test_plugin_pushme.py
@@ -31,6 +31,7 @@ import logging
 from helpers import AppriseURLTester
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.pushme import NotifyPushMe
 
 logging.disable(logging.CRITICAL)
@@ -40,13 +41,13 @@ apprise_url_tests = (
     (
         "pushme://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pushme://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Token specified

--- a/tests/test_plugin_pushover.py
+++ b/tests/test_plugin_pushover.py
@@ -37,6 +37,7 @@ import pytest
 import requests
 
 import apprise
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.pushover import NotifyPushover, PushoverPriority
 
 logging.disable(logging.CRITICAL)
@@ -49,21 +50,21 @@ apprise_url_tests = (
     (
         "pover://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # bad url
     (
         "pover://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # APIkey; no user
     (
         "pover://%s" % ("a" * 30),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # API Key + custom sound setting
@@ -277,7 +278,7 @@ apprise_url_tests = (
             "u" * 30, "a" * 30, "expire=100000"
         ),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # API Key + emergency priority setting with invalid interval
@@ -286,7 +287,7 @@ apprise_url_tests = (
             "u" * 30, "a" * 30, "interval=15"
         ),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # API Key + priority setting (empty)
@@ -349,7 +350,7 @@ apprise_url_tests = (
     (
         "pover://{}@{}?key=tooshort".format("u" * 30, "a" * 30),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # E2EE: invalid key (correct length but non-hex)
@@ -361,7 +362,7 @@ apprise_url_tests = (
             "z" * 64,
         ),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
 )
@@ -503,7 +504,7 @@ def test_plugin_pushover_edge_cases(mock_post):
     """NotifyPushover() Edge Cases."""
 
     # No token
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushover(token=None)
 
     # Initialize some generic (but valid) tokens
@@ -520,7 +521,7 @@ def test_plugin_pushover_edge_cases(mock_post):
     mock_post.return_value.status_code = requests.codes.ok
 
     # No webhook id specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushover(user_key=user_key, webhook_id=None)
 
     obj = NotifyPushover(user_key=user_key, token=token, targets=devices)
@@ -606,14 +607,14 @@ def test_plugin_pushover_edge_cases(mock_post):
     assert len(obj) == 1
 
     # No User Key specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushover(user_key=None, token="abcd")
 
     # No Access Token specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushover(user_key="abcd", token=None)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushover(user_key="abcd", token="  ")
 
 
@@ -860,11 +861,11 @@ def test_plugin_pushover_e2ee(mock_post):
     mock_post.return_value = response
 
     # --- Invalid key: too short ---
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushover(user_key=user_key, token=token, encryption_key="abc")
 
     # --- Invalid key: 64 chars but non-hex ---
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushover(user_key=user_key, token=token, encryption_key="z" * 64)
 
     # --- Valid key: object instantiates correctly ---

--- a/tests/test_plugin_pushplus.py
+++ b/tests/test_plugin_pushplus.py
@@ -36,6 +36,7 @@ import requests
 
 from apprise import Apprise
 from apprise.common import NotifyFormat
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.pushplus import (
     PUSHPLUS_CHANNEL_DEFAULT,
     PUSHPLUS_CHANNELS,
@@ -65,21 +66,21 @@ apprise_url_tests = (
         "pushplus://",
         {
             # Empty token must raise
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pushplus://short",
         {
             # Token too short (fewer than 32 characters)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pushplus://invalid!chars00000000000000000000000000000",
         {
             # Token contains characters not allowed by the regex
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # ----------------------------------------------------------------
@@ -343,10 +344,10 @@ def test_plugin_pushplus_init():
     obj = NotifyPushplus(token=GOOD_TOKEN, channel="MAIL")
     assert obj.channel == PushPlusChannel.MAIL
 
-    # Invalid channel raises TypeError
+    # An invalid channel is rejected.
     import pytest
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushplus(token=GOOD_TOKEN, channel="invalid_channel")
 
     # Invalid target (bad characters) goes to invalid_targets
@@ -354,11 +355,11 @@ def test_plugin_pushplus_init():
     assert obj.topics == []
     assert obj.invalid_targets == ["bad!target"]
 
-    # Invalid token raises TypeError
-    with pytest.raises(TypeError):
+    # An invalid token is rejected.
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushplus(token="short")
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushplus(token="bad!token" + "0" * 30)
 
     # Webhook value stored as None when falsy

--- a/tests/test_plugin_pushsafer.py
+++ b/tests/test_plugin_pushsafer.py
@@ -37,6 +37,7 @@ import pytest
 import requests
 
 from apprise import AppriseAttachment, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.pushsafer import NotifyPushSafer
 
 logging.disable(logging.CRITICAL)
@@ -49,19 +50,19 @@ apprise_url_tests = (
     (
         "psafer://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "psafer://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "psafers://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -163,7 +164,7 @@ apprise_url_tests = (
         "psafer://{}?priority=invalid".format("f" * 20),
         {
             # Invalid Priority
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Invalid priority
@@ -171,7 +172,7 @@ apprise_url_tests = (
         "psafer://{}?priority=25".format("f" * 20),
         {
             # Invalid Priority
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Set sound
@@ -200,14 +201,14 @@ apprise_url_tests = (
         "psafer://{}?sound=invalid".format("h" * 20),
         {
             # Invalid Sound
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "psafer://{}?sound=94000".format("h" * 20),
         {
             # Invalid Sound
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Set vibration (integer only)
@@ -226,7 +227,7 @@ apprise_url_tests = (
         "psafer://{}?vibration=invalid".format("h" * 20),
         {
             # Invalid Vibration
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Invalid vibration
@@ -234,7 +235,7 @@ apprise_url_tests = (
         "psafer://{}?vibration=25000".format("h" * 20),
         {
             # Invalid Vibration
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -307,7 +308,7 @@ def test_plugin_pushsafer_general(mock_post):
     )
 
     # Exception should be thrown about the fact no private key was specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushSafer(privatekey=None)
 
     # Multiple Attachment Support

--- a/tests/test_plugin_pushward.py
+++ b/tests/test_plugin_pushward.py
@@ -36,6 +36,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAsset, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.pushward import NotifyPushWard, pushward_level
 
 logging.disable(logging.CRITICAL)
@@ -46,14 +47,14 @@ apprise_url_tests = (
         "pushward://",
         {
             # No API Key specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pushward://invalid",
         {
             # API Key does not match the hlk_ pattern
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -93,28 +94,28 @@ apprise_url_tests = (
         "pushward://hlk_abc123?info=bogus",
         {
             # An invalid per-type level
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pushward://hlk_abc123?level=invalid",
         {
             # Invalid level provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pushward://hlk_abc123?volume=2.0",
         {
             # Volume out of range
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pushward://hlk_abc123?volume=invalid",
         {
             # Volume that cannot be parsed as a float
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -157,31 +158,31 @@ def test_plugin_pushward_edge_cases():
     """NotifyPushWard() Edge Cases."""
 
     # No API Key
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushWard(apikey=None)
 
     # Whitespace only API Key
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushWard(apikey="  ")
 
     # API Key that does not match the hlk_ pattern
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushWard(apikey="invalid")
 
     # Invalid level
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushWard(apikey="hlk_abc123", level="invalid")
 
     # Volume above the allowable range
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushWard(apikey="hlk_abc123", volume=2.0)
 
     # Volume below the allowable range
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushWard(apikey="hlk_abc123", volume=-0.5)
 
     # Volume that cannot be coerced to a float
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyPushWard(apikey="hlk_abc123", volume="invalid")
 
 

--- a/tests/test_plugin_pushy.py
+++ b/tests/test_plugin_pushy.py
@@ -30,6 +30,7 @@ import logging
 
 from helpers import AppriseURLTester
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.pushy import NotifyPushy
 
 logging.disable(logging.CRITICAL)
@@ -46,14 +47,14 @@ apprise_url_tests = (
         "pushy://",
         {
             # No no secret api key
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "pushy://:@/",
         {
             # just invalid all around
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_qq.py
+++ b/tests/test_plugin_qq.py
@@ -30,6 +30,7 @@ import logging
 from helpers import AppriseURLTester
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.qq import NotifyQQ
 
 logging.disable(logging.CRITICAL)
@@ -38,13 +39,13 @@ apprise_url_tests = (
     (
         "qq://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "qq://invalid!",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_reddit.py
+++ b/tests/test_plugin_reddit.py
@@ -35,6 +35,7 @@ from unittest import mock
 from helpers import AppriseURLTester
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.reddit import NotifyReddit
 
 logging.disable(logging.CRITICAL)
@@ -45,48 +46,48 @@ apprise_url_tests = (
         "reddit://",
         {
             # Missing all credentials
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "reddit://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "reddit://user@app_id/app_secret/",
         {
             # No password
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "reddit://user:password@app_id/",
         {
             # No app secret
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "reddit://user:password@app%id/appsecret/apprise",
         {
             # No invalid app_id (has percent)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "reddit://user:password@app%id/app_secret/apprise",
         {
             # No invalid app_secret (has percent)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "reddit://user:password@app-id/app-secret/apprise?kind=invalid",
         {
             # An Invalid Kind
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_resend.py
+++ b/tests/test_plugin_resend.py
@@ -35,6 +35,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.resend import NotifyResend
 
 logging.disable(logging.CRITICAL)
@@ -50,34 +51,34 @@ apprise_url_tests = (
     (
         "resend://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "resend://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "resend://abcd",
         {
             # Just an broken email (no api key or email)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "resend://abcd@host",
         {
             # Just an Email specified, no API Key
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "resend://invalid-api-key+*-d:user@example.com",
         {
             # An invalid API Key
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -225,15 +226,15 @@ def test_plugin_resend_edge_cases(mock_post, mock_get):
     """NotifyResend() Edge Cases."""
 
     # no apikey
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyResend(apikey=None, from_addr="user@example.com")
 
     # invalid from email
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyResend(apikey="abcd", from_addr="!invalid")
 
     # no email
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyResend(apikey="abcd", from_addr=None)
 
     # Invalid To email address

--- a/tests/test_plugin_revolt.py
+++ b/tests/test_plugin_revolt.py
@@ -41,6 +41,7 @@ import requests
 
 from apprise import Apprise, NotifyFormat, NotifyType
 from apprise.common import OverflowMode
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.revolt import NotifyRevolt
 
 logging.disable(logging.CRITICAL)
@@ -64,14 +65,14 @@ apprise_url_tests = (
     (
         "revolt://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # An invalid url
     (
         "revolt://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # No channel_id specified
@@ -89,7 +90,7 @@ apprise_url_tests = (
     (
         "revolt://?channel=%s" % ("i" * 24),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # channel_id specified on url
@@ -365,10 +366,10 @@ def test_plugin_revolt_general(mock_sleep, mock_post):
     }
 
     # Invalid bot_token
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyRevolt(bot_token=None, targets=channel_id)
     # Invalid bot_token (whitespace)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyRevolt(bot_token="  ", targets=channel_id)
 
     obj = NotifyRevolt(bot_token=bot_token, targets=channel_id)

--- a/tests/test_plugin_ringcentral.py
+++ b/tests/test_plugin_ringcentral.py
@@ -35,6 +35,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.ringcentral import (
     NotifyRingCentral,
     RingCentralAuthMode,
@@ -80,63 +81,63 @@ apprise_url_tests = (
         "ringc://",
         {
             # No credentials at all
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "ringc://:@/",
         {
             # No credentials at all
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "ringc://password@client_id/18005554321",
         {
             # No client secret
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "ringc://18005554321:jwt{}@client_id".format("a" * 60),
         {
             # JWT provided but no client secret
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "ringc://18005554321:jwt{}@%21%21%21/secret".format("b" * 60),
         {
             # Invalid client_id
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "ringc://18005554321:jwt{}@client_id/%21%21%21/".format("c" * 60),
         {
             # Invalid client secret
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "ringc://18005554321:password@client_id/secret?mode=invalid",
         {
             # Invalid auth mode
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "ringc://18005554321:password@client_id/secret?env=invalid",
         {
             # Invalid environment
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "ringc://18005554321:jwt=@client_id/secret?mode=jwt",
         {
             # Invalid JWT token (contains disallowed chars)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Valid JWT mode with explicit ?mode=jwt
@@ -249,7 +250,7 @@ def test_plugin_ringc_init(mock_post):
     mock_post.return_value = _mk_resp(b"{}")
 
     # No client_id
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyRingCentral(
             client_id=None,
             client_secret=CLIENT_SECRET,
@@ -257,7 +258,7 @@ def test_plugin_ringc_init(mock_post):
         )
 
     # Blank client_id
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyRingCentral(
             client_id="  ",
             client_secret=CLIENT_SECRET,
@@ -265,7 +266,7 @@ def test_plugin_ringc_init(mock_post):
         )
 
     # No client_secret
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyRingCentral(
             client_id=CLIENT_ID,
             client_secret=None,
@@ -273,7 +274,7 @@ def test_plugin_ringc_init(mock_post):
         )
 
     # Blank client_secret
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyRingCentral(
             client_id=CLIENT_ID,
             client_secret="  ",
@@ -281,7 +282,7 @@ def test_plugin_ringc_init(mock_post):
         )
 
     # Invalid source phone
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyRingCentral(
             client_id=CLIENT_ID,
             client_secret=CLIENT_SECRET,
@@ -289,7 +290,7 @@ def test_plugin_ringc_init(mock_post):
         )
 
     # Invalid auth mode
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyRingCentral(
             client_id=CLIENT_ID,
             client_secret=CLIENT_SECRET,
@@ -298,7 +299,7 @@ def test_plugin_ringc_init(mock_post):
         )
 
     # Invalid environment
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyRingCentral(
             client_id=CLIENT_ID,
             client_secret=CLIENT_SECRET,
@@ -307,7 +308,7 @@ def test_plugin_ringc_init(mock_post):
         )
 
     # Invalid JWT token in JWT mode
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyRingCentral(
             client_id=CLIENT_ID,
             client_secret=CLIENT_SECRET,

--- a/tests/test_plugin_rocket_chat.py
+++ b/tests/test_plugin_rocket_chat.py
@@ -36,6 +36,7 @@ import requests
 
 import apprise
 from apprise import NotifyFormat, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.rocketchat import NotifyRocketChat
 
 logging.disable(logging.CRITICAL)
@@ -64,35 +65,35 @@ apprise_url_tests = (
     (
         "rocket://localhost",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # No room or channel
     (
         "rocket://user:pass@localhost",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # No valid rooms or channels
     (
         "rocket://user:pass@localhost/#/!/@",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # No user/pass combo
     (
         "rocket://user@localhost/room/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # No user/pass combo
     (
         "rocket://localhost/room/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # A room and port identifier
@@ -283,7 +284,7 @@ apprise_url_tests = (
         "rockets://user:web/token@localhost/@user/?mode=invalid",
         {
             # invalid mode
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -359,7 +360,7 @@ def test_plugin_rocket_chat_edge_cases(mock_post, mock_get):
     assert len(obj.rooms) == 1
 
     # No Webhook specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         obj = NotifyRocketChat(webhook=None, mode="webhook")
 
     #

--- a/tests/test_plugin_rsyslog.py
+++ b/tests/test_plugin_rsyslog.py
@@ -36,6 +36,7 @@ import apprise
 
 logging.disable(logging.CRITICAL)
 
+from apprise.exception import AppriseImproperlyConfigured  # noqa E402
 from apprise.plugins.rsyslog import NotifyRSyslog  # noqa E402
 
 
@@ -170,8 +171,8 @@ def test_plugin_rsyslog_edge_cases():
     assert r"logpid=yes" in obj.url()
 
     # Exception should be thrown about the fact no bot token was specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyRSyslog(host="localhost", facility="invalid")
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyRSyslog(host="localhost", facility=object)

--- a/tests/test_plugin_ryver.py
+++ b/tests/test_plugin_ryver.py
@@ -32,6 +32,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.ryver import NotifyRyver
 
 logging.disable(logging.CRITICAL)
@@ -41,34 +42,34 @@ apprise_url_tests = (
     (
         "ryver://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "ryver://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "ryver://apprise",
         {
             # Just org provided (no token)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "ryver://apprise/ckhrjW8w672m6HG?mode=invalid",
         {
             # invalid mode provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "ryver://x/ckhrjW8w672m6HG?mode=slack",
         {
             # Invalid org
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -173,15 +174,15 @@ def test_plugin_ryver_edge_cases():
     """NotifyRyver() Edge Cases."""
 
     # No token
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyRyver(organization="abc", token=None)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyRyver(organization="abc", token="  ")
 
     # No organization
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyRyver(organization=None, token="abc")
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyRyver(organization="  ", token="abc")

--- a/tests/test_plugin_sendgrid.py
+++ b/tests/test_plugin_sendgrid.py
@@ -35,6 +35,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.sendgrid import NotifySendGrid
 
 logging.disable(logging.CRITICAL)
@@ -77,7 +78,7 @@ apprise_url_tests = (
         "sendgrid://invalid-api-key+*-d:user@example.com",
         {
             # An invalid API Key
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -199,15 +200,15 @@ def test_plugin_sendgrid_edge_cases(mock_post, mock_get):
     """NotifySendGrid() Edge Cases."""
 
     # no apikey
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySendGrid(apikey=None, from_email="user@example.com")
 
     # invalid from email
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySendGrid(apikey="abcd", from_email="!invalid")
 
     # no email
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySendGrid(apikey="abcd", from_email=None)
 
     # Invalid To email address

--- a/tests/test_plugin_sendpulse.py
+++ b/tests/test_plugin_sendpulse.py
@@ -37,6 +37,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.sendpulse import NotifySendPulse
 
 logging.disable(logging.CRITICAL)
@@ -58,34 +59,34 @@ apprise_url_tests = (
     (
         "sendpulse://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "sendpulse://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "sendpulse://abcd",
         {
             # invalid from email
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "sendpulse://abcd@host.com",
         {
             # Just an Email specified, no client_id or client_secret
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "sendpulse://user@example.com/client_id/cs/?template=invalid",
         {
             # Invalid template
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -145,7 +146,7 @@ apprise_url_tests = (
         "sendpulse://?id=ci&secret=cs&user=chris",
         {
             # Set login through user= only - invaild email
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -675,12 +676,12 @@ def test_plugin_sendpulse_fail_cases():
     """
 
     # no client_id
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySendPulse(
             client_id="abcd", client_secret=None, from_addr="user@example.com"
         )
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySendPulse(
             client_id=None,
             client_secret="abcd123",
@@ -688,13 +689,13 @@ def test_plugin_sendpulse_fail_cases():
         )
 
     # invalid from email
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySendPulse(
             client_id="abcd", client_secret="abcd456", from_addr="!invalid"
         )
 
     # no email
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySendPulse(
             client_id="abcd", client_secret="abcd789", from_addr=None
         )

--- a/tests/test_plugin_serverchan.py
+++ b/tests/test_plugin_serverchan.py
@@ -30,6 +30,7 @@ import logging
 
 from helpers import AppriseURLTester
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.serverchan import NotifyServerChan
 
 logging.disable(logging.CRITICAL)
@@ -40,14 +41,14 @@ apprise_url_tests = (
         "schan://",
         {
             # No Access Token specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "schan://a_bd_/",
         {
             # invalid Access Token
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_serwersms.py
+++ b/tests/test_plugin_serwersms.py
@@ -38,6 +38,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.serwersms import NotifySerwerSMS
 
 # Attachment test fixtures directory
@@ -57,35 +58,35 @@ apprise_url_tests = (
         "serwersms://",
         {
             # Missing credentials
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "serwersms://:@/",
         {
             # Empty credentials
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "serwersms://user@SenderA/+48123456789",
         {
             # Missing password
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "serwersms://user:pass@/+48123456789",
         {
             # Missing sender (empty host)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "serwersms://user:pass@!!invalid!!",
         {
             # Invalid sender name (fails regex)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -189,11 +190,11 @@ def test_plugin_serwersms_init(mock_post):
     """NotifySerwerSMS() Initialisation tests."""
 
     # Missing username
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySerwerSMS(sender="SenderA", targets=["+48123456789"])
 
     # Missing password
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySerwerSMS(
             user="user",
             sender="SenderA",
@@ -201,7 +202,7 @@ def test_plugin_serwersms_init(mock_post):
         )
 
     # Missing sender
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySerwerSMS(
             user="user",
             password="pass",
@@ -209,7 +210,7 @@ def test_plugin_serwersms_init(mock_post):
         )
 
     # Invalid sender (too long - >11 chars)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySerwerSMS(
             user="user",
             password="pass",
@@ -218,7 +219,7 @@ def test_plugin_serwersms_init(mock_post):
         )
 
     # Invalid sender (starts with non-alphanumeric)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySerwerSMS(
             user="user",
             password="pass",

--- a/tests/test_plugin_ses.py
+++ b/tests/test_plugin_ses.py
@@ -36,6 +36,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.ses import NotifySES
 
 logging.disable(logging.CRITICAL)
@@ -73,41 +74,41 @@ apprise_url_tests = (
     (
         "ses://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "ses://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "ses://user@example.com/T1JJ3T3L2",
         {
             # Just Token 1 provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "ses://user@example.com/T1JJ3TD4JD/TIiajkdnlazk7FQ/",
         {
             # Missing a region
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "ses://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcevi7FQ/us-west-2",
         {
             # No email
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "ses://user@example.com/T1JJ3TD4JD/TIiajkdnlazk7FQ/user2@example.com",
         {
             # Missing a region (but has email)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -117,7 +118,7 @@ apprise_url_tests = (
         ),
         {
             # An invalid reply-to address
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
             # Our response expected server response
             "requests_response_text": AWS_SES_GOOD_RESPONSE,
         },
@@ -310,7 +311,7 @@ def test_plugin_ses_edge_cases(mock_post):
     """NotifySES() Edge Cases."""
 
     # Initializes the plugin with a valid access, but invalid access key
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         # No access_key_id specified
         NotifySES(
             from_addr="user@example.eu",
@@ -320,7 +321,7 @@ def test_plugin_ses_edge_cases(mock_post):
             targets="user@example.ca",
         )
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         # No secret_access_key specified
         NotifySES(
             from_addr="user@example.eu",
@@ -330,7 +331,7 @@ def test_plugin_ses_edge_cases(mock_post):
             targets="user@example.ca",
         )
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         # No region_name specified
         NotifySES(
             from_addr="user@example.eu",

--- a/tests/test_plugin_seven.py
+++ b/tests/test_plugin_seven.py
@@ -32,6 +32,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.seven import NotifySeven
 
 logging.disable(logging.CRITICAL)
@@ -41,7 +42,7 @@ apprise_url_tests = (
         "seven://",
         {
             # No hostname/apikey specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -157,5 +158,5 @@ def test_plugin_seven_edge_cases(mock_post):
     mock_post.return_value = response
     source = "+1 (555) 123-3456"
     # No apikey specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySeven(apikey=None, source=source)

--- a/tests/test_plugin_sfr.py
+++ b/tests/test_plugin_sfr.py
@@ -35,6 +35,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.sfr import NotifySFR
 
 logging.disable(logging.CRITICAL)
@@ -62,91 +63,91 @@ apprise_url_tests = (
         "sfr://",
         {
             # No host specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "sfr://:@/",
         {
             # Invalid host
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "sfr://:service_password",
         {
             # No user specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "sfr://testing:serv@ice_password",
         {
             # Invalid Password
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "sfr://testing:service_password@/5555555555",
         {
             # No spaceId provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "sfr://testing:service_password@12345/",
         {
             # No target provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         f"sfr://:service_password@12345/{3 * 13}",
         {
             # No host but everything else provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "sfr://:service_password@space_id/targets?media=TEST",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "sfr://service_id:",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "sfr://service_id:@",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "sfr://service_id:@{}".format("0" * 3),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "sfr://service_id:@{}/".format("0" * 3),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "sfr://service_id:@{}/targets".format("0" * 3),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "sfr://service_id:@{}/targets?media=TEST".format("0" * 3),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -392,7 +393,7 @@ def test_plugin_sfr_notification_multiple_targets_all_ko(mock_post):
     assert results["sender"] == ""
 
     # No valid phone number provided
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySFR(**results)
 
 
@@ -588,7 +589,7 @@ def test_plugin_sfr_failure(mock_post):
     mock_post.return_value = response
 
     # Invalid service_id
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySFR(
             user=None,
             password="service_password",
@@ -597,7 +598,7 @@ def test_plugin_sfr_failure(mock_post):
         )
 
     # Invalid service_password
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySFR(
             user="service_id",
             password=None,
@@ -606,7 +607,7 @@ def test_plugin_sfr_failure(mock_post):
         )
 
     # Invalid space_id
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySFR(
             user="service_id",
             password="service_password",
@@ -615,7 +616,7 @@ def test_plugin_sfr_failure(mock_post):
         )
 
     # Invalid targets
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySFR(
             user="service_id",
             password="service_password",

--- a/tests/test_plugin_signal.py
+++ b/tests/test_plugin_signal.py
@@ -39,6 +39,7 @@ import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyType
 from apprise.config import ConfigBase
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.base import NotifyFormat
 from apprise.plugins.signal_api import NotifySignalAPI
 
@@ -64,35 +65,35 @@ apprise_url_tests = (
         "signal://",
         {
             # No host specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "signal://:@/",
         {
             # invalid host
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "signal://localhost",
         {
             # Just a host provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "signal://localhost",
         {
             # key and secret provided and from but invalid from no
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "signal://localhost/123",
         {
             # invalid from phone
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -251,7 +252,7 @@ def test_plugin_signal_edge_cases(request_mock):
     title = "My Title"
 
     # No apikey specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySignalAPI(source=None)
 
     aobj = Apprise()

--- a/tests/test_plugin_signalgrid.py
+++ b/tests/test_plugin_signalgrid.py
@@ -33,6 +33,7 @@ from helpers import AppriseURLTester
 import requests
 
 import apprise
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.signalgrid import NotifySignalgrid
 
 logging.disable(logging.CRITICAL)
@@ -45,7 +46,7 @@ apprise_url_tests = (
     (
         "signalgrid://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_signl4.py
+++ b/tests/test_plugin_signl4.py
@@ -32,6 +32,7 @@ import logging
 
 from helpers import AppriseURLTester
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.signl4 import (
     NotifySIGNL4,
     NotifyType,
@@ -51,21 +52,21 @@ apprise_url_tests = (
         "signl4://",
         {
             # We failed to identify any valid authentication
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "signl4://:@/",
         {
             # We failed to identify any valid authentication
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "signl4://%20%20/",
         {
             # invalid secret specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_simplepush.py
+++ b/tests/test_plugin_simplepush.py
@@ -37,6 +37,7 @@ import pytest
 import requests
 
 from apprise import Apprise
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.simplepush import NotifySimplePush
 
 logging.disable(logging.CRITICAL)
@@ -47,7 +48,7 @@ apprise_url_tests = (
         "spush://",
         {
             # No api key
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -161,17 +162,17 @@ def test_plugin_simplepush_edge_cases():
     """
 
     # No token
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySimplePush(apikey=None)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySimplePush(apikey="  ")
 
     # Bad event
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySimplePush(apikey="abc", event=object)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySimplePush(apikey="abc", event="  ")
 
 

--- a/tests/test_plugin_sinch.py
+++ b/tests/test_plugin_sinch.py
@@ -35,6 +35,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.sinch import NotifySinch
 
 logging.disable(logging.CRITICAL)
@@ -45,28 +46,28 @@ apprise_url_tests = (
         "sinch://",
         {
             # No Account SID specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "sinch://:@/",
         {
             # invalid Auth token
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "sinch://{}@12345678".format("a" * 32),
         {
             # Just spi provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "sinch://{}:{}@_".format("a" * 32, "b" * 32),
         {
             # spi and token provided but invalid from
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -83,7 +84,7 @@ apprise_url_tests = (
         "sinch://{}:{}@{}".format("a" * 32, "b" * 32, "3" * 9),
         {
             # spi and token provided and from but invalid from no
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -130,7 +131,7 @@ apprise_url_tests = (
         "sinch://{}:{}@{}?region=invalid".format("a" * 32, "b" * 32, "5" * 11),
         {
             # Invalid region
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -206,11 +207,11 @@ def test_plugin_sinch_edge_cases(mock_post):
     source = "+1 (555) 123-3456"
 
     # No service_plan_id specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySinch(service_plan_id=None, api_token=api_token, source=source)
 
     # No api_token specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySinch(
             service_plan_id=service_plan_id, api_token=None, source=source
         )

--- a/tests/test_plugin_slack.py
+++ b/tests/test_plugin_slack.py
@@ -39,6 +39,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyFormat, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.slack import NotifySlack, SlackMode
 
 logging.disable(logging.CRITICAL)
@@ -51,34 +52,34 @@ apprise_url_tests = (
     (
         "slack://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "slack://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "slack://T1JJ3T3L2",
         {
             # Just Token 1 provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "slack://T1JJ3T3L2/A1BRTD4JD/",
         {
             # Just 2 tokens provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "slack://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/?mode=invalid",
         {
             # invalid Mode provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -290,7 +291,7 @@ apprise_url_tests = (
             "slack://?token=T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/"
             "&to=#chan&mode=bot"
         ),
-        {"instance": TypeError},
+        {"instance": AppriseImproperlyConfigured},
     ),
     # Test blocks mode with timestamp variation
     (
@@ -427,21 +428,21 @@ apprise_url_tests = (
         "slack://username@-INVALID-/A1BRTD4JD/TIiajkdnlazkcOXrIdevi7FQ/#cool",
         {
             # invalid 1st Token
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "slack://username@T1JJ3T3L2/-INVALID-/TIiajkdnlazkcOXrIdevi7FQ/#great",
         {
             # invalid 2rd Token
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "slack://username@T1JJ3T3L2/A1BRTD4JD/-INVALID-/#channel",
         {
             # invalid 3rd Token
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -548,21 +549,21 @@ apprise_url_tests = (
     (
         "slack://T1JJ3T3L2/XXXXXXXX/?mode=workflow",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Workflow mode -- wrong count: trigger's 3 segments rejected
     (
         "slack://T1JJ3T3L2/XXXXXXXX/YYYYYYYY/?mode=workflow",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Trigger mode -- wrong count: workflow's 4 segments rejected
     (
         "slack://T1JJ3T3L2/Ft07XXXX/XXXXXXXX/YYYYYYYY/?mode=trigger",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
 )
@@ -593,7 +594,7 @@ def test_plugin_slack_oauth_access_token(mock_request):
     request.status_code = requests.codes.ok
 
     # We'll fail to validate the access_token
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySlack(access_token=token)
 
     # Generate a (valid) bot token
@@ -619,7 +620,7 @@ def test_plugin_slack_oauth_access_token(mock_request):
     assert obj.send(body="test") is True
 
     # A poorly formatted xoxe prefix should still be rejected
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySlack(access_token="xoxe.xo-invalid", targets="#apprise")
 
     # Test Valid Attachment
@@ -830,7 +831,7 @@ def test_plugin_slack_webhook_mode(mock_request):
     )
 
     # Missing first Token
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySlack(
             token_a=None, token_b=token_b, token_c=token_c, targets=channels
         )
@@ -1843,8 +1844,8 @@ def test_plugin_slack_template_load_error(mock_request, tmpdir):
 
 
 def test_plugin_slack_template_bad_tokens():
-    """NotifySlack() - invalid tokens type raises TypeError."""
-    with pytest.raises(TypeError):
+    """NotifySlack() rejects an invalid template token type."""
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySlack(
             token_a="T1JJ3T3L2",
             token_b="A1BRTD4JD",
@@ -1929,14 +1930,14 @@ def test_plugin_slack_template_inaccessible(mock_request, tmpdir):
 
 
 def test_plugin_slack_template_add_failure():
-    """NotifySlack() - TypeError when AppriseAttachment.add() drops entry."""
+    """NotifySlack() rejects a template attachment it cannot add."""
     # Simulate add() silently failing (returns 0 / len stays 0)
     with mock.patch("apprise.plugins.slack.AppriseAttachment") as mock_cls:
         inst = mock.MagicMock()
         inst.__len__ = mock.Mock(return_value=0)
         mock_cls.return_value = inst
 
-        with pytest.raises(TypeError):
+        with pytest.raises(AppriseImproperlyConfigured):
             NotifySlack(
                 token_a="T1JJ3T3L2",
                 token_b="A1BRTD4JD",
@@ -2175,33 +2176,33 @@ def test_plugin_slack_workflow_url_roundtrip(mock_request):
 
 
 def test_plugin_slack_workflow_invalid_path():
-    """NotifySlack() - invalid path segment counts raise TypeError."""
+    """NotifySlack() rejects workflow paths with the wrong segment count."""
     from apprise.plugins.slack import NotifySlack as _NS
 
     # Too few segments for explicit workflow mode (needs 4)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         _NS(workflow_path=["T1JJ3T3L2", "XXXXXXXX"], mode="workflow")
 
     # Trigger's 3 segments rejected when mode=workflow is explicit
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         _NS(
             workflow_path=["T1JJ3T3L2", "XXXXXXXX", "YYYYYYYY"],
             mode="workflow",
         )
 
     # Workflow's 4 segments rejected when mode=trigger is explicit
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         _NS(
             workflow_path=["T1JJ3T3L2", "Ft07XXXX", "XXXXXXXX", "YYYY"],
             mode="trigger",
         )
 
     # Empty path -- must raise (auto-detect path, 0 segments)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         _NS(workflow_path=[], mode="workflow")
 
     # Non-string / non-list type (else branch) -- 0 segments, must raise
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         _NS(workflow_path=42, mode="workflow")
 
     # Auto-detect: 4 segments -> WORKFLOW
@@ -2214,8 +2215,8 @@ def test_plugin_slack_workflow_invalid_path():
     assert obj.mode == "trigger"
     assert obj.workflow_path == ["T1JJ3T3L2", "XXXXXXXX", "YYYYYYYY"]
 
-    # Auto-detect: 2 segments -> TypeError (neither 3 nor 4)
-    with pytest.raises(TypeError):
+    # Auto-detection requires either three or four segments.
+    with pytest.raises(AppriseImproperlyConfigured):
         _NS(workflow_path=["T1JJ3T3L2", "XXXXXXXX"])
 
 

--- a/tests/test_plugin_smpp.py
+++ b/tests/test_plugin_smpp.py
@@ -34,6 +34,7 @@ from helpers import AppriseURLTester
 import pytest
 
 from apprise import Apprise, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.smpp import NotifySMPP
 
 with suppress(ImportError):
@@ -46,55 +47,55 @@ apprise_url_tests = (
     (
         "smpp://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "smpp:///",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "smpp://@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "smpp://user@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "smpp://user:pass/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "smpp://user:pass@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "smpp://user@hostname",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "smpp://user:pass@host:/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "smpp://user:pass@host:2775/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_sms_manager.py
+++ b/tests/test_plugin_sms_manager.py
@@ -33,6 +33,7 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import Apprise, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.smsmanager import NotifySMSManager
 
 logging.disable(logging.CRITICAL)
@@ -43,14 +44,14 @@ apprise_url_tests = (
         "smsmgr://",
         {
             # Instantiated but no auth, so no otification can happen
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "smsmgr://:@/",
         {
             # invalid auth
-            "instance": TypeError
+            "instance": AppriseImproperlyConfigured
         },
     ),
     (
@@ -89,7 +90,7 @@ apprise_url_tests = (
         "smsmgr://{}@{}?gateway=invalid".format("a" * 10, "1" * 11),
         {
             # invalid gatewwway
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_smsc.py
+++ b/tests/test_plugin_smsc.py
@@ -37,6 +37,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.smsc import NotifySMSC
 
 logging.disable(logging.CRITICAL)
@@ -57,17 +58,17 @@ apprise_url_tests = (
     # Missing everything
     (
         "smsc://",
-        {"instance": TypeError},
+        {"instance": AppriseImproperlyConfigured},
     ),
     # Missing password
     (
         "smsc://login@+71234567890",
-        {"instance": TypeError},
+        {"instance": AppriseImproperlyConfigured},
     ),
     # Missing login
     (
         "smsc://:password@+71234567890",
-        {"instance": TypeError},
+        {"instance": AppriseImproperlyConfigured},
     ),
     # Valid single target
     (
@@ -154,16 +155,16 @@ def test_plugin_smsc_urls():
 def test_plugin_smsc_init(mock_post):
     """NotifySMSC() initialization and validation."""
 
-    # Missing login raises TypeError
-    with pytest.raises(TypeError):
+    # A login is required.
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySMSC(targets=["+71234567890"])
 
-    # Missing password raises TypeError
-    with pytest.raises(TypeError):
+    # A password is required.
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySMSC(user=LOGIN, targets=["+71234567890"])
 
     # Whitespace-only sender is invalid (validate_regex strips to empty)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySMSC(
             user=LOGIN,
             password=PASSWORD,

--- a/tests/test_plugin_smseagle.py
+++ b/tests/test_plugin_smseagle.py
@@ -36,6 +36,7 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.smseagle import NotifySMSEagle
 
 logging.disable(logging.CRITICAL)
@@ -63,28 +64,28 @@ apprise_url_tests = (
         "smseagle://",
         {
             # No host specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "smseagle://:@/",
         {
             # invalid host
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "smseagle://localhost",
         {
             # Just a host provided (no access token)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "smseagle://%20@localhost",
         {
             # invalid token
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -154,7 +155,7 @@ apprise_url_tests = (
         "smseagle://token@localhost/@user/?priority=invalid",
         {
             # Invalid Priority
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Invalid priority
@@ -162,7 +163,7 @@ apprise_url_tests = (
         "smseagle://token@localhost/@user/?priority=25",
         {
             # Invalid Priority
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_smtp2go.py
+++ b/tests/test_plugin_smtp2go.py
@@ -34,6 +34,7 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.smtp2go import NotifySMTP2Go
 
 logging.disable(logging.CRITICAL)
@@ -46,20 +47,20 @@ apprise_url_tests = (
     (
         "smtp2go://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "smtp2go://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # No Token specified
     (
         "smtp2go://user@localhost.localdomain",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Token is valid, but no user name specified
@@ -68,7 +69,7 @@ apprise_url_tests = (
             "a" * 32, "b" * 8, "c" * 8
         ),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Invalid from email address
@@ -77,7 +78,7 @@ apprise_url_tests = (
             "a" * 32, "b" * 8, "c" * 8
         ),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # No To email address, but everything else is valid

--- a/tests/test_plugin_sns.py
+++ b/tests/test_plugin_sns.py
@@ -34,6 +34,7 @@ import pytest
 import requests
 
 from apprise import Apprise
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.sns import NotifySNS, SNSMode
 
 logging.disable(logging.CRITICAL)
@@ -51,27 +52,27 @@ apprise_url_tests = (
     (
         "sns://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "sns://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "sns://T1JJ3T3L2",
         {
             # Just Token 1 provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "sns://T1JJ3TD4JD/TIiajkdnlazk7FQ/",
         {
             # Missing a region
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -188,11 +189,11 @@ apprise_url_tests = (
         },
     ),
     (
-        # Invalid mode raises TypeError
+        # Invalid mode
         "sns://T1JJ3T3L2/A1BRTD4JD/TIiajkdnlazkcevi7FQ"
         "/us-west-2/12223334444?mode=invalid",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
 )
@@ -212,7 +213,7 @@ def test_plugin_sns_edge_cases(mock_post):
     """NotifySNS() Edge Cases."""
     target = "+1800555999"
     # Initializes the plugin with a valid access, but invalid access key
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         # No access_key_id specified
         NotifySNS(
             access_key_id=None,
@@ -221,7 +222,7 @@ def test_plugin_sns_edge_cases(mock_post):
             targets=target,
         )
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         # No secret_access_key specified
         NotifySNS(
             access_key_id=TEST_ACCESS_KEY_ID,
@@ -230,7 +231,7 @@ def test_plugin_sns_edge_cases(mock_post):
             targets=target,
         )
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         # No region_name specified
         NotifySNS(
             access_key_id=TEST_ACCESS_KEY_ID,
@@ -788,8 +789,8 @@ def test_plugin_sns_mode_detection():
     )
     assert obj.mode == SNSMode.TOPIC
 
-    # Invalid mode raises TypeError
-    with pytest.raises(TypeError):
+    # An invalid mode is rejected.
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySNS(
             access_key_id=TEST_ACCESS_KEY_ID,
             secret_access_key=TEST_ACCESS_KEY_SECRET,

--- a/tests/test_plugin_sogs.py
+++ b/tests/test_plugin_sogs.py
@@ -35,6 +35,7 @@ import pytest
 import requests
 
 from apprise import Apprise
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.sogs import (
     NotifySessionOGS,
     _build_session_message,
@@ -68,35 +69,35 @@ apprise_url_tests = (
     (
         f"sessions://host/{ROOM}",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Missing seed (user field present, no password)
     (
         f"sessions://{PUBLIC_KEY}@host/{ROOM}",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Missing public_key (bad key in user field, too short)
     (
         f"sessions://{BAD_KEY}:{SEED}@host/{ROOM}",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Missing room token (no path segments)
     (
         f"sessions://{PUBLIC_KEY}:{SEED}@host",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Invalid seed (too short, in password field)
     (
         f"sessions://{PUBLIC_KEY}:{BAD_KEY}@host/{ROOM}",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Valid HTTPS URL - single room
@@ -272,15 +273,15 @@ def test_plugin_sogs_init(mock_post):
 )
 @mock.patch("requests.post")
 def test_plugin_sogs_missing_public_key(mock_post):
-    """TypeError is raised when public_key is absent or invalid."""
-    with pytest.raises(TypeError):
+    """A missing or invalid public key is rejected."""
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySessionOGS(
             public_key=None,
             seed=SEED,
             targets=[ROOM],
             host="host",
         )
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySessionOGS(
             public_key=BAD_KEY,
             seed=SEED,
@@ -295,15 +296,15 @@ def test_plugin_sogs_missing_public_key(mock_post):
 )
 @mock.patch("requests.post")
 def test_plugin_sogs_missing_seed(mock_post):
-    """TypeError is raised when seed is absent or invalid."""
-    with pytest.raises(TypeError):
+    """A missing or invalid seed is rejected."""
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySessionOGS(
             public_key=PUBLIC_KEY,
             seed=None,
             targets=[ROOM],
             host="host",
         )
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySessionOGS(
             public_key=PUBLIC_KEY,
             seed=BAD_KEY,
@@ -318,15 +319,15 @@ def test_plugin_sogs_missing_seed(mock_post):
 )
 @mock.patch("requests.post")
 def test_plugin_sogs_missing_rooms(mock_post):
-    """TypeError is raised when no valid room token is provided."""
-    with pytest.raises(TypeError):
+    """At least one valid room token is required."""
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySessionOGS(
             public_key=PUBLIC_KEY,
             seed=SEED,
             targets=None,
             host="host",
         )
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySessionOGS(
             public_key=PUBLIC_KEY,
             seed=SEED,

--- a/tests/test_plugin_sparkpost.py
+++ b/tests/test_plugin_sparkpost.py
@@ -37,6 +37,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.sparkpost import NotifySparkPost
 
 logging.disable(logging.CRITICAL)
@@ -49,34 +50,34 @@ apprise_url_tests = (
     (
         "sparkpost://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "sparkpost://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # No Token specified
     (
         "sparkpost://user@localhost.localdomain",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Token is valid, but no user name specified
     (
         "sparkpost://localhost.localdomain/{}".format("a" * 32),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Invalid from email address
     (
         'sparkpost://"@localhost.localdomain/{}'.format("b" * 32),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # No To email address, but everything else is valid
@@ -218,7 +219,7 @@ apprise_url_tests = (
             "a" * 32
         ),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # One 'To' Email address
@@ -356,11 +357,11 @@ def test_plugin_sparkpost_throttling(mock_post):
     targets = f"{user}@{host}"
 
     # Exception should be thrown about the fact no user was specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySparkPost(apikey=apikey, targets=targets, host=host)
 
     # Exception should be thrown about the fact no private key was specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySparkPost(apikey=None, targets=targets, user=user, host=host)
 
     okay_response = requests.Request()

--- a/tests/test_plugin_spike.py
+++ b/tests/test_plugin_spike.py
@@ -30,6 +30,7 @@ import logging
 from helpers import AppriseURLTester
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.spike import NotifySpike
 
 logging.disable(logging.CRITICAL)
@@ -38,13 +39,13 @@ apprise_url_tests = (
     (
         "spike://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "spike://invalid-key",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_splunk.py
+++ b/tests/test_plugin_splunk.py
@@ -31,6 +31,7 @@ import logging
 from helpers import AppriseURLTester
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.splunk import NotifySplunk
 
 logging.disable(logging.CRITICAL)
@@ -40,32 +41,32 @@ apprise_url_tests = (
     (
         "splunk://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "splunk://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "splunk://routekey@%badapi%",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "splunk://abc123",
         {
             # No route key provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "splunk://%badroute%@apikey",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -220,7 +221,7 @@ apprise_url_tests = (
         "splunk://db@apikey?action=invalid",
         {
             # Invalid Action
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -234,14 +235,14 @@ apprise_url_tests = (
         "splunk://db@apikey?:invalid=critical",
         {
             # A bad Apprise Notification Type was provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "splunk://db@apikey?:warning=invalid",
         {
             # A bad Splunk Notification Type was provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_spugpush.py
+++ b/tests/test_plugin_spugpush.py
@@ -31,6 +31,7 @@ import logging
 from helpers import AppriseURLTester
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.spugpush import NotifySpugpush
 
 logging.disable(logging.CRITICAL)
@@ -39,13 +40,13 @@ apprise_url_tests = (
     (
         "spugpush://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "spugpush://invalid!",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_stackfield.py
+++ b/tests/test_plugin_stackfield.py
@@ -35,6 +35,7 @@ import pytest
 import requests
 
 from apprise import Apprise
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.stackfield import NotifyStackfield
 
 logging.disable(logging.CRITICAL)
@@ -47,21 +48,21 @@ apprise_url_tests = (
     (
         "stackfield://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Invalid token -- not a UUID
     (
         "stackfield://not-a-valid-uuid",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Invalid token -- wrong UUID length
     (
         "stackfield://11111111-2222-3333-4444-55555555555",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Valid token in URL path
@@ -155,19 +156,19 @@ def test_plugin_stackfield_init():
     assert obj2.url_identifier == obj.url_identifier
 
     # Missing token
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyStackfield(token=None)
 
     # Empty token
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyStackfield(token="")
 
     # Invalid token format (not a UUID)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyStackfield(token="not-a-valid-uuid-at-all")
 
     # Wrong UUID length (too short)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyStackfield(token="11111111-2222-3333-4444-55555555555")
 
 

--- a/tests/test_plugin_streamlabs.py
+++ b/tests/test_plugin_streamlabs.py
@@ -30,6 +30,7 @@ import logging
 
 from helpers import AppriseURLTester
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.streamlabs import NotifyStreamlabs
 
 logging.disable(logging.CRITICAL)
@@ -40,14 +41,14 @@ apprise_url_tests = (
         "strmlabs://",
         {
             # No Access Token specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "strmlabs://a_bd_/",
         {
             # invalid Access Token
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -63,7 +64,7 @@ apprise_url_tests = (
     (
         "strmlabs://IcIcArukDQtuC1is1X1UdKZjTg118Lag2vScOmso/?currency=ABCD",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Test complete params - donations
@@ -105,7 +106,7 @@ apprise_url_tests = (
             "?name=tt&identifier=pyt&amount=20&currency=USD&call=rms"
         ),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Test incorrect alert_type
@@ -115,14 +116,14 @@ apprise_url_tests = (
             "?name=tt&identifier=pyt&amount=20&currency=USD&alert_type=rms"
         ),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Test incorrect name
     (
         "strmlabs://IcIcArukDQtuC1is1X1UdKZjTg118Lag2vScOmso/?name=t",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_synology.py
+++ b/tests/test_plugin_synology.py
@@ -32,6 +32,7 @@ from unittest import mock
 from helpers import AppriseURLTester
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.synology import NotifySynology
 
 logging.disable(logging.CRITICAL)
@@ -80,7 +81,7 @@ apprise_url_tests = (
     (
         "synology://user@localhost",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_syslog.py
+++ b/tests/test_plugin_syslog.py
@@ -75,6 +75,7 @@ except ImportError:
 
 logging.disable(logging.CRITICAL)
 
+from apprise.exception import AppriseImproperlyConfigured  # noqa E402
 from apprise.plugins.syslog import NotifySyslog  # noqa E402
 
 
@@ -154,8 +155,8 @@ def test_plugin_syslog_edge_cases(openlog, syslog):
     assert r"logperror=no" in obj.url()
 
     # Exception should be thrown about the fact no bot token was specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySyslog(facility="invalid")
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifySyslog(facility=object)

--- a/tests/test_plugin_techululs_push.py
+++ b/tests/test_plugin_techululs_push.py
@@ -31,6 +31,7 @@ import logging
 from helpers import AppriseURLTester
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.techuluspush import NotifyTechulusPush
 
 logging.disable(logging.CRITICAL)
@@ -44,14 +45,14 @@ apprise_url_tests = (
         "push://",
         {
             # Missing API Key
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Invalid API Key
     (
         "push://%s" % ("+" * 24),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # APIkey
@@ -67,7 +68,7 @@ apprise_url_tests = (
     (
         "push://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_telegram.py
+++ b/tests/test_plugin_telegram.py
@@ -45,6 +45,7 @@ from apprise import (
     NotifyFormat,
     NotifyType,
 )
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.telegram import NotifyTelegram
 
 logging.disable(logging.CRITICAL)
@@ -143,14 +144,14 @@ apprise_url_tests = (
     (
         "tgram://bottest@123456789:abcdefg_hijklmnop/id1/?topic=invalid",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # content must be 'before' or 'after'
     (
         "tgram://bottest@123456789:abcdefg_hijklmnop/id1/?content=invalid",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -385,7 +386,7 @@ def test_plugin_telegram_general(mock_post):
     mock_post.return_value.content = "{}"
 
     # Exception should be thrown about the fact no bot token was specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyTelegram(bot_token=None, targets=chat_ids)
 
     # Invalid JSON while trying to detect bot owner
@@ -403,7 +404,7 @@ def test_plugin_telegram_general(mock_post):
 
     # Exception should be thrown about the fact an invalid bot token was
     # specifed
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyTelegram(bot_token=invalid_bot_token, targets=chat_ids)
 
     obj = NotifyTelegram(
@@ -2771,8 +2772,8 @@ def test_plugin_telegram_template_load_error(mock_post, tmpdir):
 
 
 def test_plugin_telegram_template_bad_tokens():
-    """NotifyTelegram() - invalid tokens type raises TypeError."""
-    with pytest.raises(TypeError):
+    """NotifyTelegram() rejects an invalid template token type."""
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyTelegram(
             bot_token="123456789:abcdefg_hijklmnop",
             targets="lead2gold",
@@ -2781,14 +2782,13 @@ def test_plugin_telegram_template_bad_tokens():
 
 
 def test_plugin_telegram_template_add_failure():
-    """NotifyTelegram() - TypeError when AppriseAttachment.add() drops
-    entry."""
+    """NotifyTelegram() rejects a template attachment it cannot add."""
     with mock.patch("apprise.plugins.telegram.AppriseAttachment") as mock_cls:
         inst = mock.MagicMock()
         inst.__len__ = mock.Mock(return_value=0)
         mock_cls.return_value = inst
 
-        with pytest.raises(TypeError):
+        with pytest.raises(AppriseImproperlyConfigured):
             NotifyTelegram(
                 bot_token="123456789:abcdefg_hijklmnop",
                 targets="lead2gold",

--- a/tests/test_plugin_threema.py
+++ b/tests/test_plugin_threema.py
@@ -33,6 +33,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.threema import NotifyThreema
 
 logging.disable(logging.CRITICAL)
@@ -43,21 +44,21 @@ apprise_url_tests = (
         "threema://",
         {
             # No user/secret specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "threema://@:",
         {
             # Invalid url
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "threema://user@secret",
         {
             # gateway id must be 8 characters in len
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -161,7 +162,7 @@ def test_plugin_threema_edge_cases(mock_post):
     targets = "+1 (555) 123-9876"
 
     # No email specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyThreema(user=gwid, secret=None, targets=targets)
 
     results = NotifyThreema.parse_url(

--- a/tests/test_plugin_trigv.py
+++ b/tests/test_plugin_trigv.py
@@ -33,6 +33,7 @@ import pytest
 import requests
 
 import apprise
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.trigv import NotifyTrigv
 
 logging.disable(logging.CRITICAL)
@@ -43,13 +44,13 @@ apprise_url_tests = (
     (
         "trigvs://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "trigv://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -109,13 +110,13 @@ apprise_url_tests = (
     (
         "trigvs://not-a-valid-key",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         f"trigvs://{VALID_API_KEY}/bad.channel/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -352,7 +353,7 @@ def test_plugin_trigv_empty_body_and_invalid_priority(mock_post):
 def test_plugin_trigv_invalid_urgency():
     """NotifyTrigv() rejects unknown urgency."""
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyTrigv(api_key=VALID_API_KEY, urgency="critical")
 
 

--- a/tests/test_plugin_twilio.py
+++ b/tests/test_plugin_twilio.py
@@ -36,6 +36,7 @@ import pytest
 import requests
 
 from apprise import Apprise
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.twilio import NotifyTwilio, TwilioNotificationMethod
 
 logging.disable(logging.CRITICAL)
@@ -46,28 +47,28 @@ apprise_url_tests = (
         "twilio://",
         {
             # No Account SID specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "twilio://:@/",
         {
             # invalid Auth token
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "twilio://AC{}@12345678".format("a" * 32),
         {
             # Just sid provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "twilio://AC{}:{}@_".format("a" * 32, "b" * 32),
         {
             # sid and token provided but invalid from
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -85,7 +86,7 @@ apprise_url_tests = (
         "twilio://AC{}:{}@{}".format("a" * 32, "b" * 32, "3" * 9),
         {
             # sid and token provided and from but invalid from no
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -124,7 +125,7 @@ apprise_url_tests = (
         ),
         {
             # Invalid short-code
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -153,7 +154,7 @@ apprise_url_tests = (
         "twilio://AC{}:{}@{}?method=mms".format("a" * 32, "b" * 32, "5" * 11),
         {
             # Invalid notification method
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -162,7 +163,7 @@ apprise_url_tests = (
         ),
         {
             # Incompatibility between Whatsapp mode and CALL method
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -353,19 +354,19 @@ def test_plugin_twilio_edge_cases(mock_post):
     whatsapp_source = "w:" + "+1 (555) 123-3456"
 
     # No account_sid specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyTwilio(account_sid=None, auth_token=auth_token, source=source)
 
     # No auth_token specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyTwilio(account_sid=account_sid, auth_token=None, source=source)
 
     # Source is bad
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyTwilio(account_sid=account_sid, auth_token=auth_token, source="")
 
     # Incompatibility between mode and method
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyTwilio(
             account_sid=account_sid,
             auth_token=auth_token,

--- a/tests/test_plugin_twist.py
+++ b/tests/test_plugin_twist.py
@@ -36,6 +36,7 @@ import pytest
 import requests
 
 from apprise import Apprise, NotifyFormat
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.twist import NotifyTwist
 
 logging.disable(logging.CRITICAL)
@@ -130,10 +131,10 @@ def test_plugin_twist_urls():
 
 def test_plugin_twist_init():
     """NotifyTwist() init()"""
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyTwist(email="invalid", targets=None)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyTwist(email="user@domain", targets=None)
 
     # Simple object initialization

--- a/tests/test_plugin_twitter.py
+++ b/tests/test_plugin_twitter.py
@@ -36,6 +36,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.twitter import NotifyTwitter
 
 # Disable logging for a cleaner testing output
@@ -56,34 +57,34 @@ apprise_url_tests = (
         "twitter://",
         {
             # Missing Consumer API Key
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "twitter://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "twitter://consumer_key",
         {
             # Missing Keys
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "twitter://consumer_key/consumer_secret/",
         {
             # Missing Keys
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "twitter://consumer_key/consumer_secret/atoken1/",
         {
             # Missing Access Secret
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -208,7 +209,7 @@ apprise_url_tests = (
         "twitter://user@ckey/csecret/atoken13/access_secret?mode=invalid",
         {
             # An invalid mode
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -618,16 +619,16 @@ def test_plugin_twitter_garbage_responses(mocker):
 def test_plugin_twitter_edge_cases():
     """NotifyTwitter() Edge Cases."""
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyTwitter(ckey=None, csecret=None, akey=None, asecret=None)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyTwitter(ckey="value", csecret=None, akey=None, asecret=None)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyTwitter(ckey="value", csecret="value", akey=None, asecret=None)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyTwitter(
             ckey="value", csecret="value", akey="value", asecret=None
         )

--- a/tests/test_plugin_vapid.py
+++ b/tests/test_plugin_vapid.py
@@ -39,6 +39,7 @@ import requests
 
 from apprise import asset, exception, url
 from apprise.common import PersistentStoreMode
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.vapid import NotifyVapid
 from apprise.plugins.vapid.subscription import (
     WebPushSubscription,
@@ -61,20 +62,20 @@ apprise_url_tests = (
     (
         "vapid://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "vapid://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "vapid://invalid-subscriber",
         {
             # An invalid Subscriber
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -289,7 +290,7 @@ def test_plugin_vapid_urls_with_required_assets(
             "vapid://user@example.com/user1?to=user2&ttl=-4000",
             {
                 # bad ttl
-                "instance": TypeError,
+                "instance": AppriseImproperlyConfigured,
             },
         ),
         (
@@ -303,14 +304,14 @@ def test_plugin_vapid_urls_with_required_assets(
             "vapid://user@example.com/user1?to=user2&mode=",
             {
                 # test mode
-                "instance": TypeError,
+                "instance": AppriseImproperlyConfigured,
             },
         ),
         (
             "vapid://user@example.com/user1?to=user2&mode=invalid",
             {
                 # test mode more
-                "instance": TypeError,
+                "instance": AppriseImproperlyConfigured,
             },
         ),
         (

--- a/tests/test_plugin_voipms.py
+++ b/tests/test_plugin_voipms.py
@@ -36,6 +36,7 @@ import pytest
 import requests
 
 from apprise import Apprise
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.voipms import NotifyVoipms
 
 logging.disable(logging.CRITICAL)
@@ -46,35 +47,35 @@ apprise_url_tests = (
         "voipms://",
         {
             # No email/password specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "voipms://@:",
         {
             # Invalid url
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "voipms://{}/{}".format("user@example.com", "1" * 11),
         {
             # No password specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "voipms://:{}".format("password"),
         {
             # No email specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "voipms://{}:{}/{}".format("user@", "pass", "1" * 11),
         {
             # Check valid email
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -83,7 +84,7 @@ apprise_url_tests = (
         ),
         {
             # No from_phone specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Invalid phone number test
@@ -93,7 +94,7 @@ apprise_url_tests = (
         ),
         {
             # Invalid phone number
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Invalid country code phone number test
@@ -103,7 +104,7 @@ apprise_url_tests = (
         ),
         {
             # Non North American phone number
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -227,7 +228,7 @@ def test_plugin_voipms_edge_cases(mock_get):
     targets = "+1 (555) 123-9876"
 
     # No email specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyVoipms(email=None, source=source)
 
     # a error response is returned

--- a/tests/test_plugin_vonage.py
+++ b/tests/test_plugin_vonage.py
@@ -35,6 +35,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.vonage import NotifyVonage
 
 logging.disable(logging.CRITICAL)
@@ -45,42 +46,42 @@ apprise_url_tests = (
         "vonage://",
         {
             # No API Key specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "vonage://:@/",
         {
             # invalid Auth key
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "vonage://AC{}@12345678".format("a" * 8),
         {
             # Just a key provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "vonage://AC{}:{}@{}".format("a" * 8, "b" * 16, "3" * 9),
         {
             # key and secret provided and from but invalid from no
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "vonage://AC{}:{}@{}/?ttl=0".format("b" * 8, "c" * 16, "3" * 11),
         {
             # Invalid ttl defined
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "vonage://AC{}:{}@{}".format("d" * 8, "e" * 16, "a" * 11),
         {
             # Invalid source number
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -153,42 +154,42 @@ apprise_url_tests = (
         "nexmo://",
         {
             # No API Key specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "nexmo://:@/",
         {
             # invalid Auth key
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "nexmo://AC{}@12345678".format("a" * 8),
         {
             # Just a key provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "nexmo://AC{}:{}@{}".format("a" * 8, "b" * 16, "3" * 9),
         {
             # key and secret provided and from but invalid from no
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "nexmo://AC{}:{}@{}/?ttl=0".format("b" * 8, "c" * 16, "3" * 11),
         {
             # Invalid ttl defined
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "nexmo://AC{}:{}@{}".format("d" * 8, "e" * 16, "a" * 11),
         {
             # Invalid source number
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -283,17 +284,17 @@ def test_plugin_vonage_edge_cases(mock_post):
     source = "+1 (555) 123-3456"
 
     # No apikey specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyVonage(apikey=None, secret=secret, source=source)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyVonage(apikey="  ", secret=secret, source=source)
 
     # No secret specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyVonage(apikey=apikey, secret=None, source=source)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyVonage(apikey=apikey, secret="  ", source=source)
 
     # a error response

--- a/tests/test_plugin_webex_teams.py
+++ b/tests/test_plugin_webex_teams.py
@@ -36,6 +36,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseAttachment, NotifyFormat, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.webexteams import (
     NotifyWebexTeams,
     WebexTeamsMode,
@@ -65,7 +66,7 @@ apprise_url_tests = (
         "wxteams://",
         {
             # Token missing
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -74,7 +75,7 @@ apprise_url_tests = (
             # We don't have strict host checking on for wxteams, so this
             # URL actually becomes parseable and :@ becomes a hostname.
             # The below errors because a second token wasn't found
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -158,7 +159,7 @@ apprise_url_tests = (
     (
         "wxteams://{}?mode=invalid".format("a" * 80),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Webhook mode: HTTP 500 response
@@ -274,12 +275,12 @@ def test_plugin_webex_teams_webhook_mode():
     assert obj_long.mode == WebexTeamsMode.BOT
     assert obj_long.send(body="test") is False
 
-    # No token -> TypeError (no candidate at all)
-    with pytest.raises(TypeError):
+    # No token candidate is invalid.
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyWebexTeams(token=None)
 
-    # Empty token -> TypeError
-    with pytest.raises(TypeError):
+    # An empty token is invalid.
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyWebexTeams(token="")
 
     # Non-alphanumeric chars -> falls to bot mode (no targets)
@@ -330,12 +331,12 @@ def test_plugin_webex_teams_bot_mode():
     assert isinstance(obj_no_rooms, NotifyWebexTeams)
     assert obj_no_rooms.send(body="test") is False
 
-    # No access_token -> TypeError
-    with pytest.raises(TypeError):
+    # An access token is required.
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyWebexTeams(access_token=None, targets=[ROOM_ID])
 
-    # Explicit bot mode with neither token nor access_token -> TypeError
-    with pytest.raises(TypeError):
+    # Bot mode requires a token or access token.
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyWebexTeams(mode="bot", targets=[ROOM_ID])
 
     # Explicit mode=bot on a short (webhook-style) token
@@ -345,7 +346,7 @@ def test_plugin_webex_teams_bot_mode():
     assert obj4.access_token == "a" * 80
 
     # Invalid mode
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyWebexTeams(
             access_token=BOT_TOKEN,
             targets=[ROOM_ID],

--- a/tests/test_plugin_wechat.py
+++ b/tests/test_plugin_wechat.py
@@ -40,6 +40,7 @@ import requests
 
 from apprise import Apprise
 from apprise.common import NotifyFormat
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.wechat import (
     WECHAT_ERROR_CODES,
     WECHAT_TOKEN_ERROR_CODES,
@@ -77,28 +78,28 @@ apprise_url_tests = (
         "wechat://",
         {
             # No credentials at all
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         # Missing corpsecret and agentid
         "wechat://{}".format(CORPID),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         # Missing agentid (non-numeric host provided as port only)
         "wechat://{}:{}@".format(CORPID, CORPSECRET),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         # Non-numeric agentid
         "wechat://{}:{}@notanumber".format(CORPID, CORPSECRET),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # ----------------------------------------------------------------
@@ -259,20 +260,20 @@ def test_plugin_wechat_init():
     with (
         mock.patch("apprise.plugins.wechat.validate_regex", return_value=None),
         mock.patch.object(NotifyWeChat, "logger"),
-        pytest.raises(TypeError),
+        pytest.raises(AppriseImproperlyConfigured),
     ):
         NotifyWeChat(corpid="", corpsecret=CORPSECRET, agentid=AGENTID)
 
     # corpsecret is required
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyWeChat(corpid=CORPID, corpsecret="", agentid=AGENTID)
 
     # agentid must be numeric
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyWeChat(corpid=CORPID, corpsecret=CORPSECRET, agentid="notnum")
 
     # agentid=None must be rejected
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyWeChat(corpid=CORPID, corpsecret=CORPSECRET, agentid=None)
 
     # Invalid targets are silently dropped; valid ones are kept

--- a/tests/test_plugin_wecombot.py
+++ b/tests/test_plugin_wecombot.py
@@ -31,6 +31,7 @@ import logging
 from helpers import AppriseURLTester
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.wecombot import NotifyWeComBot
 
 logging.disable(logging.CRITICAL)
@@ -40,13 +41,13 @@ apprise_url_tests = (
     (
         "wecombot://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "wecombot://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_whatsapp.py
+++ b/tests/test_plugin_whatsapp.py
@@ -36,6 +36,7 @@ import pytest
 import requests
 
 from apprise import Apprise, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.whatsapp import IS_GROUP_ID, NotifyWhatsApp
 
 logging.disable(logging.CRITICAL)
@@ -46,28 +47,28 @@ apprise_url_tests = (
         "whatsapp://",
         {
             # Not enough details
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "whatsapp://:@/",
         {
             # invalid Access Token
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "whatsapp://{}@_".format("a" * 32),
         {
             # token provided but invalid from
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "whatsapp://%20:{}@12345/{}".format("e" * 32, "4" * 11),
         {
             # Invalid template
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -134,7 +135,7 @@ apprise_url_tests = (
         "whatsapp://template:{}@12345/{}?lang=1234".format("e" * 32, "4" * 11),
         {
             # template with invalid language over-ride
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -159,7 +160,7 @@ apprise_url_tests = (
             # template with kwarg assignments
             # Invalid keyword specified; cna only be a digit OR `body'
             # or 'type'
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -167,7 +168,7 @@ apprise_url_tests = (
         {
             # template with kwarg assignments
             # No Body Assigment
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -177,7 +178,7 @@ apprise_url_tests = (
         {
             # template with kwarg assignments
             # Ambiguious assignment {{1}} assigned twice
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -330,13 +331,13 @@ def test_plugin_whatsapp_edge_cases(mock_post):
     targets = ("+1 (555) 123-3456",)
 
     # No token specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyWhatsApp(
             token=None, from_phone_id=from_phone_id, targets=targets
         )
 
     # No from_phone_id specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyWhatsApp(token=token, from_phone_id=None, targets=targets)
 
     # a error response

--- a/tests/test_plugin_workflows.py
+++ b/tests/test_plugin_workflows.py
@@ -38,6 +38,7 @@ import pytest
 import requests
 
 from apprise import Apprise, AppriseConfig, NotifyFormat, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.workflows import NotifyWorkflows
 
 logging.disable(logging.CRITICAL)
@@ -65,14 +66,14 @@ apprise_url_tests = (
         "workflow://host/workflow",
         {
             # workflow provided only, no signature
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "workflow://host:443/^(/signature",
         {
             # invalid workflow provided
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -693,14 +694,14 @@ def test_plugin_workflows_templating_invalid_contenttype(
     reason="Python <3.10: see test_plugin_workflows_template_add_failure_py39",
 )
 def test_plugin_workflows_template_add_failure():
-    """NotifyWorkflows() - TypeError when add() drops the entry."""
+    """NotifyWorkflows() rejects an attachment it cannot add."""
     # Simulate add() silently failing (len stays 0); no HTTP call needed
     with mock.patch("apprise.plugins.workflows.AppriseAttachment") as mock_cls:
         inst = mock.MagicMock()
         inst.__len__ = mock.Mock(return_value=0)
         mock_cls.return_value = inst
 
-        with pytest.raises(TypeError):
+        with pytest.raises(AppriseImproperlyConfigured):
             NotifyWorkflows(
                 workflow="T00000000001",
                 signature="AbCdEfGhIjKlMnOpQrStUvWx",
@@ -718,7 +719,7 @@ def test_plugin_workflows_template_add_failure():
     reason="Python 3.10+ mock.patch resolves via sys.modules directly",
 )
 def test_plugin_workflows_template_add_failure_py39_compat():
-    """NotifyWorkflows() - TypeError when add() drops the entry (Py 3.9)."""
+    """The attachment rejection remains compatible with Python 3.9."""
     import importlib
 
     # Resolve the live module so patch.object and the class share the same
@@ -732,7 +733,7 @@ def test_plugin_workflows_template_add_failure_py39_compat():
         inst.__len__ = mock.Mock(return_value=0)
         mock_cls.return_value = inst
 
-        with pytest.raises(TypeError):
+        with pytest.raises(AppriseImproperlyConfigured):
             _NotifyWorkflows(
                 workflow="T00000000001",
                 signature="AbCdEfGhIjKlMnOpQrStUvWx",
@@ -858,25 +859,25 @@ def test_workflows_yaml_config_missing_template_filename(
 def test_plugin_workflows_edge_cases():
     """NotifyWorkflows() Edge Cases."""
     # Initializes the plugin with an invalid token
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyWorkflows(workflow="@", signature="@")
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyWorkflows(workflow="", signature="abcd")
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyWorkflows(workflow=None, signature="abcd")
     # Whitespace also acts as an invalid token value
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyWorkflows(workflow="  ", signature="abcd")
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyWorkflows(workflow="abcd", signature=None)
     # Whitespace also acts as an invalid token value
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyWorkflows(workflow="abcd", signature="  ")
 
     # test case where invalid tokens are specified
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyWorkflows(
             workflow="workflow", signature="signature", tokens="not-a-dict"
         )
@@ -956,7 +957,7 @@ def test_plugin_workflows_routing_id_parse_url(key):
 def test_plugin_workflows_routing_id_invalid():
     """NotifyWorkflows() rejects a non-numeric routing ID."""
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyWorkflows(
             workflow="3XXX5", signature="iXXXU", routing_id="1/../evil"
         )

--- a/tests/test_plugin_wxpusher.py
+++ b/tests/test_plugin_wxpusher.py
@@ -36,6 +36,7 @@ from helpers import AppriseURLTester
 import requests
 
 from apprise import Apprise
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.wxpusher import NotifyWxPusher
 
 logging.disable(logging.CRITICAL)
@@ -53,21 +54,21 @@ apprise_url_tests = (
         "wxpusher://",
         {
             # No token specified
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "wxpusher://:@/",
         {
             # invalid url
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "wxpusher://invalid",
         {
             # invalid app token
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (

--- a/tests/test_plugin_xmpp.py
+++ b/tests/test_plugin_xmpp.py
@@ -45,8 +45,16 @@ from typing import Any, Optional
 import pytest
 
 from apprise import LOGGER_NAME, Apprise, NotifyType
+from apprise.exception import AppriseException, AppriseImproperlyConfigured
 from apprise.plugins.xmpp import adapter as xmpp_adapter, base as xmpp_base
 from apprise.plugins.xmpp.base import NotifyXMPP
+
+
+def test_plugin_xmpp_channel_binding_exception() -> None:
+    """Channel-binding failures use the common Apprise exception."""
+    exc = xmpp_adapter.XMPPChannelBindingError()
+    assert isinstance(exc, AppriseException)
+    assert str(exc) == "SASL SCRAM-PLUS channel-binding authentication failed."
 
 
 def run_on_loop(loop: asyncio.AbstractEventLoop, coro: Any) -> Any:
@@ -267,7 +275,7 @@ def test_slixmpp_unavailable() -> None:
 
 @pytest.mark.skipif(not SLIXMPP_AVAILABLE, reason="Requires slixmpp")
 def test_xmpp_invalid_jid() -> None:
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyXMPP(host="example.com", user="bad jid", password="x")
 
 
@@ -972,7 +980,7 @@ def test_xmpp_normalize_jid() -> None:
         "#room@conference.example.ca", "example.ca"
     ) == ("room@conference.example.ca", True)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(AppriseImproperlyConfigured):
         # Bad entry
         NotifyXMPP.normalize_jid("", "example.ca")
 
@@ -1406,7 +1414,7 @@ def test_xmpp_timeout_cleanup_loop_none_skips_disconnect_and_stop(
 def test_xmpp_process_unsupported_secure_mode(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Cover unsupported secure mode path (ValueError inside runner)."""
+    """The process runner handles an unsupported secure mode."""
     install_fake_slixmpp(monkeypatch)
     # See test_xmpp_invalid_targets_logged for why this is needed: older
     # pytest releases don't un-suppress a prior logging.disable(CRITICAL)
@@ -3203,13 +3211,10 @@ def test_adapter_keepalive_runner_failed_handlers(
 
 
 @pytest.mark.skipif(not SLIXMPP_AVAILABLE, reason="Requires slixmpp")
-def test_adapter_keepalive_runner_unsupported_secure_mode_hits_valueerror(
+def test_keepalive_runner_rejects_secure_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """
-    Cover keepalive runner unsupported secure mode ValueError.
-    The exception is caught internally, but the raise line is executed.
-    """
+    """The keepalive runner handles an unsupported secure mode."""
     install_fake_slixmpp(monkeypatch)
 
     cfg = xmpp_adapter.XMPPConfig(

--- a/tests/test_plugin_zoom.py
+++ b/tests/test_plugin_zoom.py
@@ -34,6 +34,7 @@ import pytest
 import requests
 
 from apprise import Apprise, NotifyType
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.zoom import (
     ZOOM_MODE_DEFAULT,
     NotifyZoom,
@@ -52,21 +53,21 @@ apprise_url_tests = (
     (
         "zoom://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Empty user/host segment
     (
         "zoom://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Missing token (webhook_id present but no path segment)
     (
         "zoom://{}".format(WEBHOOK_ID),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Valid full-mode (default)
@@ -97,7 +98,7 @@ apprise_url_tests = (
     (
         "zoom://{}/{}?mode=invalid".format(WEBHOOK_ID, TOKEN),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Native URL with ?token= query param
@@ -173,35 +174,35 @@ def test_plugin_zoom_init():
     """Test NotifyZoom initialization and validation."""
 
     # Missing webhook_id
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyZoom(webhook_id=None, token=TOKEN)
 
     # Empty webhook_id
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyZoom(webhook_id="", token=TOKEN)
 
     # Webhook ID with invalid characters (slash)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyZoom(webhook_id="bad/id", token=TOKEN)
 
     # Missing token
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyZoom(webhook_id=WEBHOOK_ID, token=None)
 
     # Empty token
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyZoom(webhook_id=WEBHOOK_ID, token="")
 
     # Invalid mode
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN, mode="bogus")
 
     # Empty string mode is also invalid (must not silently resolve to simple)
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN, mode="")
 
     # Whitespace-only mode is also invalid
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyZoom(webhook_id=WEBHOOK_ID, token=TOKEN, mode="   ")
 
     # Valid: default mode

--- a/tests/test_plugin_zulip.py
+++ b/tests/test_plugin_zulip.py
@@ -32,6 +32,7 @@ from helpers import AppriseURLTester
 import pytest
 import requests
 
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.plugins.zulip import NotifyZulip
 
 logging.disable(logging.CRITICAL)
@@ -41,41 +42,41 @@ apprise_url_tests = (
     (
         "zulip://",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "zulip://:@/",
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "zulip://apprise",
         {
             # Just org provided (no token or botname)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
         "zulip://botname@apprise",
         {
             # Just org and botname provided (no token)
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # invalid token
     (
         "zulip://botname@apprise/{}".format("a" * 24),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # invalid botname
     (
         "zulip://....@apprise/{}".format("a" * 32),
         {
-            "instance": TypeError,
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     # Valid everything - botname with a dash
@@ -184,5 +185,5 @@ def test_plugin_zulip_edge_cases():
     token = "a" * 32
 
     # Invalid organization
-    with pytest.raises(TypeError):
+    with pytest.raises(AppriseImproperlyConfigured):
         NotifyZulip(botname="test", organization="#", token=token)

--- a/tests/test_retry_wait.py
+++ b/tests/test_retry_wait.py
@@ -40,6 +40,7 @@ from apprise.common import (
     MATCH_ALL_TAG,
 )
 from apprise.config.base import ConfigBase
+from apprise.exception import AppriseImproperlyConfigured
 from apprise.manager_plugins import NotificationManager
 from apprise.plugins import NotifyBase
 from apprise.tag import AppriseTag
@@ -3040,25 +3041,25 @@ class TestServiceTimeout:
         with pytest.raises(ValueError):
             asyncio.run(a.async_notify(body="test", timeout=float("inf")))
 
-    def test_notify_non_numeric_timeout_raises_typeerror(self):
-        """notify(timeout="abc") raises TypeError."""
+    def test_notify_rejects_non_numeric_timeout(self):
+        """notify() rejects a non-numeric timeout."""
         a = Apprise()
         a.add("json://localhost")
-        with pytest.raises(TypeError):
+        with pytest.raises(AppriseImproperlyConfigured):
             a.notify(body="test", timeout="abc")
 
-    def test_notify_bool_timeout_raises_typeerror(self):
+    def test_notify_rejects_bool_timeout(self):
         """A bool timeout is rejected even though bool is an int subclass."""
         a = Apprise()
         a.add("json://localhost")
-        with pytest.raises(TypeError):
+        with pytest.raises(AppriseImproperlyConfigured):
             a.notify(body="test", timeout=True)
 
-    def test_async_notify_non_numeric_timeout_raises_typeerror(self):
-        """async_notify(timeout="abc") is a caller error (TypeError)."""
+    def test_async_notify_rejects_non_numeric_timeout(self):
+        """async_notify() rejects a non-numeric timeout."""
         a = Apprise()
         a.add("json://localhost")
-        with pytest.raises(TypeError):
+        with pytest.raises(AppriseImproperlyConfigured):
             asyncio.run(a.async_notify(body="test", timeout="abc"))
 
     def test_notify_timeout_defaults_to_zero(self):


### PR DESCRIPTION
## Description
**Related issue (if applicable):** n/a
 
Use Apprise exceptions so applications can handle failures consistently.

| Exception                     | Description                                                                           |
| ----------------------------- | ------------------------------------------------------------------------------------- |
| `AppriseException`            | The base for every Apprise exception. Catch it to handle all Apprise errors together. |
| `AppriseImproperlyConfigured` | A required setting is missing or invalid. Use this for plugin constructor checks.     |
| `ApprisePluginException`      | The plugin failed for a reason unrelated to its settings.                             |
| `AppriseInvalidData`          | Stored or received data cannot be used safely.                                        |
| `AppriseDiskIOError`          | A file or disk operation failed. It can also be caught as `OSError`.                  |

Import exceptions from `apprise.exception`. Existing applications that catch
`TypeError`, `ValueError`, or `AttributeError` remain compatible with
`AppriseImproperlyConfigured`.

```python
from apprise import AppriseAsset
from apprise.exception import AppriseImproperlyConfigured

try:
    asset = AppriseAsset(service_timeout=-1)
except AppriseImproperlyConfigured as error:
    print(f"Invalid Apprise settings: {error}")
```

Everything is also still catchable under the base `AppriseException`, or under the old built-in types, for anyone not ready to switch over yet.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [ ] Documentation ticket created (if applicable): [apprise-docs/125](https://github.com/caronc/apprise-docs/pull/125)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@v2-apprise-exception-handling

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    <apprise url related to this change>
```
