### PR TITLE
Delta Chat support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The table below identifies the services this tool supports and some example serv
 | [Brevo](https://appriseit.com/services/brevo/) | brevo://  | (TCP) 443   | brevo://APIToken:FromEmail/<br />brevo://APIToken:FromEmail/ToEmail<br />brevo://APIToken:FromEmail/ToEmail1/ToEmail2/ToEmailN/
 | [Chanify](https://appriseit.com/services/chanify/) | chantify://    | (TCP) 443    | chantify://token
 | [Amazon Chime](https://appriseit.com/services/chime/) | chime://   | (TCP) 443   | chime://WebhookID/Token
+| [Delta Chat](https://appriseit.com/services/deltachat/) | deltachat:// or deltachats:// | (TCP) 25 or 587 | deltachat://user:pass@smtp.example.com/friend@example.org<br />deltachats://user:pass@smtp.example.com/friend1@example.org/friend2@example.org
 | [Discord](https://appriseit.com/services/discord/)  | discord://   | (TCP) 443   | discord://webhook_id/webhook_token<br />discord://avatar@webhook_id/webhook_token
 | [Dot.](https://appriseit.com/services/dot/)  | dot:// | (TCP) 443 | dot://apikey@device_id/text/<br />dot://apikey@device_id/image/<br />**Note**: `device_id` is the Quote/0 hardware serial
 | [Emby](https://appriseit.com/services/emby/)  | emby:// or embys:// | (TCP) 8096 | emby://user@hostname/<br />emby://user:password@hostname
@@ -361,7 +362,7 @@ Tags also support an optional **priority prefix** and **retry suffix**. In your 
 * **Escalation (no prefix)**: `-g alerts` dispatches priority-1 entries first. If they all succeed, Apprise returns early and never runs the priority-5 fallbacks. A failure in the lower-priority group triggers the next group as an escalation chain.
 * **Exclusive (with prefix)**: `-g "2:alerts"` notifies *only* services whose `alerts` tag has priority 2. No other priority levels are triggered.
 * **Per-call retry**: `-g "alerts:3"` retries each matched service up to 3 times on failure (overrides the service's own retry setting for this call only).
-* **Combined**: `-g "2:alerts:3"` -- exclusive priority-2 filter with up to 3 retries.
+* **Combined**: `-g "2:alerts:3"` selects only priority-2 services and allows up to 3 retries.
 
 ```bash
 # Escalation: priority-1 first; skip priority-5 if all succeed

--- a/apprise/attachment/http.py
+++ b/apprise/attachment/http.py
@@ -25,11 +25,14 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import contextlib
 import os
 import re
 from tempfile import NamedTemporaryFile
 import threading
+from typing import Any, Optional
 
 import requests
 
@@ -61,11 +64,17 @@ class AttachHTTP(AttachBase):
     # thread safe loading
     _lock = threading.Lock()
 
-    def __init__(self, headers=None, http_session=None, **kwargs):
-        """Initialize HTTP Object.
+    def __init__(
+        self,
+        headers: Optional[dict[str, str]] = None,
+        http_session: Optional[requests.Session] = None,
+        download_dir: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize an HTTP attachment.
 
-        headers can be a dictionary of key/value pairs that you want to
-        additionally include as part of the server headers to post with
+        ``headers`` adds request headers. ``download_dir`` selects the
+        temporary-file directory and defaults to the system location.
         """
         super().__init__(**kwargs)
 
@@ -83,8 +92,14 @@ class AttachHTTP(AttachBase):
         # Applications may provide a policy-aware Requests session.
         self.http_session = http_session
 
+        # Applications may store downloads outside the system temp directory.
+        self.download_dir = download_dir
+
         # Where our content is written to upon a call to download.
         self._temp_file = None
+
+        # Preserve storage failures for callers that need a detailed error.
+        self.download_error = None
 
         # Our Query String Dictionary; we use this to track arguments
         # specified that aren't otherwise part of this class
@@ -96,9 +111,11 @@ class AttachHTTP(AttachBase):
 
         return
 
-    def download(self, **kwargs):
+    def download(self, **kwargs: Any) -> bool:
         """Perform retrieval of the configuration based on the specified
         request."""
+
+        self.download_error = None
 
         if self.location == ContentLocation.INACCESSIBLE:
             # our content is inaccessible
@@ -166,11 +183,8 @@ class AttachHTTP(AttachBase):
                     # Handle Errors
                     r.raise_for_status()
 
-                    # raise_for_status() only covers 4xx/5xx; when redirect
-                    # following is disabled any 3xx must be treated as a
-                    # failure so we do not silently stream a redirect stub.
-                    # Using a status-code range rather than r.is_redirect
-                    # catches 3xx responses that lack a Location header.
+                    # Reject every 3xx response when redirects are disabled,
+                    # including responses without a Location header.
                     if not self.redirects and 300 <= r.status_code < 400:
                         self.logger.error(
                             "HTTP redirect encountered but redirect "
@@ -191,7 +205,7 @@ class AttachHTTP(AttachBase):
                         self.max_file_size > 0
                         and file_size > self.max_file_size
                     ):
-                        # The content retrieved is to large
+                        # The content is too large.
                         self.logger.error(
                             "HTTP response exceeds allowable maximum file"
                             f" length ({int(self.max_file_size / 1024)}KB):"
@@ -212,11 +226,11 @@ class AttachHTTP(AttachBase):
                     if result:
                         self.detected_name = result.group("name").strip()
 
-                    # Create a temporary file to work with; delete must be set
-                    # to False or it isn't compatible with Microsoft Windows
-                    # instances. In lieu of this, __del__ will clean up the
-                    # file for us.
-                    self._temp_file = NamedTemporaryFile(delete=False)  # noqa: SIM115
+                    # Keep the file on Windows; __del__ cleans it up.
+                    self._temp_file = NamedTemporaryFile(  # noqa: SIM115
+                        delete=False,
+                        dir=self.download_dir,
+                    )
 
                     # Get our chunk size
                     chunk_size = self.chunk_size
@@ -229,36 +243,29 @@ class AttachHTTP(AttachBase):
                     for chunk in r.iter_content(chunk_size=chunk_size):
                         # filter out keep-alive chunks
                         if chunk:
+                            # Enforce the limit while streaming because the
+                            # server may omit or misreport Content-Length.
+                            if (
+                                self.max_file_size > 0
+                                and bytes_written + len(chunk)
+                                > self.max_file_size
+                            ):
+                                # The downloaded content is too large.
+                                self.logger.error(
+                                    "HTTP response exceeds allowable"
+                                    " maximum file length"
+                                    f" ({int(self.max_file_size / 1024)}"
+                                    f"KB): {self.url(privacy=True)}"
+                                )
+
+                                # Invalidate any variables previously set
+                                self.invalidate()
+
+                                # Return False (signifying a failure)
+                                return False
+
                             self._temp_file.write(chunk)
                             bytes_written = self._temp_file.tell()
-
-                            # Prevent a case where Content-Length isn't
-                            # provided. In this case we don't want to fetch
-                            # beyond our limits
-                            if self.max_file_size > 0:
-                                if bytes_written > self.max_file_size:
-                                    # The content retrieved is to large
-                                    self.logger.error(
-                                        "HTTP response exceeds allowable"
-                                        " maximum file length"
-                                        f" ({int(self.max_file_size / 1024)}"
-                                        f"KB): {self.url(privacy=True)}"
-                                    )
-
-                                    # Invalidate any variables previously set
-                                    self.invalidate()
-
-                                    # Return False (signifying a failure)
-                                    return False
-
-                                elif (
-                                    bytes_written + chunk_size
-                                    > self.max_file_size
-                                ):
-                                    # Adjust out next read to accommodate up to
-                                    # our limit +1. This will prevent us from
-                                    # reading to much into our memory buffer
-                                    self.max_file_size - bytes_written + 1
 
                     # Ensure our content is flushed to disk for post-processing
                     self._temp_file.flush()
@@ -282,9 +289,11 @@ class AttachHTTP(AttachBase):
                 # Return False (signifying a failure)
                 return False
 
-            except OSError:
-                # IOError is present for backwards compatibility with Python
-                # versions older then 3.3.  >= 3.3 throw OSError now.
+            except OSError as e:
+                # IOError remains for compatibility; modern Python raises
+                # OSError here.
+
+                self.download_error = e
 
                 # Could not open and/or write the temporary file
                 self.logger.error(

--- a/apprise/persistent_store.py
+++ b/apprise/persistent_store.py
@@ -108,13 +108,10 @@ class CacheObject:
         expires: Union[bool, float, int, datetime, None] = None,
         persistent: Optional[bool] = None,
     ) -> None:
-        """Sets fields on demand, if set to none, then they are left as is.
+        """Replace the value and optionally update its metadata.
 
-        The intent of set is that it allows you to set a new a value and
-        optionally alter meta information against it.
-
-        If expires or persistent isn't specified then their previous values are
-        used.
+        Existing expiry and persistence settings remain when their arguments
+        are ``None``.
         """
 
         self.__value = value
@@ -455,13 +452,10 @@ class PersistentStore:
         compress: bool = True,
         expires: Union[bool, float, int] = False,
     ) -> Optional[bytes]:
-        """Returns the content of the persistent store object.
+        """Read stored content as bytes.
 
-        if refresh is set to True, then the file's modify time is updated
-        preventing it from getting caught in prune calls.  It's a means of
-        allowing it to persist and not get cleaned up in later prune calls.
-
-        Content is always returned as a byte object
+        With ``expires=False``, the entry is marked for renewal so pruning
+        does not remove it.
         """
         try:
             with self.open(key, mode="rb", compress=compress) as fd:
@@ -496,12 +490,9 @@ class PersistentStore:
         compress: bool = True,
         _recovery: bool = False,
     ) -> bool:
-        """Writes the content to the persistent store if it doesn't exceed our
-        filesize limit.
+        """Write content when it fits within the file-size limit.
 
-        Content is always written as a byte object
-
-        _recovery is reserved for internal usage and should not be changed
+        Content is stored as bytes. ``_recovery`` is for internal use.
         """
 
         if key is None:
@@ -513,8 +504,7 @@ class PersistentStore:
             )
 
         if not isinstance(data, (bytes, str)):
-            # One last check, we will accept read() objets with the expectation
-            # it will return a binary dataset
+            # Accept readable objects when they return bytes or text.
             if not (hasattr(data, "read") and callable(data.read)):
                 raise AppriseImproperlyConfigured(
                     f"Invalid data type {type(data)} provided to Persistent"
@@ -631,7 +621,7 @@ class PersistentStore:
             self.max_file_size > 0
             and (new_file_size + self.size() - prev_size) > self.max_file_size
         ):
-            # The content to store is to large
+            # The content to store is too large.
             logger.warning(
                 "Persistent content exceeds allowable maximum file length"
                 f" ({int(self.max_file_size / 1024)}KB); provide"
@@ -762,11 +752,7 @@ class PersistentStore:
         compress: bool = False,
         compresslevel: int = 9,
     ) -> Any:
-        """Returns an iterator to our our file within our namespace identified
-        by the key provided.
-
-        If no key is provided, then the default is used
-        """
+        """Open a stored file by key, using the default when omitted."""
 
         if key is None:
             key = self.base_key
@@ -777,8 +763,10 @@ class PersistentStore:
             )
 
         if self.__mode == PersistentStoreMode.MEMORY:
-            # Nothing further can be done
-            raise FileNotFoundError()
+            # Memory-only storage has no file that can be opened.
+            raise exception.AppriseFileNotFound(
+                "Persistent storage has no disk-backed file"
+            )
 
         io_file = os.path.join(self.__data_path, f"{key}{self.__extension}")
         try:
@@ -872,13 +860,10 @@ class PersistentStore:
         return True
 
     def clear(self, *args: str) -> Optional[bool]:
-        """Remove one or more cache entry by it's key.
+        """Remove selected cache keys, or all keys when none are given.
 
-            e.g: clear('key')
-                 clear('key1', 'key2', key-12')
-
-        Or clear everything:
-                 clear()
+        Examples: ``clear("key")``, ``clear("key1", "key2")``, or
+        ``clear()``.
         """
         if self._cache is None and not self.__load_cache():
             return False
@@ -1086,7 +1071,7 @@ class PersistentStore:
         force: bool = False,
         _recovery: bool = False,
     ) -> bool:
-        """Save's our cache to disk."""
+        """Save the cache to disk."""
 
         if self._cache is None or self.__mode == PersistentStoreMode.MEMORY:
             # nothing to do
@@ -1355,7 +1340,7 @@ class PersistentStore:
         namespace: Optional[Union[str, list[str]]] = None,
         closest: bool = True,
     ) -> list[str]:
-        """Scansk a path provided and returns namespaces detected."""
+        """Scan a path and return the detected namespaces."""
 
         logger.trace("Persistent path can of: %s", path)
 
@@ -1416,16 +1401,10 @@ class PersistentStore:
         expires: Optional[Union[int, float]] = None,
         action: bool = False,
     ) -> dict[str, list[dict[str, Union[str, bool]]]]:
-        """Prune persistent disk storage entries that are old and/or
-        unreferenced.
+        """Find expired persistent files below ``path``.
 
-        you must specify a path to perform the prune within
-
-        if one or more namespaces are provided, then pruning focuses ONLY on
-        those entries (if matched).
-
-        if action is not set to False, directories to be removed are returned
-        only
+        ``namespace`` limits the scan. ``action=False`` previews matches;
+        ``action=True`` removes them and records the result.
         """
 
         # Prepare our File Expiry
@@ -1639,7 +1618,7 @@ class PersistentStore:
             self.flush()
 
     def __delitem__(self, key: str) -> None:
-        """Remove a cache entry by it's key."""
+        """Remove a cache entry by its key."""
         if self._cache is None and not self.__load_cache():
             raise KeyError("Could not initialize cache")
 
@@ -1662,11 +1641,7 @@ class PersistentStore:
         return
 
     def __contains__(self, key: str) -> bool:
-        """Verify if our storage contains the key specified or not.
-
-        In additiont to this, if the content is expired, it is considered to be
-        not contained in the storage.
-        """
+        """Return whether storage contains a non-expired key."""
         if self._cache is None and not self.__load_cache():
             return False
 
@@ -1723,9 +1698,9 @@ class PersistentStore:
         cache: Optional[bool] = None,
         validate: bool = True,
     ) -> bool:
-        """Manages our file space and tidys it up.
+        """Delete selected files, cached data, or all stored content.
 
-        delete('key', 'key2') delete(all=True) delete(temp=True, cache=True)
+        Examples: ``delete("key", "key2")`` or ``delete(all=True)``.
         """
 
         # Our failure flag

--- a/apprise/plugins/deltachat.py
+++ b/apprise/plugins/deltachat.py
@@ -1,0 +1,135 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Delta Chat reuses Email delivery and adds its chat-specific headers.
+#
+# Steps to set this up:
+#  1. Get a mailbox for your bot. Any regular e-mail account works, but a
+#     purpose-built "chatmail" relay (see https://chatmail.at/) is what
+#     most Delta Chat users are already on.
+#  2. Note the account's SMTP host, port, username, and password.
+#  3. The person you want to notify must already have (or add) your bot's
+#     address as a contact in Delta Chat; a first message from an unknown
+#     address lands in their "Contact Requests" list until accepted.
+#
+#  Your Apprise URL should be assembled as:
+#     deltachat://user:password@smtp.example.com/friend@example.org
+#
+# Many chatmail relays reject unencrypted mail outright, so consider
+# pairing this with ?pgp=sign or ?pgp=encrypt. Email's PGP documentation
+# applies here unchanged.
+#
+# Resources:
+# - https://delta.chat/
+# - https://github.com/deltachat/spec (the e-mail-chat protocol)
+# - https://docs.autocrypt.org/level1.html (the Autocrypt header format)
+
+from ..common import NotifyFormat, NotifyType
+from .email.base import NotifyEmail, PGPMode
+
+# Longest excerpt of the message body placed in the outer Subject header
+DELTACHAT_SUBJECT_EXCERPT_LEN = 50
+
+
+class NotifyDeltaChat(NotifyEmail):
+    """Send Delta Chat messages through Email's SMTP and PGP support."""
+
+    # The default descriptive name associated with the Notification
+    service_name = "Delta Chat"
+
+    # The services URL
+    service_url = "https://delta.chat/"
+
+    # The default protocol
+    protocol = "deltachat"
+
+    # The default secure protocol
+    secure_protocol = "deltachats"
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = "https://appriseit.com/services/deltachat/"
+
+    # Delta Chat clients render messages as plain text
+    notify_format = NotifyFormat.TEXT
+
+    # Delta Chat has no separate subject/title field in the chat bubble
+    # itself, so let the framework merge the title into the body for us
+    title_maxlen = 0
+
+    @staticmethod
+    def parse_url(url):
+        """Parse an Email URL while always selecting plain text."""
+        results = NotifyEmail.parse_url(url)
+        if results:
+            results["format"] = "text"
+
+        return results
+
+    def send(
+        self,
+        body,
+        title="",
+        notify_type=NotifyType.INFO,
+        attach=None,
+        body_format=None,
+        **kwargs,
+    ):
+        """Perform Delta Chat Notification."""
+
+        # The framework has merged the title into the body. Build the chat
+        # subject from that combined text.
+        return super().send(
+            body=body,
+            title=self._chat_subject(body),
+            notify_type=notify_type,
+            attach=attach,
+            body_format=body_format,
+            **kwargs,
+        )
+
+    def _protocol_headers(self, body):
+        """Return Delta Chat's protocol headers."""
+
+        # Chat-Version is required by the spec on every outgoing message
+        return {"Chat-Version": "1.0"}
+
+    def _chat_subject(self, body):
+        """Build a ``Chat:`` subject without exposing protected content."""
+
+        if self.pgp_mode == PGPMode.ENCRYPT:
+            # Delta Chat recommends this placeholder when encrypted metadata
+            # is not carried with Memoryhole.
+            return "Chat: Encrypted message"
+
+        if self.pgp_mode == PGPMode.SIGN:
+            return "Chat:"
+
+        excerpt = " ".join(body.split())
+        if len(excerpt) > DELTACHAT_SUBJECT_EXCERPT_LEN:
+            excerpt = excerpt[:DELTACHAT_SUBJECT_EXCERPT_LEN] + "..."
+
+        return f"Chat: {excerpt}" if excerpt else "Chat:"

--- a/apprise/plugins/email/base.py
+++ b/apprise/plugins/email/base.py
@@ -25,7 +25,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import contextlib
 from datetime import datetime
 from email.header import Header
 from email.mime.application import MIMEApplication
@@ -35,7 +34,6 @@ from email.mime.text import MIMEText
 from email.utils import format_datetime, formataddr, make_msgid
 import re
 import smtplib
-import ssl
 from typing import Optional
 
 from ...common import NotifyFormat, NotifyType, PersistentStoreMode
@@ -61,6 +59,7 @@ from .common import (
     SecureMailMode,
     WebBaseLogin,
 )
+from .smtp import AppriseSMTPController
 
 
 class PGPMode:
@@ -472,14 +471,23 @@ class NotifyEmail(NotifyBase):
         # does not override a deliberate pgp=none choice
         pgp_mode_explicit = pgp_mode is not None
 
-        # Resolve PGP mode via prefix match (allows 'e', 'en', 'encrypt')
+        # Accept unambiguous prefixes such as "e" and "en". Treat "none"
+        # as "no", and reject unknown values instead of disabling PGP.
         if not pgp_mode:
             self.pgp_mode = PGP_MODE_DEFAULT
+
+        elif str(pgp_mode).lower() == "none":
+            self.pgp_mode = PGPMode.NONE
+
         else:
             self.pgp_mode = next(
                 (m for m in PGP_MODES if m.startswith(str(pgp_mode).lower())),
-                PGP_MODE_DEFAULT,
+                None,
             )
+            if self.pgp_mode is None:
+                msg = f"The Email PGP mode specified ({pgp_mode}) is invalid."
+                self.logger.warning(msg)
+                raise AppriseImproperlyConfigured(msg)
 
         # Parse string values such as "no" correctly.
         self.use_wkd = parse_bool(use_wkd)
@@ -529,6 +537,10 @@ class NotifyEmail(NotifyBase):
         )
 
         return
+
+    def _protocol_headers(self, body):
+        """Return protocol headers supplied by an Email subclass."""
+        return {}
 
     def apply_email_defaults(self, secure_mode=None, port=None, **kwargs):
         """Apply provider defaults inferred from the sender address."""
@@ -637,93 +649,67 @@ class NotifyEmail(NotifyBase):
         # error tracking (used for function return)
         has_error = False
 
-        # bind the socket variable to the current namespace
-        socket = None
-
         # Always call throttle before any remote server i/o is made
         self.throttle()
 
-        # Build an SSL context that honours our verify_certificate setting so
-        # that SMTPS/STARTTLS connections actually validate the remote server's
-        # certificate (and hostname) instead of silently accepting any
-        # certificate presented to us.
-        context = ssl.create_default_context()
-        if not self.verify_certificate:
-            context.check_hostname = False
-            context.verify_mode = ssl.CERT_NONE
-
         try:
-            self.logger.debug("Connecting to remote SMTP server...")
-            socket_func = smtplib.SMTP
-            socket_args = {}
-            if self.secure_mode == SecureMailMode.SSL:
-                self.logger.debug("Securing connection with SSL...")
-                socket_func = smtplib.SMTP_SSL
-                socket_args["context"] = context
+            with AppriseSMTPController(
+                host=self.smtp_host,
+                port=self.port,
+                secure_mode=self.secure_mode,
+                user=self.user,
+                password=self.password,
+                verify_certificate=self.verify_certificate,
+                socket_connect_timeout=self.socket_connect_timeout,
+            ) as smtp:
+                # Prepare our headers
+                headers = {
+                    "X-Application": self.app_id,
+                }
+                headers.update(self.headers)
 
-            socket = socket_func(
-                self.smtp_host,
-                self.port,
-                None,
-                timeout=self.socket_connect_timeout,
-                **socket_args,
-            )
+                # Add any protocol headers supplied by a subclass.
+                headers.update(self._protocol_headers(body))
 
-            if self.secure_mode == SecureMailMode.STARTTLS:
-                # Handle Secure Connections
-                self.logger.debug("Securing connection with STARTTLS...")
-                socket.starttls(context=context)
-
-            self.logger.trace("Login ID: {}".format(self.user))
-            if self.user and self.password:
-                # Apply Login credentials
-                self.logger.debug("Applying user credentials...")
-                socket.login(self.user, self.password)
-
-            # Prepare our headers
-            headers = {
-                "X-Application": self.app_id,
-            }
-            headers.update(self.headers)
-
-            # Resolve the active representation once for each prepared
-            # message. prepare_emails() then decides whether to build an
-            # HTML multipart message or a plain text message.
-            for message in NotifyEmail.prepare_emails(
-                subject=title,
-                body=body,
-                notify_format=self.resolve_format(body_format),
-                from_addr=self.from_addr,
-                to=self.targets,
-                cc=self.cc,
-                bcc=self.bcc,
-                reply_to=self.reply_to,
-                smtp_host=self.smtp_host,
-                attach=attach,
-                headers=headers,
-                names=self.names,
-                pgp=self.pgp,
-                pgp_mode=self.pgp_mode,
-                inline=self.inline,
-                tzinfo=self.tzinfo,
-            ):
-                try:
-                    socket.sendmail(
+                # Build each message in its resolved text or HTML format.
+                for message in NotifyEmail.prepare_emails(
+                    subject=title,
+                    body=body,
+                    notify_format=self.resolve_format(body_format),
+                    from_addr=self.from_addr,
+                    to=self.targets,
+                    cc=self.cc,
+                    bcc=self.bcc,
+                    reply_to=self.reply_to,
+                    smtp_host=self.smtp_host,
+                    attach=attach,
+                    headers=headers,
+                    names=self.names,
+                    pgp=self.pgp,
+                    pgp_mode=self.pgp_mode,
+                    inline=self.inline,
+                    tzinfo=self.tzinfo,
+                ):
+                    if smtp.sendmail(
                         self.from_addr[1], message.to_addrs, message.body
-                    )
+                    ):
+                        self.logger.info("Sent Email to %s", message.recipient)
 
-                    self.logger.info("Sent Email to %s", message.recipient)
+                    else:
+                        self.logger.warning(
+                            'Sending email to "%s" failed.',
+                            message.recipient,
+                        )
 
-                except (OSError, smtplib.SMTPException, RuntimeError) as e:
-                    self.logger.warning(
-                        'Sending email to "%s" failed.', message.recipient
-                    )
-                    self.logger.debug(f"Socket Exception: {e}")
+                        # Mark as failure
+                        has_error = True
 
-                    # Mark as failure
-                    has_error = True
-
-        except (OSError, smtplib.SMTPException, RuntimeError) as e:
+        except (
+            OSError,
+            smtplib.SMTPException,
+            RuntimeError,
+            AppriseImproperlyConfigured,
+        ) as e:
             self.logger.warning(
                 'Connection error while submitting email to "%s"',
                 self.smtp_host,
@@ -738,17 +724,6 @@ class NotifyEmail(NotifyBase):
 
             # Mark as failure
             has_error = True
-
-        finally:
-            # Gracefully terminate the connection with the server
-            if socket is not None:
-                with contextlib.suppress(
-                    OSError, smtplib.SMTPException, RuntimeError
-                ):
-                    # Handles a failed TLS handshake that may have already
-                    # invalidated the socket.
-                    socket.quit()
-                    pass
 
         # Reduce our dictionary (eliminate expired keys if any)
         self.pgp.prune()
@@ -986,13 +961,17 @@ class NotifyEmail(NotifyBase):
             # Clear invalid hosts so a later step can infer one.
             results["host"] = ""
 
-        # Unknown PGP modes fall back to the default.
+        # Accept PGP mode prefixes and treat "none" as "no".
         pgp_raw = results["qsd"].get("pgp", "")
         if pgp_raw:
-            results["pgp_mode"] = next(
+            pgp_mode = next(
                 (m for m in PGP_MODES if m.startswith(str(pgp_raw).lower())),
-                PGP_MODE_DEFAULT,
+                None,
             )
+            if pgp_mode is None:
+                # Let __init__ report invalid and removed boolean values.
+                pgp_mode = pgp_raw
+            results["pgp_mode"] = pgp_mode
 
         # Get Web Key Directory flag
         if "wkd" in results["qsd"] and results["qsd"]["wkd"]:
@@ -1102,17 +1081,15 @@ class NotifyEmail(NotifyBase):
         cc: Optional[set] = None,
         bcc: Optional[set] = None,
         reply_to: Optional[set] = None,
-        # Providing an SMTP Host helps improve Email Message-ID
-        # and avoids getting flagged as spam
+        # SMTP host used in the Message-ID
         smtp_host=None,
-        # Can be either 'html' or 'text'
+        # Either HTML or plain text
         notify_format=NotifyFormat.HTML,
         attach=None,
         headers: Optional[dict] = None,
-        # Names can be a dictionary
+        # Display names keyed by address
         names=None,
-        # Pretty Good Privacy Support; Pass in an
-        # ApprisePGPController if you wish to use it
+        # Optional PGP controller
         pgp=None,
         # PGP mode string (PGPMode.NONE / PGPMode.SIGN / PGPMode.ENCRYPT)
         pgp_mode=PGP_MODE_DEFAULT,
@@ -1122,30 +1099,16 @@ class NotifyEmail(NotifyBase):
         # Use the system timezone when none is provided.
         tzinfo=None,
     ):
-        """
-        Generator for emails
-            from_addr: must be in format: (from_name, from_addr)
-            to: must be in the format:
-                 [(to_name, to_addr), (to_name, to_addr)), ...]
-            cc: must be a set of email addresses
-            bcc: must be a set of email addresses
-            reply_to: must be either None, or an email address
-            smtp_host: This is used to generate the email's Message-ID. Set
-                       this correctly to avoid getting flagged as Spam
-            notify_format: can be either 'text' or 'html'
-            attach: must be of class AppriseAttachment
-            headers: Optionally provide a dictionary of additional headers you
-                     would like to include in the email payload
-            names: This is a dictionary of email addresses as keys and the
-                   Names to associate with them when sending the email.
-                   This is cross referenced for the cc and bcc lists
-            pgp:      ApprisePGPController for signing and/or encrypting
-                      email via Pretty Good Privacy.  Pass None to skip.
-            pgp_mode: PGPMode string controlling what PGP operation to
-                      perform.  PGPMode.ENCRYPT encrypts (existing
-                      behaviour).  PGPMode.SIGN signs with the sender's
-                      private key and opportunistically encrypts when a
-                      recipient public key is available.
+        """Yield prepared email messages.
+
+        - ``from_addr`` is ``(name, address)``; ``to`` contains those pairs.
+        - ``cc`` and ``bcc`` are address sets; ``reply_to`` is one address.
+        - ``smtp_host`` forms the Message-ID, and ``notify_format`` selects
+          plain text or HTML.
+        - ``attach`` contains Apprise attachments; ``headers`` adds headers.
+        - ``names`` maps addresses to display names for CC and BCC entries.
+        - ``pgp`` supplies signing or encryption. ``PGPMode.SIGN`` may also
+          encrypt when a recipient key is available.
         """
         if not to:
             # There is no one to email; we're done
@@ -1384,6 +1347,10 @@ class NotifyEmail(NotifyBase):
 
                 base = mixed
 
+            # Suppress a custom Autocrypt value only when the controller
+            # supplies one of its own.
+            autocrypt_added = False
+
             if pgp and pgp_mode == PGPMode.SIGN:
                 logger.debug("Securing Email with PGP Signature")
                 # RFC 3156 requires the signature to be computed over the CRLF
@@ -1447,14 +1414,6 @@ class NotifyEmail(NotifyBase):
                         protocol="application/pgp-encrypted",
                     )
 
-                    # Autocrypt header for DeltaChat / compatible clients
-                    enc.add_header(
-                        "Autocrypt",
-                        "addr={}; prefer-encrypt=mutual".format(
-                            formataddr((False, to_addr), charset="utf-8")
-                        ),
-                    )
-
                     # Version identifier part (required by RFC 3156)
                     ver_part = MIMEText("Version: 1", "plain")
                     ver_part.set_type("application/pgp-encrypted")
@@ -1468,6 +1427,13 @@ class NotifyEmail(NotifyBase):
                     # Replace base with the fully encrypted container
                     base = enc
 
+                # Advertise our key on the outer message so an Autocrypt-aware
+                # recipient can encrypt future replies.
+                autocrypt = pgp.autocrypt_header()
+                if autocrypt:
+                    base.add_header("Autocrypt", autocrypt)
+                    autocrypt_added = True
+
             elif pgp and pgp_mode == PGPMode.ENCRYPT:
                 logger.debug("Securing Email with PGP Encryption")
                 # Set our header information to include in the encryption
@@ -1479,13 +1445,17 @@ class NotifyEmail(NotifyBase):
                     subject, NotifyEmail._get_charset(subject)
                 )
 
-                # Apply our encryption
-                encrypted_content = pgp.encrypt(base.as_string(), to_addr)
+                # External recipients need an existing key. Self-sends may
+                # generate the sender's key when pgp_autogen permits it.
+                autogen = (
+                    None if to_addr.lower() == from_addr[1].lower() else False
+                )
+                encrypted_content = pgp.encrypt(
+                    base.as_string(), to_addr, autogen=autogen
+                )
 
                 if not encrypted_content:
-                    # Unable to send notification.  Include the plugin-specific
-                    # hint here (pgp.py logs only generic debug detail so it
-                    # stays reusable across plugins).
+                    # Give Email users a plugin-specific recovery hint.
                     msg = (
                         "Unable to encrypt email via PGP; supply a public key"
                         " via pgppub= or place one in the cache directory"
@@ -1498,24 +1468,30 @@ class NotifyEmail(NotifyBase):
                     "encrypted", protocol="application/pgp-encrypted"
                 )
 
-                # Store Autocrypt header (DeltaChat Support)
-                base.add_header(
-                    "Autocrypt",
-                    f"addr={formataddr((False, to_addr), charset='utf-8')}; "
-                    "prefer-encrypt=mutual",
-                )
+                # Advertise our key for encrypted replies.
+                autocrypt = pgp.autocrypt_header()
+                if autocrypt:
+                    base.add_header("Autocrypt", autocrypt)
+                    autocrypt_added = True
 
                 # Set Encryption Info Part
                 enc_payload = MIMEText("Version: 1", "plain")
                 enc_payload.set_type("application/pgp-encrypted")
                 base.attach(enc_payload)
 
+                # Set Encrypted Data Part
                 enc_payload = MIMEBase("application", "octet-stream")
                 enc_payload.set_payload(encrypted_content)
                 base.attach(enc_payload)
 
-            # Apply any provided custom headers
+            # Header names are case-insensitive; keep only the first
+            # Autocrypt value unless the controller supplied its own.
+            autocrypt_seen = autocrypt_added
             for k, v in headers.items():
+                if k.strip().lower() == "autocrypt":
+                    if autocrypt_seen:
+                        continue
+                    autocrypt_seen = True
                 base[k] = Header(v, NotifyEmail._get_charset(v))
 
             base["Subject"] = Header(
@@ -1540,7 +1516,5 @@ class NotifyEmail(NotifyBase):
 
     @staticmethod
     def runtime_deps():
-        """Return a tuple of top-level Python package names that this plugin
-        imported as optional runtime dependencies.
-        """
+        """Return this plugin's optional package names."""
         return ("pgpy",)

--- a/apprise/plugins/email/common.py
+++ b/apprise/plugins/email/common.py
@@ -29,56 +29,38 @@
 import dataclasses
 
 from ...exception import ApprisePluginException
+from .smtp import SMTP_DEFAULT_PORTS, SMTPSecureMode
 
 
 class AppriseEmailException(ApprisePluginException):
-    """
-    Thrown when there is an error with the Email Attachment
-    """
+    """Raised when an email cannot be prepared."""
 
     def __init__(self, message, error_code=601):
         super().__init__(message, error_code=error_code)
 
 
 class WebBaseLogin:
-    """
-    This class is just used in conjunction of the default emailers
-    to best formulate a login to it using the data detected
-    """
+    """Identify the login format expected by an email provider."""
 
     # User Login must be Email Based
     EMAIL = "Email"
 
-    # User Login must UserID Based
+    # Login must use a user ID
     USERID = "UserID"
 
 
-# Secure Email Modes
-class SecureMailMode:
-    INSECURE = "insecure"
-    SSL = "ssl"
-    STARTTLS = "starttls"
+# Keep the established email name as an alias for the shared SMTP modes.
+SecureMailMode = SMTPSecureMode
 
-
-# Define all of the secure modes (used during validation)
+# Preserve the existing mode-to-default-port format for email callers.
 SECURE_MODES = {
-    SecureMailMode.STARTTLS: {
-        "default_port": 587,
-    },
-    SecureMailMode.SSL: {
-        "default_port": 465,
-    },
-    SecureMailMode.INSECURE: {
-        "default_port": 25,
-    },
+    mode: {"default_port": port} for mode, port in SMTP_DEFAULT_PORTS.items()
 }
 
 
 @dataclasses.dataclass
 class EmailMessage:
-    """
-    Our message structure
-    """
+    """Prepared email payload and recipients."""
 
     recipient: str
     to_addrs: list[str]

--- a/apprise/plugins/email/smtp.py
+++ b/apprise/plugins/email/smtp.py
@@ -1,0 +1,186 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Shared SMTP connection handling for Email and its subclasses.
+
+import contextlib
+import smtplib
+import ssl
+from typing import Optional
+
+from ...exception import AppriseImproperlyConfigured
+from ...logger import logger
+
+
+class SMTPSecureMode:
+    """SMTP transport security mode."""
+
+    # No transport security at all
+    INSECURE = "insecure"
+
+    # Implicit TLS from the first byte of the connection
+    SSL = "ssl"
+
+    # Plaintext connection upgraded to TLS via STARTTLS
+    STARTTLS = "starttls"
+
+
+# Every valid secure mode
+SMTP_SECURE_MODES = (
+    SMTPSecureMode.STARTTLS,
+    SMTPSecureMode.SSL,
+    SMTPSecureMode.INSECURE,
+)
+
+# Default SMTP submission port per security mode
+SMTP_DEFAULT_PORTS = {
+    SMTPSecureMode.STARTTLS: 587,
+    SMTPSecureMode.SSL: 465,
+    SMTPSecureMode.INSECURE: 25,
+}
+
+# The exceptions every SMTP operation in this module guards against
+SMTP_EXCEPTIONS = (OSError, smtplib.SMTPException, RuntimeError)
+
+
+class AppriseSMTPController:
+    """Manage one authenticated SMTP connection within a context manager.
+
+    ``sendmail()`` returns false for delivery errors. Connection and login
+    errors leave the context so the plugin can report the whole send as failed.
+
+        with AppriseSMTPController(
+            host=host, port=port, secure_mode=secure_mode,
+            user=user, password=password,
+        ) as smtp:
+            for target in targets:
+                message = build_message(target)
+                if not smtp.sendmail(from_addr, [target], message):
+                    has_error = True
+    """
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        secure_mode: str,
+        user: Optional[str] = None,
+        password: Optional[str] = None,
+        verify_certificate: bool = True,
+        socket_connect_timeout: int = 15,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.secure_mode = secure_mode
+        self.user = user
+        self.password = password
+        self.verify_certificate = verify_certificate
+        self.socket_connect_timeout = socket_connect_timeout
+
+        # Bind our socket variable to the current namespace
+        self._socket = None
+
+    def __enter__(self) -> "AppriseSMTPController":
+        """Connects, secures, and authenticates the SMTP session."""
+
+        if self.secure_mode not in SMTP_SECURE_MODES:
+            # Reject unknown modes rather than silently using plain SMTP.
+            raise AppriseImproperlyConfigured(
+                f"Invalid SMTP secure mode: {self.secure_mode!r}"
+            )
+
+        # Configure certificate and hostname checks for encrypted connections.
+        context = ssl.create_default_context()
+        if not self.verify_certificate:
+            context.check_hostname = False
+            context.verify_mode = ssl.CERT_NONE
+
+        try:
+            logger.debug("Connecting to remote SMTP server...")
+            socket_func = smtplib.SMTP
+            socket_args = {}
+            if self.secure_mode == SMTPSecureMode.SSL:
+                logger.debug("Securing connection with SSL...")
+                socket_func = smtplib.SMTP_SSL
+                socket_args["context"] = context
+
+            self._socket = socket_func(
+                self.host,
+                self.port,
+                None,
+                timeout=self.socket_connect_timeout,
+                **socket_args,
+            )
+
+            if self.secure_mode == SMTPSecureMode.STARTTLS:
+                # Handle Secure Connections
+                logger.debug("Securing connection with STARTTLS...")
+                self._socket.starttls(context=context)
+
+            logger.trace("Login ID: %s", self.user)
+            if self.user and self.password:
+                # Apply Login credentials
+                logger.debug("Applying user credentials...")
+                self._socket.login(self.user, self.password)
+
+        except SMTP_EXCEPTIONS:
+            # Close a connection that failed during STARTTLS or login.
+            if self._socket is not None:
+                with contextlib.suppress(*SMTP_EXCEPTIONS):
+                    self._socket.quit()
+                self._socket = None
+            raise
+
+        return self
+
+    def sendmail(self, from_addr: str, to_addrs: list, message: str) -> bool:
+        """Send one prepared message and return whether it succeeded."""
+
+        try:
+            # A non-empty result lists recipients SMTP refused.
+            refused = self._socket.sendmail(from_addr, to_addrs, message)
+
+        except SMTP_EXCEPTIONS as e:
+            logger.debug("Socket Exception: %s", str(e))
+            return False
+
+        if refused:
+            for addr, (code, resp) in refused.items():
+                logger.warning(
+                    "SMTP recipient %s was refused: %s %s", addr, code, resp
+                )
+            return False
+
+        return True
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Gracefully terminates the connection with the server."""
+
+        if self._socket is not None:
+            with contextlib.suppress(*SMTP_EXCEPTIONS):
+                # The socket may already be invalid after a TLS failure.
+                self._socket.quit()

--- a/apprise/plugins/sogs.py
+++ b/apprise/plugins/sogs.py
@@ -34,22 +34,19 @@
 #  - https://github.com/session-foundation/session-pysogs
 #
 # Setting up a bot account
-# -------------------------
 # 1. Generate a 32-byte Ed25519 seed and note its 64-character hex encoding.
 #    In Python:
 #        import os; print(os.urandom(32).hex())
-#    Keep this value secret -- it is your bot's seed.
+#    Keep this value secret because it controls your bot.
 #
 # 2. Find the SOGS public_key from any Session group join link.
 #    The link looks like:
 #        https://open.getsession.org/discussion?public_key=a03c383c...
 #    The value after "public_key=" is the 64-hex-char public_key.
 #
-# 3. Find the room token -- the path segment of the join link above
-#    ("discussion" in the example).
+# 3. Find the room token in the join-link path ("discussion" above).
 #
 # Apprise URL format
-# -------------------
 # Secure (HTTPS):
 #    sessions://{public_key}:{seed}@{host}/{room}
 #    sessions://{public_key}:{seed}@{host}/{room1}/{room2}
@@ -186,6 +183,10 @@ class NotifySessionOGS(NotifyBase):
     # 2000-character soft limit (Session app displays long messages fine).
     body_maxlen = 2000
 
+    # Stop reading a response once it grows beyond a normal
+    # acknowledgement; protects against a hostile or compromised server.
+    max_response_size = 32768
+
     # Set our global enabled flag.
     enabled = NOTIFY_SESSIONOGS_ENABLED
 
@@ -267,17 +268,6 @@ class NotifySessionOGS(NotifyBase):
         """Initialize Session Open Group Server Object."""
         super().__init__(**kwargs)
 
-        # Raise a clear error when the cryptography library is absent so
-        # callers get an explicit message rather than a confusing
-        # AttributeError from None.from_private_bytes().
-        if not NOTIFY_SESSIONOGS_ENABLED:
-            msg = (
-                "The cryptography library is required for SOGS "
-                "notifications.  Install it with: pip install cryptography"
-            )
-            self.logger.warning(msg)
-            raise ImportError(msg)
-
         # Validate the public key (64-char hex Curve25519 public key).
         _pk = (public_key or "").strip().lower()
         if not IS_PUBLIC_KEY.match(_pk):
@@ -304,15 +294,18 @@ class NotifySessionOGS(NotifyBase):
         # Store the validated seed hex string.
         self.seed = _seed
 
-        # Derive the Ed25519 signing key from the seed.
-        self._signing_key = Ed25519PrivateKey.from_private_bytes(
-            bytes.fromhex(self.seed)
-        )
-
-        # Derive the 32-byte Ed25519 public key for auth headers.
-        self._bot_pubkey_bytes = self._signing_key.public_key().public_bytes(
-            Encoding.Raw, PublicFormat.Raw
-        )
+        self._signing_key = None
+        self._bot_pubkey_bytes = None
+        if NOTIFY_SESSIONOGS_ENABLED:
+            # Prepare the signing identity used by every request.
+            self._signing_key = Ed25519PrivateKey.from_private_bytes(
+                bytes.fromhex(self.seed)
+            )
+            public_key = self._signing_key.public_key()
+            self._bot_pubkey_bytes = public_key.public_bytes(
+                Encoding.Raw,
+                PublicFormat.Raw,
+            )
 
         # Parse and validate the room token list.
         self.rooms = []
@@ -334,13 +327,10 @@ class NotifySessionOGS(NotifyBase):
             raise AppriseImproperlyConfigured(msg)
 
     def _sogs_auth_headers(self, method, path, body_bytes=None):
-        """
-        Build the four X-SOGS-* authentication headers for a request.
+        """Build the four ``X-SOGS-*`` authentication headers.
 
-        The signature covers:
-            SERVER_KEY || NONCE || TIMESTAMP || METHOD || PATH [|| HBODY]
-        where HBODY is the 64-byte blake2b hash of the request body when
-        the body is non-empty.  The signing key is the bot's Ed25519 key.
+        The Ed25519 signature covers the server key, nonce, timestamp, method,
+        path, and the body hash when content is present.
         """
         # Generate a fresh 16-byte random nonce for each request.
         nonce = os.urandom(16)
@@ -376,6 +366,12 @@ class NotifySessionOGS(NotifyBase):
     def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
         """Perform Session Open Group Server Notification."""
 
+        if not NOTIFY_SESSIONOGS_ENABLED:
+            self.logger.warning(
+                "SOGS notifications require the cryptography library."
+            )
+            return False
+
         # Encode as a Session protocol protobuf message with padding.
         # title_maxlen=0 ensures the framework already prepended any title.
         msg_data = _build_session_message(body)
@@ -399,6 +395,28 @@ class NotifySessionOGS(NotifyBase):
                 has_error = True
 
         return not has_error
+
+    @staticmethod
+    def _read_bounded(r, max_bytes):
+        """Read a response body, stopping once it exceeds max_bytes.
+
+        Returns None (and closes the connection early) if the body grows
+        past the limit, instead of buffering the whole thing first.
+        """
+        chunks = []
+        total = 0
+        try:
+            for chunk in r.iter_content(chunk_size=8192):
+                if not chunk:
+                    continue
+                total += len(chunk)
+                if total > max_bytes:
+                    return None
+                chunks.append(chunk)
+            return b"".join(chunks)
+
+        finally:
+            r.close()
 
     def _post(self, room, body_bytes):
         """POST a notification to a single SOGS room."""
@@ -443,16 +461,29 @@ class NotifySessionOGS(NotifyBase):
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
                 allow_redirects=self.redirects,
+                stream=True,
             )
+
+            # Read the body incrementally and stop early if it grows too
+            # large, instead of letting Requests buffer it all up front.
+            body = self._read_bounded(r, self.max_response_size)
+            if body is None:
+                self.logger.warning(
+                    "SOGS response from room %r exceeds %d bytes; "
+                    "not parsing it.",
+                    room,
+                    self.max_response_size,
+                )
+                return False
 
             # Parse response body defensively.
             try:
-                content = loads(r.content)
+                content = loads(body)
             except (AttributeError, TypeError, ValueError):
                 content = {}
                 self.logger.debug(
                     "Failed to parse SOGS JSON response; body: %r",
-                    (r.content or b"")[:2000],
+                    body[:2000],
                 )
 
             if r.status_code not in (
@@ -470,7 +501,7 @@ class NotifySessionOGS(NotifyBase):
                     ", " if status_str else "",
                     r.status_code,
                 )
-                self.logger.debug("Response Details:\r\n%s", r.content)
+                self.logger.debug("Response Details:\r\n%s", body)
                 return False
 
             self.logger.info("Sent SOGS notification to room %r.", room)
@@ -587,8 +618,5 @@ class NotifySessionOGS(NotifyBase):
 
     @staticmethod
     def runtime_deps():
-        """
-        Return a tuple of top-level Python package names that this
-        plugin imported as optional runtime dependencies.
-        """
+        """Return this plugin's optional package names."""
         return ("cryptography",)

--- a/apprise/utils/pgp.py
+++ b/apprise/utils/pgp.py
@@ -25,6 +25,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from base64 import b64encode
 from datetime import datetime, timedelta, timezone
 import hashlib
 import os
@@ -38,14 +39,13 @@ from ..logger import logger
 def _ensure_imghdr_shim():
     """Install a minimal imghdr shim when the module is absent.
 
-    pgpy 0.6.0 imports imghdr, which was removed from the standard
-    library in Python 3.13 (PEP 594). pgpy's only use of imghdr is
-    ImageEncoding.encodingof(), which Apprise never calls. Returning
-    None from what() is the same safe fallback the library uses
-    internally for non-JPEG data.
+    PGPy 0.6.0 still imports this module after Python 3.13 removed it.
+    Apprise does not use PGPy's image detection, so a minimal fallback is
+    sufficient.
     """
     try:
         import imghdr  # noqa: F401
+
     except ImportError:
         import sys
         import types
@@ -71,24 +71,19 @@ except ImportError:
 
 
 class ApprisePGPException(ApprisePluginException):
-    """Thrown when there is an error with the Pretty Good Privacy
-    Controller."""
+    """Raised when PGP processing fails."""
 
     def __init__(self, message, error_code=602):
         super().__init__(message, error_code=error_code)
 
 
 class ApprisePGPController:
-    """Pretty Good Privacy Controller Tool for the Apprise Library."""
+    """Manage PGP keys, signing, encryption, and discovery."""
 
-    # There is no reason a PGP Public Key should exceed 8K in size
-    # If it is more than this, then it is not accepted
+    # Keep public-key attachment reads bounded.
     max_pgp_public_key_size = 8000
 
-    # Private keys can be materially larger than public keys, especially for
-    # 4096-bit RSA or keys carrying multiple subkeys and UIDs; 32K is
-    # generous enough to accommodate all realistic cases without being
-    # unbounded.
+    # Allow larger private keys while keeping attachment reads bounded.
     max_pgp_private_key_size = 32000
 
     def __init__(
@@ -101,12 +96,10 @@ class ApprisePGPController:
         wkd=None,
         **kwargs,
     ):
-        """Path should be the directory keys can be written and read from such
-        as <notifyobject>.store.path.
+        """Configure PGP key storage and discovery.
 
-        Optionally additionally specify a pub_keyfile and/or prv_keyfile to
-        use explicit key files, and/or an AppriseWKDController to enable Web
-        Key Directory key discovery when no local key is found.
+        ``path`` stores generated keys. Explicit key files and a WKD
+        controller may provide keys from other sources.
         """
 
         # PGP hash
@@ -149,8 +142,7 @@ class ApprisePGPController:
             # Add our definition to our pgp_key reference
             self._prv_keyfile.add(prv_keyfile)
 
-            # Enforce a private-key-specific size limit; private keys can be
-            # larger than public keys (4096-bit RSA, multiple subkeys/UIDs)
+            # Private keys may contain extra identities and subkeys.
             self._prv_keyfile[0].max_file_size = self.max_pgp_private_key_size
 
         else:
@@ -158,17 +150,6 @@ class ApprisePGPController:
 
     def keygen(self, email=None, name=None, force=False):
         """Generates a set of keys based on email configured."""
-
-        try:
-            # Create a new RSA key pair with 2048-bit strength
-            key = pgpy.PGPKey.new(
-                pgpy.constants.PubKeyAlgorithm.RSAEncryptOrSign, 2048
-            )
-
-        except NameError:
-            # PGPy not installed
-            logger.debug("PGPy not installed; keygen disabled")
-            return False
 
         if self._pub_keyfile is not None or not self.path:
             logger.trace(
@@ -179,6 +160,21 @@ class ApprisePGPController:
                     else "no-write-path"
                 ),
             )
+            return False
+
+        try:
+            # Autocrypt uses a signing primary key and a separate encryption
+            # subkey, which is attached below.
+            key = pgpy.PGPKey.new(
+                pgpy.constants.PubKeyAlgorithm.RSAEncryptOrSign, 2048
+            )
+            subkey = pgpy.PGPKey.new(
+                pgpy.constants.PubKeyAlgorithm.RSAEncryptOrSign, 2048
+            )
+
+        except NameError:
+            # PGPy not installed
+            logger.debug("PGPy not installed; keygen disabled")
             return False
 
         if not name:
@@ -211,16 +207,25 @@ class ApprisePGPController:
             # Ensure our key no longer exists
             del self.__key_lookup[lookup_key]
 
-        # Add the user ID to the key
+        # Add a signing and certification identity to the primary key.
         key.add_uid(
             uid,
             usage={
                 pgpy.constants.KeyFlags.Sign,
-                pgpy.constants.KeyFlags.EncryptCommunications,
+                pgpy.constants.KeyFlags.Certify,
             },
             hashes=[pgpy.constants.HashAlgorithm.SHA256],
             ciphers=[pgpy.constants.SymmetricKeyAlgorithm.AES256],
             compression=[pgpy.constants.CompressionAlgorithm.ZLIB],
+        )
+
+        # Bind the encryption-capable subkey to the primary key
+        key.add_subkey(
+            subkey,
+            usage={
+                pgpy.constants.KeyFlags.EncryptCommunications,
+                pgpy.constants.KeyFlags.EncryptStorage,
+            },
         )
 
         try:
@@ -272,12 +277,7 @@ class ApprisePGPController:
         return True
 
     def _pub_key_candidates(self, *emails):
-        """Returns the ordered list of candidate public-key filenames to
-        search, highest priority first.
-
-        Shared by public_keyfile() and the diagnostic warning in public_key()
-        so both always reflect exactly the same search order.
-        """
+        """Return public-key filenames in search order."""
 
         # Base candidates, lowest priority first
         fnames = [
@@ -287,16 +287,13 @@ class ApprisePGPController:
             "pub.asc",
         ]
 
-        # Merge the controller's own email with any caller-supplied addresses.
-        # Two filenames are prepended per address: localpart shorthand is
-        # inserted at index 0 first, then the full address is also inserted
-        # at index 0 -- so the full address lands ahead of the localpart in
-        # the list (full address has higher priority as it is more specific).
-        all_emails = [self.email, *emails] if self.email else list(emails)
+        # Use the sender only when no recipient address was supplied.
+        all_emails = (
+            list(emails) if emails else ([self.email] if self.email else [])
+        )
         for em in all_emails:
-            # Localpart shorthand (e.g. "chris-pub.asc")
+            # Prefer the full address over its local-part shorthand.
             fnames.insert(0, f"{em.split('@')[0].lower()}-pub.asc")
-            # Full lowercase email (e.g. "chris@nuxref.com-pub.asc")
             fnames.insert(0, f"{em.lower()}-pub.asc")
 
         return fnames
@@ -327,8 +324,7 @@ class ApprisePGPController:
         return fnames
 
     def public_keyfile(self, *emails):
-        """Returns the first match of a useable public key based emails
-        provided."""
+        """Return the first usable public-key path for these addresses."""
 
         if not PGP_SUPPORT:
             msg = "PGP Support unavailable; install PGPy library"
@@ -366,12 +362,10 @@ class ApprisePGPController:
         )
 
     def private_keyfile(self):
-        """Returns the path to the private key file if one can be found.
+        """Return the selected private-key path.
 
-        Returns the explicit path when prv_keyfile was provided, looks for a
-        matching auto-generated key in self.path otherwise.  Returns False
-        when an explicit keyfile was given but could not be accessed, and
-        None when no key file could be located at all.
+        An inaccessible explicit key returns ``False``. A missing discovered
+        key returns ``None``.
         """
 
         if self._prv_keyfile is not None:
@@ -405,12 +399,9 @@ class ApprisePGPController:
         )
 
     def private_key(self):
-        """Loads and returns the PGP private key object.
+        """Load an explicit or stored PGP private key.
 
-        Reads from the explicit prv_keyfile if one was provided, otherwise
-        scans the persistent storage path for an auto-generated private key.
-        Returns None when no usable private key could be found or loaded.
-        Passphrase-protected keys are not supported and will be rejected.
+        Returns ``None`` for missing, unusable, or passphrase-protected keys.
         """
 
         # Locate the private key file
@@ -419,12 +410,12 @@ class ApprisePGPController:
             if path is False:
                 # An explicit pgpprv= file was given but could not be accessed;
                 # keep as WARNING because the user made an explicit choice that
-                # failed -- this is always actionable regardless of plugin
+                # failed. This is actionable regardless of the plugin.
                 logger.warning("PGP Private Key could not be accessed")
 
             elif self.path:
                 # path is None: storage was searched but nothing matched.
-                # Only hash + filename is shown -- never an absolute path.
+                # Show only the namespace hash and filename.
                 ns = os.path.basename(self.path)
                 candidates = self._prv_key_candidates()
                 shown = ", ".join(f"'{ns}/{fn}'" for fn in candidates[:4])
@@ -436,7 +427,7 @@ class ApprisePGPController:
                 )
 
             else:
-                # No storage path at all -- nothing was searched
+                # No storage path was available to search.
                 logger.debug("No PGP private key found")
 
             return None
@@ -452,7 +443,7 @@ class ApprisePGPController:
             if entry["expires"] > datetime.now(timezone.utc):
                 return entry["private_key"]
 
-            # Expired -- remove and re-load below
+            # Remove expired entries before reloading.
             del self.__key_lookup[cache_key]
 
         try:
@@ -490,6 +481,15 @@ class ApprisePGPController:
             )
             return None
 
+        if private_key.is_public:
+            # Reject a public-only file supplied through pgpprv=.
+            logger.warning(
+                "PGP Private Key file does not contain secret key "
+                "material: %s",
+                path,
+            )
+            return None
+
         # Cache the successfully loaded key
         self.__key_lookup[cache_key] = {
             "private_key": private_key,
@@ -499,13 +499,10 @@ class ApprisePGPController:
         return private_key
 
     def sign(self, message):
-        """Creates a detached PGP signature for the given message string.
+        """Create a detached PGP signature.
 
-        Returns a (signature_str, micalg) tuple on success where
-        signature_str is the armored PGP signature block and micalg is the
-        MIME hash algorithm label (e.g. 'pgp-sha256') for the
-        Content-Type header of the multipart/signed container.
-        Returns None when signing is not possible.
+        Returns the armored signature and MIME hash label, or ``None`` when
+        signing is unavailable.
         """
 
         # Load our private key
@@ -606,8 +603,7 @@ class ApprisePGPController:
         return None
 
     def public_key(self, *emails, autogen=None):
-        """Opens a spcified pgp public file and returns the key from it which
-        is used to encrypt the message."""
+        """Load the public key used to encrypt a message."""
         path = self.public_keyfile(*emails)
         if not path:
             # Try Web Key Directory before falling back to autogen
@@ -623,11 +619,7 @@ class ApprisePGPController:
                     # We should get a hit now
                     return self.public_key(*emails)
 
-            # All discovery methods exhausted (local file, WKD, autogen).
-            # Log at DEBUG so the caller's warning (with plugin-specific hints)
-            # is the only user-visible message.  Only the namespace hash +
-            # filename is shown -- never an absolute path -- so no sensitive
-            # filesystem layout is revealed.
+            # Keep discovery details at DEBUG and avoid exposing full paths.
             if self.path:
                 ns = os.path.basename(self.path)
                 candidates = self._pub_key_candidates(*emails)
@@ -679,13 +671,130 @@ class ApprisePGPController:
         }
         return public_key
 
+    # Autocrypt Level 1 specification:
+    # https://docs.autocrypt.org/level1.html
+    # Autocrypt limits the complete encoded header to 10 KiB.
+    max_autocrypt_header_size = 10 * 1024
+
+    # Add whitespace every 76 characters so long keydata can be folded safely.
+    autocrypt_fold_width = 76
+
+    @staticmethod
+    def _has_encryption_subkey(key):
+        """Check the exported key's UID and encryption-subkey shape.
+
+        It requires one self-signed UID, no user attributes, and one usable
+        encryption subkey. Pass a key parsed from the bytes being advertised.
+        """
+        if key.userattributes:
+            return False
+
+        # Revocations are separate from the signatures checked below.
+        if list(key.revocation_signatures):
+            return False
+
+        if len(key.userids) != 1 or len(key.subkeys) != 1:
+            return False
+
+        uid = key.userids[0]
+
+        # PGPy selects signatures that identify the primary key as issuer.
+        if uid.selfsig is None:
+            return False
+
+        # PGPy has no public signature-count accessor. Fail safely if its
+        # private collection changes in a future release.
+        try:
+            uid_signature_count = len(uid._signatures)
+        except AttributeError:
+            logger.debug(
+                "PGPy internals changed; cannot verify UID signature "
+                "count for Autocrypt compliance"
+            )
+            return False
+
+        if uid_signature_count != 1:
+            return False
+
+        subkey = next(iter(key.subkeys.values()))
+        if list(subkey.revocation_signatures):
+            return False
+
+        # PGPy filters non-expired bindings by their identified issuer.
+        subkey_sigs = list(subkey.self_signatures)
+        if len(subkey_sigs) != 1:
+            return False
+
+        encrypt_flags = {
+            pgpy.constants.KeyFlags.EncryptCommunications,
+            pgpy.constants.KeyFlags.EncryptStorage,
+        }
+        return bool(subkey_sigs[0].key_flags & encrypt_flags)
+
+    def autocrypt_header(self):
+        """Build an Autocrypt header advertising our public key.
+
+        Returns ``None`` when the sender address or a usable sender private
+        key is missing, or when the result exceeds Autocrypt's size limit.
+        """
+        if not self.email:
+            return None
+
+        # Advertise only a key we can decrypt with. Generate a sender pair
+        # when allowed; public-only files and WKD results are not eligible.
+        private_key = self.private_key()
+        if not private_key and self.asset.pgp_autogen and self.keygen():
+            private_key = self.private_key()
+
+        if not private_key:
+            return None
+
+        # Re-parse the exported bytes so validation matches the advertised key.
+        exported = bytes(private_key.pubkey)
+        try:
+            exported_key, _ = pgpy.PGPKey.from_blob(exported)
+        except Exception:
+            logger.debug("Unable to re-parse our own exported PGP key")
+            return None
+
+        if not self._has_encryption_subkey(exported_key):
+            logger.debug(
+                "PGP private key lacks an Autocrypt-compatible encryption "
+                "subkey; omitting Autocrypt header"
+            )
+            return None
+
+        # Autocrypt uses the base64-encoded raw public key, without armor.
+        keydata = b64encode(exported).decode("ascii")
+
+        # Fold only keydata; Base64 decoders ignore the added whitespace.
+        folded_keydata = "\r\n ".join(
+            keydata[i : i + self.autocrypt_fold_width]
+            for i in range(0, len(keydata), self.autocrypt_fold_width)
+        )
+        header = (
+            f"addr={self.email}; prefer-encrypt=mutual; "
+            f"keydata={folded_keydata}"
+        )
+
+        # Count folding whitespace when enforcing the complete header limit.
+        rendered_size = len(f"Autocrypt: {header}".encode())
+        if rendered_size > self.max_autocrypt_header_size:
+            logger.debug(
+                "Autocrypt header (%d bytes) exceeds the %d byte spec "
+                "limit; omitting",
+                rendered_size,
+                self.max_autocrypt_header_size,
+            )
+            return None
+
+        return header
+
     # Encrypt message using the recipient's public key
     def encrypt(self, message, *emails, autogen=None):
-        """If provided a path to a pgp-key, content is encrypted.
+        """Encrypt with the selected public key.
 
-        Pass autogen=False to suppress key auto-generation during the
-        public-key lookup.  This is used in sign mode for opportunistic
-        encryption: only encrypt when a pre-existing key is found.
+        ``autogen=False`` limits lookup to existing keys.
         """
 
         # Acquire our key; autogen controls whether a missing key is created

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -62,7 +62,8 @@ notification services. It supports sending alerts to platforms such as: \
 `APRS`, \
 `AWS SES`, `AWS SNS`, `Bark`, `Blink(1)`, `BlueSky`, `Brevo`, \
 `Burst SMS`, `BulkSMS`, `BulkVS`, \
-`Chanify`, `Clickatell`, `ClickSend`, `DAPNET`, `DingTalk`, `Discord`, \
+`Chanify`, `Clickatell`, `ClickSend`, `DAPNET`, `Delta Chat`, \
+`DingTalk`, `Discord`, \
 `Dot. (Quote/0)`, `E-Mail`, `Emby`, `Evolution API`, `Exotel`, \
 `FCM`, `Feishu`, `Flock`, `Flowtriq`, `Fluxer`, `Free Mobile`, `Google Chat`, \
 `Gotify`, `GroupMe`, `Growl`, `Guilded`, `Home Assistant`, `httpSMS`, \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ keywords = [
     "D7Networks",
     "Dapnet",
     "DBus",
+    "Delta Chat",
     "DingTalk",
     "Discord",
     "Dot",
@@ -250,7 +251,7 @@ all-plugins = [
     # Provides mqtt:// support
     "paho-mqtt >= 2.1.0",
 
-     # Pretty Good Privacy (PGP) Provides mailto:// and deltachat:// support
+    # Enables PGP for mailto:// and deltachat://
     "PGPy",
 
     # Provides blink1:// support

--- a/tests/helpers/rest.py
+++ b/tests/helpers/rest.py
@@ -100,6 +100,21 @@ class AppriseURLTester:
         if tests:
             self.__tests = tests
 
+    @staticmethod
+    def __iter_content(robj):
+        """Build ``iter_content()`` for a mocked response.
+
+        The configured body is returned as one chunk for streaming plugins.
+        """
+
+        def _iter_content(chunk_size=None, *args, **kwargs):
+            content = robj.content or b""
+            if isinstance(content, str):
+                content = content.encode("utf-8")
+            return iter([content]) if content else iter([])
+
+        return _iter_content
+
     def add(self, url, meta):
         """Adds a test suite to our object."""
         self.__tests.append(
@@ -184,6 +199,7 @@ class AppriseURLTester:
         # Mock our request object
         robj = mock.Mock()
         robj.content = ""
+        robj.iter_content = self.__iter_content(robj)
         mock_get.return_value = robj
         mock_post.return_value = robj
         mock_request.return_value = robj
@@ -408,6 +424,7 @@ class AppriseURLTester:
         robj = mock.Mock()
         robj.content = ""
         robj.text = ""
+        robj.iter_content = self.__iter_content(robj)
         mock_get.return_value = robj
         mock_post.return_value = robj
         mock_head.return_value = robj

--- a/tests/test_apprise_cli.py
+++ b/tests/test_apprise_cli.py
@@ -3111,12 +3111,7 @@ def test_apprise_cli_limit_hard_exit(mock_request, mock_force_exit):
 
 
 def test_wait_for_abandoned_calls_polls_full_grace_period():
-    """_wait_for_abandoned_calls() polls in
-    CLI_TIMEOUT_EXIT_POLL_INTERVAL increments (never a single lump
-    sleep) and returns False once the full timeout elapses with
-    _any_abandoned_calls_still_running() still reporting True
-    throughout.
-    """
+    """Poll in short intervals until the full grace period expires."""
     with (
         mock.patch("apprise.cli.time.sleep") as mock_sleep,
         mock.patch(

--- a/tests/test_attach_http.py
+++ b/tests/test_attach_http.py
@@ -26,6 +26,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 # Disable logging for a cleaner testing output
+import errno
 import logging
 import mimetypes
 from os.path import dirname, getsize, join
@@ -234,7 +235,7 @@ def test_attach_http(mock_get, mock_request):
     # Now a call would yield a detected result that we'd agree with:
     assert attachment.mimetype == "image/gif"
 
-    # had it not been there and it was forced to detect it on it's own
+    # Detect the MIME type again without a Content-Type header.
     # we would have had a different result; the below forces it to detect it
     # again:
     attachment.detected_mimetype = None
@@ -260,11 +261,7 @@ def test_attach_http(mock_get, mock_request):
     assert attachment
     assert len(attachment) == getsize(path)
 
-    # Test case where location is simply set to INACCESSIBLE
-    # Below is a bad example, but it proves the section of code properly works.
-    # Ideally a server admin may wish to just disable all HTTP based
-    # attachments entirely. In this case, they simply just need to change the
-    # global singleton at the start of their program like:
+    # Administrators can disable all HTTP attachments globally:
     #
     # import apprise
     # apprise.attachment.AttachHTTP.location = \
@@ -272,7 +269,7 @@ def test_attach_http(mock_get, mock_request):
     attachment = AttachHTTP(**results)
     attachment.location = ContentLocation.INACCESSIBLE
     assert attachment.path is None
-    # Downloads just don't work period
+    # Downloads are blocked when HTTP attachments are inaccessible.
     assert attachment.download() is False
 
     # No path specified
@@ -561,7 +558,7 @@ def test_attach_http(mock_get, mock_request):
     assert isinstance(results, dict)
     obj_no_redir = AttachHTTP(**results)
     assert obj_no_redir.redirects is False
-    # Download must fail -- streaming a redirect stub would be wrong
+    # Do not stream a redirect response when redirects are disabled.
     assert obj_no_redir.download() is False
     # Restore for downstream tests
     mock_get.return_value = dummy_response
@@ -579,3 +576,110 @@ def test_attach_http(mock_get, mock_request):
         mock_file.side_effect = OSError
         with pytest.raises(exception.AppriseDiskIOError):
             obj.base64()
+
+
+class SizedResponse:
+    """A dummy response that streams a fixed payload in small chunks."""
+
+    status_code = requests.codes.ok
+    headers: ClassVar[dict[str, str]] = {"Content-Type": "text/plain"}
+
+    # The payload streamed back to the caller
+    payload = b"abcdefghij"
+
+    def close(self):
+        return
+
+    def iter_content(self, chunk_size=1024):
+        """Stream our payload back 2 bytes at a time."""
+        for index in range(0, len(self.payload), 2):
+            yield self.payload[index : index + 2]
+
+    def raise_for_status(self):
+        return
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        return
+
+
+@mock.patch("requests.get")
+def test_attach_http_download_dir(mock_get, tmpdir):
+    """AttachHTTP writes downloads into the requested directory."""
+
+    mock_get.return_value = SizedResponse()
+
+    # Point our download at a directory of our own choosing
+    download_dir = str(tmpdir.mkdir("attachments"))
+    results = AttachHTTP.parse_url("http://localhost/file.txt")
+    assert isinstance(results, dict)
+    attachment = AttachHTTP(download_dir=download_dir, **results)
+    assert attachment
+
+    # Our content lives in the directory we asked for
+    assert dirname(attachment.path) == download_dir
+    assert len(attachment) == len(SizedResponse.payload)
+
+    # Without a download_dir we fall back to the system temporary directory
+    attachment = AttachHTTP(**results)
+    assert attachment
+    assert dirname(attachment.path) != download_dir
+
+
+@mock.patch("requests.get")
+def test_attach_http_size_limit(mock_get):
+    """AttachHTTP never writes more than max_file_size bytes."""
+
+    mock_get.return_value = SizedResponse()
+
+    # Track how large the file grew before it was thrown away
+    written = []
+    invalidate = AttachHTTP.invalidate
+
+    def record(self):
+        if self._temp_file:
+            # tell() covers buffered writes that have not reached disk yet
+            written.append(self._temp_file.tell())
+
+        invalidate(self)
+
+    results = AttachHTTP.parse_url("http://localhost/file.txt")
+    assert isinstance(results, dict)
+
+    with mock.patch.object(AttachHTTP, "invalidate", record):
+        attachment = AttachHTTP(**results)
+
+        # Allow 5 of the 10 bytes on offer
+        attachment.max_file_size = 5
+
+        # Our download fails because the payload is over our limit
+        assert attachment.download() is False
+
+    # Stop before the chunk that would cross the limit.
+    assert written
+    assert all(size <= 5 for size in written)
+    assert written[0] == 4
+
+    # A payload landing exactly on our limit is still accepted
+    attachment = AttachHTTP(**results)
+    attachment.max_file_size = len(SizedResponse.payload)
+    assert attachment.download() is True
+    assert len(attachment) == len(SizedResponse.payload)
+
+
+@mock.patch("apprise.attachment.http.NamedTemporaryFile")
+@mock.patch("requests.get")
+def test_attach_http_preserves_storage_error(mock_get, mock_temp_file):
+    """Callers can inspect a download failure caused by local storage."""
+
+    mock_get.return_value = SizedResponse()
+    storage_error = OSError(errno.ENOSPC, "disk full")
+    mock_temp_file.side_effect = storage_error
+
+    results = AttachHTTP.parse_url("http://localhost/file.txt")
+    attachment = AttachHTTP(**results)
+
+    assert attachment.download() is False
+    assert attachment.download_error is storage_error

--- a/tests/test_persistent_store.py
+++ b/tests/test_persistent_store.py
@@ -314,7 +314,7 @@ def test_persistent_storage_flush_mode(tmpdir):
     # Setting the same value and explictly marking the field as not being
     # perisistent
     pc.set("key-xx", "abc123", persistent=False)
-    # Changing it's value doesn't alter the persistent flag
+    # Changing its value does not alter the persistent flag.
     pc["key-xx"] = "def678"
     # Setting it twice
     pc["key-xx"] = "def678"
@@ -548,7 +548,7 @@ def test_persistent_storage_flush_mode(tmpdir):
         expires=datetime.now() - timedelta(days=1),
     )
 
-    # It's actually there... but it's expired so our persistent
+    # The expired persistent entry still exists on disk.
     # storage is behaving as it should
     assert "expired" not in pc
     assert pc.get("expired") is None
@@ -1180,6 +1180,19 @@ def test_persistent_custom_io(tmpdir):
         mock.patch("os.unlink", side_effect=FileNotFoundError()),
     ):
         assert pc.write(b"test") is False
+
+
+def test_persistent_memory_open_uses_apprise_exception(tmpdir):
+    """Opening memory-only storage raises the compatible Apprise error."""
+    store = PersistentStore(
+        path=str(tmpdir),
+        mode=PersistentStoreMode.MEMORY,
+    )
+
+    with pytest.raises(exception.AppriseFileNotFound) as error:
+        store.open("key")
+
+    assert isinstance(error.value, FileNotFoundError)
 
 
 def test_persistent_storage_cache_object(tmpdir):

--- a/tests/test_plugin_deltachat.py
+++ b/tests/test_plugin_deltachat.py
@@ -30,7 +30,10 @@
 
 import logging
 import os
+import sys
 from unittest import mock
+
+import pytest
 
 from apprise import Apprise, AppriseAsset, NotifyBase, PersistentStoreMode
 from apprise.exception import AppriseImproperlyConfigured
@@ -333,6 +336,7 @@ def test_plugin_deltachat_send_forces_text_format(mock_smtp, mock_smtpssl):
     assert "text/html" not in raw
 
 
+@pytest.mark.skipif("pgpy" not in sys.modules, reason="Requires PGPy")
 @mock.patch("smtplib.SMTP")
 @mock.patch("smtplib.SMTP_SSL")
 def test_plugin_deltachat_autocrypt_and_pgp_inherited(
@@ -374,6 +378,7 @@ def test_plugin_deltachat_autocrypt_and_pgp_inherited(
     assert "Subject: Chat: T secret chat message" not in raw
 
 
+@pytest.mark.skipif("pgpy" not in sys.modules, reason="Requires PGPy")
 @mock.patch("smtplib.SMTP")
 @mock.patch("smtplib.SMTP_SSL")
 def test_plugin_deltachat_encrypt_subject_privacy(

--- a/tests/test_plugin_deltachat.py
+++ b/tests/test_plugin_deltachat.py
@@ -1,0 +1,413 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Email tests cover inherited delivery behavior. These tests cover the
+# Delta Chat schema, plain-text envelope, and chat headers.
+
+import logging
+import os
+from unittest import mock
+
+from apprise import Apprise, AppriseAsset, NotifyBase, PersistentStoreMode
+from apprise.exception import AppriseImproperlyConfigured
+from apprise.plugins.deltachat import NotifyDeltaChat
+
+logging.disable(logging.CRITICAL)
+
+# PGP fixture directory (shared with test_plugin_email.py / test_utils_pgp.py)
+PGP_VAR_DIR = os.path.join(os.path.dirname(__file__), "var", "pgp")
+VALID_PRV_KEY = os.path.join(PGP_VAR_DIR, "valid-prv.asc")
+VALID_PUB_KEY = os.path.join(PGP_VAR_DIR, "valid-pub.asc")
+
+# Our Testing URLs
+apprise_url_tests = (
+    (
+        "deltachat://",
+        {
+            "instance": AppriseImproperlyConfigured,
+        },
+    ),
+    # A minimal, valid URL: login doubles as our sender identity
+    (
+        "deltachat://user:pass@smtp.example.com/friend@example.org",
+        {
+            "instance": NotifyDeltaChat,
+            "privacy_url": (
+                "deltachat://user:****@smtp.example.com/friend%40example.org"
+            ),
+        },
+    ),
+    # The secure schema variant round-trips as itself
+    (
+        "deltachats://user:pass@smtp.example.com/friend@example.org",
+        {
+            "instance": NotifyDeltaChat,
+            "privacy_url": (
+                "deltachats://user:****@smtp.example.com/friend%40example.org"
+            ),
+        },
+    ),
+    # Multiple targets
+    (
+        "deltachat://user:pass@smtp.example.com/"
+        "friend1@example.org/friend2@example.org",
+        {
+            "instance": NotifyDeltaChat,
+        },
+    ),
+    # ?to= adds an additional target
+    (
+        "deltachat://user:pass@smtp.example.com/friend1@example.org"
+        "?to=friend2@example.org",
+        {
+            "instance": NotifyDeltaChat,
+        },
+    ),
+    # Explicit insecure mode (no transport security at all)
+    (
+        "deltachat://user:pass@smtp.example.com/friend@example.org"
+        "?mode=insecure",
+        {
+            "instance": NotifyDeltaChat,
+        },
+    ),
+    # An invalid secure mode
+    (
+        "deltachat://user:pass@smtp.example.com/friend@example.org"
+        "?mode=invalid",
+        {
+            "instance": AppriseImproperlyConfigured,
+        },
+    ),
+    # An invalid PGP mode
+    (
+        "deltachat://user:pass@smtp.example.com/friend@example.org"
+        "?pgp=invalid",
+        {
+            "instance": AppriseImproperlyConfigured,
+        },
+    ),
+    # Encryption fails without a recipient key.
+    (
+        "deltachat://user:pass@smtp.example.com/friend@example.org"
+        "?pgp=encrypt",
+        {
+            "instance": NotifyDeltaChat,
+            "response": False,
+        },
+    ),
+    # A custom display name
+    (
+        "deltachat://user:pass@smtp.example.com/friend@example.org"
+        "?name=My%20Bot",
+        {
+            "instance": NotifyDeltaChat,
+        },
+    ),
+    # The explicit secure schema, with a custom port
+    (
+        "deltachats://user:pass@smtp.example.com:2525/friend@example.org",
+        {
+            "instance": NotifyDeltaChat,
+        },
+    ),
+)
+
+
+@mock.patch("smtplib.SMTP")
+@mock.patch("smtplib.SMTP_SSL")
+def test_plugin_deltachat_urls(mock_smtp, mock_smtpssl):
+    """NotifyDeltaChat() Apprise URLs."""
+
+    mock_socket = mock.Mock()
+    mock_socket.starttls.return_value = True
+    mock_socket.login.return_value = True
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
+    mock_smtp.return_value = mock_socket
+    mock_smtpssl.return_value = mock_socket
+
+    for url, meta in apprise_url_tests:
+        instance = meta.get("instance", None)
+        response = meta.get("response", True)
+        privacy_url = meta.get("privacy_url")
+
+        try:
+            obj = Apprise.instantiate(url, suppress_exceptions=False)
+
+        except Exception as e:
+            if instance is None or not isinstance(e, instance):
+                raise
+            continue
+
+        assert isinstance(obj, instance)
+        assert isinstance(obj, NotifyBase)
+
+        # Confirm a lossless round trip through our own generated URL
+        assert isinstance(obj.url(), str)
+        assert isinstance(obj.url_id(), str)
+        assert isinstance(len(obj), int)
+        assert isinstance(obj.url(privacy=True), str)
+
+        # Invalid input remains safe through the parse override.
+        assert instance.parse_url(None) is None
+        assert instance.parse_url(object) is None
+        assert instance.parse_url(42) is None
+
+        if privacy_url and not obj.url(privacy=True).startswith(privacy_url):
+            raise AssertionError(
+                f"URL: {url} Privacy URL:"
+                f" '{obj.url(privacy=True)[: len(privacy_url)]}' !="
+                f" expected '{privacy_url}'"
+            )
+
+        obj_cmp = Apprise.instantiate(obj.url())
+        assert isinstance(obj_cmp, NotifyBase)
+        assert len(obj) == len(obj_cmp)
+        assert obj.url_identifier == obj_cmp.url_identifier
+
+        assert obj.notify(title="test", body="body test message") == response
+
+
+def test_plugin_deltachat_schema_identity():
+    """NotifyDeltaChat() class-level schema/format identity."""
+
+    assert NotifyDeltaChat.protocol == "deltachat"
+    assert NotifyDeltaChat.secure_protocol == "deltachats"
+    assert NotifyDeltaChat.service_name == "Delta Chat"
+
+    # Plain-text only; no separate title field, so the framework merges
+    # any title into the body for us
+    assert NotifyDeltaChat.notify_format == "text"
+    assert NotifyDeltaChat.title_maxlen == 0
+
+    # PGPy remains the one optional dependency, inherited from Email
+    assert NotifyDeltaChat.runtime_deps() == ("pgpy",)
+
+
+def _deltachat_instance(pgp="no"):
+    """Build an instance for subject tests without sending."""
+
+    return NotifyDeltaChat(
+        host="smtp.example.com",
+        user="bot",
+        password="secret",
+        targets=["friend@example.org"],
+        pgp_mode=pgp,
+    )
+
+
+def test_plugin_deltachat_chat_subject():
+    """Plain subjects contain a shortened body excerpt."""
+
+    obj = _deltachat_instance(pgp="no")
+
+    # A short body is used verbatim
+    assert obj._chat_subject("hello there") == "Chat: hello there"
+
+    # Collapse internal whitespace, including a merged title.
+    assert (
+        obj._chat_subject("My Title\nhello   world")
+        == "Chat: My Title hello world"
+    )
+
+    # An empty body still produces a valid, generic subject
+    assert obj._chat_subject("") == "Chat:"
+
+    # Truncate long bodies and append an ellipsis.
+    long_body = "x" * 80
+    subject = obj._chat_subject(long_body)
+    assert subject == f"Chat: {'x' * 50}..."
+
+
+def test_plugin_deltachat_pgp_subject_privacy():
+    """PGP modes keep body text out of the unencrypted subject."""
+
+    secret = "CONFIDENTIAL body content must remain private"
+
+    expected = {
+        "sign": "Chat:",
+        "encrypt": "Chat: Encrypted message",
+    }
+    for pgp_mode, subject in expected.items():
+        obj = _deltachat_instance(pgp=pgp_mode)
+
+        assert obj._chat_subject(secret) == subject
+        assert secret not in obj._chat_subject(secret)
+
+        # Still a valid, generic subject for an empty body
+        assert obj._chat_subject("") == subject
+
+
+def test_plugin_deltachat_protocol_headers():
+    """NotifyDeltaChat._protocol_headers() emits Chat-Version only."""
+
+    obj = NotifyDeltaChat(
+        host="smtp.example.com",
+        user="bot",
+        password="secret",
+        targets=["friend@example.org"],
+    )
+    assert obj._protocol_headers("any body") == {"Chat-Version": "1.0"}
+
+
+@mock.patch("smtplib.SMTP")
+@mock.patch("smtplib.SMTP_SSL")
+def test_plugin_deltachat_send_envelope(mock_smtp, mock_smtpssl):
+    """NotifyDeltaChat() send() builds a spec-compliant envelope."""
+
+    mock_socket = mock.Mock()
+    mock_socket.starttls.return_value = True
+    mock_socket.login.return_value = True
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
+    mock_smtp.return_value = mock_socket
+    mock_smtpssl.return_value = mock_socket
+
+    obj = Apprise.instantiate(
+        "deltachat://user:pass@smtp.example.com/friend@example.org",
+        suppress_exceptions=False,
+    )
+
+    assert obj.notify(title="My Title", body="hello world") is True
+
+    raw = mock_socket.sendmail.call_args[0][2]
+
+    # Chat-Version is a hard protocol requirement on every message
+    assert "Chat-Version: 1.0" in raw
+
+    # The subject uses the title already merged into the body.
+    assert "Subject: Chat: My Title hello world" in raw
+
+    # The body itself is always sent as plain text
+    assert 'Content-Type: text/plain; charset="utf-8"' in raw
+
+
+@mock.patch("smtplib.SMTP")
+@mock.patch("smtplib.SMTP_SSL")
+def test_plugin_deltachat_send_forces_text_format(mock_smtp, mock_smtpssl):
+    """NotifyDeltaChat() send() ignores an explicit HTML body_format."""
+
+    mock_socket = mock.Mock()
+    mock_socket.starttls.return_value = True
+    mock_socket.login.return_value = True
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
+    mock_smtp.return_value = mock_socket
+    mock_smtpssl.return_value = mock_socket
+
+    obj = Apprise.instantiate(
+        "deltachat://user:pass@smtp.example.com/friend@example.org"
+        "?format=html",
+        suppress_exceptions=False,
+    )
+
+    assert obj.notify(title="T", body="<b>hi</b>") is True
+
+    raw = mock_socket.sendmail.call_args[0][2]
+    assert 'Content-Type: text/plain; charset="utf-8"' in raw
+    assert "text/html" not in raw
+
+
+@mock.patch("smtplib.SMTP")
+@mock.patch("smtplib.SMTP_SSL")
+def test_plugin_deltachat_autocrypt_and_pgp_inherited(
+    mock_smtp, mock_smtpssl, tmpdir
+):
+    """Delta Chat inherits Email signing and Autocrypt handling."""
+
+    mock_socket = mock.Mock()
+    mock_socket.starttls.return_value = True
+    mock_socket.login.return_value = True
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
+    mock_smtp.return_value = mock_socket
+    mock_smtpssl.return_value = mock_socket
+
+    asset = AppriseAsset(
+        storage_mode=PersistentStoreMode.FLUSH,
+        storage_path=str(tmpdir),
+    )
+
+    obj = Apprise.instantiate(
+        "deltachat://user:pass@smtp.example.com/friend@example.org?pgp=sign",
+        asset=asset,
+        suppress_exceptions=False,
+    )
+
+    # Generate an Autocrypt-compatible key in this instance's store.
+    assert obj.pgp.keygen() is True
+
+    assert obj.notify(title="T", body="secret chat message") is True
+
+    raw = mock_socket.sendmail.call_args[0][2]
+    assert "Chat-Version: 1.0" in raw
+    assert "multipart/signed" in raw
+    assert raw.count("Autocrypt:") == 1
+
+    # PGP is in play, so the outer Subject must be generic
+    assert "Subject: Chat:" in raw
+    assert "Subject: Chat: T secret chat message" not in raw
+
+
+@mock.patch("smtplib.SMTP")
+@mock.patch("smtplib.SMTP_SSL")
+def test_plugin_deltachat_encrypt_subject_privacy(
+    mock_smtp, mock_smtpssl, tmpdir
+):
+    """Encrypted sends keep body text out of the outer subject."""
+
+    mock_socket = mock.Mock()
+    mock_socket.starttls.return_value = True
+    mock_socket.login.return_value = True
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
+    mock_smtp.return_value = mock_socket
+    mock_smtpssl.return_value = mock_socket
+
+    asset = AppriseAsset(
+        storage_mode=PersistentStoreMode.FLUSH,
+        storage_path=str(tmpdir),
+    )
+    obj = Apprise.instantiate(
+        "deltachat://user:pass@smtp.example.com/friend@example.org"
+        f"?pgp=encrypt&pgppub={VALID_PUB_KEY}",
+        asset=asset,
+        suppress_exceptions=False,
+    )
+
+    secret = "CONFIDENTIAL body content must remain private"
+    assert obj.notify(title="T", body=secret) is True
+
+    raw = mock_socket.sendmail.call_args[0][2]
+
+    # Use Delta Chat's recommended placeholder without exposing the body.
+    assert "Subject: Chat: Encrypted message" in raw
+
+    # Protected body text must not appear in the outer envelope.
+    assert secret not in raw
+    assert "CONFIDENTIAL body content" not in raw

--- a/tests/test_plugin_email.py
+++ b/tests/test_plugin_email.py
@@ -3390,6 +3390,7 @@ def test_plugin_email_pgp_sign_send(mock_smtp, mock_smtpssl, tmpdir):
     assert "application/pgp-signature" in raw
 
 
+@pytest.mark.skipif("pgpy" not in sys.modules, reason="Requires PGPy")
 @mock.patch("smtplib.SMTP_SSL")
 @mock.patch("smtplib.SMTP")
 def test_plugin_email_pgp_encrypt_send_with_autocrypt(
@@ -3432,6 +3433,7 @@ def test_plugin_email_pgp_encrypt_send_with_autocrypt(
     assert raw.count("Autocrypt:") == 1
 
 
+@pytest.mark.skipif("pgpy" not in sys.modules, reason="Requires PGPy")
 @mock.patch("smtplib.SMTP_SSL")
 @mock.patch("smtplib.SMTP")
 def test_plugin_email_pgp_encrypt_self_send_autogens_key(
@@ -3463,6 +3465,7 @@ def test_plugin_email_pgp_encrypt_self_send_autogens_key(
     assert obj.pgp.private_key() is not None
 
 
+@pytest.mark.skipif("pgpy" not in sys.modules, reason="Requires PGPy")
 @mock.patch("smtplib.SMTP_SSL")
 @mock.patch("smtplib.SMTP")
 def test_plugin_email_pgp_encrypt_external_recipient_no_autogen(
@@ -3491,6 +3494,7 @@ def test_plugin_email_pgp_encrypt_external_recipient_no_autogen(
     assert obj.pgp.public_keyfile("other@example.org") is None
 
 
+@pytest.mark.skipif("pgpy" not in sys.modules, reason="Requires PGPy")
 @mock.patch("smtplib.SMTP_SSL")
 @mock.patch("smtplib.SMTP")
 def test_plugin_email_send_without_autocrypt(mock_smtp, mock_smtpssl, tmpdir):
@@ -3545,6 +3549,7 @@ def test_plugin_email_send_without_autocrypt(mock_smtp, mock_smtpssl, tmpdir):
         assert "Autocrypt:" not in raw
 
 
+@pytest.mark.skipif("pgpy" not in sys.modules, reason="Requires PGPy")
 @mock.patch("smtplib.SMTP_SSL")
 @mock.patch("smtplib.SMTP")
 def test_plugin_email_autocrypt_deduplication(mock_smtp, mock_smtpssl, tmpdir):
@@ -3565,11 +3570,14 @@ def test_plugin_email_autocrypt_deduplication(mock_smtp, mock_smtpssl, tmpdir):
     assert keygen_ctrl.keygen() is True
     prv_path = keygen_ctrl.private_keyfile()
 
-    for custom_key in ("Autocrypt", "autocrypt", "AUTOCRYPT"):
+    # Keep iterations isolated, even on case-insensitive filesystems.
+    for index, custom_key in enumerate(
+        ("Autocrypt", "autocrypt", "AUTOCRYPT")
+    ):
         mock_socket.reset_mock()
         asset = AppriseAsset(
             storage_mode=PersistentStoreMode.FLUSH,
-            storage_path=str(tmpdir.mkdir(f"sign-{custom_key}")),
+            storage_path=str(tmpdir.mkdir(f"sign-{index}")),
         )
         spoofed_value = "addr%3Dattacker%40example.com%3B%20keydata%3Dbogus"
         obj = Apprise.instantiate(

--- a/tests/test_plugin_email.py
+++ b/tests/test_plugin_email.py
@@ -243,11 +243,11 @@ TEST_URLS = (
         },
     ),
     (
-        "mailtos://%20@domain.com?user=admin@mail-domain.com&pgp=encrypt",
+        "mailtos://%20@domain.com?user=admin@mail-domain.com&pgp=yes",
         {
-            # Encryption fails without a public key.
-            "instance": email.NotifyEmail,
-            "response": False,
+            # The legacy yes/no boolean spelling of pgp= is no longer
+            # supported because it is now an unrecognized mode string.
+            "instance": AppriseImproperlyConfigured,
         },
     ),
     (
@@ -555,6 +555,8 @@ def test_plugin_email(mock_smtp, mock_smtpssl):
         mock_socket = mock.Mock()
         mock_socket.starttls.return_value = True
         mock_socket.login.return_value = True
+        # An empty refusal map means SMTP accepted every recipient.
+        mock_socket.sendmail.return_value = {}
 
         # Create a mock SMTP Object
         mock_smtp.return_value = mock_socket
@@ -570,7 +572,6 @@ def test_plugin_email(mock_smtp, mock_smtpssl):
                 smtplib.SMTPException(
                     0, "smtplib.SMTPException() not handled"
                 ),
-                RuntimeError(0, "smtplib.HTTPError() not handled"),
                 smtplib.SMTPRecipientsRefused(
                     "smtplib.SMTPRecipientsRefused() not handled"
                 ),
@@ -774,7 +775,7 @@ def test_plugin_email_smtplib_init_fail(mock_smtplib):
     assert isinstance(obj, email.NotifyEmail)
 
     # Support Exception handling of smtplib.SMTP
-    mock_smtplib.side_effect = RuntimeError("Test")
+    mock_smtplib.side_effect = OSError("Test")
 
     assert (
         bool(
@@ -785,6 +786,17 @@ def test_plugin_email_smtplib_init_fail(mock_smtplib):
 
     # A handled and expected exception
     mock_smtplib.side_effect = smtplib.SMTPException("Test")
+    assert (
+        bool(
+            obj.notify(body="body", title="test", notify_type=NotifyType.INFO)
+        )
+        is False
+    )
+
+    # AppriseSMTPController re-raises RuntimeError (part of its own
+    # SMTP_EXCEPTIONS catch-all in __enter__) after cleanup, so send()
+    # must still catch it here rather than let it escape
+    mock_smtplib.side_effect = RuntimeError("Test")
     assert (
         bool(
             obj.notify(body="body", title="test", notify_type=NotifyType.INFO)
@@ -804,10 +816,10 @@ def test_plugin_email_smtplib_send_okay(mock_smtplib):
     assert isinstance(obj, email.NotifyEmail)
 
     # Support an email simulation where we can correctly quit
-    mock_smtplib.starttls.return_value = True
-    mock_smtplib.login.return_value = True
-    mock_smtplib.sendmail.return_value = True
-    mock_smtplib.quit.return_value = True
+    mock_smtplib.return_value.starttls.return_value = True
+    mock_smtplib.return_value.login.return_value = True
+    mock_smtplib.return_value.sendmail.return_value = {}
+    mock_smtplib.return_value.quit.return_value = True
 
     assert (
         bool(
@@ -934,6 +946,7 @@ def test_plugin_email_smtplib_send_multiple_recipients(mock_smtplib):
         suppress_exceptions=False,
     )
     assert isinstance(obj, email.NotifyEmail)
+    mock_smtplib.return_value.sendmail.return_value = {}
 
     assert (
         bool(
@@ -983,6 +996,8 @@ def test_plugin_email_timezone(mock_smtp):
     """NotifyEmail() Timezone Handling"""
 
     response = mock.Mock()
+    # An empty refusal map means SMTP accepted every recipient.
+    response.sendmail.return_value = {}
     mock_smtp.return_value = response
 
     # Loads America/Toronto
@@ -1351,6 +1366,8 @@ def test_plugin_email_url_parsing(mock_smtp, mock_smtp_ssl):
     """NotifyEmail() Test email url parsing."""
 
     response = mock.Mock()
+    # An empty refusal map means SMTP accepted every recipient.
+    response.sendmail.return_value = {}
     mock_smtp_ssl.return_value = response
     mock_smtp.return_value = response
 
@@ -2040,6 +2057,8 @@ def test_plugin_email_plus_in_toemail(mock_smtp, mock_smtp_ssl):
     """NotifyEmail() support + in To Email address."""
 
     response = mock.Mock()
+    # An empty refusal map means SMTP accepted every recipient.
+    response.sendmail.return_value = {}
     mock_smtp_ssl.return_value = response
     mock_smtp.return_value = response
 
@@ -2187,6 +2206,8 @@ def test_plugin_email_formatting_990(mock_smtp, mock_smtp_ssl):
     """
 
     response = mock.Mock()
+    # An empty refusal map means SMTP accepted every recipient.
+    response.sendmail.return_value = {}
     mock_smtp_ssl.return_value = response
     mock_smtp.return_value = response
 
@@ -2285,6 +2306,8 @@ def test_plugin_email_to_handling_1356(mock_smtp, mock_smtp_ssl):
     """
 
     response = mock.Mock()
+    # An empty refusal map means SMTP accepted every recipient.
+    response.sendmail.return_value = {}
     mock_smtp_ssl.return_value = response
     mock_smtp.return_value = response
 
@@ -2347,6 +2370,8 @@ def test_plugin_email_variables_1334(mock_smtp, mock_smtp_ssl):
     """
 
     response = mock.Mock()
+    # An empty refusal map means SMTP accepted every recipient.
+    response.sendmail.return_value = {}
     mock_smtp_ssl.return_value = response
     mock_smtp.return_value = response
 
@@ -2433,6 +2458,8 @@ def test_plugin_host_detection_from_source_email(mock_smtp, mock_smtp_ssl):
     """
 
     response = mock.Mock()
+    # An empty refusal map means SMTP accepted every recipient.
+    response.sendmail.return_value = {}
     mock_smtp_ssl.return_value = response
     mock_smtp.return_value = response
 
@@ -2497,7 +2524,7 @@ def test_plugin_host_detection_from_source_email(mock_smtp, mock_smtp_ssl):
 
     assert isinstance(results, dict)
     assert results["user"] == "name@spectrum.net"
-    assert results["host"] == ""  # No hostname defined; it's detected later
+    assert results["host"] == ""  # No hostname; it is detected later.
     assert results["smtp_host"] == "mobile.charter.net"
     assert results["password"] == "password"
 
@@ -2574,7 +2601,7 @@ def test_plugin_host_detection_from_source_email(mock_smtp, mock_smtp_ssl):
 
     assert isinstance(results, dict)
     assert results["user"] == "name@spectrum.net"
-    assert results["host"] == ""  # No hostname defined; it's detected later
+    assert results["host"] == ""  # No hostname; it is detected later.
     assert results["smtp_host"] == "mobile.charter.net"
     assert results["password"] == "password"
 
@@ -2625,6 +2652,8 @@ def test_plugin_email_by_ipaddr_1113(mock_smtp, mock_smtp_ssl):
     """
 
     response = mock.Mock()
+    # An empty refusal map means SMTP accepted every recipient.
+    response.sendmail.return_value = {}
     mock_smtp_ssl.return_value = response
     mock_smtp.return_value = response
 
@@ -2665,6 +2694,8 @@ def test_plugin_email_pgp(mock_smtp, mock_smtpssl, tmpdir):
     mock_socket = mock.Mock()
     mock_socket.starttls.return_value = True
     mock_socket.login.return_value = True
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
 
     # Create a mock SMTP Object
     mock_smtp.return_value = mock_socket
@@ -2802,9 +2833,7 @@ def test_plugin_email_pgp(mock_smtp, mock_smtpssl, tmpdir):
     # We will find our key
     assert obj.pgp.public_key() is not None
 
-    # We do this again but even when we do a requisition for a public key
-    # it will generate a new pair or keys for us once it detects we don't
-    # have any
+    # Direct lookups without an address still use the sender's own key.
     tmpdir3 = tmpdir.mkdir("tmp03")
     asset = AppriseAsset(
         storage_mode=PersistentStoreMode.FLUSH,
@@ -2830,7 +2859,8 @@ def test_plugin_email_pgp(mock_smtp, mock_smtpssl, tmpdir):
 
     assert obj.pgp.public_keyfile().endswith("chris-pub.asc")
 
-    assert bool(obj.notify("test body")) is True
+    # A real send fails rather than generating an unknown recipient's key.
+    assert bool(obj.notify("test body")) is False
 
     # The private key is not needed for sending the encrypted messages
     os.unlink(os.path.join(obj.store.path, "chris-prv.asc"))
@@ -2880,19 +2910,16 @@ def test_plugin_email_pgp(mock_smtp, mock_smtpssl, tmpdir):
     )
     # user-pub still trumps
     assert obj.pgp.public_keyfile("user@example.com").endswith("user-pub.asc")
-    assert obj.pgp.public_keyfile("invalid@example.com").endswith(
-        "chris@nuxref.com-pub.asc"
-    )
+    # Never substitute the sender's key for a missing recipient key.
+    assert obj.pgp.public_keyfile("invalid@example.com") is None
 
     # remove this file
     os.unlink(os.path.join(obj.store.path, "user-pub.asc"))
 
-    # now we fall back to basic/default configuration
-    assert obj.pgp.public_keyfile("user@example.com").endswith(
-        "chris@nuxref.com-pub.asc"
-    )
+    # Removing the recipient key must not expose sender keys as fallbacks.
+    assert obj.pgp.public_keyfile("user@example.com") is None
     os.unlink(os.path.join(obj.store.path, "chris@nuxref.com-pub.asc"))
-    assert obj.pgp.public_keyfile("user@example.com").endswith("chris-pub.asc")
+    assert obj.pgp.public_keyfile("user@example.com") is None
 
     # Testing again
     tmpdir4 = tmpdir.mkdir("tmp04")
@@ -3000,9 +3027,10 @@ def test_plugin_email_pgp(mock_smtp, mock_smtpssl, tmpdir):
         asset=asset,
     )
 
+    # Use the recipient's filename to exercise the corrupt-key path.
     shutil.copyfile(
         os.path.join(TEST_VAR_DIR, "pgp", "corrupt-pub.asc"),
-        os.path.join(obj.store.path, "chris-pub.asc"),
+        os.path.join(obj.store.path, "user@example.com-pub.asc"),
     )
 
     # Key is corrupted
@@ -3010,7 +3038,7 @@ def test_plugin_email_pgp(mock_smtp, mock_smtpssl, tmpdir):
 
     shutil.copyfile(
         os.path.join(TEST_VAR_DIR, "apprise-test.jpeg"),
-        os.path.join(obj.store.path, "chris-pub.asc"),
+        os.path.join(obj.store.path, "user@example.com-pub.asc"),
     )
 
     # Key is a binary image; definitely not a valid key
@@ -3025,6 +3053,8 @@ def test_plugin_email_pgp_modes(mock_smtp, mock_smtpssl):
     mock_socket = mock.Mock()
     mock_socket.starttls.return_value = True
     mock_socket.login.return_value = True
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
     mock_smtp.return_value = mock_socket
     mock_smtpssl.return_value = mock_socket
 
@@ -3042,7 +3072,7 @@ def test_plugin_email_pgp_modes(mock_smtp, mock_smtpssl):
     obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=e")
     assert obj.pgp_mode == "encrypt"
 
-    # pgp=none -> no mode match; falls to default 'no' (backward compat)
+    # "none" is an explicit synonym for "no".
     obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=none")
     assert obj.pgp_mode == "no"
 
@@ -3054,9 +3084,13 @@ def test_plugin_email_pgp_modes(mock_smtp, mock_smtpssl):
     obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=no")
     assert obj.pgp_mode == "no"
 
-    # Unknown values fall back to the default "no" mode.
-    obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=invalid")
-    assert obj.pgp_mode == "no"
+    # Removed boolean spellings are rejected; canonical "no" remains valid.
+    for legacy in ("yes", "true", "false"):
+        with pytest.raises(AppriseImproperlyConfigured):
+            Apprise.instantiate(
+                f"mailto://user:pass@nuxref.com?pgp={legacy}",
+                suppress_exceptions=False,
+            )
 
     # url() emits 'pgp=encrypt' when mode is encrypt, and nothing when no
     obj = Apprise.instantiate("mailto://user:pass@nuxref.com?pgp=encrypt")
@@ -3087,6 +3121,38 @@ def test_plugin_email_pgp_modes(mock_smtp, mock_smtpssl):
     assert "pgppub=****" in obj.url(privacy=True)
     assert "my-pub.asc" not in obj.url(privacy=True)
 
+    # The removed pgpkey alias is ignored and is no longer advertised.
+    assert "pgpkey" not in email.NotifyEmail.template_args
+    obj = Apprise.instantiate(
+        "mailto://user:pass@nuxref.com?pgpkey=/old/public-key.asc"
+    )
+    assert obj is not None
+    assert obj.pgp_key is None
+
+    # An unknown old alias cannot replace the supported parameter.
+    obj = Apprise.instantiate(
+        "mailto://user:pass@nuxref.com"
+        "?pgppub=/current/public-key.asc&pgpkey=/old/public-key.asc"
+    )
+    assert obj is not None
+    assert obj.pgp_key == "/current/public-key.asc"
+
+    # Reject typos instead of silently disabling encryption.
+    with pytest.raises(AppriseImproperlyConfigured):
+        email.NotifyEmail(
+            user="user",
+            password="pass",
+            host="nuxref.com",
+            pgp_mode="encrpyt",
+        )
+
+    # Same applies when the value arrives via the URL
+    with pytest.raises(AppriseImproperlyConfigured):
+        Apprise.instantiate(
+            "mailto://user:pass@nuxref.com?pgp=encrpyt",
+            suppress_exceptions=False,
+        )
+
 
 @mock.patch("smtplib.SMTP_SSL")
 @mock.patch("smtplib.SMTP")
@@ -3096,6 +3162,8 @@ def test_plugin_email_wkd_param(mock_smtp, mock_smtpssl):
     mock_socket = mock.Mock()
     mock_socket.starttls.return_value = True
     mock_socket.login.return_value = True
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
     mock_smtp.return_value = mock_socket
     mock_smtpssl.return_value = mock_socket
 
@@ -3162,6 +3230,8 @@ def test_plugin_email_wkd_key_discovery(mock_smtp, mock_smtpssl, tmpdir):
     mock_socket = mock.Mock()
     mock_socket.starttls.return_value = True
     mock_socket.login.return_value = True
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
     mock_smtp.return_value = mock_socket
     mock_smtpssl.return_value = mock_socket
 
@@ -3182,9 +3252,11 @@ def test_plugin_email_wkd_key_discovery(mock_smtp, mock_smtpssl, tmpdir):
     )
     pub_bytes = str(key.pubkey).encode()
 
+    # Keep WKD as the only key source in this test.
     asset = AppriseAsset(
         storage_mode=PersistentStoreMode.FLUSH,
         storage_path=str(tmpdir),
+        pgp_autogen=False,
     )
 
     obj = Apprise.instantiate(
@@ -3201,7 +3273,6 @@ def test_plugin_email_wkd_key_discovery(mock_smtp, mock_smtpssl, tmpdir):
     obj.pgp._ApprisePGPController__key_lookup.clear()
 
     # WKD returning None with autogen disabled falls through gracefully
-    asset.pgp_autogen = False
     with mock.patch.object(obj.pgp.wkd, "fetch", return_value=None):
         assert bool(obj.notify("test body")) is False
 
@@ -3214,6 +3285,8 @@ def test_plugin_email_pgp_sign_mode_param(mock_smtp, mock_smtpssl):
     mock_socket = mock.Mock()
     mock_socket.starttls.return_value = True
     mock_socket.login.return_value = True
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
     mock_smtp.return_value = mock_socket
     mock_smtpssl.return_value = mock_socket
 
@@ -3250,6 +3323,8 @@ def test_plugin_email_pgp_privkey_param(mock_smtp, mock_smtpssl, tmpdir):
     mock_socket = mock.Mock()
     mock_socket.starttls.return_value = True
     mock_socket.login.return_value = True
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
     mock_smtp.return_value = mock_socket
     mock_smtpssl.return_value = mock_socket
 
@@ -3287,6 +3362,8 @@ def test_plugin_email_pgp_sign_send(mock_smtp, mock_smtpssl, tmpdir):
     mock_socket = mock.Mock()
     mock_socket.starttls.return_value = True
     mock_socket.login.return_value = True
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
     mock_smtp.return_value = mock_socket
     mock_smtpssl.return_value = mock_socket
 
@@ -3311,6 +3388,229 @@ def test_plugin_email_pgp_sign_send(mock_smtp, mock_smtpssl, tmpdir):
     raw = mock_socket.sendmail.call_args[0][2]
     assert "multipart/signed" in raw
     assert "application/pgp-signature" in raw
+
+
+@mock.patch("smtplib.SMTP_SSL")
+@mock.patch("smtplib.SMTP")
+def test_plugin_email_pgp_encrypt_send_with_autocrypt(
+    mock_smtp, mock_smtpssl, tmpdir
+):
+    """Encrypt with a recipient key and advertise the sender key."""
+
+    mock_socket = mock.Mock()
+    mock_socket.starttls.return_value = True
+    mock_socket.login.return_value = True
+    mock_socket.sendmail.return_value = {}
+    mock_smtp.return_value = mock_socket
+    mock_smtpssl.return_value = mock_socket
+
+    pub_path = os.path.join(
+        os.path.dirname(__file__), "var", "pgp", "valid-pub.asc"
+    )
+
+    # Generate a sender key that includes an encryption subkey.
+    keygen_ctrl = utils.pgp.ApprisePGPController(
+        path=str(tmpdir.mkdir("keygen")), email="user@nuxref.com"
+    )
+    assert keygen_ctrl.keygen() is True
+    own_prv_path = keygen_ctrl.private_keyfile()
+
+    asset = AppriseAsset(
+        storage_mode=PersistentStoreMode.FLUSH,
+        storage_path=str(tmpdir.mkdir("send")),
+    )
+    obj = Apprise.instantiate(
+        "mailto://user:pass@nuxref.com/recipient@example.com"
+        f"?pgp=encrypt&pgppub={pub_path}&pgpprv={own_prv_path}",
+        asset=asset,
+    )
+    assert obj is not None
+    assert bool(obj.notify("test body")) is True
+
+    raw = mock_socket.sendmail.call_args[0][2]
+    assert "multipart/encrypted" in raw
+    assert raw.count("Autocrypt:") == 1
+
+
+@mock.patch("smtplib.SMTP_SSL")
+@mock.patch("smtplib.SMTP")
+def test_plugin_email_pgp_encrypt_self_send_autogens_key(
+    mock_smtp, mock_smtpssl, tmpdir
+):
+    """Encrypted self-sends may generate the sender's key."""
+
+    mock_socket = mock.Mock()
+    mock_socket.starttls.return_value = True
+    mock_socket.login.return_value = True
+    mock_socket.sendmail.return_value = {}
+    mock_smtp.return_value = mock_socket
+    mock_smtpssl.return_value = mock_socket
+
+    asset = AppriseAsset(
+        storage_mode=PersistentStoreMode.FLUSH,
+        storage_path=str(tmpdir),
+    )
+    obj = Apprise.instantiate(
+        "mailto://user:pass@nuxref.com?pgp=encrypt", asset=asset
+    )
+    assert obj is not None
+    assert obj.pgp.private_key() is None
+
+    assert bool(obj.notify("test body")) is True
+
+    raw = mock_socket.sendmail.call_args[0][2]
+    assert "multipart/encrypted" in raw
+    assert obj.pgp.private_key() is not None
+
+
+@mock.patch("smtplib.SMTP_SSL")
+@mock.patch("smtplib.SMTP")
+def test_plugin_email_pgp_encrypt_external_recipient_no_autogen(
+    mock_smtp, mock_smtpssl, tmpdir
+):
+    """Encrypted external sends never generate the recipient's key."""
+
+    mock_socket = mock.Mock()
+    mock_socket.starttls.return_value = True
+    mock_socket.login.return_value = True
+    mock_socket.sendmail.return_value = {}
+    mock_smtp.return_value = mock_socket
+    mock_smtpssl.return_value = mock_socket
+
+    asset = AppriseAsset(
+        storage_mode=PersistentStoreMode.FLUSH,
+        storage_path=str(tmpdir),
+    )
+    obj = Apprise.instantiate(
+        "mailto://user:pass@nuxref.com/other@example.org?pgp=encrypt",
+        asset=asset,
+    )
+    assert obj is not None
+
+    assert bool(obj.notify("test body")) is False
+    assert obj.pgp.public_keyfile("other@example.org") is None
+
+
+@mock.patch("smtplib.SMTP_SSL")
+@mock.patch("smtplib.SMTP")
+def test_plugin_email_send_without_autocrypt(mock_smtp, mock_smtpssl, tmpdir):
+    """Protected sends omit Autocrypt when no sender key is available."""
+
+    mock_socket = mock.Mock()
+    mock_socket.starttls.return_value = True
+    mock_socket.login.return_value = True
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
+    mock_smtp.return_value = mock_socket
+    mock_smtpssl.return_value = mock_socket
+
+    prv_path = os.path.join(
+        os.path.dirname(__file__), "var", "pgp", "valid-prv.asc"
+    )
+    pub_path = os.path.join(
+        os.path.dirname(__file__), "var", "pgp", "valid-pub.asc"
+    )
+
+    with mock.patch.object(
+        utils.pgp.ApprisePGPController,
+        "autocrypt_header",
+        return_value=None,
+    ):
+        # Sign mode
+        asset = AppriseAsset(
+            storage_mode=PersistentStoreMode.FLUSH,
+            storage_path=str(tmpdir.mkdir("sign")),
+        )
+        obj = Apprise.instantiate(
+            f"mailto://user:pass@nuxref.com?pgp=sign&pgpprv={prv_path}",
+            asset=asset,
+        )
+        assert bool(obj.notify("test body")) is True
+        raw = mock_socket.sendmail.call_args[0][2]
+        assert "Autocrypt:" not in raw
+
+        mock_socket.reset_mock()
+
+        # Encrypt mode
+        asset = AppriseAsset(
+            storage_mode=PersistentStoreMode.FLUSH,
+            storage_path=str(tmpdir.mkdir("encrypt")),
+        )
+        obj = Apprise.instantiate(
+            f"mailto://user:pass@nuxref.com?pgp=encrypt&pgppub={pub_path}",
+            asset=asset,
+        )
+        assert bool(obj.notify("test body")) is True
+        raw = mock_socket.sendmail.call_args[0][2]
+        assert "Autocrypt:" not in raw
+
+
+@mock.patch("smtplib.SMTP_SSL")
+@mock.patch("smtplib.SMTP")
+def test_plugin_email_autocrypt_deduplication(mock_smtp, mock_smtpssl, tmpdir):
+    """Generated Autocrypt headers replace custom case variants."""
+
+    mock_socket = mock.Mock()
+    mock_socket.starttls.return_value = True
+    mock_socket.login.return_value = True
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
+    mock_smtp.return_value = mock_socket
+    mock_smtpssl.return_value = mock_socket
+
+    # Generate a sender key that Autocrypt can advertise.
+    keygen_ctrl = utils.pgp.ApprisePGPController(
+        path=str(tmpdir.mkdir("keygen")), email="user@nuxref.com"
+    )
+    assert keygen_ctrl.keygen() is True
+    prv_path = keygen_ctrl.private_keyfile()
+
+    for custom_key in ("Autocrypt", "autocrypt", "AUTOCRYPT"):
+        mock_socket.reset_mock()
+        asset = AppriseAsset(
+            storage_mode=PersistentStoreMode.FLUSH,
+            storage_path=str(tmpdir.mkdir(f"sign-{custom_key}")),
+        )
+        spoofed_value = "addr%3Dattacker%40example.com%3B%20keydata%3Dbogus"
+        obj = Apprise.instantiate(
+            f"mailto://user:pass@nuxref.com?pgp=sign&pgpprv={prv_path}"
+            f"&+{custom_key}={spoofed_value}",
+            asset=asset,
+        )
+        assert bool(obj.notify("test body")) is True
+        raw = mock_socket.sendmail.call_args[0][2]
+
+        # Keep only the controller-generated Autocrypt value.
+        assert raw.lower().count("autocrypt:") == 1
+        assert "attacker@example.com" not in raw
+        assert "keydata=bogus" not in raw
+
+
+@mock.patch("smtplib.SMTP_SSL")
+@mock.patch("smtplib.SMTP")
+def test_plugin_email_autocrypt_custom_only_deduplication(
+    mock_smtp, mock_smtpssl
+):
+    """Custom Autocrypt header names are deduplicated case-insensitively."""
+
+    mock_socket = mock.Mock()
+    mock_socket.starttls.return_value = True
+    mock_socket.login.return_value = True
+    mock_socket.sendmail.return_value = {}
+    mock_smtp.return_value = mock_socket
+    mock_smtpssl.return_value = mock_socket
+
+    # pgp=no prevents a controller-generated Autocrypt header.
+    obj = Apprise.instantiate(
+        "mailto://user:pass@nuxref.com/friend@example.org"
+        "?+Autocrypt=first&+autocrypt=second"
+    )
+    assert bool(obj.notify("test body")) is True
+
+    raw = mock_socket.sendmail.call_args[0][2]
+    assert raw.lower().count("autocrypt:") == 1
+    assert "Autocrypt: first" in raw
+    assert "second" not in raw
 
 
 @pytest.mark.skipif("pgpy" not in sys.modules, reason="Requires PGPy")
@@ -3360,8 +3660,7 @@ def test_plugin_email_pgp_sign_crlf_roundtrip(tmpdir):
         "the signed body must use CRLF line endings (RFC 3156)"
     )
 
-    # The bare-LF form must NOT verify (regression guard: CRLF
-    # normalisation before pgp.sign() must not be removed).
+    # The bare-LF form must not verify after CRLF normalization.
     lf_ok = bool(pub_key.verify(lf_body, sig))
     assert not lf_ok, (
         "Signature verified against bare-LF content -- CRLF normalisation "
@@ -3382,6 +3681,8 @@ def test_plugin_email_pgp_sign_wire_content_crlf(
     mock_socket = mock.Mock()
     mock_socket.starttls.return_value = True
     mock_socket.login.return_value = True
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
     mock_smtp.return_value = mock_socket
     mock_smtpssl.return_value = mock_socket
 
@@ -3438,6 +3739,8 @@ def test_plugin_email_pgp_sign_no_privkey_fails(
     mock_socket = mock.Mock()
     mock_socket.starttls.return_value = True
     mock_socket.login.return_value = True
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
     mock_smtp.return_value = mock_socket
     mock_smtpssl.return_value = mock_socket
 
@@ -3465,6 +3768,8 @@ def test_plugin_email_pgp_sign_opportunistic_encrypt(
     mock_socket = mock.Mock()
     mock_socket.starttls.return_value = True
     mock_socket.login.return_value = True
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
     mock_smtp.return_value = mock_socket
     mock_smtpssl.return_value = mock_socket
 
@@ -3530,6 +3835,8 @@ def test_plugin_email_pgp_sign_no_pgp_support(mock_smtp, mock_smtpssl):
     mock_socket = mock.Mock()
     mock_socket.starttls.return_value = True
     mock_socket.login.return_value = True
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
     mock_smtp.return_value = mock_socket
     mock_smtpssl.return_value = mock_socket
 
@@ -3563,6 +3870,8 @@ def test_plugin_email_pgp_sign_encrypt_none_mode(
     mock_socket = mock.Mock()
     mock_socket.starttls.return_value = True
     mock_socket.login.return_value = True
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
     mock_smtp.return_value = mock_socket
     mock_smtpssl.return_value = mock_socket
 
@@ -3597,6 +3906,8 @@ def test_plugin_email_pgp_sign_keygen_auto(mock_smtp, mock_smtpssl, tmpdir):
     mock_socket = mock.Mock()
     mock_socket.starttls.return_value = True
     mock_socket.login.return_value = True
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
     mock_smtp.return_value = mock_socket
     mock_smtpssl.return_value = mock_socket
 
@@ -3627,6 +3938,7 @@ def test_plugin_email_multi_format(mock_smtp):
     )
 
     instance = mock_smtp.return_value
+    instance.sendmail.return_value = {}
 
     aobj = Apprise()
     assert aobj.add("mailto://user:pass@example.com") is True
@@ -3750,6 +4062,8 @@ def test_plugin_email_gmx_template_lookup(mock_smtp):
     """NotifyEmail() GMX template lookup tests."""
 
     response = mock.Mock()
+    # An empty refusal map means SMTP accepted every recipient.
+    response.sendmail.return_value = {}
     mock_smtp.return_value = response
 
     for domain in (
@@ -3795,9 +4109,11 @@ def test_plugin_email_tls_certificate_verification(mock_smtpssl, mock_smtp):
     passing a validating SSL context to smtplib."""
 
     response = mock.Mock()
+    # An empty refusal map means SMTP accepted every recipient.
+    response.sendmail.return_value = {}
     response.starttls.return_value = True
     response.login.return_value = True
-    response.sendmail.return_value = True
+    response.sendmail.return_value = {}
     response.quit.return_value = True
     mock_smtp.return_value = response
     mock_smtpssl.return_value = response
@@ -3875,6 +4191,8 @@ def test_plugin_email_tls_certificate_verification(mock_smtpssl, mock_smtp):
 def test_plugin_email_starttls_certificate_failure_handling(mock_smtp):
     """A rejected STARTTLS certificate must be a normal send failure."""
     response = mock.Mock()
+    # An empty refusal map means SMTP accepted every recipient.
+    response.sendmail.return_value = {}
     response.starttls.side_effect = ssl.SSLCertVerificationError(
         "certificate verify failed"
     )

--- a/tests/test_plugin_email_smtp.py
+++ b/tests/test_plugin_email_smtp.py
@@ -1,0 +1,392 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Disable logging for a cleaner testing output
+import logging
+import smtplib
+from unittest import mock
+
+import pytest
+
+from apprise.exception import AppriseImproperlyConfigured
+from apprise.plugins.email.smtp import (
+    SMTP_DEFAULT_PORTS,
+    SMTP_SECURE_MODES,
+    AppriseSMTPController,
+    SMTPSecureMode,
+)
+
+logging.disable(logging.CRITICAL)
+
+
+def test_smtp_secure_mode_constants():
+    """SMTPSecureMode / SMTP_SECURE_MODES / SMTP_DEFAULT_PORTS basics."""
+
+    assert SMTPSecureMode.INSECURE == "insecure"
+    assert SMTPSecureMode.SSL == "ssl"
+    assert SMTPSecureMode.STARTTLS == "starttls"
+
+    assert set(SMTP_SECURE_MODES) == {
+        SMTPSecureMode.STARTTLS,
+        SMTPSecureMode.SSL,
+        SMTPSecureMode.INSECURE,
+    }
+
+    assert SMTP_DEFAULT_PORTS[SMTPSecureMode.STARTTLS] == 587
+    assert SMTP_DEFAULT_PORTS[SMTPSecureMode.SSL] == 465
+    assert SMTP_DEFAULT_PORTS[SMTPSecureMode.INSECURE] == 25
+
+
+@mock.patch("smtplib.SMTP")
+def test_smtp_controller_starttls_flow(mock_smtp):
+    """AppriseSMTPController applies STARTTLS and login in starttls mode."""
+
+    mock_socket = mock.Mock()
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
+    mock_smtp.return_value = mock_socket
+
+    with AppriseSMTPController(
+        host="smtp.example.com",
+        port=587,
+        secure_mode=SMTPSecureMode.STARTTLS,
+        user="user",
+        password="pass",
+    ) as smtp:
+        assert isinstance(smtp, AppriseSMTPController)
+        assert smtp.sendmail("from@example.com", ["to@example.com"], "body")
+
+    mock_smtp.assert_called_once_with(
+        "smtp.example.com", 587, None, timeout=15
+    )
+    assert mock_socket.starttls.called
+    mock_socket.login.assert_called_once_with("user", "pass")
+    mock_socket.sendmail.assert_called_once_with(
+        "from@example.com", ["to@example.com"], "body"
+    )
+    assert mock_socket.quit.called
+
+
+@mock.patch("smtplib.SMTP_SSL")
+def test_smtp_controller_ssl_flow(mock_smtp_ssl):
+    """SSL mode uses SMTP_SSL without STARTTLS."""
+
+    mock_socket = mock.Mock()
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
+    mock_smtp_ssl.return_value = mock_socket
+
+    with AppriseSMTPController(
+        host="smtp.example.com",
+        port=465,
+        secure_mode=SMTPSecureMode.SSL,
+    ) as smtp:
+        assert smtp.sendmail("from@example.com", ["to@example.com"], "body")
+
+    assert mock_smtp_ssl.called
+    assert not mock_socket.starttls.called
+    # No credentials supplied; login must not be attempted
+    assert not mock_socket.login.called
+    assert mock_socket.quit.called
+
+
+@mock.patch("smtplib.SMTP")
+def test_smtp_controller_insecure_flow(mock_smtp):
+    """Insecure mode uses plain SMTP."""
+
+    mock_socket = mock.Mock()
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
+    mock_smtp.return_value = mock_socket
+
+    with AppriseSMTPController(
+        host="smtp.example.com",
+        port=25,
+        secure_mode=SMTPSecureMode.INSECURE,
+    ) as smtp:
+        assert smtp.sendmail("from@example.com", ["to@example.com"], "body")
+
+    assert not mock_socket.starttls.called
+    assert not mock_socket.login.called
+
+
+@mock.patch("smtplib.SMTP")
+def test_smtp_controller_skips_partial_login(mock_smtp):
+    """Login requires both a username and password."""
+
+    mock_socket = mock.Mock()
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
+    mock_smtp.return_value = mock_socket
+
+    with AppriseSMTPController(
+        host="smtp.example.com",
+        port=25,
+        secure_mode=SMTPSecureMode.INSECURE,
+        user="user",
+        password=None,
+    ):
+        pass
+
+    assert not mock_socket.login.called
+
+
+@mock.patch("smtplib.SMTP")
+def test_smtp_controller_connect_failure(mock_smtp):
+    """A connection failure escapes without attempting to quit."""
+
+    mock_smtp.side_effect = OSError("connection refused")
+
+    with (
+        pytest.raises(OSError),
+        AppriseSMTPController(
+            host="smtp.example.com",
+            port=25,
+            secure_mode=SMTPSecureMode.INSECURE,
+        ),
+    ):
+        raise AssertionError("should never enter the with block")
+
+
+@mock.patch("smtplib.SMTP")
+def test_smtp_controller_starttls_cleanup(mock_smtp):
+    """A STARTTLS failure closes the partial connection."""
+
+    mock_socket = mock.Mock()
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
+    mock_socket.starttls.side_effect = smtplib.SMTPException("tls failed")
+    mock_smtp.return_value = mock_socket
+
+    with (
+        pytest.raises(smtplib.SMTPException),
+        AppriseSMTPController(
+            host="smtp.example.com",
+            port=587,
+            secure_mode=SMTPSecureMode.STARTTLS,
+        ),
+    ):
+        raise AssertionError("should never enter the with block")
+
+    assert mock_socket.quit.called
+
+
+@mock.patch("smtplib.SMTP")
+def test_smtp_controller_login_cleanup(mock_smtp):
+    """A login failure closes the established connection."""
+
+    mock_socket = mock.Mock()
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
+    mock_socket.login.side_effect = smtplib.SMTPAuthenticationError(
+        535, "bad credentials"
+    )
+    mock_smtp.return_value = mock_socket
+
+    with (
+        pytest.raises(smtplib.SMTPAuthenticationError),
+        AppriseSMTPController(
+            host="smtp.example.com",
+            port=587,
+            secure_mode=SMTPSecureMode.STARTTLS,
+            user="user",
+            password="pass",
+        ),
+    ):
+        raise AssertionError("should never enter the with block")
+
+    assert mock_socket.starttls.called
+    assert mock_socket.quit.called
+
+
+@mock.patch("smtplib.SMTP")
+def test_smtp_controller_sendmail_exceptions(mock_smtp):
+    """Delivery errors return false instead of escaping."""
+
+    mock_socket = mock.Mock()
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
+    mock_smtp.return_value = mock_socket
+
+    for exception in (
+        OSError("boom"),
+        smtplib.SMTPHeloError(0, "boom"),
+        smtplib.SMTPException(0, "boom"),
+        smtplib.SMTPRecipientsRefused("boom"),
+        smtplib.SMTPSenderRefused(0, "boom", "addr@example.com"),
+        smtplib.SMTPDataError(0, "boom"),
+        smtplib.SMTPServerDisconnected("boom"),
+        RuntimeError("boom"),
+    ):
+        mock_socket.sendmail.side_effect = exception
+        with AppriseSMTPController(
+            host="smtp.example.com",
+            port=25,
+            secure_mode=SMTPSecureMode.INSECURE,
+        ) as smtp:
+            assert (
+                smtp.sendmail("from@example.com", ["to@example.com"], "body")
+                is False
+            )
+
+
+@mock.patch("smtplib.SMTP")
+def test_smtp_controller_sendmail_partial_rejection(mock_smtp):
+    """A partial recipient rejection makes the delivery fail."""
+
+    mock_socket = mock.Mock()
+    mock_socket.sendmail.return_value = {
+        "bad@example.com": (550, b"Mailbox unavailable")
+    }
+    mock_smtp.return_value = mock_socket
+
+    with AppriseSMTPController(
+        host="smtp.example.com",
+        port=25,
+        secure_mode=SMTPSecureMode.INSECURE,
+    ) as smtp:
+        assert (
+            smtp.sendmail(
+                "from@example.com",
+                ["good@example.com", "bad@example.com"],
+                "body",
+            )
+            is False
+        )
+
+
+@mock.patch("smtplib.SMTP")
+def test_smtp_controller_quit_failure_suppressed(mock_smtp):
+    """__exit__ suppresses errors raised while closing the connection."""
+
+    mock_socket = mock.Mock()
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
+    mock_socket.quit.side_effect = smtplib.SMTPServerDisconnected("bye")
+    mock_smtp.return_value = mock_socket
+
+    # Must not raise despite quit() failing
+    with AppriseSMTPController(
+        host="smtp.example.com",
+        port=25,
+        secure_mode=SMTPSecureMode.INSECURE,
+    ):
+        pass
+
+    assert mock_socket.quit.called
+
+
+@mock.patch("smtplib.SMTP")
+def test_smtp_controller_quits_on_caller_error(mock_smtp):
+    """Caller errors still close the connection and propagate."""
+
+    mock_socket = mock.Mock()
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
+    mock_smtp.return_value = mock_socket
+
+    with (
+        pytest.raises(ValueError),
+        AppriseSMTPController(
+            host="smtp.example.com",
+            port=25,
+            secure_mode=SMTPSecureMode.INSECURE,
+        ),
+    ):
+        raise ValueError("caller-side failure")
+
+    assert mock_socket.quit.called
+
+
+@mock.patch("smtplib.SMTP_SSL")
+def test_smtp_controller_disables_verification(mock_smtp_ssl):
+    """The verification option controls certificate and hostname checks."""
+
+    mock_socket = mock.Mock()
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
+    mock_smtp_ssl.return_value = mock_socket
+
+    with AppriseSMTPController(
+        host="smtp.example.com",
+        port=465,
+        secure_mode=SMTPSecureMode.SSL,
+        verify_certificate=False,
+    ):
+        pass
+
+    context = mock_smtp_ssl.call_args.kwargs["context"]
+    assert context.check_hostname is False
+
+    import ssl
+
+    assert context.verify_mode == ssl.CERT_NONE
+
+
+@mock.patch("smtplib.SMTP")
+def test_smtp_controller_connect_timeout(mock_smtp):
+    """The configured connection timeout reaches smtplib."""
+
+    mock_socket = mock.Mock()
+    # An empty refusal map means SMTP accepted every recipient.
+    mock_socket.sendmail.return_value = {}
+    mock_smtp.return_value = mock_socket
+
+    with AppriseSMTPController(
+        host="smtp.example.com",
+        port=25,
+        secure_mode=SMTPSecureMode.INSECURE,
+        socket_connect_timeout=42,
+    ):
+        pass
+
+    mock_smtp.assert_called_once_with("smtp.example.com", 25, None, timeout=42)
+
+
+def test_smtp_controller_exit_before_enter():
+    """Exiting before entering is harmless."""
+
+    smtp = AppriseSMTPController(
+        host="smtp.example.com",
+        port=25,
+        secure_mode=SMTPSecureMode.INSECURE,
+    )
+    smtp.__exit__(None, None, None)
+
+
+def test_smtp_controller_invalid_secure_mode_rejected():
+    """Unknown security modes cannot fall back to plain SMTP."""
+
+    with (
+        pytest.raises(AppriseImproperlyConfigured),
+        AppriseSMTPController(
+            host="smtp.example.com",
+            port=25,
+            secure_mode="bogus",
+        ),
+    ):
+        raise AssertionError("should never enter the with block")

--- a/tests/test_plugin_sogs.py
+++ b/tests/test_plugin_sogs.py
@@ -36,6 +36,7 @@ import requests
 
 from apprise import Apprise
 from apprise.exception import AppriseImproperlyConfigured
+from apprise.plugins import sogs
 from apprise.plugins.sogs import (
     NotifySessionOGS,
     _build_session_message,
@@ -226,10 +227,34 @@ def test_plugin_sogs_no_cryptography():
     obj = Apprise.instantiate(BASE_URL)
     assert obj is None
 
-    # Direct instantiation must raise ImportError with a helpful message,
-    # not the confusing AttributeError from None.from_private_bytes().
-    with pytest.raises(ImportError, match="cryptography"):
-        NotifySessionOGS(public_key=PUBLIC_KEY, seed=SEED, targets=[ROOM])
+    # Direct construction remains safe, but sending is unavailable.
+    direct = NotifySessionOGS(
+        public_key=PUBLIC_KEY,
+        seed=SEED,
+        targets=[ROOM],
+    )
+    assert direct.enabled is False
+    assert direct.send("test") is False
+
+
+def test_plugin_sogs_disabled_dependency(monkeypatch):
+    """Direct use fails safely when cryptography is unavailable."""
+    monkeypatch.setattr(sogs, "NOTIFY_SESSIONOGS_ENABLED", False)
+    monkeypatch.setattr(NotifySessionOGS, "enabled", False)
+
+    assert Apprise.instantiate(BASE_URL) is None
+
+    direct = NotifySessionOGS(
+        public_key=PUBLIC_KEY,
+        seed=SEED,
+        targets=[ROOM],
+    )
+    assert direct._signing_key is None
+    assert direct._bot_pubkey_bytes is None
+
+    with mock.patch("requests.post") as mock_post:
+        assert direct.send("test") is False
+        mock_post.assert_not_called()
 
 
 @pytest.mark.skipif(
@@ -244,6 +269,7 @@ def test_plugin_sogs_init(mock_post):
         r = mock.Mock()
         r.status_code = code
         r.content = b'{"id": 1}'
+        r.iter_content = lambda chunk_size=None: iter([r.content])
         return r
 
     mock_post.return_value = _mk_resp()
@@ -348,6 +374,7 @@ def test_plugin_sogs_send_success(mock_post):
         r = mock.Mock()
         r.status_code = code
         r.content = b'{"id": 1}'
+        r.iter_content = lambda chunk_size=None: iter([r.content])
         return r
 
     mock_post.return_value = _mk_resp()
@@ -378,6 +405,7 @@ def test_plugin_sogs_send_multi_room(mock_post):
         r = mock.Mock()
         r.status_code = code
         r.content = b'{"id": 1}'
+        r.iter_content = lambda chunk_size=None: iter([r.content])
         return r
 
     mock_post.return_value = _mk_resp()
@@ -404,6 +432,7 @@ def test_plugin_sogs_send_partial_failure(mock_post):
         r = mock.Mock()
         r.status_code = code
         r.content = b""
+        r.iter_content = lambda chunk_size=None: iter([r.content])
         return r
 
     mock_post.side_effect = [
@@ -433,6 +462,7 @@ def test_plugin_sogs_http_error(mock_post):
         r = mock.Mock()
         r.status_code = code
         r.content = b""
+        r.iter_content = lambda chunk_size=None: iter([r.content])
         return r
 
     obj = NotifySessionOGS(
@@ -485,6 +515,7 @@ def test_plugin_sogs_http_insecure(mock_post):
         r = mock.Mock()
         r.status_code = requests.codes.created
         r.content = b'{"id": 1}'
+        r.iter_content = lambda chunk_size=None: iter([r.content])
         return r
 
     mock_post.return_value = _mk_resp()
@@ -511,6 +542,7 @@ def test_plugin_sogs_url_and_privacy(mock_post):
         r = mock.Mock()
         r.status_code = requests.codes.created
         r.content = b'{"id": 1}'
+        r.iter_content = lambda chunk_size=None: iter([r.content])
         return r
 
     mock_post.return_value = _mk_resp()
@@ -548,6 +580,7 @@ def test_plugin_sogs_custom_port(mock_post):
         r = mock.Mock()
         r.status_code = requests.codes.created
         r.content = b'{"id": 1}'
+        r.iter_content = lambda chunk_size=None: iter([r.content])
         return r
 
     mock_post.return_value = _mk_resp()
@@ -636,6 +669,7 @@ def test_plugin_sogs_invalid_room_token(mock_post):
         r = mock.Mock()
         r.status_code = requests.codes.created
         r.content = b'{"id": 1}'
+        r.iter_content = lambda chunk_size=None: iter([r.content])
         return r
 
     mock_post.return_value = _mk_resp()
@@ -700,6 +734,7 @@ def test_plugin_sogs_auth_headers(mock_post):
         r = mock.Mock()
         r.status_code = requests.codes.created
         r.content = b'{"id": 1}'
+        r.iter_content = lambda chunk_size=None: iter([r.content])
         return r
 
     mock_post.return_value = _mk_resp()
@@ -754,6 +789,7 @@ def test_plugin_sogs_response_unparseable_json(mock_post):
     r = mock.Mock()
     r.status_code = requests.codes.created
     r.content = b"not-json"
+    r.iter_content = lambda chunk_size=None: iter([r.content])
     mock_post.return_value = r
 
     obj = NotifySessionOGS(
@@ -763,6 +799,56 @@ def test_plugin_sogs_response_unparseable_json(mock_post):
         host="open.getsession.org",
     )
     assert bool(obj.notify(body="Hello")) is True
+
+
+@pytest.mark.skipif(
+    "cryptography" not in sys.modules,
+    reason="Requires cryptography",
+)
+@mock.patch("requests.post")
+def test_plugin_sogs_oversized_response_rejected(mock_post):
+    """Reject a response whose body grows past the acknowledgement limit.
+
+    The empty chunk confirms that keep-alive chunks are ignored.
+    """
+    over_limit = b"x" * (NotifySessionOGS.max_response_size + 1)
+    r = mock.Mock()
+    r.status_code = requests.codes.created
+    r.headers = {}
+    r.iter_content = lambda chunk_size=None: iter([b"", over_limit])
+    mock_post.return_value = r
+
+    obj = NotifySessionOGS(
+        public_key=PUBLIC_KEY,
+        seed=SEED,
+        targets=[ROOM],
+        host="open.getsession.org",
+    )
+    assert bool(obj.notify(body="Hello")) is False
+    r.close.assert_called_once()
+
+
+@pytest.mark.skipif(
+    "cryptography" not in sys.modules,
+    reason="Requires cryptography",
+)
+@mock.patch("requests.post")
+def test_plugin_sogs_closes_connection_after_read(mock_post):
+    """The streamed connection is closed once the body is read."""
+    r = mock.Mock()
+    r.status_code = requests.codes.created
+    r.content = b'{"id": 1}'
+    r.iter_content = lambda chunk_size=None: iter([r.content])
+    mock_post.return_value = r
+
+    obj = NotifySessionOGS(
+        public_key=PUBLIC_KEY,
+        seed=SEED,
+        targets=[ROOM],
+        host="open.getsession.org",
+    )
+    assert bool(obj.notify(body="Hello")) is True
+    r.close.assert_called_once()
 
 
 def test_plugin_sogs_build_session_message():
@@ -813,6 +899,7 @@ def test_plugin_sogs_apprise_integration(mock_post):
         r = mock.Mock()
         r.status_code = requests.codes.created
         r.content = b'{"id": 1}'
+        r.iter_content = lambda chunk_size=None: iter([r.content])
         return r
 
     mock_post.return_value = _mk_resp()

--- a/tests/test_utils_pgp.py
+++ b/tests/test_utils_pgp.py
@@ -26,26 +26,28 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 # Disable logging for a cleaner testing output
+import base64
 import logging
 import os
+import shutil
 import sys
 from unittest import mock
 
 import pytest
 
+from apprise import AppriseAsset
 from apprise.utils import pgp as pgp_module
 from apprise.utils.pgp import ApprisePGPController, _ensure_imghdr_shim
 
 logging.disable(logging.CRITICAL)
 
-# Path to the pre-generated private key fixture used by signing tests
+# Path to the pre-generated key fixtures used by signing/autocrypt tests
 _VAR_DIR = os.path.join(os.path.dirname(__file__), "var", "pgp")
 _VALID_PRV_ASC = os.path.join(_VAR_DIR, "valid-prv.asc")
+_VALID_PUB_ASC = os.path.join(_VAR_DIR, "valid-pub.asc")
 
 
-# ---------------------------------------------------------------------------
 # imghdr shim
-# ---------------------------------------------------------------------------
 
 
 def test_imghdr_shim_when_present():
@@ -63,7 +65,7 @@ def test_imghdr_shim_when_present():
         assert sys.modules.get("imghdr") is _real
 
     except ImportError:
-        # Python 3.13+ -- imghdr is gone; skip this branch
+        # Python 3.13 and newer removed imghdr.
         pytest.skip("imghdr not present on this Python version")
 
     finally:
@@ -102,9 +104,7 @@ def test_imghdr_shim_when_absent():
             sys.modules["imghdr"] = saved
 
 
-# ---------------------------------------------------------------------------
-# ApprisePGPController -- WKD integration
-# ---------------------------------------------------------------------------
+# ApprisePGPController WKD integration
 
 
 def test_pgp_controller_wkd_none_by_default(tmpdir):
@@ -189,8 +189,7 @@ def test_fetch_wkd_key_success(tmpdir):
     assert isinstance(result, pgpy.PGPKey)
     mock_wkd.fetch.assert_called_once_with("user@example.com")
 
-    # Second call must use the parsed-key cache -- wkd.fetch must NOT be
-    # called again (the cache check now happens before wkd.fetch())
+    # The second call must use the parsed-key cache.
     mock_wkd.fetch.reset_mock()
     result2 = ctrl._fetch_wkd_key("user@example.com")
     assert result2 is not None
@@ -296,7 +295,7 @@ def test_fetch_wkd_key_pgpy_not_installed(tmpdir):
     mock_wkd.fetch.return_value = b"fake-key-bytes"
     ctrl = ApprisePGPController(path=str(tmpdir), wkd=mock_wkd)
     # In a minimal env pgpy is not installed, so pgpy.PGPKey.from_blob
-    # raises NameError naturally -- no mock needed.
+    # raises NameError naturally, so no mock is needed.
     result = ctrl._fetch_wkd_key("user@example.com")
     assert result is None
 
@@ -392,9 +391,865 @@ def test_public_key_malformed_local_file_returns_none(tmpdir):
     assert result is None
 
 
-# ---------------------------------------------------------------------------
-# prune() -- WKD delegation
-# ---------------------------------------------------------------------------
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+@pytest.mark.parametrize("use_keyfile", (False, True))
+def test_keygen_checks_eligibility_before_rsa(tmpdir, use_keyfile):
+    """Disabled key generation does not perform expensive RSA work."""
+
+    ctrl = ApprisePGPController(
+        path=str(tmpdir) if use_keyfile else None,
+        pub_keyfile=_VALID_PUB_ASC if use_keyfile else None,
+        email="test@example.com",
+    )
+
+    with mock.patch.object(pgp_module.pgpy.PGPKey, "new") as mock_new:
+        assert ctrl.keygen() is False
+        mock_new.assert_not_called()
+
+
+# autocrypt_header()
+
+
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+def test_autocrypt_header_no_sender_key(tmpdir):
+    """Autocrypt is omitted when no sender key is available."""
+
+    asset = AppriseAsset(pgp_autogen=False)
+    ctrl = ApprisePGPController(
+        path=str(tmpdir), email="test@example.com", asset=asset
+    )
+    assert ctrl.autocrypt_header() is None
+
+
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+@pytest.mark.parametrize("missing_email", (None, ""))
+def test_autocrypt_header_none_without_email(tmpdir, missing_email):
+    """Autocrypt requires an address even when a sender key exists."""
+
+    ctrl = ApprisePGPController(
+        path=str(tmpdir),
+        prv_keyfile=_VALID_PRV_ASC,
+        email=missing_email,
+    )
+    # Only the address is missing.
+    assert ctrl.private_key() is not None
+    assert ctrl.autocrypt_header() is None
+
+
+def _fingerprint_of(path):
+    """Loads a key fixture from disk and returns its fingerprint string."""
+    import pgpy
+
+    with open(path) as key_file:
+        key, _ = pgpy.PGPKey.from_blob(key_file.read())
+    return str(key.fingerprint)
+
+
+def _keydata_fingerprint(header):
+    """Decodes an Autocrypt header's keydata= and returns its fingerprint."""
+    import pgpy
+
+    keydata = header.split("keydata=", 1)[1]
+    key, _ = pgpy.PGPKey.from_blob(base64.b64decode(keydata))
+    return str(key.fingerprint)
+
+
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+def test_autocrypt_header_valid_key(tmpdir):
+    """Autocrypt advertises the public half of a generated sender key."""
+
+    ctrl = ApprisePGPController(path=str(tmpdir), email="test@example.com")
+    assert ctrl.keygen() is True
+
+    header = ctrl.autocrypt_header()
+    assert header is not None
+    assert header.startswith(
+        "addr=test@example.com; prefer-encrypt=mutual; keydata="
+    )
+
+    # Compare fingerprints so an unrelated but valid key cannot pass.
+    assert _keydata_fingerprint(header) == str(ctrl.private_key().fingerprint)
+
+
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+def test_autocrypt_header_ignores_recipient_pgppub(tmpdir):
+    """Autocrypt uses our signing key instead of recipient pgppub=."""
+
+    # Generate the sender key before configuring a recipient override.
+    keygen_ctrl = ApprisePGPController(
+        path=str(tmpdir), email="test@example.com"
+    )
+    assert keygen_ctrl.keygen() is True
+    own_fingerprint = str(keygen_ctrl.private_key().fingerprint)
+
+    # The fixture represents an unrelated recipient's key
+    assert own_fingerprint != _fingerprint_of(_VALID_PUB_ASC)
+
+    # The sender key remains discoverable beside the recipient override.
+    ctrl = ApprisePGPController(
+        path=str(tmpdir),
+        pub_keyfile=_VALID_PUB_ASC,
+        email="test@example.com",
+    )
+    header = ctrl.autocrypt_header()
+    assert header is not None
+    assert _keydata_fingerprint(header) == own_fingerprint
+
+
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+def test_autocrypt_header_ignores_recipient_only_key(tmpdir):
+    """Autocrypt omits a recipient pgppub= when no sender key exists."""
+
+    asset = AppriseAsset(pgp_autogen=False)
+    ctrl = ApprisePGPController(
+        path=str(tmpdir),
+        pub_keyfile=_VALID_PUB_ASC,
+        email="test@example.com",
+        asset=asset,
+    )
+    assert ctrl.autocrypt_header() is None
+
+
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+@pytest.mark.parametrize(
+    "filename",
+    (
+        # Sender-specific names still require a matching private key.
+        "sender@example.com-pub.asc",
+        "sender-pub.asc",
+        "pgp-public.asc",
+        "pgp-pub.asc",
+        "public.asc",
+        "pub.asc",
+    ),
+)
+def test_autocrypt_header_ignores_public_only_local_files(tmpdir, filename):
+    """Autocrypt ignores local public keys without a matching private key."""
+
+    shutil.copy(_VALID_PUB_ASC, str(tmpdir.join(filename)))
+
+    asset = AppriseAsset(pgp_autogen=False)
+    ctrl = ApprisePGPController(
+        path=str(tmpdir), email="sender@example.com", asset=asset
+    )
+    assert ctrl.autocrypt_header() is None
+
+
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+def test_autocrypt_header_autogen_generates_own_key(tmpdir):
+    """Autocrypt may generate and advertise a sender-owned key pair."""
+
+    asset = AppriseAsset(pgp_autogen=True)
+    ctrl = ApprisePGPController(
+        path=str(tmpdir), email="sender@example.com", asset=asset
+    )
+    assert ctrl.private_key() is None
+
+    header = ctrl.autocrypt_header()
+    assert header is not None
+    assert header.startswith("addr=sender@example.com;")
+
+    # A private key must now exist, and it must be the one advertised
+    private_key = ctrl.private_key()
+    assert private_key is not None
+    assert _keydata_fingerprint(header) == str(private_key.fingerprint)
+
+
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+def test_autocrypt_header_respects_autogen_disabled(tmpdir):
+    """Autocrypt respects disabled key generation."""
+
+    asset = AppriseAsset(pgp_autogen=False)
+    ctrl = ApprisePGPController(
+        path=str(tmpdir), email="sender@example.com", asset=asset
+    )
+    assert ctrl.autocrypt_header() is None
+    assert ctrl.private_key() is None
+
+
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+def test_autocrypt_header_enforces_size_limit(tmpdir):
+    """Autocrypt rejects headers over its 10 KiB limit."""
+
+    ctrl = ApprisePGPController(path=str(tmpdir), email="test@example.com")
+    assert ctrl.keygen() is True
+
+    # Sanity: the real key comfortably fits within the real limit
+    assert ctrl.autocrypt_header() is not None
+
+    # Force the limit far below anything a real key could satisfy
+    ctrl.max_autocrypt_header_size = 10
+    assert ctrl.autocrypt_header() is None
+
+
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+def test_autocrypt_header_rejects_key_without_encryption_subkey(tmpdir):
+    """Autocrypt rejects a private key without an encryption subkey."""
+
+    ctrl = ApprisePGPController(
+        path=str(tmpdir),
+        prv_keyfile=_VALID_PRV_ASC,
+        email="test@example.com",
+    )
+    private_key = ctrl.private_key()
+    assert private_key is not None
+    assert not ApprisePGPController._has_encryption_subkey(private_key)
+
+    assert ctrl.autocrypt_header() is None
+
+
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+def test_autocrypt_header_accepts_key_with_encryption_subkey(tmpdir):
+    """_has_encryption_subkey() recognizes a properly structured key."""
+
+    ctrl = ApprisePGPController(path=str(tmpdir), email="test@example.com")
+    assert ctrl.keygen() is True
+
+    private_key = ctrl.private_key()
+    assert ApprisePGPController._has_encryption_subkey(private_key)
+
+
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+def test_autocrypt_header_rejects_key_with_extra_userid(tmpdir):
+    """Autocrypt rejects an otherwise valid key with multiple UIDs."""
+
+    import pgpy
+    from pgpy.constants import (
+        CompressionAlgorithm,
+        HashAlgorithm,
+        KeyFlags,
+        PubKeyAlgorithm,
+        SymmetricKeyAlgorithm,
+    )
+
+    primary = pgpy.PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    for name, email in (
+        ("Test", "test@example.com"),
+        ("Test (work)", "test@work.example.com"),
+    ):
+        primary.add_uid(
+            pgpy.PGPUID.new(name, email=email),
+            usage={KeyFlags.Sign, KeyFlags.Certify},
+            hashes=[HashAlgorithm.SHA256],
+            ciphers=[SymmetricKeyAlgorithm.AES256],
+            compression=[CompressionAlgorithm.ZLIB],
+        )
+    subkey = pgpy.PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    primary.add_subkey(
+        subkey,
+        usage={KeyFlags.EncryptCommunications, KeyFlags.EncryptStorage},
+    )
+
+    prv_path = str(tmpdir.join("multi-uid-prv.asc"))
+    with open(prv_path, "w") as f:
+        f.write(str(primary))
+
+    ctrl = ApprisePGPController(
+        path=str(tmpdir), prv_keyfile=prv_path, email="test@example.com"
+    )
+    private_key = ctrl.private_key()
+    assert private_key is not None
+    assert not ApprisePGPController._has_encryption_subkey(private_key)
+    assert ctrl.autocrypt_header() is None
+
+
+def _mock_uid_with_one_selfsig():
+    """A mock UID with exactly the one self-signature a compliant key
+    is expected to have, so tests can focus on the subkey side."""
+    uid = mock.Mock()
+    selfsig = mock.Mock()
+    uid.selfsig = selfsig
+    uid._signatures = [selfsig]
+    return uid
+
+
+def test_has_encryption_subkey_skips_subkey_without_selfsig():
+    """A lone subkey with no self-signature at all is not usable."""
+
+    no_selfsig_subkey = mock.Mock()
+    no_selfsig_subkey.revocation_signatures = []
+    no_selfsig_subkey.self_signatures = iter(())
+
+    key = mock.Mock()
+    key.userattributes = []
+    key.revocation_signatures = []
+    key.userids = [_mock_uid_with_one_selfsig()]
+    key.subkeys = {"a": no_selfsig_subkey}
+
+    assert ApprisePGPController._has_encryption_subkey(key) is False
+
+
+def test_has_encryption_subkey_skips_subkey_with_wrong_flags():
+    """A signed subkey without encryption usage is not usable."""
+
+    wrong_flags_subkey = mock.Mock()
+    wrong_flags_subkey.revocation_signatures = []
+    wrong_flags_subkey.self_signatures = iter(
+        [mock.Mock(key_flags={pgp_module.pgpy.constants.KeyFlags.Sign})]
+    )
+
+    key = mock.Mock()
+    key.userattributes = []
+    key.revocation_signatures = []
+    key.userids = [_mock_uid_with_one_selfsig()]
+    key.subkeys = {"a": wrong_flags_subkey}
+
+    assert ApprisePGPController._has_encryption_subkey(key) is False
+
+
+def test_has_encryption_subkey_rejects_multiple_userids():
+    """Autocrypt rejects keys with multiple identities."""
+
+    good_subkey = mock.Mock()
+    good_subkey.self_signatures = iter(
+        [
+            mock.Mock(
+                key_flags={
+                    pgp_module.pgpy.constants.KeyFlags.EncryptCommunications
+                }
+            )
+        ]
+    )
+
+    key = mock.Mock()
+    key.userattributes = []
+    key.revocation_signatures = []
+    key.userids = ["user@example.com", "user@work.example.com"]
+    key.subkeys = {"a": good_subkey}
+
+    assert ApprisePGPController._has_encryption_subkey(key) is False
+
+
+def test_has_encryption_subkey_rejects_multiple_subkeys():
+    """Autocrypt Level 1 requires exactly one subkey."""
+
+    def make_subkey():
+        subkey = mock.Mock()
+        subkey.self_signatures = iter(
+            [
+                mock.Mock(
+                    key_flags={
+                        pgp_module.pgpy.constants.KeyFlags.EncryptCommunications
+                    }
+                )
+            ]
+        )
+        return subkey
+
+    key = mock.Mock()
+    key.userattributes = []
+    key.revocation_signatures = []
+    key.userids = ["user@example.com"]
+    key.subkeys = {"a": make_subkey(), "b": make_subkey()}
+
+    assert ApprisePGPController._has_encryption_subkey(key) is False
+
+
+def test_has_encryption_subkey_rejects_extra_uid_selfsig():
+    """Autocrypt rejects a UID with an extra self-signature."""
+
+    uid = mock.Mock()
+    uid._signatures = [mock.Mock(), mock.Mock()]
+
+    subkey = mock.Mock()
+    subkey.self_signatures = iter(
+        [
+            mock.Mock(
+                key_flags={
+                    pgp_module.pgpy.constants.KeyFlags.EncryptCommunications
+                }
+            )
+        ]
+    )
+
+    key = mock.Mock()
+    key.userattributes = []
+    key.revocation_signatures = []
+    key.userids = [uid]
+    key.subkeys = {"a": subkey}
+
+    assert ApprisePGPController._has_encryption_subkey(key) is False
+
+
+def test_has_encryption_subkey_rejects_extra_subkey_binding_sig():
+    """Autocrypt rejects a subkey with an extra binding signature."""
+
+    uid = mock.Mock()
+    uid._signatures = [mock.Mock()]
+
+    subkey = mock.Mock()
+    subkey.revocation_signatures = []
+    subkey.self_signatures = iter(
+        [
+            mock.Mock(
+                key_flags={
+                    pgp_module.pgpy.constants.KeyFlags.EncryptCommunications
+                }
+            ),
+            mock.Mock(
+                key_flags={
+                    pgp_module.pgpy.constants.KeyFlags.EncryptCommunications
+                }
+            ),
+        ]
+    )
+
+    key = mock.Mock()
+    key.userattributes = []
+    key.revocation_signatures = []
+    key.userids = [uid]
+    key.subkeys = {"a": subkey}
+
+    assert ApprisePGPController._has_encryption_subkey(key) is False
+
+
+def test_has_encryption_subkey_rejects_uid_without_selfsig():
+    """Reject a UID whose only signature is from a third party."""
+
+    uid = mock.Mock()
+    uid.selfsig = None
+    uid._signatures = [mock.Mock()]
+
+    subkey = mock.Mock()
+    subkey.self_signatures = iter(
+        [
+            mock.Mock(
+                key_flags={
+                    pgp_module.pgpy.constants.KeyFlags.EncryptCommunications
+                }
+            )
+        ]
+    )
+
+    key = mock.Mock()
+    key.userattributes = []
+    key.revocation_signatures = []
+    key.userids = [uid]
+    key.subkeys = {"a": subkey}
+
+    assert ApprisePGPController._has_encryption_subkey(key) is False
+
+
+def test_has_encryption_subkey_rejects_missing_signature_list():
+    """Reject the key if PGPy's private signature collection is absent."""
+
+    uid = mock.Mock(spec=["selfsig"])
+    uid.selfsig = mock.Mock()
+
+    key = mock.Mock()
+    key.userattributes = []
+    key.revocation_signatures = []
+    key.userids = [uid]
+    key.subkeys = {"a": mock.Mock()}
+
+    assert ApprisePGPController._has_encryption_subkey(key) is False
+
+
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+def test_autocrypt_header_rejects_third_party_only_uid(tmpdir):
+    """Reject a serialized key with only a third-party UID signature."""
+
+    import pgpy
+    from pgpy.constants import (
+        CompressionAlgorithm,
+        HashAlgorithm,
+        KeyFlags,
+        PubKeyAlgorithm,
+        SymmetricKeyAlgorithm,
+    )
+
+    victim = pgpy.PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    uid = pgpy.PGPUID.new("Victim", email="victim@example.com")
+    victim.add_uid(
+        uid,
+        usage={KeyFlags.Sign, KeyFlags.Certify},
+        hashes=[HashAlgorithm.SHA256],
+        ciphers=[SymmetricKeyAlgorithm.AES256],
+        compression=[CompressionAlgorithm.ZLIB],
+    )
+    subkey = pgpy.PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    victim.add_subkey(
+        subkey,
+        usage={KeyFlags.EncryptCommunications, KeyFlags.EncryptStorage},
+    )
+
+    # A third party certifies the UID instead of the primary itself
+    thirdparty = pgpy.PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    tp_uid = pgpy.PGPUID.new("ThirdParty", email="tp@example.com")
+    thirdparty.add_uid(
+        tp_uid,
+        usage={KeyFlags.Sign, KeyFlags.Certify},
+        hashes=[HashAlgorithm.SHA256],
+        ciphers=[SymmetricKeyAlgorithm.AES256],
+        compression=[CompressionAlgorithm.ZLIB],
+    )
+    cert_sig = thirdparty.certify(uid)
+
+    # Replace the genuine self-signature with the third-party one, so
+    # the UID's only signature is not from its own primary key
+    uid._signatures.clear()
+    uid._signatures.append(cert_sig)
+
+    prv_path = str(tmpdir.join("thirdparty-only-prv.asc"))
+    with open(prv_path, "w") as f:
+        f.write(str(victim))
+
+    ctrl = ApprisePGPController(
+        path=str(tmpdir), prv_keyfile=prv_path, email="victim@example.com"
+    )
+    private_key = ctrl.private_key()
+    assert private_key is not None
+    assert private_key.userids[0].selfsig is None
+    assert not ApprisePGPController._has_encryption_subkey(private_key)
+    assert ctrl.autocrypt_header() is None
+
+
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+def test_autocrypt_header_rejects_key_with_extra_uid_signature(tmpdir):
+    """Autocrypt rejects an extra UID signature after serialization."""
+
+    import pgpy
+    from pgpy.constants import (
+        CompressionAlgorithm,
+        HashAlgorithm,
+        KeyFlags,
+        PubKeyAlgorithm,
+        SymmetricKeyAlgorithm,
+    )
+
+    primary = pgpy.PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    uid = pgpy.PGPUID.new("Test", email="test@example.com")
+    primary.add_uid(
+        uid,
+        usage={KeyFlags.Sign, KeyFlags.Certify},
+        hashes=[HashAlgorithm.SHA256],
+        ciphers=[SymmetricKeyAlgorithm.AES256],
+        compression=[CompressionAlgorithm.ZLIB],
+    )
+    subkey = pgpy.PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    primary.add_subkey(
+        subkey,
+        usage={KeyFlags.EncryptCommunications, KeyFlags.EncryptStorage},
+    )
+
+    # Add another genuine self-certification to the same UID.
+    extra_sig = primary.certify(uid, expires=None)
+    uid._signatures.insert(0, extra_sig)
+
+    prv_path = str(tmpdir.join("extra-sig-prv.asc"))
+    with open(prv_path, "w") as f:
+        f.write(str(primary))
+
+    ctrl = ApprisePGPController(
+        path=str(tmpdir), prv_keyfile=prv_path, email="test@example.com"
+    )
+    private_key = ctrl.private_key()
+    assert private_key is not None
+    assert len(private_key.userids[0]._signatures) == 2
+    assert not ApprisePGPController._has_encryption_subkey(private_key)
+    assert ctrl.autocrypt_header() is None
+
+
+def test_has_encryption_subkey_rejects_user_attribute():
+    """Reject user attributes because they add packets to the key."""
+
+    key = mock.Mock()
+    key.userattributes = [mock.Mock()]
+
+    assert ApprisePGPController._has_encryption_subkey(key) is False
+
+
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+def test_autocrypt_header_rejects_photo_attribute(tmpdir):
+    """Reject a serialized key containing a photo attribute."""
+
+    import pgpy
+    from pgpy.constants import (
+        CompressionAlgorithm,
+        HashAlgorithm,
+        KeyFlags,
+        PubKeyAlgorithm,
+        SymmetricKeyAlgorithm,
+    )
+
+    primary = pgpy.PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    uid = pgpy.PGPUID.new("Test", email="test@example.com")
+    primary.add_uid(
+        uid,
+        usage={KeyFlags.Sign, KeyFlags.Certify},
+        hashes=[HashAlgorithm.SHA256],
+        ciphers=[SymmetricKeyAlgorithm.AES256],
+        compression=[CompressionAlgorithm.ZLIB],
+    )
+    subkey = pgpy.PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    primary.add_subkey(
+        subkey,
+        usage={KeyFlags.EncryptCommunications, KeyFlags.EncryptStorage},
+    )
+
+    # A minimal (fake, but structurally-tagged) JPEG photo attribute
+    photo_bytes = bytearray(b"\xff\xd8\xff\xe0" + b"\x00" * 100 + b"\xff\xd9")
+    photo_uid = pgpy.PGPUID.new(photo_bytes)
+    primary.add_uid(photo_uid)
+
+    prv_path = str(tmpdir.join("photo-prv.asc"))
+    with open(prv_path, "w") as f:
+        f.write(str(primary))
+
+    ctrl = ApprisePGPController(
+        path=str(tmpdir), prv_keyfile=prv_path, email="test@example.com"
+    )
+    private_key = ctrl.private_key()
+    assert private_key is not None
+    assert len(private_key.userattributes) == 1
+    assert not ApprisePGPController._has_encryption_subkey(private_key)
+    assert ctrl.autocrypt_header() is None
+
+
+def test_has_encryption_subkey_rejects_revoked_primary_key():
+    """Reject a revoked primary key despite its valid UID and subkey."""
+
+    key = mock.Mock()
+    key.userattributes = []
+    key.revocation_signatures = [mock.Mock()]
+
+    assert ApprisePGPController._has_encryption_subkey(key) is False
+
+
+def test_has_encryption_subkey_rejects_revoked_subkey():
+    """Reject an encryption subkey carrying a revocation signature."""
+
+    subkey = mock.Mock()
+    subkey.revocation_signatures = [mock.Mock()]
+
+    key = mock.Mock()
+    key.userattributes = []
+    key.revocation_signatures = []
+    key.userids = [_mock_uid_with_one_selfsig()]
+    key.subkeys = {"a": subkey}
+
+    assert ApprisePGPController._has_encryption_subkey(key) is False
+
+
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+def test_autocrypt_header_rejects_revoked_primary_key(tmpdir):
+    """Reject a serialized key with a revoked primary key."""
+
+    import pgpy
+    from pgpy.constants import (
+        CompressionAlgorithm,
+        HashAlgorithm,
+        KeyFlags,
+        PubKeyAlgorithm,
+        SymmetricKeyAlgorithm,
+    )
+
+    primary = pgpy.PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    uid = pgpy.PGPUID.new("Test", email="test@example.com")
+    primary.add_uid(
+        uid,
+        usage={KeyFlags.Sign, KeyFlags.Certify},
+        hashes=[HashAlgorithm.SHA256],
+        ciphers=[SymmetricKeyAlgorithm.AES256],
+        compression=[CompressionAlgorithm.ZLIB],
+    )
+    subkey = pgpy.PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    primary.add_subkey(
+        subkey,
+        usage={KeyFlags.EncryptCommunications, KeyFlags.EncryptStorage},
+    )
+
+    # Revoke the primary key itself
+    revoke_sig = primary.revoke(primary)
+    primary |= revoke_sig
+
+    prv_path = str(tmpdir.join("revoked-primary-prv.asc"))
+    with open(prv_path, "w") as f:
+        f.write(str(primary))
+
+    ctrl = ApprisePGPController(
+        path=str(tmpdir), prv_keyfile=prv_path, email="test@example.com"
+    )
+    private_key = ctrl.private_key()
+    assert private_key is not None
+    assert len(list(private_key.revocation_signatures)) == 1
+    assert not ApprisePGPController._has_encryption_subkey(private_key)
+    assert ctrl.autocrypt_header() is None
+
+
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+def test_autocrypt_header_rejects_revoked_subkey(tmpdir):
+    """Reject a serialized key with a revoked encryption subkey."""
+
+    import pgpy
+    from pgpy.constants import (
+        CompressionAlgorithm,
+        HashAlgorithm,
+        KeyFlags,
+        PubKeyAlgorithm,
+        SymmetricKeyAlgorithm,
+    )
+
+    primary = pgpy.PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    uid = pgpy.PGPUID.new("Test", email="test@example.com")
+    primary.add_uid(
+        uid,
+        usage={KeyFlags.Sign, KeyFlags.Certify},
+        hashes=[HashAlgorithm.SHA256],
+        ciphers=[SymmetricKeyAlgorithm.AES256],
+        compression=[CompressionAlgorithm.ZLIB],
+    )
+    subkey = pgpy.PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    primary.add_subkey(
+        subkey,
+        usage={KeyFlags.EncryptCommunications, KeyFlags.EncryptStorage},
+    )
+
+    # Revoke only the subkey, not the primary
+    revoke_sig = primary.revoke(subkey)
+    subkey |= revoke_sig
+
+    prv_path = str(tmpdir.join("revoked-subkey-prv.asc"))
+    with open(prv_path, "w") as f:
+        f.write(str(primary))
+
+    ctrl = ApprisePGPController(
+        path=str(tmpdir), prv_keyfile=prv_path, email="test@example.com"
+    )
+    private_key = ctrl.private_key()
+    assert private_key is not None
+    assert not list(private_key.revocation_signatures)  # primary is fine
+    reparsed_subkey = next(iter(private_key.subkeys.values()))
+    assert len(list(reparsed_subkey.revocation_signatures)) == 1
+    assert not ApprisePGPController._has_encryption_subkey(private_key)
+    assert ctrl.autocrypt_header() is None
+
+
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+def test_autocrypt_header_preserves_exported_fingerprint(tmpdir):
+    """The advertised key retains the exported key's fingerprint."""
+
+    import pgpy
+
+    ctrl = ApprisePGPController(path=str(tmpdir), email="test@example.com")
+    assert ctrl.keygen() is True
+
+    private_key = ctrl.private_key()
+    exported = bytes(private_key.pubkey)
+    reparsed, _ = pgpy.PGPKey.from_blob(exported)
+
+    header = ctrl.autocrypt_header()
+    assert header is not None
+
+    # The advertised key must retain the exported primary-key identity.
+    assert _keydata_fingerprint(header) == str(reparsed.fingerprint)
+
+
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+def test_autocrypt_header_accepts_nonexportable_signature(tmpdir):
+    """Validate the exported form of a key.
+
+    PGPy drops the extra non-exportable signature, leaving one valid UID
+    signature in the advertised key.
+    """
+
+    import pgpy
+    from pgpy.constants import (
+        CompressionAlgorithm,
+        HashAlgorithm,
+        KeyFlags,
+        PubKeyAlgorithm,
+        SymmetricKeyAlgorithm,
+    )
+
+    primary = pgpy.PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    uid = pgpy.PGPUID.new("Test", email="test@example.com")
+    primary.add_uid(
+        uid,
+        usage={KeyFlags.Sign, KeyFlags.Certify},
+        hashes=[HashAlgorithm.SHA256],
+        ciphers=[SymmetricKeyAlgorithm.AES256],
+        compression=[CompressionAlgorithm.ZLIB],
+    )
+    subkey = pgpy.PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    primary.add_subkey(
+        subkey,
+        usage={KeyFlags.EncryptCommunications, KeyFlags.EncryptStorage},
+    )
+
+    # A second, non-exportable certification over the same UID
+    extra_sig = primary.certify(uid, exportable=False)
+    uid._signatures.insert(0, extra_sig)
+
+    # The live in-memory object has two signatures and fails validation
+    assert len(uid._signatures) == 2
+    assert not ApprisePGPController._has_encryption_subkey(primary)
+
+    # PGPy omits the extra signature from the exported key.
+    exported = bytes(primary.pubkey)
+    reparsed, _ = pgpy.PGPKey.from_blob(exported)
+    assert len(reparsed.userids[0]._signatures) == 1
+    assert ApprisePGPController._has_encryption_subkey(reparsed)
+
+    prv_path = str(tmpdir.join("nonexportable-extra-prv.asc"))
+    with open(prv_path, "w") as f:
+        f.write(str(primary))
+
+    ctrl = ApprisePGPController(
+        path=str(tmpdir), prv_keyfile=prv_path, email="test@example.com"
+    )
+    # The header validates the exported key rather than the live object.
+    header = ctrl.autocrypt_header()
+    assert header is not None
+    assert _keydata_fingerprint(header) == str(reparsed.fingerprint)
+
+
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+def test_autocrypt_header_handles_reparse_failure(tmpdir):
+    """Omit the header when the exported key cannot be parsed."""
+
+    ctrl = ApprisePGPController(path=str(tmpdir), email="test@example.com")
+    assert ctrl.keygen() is True
+
+    # Warm the cache so the mock affects only the exported-key reparse.
+    assert ctrl.private_key() is not None
+
+    with mock.patch.object(
+        pgp_module.pgpy.PGPKey,
+        "from_blob",
+        side_effect=ValueError("corrupt export"),
+    ):
+        assert ctrl.autocrypt_header() is None
+
+
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+def test_autocrypt_header_folds_long_keydata(tmpdir):
+    """Folded keydata stays within line limits and remains decodable."""
+
+    ctrl = ApprisePGPController(path=str(tmpdir), email="test@example.com")
+    assert ctrl.keygen() is True
+
+    header = ctrl.autocrypt_header()
+    assert header is not None
+
+    # Keep every physical header line within RFC 5322's hard limit.
+    rendered = f"Autocrypt: {header}"
+    for line in rendered.split("\r\n"):
+        assert len(line) <= 998
+
+    # Folding must have actually happened for a real 2048-bit RSA key
+    assert "\r\n " in header
+
+    # addr= and prefer-encrypt= must stay intact and unfolded
+    assert header.startswith(
+        "addr=test@example.com; prefer-encrypt=mutual; keydata="
+    )
+
+    # Folding must not alter the advertised key.
+    assert _keydata_fingerprint(header) == str(ctrl.private_key().fingerprint)
+
+
+# prune() WKD delegation
 
 
 def test_prune_delegates_to_wkd(tmpdir):
@@ -411,9 +1266,7 @@ def test_prune_without_wkd(tmpdir):
     ctrl.prune()  # must not raise
 
 
-# ---------------------------------------------------------------------------
-# PGP_SUPPORT flag consistency
-# ---------------------------------------------------------------------------
+# PGP_SUPPORT consistency
 
 
 def test_pgp_support_flag_present():
@@ -421,9 +1274,7 @@ def test_pgp_support_flag_present():
     assert isinstance(pgp_module.PGP_SUPPORT, bool)
 
 
-# ---------------------------------------------------------------------------
-# private_keyfile() -- path resolution
-# ---------------------------------------------------------------------------
+# private_keyfile() path resolution
 
 
 def test_private_keyfile_no_path():
@@ -490,7 +1341,7 @@ def test_prv_keyfile_property_path_when_valid(tmpdir):
     """prv_keyfile property returns the resolved path for a valid key."""
     ctrl = ApprisePGPController(path=str(tmpdir), prv_keyfile=_VALID_PRV_ASC)
     # Property accesses the attachment; it may return None before loading
-    # because the attachment is resolved lazily -- just confirm it is not False
+    # because the attachment is resolved lazily. It must not be False.
     assert ctrl.prv_keyfile is not False
 
 
@@ -503,9 +1354,7 @@ def test_prv_keyfile_property_false_when_invalid(tmpdir):
     assert ctrl.prv_keyfile is False
 
 
-# ---------------------------------------------------------------------------
-# private_key() -- loading the private PGP key object
-# ---------------------------------------------------------------------------
+# Loading private PGP keys
 
 
 @pytest.mark.skipif("pgpy" not in sys.modules, reason="Requires PGPy")
@@ -655,9 +1504,21 @@ def test_private_key_rejects_passphrase_protected(tmpdir):
     assert result is None
 
 
-# ---------------------------------------------------------------------------
-# sign() -- creating detached PGP signatures
-# ---------------------------------------------------------------------------
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
+def test_private_key_rejects_public_only_file(tmpdir):
+    """private_key() rejects public-only files supplied by pgpprv=."""
+
+    ctrl = ApprisePGPController(
+        path=str(tmpdir), prv_keyfile=_VALID_PUB_ASC, email="test@example.com"
+    )
+    result = ctrl.private_key()
+    assert result is None
+
+    # autocrypt_header() must not advertise it either
+    assert ctrl.autocrypt_header() is None
+
+
+# Detached PGP signatures
 
 
 @pytest.mark.skipif("pgpy" not in sys.modules, reason="Requires PGPy")
@@ -705,9 +1566,7 @@ def test_sign_returns_none_when_pgpy_missing(tmpdir):
     assert result is None
 
 
-# ---------------------------------------------------------------------------
-# _pub_key_candidates() -- candidate filename ordering
-# ---------------------------------------------------------------------------
+# Public-key candidate order
 
 
 def test_pub_key_candidates_no_email(tmpdir):
@@ -739,24 +1598,18 @@ def test_pub_key_candidates_with_email(tmpdir):
 
 
 def test_pub_key_candidates_extra_email(tmpdir):
-    """_pub_key_candidates() gives caller-supplied addresses higher priority
-    than self.email because a per-recipient key lookup should prefer the
-    recipient-specific file over the controller's own identity key."""
+    """Recipient lookups never fall back to the sender's key."""
     ctrl = ApprisePGPController(path=str(tmpdir), email="sender@example.com")
     # Simulate a lookup for a recipient address
     candidates = ctrl._pub_key_candidates("recipient@example.com")
-    # Caller-supplied (recipient) address is processed last in the loop,
-    # so its entries end up at the front of the list (highest priority)
     assert candidates[0] == "recipient@example.com-pub.asc"
     assert candidates[1] == "recipient-pub.asc"
-    # self.email (sender) entries appear after
-    assert "sender@example.com-pub.asc" in candidates
-    assert "sender-pub.asc" in candidates
+    # Sender entries must not appear in a recipient lookup.
+    assert "sender@example.com-pub.asc" not in candidates
+    assert "sender-pub.asc" not in candidates
 
 
-# ---------------------------------------------------------------------------
-# _prv_key_candidates() -- candidate filename ordering
-# ---------------------------------------------------------------------------
+# Private-key candidate order
 
 
 def test_prv_key_candidates_no_email(tmpdir):
@@ -785,9 +1638,7 @@ def test_prv_key_candidates_with_email(tmpdir):
     assert "pgp-prv.asc" in candidates
 
 
-# ---------------------------------------------------------------------------
-# public_key() -- diagnostic warning when no key is found
-# ---------------------------------------------------------------------------
+# Missing public-key diagnostics
 
 
 def test_public_key_no_key_emits_path_debug(tmpdir):
@@ -819,9 +1670,7 @@ def test_public_key_no_key_no_path_emits_generic_debug():
     assert result is None
 
 
-# ---------------------------------------------------------------------------
-# private_key() -- diagnostic debug message when no key is found
-# ---------------------------------------------------------------------------
+# Missing private-key diagnostics
 
 
 def test_private_key_not_found_emits_path_debug(tmpdir):

--- a/tests/test_utils_pgp.py
+++ b/tests/test_utils_pgp.py
@@ -679,6 +679,7 @@ def test_has_encryption_subkey_skips_subkey_without_selfsig():
     assert ApprisePGPController._has_encryption_subkey(key) is False
 
 
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
 def test_has_encryption_subkey_skips_subkey_with_wrong_flags():
     """A signed subkey without encryption usage is not usable."""
 
@@ -697,6 +698,7 @@ def test_has_encryption_subkey_skips_subkey_with_wrong_flags():
     assert ApprisePGPController._has_encryption_subkey(key) is False
 
 
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
 def test_has_encryption_subkey_rejects_multiple_userids():
     """Autocrypt rejects keys with multiple identities."""
 
@@ -720,6 +722,7 @@ def test_has_encryption_subkey_rejects_multiple_userids():
     assert ApprisePGPController._has_encryption_subkey(key) is False
 
 
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
 def test_has_encryption_subkey_rejects_multiple_subkeys():
     """Autocrypt Level 1 requires exactly one subkey."""
 
@@ -745,6 +748,7 @@ def test_has_encryption_subkey_rejects_multiple_subkeys():
     assert ApprisePGPController._has_encryption_subkey(key) is False
 
 
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
 def test_has_encryption_subkey_rejects_extra_uid_selfsig():
     """Autocrypt rejects a UID with an extra self-signature."""
 
@@ -771,6 +775,7 @@ def test_has_encryption_subkey_rejects_extra_uid_selfsig():
     assert ApprisePGPController._has_encryption_subkey(key) is False
 
 
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
 def test_has_encryption_subkey_rejects_extra_subkey_binding_sig():
     """Autocrypt rejects a subkey with an extra binding signature."""
 
@@ -803,6 +808,7 @@ def test_has_encryption_subkey_rejects_extra_subkey_binding_sig():
     assert ApprisePGPController._has_encryption_subkey(key) is False
 
 
+@pytest.mark.skipif(not pgp_module.PGP_SUPPORT, reason="Requires PGPy")
 def test_has_encryption_subkey_rejects_uid_without_selfsig():
     """Reject a UID whose only signature is from a third party."""
 


### PR DESCRIPTION
## Description
**Related issue (if applicable):** N/a

Adds Delta Chat as a notification service (`deltachat://` / `deltachats://`), built as a thin extension of the existing Email 

## *Delta Chat* Notifications
* **Source**: https://delta.chat/
* **Image Support**: No
* **Attachment Support**: Yes (inherited from Email)
* **Message Format**: Plain Text
* **Message Limit**: Same as Email - no cap

Delta Chat is a messaging app that works over ordinary e-mail. This plugin sends notifications to a Delta Chat contact as plain-text e-mail carrying Delta Chat's `Chat-Version` header, optionally signed/encrypted with PGP (Autocrypt) the same way Email already supports.

## Account Setup
1. Get a mailbox for your bot. Any regular e-mail account works, but a purpose-built "chatmail" relay (see https://chatmail.at/) is what most Delta Chat users are already on.
2. Note the account's SMTP host, port, username, and password.
3. The person you want to notify must already have (or add) your bot's address as a contact in Delta Chat; a first message from an unknown address lands in their "Contact Requests" list until accepted.

## Syntax

Valid syntax is as follows:
- `deltachat://user:pass@smtp.example.com/friend@example.org`
- `deltachats://user:pass@smtp.example.com/friend1@example.org/friend2@example.org`
- `deltachats://user:pass@smtp.example.com/friend@example.org?pgp=encrypt`

## Parameter Breakdown

| Variable  | Required |  Description   |
|-----------|----------|----------------|
| host      | Yes      | Your bot's SMTP host |
| user      | Yes      | SMTP account username |
| password  | Yes      | SMTP account password |
| targets   | Yes      | One or more Delta Chat contact e-mail addresses |
| mode      | No       | SMTP transport: `starttls` (default on `deltachats://`), `ssl`, or `insecure` (default on `deltachat://`) |
| pgp       | No       | `no` (default), `sign`, or `encrypt` -- many chatmail relays reject unencrypted mail outright |
| wkd       | No       | Enable Web Key Directory lookup for a recipient's public key |

## Examples

Sends a simple example:
```bash
apprise -vv -t "Title" -b "Message content" \
    deltachats://user:pass@smtp.example.com/friend@example.org?pgp=encrypt
```

## New Service Completion Status
* [x] apprise/plugins/deltachat.py
* [x] pyproject.toml
    - Added "Delta Chat" to the `keywords` list (alphabetically).
* [x] README.md
    - Added entry for the new service (quick reference only).
* [x] packaging/redhat/python-apprise.spec
    - Added Delta Chat into the `%global common_description`
* [x] apprise-docs service page : https://github.com/caronc/apprise-docs/pull/128

<!-- The following must be completed or your PR cannot be merged -->
## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/128](https://github.com/caronc/apprise-docs/pull/128)
* [x] The change is tested and works locally.
* [x] No commented-out code in this PR.
* [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
* [x] Test coverage added or updated (use `tox -e qa`).

## Testing
Anyone can help test as follows:
```bash
# Create a virtual environment
python3 -m venv apprise

# Change into our new directory
cd apprise

# Activate our virtual environment
source bin/activate

# Install the branch
pip install git+https://github.com/caronc/apprise.git@delta-chat-support

# If you have cloned the branch and have tox available to you:
tox -e apprise -- -t "Test Title" -b "Test Message" \
    deltachats://user:pass@smtp.example.com/friend@example.org
```
