### PR TITLE
Support environment templates for declarative configuration backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,60 @@ apprise -vv --title 'custom override' \
 
 You can read more about creating your own custom notifications and/or hooks [here](https://appriseit.com/library/extending/decorator/).
 
+### Environment variables in configuration
+
+Notification URLs in local TEXT and YAML configuration files can reference
+environment variables using `${NAME}`. YAML URL option values support the same
+syntax:
+
+```text
+notifications = tgram://123456789:${TELEGRAM_BOT_TOKEN}/-1001234567890
+```
+
+```yaml
+urls:
+  - tgram://123456789:${TELEGRAM_BOT_TOKEN}/-1001234567890:
+      tag: notifications
+```
+
+Supply the variables in the environment of the process running Apprise. No
+allowlist or additional setting is needed:
+
+```sh
+# Supply TELEGRAM_BOT_TOKEN through your secret manager or container environment.
+apprise --config=apprise.conf --tag=notifications --body='Test notification'
+```
+
+Substitution applies to files loaded through `--config`, the default local
+configuration paths, or `AppriseConfig.add(path)`. It does not apply to HTTP
+configuration, in-memory content passed to `add_config()`, or notification URLs
+passed directly to `Apprise.add()` or the CLI. These sources preserve placeholders
+literally and cannot enable substitution through a URL parameter or YAML setting.
+Local includes inherit substitution only when every source in the include chain
+is local; a remote source cannot regain access by including a file, even with
+`insecure_includes=True`.
+
+Only load trusted, administrator-managed files through the local file loader.
+Applications that accept uploaded configuration should continue to use
+`add_config()` for that content, even if it is stored on disk. Apprise API
+currently uses this in-memory path for saved configurations, so those
+configurations do not receive environment substitution with this library change.
+
+An unset or empty variable rejects the local configuration source rather than
+sending with a partially substituted URL. Values containing
+newlines or NUL characters are also rejected. Errors identify the variable name,
+not its value. Existing logging and configuration export policies still apply
+to the resolved notification services.
+
+Substitution is literal and occurs once; default value syntax and recursive
+expansion are not supported. `$${NAME}` produces literal `${NAME}` in local
+files. URL substitutions must already be appropriately
+percent-encoded; YAML option values are substituted after YAML parsing and
+remain strings. Includes, tag-group definitions, and global assets are not
+expanded. Configuration files are never rewritten. Resolved services follow
+the normal configuration cache lifetime; reload the configuration after changing
+environment values.
+
 ## CLI Environment Variables
 
 Those using the Command Line Interface (CLI) can also leverage environment variables to pre-set the default settings:

--- a/README.md
+++ b/README.md
@@ -446,9 +446,9 @@ You can read more about creating your own custom notifications and/or hooks [her
 
 ### Environment variables in configuration
 
-Notification URLs in local TEXT and YAML configuration files can reference
-environment variables using `${NAME}`. YAML URL option values support the same
-syntax:
+Notification URLs in local TEXT and YAML configuration files and content supplied
+through `AppriseConfig.add_config()` can reference environment variables using
+`${NAME}`. YAML URL option values support the same syntax:
 
 ```text
 notifications = tgram://123456789:${TELEGRAM_BOT_TOKEN}/-1001234567890
@@ -469,21 +469,29 @@ apprise --config=apprise.conf --tag=notifications --body='Test notification'
 ```
 
 Substitution applies to files loaded through `--config`, the default local
-configuration paths, or `AppriseConfig.add(path)`. It does not apply to HTTP
-configuration, in-memory content passed to `add_config()`, or notification URLs
+configuration paths, `AppriseConfig.add(path)`, or `AppriseConfig.add_config(content)`.
+It does not apply to HTTP-fetched configuration or notification URLs
 passed directly to `Apprise.add()` or the CLI. These sources preserve placeholders
 literally and cannot enable substitution through a URL parameter or YAML setting.
-Local includes inherit substitution only when every source in the include chain
-is local; a remote source cannot regain access by including a file, even with
+Local includes inherit substitution from files and application-managed content;
+a remote source cannot regain access by including a file, even with
 `insecure_includes=True`.
 
-Only load trusted, administrator-managed files through the local file loader.
-Applications that accept uploaded configuration should continue to use
-`add_config()` for that content, even if it is stored on disk. Apprise API
-currently uses this in-memory path for saved configurations, so those
-configurations do not receive environment substitution with this library change.
+Both local files and content passed to `add_config()` are treated as
+application-managed configuration with access to the process environment.
 
-An unset or empty variable rejects the local configuration source rather than
+Apprise API uses `add_config()` for saved configurations, so both mounted files
+and configurations saved through its admin UI support substitution. For a mounted
+`/config/apprise.cfg`, use the TEXT example above with
+`APPRISE_STATEFUL_MODE=simple`, supply `TELEGRAM_BOT_TOKEN` in the container
+environment, and send notifications to `/notify/apprise` with `tag=notifications`.
+No configuration lock is required. With Compose, an `env_file` can supply the
+token from a separate, untracked file; Compose's `.env` file alone does not pass
+variables into the container. Recreate the container after changing its environment.
+The stored configuration retains its placeholders, so protocols, tags, and chat
+IDs can be backed up separately from credentials.
+
+An unset or empty variable rejects the configuration source rather than
 sending with a partially substituted URL. Values containing
 newlines or NUL characters are also rejected. Errors identify the variable name,
 not its value. Existing logging and configuration export policies still apply

--- a/apprise/apprise_config.py
+++ b/apprise/apprise_config.py
@@ -252,6 +252,10 @@ class AppriseConfig:
         as a memory based object and only exists for the life of this
         AppriseConfig object it was loaded into.
 
+        Notification URLs and YAML URL option values can reference environment
+        variables using ${NAME}. Content supplied here is treated as
+        application-managed configuration, like an explicitly loaded file.
+
         If you know the format ('yaml' or 'text') you can specify it for
         slightly less overhead during this call.  Otherwise the configuration
         is auto-detected.

--- a/apprise/config/base.py
+++ b/apprise/config/base.py
@@ -74,7 +74,7 @@ C_MGR = ConfigurationManager()
 
 
 class _ConfigEnvironment:
-    """Substitute environment variables in parsed local configuration."""
+    """Substitute variables in parsed application-managed configuration."""
 
     pattern = re.compile(
         r"\$\$\{([A-Za-z_][A-Za-z0-9_]*)\}|"
@@ -156,8 +156,8 @@ class ConfigBase(URLBase):
     # line found in configuration files.
     allow_cross_includes = common.ContentIncludeMode.NEVER
 
-    # Only local files may expand environment variables. This is not a URL
-    # option and is disabled for descendants of remote/in-memory sources.
+    # Local files and application-managed content may expand variables.
+    # This is not a URL option; remote descendants keep it disabled.
     _allow_environment = False
 
     # the config path manages the handling of relative include

--- a/apprise/config/base.py
+++ b/apprise/config/base.py
@@ -73,6 +73,66 @@ N_MGR = NotificationManager()
 C_MGR = ConfigurationManager()
 
 
+class _ConfigEnvironment:
+    """Substitute environment variables in parsed local configuration."""
+
+    pattern = re.compile(
+        r"\$\$\{([A-Za-z_][A-Za-z0-9_]*)\}|"
+        r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}"
+    )
+
+    def expand(self, value, depth=0, memo=None):
+        """Substitute once, preserving parsed YAML structure and types."""
+        if depth > 64:
+            raise ValueError("Environment template nesting limit exceeded.")
+        if isinstance(value, str):
+            return self.pattern.sub(self._replace, value)
+        if not isinstance(value, (list, dict)):
+            return value
+        if memo is None:
+            memo = {}
+        identity = id(value)
+        if identity in memo:
+            if memo[identity] is None:
+                raise ValueError("Recursive environment template structure.")
+            return memo[identity]
+        # Cache expanded aliases and reject cycles without expanding a YAML
+        # alias graph into an exponentially larger tree.
+        memo[identity] = None
+        if isinstance(value, list):
+            result = [self.expand(item, depth + 1, memo) for item in value]
+        else:
+            result = {}
+            for key, item in value.items():
+                # YAML supports URLs as keys; option names remain literal.
+                expanded_key = (
+                    self.expand(key, depth + 1, memo)
+                    if isinstance(key, str) and "://" in key
+                    else key
+                )
+                if expanded_key in result:
+                    raise ValueError("Duplicate environment template URL.")
+                result[expanded_key] = self.expand(item, depth + 1, memo)
+        memo[identity] = result
+        return result
+
+    def _replace(self, match):
+        """Resolve a placeholder from the process environment."""
+        if match.group(1):
+            return "${" + match.group(1) + "}"
+        name = match.group(2)
+        value = os.environ.get(name)
+        if not value:
+            raise ValueError(
+                f"Environment variable {name} is missing or empty."
+            )
+        if any(char in value for char in ("\r", "\n", "\0")):
+            raise ValueError(
+                f"Environment variable {name} contains a control character."
+            )
+        return value
+
+
 class ConfigBase(URLBase):
     """This is the base class for all supported configuration sources."""
 
@@ -95,6 +155,10 @@ class ConfigBase(URLBase):
     # By default all configuration is not includable using the 'include'
     # line found in configuration files.
     allow_cross_includes = common.ContentIncludeMode.NEVER
+
+    # Only local files may expand environment variables. This is not a URL
+    # option and is disabled for descendants of remote/in-memory sources.
+    _allow_environment = False
 
     # the config path manages the handling of relative include
     config_path = os.getcwd()
@@ -236,7 +300,9 @@ class ConfigBase(URLBase):
 
         # Execute our config parse function which always returns a tuple
         # of our servers and our configuration
-        servers, configs = fn(content=content, asset=asset)
+        servers, configs = fn(
+            content=content, asset=asset, _environment=self._allow_environment
+        )
 
         # Free memory
         del content
@@ -330,6 +396,12 @@ class ConfigBase(URLBase):
                     )
                     self.logger.debug(f"Loading Exception: {e!s}")
                     continue
+
+                # A remote source cannot gain environment access by including
+                # a local file, even when insecure_includes is enabled.
+                cfg_plugin._allow_environment = (
+                    self._allow_environment and cfg_plugin._allow_environment
+                )
 
                 # if we reach here, we can now add this servers found
                 # in this configuration file to our list
@@ -641,6 +713,8 @@ class ConfigBase(URLBase):
     def config_parse_text(
         content: str,
         asset: AppriseAsset | None = None,
+        *,
+        _environment: bool = False,
     ) -> tuple[list[object], list[str]]:
         """Parse the specified content as though it were a simple text file
         only containing a list of URLs.
@@ -710,6 +784,8 @@ class ConfigBase(URLBase):
             )
             return ([], [])
 
+        environment = _ConfigEnvironment()
+
         for line, entry in enumerate(content, start=1):
             result = valid_line_re.match(entry)
             if not result:
@@ -746,6 +822,15 @@ class ConfigBase(URLBase):
                 # Store our include line
                 configs.append(config.strip())
                 continue
+
+            try:
+                if _environment:
+                    url = environment.expand(url)
+            except ValueError as error:
+                ConfigBase.logger.error(
+                    "Invalid configuration template: %s", error
+                )
+                return ([], [])
 
             # CWE-312 (Secure Logging) Handling
             loggable_url = url if not asset.secure_logging else cwe312_url(url)
@@ -874,6 +959,8 @@ class ConfigBase(URLBase):
     def config_parse_yaml(
         content: str,
         asset: AppriseAsset | None = None,
+        *,
+        _environment: bool = False,
     ) -> tuple[list[object], list[str]]:
         """Parse the specified content as though it were a yaml file
         specifically formatted for Apprise.
@@ -1097,6 +1184,15 @@ class ConfigBase(URLBase):
         if not isinstance(urls, (list, tuple)):
             # Not a problem; we simply have no urls
             urls = []
+
+        try:
+            if _environment:
+                urls = _ConfigEnvironment().expand(urls)
+        except ValueError as error:
+            ConfigBase.logger.error(
+                "Invalid configuration template: %s", error
+            )
+            return ([], [])
 
         # Iterate over each URL
         for no, url in enumerate(urls):

--- a/apprise/config/file.py
+++ b/apprise/config/file.py
@@ -46,6 +46,9 @@ class ConfigFile(ConfigBase):
     # Configuration file inclusion can only be of the same type
     allow_cross_includes = ContentIncludeMode.STRICT
 
+    # Files explicitly loaded by the application are trusted local configs.
+    _allow_environment = True
+
     def __init__(self, path, **kwargs):
         """Initialize File Object.
 

--- a/apprise/config/memory.py
+++ b/apprise/config/memory.py
@@ -39,6 +39,9 @@ class ConfigMemory(ConfigBase):
     # The default protocol
     protocol = "memory"
 
+    # Configuration supplied explicitly by the embedding application.
+    _allow_environment = True
+
     def __init__(self, content, **kwargs):
         """Initialize Memory Object.
 

--- a/tests/test_config_environment.py
+++ b/tests/test_config_environment.py
@@ -1,0 +1,304 @@
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from click.testing import CliRunner
+import pytest
+import requests
+
+from apprise import Apprise, AppriseConfig, cli
+from apprise.config import ConfigBase
+from apprise.config.base import _ConfigEnvironment
+from apprise.config.file import ConfigFile
+from apprise.config.memory import ConfigMemory
+from apprise.plugins.telegram import NotifyTelegram
+
+
+@pytest.fixture
+def environment(monkeypatch):
+    """Supply test credentials through the process environment."""
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test_token")
+    monkeypatch.setenv("PASSWORD", "test_password")
+
+
+@pytest.fixture
+def local_config(tmp_path):
+    """Create a local configuration source without changing its contents."""
+
+    def create(content, fmt="text", **kwargs):
+        path = tmp_path / ("apprise.yaml" if fmt == "yaml" else "apprise.conf")
+        path.write_text(content)
+        return ConfigFile(str(path), **kwargs)
+
+    return create
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "notifications=tgram://123456789:${TELEGRAM_BOT_TOKEN}/-1001234567890",
+        "urls:\n  - tgram://123456789:${TELEGRAM_BOT_TOKEN}/-1001234567890:\n"
+        "      tag: notifications",
+        "urls:\n  - tgram://123456789:placeholder/-1001234567890:\n"
+        "      bot_token: '123456789:${TELEGRAM_BOT_TOKEN}'\n"
+        "      tag: notifications",
+    ],
+)
+def test_config_environment_telegram(environment, local_config, content):
+    """TEXT and YAML URL/token forms resolve through the public loader."""
+    config = AppriseConfig()
+    source = local_config(
+        content, fmt="yaml" if content.startswith("urls:") else "text"
+    )
+    assert config.add(source)
+    services = config.servers()
+    assert len(services) == 1
+    assert services[0].bot_token == "123456789:test_token"
+    assert "notifications" in services[0].tags
+
+
+def test_config_environment_file(environment, tmp_path):
+    """Reading local configuration never writes resolved secrets back."""
+    source = (
+        "notifications=tgram://123456789:${TELEGRAM_BOT_TOKEN}/-1001234567890"
+    )
+    path = tmp_path / "apprise.conf"
+    path.write_text(source)
+    config = AppriseConfig()
+    assert config.add(str(path))
+    assert config.servers()[0].bot_token == "123456789:test_token"
+    assert path.read_text() == source
+
+
+@pytest.mark.parametrize("value", ["", "one\ntwo", "one\rtwo", None])
+@pytest.mark.parametrize("fmt", ["text", "yaml"])
+def test_config_environment_invalid(
+    environment, local_config, monkeypatch, value, fmt, mocker
+):
+    """A bad secret rejects the whole source, including preceding URLs."""
+    if value is None:
+        monkeypatch.delenv("PASSWORD")
+    else:
+        monkeypatch.setenv("PASSWORD", value)
+    source = "json://localhost\njson://user:${PASSWORD}@localhost"
+    if fmt == "yaml":
+        source = (
+            "urls:\n  - json://localhost\n"
+            "  - json://user:${PASSWORD}@localhost"
+        )
+    error = mocker.patch.object(ConfigBase.logger, "error")
+    assert local_config(source, fmt=fmt).servers() == []
+    assert "PASSWORD" in str(error.call_args)
+    if value:
+        assert value not in str(error.call_args)
+
+
+@pytest.mark.parametrize("fmt", ["text", "yaml"])
+def test_config_environment_memory(environment, fmt):
+    """Raw or API-supplied content must keep placeholders literal."""
+    source = "json://user:${PASSWORD}@localhost"
+    if fmt == "yaml":
+        source = "urls:\n  - " + source
+    config = AppriseConfig()
+    assert config.add_config(source, format=fmt)
+    assert config.servers()[0].password == "${PASSWORD}"
+    services, _ = ConfigBase.config_parse(source, config_format=fmt)
+    assert services[0].password == "${PASSWORD}"
+
+
+def test_config_environment_literal(environment, monkeypatch):
+    """Escapes and substituted values are not recursively expanded."""
+    value = "${PASSWORD}&\\literal"
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", value)
+    resolver = _ConfigEnvironment()
+    assert resolver.expand("${TELEGRAM_BOT_TOKEN}") == value
+    assert resolver.expand("$${PASSWORD}") == "${PASSWORD}"
+    assert resolver.expand("$PASSWORD ${PASSWORD:-default}") == (
+        "$PASSWORD ${PASSWORD:-default}"
+    )
+
+
+def test_config_environment_yaml_structure(
+    environment, local_config, monkeypatch
+):
+    """YAML delimiters in a secret remain one string option value."""
+    value = "quote' colon: # [list] {mapping} &anchor"
+    monkeypatch.setenv("PASSWORD", value)
+    config = local_config(
+        "urls:\n  - json://localhost:\n"
+        "      user: example\n      password: '${PASSWORD}'",
+        fmt="yaml",
+    )
+    services = config.servers()
+    assert len(services) == 1
+    assert services[0].password == value
+
+
+def test_config_environment_yaml_cycles(environment, local_config):
+    """Recursive YAML nodes cannot cause uncontrolled recursion."""
+    assert local_config("urls: &urls [*urls]", fmt="yaml").servers() == []
+
+
+def test_config_environment_yaml_collision(
+    environment, local_config, monkeypatch
+):
+    """URL collisions fail rather than silently discarding destinations."""
+    monkeypatch.setenv("PASSWORD", "localhost")
+    config = local_config(
+        "urls:\n  - 'json://${PASSWORD}': {}\n    'json://localhost': {}",
+        fmt="yaml",
+    )
+    assert config.servers() == []
+
+
+def test_config_environment_comments_and_includes(environment):
+    """Comments and includes do not expand environment values."""
+    services, includes = ConfigBase.config_parse_text(
+        "# ${NOT_ALLOWED}\ninclude https://localhost/${PASSWORD}\n"
+        "notifications = json://localhost",
+        _environment=True,
+    )
+    assert len(services) == 1
+    assert includes == ["https://localhost/${PASSWORD}"]
+
+
+def test_config_environment_cache(environment, local_config, monkeypatch):
+    """Substitution follows the resolved-service cache lifecycle."""
+    config = local_config("json://user:${PASSWORD}@localhost")
+    assert config.servers()[0].password == "test_password"
+    monkeypatch.setenv("PASSWORD", "changed")
+    assert config.servers()[0].password == "test_password"
+    config.cache = False
+    assert config.servers()[0].password == "changed"
+
+
+def test_config_environment_http(environment, mocker):
+    """An HTTP source cannot enable substitution through URL options."""
+    response = requests.Response()
+    response.status_code = 200
+    response._content = b"json://user:${PASSWORD}@localhost"
+    response.encoding = "utf-8"
+    response.headers["Content-Type"] = "text/plain"
+    mocker.patch("requests.post", return_value=response)
+    config = AppriseConfig()
+    assert config.add(
+        "https://localhost/apprise.conf?environment=yes&_allow_environment=yes"
+    )
+    assert config.servers()[0].password == "${PASSWORD}"
+
+
+def test_config_environment_cli(environment, tmp_path, mocker):
+    """The CLI delivers the resolved token to the notifier without I/O."""
+    path = tmp_path / "apprise.conf"
+    path.write_text(
+        "notifications=tgram://123456789:${TELEGRAM_BOT_TOKEN}/-1001234567890"
+    )
+    notify = mocker.patch.object(
+        NotifyTelegram, "notify", autospec=True, return_value=True
+    )
+    result = CliRunner().invoke(
+        cli.main,
+        [
+            "--config",
+            str(path),
+            "--body",
+            "test",
+            "--disable-async",
+            "--tag",
+            "notifications",
+        ],
+    )
+    assert result.exit_code == 0
+    notify.assert_called_once()
+    assert notify.call_args.args[0].bot_token == "123456789:test_token"
+
+
+def test_config_environment_direct_url(environment):
+    """Direct notification URLs keep their original literal behavior."""
+    source = "json://user:${PASSWORD}@localhost"
+    app = Apprise()
+    assert app.add(source)
+    assert app[0].password == "${PASSWORD}"
+
+
+def test_config_environment_local_include(environment, tmp_path):
+    """Local includes inherit environment expansion from a local parent."""
+    child = tmp_path / "child.conf"
+    child.write_text("json://user:${PASSWORD}@localhost")
+    parent = tmp_path / "parent.conf"
+    parent.write_text("include child.conf")
+    config = ConfigFile(str(parent), recursion=1)
+    assert config.servers()[0].password == "test_password"
+
+
+def test_config_environment_memory_include(environment, tmp_path):
+    """Allowing file includes does not grant environment access to memory."""
+    child = tmp_path / "child.conf"
+    child.write_text("json://user:${PASSWORD}@localhost")
+    config = ConfigMemory(
+        content=f"include {child}",
+        format="text",
+        recursion=1,
+        insecure_includes=True,
+    )
+    assert config.servers()[0].password == "${PASSWORD}"
+
+
+def test_config_environment_remote_include(environment, tmp_path, mocker):
+    """Local -> HTTP -> local chains lose environment access at HTTP."""
+    child = tmp_path / "child.conf"
+    child.write_text("json://user:${PASSWORD}@localhost")
+    parent = tmp_path / "parent.conf"
+    parent.write_text("include https://localhost/config")
+    response = requests.Response()
+    response.status_code = 200
+    response._content = f"include {child}".encode()
+    response.encoding = "utf-8"
+    response.headers["Content-Type"] = "text/plain"
+    mocker.patch("requests.post", return_value=response)
+    config = ConfigFile(str(parent), recursion=2, insecure_includes=True)
+    assert config.servers()[0].password == "${PASSWORD}"
+
+
+def test_config_environment_yaml_aliases(environment):
+    """Shared YAML nodes stay shared and are expanded only once."""
+    item = {"password": "${PASSWORD}", "port": 80, "verify": True}
+    expanded = _ConfigEnvironment().expand([item, item])
+    assert expanded[0] is expanded[1]
+    assert expanded[0] == {
+        "password": "test_password",
+        "port": 80,
+        "verify": True,
+    }
+    assert item["password"] == "${PASSWORD}"
+
+
+def test_config_environment_nul(environment, mocker):
+    """NUL is rejected even when a custom environment mapping supplies it."""
+    resolver = _ConfigEnvironment()
+    mocker.patch("apprise.config.base.os.environ.get", return_value="a\0b")
+    with pytest.raises(ValueError, match="PASSWORD contains a control"):
+        resolver.expand("${PASSWORD}")

--- a/tests/test_config_environment.py
+++ b/tests/test_config_environment.py
@@ -67,13 +67,19 @@ def local_config(tmp_path):
         "      tag: notifications",
     ],
 )
-def test_config_environment_telegram(environment, local_config, content):
+@pytest.mark.parametrize("memory", [False, True])
+def test_config_environment_telegram(
+    environment, local_config, content, memory
+):
     """TEXT and YAML URL/token forms resolve through the public loader."""
     config = AppriseConfig()
     source = local_config(
         content, fmt="yaml" if content.startswith("urls:") else "text"
     )
-    assert config.add(source)
+    if memory:
+        assert config.add_config(content)
+    else:
+        assert config.add(source)
     services = config.servers()
     assert len(services) == 1
     assert services[0].bot_token == "123456789:test_token"
@@ -95,8 +101,9 @@ def test_config_environment_file(environment, tmp_path):
 
 @pytest.mark.parametrize("value", ["", "one\ntwo", "one\rtwo", None])
 @pytest.mark.parametrize("fmt", ["text", "yaml"])
+@pytest.mark.parametrize("memory", [False, True])
 def test_config_environment_invalid(
-    environment, local_config, monkeypatch, value, fmt, mocker
+    environment, local_config, monkeypatch, value, fmt, mocker, memory
 ):
     """A bad secret rejects the whole source, including preceding URLs."""
     if value is None:
@@ -110,7 +117,12 @@ def test_config_environment_invalid(
             "  - json://user:${PASSWORD}@localhost"
         )
     error = mocker.patch.object(ConfigBase.logger, "error")
-    assert local_config(source, fmt=fmt).servers() == []
+    config = (
+        ConfigMemory(source, format=fmt)
+        if memory
+        else local_config(source, fmt=fmt)
+    )
+    assert config.servers() == []
     assert "PASSWORD" in str(error.call_args)
     if value:
         assert value not in str(error.call_args)
@@ -118,13 +130,14 @@ def test_config_environment_invalid(
 
 @pytest.mark.parametrize("fmt", ["text", "yaml"])
 def test_config_environment_memory(environment, fmt):
-    """Raw or API-supplied content must keep placeholders literal."""
+    """Application-managed content expands without rewriting the input."""
     source = "json://user:${PASSWORD}@localhost"
     if fmt == "yaml":
         source = "urls:\n  - " + source
     config = AppriseConfig()
     assert config.add_config(source, format=fmt)
-    assert config.servers()[0].password == "${PASSWORD}"
+    assert config.servers()[0].password == "test_password"
+    assert config[0].content == source
     services, _ = ConfigBase.config_parse(source, config_format=fmt)
     assert services[0].password == "${PASSWORD}"
 
@@ -255,7 +268,7 @@ def test_config_environment_local_include(environment, tmp_path):
 
 
 def test_config_environment_memory_include(environment, tmp_path):
-    """Allowing file includes does not grant environment access to memory."""
+    """Explicitly allowed local includes retain environment expansion."""
     child = tmp_path / "child.conf"
     child.write_text("json://user:${PASSWORD}@localhost")
     config = ConfigMemory(
@@ -264,7 +277,7 @@ def test_config_environment_memory_include(environment, tmp_path):
         recursion=1,
         insecure_includes=True,
     )
-    assert config.servers()[0].password == "${PASSWORD}"
+    assert config.servers()[0].password == "test_password"
 
 
 def test_config_environment_remote_include(environment, tmp_path, mocker):


### PR DESCRIPTION
## Description

**Related issue (if applicable):** None.

Sometimes, users need to back up a declarative copy of their notification configuration, including multiple service URLs, tags, and destination IDs, without exposing credentials in those backups or in version control. Today, credentials embedded in the URLs make it difficult to preserve that complete configuration separately from its secrets.

Add `${NAME}` substitution to local files and application-managed content supplied through `AppriseConfig.add_config()`. The stored configuration retains the complete set of URLs, tags, and destinations with placeholders; credentials are supplied separately through the process environment and resolved when the configuration is loaded. This allows the same declarative configuration to be backed up and restored without writing resolved secrets into it.

For example, these routes and tags can be kept in a declarative TEXT configuration while both bot tokens are supplied through the process environment:

```text
notifications = tgram://123456789:${TELEGRAM_BOT_TOKEN}/-1001234567890
critical = tgram://987654321:${ALERTS_BOT_TOKEN}/-1009876543210
```

The same syntax works in YAML URLs and URL option values. YAML expansion happens after parsing so quotes and delimiters in variable values remain string data. Source files are not rewritten, and resolved services retain the existing cache behavior.

Both local files and `add_config()` content are treated as application-managed configurations. HTTP-fetched configurations and directly supplied notification URLs retain their literal behavior. Local includes inherit substitution from local files and application-managed content; remote sources cannot gain access by including a file, even with `insecure_includes=True`. This is an internal source property, not a URL or YAML option.

Missing, empty, or multiline values reject the configuration source. Substitution happens once; `$${NAME}` escapes a literal placeholder. Include paths and global settings remain unchanged. URL values require the usual percent-encoding.

Apprise API already uses `add_config()` for saved configurations. This change therefore supports both mounted configuration files and TEXT/YAML configurations saved through its admin UI without any API code changes or configuration lock. The README documents this workflow, environment setup, and caching.

## Checklist

- [x] Documentation ticket created (if applicable): README documentation is included in this PR.
- [x] The change is tested and works locally.
- [x] No commented-out code in this PR.
- [x] No lint errors (use `tox -e lint` and optionally `tox -e format`).
- [x] Test coverage added or updated (use `tox -e qa`).

## Testing

- `tox -e lint` and `tox -e qa` on Python 3.14.7: passed; 2,046 tests passed and 20 skipped, with 99.9% reported coverage.
- 39 environment-substitution tests cover local files and application-managed content, includes, HTTP isolation, CLI notification delivery with mocked I/O, missing values, escaping, YAML structure and aliases, and caching.
- Validated against unchanged Apprise API master: 154 existing tests passed. Seven additional integration checks passed separately, covering mounted TEXT/YAML files, TEXT/YAML uploads in simple/hash storage, Telegram delivery with mocked outbound HTTP, preserved templates, tags and chat IDs, masked URL listings, and literal stateless URLs.

Anyone can help test as follows:

```bash
git clone -b feature/config-environment-variables https://github.com/dougmaitelli/apprise.git
cd apprise
python3 -m venv .venv
. .venv/bin/activate
pip install '.[dev,all-plugins]'
tox -e lint,qa
```
