### PR TITLE
Support for Mac OS v26 terminal-notifier

### DIFF
--- a/apprise/plugins/macosx.py
+++ b/apprise/plugins/macosx.py
@@ -128,10 +128,23 @@ class NotifyMacOSX(NotifyBase):
                 "name": _("Open/Click URL"),
                 "type": "string",
             },
+            # Some terminal-notifier builds require a sender; defaults
+            # to our app_id when not explicitly set
+            "sender": {
+                "name": _("Sender"),
+                "type": "string",
+            },
         },
     )
 
-    def __init__(self, sound=None, include_image=True, click=None, **kwargs):
+    def __init__(
+        self,
+        sound=None,
+        include_image=True,
+        click=None,
+        sender=None,
+        **kwargs,
+    ):
         """Initialize MacOSX Object."""
 
         super().__init__(**kwargs)
@@ -150,6 +163,10 @@ class NotifyMacOSX(NotifyBase):
 
         # Set sound object (no q/a for now)
         self.sound = sound
+
+        # Some builds require a sender to display notifications; if
+        # unset we fall back to our own app_id at send time
+        self.sender = sender
 
     def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
         """Perform MacOSX Notification."""
@@ -178,6 +195,13 @@ class NotifyMacOSX(NotifyBase):
         # The sound to play
         if self.sound:
             cmd.extend(["-sound", self.sound])
+
+        # Identify ourselves to terminal-notifier. Some builds silently
+        # refuse to display anything without this set, so fall back to
+        # our own app_id when the caller hasn't overridden it.
+        sender = self.sender if self.sender else self.app_id
+        if sender:
+            cmd.extend(["-sender", sender])
 
         # Support any defined images if set
         image_path = (
@@ -217,6 +241,9 @@ class NotifyMacOSX(NotifyBase):
         if self.click:
             params["click"] = self.click
 
+        if self.sender:
+            params["sender"] = self.sender
+
         # Extend our parameters
         params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
 
@@ -248,5 +275,9 @@ class NotifyMacOSX(NotifyBase):
         # Support 'sound'
         if "sound" in results["qsd"] and len(results["qsd"]["sound"]):
             results["sound"] = NotifyMacOSX.unquote(results["qsd"]["sound"])
+
+        # Support 'sender'
+        if "sender" in results["qsd"] and len(results["qsd"]["sender"]):
+            results["sender"] = NotifyMacOSX.unquote(results["qsd"]["sender"])
 
         return results

--- a/tests/test_plugin_macosx.py
+++ b/tests/test_plugin_macosx.py
@@ -251,3 +251,79 @@ def test_plugin_macosx_pretend_old_macos(mocker, macos_version):
 
     obj = apprise.Apprise.instantiate("macosx://", suppress_exceptions=False)
     assert obj is None
+
+
+def test_plugin_macosx_sender(mocker, macos_notify_environment):
+    """Pass `-sender` through and preserve it in generated URLs."""
+
+    mock_popen = mocker.patch(
+        "subprocess.Popen", return_value=Mock(returncode=0)
+    )
+
+    obj = apprise.Apprise.instantiate(
+        "macosx://_/?sender=me", suppress_exceptions=False
+    )
+    assert isinstance(obj, NotifyMacOSX) is True
+    assert obj.sender == "me"
+    assert "sender=me" in obj.url()
+
+    assert (
+        obj.notify(
+            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        )
+        is True
+    )
+
+    cmd = mock_popen.call_args[0][0]
+    assert "-sender" in cmd
+    assert cmd[cmd.index("-sender") + 1] == "me"
+
+
+def test_plugin_macosx_sender_default(mocker, macos_notify_environment):
+    """Without an explicit override, `-sender` falls back to our own
+    app_id so notifications work out of the box."""
+
+    mock_popen = mocker.patch(
+        "subprocess.Popen", return_value=Mock(returncode=0)
+    )
+
+    obj = apprise.Apprise.instantiate("macosx://", suppress_exceptions=False)
+    assert obj.sender is None
+
+    # The default isn't baked into the URL; it is resolved at send time
+    assert "sender=" not in obj.url()
+
+    assert (
+        obj.notify(
+            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        )
+        is True
+    )
+
+    cmd = mock_popen.call_args[0][0]
+    assert "-sender" in cmd
+    assert cmd[cmd.index("-sender") + 1] == obj.app_id
+
+
+def test_plugin_macosx_sender_empty_app_id(mocker, macos_notify_environment):
+    """When both `sender` and our own app_id are unset, `-sender` is
+    left off the command entirely rather than being sent empty."""
+
+    mock_popen = mocker.patch(
+        "subprocess.Popen", return_value=Mock(returncode=0)
+    )
+
+    asset = apprise.AppriseAsset(app_id="")
+    obj = apprise.Apprise.instantiate(
+        "macosx://", asset=asset, suppress_exceptions=False
+    )
+    assert obj.app_id == ""
+
+    assert (
+        obj.notify(
+            title="title", body="body", notify_type=apprise.NotifyType.INFO
+        )
+        is True
+    )
+
+    assert "-sender" not in mock_popen.call_args[0][0]


### PR DESCRIPTION
## Description
**Related issue (if applicable):** #1705

- Fixes `macosx://` notifications silently failing on macOS 26 (Tahoe) when using an older `terminal-notifier` (2.x) install — they used to report success but never actually show up. `sender` now enforced.

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/127](https://github.com/caronc/apprise-docs/pull/127)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@1705-macos26-terminal-notifier-fix

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    "macosx://_/sender=me"
