### PR TITLE
Add YouLMK notification support (youlmk://)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ The table below identifies the services this tool supports and some example serv
 | [WxPusher](https://appriseit.com/services/wxpusher/) | wxpusher://  | (TCP) 443   | wxpusher://AppToken@UserID1/UserID2/UserIDN<br/>wxpusher://AppToken@Topic1/Topic2/Topic3<br/>wxpusher://AppToken@UserID1/Topic1/
 | [XBMC](https://appriseit.com/services/xbmc/) | xbmc:// or xbmcs://    | (TCP) 8080 or 443   | xbmc://hostname<br />xbmc://user@hostname<br />xbmc://user:password@hostname:port
 | [XMPP](https://appriseit.com/services/xmpp/) | xmpp:// or xmpps://    | (TCP) 5222 or 5223   | xmpp://user:pass@hostname<br />xmpps://user:pass@hostname/jid<br />xmpps://user:pass@hostname/jid1/jid2@example.ca
+| [YouLMK](https://appriseit.com/services/youlmk/) | youlmk://  | (TCP) 443   | youlmk://ylk_token<br/>youlmk://k_key<br/>youlmk://ylk_token?priority=critical<br/>youlmk://ylk_token?failure=critical&url=https://example.com/runs/1
 | [Zoom](https://appriseit.com/services/zoom/) | zoom://  | (TCP) 443   | zoom://WebhookID/Token
 | [Zulip Chat](https://appriseit.com/services/zulip/) | zulip://  | (TCP) 443   | zulip://botname@Organization/Token<br />zulip://botname@Organization/Token/Stream<br />zulip://botname@Organization/Token/Email
 

--- a/apprise/plugins/youlmk.py
+++ b/apprise/plugins/youlmk.py
@@ -1,0 +1,454 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# YouLMK (https://youlmk.com) is a hosted notification inbox: anything with
+# an HTTP client sends into it, and the receiver decides per sender (a
+# "source") how far a message may reach, whether quiet hours hold it and how
+# repeats group. A notification lands on the person's phone, in their
+# browser, in email, in Slack or on a webhook they own.
+#
+# Every source has two credentials, shown on its Key screen. Either one works
+# here:
+#   - the bearer token, "ylk_" followed by 32 characters:
+#       youlmk://ylk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+#   - the URL key, "k_" followed by 14 characters:
+#       youlmk://k_xxxxxxxxxxxxxx
+#
+# The priority (low, normal, high, critical) is derived from the Apprise
+# notification type unless forced with ?priority=, and each type's mapping
+# can be changed (e.g. ?failure=critical). A primary button and a grouping
+# key can be set with ?url= and ?group=.
+#
+# References:
+# - https://youlmk.com/docs/http
+# - https://youlmk.com/docs/payload
+
+from json import dumps
+
+import requests
+
+from ..common import NotifyType
+from ..locale import gettext_lazy as _
+from ..utils.parse import validate_regex
+from .base import NotifyBase
+
+# Extend HTTP Error Messages with YouLMK's own codes
+YOULMK_HTTP_ERROR_MAP = {
+    401: "Unauthorized - Unknown key or token.",
+    402: "Payment Required - The trial's 10 notifications are used.",
+    410: "Gone - The key was rotated or the source deleted.",
+    413: "Payload Too Large - The body is over 8 KB.",
+    422: "Unprocessable - A field is over its limit.",
+    429: "Too Many Requests - 60 a minute per key.",
+    503: "Service Unavailable - Sending is paused.",
+}
+
+# The four priorities a sender may set. The receiver's Reach is the ceiling;
+# a priority only moves down from it.
+YOULMK_PRIORITIES = (
+    "low",
+    "normal",
+    "high",
+    "critical",
+)
+
+# The default priority for each Apprise notification type. Each can be
+# changed from the URL (e.g. ?failure=critical). "critical" is never a
+# default: it may break through quiet hours and Focus when the source allows
+# it, so it is opted into.
+YOULMK_DEFAULT_PRIORITIES = {
+    NotifyType.INFO: "normal",
+    NotifyType.SUCCESS: "normal",
+    NotifyType.WARNING: "high",
+    NotifyType.FAILURE: "high",
+}
+
+
+def youlmk_priority(value):
+    """Resolve a full or short-form priority (e.g. 'crit', 'c') to one of
+    YouLMK's four, or None when it matches none."""
+    value = str(value).strip().lower()
+    if not value:
+        return None
+    return next(
+        (
+            priority
+            for priority in YOULMK_PRIORITIES
+            if priority.startswith(value)
+        ),
+        None,
+    )
+
+
+class NotifyYouLMK(NotifyBase):
+    """A wrapper for YouLMK Notifications."""
+
+    # The default descriptive name associated with the Notification
+    service_name = "YouLMK"
+
+    # The services URL
+    service_url = "https://youlmk.com/"
+
+    # The default secure protocol
+    secure_protocol = "youlmk"
+
+    # A URL that takes you to the setup/help of the specific protocol
+    setup_url = "https://appriseit.com/services/youlmk/"
+
+    # The bearer door (used with a token) and the key door (used with a key)
+    notify_url = "https://youlmk.com/v1/notify"
+    key_url = "https://youlmk.com/k/{key}"
+
+    # The payload's own limits (https://youlmk.com/docs/payload)
+    title_maxlen = 120
+    body_maxlen = 2000
+
+    # 60 a minute per key, in bursts of up to 10 a second
+    request_rate_per_sec = 1.0
+
+    # An attachment has no place in the payload; an image is a URL the
+    # sender already hosts, so file attachments are not wired in
+    attachment_support = False
+
+    # Define object URL templates
+    templates = ("{schema}://{token}",)
+
+    # Define our template tokens
+    template_tokens = dict(
+        NotifyBase.template_tokens,
+        **{
+            "token": {
+                "name": _("Token or Key"),
+                "type": "string",
+                "private": True,
+                "required": True,
+                "regex": (r"^(ylk_[a-z0-9]{32}|k_[a-z0-9]{14})$", "i"),
+            },
+        },
+    )
+
+    # Define our template arguments
+    template_args = dict(
+        NotifyBase.template_args,
+        **{
+            "token": {
+                "alias_of": "token",
+            },
+            # Force the priority for every notification regardless of type
+            "priority": {
+                "name": _("Priority"),
+                "type": "choice:string",
+                "values": YOULMK_PRIORITIES,
+            },
+            # Per-type priority overrides; default to YOULMK_DEFAULT_PRIORITIES
+            "info": {
+                "name": _("Info Priority"),
+                "type": "choice:string",
+                "values": YOULMK_PRIORITIES,
+                "default": YOULMK_DEFAULT_PRIORITIES[NotifyType.INFO],
+            },
+            "success": {
+                "name": _("Success Priority"),
+                "type": "choice:string",
+                "values": YOULMK_PRIORITIES,
+                "default": YOULMK_DEFAULT_PRIORITIES[NotifyType.SUCCESS],
+            },
+            "warning": {
+                "name": _("Warning Priority"),
+                "type": "choice:string",
+                "values": YOULMK_PRIORITIES,
+                "default": YOULMK_DEFAULT_PRIORITIES[NotifyType.WARNING],
+            },
+            "failure": {
+                "name": _("Failure Priority"),
+                "type": "choice:string",
+                "values": YOULMK_PRIORITIES,
+                "default": YOULMK_DEFAULT_PRIORITIES[NotifyType.FAILURE],
+            },
+            # The primary button's address on every notification. Kept
+            # apart from the "url" the parser fills with the Apprise URL
+            # itself, hence the map to "link"
+            "url": {
+                "name": _("Link"),
+                "type": "string",
+                "map_to": "link",
+            },
+            # Notifications with the same group within ten minutes become
+            # one card with a count; the default is the title
+            "group": {
+                "name": _("Group"),
+                "type": "string",
+            },
+        },
+    )
+
+    def __init__(
+        self,
+        token,
+        priority=None,
+        info=None,
+        success=None,
+        warning=None,
+        failure=None,
+        link=None,
+        group=None,
+        **kwargs,
+    ):
+        """Initialize YouLMK Object."""
+        super().__init__(**kwargs)
+
+        # Validate the token or key (ylk_ or k_ prefix)
+        self.token = validate_regex(
+            token, *self.template_tokens["token"]["regex"]
+        )
+        if not self.token:
+            msg = f"An invalid YouLMK token or key ({token}) was specified."
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        # An explicit priority forces every notification to it
+        self.priority = None
+        if priority:
+            self.priority = youlmk_priority(priority)
+            if self.priority is None:
+                msg = f"An invalid YouLMK priority ({priority}) was specified."
+                self.logger.warning(msg)
+                raise TypeError(msg)
+
+        # Per-notification-type priority mapping; each type may be overridden
+        # from the URL, otherwise it falls back to the default
+        self.priority_map = {}
+        for ntype, value in (
+            (NotifyType.INFO, info),
+            (NotifyType.SUCCESS, success),
+            (NotifyType.WARNING, warning),
+            (NotifyType.FAILURE, failure),
+        ):
+            if not value:
+                self.priority_map[ntype] = YOULMK_DEFAULT_PRIORITIES[ntype]
+                continue
+
+            resolved = youlmk_priority(value)
+            if resolved is None:
+                msg = f"An invalid YouLMK priority ({value}) was specified."
+                self.logger.warning(msg)
+                raise TypeError(msg)
+            self.priority_map[ntype] = resolved
+
+        # The primary button's address, if any
+        self.link = link if link else None
+
+        # The grouping key, if any
+        self.group = group if group else None
+
+        return
+
+    @property
+    def is_token(self):
+        """True when the credential is the bearer token, False for the URL
+        key."""
+        return self.token.lower().startswith("ylk_")
+
+    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+        """Perform YouLMK Notification."""
+
+        # Prepare our headers
+        headers = {
+            "User-Agent": self.app_id,
+            "Content-Type": "application/json; charset=utf-8",
+        }
+
+        # The bearer token goes in the header and the request to the /v1
+        # door; the URL key goes in the address of the /k door
+        if self.is_token:
+            url = self.notify_url
+            headers["Authorization"] = f"Bearer {self.token}"
+
+        else:
+            url = self.key_url.format(key=self.token)
+
+        # Resolve the priority: an explicit override wins, otherwise the
+        # per-notification-type mapping applies
+        priority = (
+            self.priority if self.priority else self.priority_map[notify_type]
+        )
+
+        # A title is required by the door; when Apprise has none, the
+        # application descriptor stands in
+        title = title if title else self.app_desc
+        if not title:
+            title = self.app_id
+
+        # Prepare our payload
+        payload = {
+            "title": title,
+            "body": body,
+            "priority": priority,
+        }
+
+        if self.link:
+            payload["url"] = self.link
+
+        if self.group:
+            payload["group"] = self.group
+
+        self.logger.debug(
+            "YouLMK POST URL: %s (cert_verify=%s)",
+            url,
+            self.verify_certificate,
+        )
+        self.logger.debug("YouLMK Payload: %s", str(payload))
+
+        # Always call throttle before any remote server i/o is made
+        self.throttle()
+
+        try:
+            r = requests.post(
+                url,
+                data=dumps(payload),
+                headers=headers,
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+                allow_redirects=self.redirects,
+            )
+
+            if r.status_code != requests.codes.ok:
+                # We had a problem
+                status_str = NotifyYouLMK.http_response_code_lookup(
+                    r.status_code, YOULMK_HTTP_ERROR_MAP
+                )
+
+                self.logger.warning(
+                    "Failed to send YouLMK notification: {}{}error={}.".format(
+                        status_str,
+                        ", " if status_str else "",
+                        r.status_code,
+                    )
+                )
+
+                self.logger.debug(
+                    "Response Details:\r\n%r", (r.content or b"")[:2000]
+                )
+
+                # Return; we're done
+                return False
+
+            else:
+                self.logger.info("Sent YouLMK notification.")
+
+        except requests.RequestException as e:
+            self.logger.warning(
+                "A Connection error occurred posting to YouLMK."
+            )
+            self.logger.debug("Socket Exception: %s", str(e))
+            return False
+
+        return True
+
+    @property
+    def url_identifier(self):
+        """Returns all of the identifiers that make this URL unique from
+        another simliar one.
+
+        Targets or end points should never be identified here.
+        """
+        return (
+            self.secure_protocol,
+            self.token,
+        )
+
+    def url(self, privacy=False, *args, **kwargs):
+        """Returns the URL built dynamically based on specified arguments."""
+
+        # Define any URL parameters
+        params = {}
+        if self.priority:
+            params["priority"] = self.priority
+
+        # Include any per-type priority that differs from the default
+        for ntype, key in (
+            (NotifyType.INFO, "info"),
+            (NotifyType.SUCCESS, "success"),
+            (NotifyType.WARNING, "warning"),
+            (NotifyType.FAILURE, "failure"),
+        ):
+            if self.priority_map[ntype] != YOULMK_DEFAULT_PRIORITIES[ntype]:
+                params[key] = self.priority_map[ntype]
+
+        if self.link:
+            params["url"] = self.link
+
+        if self.group:
+            params["group"] = self.group
+
+        # Extend our parameters
+        params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
+
+        return "{schema}://{token}/?{params}".format(
+            schema=self.secure_protocol,
+            token=self.pprint(self.token, privacy, safe=""),
+            params=NotifyYouLMK.urlencode(params),
+        )
+
+    @staticmethod
+    def parse_url(url):
+        """Parses the URL and returns enough arguments that can allow us to re-
+        instantiate this object."""
+        results = NotifyBase.parse_url(url, verify_host=False)
+        if not results:
+            # We're done early as we couldn't load the results
+            return results
+
+        # The token or key is in the host position (case is preserved
+        # because verify_host=False skips hostname normalization)
+        results["token"] = NotifyYouLMK.unquote(results["host"])
+
+        # Allow ?token= to override the host-supplied credential
+        if "token" in results["qsd"] and results["qsd"]["token"]:
+            results["token"] = NotifyYouLMK.unquote(results["qsd"]["token"])
+
+        # Allow the priority to be forced for every notification type
+        if "priority" in results["qsd"] and results["qsd"]["priority"]:
+            results["priority"] = NotifyYouLMK.unquote(
+                results["qsd"]["priority"]
+            )
+
+        # Allow per-notification-type priority overrides
+        for key in ("info", "success", "warning", "failure"):
+            if key in results["qsd"] and results["qsd"][key]:
+                results[key] = NotifyYouLMK.unquote(results["qsd"][key])
+
+        # The primary button's address; "url" in the results is the Apprise
+        # URL itself, so the link is stored under its own name
+        if "url" in results["qsd"] and results["qsd"]["url"]:
+            results["link"] = NotifyYouLMK.unquote(results["qsd"]["url"])
+
+        # The grouping key
+        if "group" in results["qsd"] and results["qsd"]["group"]:
+            results["group"] = NotifyYouLMK.unquote(results["qsd"]["group"])
+
+        return results

--- a/packaging/redhat/python-apprise.spec
+++ b/packaging/redhat/python-apprise.spec
@@ -92,8 +92,8 @@ notification services. It supports sending alerts to platforms such as: \
 `Synology Chat`, `Syslog`, `Techulus Push`, `Telegram`, `Threema Gateway`, \
 `Trigv`, `Twilio`, `Twitter`, `Twist`, `Vapid`, `Viber`, `VictorOps`, \
 `Voipms`, `Vonage`, `WebPush`, `WeChat (WeCom)`, `WeCom Bot`, `WhatsApp`, \
-`Webex Teams`, `Workflows`, `WPUSH`, `WxPusher`, `XBMC`, `XMPP`, `Zoom`, \
-and `Zulip`.}
+`Webex Teams`, `Workflows`, `WPUSH`, `WxPusher`, `XBMC`, `XMPP`, `YouLMK`, \
+`Zoom`, and `Zulip`.}
 
 Name:           python-%{pypi_name}
 Version:        1.13.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,6 +219,7 @@ keywords = [
     "XBMC",
     "XML",
     "XMPP",
+    "YouLMK",
     "Zoom",
     "Zulip",
 ]

--- a/tests/test_plugin_youlmk.py
+++ b/tests/test_plugin_youlmk.py
@@ -1,0 +1,458 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from json import loads
+
+# Disable logging for a cleaner testing output
+import logging
+from unittest import mock
+
+from helpers import AppriseURLTester
+import pytest
+import requests
+
+from apprise import Apprise, AppriseAsset, NotifyType
+from apprise.plugins.youlmk import NotifyYouLMK, youlmk_priority
+
+logging.disable(logging.CRITICAL)
+
+# The handoff's placeholder key and a token of the same shape; neither is real
+TOKEN = "ylk_" + "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
+KEY = "k_7hq2nk3f9qd8w4"
+
+# Our Testing URLs
+apprise_url_tests = (
+    (
+        "youlmk://",
+        {
+            # No token specified
+            "instance": TypeError,
+        },
+    ),
+    (
+        "youlmk://invalid",
+        {
+            # Neither a ylk_ token nor a k_ key
+            "instance": TypeError,
+        },
+    ),
+    (
+        "youlmk://ylk_tooshort",
+        {
+            # The token's shape is ylk_ and 32 characters
+            "instance": TypeError,
+        },
+    ),
+    (
+        f"youlmk://{TOKEN}",
+        {
+            # A valid bearer token
+            "instance": NotifyYouLMK,
+            # Our expected url(privacy=True) startswith() response:
+            "privacy_url": "youlmk://y...6/",
+        },
+    ),
+    (
+        f"youlmk://{KEY}",
+        {
+            # A valid URL key
+            "instance": NotifyYouLMK,
+            "privacy_url": "youlmk://k...4/",
+        },
+    ),
+    (
+        f"youlmk://?token={TOKEN}",
+        {
+            # The token provided as a query argument
+            "instance": NotifyYouLMK,
+            "privacy_url": "youlmk://y...6/",
+        },
+    ),
+    (
+        f"youlmk://{TOKEN}?priority=critical",
+        {
+            # A forced priority
+            "instance": NotifyYouLMK,
+        },
+    ),
+    (
+        f"youlmk://{TOKEN}?priority=bogus",
+        {
+            # An unknown priority
+            "instance": TypeError,
+        },
+    ),
+    (
+        f"youlmk://{TOKEN}?failure=critical&info=low",
+        {
+            # Per-type priorities
+            "instance": NotifyYouLMK,
+        },
+    ),
+    (
+        f"youlmk://{TOKEN}?warning=bogus",
+        {
+            # An unknown per-type priority
+            "instance": TypeError,
+        },
+    ),
+    (
+        f"youlmk://{TOKEN}?url=https://example.com/runs/1&group=deploys",
+        {
+            # A link and a group
+            "instance": NotifyYouLMK,
+        },
+    ),
+    (
+        f"youlmk://{TOKEN}",
+        {
+            "instance": NotifyYouLMK,
+            # Throw an exception on the send
+            "test_requests_exceptions": True,
+        },
+    ),
+    (
+        f"youlmk://{TOKEN}",
+        {
+            "instance": NotifyYouLMK,
+            # An unknown key
+            "response": False,
+            "requests_response_code": 401,
+        },
+    ),
+    (
+        f"youlmk://{TOKEN}",
+        {
+            "instance": NotifyYouLMK,
+            # The trial's notifications are used
+            "response": False,
+            "requests_response_code": 402,
+        },
+    ),
+    (
+        f"youlmk://{TOKEN}",
+        {
+            "instance": NotifyYouLMK,
+            # A code the map does not name
+            "response": False,
+            "requests_response_code": 999,
+        },
+    ),
+)
+
+
+def test_plugin_youlmk_urls():
+    """NotifyYouLMK() Apprise URLs."""
+
+    # Run our general tests
+    AppriseURLTester(tests=apprise_url_tests).run_all()
+
+
+def test_plugin_youlmk_edge_cases():
+    """NotifyYouLMK() Edge Cases."""
+
+    # No token
+    with pytest.raises(TypeError):
+        NotifyYouLMK(token=None)
+
+    # An empty token
+    with pytest.raises(TypeError):
+        NotifyYouLMK(token="  ")
+
+    # The wrong shape
+    with pytest.raises(TypeError):
+        NotifyYouLMK(token="ylk_" + "x" * 31)
+
+    # A bad forced priority
+    with pytest.raises(TypeError):
+        NotifyYouLMK(token=TOKEN, priority="bogus")
+
+    # A bad per-type priority
+    with pytest.raises(TypeError):
+        NotifyYouLMK(token=TOKEN, failure="bogus")
+
+    # Both shapes are accepted, and the case of the token is kept
+    obj = NotifyYouLMK(token=TOKEN.upper())
+    assert obj.token == TOKEN.upper()
+    assert obj.is_token is True
+
+    obj = NotifyYouLMK(token=KEY)
+    assert obj.is_token is False
+
+
+@mock.patch("requests.post")
+def test_plugin_youlmk_send_token(mock_post):
+    """NotifyYouLMK() Send with the bearer token."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    obj = Apprise.instantiate(f"youlmk://{TOKEN}")
+    assert isinstance(obj, NotifyYouLMK)
+
+    assert obj.notify(title="backup finished", body="4.2 GB") is True
+    assert mock_post.call_count == 1
+
+    # The bearer door, with the token in the header
+    assert mock_post.call_args[0][0] == "https://youlmk.com/v1/notify"
+    headers = mock_post.call_args[1]["headers"]
+    assert headers["Authorization"] == f"Bearer {TOKEN}"
+    assert headers["Content-Type"] == "application/json; charset=utf-8"
+
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["title"] == "backup finished"
+    assert payload["body"] == "4.2 GB"
+    # INFO maps to normal by default
+    assert payload["priority"] == "normal"
+    assert "url" not in payload
+    assert "group" not in payload
+
+
+@mock.patch("requests.post")
+def test_plugin_youlmk_send_key(mock_post):
+    """NotifyYouLMK() Send with the URL key."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    obj = Apprise.instantiate(f"youlmk://{KEY}")
+    assert isinstance(obj, NotifyYouLMK)
+
+    assert obj.notify(title="deployed", body="v2.4.1") is True
+    assert mock_post.call_count == 1
+
+    # The key door, with the key in the address and no bearer header
+    assert mock_post.call_args[0][0] == f"https://youlmk.com/k/{KEY}"
+    assert "Authorization" not in mock_post.call_args[1]["headers"]
+
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["title"] == "deployed"
+    assert payload["priority"] == "normal"
+
+
+@mock.patch("requests.post")
+def test_plugin_youlmk_notify_type_mapping(mock_post):
+    """NotifyYouLMK() Priority derived from the notification type."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    obj = Apprise.instantiate(f"youlmk://{TOKEN}")
+
+    expected = {
+        NotifyType.INFO: "normal",
+        NotifyType.SUCCESS: "normal",
+        NotifyType.WARNING: "high",
+        NotifyType.FAILURE: "high",
+    }
+    for notify_type, priority in expected.items():
+        mock_post.reset_mock()
+        assert obj.notify(title="t", body="b", notify_type=notify_type) is True
+        payload = loads(mock_post.call_args[1]["data"])
+        assert payload["priority"] == priority
+
+
+@mock.patch("requests.post")
+def test_plugin_youlmk_priority_override(mock_post):
+    """NotifyYouLMK() A forced priority wins over the type."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    obj = Apprise.instantiate(f"youlmk://{TOKEN}?priority=crit")
+    assert obj.priority == "critical"
+
+    assert obj.notify(title="t", body="b", notify_type=NotifyType.INFO) is True
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["priority"] == "critical"
+
+
+@mock.patch("requests.post")
+def test_plugin_youlmk_per_type_priorities(mock_post):
+    """NotifyYouLMK() Per-type priorities from the URL."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    obj = Apprise.instantiate(
+        f"youlmk://{TOKEN}?info=low&success=l&warning=n&failure=critical"
+    )
+    assert obj.priority is None
+    assert obj.priority_map[NotifyType.INFO] == "low"
+    assert obj.priority_map[NotifyType.SUCCESS] == "low"
+    assert obj.priority_map[NotifyType.WARNING] == "normal"
+    assert obj.priority_map[NotifyType.FAILURE] == "critical"
+
+    assert (
+        obj.notify(title="t", body="b", notify_type=NotifyType.FAILURE) is True
+    )
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["priority"] == "critical"
+
+    # Every changed mapping is carried by the URL
+    url = obj.url()
+    assert "info=low" in url
+    assert "success=low" in url
+    assert "warning=normal" in url
+    assert "failure=critical" in url
+
+
+@mock.patch("requests.post")
+def test_plugin_youlmk_link_and_group(mock_post):
+    """NotifyYouLMK() A link and a group travel with the payload."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    obj = Apprise.instantiate(
+        f"youlmk://{TOKEN}?url=https://example.com/runs/1&group=deploys"
+    )
+    assert obj.link == "https://example.com/runs/1"
+    assert obj.group == "deploys"
+
+    assert obj.notify(title="deployed", body="v2.4.1") is True
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["url"] == "https://example.com/runs/1"
+    assert payload["group"] == "deploys"
+
+    # And come back out of the URL
+    url = obj.url()
+    assert "url=https%3A%2F%2Fexample.com%2Fruns%2F1" in url
+    assert "group=deploys" in url
+
+
+@mock.patch("requests.post")
+def test_plugin_youlmk_empty_title(mock_post):
+    """NotifyYouLMK() A title is always sent."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    # The application description stands in for a missing title
+    asset = AppriseAsset(app_desc="My App")
+    obj = Apprise.instantiate(f"youlmk://{TOKEN}", asset=asset)
+    assert obj.notify(body="b", title="") is True
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["title"] == "My App"
+
+    # And the application id when there is no description either
+    mock_post.reset_mock()
+    asset = AppriseAsset(app_desc="", app_id="apprise")
+    obj = Apprise.instantiate(f"youlmk://{TOKEN}", asset=asset)
+    assert obj.notify(body="b", title="") is True
+    payload = loads(mock_post.call_args[1]["data"])
+    assert payload["title"] == "apprise"
+
+
+@mock.patch("requests.post")
+def test_plugin_youlmk_failures(mock_post):
+    """NotifyYouLMK() The door's own codes read as failures."""
+
+    for code in (401, 402, 410, 413, 422, 429, 503):
+        response = mock.Mock()
+        response.status_code = code
+        response.content = b'{"error":"code"}'
+        mock_post.return_value = response
+
+        obj = Apprise.instantiate(f"youlmk://{TOKEN}")
+        assert obj.notify(title="t", body="b") is False
+
+    # A connection error
+    mock_post.side_effect = requests.RequestException("down")
+    obj = Apprise.instantiate(f"youlmk://{TOKEN}")
+    assert obj.notify(title="t", body="b") is False
+
+
+@mock.patch("requests.post")
+def test_plugin_youlmk_url_roundtrip(mock_post):
+    """NotifyYouLMK() A URL survives a round trip."""
+
+    response = mock.Mock()
+    response.status_code = requests.codes.ok
+    mock_post.return_value = response
+
+    source = f"youlmk://{TOKEN}?priority=high&failure=critical&group=g"
+    obj = Apprise.instantiate(source)
+    url = obj.url()
+    assert url.startswith(f"youlmk://{TOKEN}/?")
+    assert "priority=high" in url
+    assert "failure=critical" in url
+    assert "group=g" in url
+
+    again = Apprise.instantiate(url)
+    assert isinstance(again, NotifyYouLMK)
+    assert again.token == TOKEN
+    assert again.priority == "high"
+    assert again.priority_map[NotifyType.FAILURE] == "critical"
+    assert again.group == "g"
+    assert again.url_identifier == obj.url_identifier
+
+    # Two credentials are two identifiers
+    other = Apprise.instantiate(f"youlmk://{KEY}")
+    assert other.url_identifier != obj.url_identifier
+
+
+def test_plugin_youlmk_parse_url():
+    """NotifyYouLMK() parse_url()."""
+
+    # An unparseable (non-string) URL returns None
+    assert NotifyYouLMK.parse_url(None) is None
+
+    results = NotifyYouLMK.parse_url(f"youlmk://{TOKEN}")
+    assert results["token"] == TOKEN
+    assert "priority" not in results
+    assert "link" not in results
+
+    results = NotifyYouLMK.parse_url(
+        f"youlmk://ignored?token={TOKEN}&priority=low&info=high"
+        "&url=https://example.com&group=g"
+    )
+    assert results["token"] == TOKEN
+    assert results["priority"] == "low"
+    assert results["info"] == "high"
+    assert results["link"] == "https://example.com"
+    assert results["group"] == "g"
+
+
+def test_plugin_youlmk_priority_resolution():
+    """youlmk_priority() resolves short forms and refuses the rest."""
+
+    assert youlmk_priority("low") == "low"
+    assert youlmk_priority("l") == "low"
+    assert youlmk_priority("NORMAL") == "normal"
+    assert youlmk_priority("hi") == "high"
+    assert youlmk_priority("crit") == "critical"
+    assert youlmk_priority("") is None
+    assert youlmk_priority("   ") is None
+    assert youlmk_priority("bogus") is None


### PR DESCRIPTION
## Description
**Related issue (if applicable):** none

Adds a plugin for YouLMK, a hosted notification inbox: anything with an HTTP client sends into it, and the receiver decides per sender (a source) how far a message may reach, whether quiet hours hold it and how repeats group. A notification lands on the person's phone, in their browser, in email, in Slack, or on a webhook they own.

Modelled on the PushWard plugin: a credential in the host position, a priority derived from the Apprise notification type with per-type overrides, and the payload's own limits.

## YouLMK Notifications
* **Source**: https://youlmk.com
* **Image Support**: No
* **Message Format**: Plain Text
* **Message Limit**: 120 characters for the title, 2000 for the body

Every source in YouLMK has two credentials on its Key screen, and either one works: the bearer token (`ylk_` and 32 characters), sent as an `Authorization: Bearer` header to `https://youlmk.com/v1/notify`, or the URL key (`k_` and 14 characters), sent to `https://youlmk.com/k/{key}`. The API is documented at https://youlmk.com/docs/http and https://youlmk.com/docs/payload.

## Account Setup
1. Sign in at https://youlmk.com or in the app and create a source (for example `apprise`).
2. Open the source's Key screen and copy its token or its key.

## Syntax

Valid syntax is as follows:
- `youlmk://{token}`
- `youlmk://{key}`
- `youlmk://{token}?priority={priority}`
- `youlmk://{token}?info={priority}&success={priority}&warning={priority}&failure={priority}`
- `youlmk://{token}?url={link}&group={group}`

## Parameter Breakdown

| Variable  | Required |  Description   |
|-----------|----------|----------------|
| token | Yes | The bearer token (`ylk_…`) or the URL key (`k_…`); also accepted as `?token=` |
| priority | No | Forces `low`, `normal`, `high` or `critical` for every notification; short forms work (`crit`) |
| info / success / warning / failure | No | The priority for that notification type; defaults `normal` / `normal` / `high` / `high`. `critical` is never a default since it may break through quiet hours when the source allows it |
| url | No | The address behind the notification's primary button |
| group | No | Notifications with the same group within ten minutes become one card with a count; defaults to the title |

## Examples

Sends a simple example:
```bash
apprise -vv -t "Backup finished" -b "4.2 GB in 3 min 10 s" \
    youlmk://ylk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
```

Every failure critical, with a link to the log:
```bash
apprise -vv -n failure -t "Backup failed" -b "exit 2" \
    "youlmk://ylk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx?failure=critical&url=https://example.com/logs/2041"
```

## New Service Completion Status
* [x] apprise/plugins/youlmk.py
* [x] pyproject.toml
    - Update keywords section to identify the new service (alphabetically).
* [x] README.md
    - Add entry for the new service (quick reference only).
* [x] packaging/redhat/python-apprise.spec
    - add new service into the `%global common_description`

## Checklist
* [x] Documentation ticket created (if applicable): [apprise-docs/129](https://github.com/caronc/apprise-docs/pull/129)
* [x] The change is tested and works locally: `tests/test_plugin_youlmk.py`, 13 tests, 100% line and branch coverage of the plugin, run with pytest 9.1.1 on Python 3.12
* [x] No commented-out code in this PR.
* [x] No lint errors (`ruff check` and `ruff format --check` pass on both files).

Disclosure: this plugin is contributed by the service's own maintainers (hello@youlmk.com).